### PR TITLE
refactor(transformer/typescript): improve transforming namespace

### DIFF
--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -1,16 +1,14 @@
-use rustc_hash::FxHashSet;
-
 use oxc_allocator::{Box as ArenaBox, Vec as ArenaVec};
 use oxc_ast::{ast::*, NONE};
 use oxc_ecmascript::BoundNames;
 use oxc_semantic::Reference;
-use oxc_span::{Atom, CompactStr, SPAN};
+use oxc_span::SPAN;
 use oxc_syntax::{
     operator::{AssignmentOperator, LogicalOperator},
     scope::{ScopeFlags, ScopeId},
     symbol::SymbolFlags,
 };
-use oxc_traverse::{Traverse, TraverseCtx};
+use oxc_traverse::{BoundIdentifier, Traverse, TraverseCtx};
 
 use crate::TransformCtx;
 
@@ -46,9 +44,6 @@ impl<'a> Traverse<'a> for TypeScriptNamespace<'a, '_> {
             return;
         }
 
-        // Collect function/class/enum/namespace binding names
-        let mut names: FxHashSet<Atom<'a>> = FxHashSet::default();
-
         // Recreate the statements vec for memory efficiency.
         // Inserting the `let` declaration multiple times will reallocate the whole statements vec
         // every time a namespace declaration is encountered.
@@ -57,86 +52,33 @@ impl<'a> Traverse<'a> for TypeScriptNamespace<'a, '_> {
         for stmt in ctx.ast.move_vec(&mut program.body) {
             match stmt {
                 Statement::TSModuleDeclaration(decl) => {
-                    if !decl.declare {
-                        if !self.allow_namespaces {
-                            self.ctx.error(namespace_not_supported(decl.span));
-                        }
-
-                        if let Some(transformed_stmt) = self.handle_nested(
-                            {
-                                // SAFETY: `ast.copy` is unsound! We need to fix.
-                                unsafe { ctx.ast.copy(&decl) }.unbox()
-                            },
-                            None,
-                            ctx,
-                        ) {
-                            let name = decl.id.name();
-                            if names.insert(name.clone()) {
-                                new_stmts.push(Statement::from(Self::create_variable_declaration(
-                                    name, ctx,
-                                )));
-                            }
-                            new_stmts.push(transformed_stmt);
-                            continue;
-                        }
+                    if !self.allow_namespaces {
+                        self.ctx.error(namespace_not_supported(decl.span));
                     }
-                    new_stmts.push(Statement::TSModuleDeclaration(decl));
+
+                    self.handle_nested(decl, /* is_export */ false, &mut new_stmts, None, ctx);
                     continue;
                 }
-                Statement::ExportNamedDeclaration(ref export_decl) => {
-                    match &export_decl.declaration {
-                        Some(Declaration::TSModuleDeclaration(decl)) => {
-                            if !decl.declare {
-                                if !self.allow_namespaces {
-                                    self.ctx.error(namespace_not_supported(decl.span));
-                                }
-
-                                if let Some(transformed_stmt) = self.handle_nested(
-                                    {
-                                        // SAFETY: `ast.copy` is unsound! We need to fix.
-                                        unsafe { ctx.ast.copy(decl) }
-                                    },
-                                    None,
-                                    ctx,
-                                ) {
-                                    let name = decl.id.name();
-                                    if names.insert(name.clone()) {
-                                        let declaration =
-                                            Self::create_variable_declaration(name, ctx);
-                                        let export_named_decl =
-                                            ctx.ast.plain_export_named_declaration_declaration(
-                                                SPAN,
-                                                declaration,
-                                            );
-                                        let stmt =
-                                            Statement::ExportNamedDeclaration(export_named_decl);
-                                        new_stmts.push(stmt);
-                                    }
-                                    new_stmts.push(transformed_stmt);
-                                    continue;
-                                }
-                            }
-
-                            if let TSModuleDeclarationName::Identifier(id) = &decl.id {
-                                names.insert(id.name.clone());
-                            }
-                        }
-                        Some(decl) => match decl {
-                            Declaration::FunctionDeclaration(_)
-                            | Declaration::ClassDeclaration(_)
-                            | Declaration::TSEnumDeclaration(_) => {
-                                names.insert(decl.id().as_ref().unwrap().name.clone());
-                            }
-                            _ => {}
-                        },
-                        _ => {}
+                Statement::ExportNamedDeclaration(export_decl) => {
+                    if export_decl.declaration.as_ref().map_or(true, |decl| {
+                        decl.declare() || !matches!(decl, Declaration::TSModuleDeclaration(_))
+                    }) {
+                        new_stmts.push(Statement::ExportNamedDeclaration(export_decl));
+                        continue;
                     }
-                }
-                // Collect bindings from class, function and enum declarations
-                Statement::FunctionDeclaration(_)
-                | Statement::ClassDeclaration(_)
-                | Statement::TSEnumDeclaration(_) => {
-                    names.insert(stmt.to_declaration().id().as_ref().unwrap().name.clone());
+
+                    let Some(Declaration::TSModuleDeclaration(decl)) =
+                        export_decl.unbox().declaration
+                    else {
+                        unreachable!()
+                    };
+
+                    if !self.allow_namespaces {
+                        self.ctx.error(namespace_not_supported(decl.span));
+                    }
+
+                    self.handle_nested(decl, /* is_export */ true, &mut new_stmts, None, ctx);
+                    continue;
                 }
                 _ => {}
             }
@@ -151,25 +93,34 @@ impl<'a> Traverse<'a> for TypeScriptNamespace<'a, '_> {
 impl<'a> TypeScriptNamespace<'a, '_> {
     fn handle_nested(
         &self,
-        decl: TSModuleDeclaration<'a>,
-        parent_export: Option<Expression<'a>>,
+        decl: ArenaBox<'a, TSModuleDeclaration<'a>>,
+        is_export: bool,
+        parent_stmts: &mut ArenaVec<'a, Statement<'a>>,
+        parent_binding: Option<&BoundIdentifier<'a>>,
         ctx: &mut TraverseCtx<'a>,
-    ) -> Option<Statement<'a>> {
+    ) {
+        if decl.declare {
+            return;
+        }
+
         // Skip empty declaration e.g. `namespace x;`
-        let body = decl.body?;
+        let TSModuleDeclaration { span, id, body, scope_id, .. } = decl.unbox();
 
-        let mut names: FxHashSet<Atom<'a>> = FxHashSet::default();
-
-        let TSModuleDeclarationName::Identifier(BindingIdentifier { name: real_name, .. }) =
-            decl.id
-        else {
-            return None;
+        let TSModuleDeclarationName::Identifier(ident) = id else {
+            self.ctx.error(ambient_module_nested(span));
+            return;
         };
 
+        let Some(body) = body else {
+            return;
+        };
+
+        let binding = BoundIdentifier::from_binding_ident(&ident);
+
         // Reuse `TSModuleDeclaration`'s scope in transformed function
-        let scope_id = decl.scope_id.get().unwrap();
-        let binding = ctx.generate_uid(&real_name, scope_id, SymbolFlags::FunctionScopedVariable);
-        let name = binding.name;
+        let scope_id = scope_id.get().unwrap();
+        let uid_binding =
+            ctx.generate_uid(&binding.name, scope_id, SymbolFlags::FunctionScopedVariable);
 
         let directives;
         let namespace_top_level;
@@ -199,21 +150,7 @@ impl<'a> TypeScriptNamespace<'a, '_> {
         for stmt in namespace_top_level {
             match stmt {
                 Statement::TSModuleDeclaration(decl) => {
-                    if decl.id.is_string_literal() {
-                        self.ctx.error(ambient_module_nested(decl.span));
-                        continue;
-                    }
-
-                    let module_name = decl.id.name().clone();
-                    if let Some(transformed) = self.handle_nested(decl.unbox(), None, ctx) {
-                        if names.insert(module_name.clone()) {
-                            new_stmts.push(Statement::from(Self::create_variable_declaration(
-                                module_name.clone(),
-                                ctx,
-                            )));
-                        }
-                        new_stmts.push(transformed);
-                    }
+                    self.handle_nested(decl, /* is_export */ false, &mut new_stmts, None, ctx);
                     continue;
                 }
                 Statement::ExportNamedDeclaration(export_decl) => {
@@ -225,16 +162,28 @@ impl<'a> TypeScriptNamespace<'a, '_> {
                             continue;
                         }
                         match decl {
-                            Declaration::TSEnumDeclaration(_)
-                            | Declaration::FunctionDeclaration(_)
-                            | Declaration::ClassDeclaration(_) => {
-                                Self::add_declaration(
-                                    decl,
-                                    name.clone(),
-                                    &mut names,
-                                    &mut new_stmts,
-                                    ctx,
+                            Declaration::TSEnumDeclaration(ref enum_decl) => {
+                                let binding = BoundIdentifier::from_binding_ident(&enum_decl.id);
+                                new_stmts.push(Statement::from(decl));
+                                Self::add_declaration(&uid_binding, &binding, &mut new_stmts, ctx);
+                            }
+                            Declaration::ClassDeclaration(ref class_decl) => {
+                                // Class declaration always has a binding
+                                let binding = BoundIdentifier::from_binding_ident(
+                                    class_decl.id.as_ref().unwrap(),
                                 );
+                                new_stmts.push(Statement::from(decl));
+                                Self::add_declaration(&uid_binding, &binding, &mut new_stmts, ctx);
+                            }
+                            Declaration::FunctionDeclaration(ref func_decl)
+                                if !func_decl.is_typescript_syntax() =>
+                            {
+                                // Function declaration always has a binding
+                                let binding = BoundIdentifier::from_binding_ident(
+                                    func_decl.id.as_ref().unwrap(),
+                                );
+                                new_stmts.push(Statement::from(decl));
+                                Self::add_declaration(&uid_binding, &binding, &mut new_stmts, ctx);
                             }
                             Declaration::VariableDeclaration(var_decl) => {
                                 var_decl.declarations.iter().for_each(|decl| {
@@ -243,42 +192,23 @@ impl<'a> TypeScriptNamespace<'a, '_> {
                                     }
                                 });
                                 let stmts =
-                                    Self::handle_variable_declaration(var_decl, name.clone(), ctx);
+                                    Self::handle_variable_declaration(var_decl, &uid_binding, ctx);
                                 new_stmts.extend(stmts);
                             }
                             Declaration::TSModuleDeclaration(module_decl) => {
-                                if module_decl.id.is_string_literal() {
-                                    self.ctx.error(ambient_module_nested(module_decl.span));
-                                    continue;
-                                }
-
-                                let module_name = module_decl.id.name().clone();
-                                if let Some(transformed) = self.handle_nested(
-                                    module_decl.unbox(),
-                                    Some(ctx.ast.expression_identifier_reference(SPAN, &name)),
+                                self.handle_nested(
+                                    module_decl,
+                                    /* is_export */
+                                    false,
+                                    &mut new_stmts,
+                                    Some(&uid_binding),
                                     ctx,
-                                ) {
-                                    if names.insert(module_name.clone()) {
-                                        new_stmts.push(Statement::from(
-                                            Self::create_variable_declaration(
-                                                module_name.clone(),
-                                                ctx,
-                                            ),
-                                        ));
-                                    }
-                                    new_stmts.push(transformed);
-                                }
+                                );
                             }
                             _ => {}
                         }
                     }
                     continue;
-                }
-                // Collect bindings from class, function and enum declarations
-                Statement::ClassDeclaration(_)
-                | Statement::FunctionDeclaration(_)
-                | Statement::TSEnumDeclaration(_) => {
-                    names.insert(stmt.to_declaration().id().as_ref().unwrap().name.clone());
                 }
                 // Retain when `only_remove_type_imports` is true or there are value references
                 // The behavior is the same as `TypeScriptModule::transform_ts_import_equals`
@@ -302,30 +232,45 @@ impl<'a> TypeScriptNamespace<'a, '_> {
         if new_stmts.is_empty() {
             // Delete the scope binding that `ctx.generate_uid` created above,
             // as no binding is actually being created
-            ctx.scopes_mut().remove_binding(scope_id, &CompactStr::from(name.as_str()));
+            ctx.scopes_mut().remove_binding(scope_id, uid_binding.name.as_str());
 
-            return None;
+            return;
         }
 
-        Some(Self::transform_namespace(
-            name,
-            real_name,
-            new_stmts,
-            directives,
-            parent_export,
+        if !Self::is_redeclaration_namespace(&ident, ctx) {
+            let declaration = Self::create_variable_declaration(&binding, ctx);
+            if is_export {
+                let export_named_decl =
+                    ctx.ast.plain_export_named_declaration_declaration(SPAN, declaration);
+                let stmt = Statement::ExportNamedDeclaration(export_named_decl);
+                parent_stmts.push(stmt);
+            } else {
+                parent_stmts.push(Statement::from(declaration));
+            }
+        }
+        let func_body = ctx.ast.function_body(SPAN, directives, new_stmts);
+
+        parent_stmts.push(Self::transform_namespace(
+            span,
+            &uid_binding,
+            &binding,
+            parent_binding,
+            func_body,
             scope_id,
             ctx,
-        ))
+        ));
     }
 
     // `namespace Foo { }` -> `let Foo; (function (_Foo) { })(Foo || (Foo = {}));`
     //                         ^^^^^^^
-    fn create_variable_declaration(name: Atom<'a>, ctx: &TraverseCtx<'a>) -> Declaration<'a> {
+    fn create_variable_declaration(
+        binding: &BoundIdentifier<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) -> Declaration<'a> {
         let kind = VariableDeclarationKind::Let;
         let declarations = {
-            let pattern_kind = ctx.ast.binding_pattern_kind_binding_identifier(SPAN, name);
-            let binding = ctx.ast.binding_pattern(pattern_kind, NONE, false);
-            let decl = ctx.ast.variable_declarator(SPAN, kind, binding, None, false);
+            let pattern = binding.create_binding_pattern(ctx);
+            let decl = ctx.ast.variable_declarator(SPAN, kind, pattern, None, false);
             ctx.ast.vec1(decl)
         };
         ctx.ast.declaration_variable(SPAN, kind, declarations, false)
@@ -333,21 +278,19 @@ impl<'a> TypeScriptNamespace<'a, '_> {
 
     // `namespace Foo { }` -> `let Foo; (function (_Foo) { })(Foo || (Foo = {}));`
     fn transform_namespace(
-        arg_name: Atom<'a>,
-        real_name: Atom<'a>,
-        stmts: ArenaVec<'a, Statement<'a>>,
-        directives: ArenaVec<'a, Directive<'a>>,
-        parent_export: Option<Expression<'a>>,
+        span: Span,
+        param_binding: &BoundIdentifier<'a>,
+        binding: &BoundIdentifier<'a>,
+        parent_binding: Option<&BoundIdentifier<'a>>,
+        func_body: FunctionBody<'a>,
         scope_id: ScopeId,
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {
         // `(function (_N) { var x; })(N || (N = {}))`;
         //  ^^^^^^^^^^^^^^^^^^^^^^^^^^
         let callee = {
-            let body = ctx.ast.function_body(SPAN, directives, stmts);
             let params = {
-                let ident = ctx.ast.binding_pattern_kind_binding_identifier(SPAN, arg_name);
-                let pattern = ctx.ast.binding_pattern(ident, NONE, false);
+                let pattern = param_binding.create_binding_pattern(ctx);
                 let items = ctx.ast.vec1(ctx.ast.plain_formal_parameter(SPAN, pattern));
                 ctx.ast.formal_parameters(SPAN, FormalParameterKind::FormalParameter, items, NONE)
             };
@@ -357,7 +300,7 @@ impl<'a> TypeScriptNamespace<'a, '_> {
                     SPAN,
                     None,
                     params,
-                    body,
+                    func_body,
                     scope_id,
                 ));
             *ctx.scopes_mut().get_flags_mut(scope_id) =
@@ -370,26 +313,21 @@ impl<'a> TypeScriptNamespace<'a, '_> {
         //                                                   Nested namespace arguments         Normal namespace arguments
         let arguments = {
             // M
-            let logical_left = ctx.ast.expression_identifier_reference(SPAN, real_name.clone());
+            let logical_left = binding.create_read_expression(ctx);
 
             // (_N.M = {}) or (N = {})
             let mut logical_right = {
                 // _N.M
-                // SAFETY: `ast.copy` is unsound! We need to fix.
-                let parent_export = unsafe { ctx.ast.copy(&parent_export) };
-                let assign_left = if let Some(parent_export) = parent_export {
+                let assign_left = if let Some(parent_binding) = parent_binding {
                     AssignmentTarget::from(ctx.ast.member_expression_static(
                         SPAN,
-                        parent_export,
-                        ctx.ast.identifier_name(SPAN, real_name.clone()),
+                        parent_binding.create_read_expression(ctx),
+                        ctx.ast.identifier_name(SPAN, binding.name.clone()),
                         false,
                     ))
                 } else {
                     // _N
-                    AssignmentTarget::from(
-                        ctx.ast
-                            .simple_assignment_target_identifier_reference(SPAN, real_name.clone()),
-                    )
+                    AssignmentTarget::from(binding.create_write_simple_target(ctx))
                 };
 
                 let assign_right = ctx.ast.expression_object(SPAN, ctx.ast.vec(), None);
@@ -400,19 +338,21 @@ impl<'a> TypeScriptNamespace<'a, '_> {
             };
 
             // (M = _N.M || (_N.M = {}))
-            if let Some(parent_export) = parent_export {
-                let assign_left =
-                    ctx.ast.simple_assignment_target_identifier_reference(SPAN, real_name.clone());
+            if let Some(parent_binding) = parent_binding {
+                let assign_left = AssignmentTarget::from(binding.create_write_simple_target(ctx));
                 let assign_right = {
-                    let property = ctx.ast.identifier_name(SPAN, real_name);
-                    let logical_left =
-                        ctx.ast.member_expression_static(SPAN, parent_export, property, false);
+                    let property = ctx.ast.identifier_name(SPAN, binding.name.clone());
+                    let logical_left = ctx.ast.member_expression_static(
+                        SPAN,
+                        parent_binding.create_read_expression(ctx),
+                        property,
+                        false,
+                    );
                     let op = LogicalOperator::Or;
                     ctx.ast.expression_logical(SPAN, logical_left.into(), op, logical_right)
                 };
                 let op = AssignmentOperator::Assign;
-                logical_right =
-                    ctx.ast.expression_assignment(SPAN, op, assign_left.into(), assign_right);
+                logical_right = ctx.ast.expression_assignment(SPAN, op, assign_left, assign_right);
                 logical_right = ctx.ast.expression_parenthesized(SPAN, logical_right);
             }
 
@@ -422,50 +362,43 @@ impl<'a> TypeScriptNamespace<'a, '_> {
         };
 
         let expr = ctx.ast.expression_call(SPAN, callee, NONE, arguments, false);
-        ctx.ast.statement_expression(SPAN, expr)
+        ctx.ast.statement_expression(span, expr)
     }
 
     /// Add assignment statement for decl id
     /// function id() {} -> function id() {}; Name.id = id;
     fn add_declaration(
-        decl: Declaration<'a>,
-        name: Atom<'a>,
-        names: &mut FxHashSet<Atom<'a>>,
+        namespace_binding: &BoundIdentifier<'a>,
+        value_binding: &BoundIdentifier<'a>,
         new_stmts: &mut ArenaVec<'a, Statement<'a>>,
-        ctx: &TraverseCtx<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) {
-        // This function is only called with a function, class, or enum declaration,
-        // all of which are guaranteed to have an `id`
-        let ident = decl.id().unwrap();
-        let item_name = ident.name.clone();
-        new_stmts.push(Statement::from(decl));
-        let assignment_statement = Self::create_assignment_statement(name, item_name.clone(), ctx);
+        let assignment_statement =
+            Self::create_assignment_statement(namespace_binding, value_binding, ctx);
         let assignment_statement = ctx.ast.statement_expression(SPAN, assignment_statement);
         new_stmts.push(assignment_statement);
-        names.insert(item_name);
     }
 
-    // name.item_name = item_name
+    // parent_binding.binding = binding
     fn create_assignment_statement(
-        name: Atom<'a>,
-        item_name: Atom<'a>,
-        ctx: &TraverseCtx<'a>,
+        object_binding: &BoundIdentifier<'a>,
+        value_binding: &BoundIdentifier<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
-        let object = ctx.ast.expression_identifier_reference(SPAN, name);
-        let property = ctx.ast.identifier_name(SPAN, &item_name);
+        let object = object_binding.create_read_expression(ctx);
+        let property = ctx.ast.identifier_name(SPAN, &value_binding.name);
         let left = ctx.ast.member_expression_static(SPAN, object, property, false);
         let left = AssignmentTarget::from(left);
-        let right = ctx.ast.expression_identifier_reference(SPAN, item_name);
+        let right = value_binding.create_read_expression(ctx);
         let op = AssignmentOperator::Assign;
         ctx.ast.expression_assignment(SPAN, op, left, right)
     }
 
     /// Convert `export const foo = 1` to `Namespace.foo = 1`;
-    #[expect(clippy::needless_pass_by_value)]
     fn handle_variable_declaration(
         mut var_decl: ArenaBox<'a, VariableDeclaration<'a>>,
-        name: Atom<'a>,
-        ctx: &TraverseCtx<'a>,
+        binding: &BoundIdentifier<'a>,
+        ctx: &mut TraverseCtx<'a>,
     ) -> ArenaVec<'a, Statement<'a>> {
         let is_all_binding_identifier = var_decl
             .declarations
@@ -486,7 +419,7 @@ impl<'a> TypeScriptNamespace<'a, '_> {
                             AssignmentOperator::Assign,
                             SimpleAssignmentTarget::from(ctx.ast.member_expression_static(
                                 SPAN,
-                                ctx.ast.expression_identifier_reference(SPAN, name.clone()),
+                                binding.create_read_expression(ctx),
                                 ctx.ast.identifier_name(SPAN, property_name),
                                 false,
                             ))
@@ -503,13 +436,34 @@ impl<'a> TypeScriptNamespace<'a, '_> {
         // `export const [a] = 1` transforms to `const [a] = 1; N.a = a`
         let mut assignments = ctx.ast.vec();
         var_decl.bound_names(&mut |id| {
-            assignments.push(Self::create_assignment_statement(name.clone(), id.name.clone(), ctx));
+            assignments.push(Self::create_assignment_statement(
+                binding,
+                &BoundIdentifier::from_binding_ident(id),
+                ctx,
+            ));
         });
 
         ctx.ast.vec_from_array([
             Statement::VariableDeclaration(var_decl),
             ctx.ast.statement_expression(SPAN, ctx.ast.expression_sequence(SPAN, assignments)),
         ])
+    }
+
+    /// Check the namespace binding identifier if it is a redeclaration
+    fn is_redeclaration_namespace(id: &BindingIdentifier<'a>, ctx: &TraverseCtx<'a>) -> bool {
+        let symbol_id = id.symbol_id();
+        // Only `enum`, `class`, `function` and `namespace` can be re-declared in same scope
+        ctx.symbols()
+            .get_flags(symbol_id)
+            .intersects(SymbolFlags::RegularEnum | SymbolFlags::Class | SymbolFlags::Function)
+            || {
+                // ```
+                // namespace Foo {}
+                // namespace Foo {} // is redeclaration
+                // ```
+                let redeclarations = ctx.symbols().get_redeclarations(symbol_id);
+                !redeclarations.is_empty() && redeclarations.contains(&id.span)
+            }
     }
 }
 

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -676,17 +676,12 @@ after transform: SymbolId(3): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/export/nested-same-name/input.ts
-semantic error: Missing SymbolId: "N"
-Missing SymbolId: "_N"
-Missing ReferenceId: "_N"
-Missing ReferenceId: "N"
-Missing ReferenceId: "N"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(2), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
+semantic error: Symbol flags mismatch for "N":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N":
+after transform: SymbolId(1): Span { start: 37, end: 38 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/function/anonymous-generator/input.ts
 semantic error: Unresolved references mismatch:
@@ -1036,16 +1031,12 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/body/input.ts
-semantic error: Missing SymbolId: "N"
-Missing SymbolId: "_N"
-Missing ReferenceId: "N"
-Missing ReferenceId: "N"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+semantic error: Symbol flags mismatch for "N":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N":
+after transform: SymbolId(0): Span { start: 10, end: 11 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/body-declare/input.ts
 semantic error: Bindings mismatch:
@@ -1096,12 +1087,7 @@ after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/head/input.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["M", "N", "m"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(6)]
-rebuilt        : ScopeId(0): []
+semantic error: Ambient modules cannot be nested in other modules or namespaces.
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/head-declare/input.ts
 semantic error: Bindings mismatch:

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -376,33 +376,28 @@ after transform: ["N"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/aliasInaccessibleModule2.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing SymbolId: "N"
-Missing SymbolId: "_N"
-Missing ReferenceId: "N"
-Missing ReferenceId: "N"
-Missing SymbolId: "R"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
+semantic error: Missing SymbolId: "R"
 Bindings mismatch:
 after transform: ScopeId(1): ["N", "R", "X", "_M"]
 rebuilt        : ScopeId(1): ["N", "R", "_M"]
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Reference symbol mismatch for "N":
-after transform: SymbolId(1) "N"
-rebuilt        : SymbolId(2) "N"
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "N":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N":
+after transform: SymbolId(1): Span { start: 22, end: 23 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/aliasOfGenericFunctionWithRestBehavedSameAsUnaliased.ts
 semantic error: Scope children mismatch:
@@ -514,22 +509,15 @@ after transform: []
 rebuilt        : ["Color"]
 
 tasks/coverage/typescript/tests/cases/compiler/ambientClassDeclarationWithExtends.ts
-semantic error: Missing SymbolId: "D"
-Missing SymbolId: "_D"
-Missing ReferenceId: "D"
-Missing ReferenceId: "D"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(2)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Reference symbol mismatch for "D":
-after transform: SymbolId(0) "D"
-rebuilt        : SymbolId(0) "D"
+Symbol flags mismatch for "D":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "D":
+after transform: SymbolId(0): Span { start: 97, end: 98 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["A", "C"]
 rebuilt        : []
@@ -716,27 +704,15 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
 
 tasks/coverage/typescript/tests/cases/compiler/anonterface.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "C"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(4)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(3)]
-Reference symbol mismatch for "M":
-after transform: SymbolId(0) "M"
-rebuilt        : SymbolId(0) "M"
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/anyAndUnknownHaveFalsyComponents.ts
 semantic error: Bindings mismatch:
@@ -777,27 +753,18 @@ after transform: ["Array", "use"]
 rebuilt        : ["use"]
 
 tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest6.ts
-semantic error: Missing SymbolId: "Test"
-Missing SymbolId: "_Test"
-Missing ReferenceId: "_Test"
-Missing ReferenceId: "Bug"
-Missing ReferenceId: "Test"
-Missing ReferenceId: "Test"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(5), SymbolId(9)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(7)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
-Symbol reference IDs mismatch for "Bug":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol flags mismatch for "Test":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Test":
+after transform: SymbolId(0): Span { start: 7, end: 11 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/arrayAugment.ts
 semantic error: Scope children mismatch:
@@ -805,21 +772,7 @@ after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/arrayBestCommonTypes.ts
-semantic error: Missing SymbolId: "EmptyTypes"
-Missing SymbolId: "_EmptyTypes"
-Missing ReferenceId: "EmptyTypes"
-Missing ReferenceId: "EmptyTypes"
-Missing SymbolId: "NonEmptyTypes"
-Missing SymbolId: "_NonEmptyTypes"
-Missing ReferenceId: "NonEmptyTypes"
-Missing ReferenceId: "NonEmptyTypes"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(28), SymbolId(58)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(23)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(56)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
@@ -828,9 +781,6 @@ rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 Scope children mismatch:
 after transform: ScopeId(6): [ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
 rebuilt        : ScopeId(5): [ScopeId(6), ScopeId(7)]
-Binding symbols mismatch:
-after transform: ScopeId(12): [SymbolId(30), SymbolId(31), SymbolId(32), SymbolId(33), SymbolId(57)]
-rebuilt        : ScopeId(8): [SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(27), SymbolId(29)]
 Scope flags mismatch:
 after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(8): ScopeFlags(Function)
@@ -840,9 +790,21 @@ rebuilt        : ScopeId(8): [ScopeId(9), ScopeId(11), ScopeId(13), ScopeId(15)]
 Scope children mismatch:
 after transform: ScopeId(17): [ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22)]
 rebuilt        : ScopeId(15): [ScopeId(16), ScopeId(17)]
+Symbol flags mismatch for "EmptyTypes":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "EmptyTypes":
+after transform: SymbolId(0): Span { start: 7, end: 17 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "base":
 after transform: SymbolId(2): [ReferenceId(2), ReferenceId(9), ReferenceId(11), ReferenceId(12), ReferenceId(14), ReferenceId(15), ReferenceId(17), ReferenceId(23)]
 rebuilt        : SymbolId(3): [ReferenceId(1), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(18)]
+Symbol flags mismatch for "NonEmptyTypes":
+after transform: SymbolId(28): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(23): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "NonEmptyTypes":
+after transform: SymbolId(28): Span { start: 2225, end: 2238 }
+rebuilt        : SymbolId(23): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "base":
 after transform: SymbolId(30): [ReferenceId(39), ReferenceId(46), ReferenceId(48), ReferenceId(49), ReferenceId(51), ReferenceId(52), ReferenceId(54), ReferenceId(60)]
 rebuilt        : SymbolId(25): [ReferenceId(38), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(57)]
@@ -931,19 +893,15 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/arrowFunctionInExpressionStatement2.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1)]
-rebuilt        : ScopeId(1): [SymbolId(1)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts
 semantic error: Bindings mismatch:
@@ -998,22 +956,18 @@ after transform: ["assertEqual", "const", "true"]
 rebuilt        : ["assertEqual"]
 
 tasks/coverage/typescript/tests/cases/compiler/assign1.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(2), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2)]
 rebuilt        : ScopeId(1): []
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/assignToObjectTypeWithPrototypeProperty.ts
 semantic error: Symbol reference IDs mismatch for "XEvent":
@@ -1393,24 +1347,18 @@ after transform: ["Pick", "pick"]
 rebuilt        : ["pick"]
 
 tasks/coverage/typescript/tests/cases/compiler/binopAssignmentShouldHaveType.ts
-semantic error: Missing SymbolId: "Test"
-Missing SymbolId: "_Test"
-Missing ReferenceId: "_Test"
-Missing ReferenceId: "Bug"
-Missing ReferenceId: "Test"
-Missing ReferenceId: "Test"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Test", "console"]
 rebuilt        : ScopeId(0): ["Test"]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(2), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol reference IDs mismatch for "Bug":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(2): [ReferenceId(4)]
+Symbol flags mismatch for "Test":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Test":
+after transform: SymbolId(1): Span { start: 42, end: 46 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Reference symbol mismatch for "console":
 after transform: SymbolId(0) "console"
 rebuilt        : <None>
@@ -1429,21 +1377,12 @@ after transform: ["C"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/blockScopedNamespaceDifferentFile.ts
-semantic error: Missing SymbolId: "C"
-Missing SymbolId: "_C"
-Missing ReferenceId: "_C"
-Missing ReferenceId: "Name"
-Missing ReferenceId: "C"
-Missing ReferenceId: "C"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(4)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
-Symbol reference IDs mismatch for "Name":
-after transform: SymbolId(1): [ReferenceId(2), ReferenceId(4)]
-rebuilt        : SymbolId(3): [ReferenceId(1), ReferenceId(4), ReferenceId(7)]
+semantic error: Symbol flags mismatch for "C":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "C":
+after transform: SymbolId(0): Span { start: 66, end: 67 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/bom-utf16be.ts
 semantic error: Invalid Character `￾`
@@ -1644,24 +1583,15 @@ after transform: ["Date", "RegExp"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/chainedImportAlias.ts
-semantic error: Missing SymbolId: "m"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "m"
-Missing ReferenceId: "m"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+semantic error: Symbol flags mismatch for "m":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m":
+after transform: SymbolId(0): Span { start: 14, end: 15 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "foo":
 after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/chainedSpecializationToObjectTypeLiteral.ts
 semantic error: Scope children mismatch:
@@ -1755,29 +1685,18 @@ after transform: ScopeId(0): ["Db", "foo"]
 rebuilt        : ScopeId(0): ["foo"]
 
 tasks/coverage/typescript/tests/cases/compiler/circularTypeofWithFunctionModule.ts
-semantic error: Missing SymbolId: "_maker"
-Missing ReferenceId: "_maker"
-Missing ReferenceId: "Bar"
-Missing ReferenceId: "maker"
-Missing ReferenceId: "maker"
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(3), SymbolId(4)]
-rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch for "maker":
 after transform: SymbolId(1): SymbolFlags(FunctionScopedVariable | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "maker":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1)]
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(5), ReferenceId(6)]
 rebuilt        : SymbolId(1): [ReferenceId(0), ReferenceId(4), ReferenceId(5)]
 Symbol redeclarations mismatch for "maker":
 after transform: SymbolId(1): [Span { start: 121, end: 126 }]
 rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "Bar":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(4): [ReferenceId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/circularlySimplifyingConditionalTypesNoCrash.ts
 semantic error: Bindings mismatch:
@@ -1860,27 +1779,15 @@ after transform: []
 rebuilt        : ["Err"]
 
 tasks/coverage/typescript/tests/cases/compiler/classExtendingQualifiedName2.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "C"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Reference symbol mismatch for "M":
-after transform: SymbolId(0) "M"
-rebuilt        : SymbolId(0) "M"
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/classFunctionMerging.ts
 semantic error: Bindings mismatch:
@@ -1926,11 +1833,7 @@ after transform: SymbolId(2): [ReferenceId(3)]
 rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/compiler/classImplementsImportedInterface.ts
-semantic error: Missing SymbolId: "M2"
-Missing SymbolId: "_M2"
-Missing ReferenceId: "M2"
-Missing ReferenceId: "M2"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["M1", "M2"]
 rebuilt        : ScopeId(0): ["M2"]
 Scope children mismatch:
@@ -1942,6 +1845,12 @@ rebuilt        : ScopeId(1): ["C", "_M2"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "M2":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M2":
+after transform: SymbolId(2): Span { start: 68, end: 70 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["M1"]
 rebuilt        : []
@@ -2037,53 +1946,21 @@ after transform: SymbolId(4): [ReferenceId(1), ReferenceId(3), ReferenceId(4), R
 rebuilt        : SymbolId(2): [ReferenceId(3), ReferenceId(6)]
 
 tasks/coverage/typescript/tests/cases/compiler/classdecl.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "b"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Missing SymbolId: "m2"
-Missing SymbolId: "_m2"
-Missing SymbolId: "m3"
-Missing SymbolId: "_m3"
-Missing ReferenceId: "_m3"
-Missing ReferenceId: "c"
-Missing ReferenceId: "_m3"
-Missing ReferenceId: "ib2"
-Missing ReferenceId: "m3"
-Missing ReferenceId: "m3"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m2"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(8), SymbolId(9), SymbolId(13), SymbolId(17), SymbolId(18), SymbolId(22), SymbolId(26), SymbolId(33)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(6), SymbolId(10), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(20)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(14), ScopeId(15), ScopeId(19), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(31), ScopeId(35)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(10), ScopeId(11), ScopeId(14), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(22)]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-Binding symbols mismatch:
-after transform: ScopeId(15): [SymbolId(10), SymbolId(11), SymbolId(30)]
-rebuilt        : ScopeId(11): [SymbolId(7), SymbolId(8), SymbolId(9)]
 Scope flags mismatch:
 after transform: ScopeId(15): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(11): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(15): [ScopeId(16), ScopeId(17), ScopeId(18)]
 rebuilt        : ScopeId(11): [ScopeId(12), ScopeId(13)]
-Binding symbols mismatch:
-after transform: ScopeId(19): [SymbolId(14), SymbolId(31)]
-rebuilt        : ScopeId(14): [SymbolId(11), SymbolId(12)]
 Scope flags mismatch:
 after transform: ScopeId(19): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(14): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(20): [SymbolId(15), SymbolId(16), SymbolId(32)]
-rebuilt        : ScopeId(15): [SymbolId(13), SymbolId(14), SymbolId(15)]
 Scope flags mismatch:
 after transform: ScopeId(20): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(15): ScopeFlags(Function)
@@ -2093,28 +1970,30 @@ rebuilt        : ScopeId(20): [ScopeId(21)]
 Scope children mismatch:
 after transform: ScopeId(35): [ScopeId(36), ScopeId(37), ScopeId(38)]
 rebuilt        : ScopeId(22): [ScopeId(23)]
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(10): []
-rebuilt        : SymbolId(8): [ReferenceId(6)]
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(15): []
-rebuilt        : SymbolId(14): [ReferenceId(11)]
-Symbol reference IDs mismatch for "ib2":
-after transform: SymbolId(16): []
-rebuilt        : SymbolId(15): [ReferenceId(13)]
-Reference symbol mismatch for "m1":
-after transform: SymbolId(9) "m1"
-rebuilt        : SymbolId(6) "m1"
+Symbol flags mismatch for "m1":
+after transform: SymbolId(9): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(9): Span { start: 594, end: 596 }
+rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
+Symbol flags mismatch for "m2":
+after transform: SymbolId(13): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m2":
+after transform: SymbolId(13): Span { start: 690, end: 692 }
+rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
+Symbol flags mismatch for "m3":
+after transform: SymbolId(14): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m3":
+after transform: SymbolId(14): Span { start: 714, end: 716 }
+rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["m1", "require"]
 rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/clinterfaces.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["M", "_defineProperty"]
 rebuilt        : ScopeId(0): ["Bar", "Foo", "M", "_defineProperty"]
 Scope children mismatch:
@@ -2126,6 +2005,12 @@ rebuilt        : ScopeId(1): ["C", "D", "_M"]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol flags mismatch for "C":
 after transform: SymbolId(1): SymbolFlags(Class | Interface)
 rebuilt        : SymbolId(3): SymbolFlags(Class)
@@ -2161,15 +2046,7 @@ tasks/coverage/typescript/tests/cases/compiler/cloduleAcrossModuleDefinitions.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/cloduleAndTypeParameters.ts
-semantic error: Missing SymbolId: "_Foo"
-Missing ReferenceId: "_Foo"
-Missing ReferenceId: "Baz"
-Missing ReferenceId: "Foo"
-Missing ReferenceId: "Foo"
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(3), SymbolId(4)]
-rebuilt        : ScopeId(3): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
 Scope children mismatch:
@@ -2179,57 +2056,42 @@ Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(0): [ReferenceId(0)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(4)]
 rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 63, end: 66 }]
 rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "Baz":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/cloduleGenericOnSelfMember.ts
-semantic error: Missing SymbolId: "_Service"
-Missing ReferenceId: "_Service"
-Missing ReferenceId: "Service"
-Missing ReferenceId: "Service"
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(3), SymbolId(4)]
-rebuilt        : ScopeId(4): [SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Symbol flags mismatch for "Service":
 after transform: SymbolId(2): SymbolFlags(Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(Class)
 Symbol reference IDs mismatch for "Service":
-after transform: SymbolId(2): [ReferenceId(2)]
+after transform: SymbolId(2): [ReferenceId(2), ReferenceId(4), ReferenceId(5)]
 rebuilt        : SymbolId(2): [ReferenceId(4), ReferenceId(5)]
 Symbol redeclarations mismatch for "Service":
 after transform: SymbolId(2): [Span { start: 108, end: 115 }]
 rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/compiler/cloduleTest1.ts
-semantic error: Missing SymbolId: "_$"
-Missing ReferenceId: "_$"
-Missing ReferenceId: "ajax"
-Missing ReferenceId: "$"
-Missing ReferenceId: "$"
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(3), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(0), SymbolId(1)]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(4): [ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
-Symbol reference IDs mismatch for "ajax":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(1): [ReferenceId(1)]
+Reference symbol mismatch for "$":
+after transform: SymbolId(1) "$"
+rebuilt        : <None>
+Reference symbol mismatch for "$":
+after transform: SymbolId(1) "$"
+rebuilt        : <None>
 Reference symbol mismatch for "$":
 after transform: SymbolId(1) "$"
 rebuilt        : <None>
@@ -2238,17 +2100,9 @@ after transform: []
 rebuilt        : ["$"]
 
 tasks/coverage/typescript/tests/cases/compiler/cloduleWithPriorUninstantiatedModule.ts
-semantic error: Missing SymbolId: "_Moclodule2"
-Missing ReferenceId: "_Moclodule2"
-Missing ReferenceId: "Manager"
-Missing ReferenceId: "Moclodule"
-Missing ReferenceId: "Moclodule"
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(2), SymbolId(4)]
-rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
@@ -2258,15 +2112,9 @@ rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol span mismatch for "Moclodule":
 after transform: SymbolId(0): Span { start: 47, end: 56 }
 rebuilt        : SymbolId(0): Span { start: 132, end: 141 }
-Symbol reference IDs mismatch for "Moclodule":
-after transform: SymbolId(0): []
-rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
 Symbol redeclarations mismatch for "Moclodule":
 after transform: SymbolId(0): [Span { start: 132, end: 141 }, Span { start: 178, end: 187 }]
 rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "Manager":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/cloduleWithRecursiveReference.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -2474,17 +2322,7 @@ tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithConstru
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithEnumMemberConflict.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Bindings mismatch:
@@ -2493,6 +2331,12 @@ rebuilt        : ScopeId(2): ["e"]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(0x0)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch for "m1":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(0): Span { start: 7, end: 9 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "e":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
@@ -2501,79 +2345,38 @@ tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithFunctio
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithMemberClassConflict.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Missing SymbolId: "m2"
-Missing SymbolId: "_m3"
-Missing ReferenceId: "_m3"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "_m3"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m2"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(3)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(4), SymbolId(5), SymbolId(7)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6), SymbolId(7)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Symbol reference IDs mismatch for "m1":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Symbol reference IDs mismatch for "m2":
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(6): [ReferenceId(6)]
-Symbol reference IDs mismatch for "_m2":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(7): [ReferenceId(8)]
-Reference symbol mismatch for "m1":
-after transform: SymbolId(0) "m1"
-rebuilt        : SymbolId(0) "m1"
-Reference symbol mismatch for "m2":
-after transform: SymbolId(3) "m2"
-rebuilt        : SymbolId(4) "m2"
-Reference symbol mismatch for "m2":
-after transform: SymbolId(3) "m2"
-rebuilt        : SymbolId(4) "m2"
+Symbol flags mismatch for "m1":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(0): Span { start: 7, end: 9 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "m2":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m2":
+after transform: SymbolId(3): Span { start: 73, end: 75 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithMemberInterfaceConflict.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(2), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
-Symbol reference IDs mismatch for "m2":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Reference symbol mismatch for "m1":
-after transform: SymbolId(0) "m1"
-rebuilt        : SymbolId(0) "m1"
+Symbol flags mismatch for "m1":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(0): Span { start: 7, end: 9 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithMemberVariable.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -2588,50 +2391,26 @@ tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithModuleR
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithPrivateMember.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "c1"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(4)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol reference IDs mismatch for "c1":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(4): [ReferenceId(2)]
-Reference symbol mismatch for "m1":
-after transform: SymbolId(0) "m1"
-rebuilt        : SymbolId(0) "m1"
+Symbol flags mismatch for "m1":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(0): Span { start: 7, end: 9 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithUnicodeNames.ts
-semantic error: Missing SymbolId: "才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüßAbcd123"
-Missing SymbolId: "_才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüßAbcd"
-Missing ReferenceId: "_才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüßAbcd"
-Missing ReferenceId: "才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüßAbcd123"
-Missing ReferenceId: "才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüßAbcd123"
-Missing ReferenceId: "才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüßAbcd123"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(2)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol reference IDs mismatch for "才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüßAbcd123":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Reference symbol mismatch for "才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüßAbcd123":
-after transform: SymbolId(0) "才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüßAbcd123"
-rebuilt        : SymbolId(0) "才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüßAbcd123"
+Symbol flags mismatch for "才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüßAbcd123":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüßAbcd123":
+after transform: SymbolId(0): Span { start: 7, end: 170 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientClass.ts
 semantic error: Bindings mismatch:
@@ -2650,50 +2429,44 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientFunction.ts
-semantic error: Missing SymbolId: "m2"
-Missing SymbolId: "_m"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m2"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["m1", "m2"]
 rebuilt        : ScopeId(0): ["m2"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(2), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 Scope children mismatch:
 after transform: ScopeId(6): [ScopeId(7), ScopeId(8)]
 rebuilt        : ScopeId(1): []
+Symbol flags mismatch for "m2":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m2":
+after transform: SymbolId(1): Span { start: 187, end: 189 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientFunctionInGlobalFile.ts
-semantic error: Missing SymbolId: "m4"
-Missing SymbolId: "_m"
-Missing ReferenceId: "m4"
-Missing ReferenceId: "m4"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["m3", "m4"]
 rebuilt        : ScopeId(0): ["m4"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(2), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(6): [ScopeId(7), ScopeId(8)]
 rebuilt        : ScopeId(1): []
+Symbol flags mismatch for "m4":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m4":
+after transform: SymbolId(1): Span { start: 169, end: 171 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientModule.ts
-semantic error: Missing SymbolId: "m2"
-Missing SymbolId: "_m"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m2"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["exports", "foo", "foo2", "m1", "m2", "require"]
 rebuilt        : ScopeId(0): ["foo", "foo2", "m2"]
 Scope children mismatch:
@@ -2705,16 +2478,18 @@ rebuilt        : ScopeId(3): ["_m", "a"]
 Scope children mismatch:
 after transform: ScopeId(16): [ScopeId(17), ScopeId(20)]
 rebuilt        : ScopeId(3): []
+Symbol flags mismatch for "m2":
+after transform: SymbolId(15): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m2":
+after transform: SymbolId(15): Span { start: 524, end: 526 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["exports", "require"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientVar.ts
-semantic error: Missing SymbolId: "m2"
-Missing SymbolId: "_m"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m2"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["exports", "m1", "m2", "require"]
 rebuilt        : ScopeId(0): ["m2"]
 Scope children mismatch:
@@ -2723,67 +2498,41 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
 after transform: ScopeId(2): ["_m", "a", "exports", "require"]
 rebuilt        : ScopeId(1): ["_m", "a"]
+Symbol flags mismatch for "m2":
+after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m2":
+after transform: SymbolId(5): Span { start: 151, end: 153 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndFunctionInGlobalFile.ts
-semantic error: Missing SymbolId: "m3"
-Missing SymbolId: "_m"
-Missing ReferenceId: "m3"
-Missing ReferenceId: "m3"
-Missing SymbolId: "m4"
-Missing SymbolId: "_m2"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "exports"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "require"
-Missing ReferenceId: "m4"
-Missing ReferenceId: "m4"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(5)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(8)]
-rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(5)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(6), SymbolId(7), SymbolId(9)]
-rebuilt        : ScopeId(6): [SymbolId(7), SymbolId(8), SymbolId(9)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
-Symbol reference IDs mismatch for "exports":
-after transform: SymbolId(6): []
-rebuilt        : SymbolId(8): [ReferenceId(3)]
-Symbol reference IDs mismatch for "require":
-after transform: SymbolId(7): []
-rebuilt        : SymbolId(9): [ReferenceId(5)]
+Symbol flags mismatch for "m3":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m3":
+after transform: SymbolId(2): Span { start: 89, end: 91 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "m4":
+after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m4":
+after transform: SymbolId(5): Span { start: 209, end: 211 }
+rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndInternalModuleAliasInGlobalFile.ts
-semantic error: Missing SymbolId: "mOfGloalFile"
-Missing SymbolId: "_mOfGloalFile"
-Missing ReferenceId: "_mOfGloalFile"
-Missing ReferenceId: "c"
-Missing ReferenceId: "mOfGloalFile"
-Missing ReferenceId: "mOfGloalFile"
+semantic error: Missing SymbolId: "exports"
+Missing SymbolId: "require"
 Missing SymbolId: "exports"
 Missing SymbolId: "require"
-Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing SymbolId: "exports"
-Missing SymbolId: "require"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Missing SymbolId: "m2"
-Missing SymbolId: "_m2"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m2"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(7)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(9)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(10)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
@@ -2799,27 +2548,33 @@ rebuilt        : ScopeId(4): ["_m2"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Reference symbol mismatch for "mOfGloalFile":
-after transform: SymbolId(0) "mOfGloalFile"
-rebuilt        : SymbolId(0) "mOfGloalFile"
-Reference symbol mismatch for "mOfGloalFile":
-after transform: SymbolId(0) "mOfGloalFile"
-rebuilt        : SymbolId(0) "mOfGloalFile"
+Symbol flags mismatch for "mOfGloalFile":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "mOfGloalFile":
+after transform: SymbolId(0): Span { start: 7, end: 19 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "mOfGloalFile":
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(9), ReferenceId(14), ReferenceId(15)]
+rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(9)]
+Symbol flags mismatch for "m1":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(4): Span { start: 155, end: 157 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
+Symbol flags mismatch for "m2":
+after transform: SymbolId(7): SymbolFlags(NameSpaceModule)
+rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m2":
+after transform: SymbolId(7): Span { start: 282, end: 284 }
+rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
 Reference symbol mismatch for "exports":
 after transform: SymbolId(2) "exports"
 rebuilt        : SymbolId(3) "exports"
 Reference symbol mismatch for "require":
 after transform: SymbolId(3) "require"
 rebuilt        : SymbolId(4) "require"
-Reference symbol mismatch for "mOfGloalFile":
-after transform: SymbolId(0) "mOfGloalFile"
-rebuilt        : SymbolId(0) "mOfGloalFile"
-Reference symbol mismatch for "mOfGloalFile":
-after transform: SymbolId(0) "mOfGloalFile"
-rebuilt        : SymbolId(0) "mOfGloalFile"
 Reference symbol mismatch for "exports":
 after transform: SymbolId(5) "exports"
 rebuilt        : SymbolId(7) "exports"
@@ -2962,19 +2717,15 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndModuleInGlobal.ts
-semantic error: Missing SymbolId: "_this"
-Missing SymbolId: "_this2"
-Missing ReferenceId: "_this"
-Missing ReferenceId: "_this"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(2)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "_this":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "_this":
+after transform: SymbolId(0): Span { start: 7, end: 12 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndNameResolution.ts
 semantic error: Scope children mismatch:
@@ -3010,22 +2761,21 @@ after transform: ScopeId(15): [ScopeId(16), ScopeId(17), ScopeId(18)]
 rebuilt        : ScopeId(13): [ScopeId(14)]
 
 tasks/coverage/typescript/tests/cases/compiler/commentEmitAtEndOfFile1.ts
-semantic error: Missing SymbolId: "foo"
-Missing SymbolId: "_foo"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "foo"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["empty", "f", "foo"]
 rebuilt        : ScopeId(0): ["f", "foo"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(2), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "foo":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "foo":
+after transform: SymbolId(1): Span { start: 37, end: 40 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/commentEmitOnParenthesizedAssertionInReturnStatement.ts
 semantic error: Unresolved reference IDs mismatch for "Promise":
@@ -3038,43 +2788,33 @@ after transform: [ReferenceId(0), ReferenceId(1)]
 rebuilt        : [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/commentInNamespaceDeclarationWithIdentifierPathName.ts
-semantic error: Missing SymbolId: "hello"
-Missing SymbolId: "_hello"
-Missing SymbolId: "hi"
-Missing SymbolId: "_hi"
-Missing SymbolId: "world"
-Missing SymbolId: "_world"
-Missing ReferenceId: "world"
-Missing ReferenceId: "world"
-Missing ReferenceId: "_hi"
-Missing ReferenceId: "_hi"
-Missing ReferenceId: "hi"
-Missing ReferenceId: "hi"
-Missing ReferenceId: "_hello"
-Missing ReferenceId: "_hello"
-Missing ReferenceId: "hello"
-Missing ReferenceId: "hello"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(5)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(3), SymbolId(6)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch for "hello":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "hello":
+after transform: SymbolId(0): Span { start: 10, end: 15 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "hi":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "hi":
+after transform: SymbolId(1): Span { start: 16, end: 18 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "world":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "world":
+after transform: SymbolId(2): Span { start: 19, end: 24 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/commentLeadingCloseBrace.ts
 semantic error: Scope children mismatch:
@@ -3166,30 +2906,18 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), Sc
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22)]
 
 tasks/coverage/typescript/tests/cases/compiler/commentsDottedModuleName.ts
-semantic error: Missing SymbolId: "outerModule"
-Missing SymbolId: "_outerModule"
-Missing SymbolId: "InnerModule"
-Missing SymbolId: "_InnerModule"
-Missing ReferenceId: "_InnerModule"
-Missing ReferenceId: "b"
-Missing ReferenceId: "InnerModule"
-Missing ReferenceId: "InnerModule"
-Missing ReferenceId: "_outerModule"
-Missing ReferenceId: "_outerModule"
-Missing ReferenceId: "outerModule"
-Missing ReferenceId: "outerModule"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(4)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
+semantic error: Symbol flags mismatch for "outerModule":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "outerModule":
+after transform: SymbolId(0): Span { start: 49, end: 60 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "InnerModule":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "InnerModule":
+after transform: SymbolId(1): Span { start: 61, end: 72 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/commentsEnums.ts
 semantic error: Bindings mismatch:
@@ -3221,39 +2949,15 @@ Namespaces exporting non-const are not supported by Babel. Change to const or se
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/commentsFormatting.ts
-semantic error: Missing SymbolId: "m"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "c"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "c2"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "c3"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "c4"
-Missing ReferenceId: "m"
-Missing ReferenceId: "m"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Symbol reference IDs mismatch for "c2":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(3): [ReferenceId(3)]
-Symbol reference IDs mismatch for "c3":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(4): [ReferenceId(5)]
-Symbol reference IDs mismatch for "c4":
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(5): [ReferenceId(7)]
+Symbol flags mismatch for "m":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/commentsInheritance.ts
 semantic error: Scope children mismatch:
@@ -3270,93 +2974,32 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/commentsMultiModuleMultiFile.ts
-semantic error: Missing SymbolId: "multiM"
-Missing SymbolId: "_multiM"
-Missing ReferenceId: "_multiM"
-Missing ReferenceId: "b"
-Missing ReferenceId: "multiM"
-Missing ReferenceId: "multiM"
-Missing SymbolId: "_multiM2"
-Missing ReferenceId: "_multiM2"
-Missing ReferenceId: "c"
-Missing ReferenceId: "_multiM2"
-Missing ReferenceId: "e"
-Missing ReferenceId: "multiM"
-Missing ReferenceId: "multiM"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(2), SymbolId(3), SymbolId(5)]
-rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(5)]
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(5)]
-Symbol reference IDs mismatch for "e":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(5): [ReferenceId(7)]
-Reference symbol mismatch for "multiM":
-after transform: SymbolId(0) "multiM"
-rebuilt        : SymbolId(0) "multiM"
-Reference symbol mismatch for "multiM":
-after transform: SymbolId(0) "multiM"
-rebuilt        : SymbolId(0) "multiM"
+semantic error: Symbol flags mismatch for "multiM":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "multiM":
+after transform: SymbolId(0): Span { start: 49, end: 55 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "multiM":
+after transform: SymbolId(0): [Span { start: 153, end: 159 }]
+rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/commentsMultiModuleSingleFile.ts
-semantic error: Missing SymbolId: "multiM"
-Missing SymbolId: "_multiM"
-Missing ReferenceId: "_multiM"
-Missing ReferenceId: "b"
-Missing ReferenceId: "_multiM"
-Missing ReferenceId: "d"
-Missing ReferenceId: "multiM"
-Missing ReferenceId: "multiM"
-Missing SymbolId: "_multiM2"
-Missing ReferenceId: "_multiM2"
-Missing ReferenceId: "c"
-Missing ReferenceId: "_multiM2"
-Missing ReferenceId: "e"
-Missing ReferenceId: "multiM"
-Missing ReferenceId: "multiM"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(3), SymbolId(4), SymbolId(6)]
-rebuilt        : ScopeId(4): [SymbolId(4), SymbolId(5), SymbolId(6)]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Symbol reference IDs mismatch for "d":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(3): [ReferenceId(3)]
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(5): [ReferenceId(7)]
-Symbol reference IDs mismatch for "e":
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(6): [ReferenceId(9)]
-Reference symbol mismatch for "multiM":
-after transform: SymbolId(0) "multiM"
-rebuilt        : SymbolId(0) "multiM"
-Reference symbol mismatch for "multiM":
-after transform: SymbolId(0) "multiM"
-rebuilt        : SymbolId(0) "multiM"
+Symbol flags mismatch for "multiM":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "multiM":
+after transform: SymbolId(0): Span { start: 42, end: 48 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "multiM":
+after transform: SymbolId(0): [Span { start: 176, end: 182 }]
+rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx
 semantic error: Bindings mismatch:
@@ -3390,13 +3033,7 @@ after transform: ScopeId(68): [ScopeId(69), ScopeId(70), ScopeId(71)]
 rebuilt        : ScopeId(19): [ScopeId(20)]
 
 tasks/coverage/typescript/tests/cases/compiler/commentsdoNotEmitComments.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "b"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["_defineProperty", "c", "color", "foo", "fooVar", "i", "i1_i", "m1", "myVariable", "shade", "x"]
 rebuilt        : ScopeId(0): ["_defineProperty", "c", "color", "foo", "fooVar", "i", "i1_i", "m1", "myVariable", "shade"]
 Scope children mismatch:
@@ -3420,24 +3057,21 @@ rebuilt        : ScopeId(11): ["color"]
 Scope flags mismatch:
 after transform: ScopeId(17): ScopeFlags(0x0)
 rebuilt        : ScopeId(11): ScopeFlags(Function)
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(13): []
-rebuilt        : SymbolId(12): [ReferenceId(9)]
+Symbol flags mismatch for "m1":
+after transform: SymbolId(12): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(12): Span { start: 1256, end: 1258 }
+rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 Symbol flags mismatch for "color":
 after transform: SymbolId(17): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(14): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "color":
-after transform: SymbolId(17): [ReferenceId(6), ReferenceId(7), ReferenceId(17)]
+after transform: SymbolId(17): [ReferenceId(6), ReferenceId(7), ReferenceId(21)]
 rebuilt        : SymbolId(14): [ReferenceId(19), ReferenceId(20)]
 
 tasks/coverage/typescript/tests/cases/compiler/commentsemitComments.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "b"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["_defineProperty", "c", "foo", "fooVar", "i", "i1_i", "m1", "myVariable", "x"]
 rebuilt        : ScopeId(0): ["_defineProperty", "c", "foo", "fooVar", "i", "i1_i", "m1", "myVariable"]
 Scope children mismatch:
@@ -3455,9 +3089,12 @@ rebuilt        : ScopeId(8): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(13): [ScopeId(14), ScopeId(16)]
 rebuilt        : ScopeId(8): [ScopeId(9)]
-Symbol reference IDs mismatch for "b":
-after transform: SymbolId(13): []
-rebuilt        : SymbolId(12): [ReferenceId(9)]
+Symbol flags mismatch for "m1":
+after transform: SymbolId(12): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(12): Span { start: 1256, end: 1258 }
+rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/commonJsImportClassExpression.ts
 semantic error: Bindings mismatch:
@@ -3518,19 +3155,15 @@ after transform: SymbolId(0) "myModule"
 rebuilt        : SymbolId(0) "myModule"
 
 tasks/coverage/typescript/tests/cases/compiler/compoundVarDecl1.ts
-semantic error: Missing SymbolId: "Foo"
-Missing SymbolId: "_Foo"
-Missing ReferenceId: "Foo"
-Missing ReferenceId: "Foo"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "Foo":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Foo":
+after transform: SymbolId(0): Span { start: 7, end: 10 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/computedEnumMemberSyntacticallyString.ts
 semantic error: Missing ReferenceId: "Foo"
@@ -3619,23 +3252,15 @@ after transform: ["computed", "const", "require"]
 rebuilt        : ["E2", "MyDeclaredEnum", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/computedPropertiesTransformedInOtherwiseNonTSClasses.ts
-semantic error: Missing SymbolId: "NS"
-Missing SymbolId: "_NS"
-Missing ReferenceId: "_NS"
-Missing ReferenceId: "NS"
-Missing ReferenceId: "NS"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(5)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Reference symbol mismatch for "NS":
-after transform: SymbolId(0) "NS"
-rebuilt        : SymbolId(1) "NS"
+Symbol flags mismatch for "NS":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "NS":
+after transform: SymbolId(0): Span { start: 10, end: 12 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/computedPropertiesWithSetterAssignment.ts
 semantic error: Bindings mismatch:
@@ -3818,24 +3443,15 @@ after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/constDeclarations2.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 19, end: 20 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/constEnumDeclarations.ts
 semantic error: Bindings mismatch:
@@ -3869,13 +3485,7 @@ after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/constEnumMergingWithValues1.ts
-semantic error: Missing SymbolId: "_foo"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "foo"
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(3): ["E", "X"]
 rebuilt        : ScopeId(3): ["E"]
 Scope flags mismatch:
@@ -3884,9 +3494,6 @@ rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "foo":
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Function | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Function)
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(6)]
 Symbol redeclarations mismatch for "foo":
 after transform: SymbolId(0): [Span { start: 25, end: 28 }]
 rebuilt        : SymbolId(0): []
@@ -3895,13 +3502,7 @@ after transform: SymbolId(1): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/constEnumMergingWithValues2.ts
-semantic error: Missing SymbolId: "_foo"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "foo"
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(3): ["E", "X"]
 rebuilt        : ScopeId(3): ["E"]
 Scope flags mismatch:
@@ -3910,9 +3511,6 @@ rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "foo":
 after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(6)]
 Symbol redeclarations mismatch for "foo":
 after transform: SymbolId(0): [Span { start: 20, end: 23 }]
 rebuilt        : SymbolId(0): []
@@ -3921,18 +3519,12 @@ after transform: SymbolId(1): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/constEnumMergingWithValues3.ts
-semantic error: Missing SymbolId: "_foo"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "foo"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["A", "foo"]
 rebuilt        : ScopeId(1): ["foo"]
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(4)]
-rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3)]
 Bindings mismatch:
 after transform: ScopeId(3): ["E", "X"]
 rebuilt        : ScopeId(3): ["E"]
@@ -3942,9 +3534,6 @@ rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "foo":
 after transform: SymbolId(0): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(7), ReferenceId(8), ReferenceId(10)]
 Symbol redeclarations mismatch for "foo":
 after transform: SymbolId(0): [Span { start: 22, end: 25 }]
 rebuilt        : SymbolId(0): []
@@ -3953,58 +3542,41 @@ after transform: SymbolId(2): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/constEnumMergingWithValues4.ts
-semantic error: Missing SymbolId: "foo"
-Missing SymbolId: "_foo"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "foo"
-Missing SymbolId: "_foo2"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "foo"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["E", "X"]
 rebuilt        : ScopeId(2): ["E"]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(3), SymbolId(5)]
-rebuilt        : ScopeId(3): [SymbolId(4), SymbolId(5)]
+Symbol flags mismatch for "foo":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "foo":
+after transform: SymbolId(0): Span { start: 7, end: 10 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "foo":
+after transform: SymbolId(0): [Span { start: 46, end: 49 }]
+rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "E":
 after transform: SymbolId(1): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Reference symbol mismatch for "foo":
-after transform: SymbolId(0) "foo"
-rebuilt        : SymbolId(0) "foo"
 
 tasks/coverage/typescript/tests/cases/compiler/constEnumMergingWithValues5.ts
-semantic error: Missing SymbolId: "foo"
-Missing SymbolId: "_foo"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "foo"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["E", "X"]
 rebuilt        : ScopeId(2): ["E"]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "foo":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "foo":
+after transform: SymbolId(0): Span { start: 7, end: 10 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "E":
 after transform: SymbolId(1): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Reference symbol mismatch for "foo":
-after transform: SymbolId(0) "foo"
-rebuilt        : SymbolId(0) "foo"
 
 tasks/coverage/typescript/tests/cases/compiler/constEnumNamespaceReferenceCausesNoImport.ts
 semantic error: Bindings mismatch:
@@ -4018,30 +3590,21 @@ after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/constEnumNamespaceReferenceCausesNoImport2.ts
-semantic error: Missing SymbolId: "ConstEnumOnlyModule"
-Missing SymbolId: "_ConstEnumOnlyModule"
-Missing ReferenceId: "_ConstEnumOnlyModule"
-Missing ReferenceId: "ConstFooEnum"
-Missing ReferenceId: "ConstEnumOnlyModule"
-Missing ReferenceId: "ConstEnumOnlyModule"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["ConstFooEnum", "Here", "Some", "Values"]
 rebuilt        : ScopeId(2): ["ConstFooEnum"]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "ConstEnumOnlyModule":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "ConstEnumOnlyModule":
+after transform: SymbolId(0): Span { start: 14, end: 33 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "ConstFooEnum":
 after transform: SymbolId(1): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "ConstFooEnum":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(8)]
 
 tasks/coverage/typescript/tests/cases/compiler/constEnumNoEmitReexport.ts
 semantic error: Bindings mismatch:
@@ -4127,83 +3690,7 @@ after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/constEnums.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing SymbolId: "B"
-Missing SymbolId: "_B"
-Missing SymbolId: "C"
-Missing SymbolId: "_C"
-Missing ReferenceId: "_C"
-Missing ReferenceId: "E"
-Missing ReferenceId: "C"
-Missing ReferenceId: "C"
-Missing ReferenceId: "_B"
-Missing ReferenceId: "_B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Missing SymbolId: "_A2"
-Missing SymbolId: "B"
-Missing SymbolId: "_B2"
-Missing SymbolId: "C"
-Missing SymbolId: "_C2"
-Missing ReferenceId: "_C2"
-Missing ReferenceId: "E"
-Missing ReferenceId: "C"
-Missing ReferenceId: "C"
-Missing ReferenceId: "_B2"
-Missing ReferenceId: "_B2"
-Missing ReferenceId: "B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "_A2"
-Missing ReferenceId: "_A2"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Missing SymbolId: "A1"
-Missing SymbolId: "_A3"
-Missing SymbolId: "B"
-Missing SymbolId: "_B3"
-Missing SymbolId: "C"
-Missing SymbolId: "_C3"
-Missing ReferenceId: "_C3"
-Missing ReferenceId: "E"
-Missing ReferenceId: "C"
-Missing ReferenceId: "C"
-Missing ReferenceId: "_B3"
-Missing ReferenceId: "_B3"
-Missing ReferenceId: "B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "_A3"
-Missing ReferenceId: "_A3"
-Missing ReferenceId: "A1"
-Missing ReferenceId: "A1"
-Missing SymbolId: "A2"
-Missing SymbolId: "_A4"
-Missing SymbolId: "B"
-Missing SymbolId: "_B4"
-Missing SymbolId: "C"
-Missing SymbolId: "_C4"
-Missing ReferenceId: "_C4"
-Missing ReferenceId: "E"
-Missing ReferenceId: "C"
-Missing ReferenceId: "C"
-Missing ReferenceId: "_B4"
-Missing ReferenceId: "_B4"
-Missing SymbolId: "_C5"
-Missing ReferenceId: "C"
-Missing ReferenceId: "C"
-Missing ReferenceId: "_B4"
-Missing ReferenceId: "_B4"
-Missing ReferenceId: "B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "_A4"
-Missing ReferenceId: "_A4"
-Missing ReferenceId: "A2"
-Missing ReferenceId: "A2"
-Missing SymbolId: "I"
+semantic error: Missing SymbolId: "I"
 Missing SymbolId: "I1"
 Missing SymbolId: "I2"
 Binding symbols mismatch:
@@ -4227,21 +3714,12 @@ rebuilt        : ScopeId(3): ["Comments"]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(0x0)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(40), SymbolId(78)]
-rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7)]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(41), SymbolId(79)]
-rebuilt        : ScopeId(5): [SymbolId(8), SymbolId(9)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(42), SymbolId(80)]
-rebuilt        : ScopeId(6): [SymbolId(10), SymbolId(11)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
@@ -4251,15 +3729,9 @@ rebuilt        : ScopeId(7): ["E"]
 Scope flags mismatch:
 after transform: ScopeId(7): ScopeFlags(0x0)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(8): [SymbolId(45), SymbolId(81)]
-rebuilt        : ScopeId(8): [SymbolId(13), SymbolId(14)]
 Scope flags mismatch:
 after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(8): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(9): [SymbolId(46), SymbolId(82)]
-rebuilt        : ScopeId(9): [SymbolId(15), SymbolId(16)]
 Scope flags mismatch:
 after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(9): ScopeFlags(Function)
@@ -4275,15 +3747,9 @@ rebuilt        : ScopeId(11): ["E"]
 Scope flags mismatch:
 after transform: ScopeId(11): ScopeFlags(0x0)
 rebuilt        : ScopeId(11): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(12): [SymbolId(51), SymbolId(84)]
-rebuilt        : ScopeId(12): [SymbolId(20), SymbolId(21)]
 Scope flags mismatch:
 after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(12): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(13): [SymbolId(52), SymbolId(85)]
-rebuilt        : ScopeId(13): [SymbolId(22), SymbolId(23)]
 Scope flags mismatch:
 after transform: ScopeId(13): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(13): ScopeFlags(Function)
@@ -4299,15 +3765,9 @@ rebuilt        : ScopeId(15): ["E"]
 Scope flags mismatch:
 after transform: ScopeId(15): ScopeFlags(0x0)
 rebuilt        : ScopeId(15): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(16): [SymbolId(57), SymbolId(87)]
-rebuilt        : ScopeId(16): [SymbolId(27), SymbolId(28)]
 Scope flags mismatch:
 after transform: ScopeId(16): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(16): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(17): [SymbolId(58), SymbolId(88)]
-rebuilt        : ScopeId(17): [SymbolId(29), SymbolId(30)]
 Scope flags mismatch:
 after transform: ScopeId(17): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(17): ScopeFlags(Function)
@@ -4323,9 +3783,6 @@ rebuilt        : ScopeId(19): ["E"]
 Scope flags mismatch:
 after transform: ScopeId(19): ScopeFlags(0x0)
 rebuilt        : ScopeId(19): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(20): [SymbolId(62), SymbolId(90)]
-rebuilt        : ScopeId(20): [SymbolId(33), SymbolId(34)]
 Scope flags mismatch:
 after transform: ScopeId(20): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(20): ScopeFlags(Function)
@@ -4333,26 +3790,95 @@ Symbol flags mismatch for "Enum1":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Enum1":
-after transform: SymbolId(0): [ReferenceId(23), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(50), ReferenceId(52), ReferenceId(53), ReferenceId(54), ReferenceId(55), ReferenceId(56), ReferenceId(57), ReferenceId(58), ReferenceId(59), ReferenceId(60), ReferenceId(61), ReferenceId(62), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(68), ReferenceId(69), ReferenceId(70), ReferenceId(71), ReferenceId(72), ReferenceId(73), ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(97), ReferenceId(157), ReferenceId(158)]
+after transform: SymbolId(0): [ReferenceId(23), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(50), ReferenceId(52), ReferenceId(53), ReferenceId(54), ReferenceId(55), ReferenceId(56), ReferenceId(57), ReferenceId(58), ReferenceId(59), ReferenceId(60), ReferenceId(61), ReferenceId(62), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(68), ReferenceId(69), ReferenceId(70), ReferenceId(71), ReferenceId(72), ReferenceId(73), ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(149), ReferenceId(209), ReferenceId(210)]
 rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4), ReferenceId(67), ReferenceId(181), ReferenceId(182), ReferenceId(183), ReferenceId(184), ReferenceId(185), ReferenceId(186), ReferenceId(187), ReferenceId(188), ReferenceId(189), ReferenceId(190), ReferenceId(191), ReferenceId(192), ReferenceId(193), ReferenceId(194), ReferenceId(195), ReferenceId(196), ReferenceId(197), ReferenceId(198), ReferenceId(199), ReferenceId(200), ReferenceId(201), ReferenceId(202), ReferenceId(203), ReferenceId(204), ReferenceId(205), ReferenceId(206), ReferenceId(207), ReferenceId(208)]
 Symbol redeclarations mismatch for "Enum1":
 after transform: SymbolId(0): [Span { start: 46, end: 51 }]
 rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch for "Enum1":
-after transform: SymbolId(92): [ReferenceId(98), ReferenceId(99), ReferenceId(100), ReferenceId(101), ReferenceId(102), ReferenceId(103), ReferenceId(104), ReferenceId(105), ReferenceId(106), ReferenceId(107), ReferenceId(108), ReferenceId(109), ReferenceId(110), ReferenceId(111), ReferenceId(112), ReferenceId(113), ReferenceId(114), ReferenceId(115), ReferenceId(116), ReferenceId(117), ReferenceId(118), ReferenceId(119), ReferenceId(120), ReferenceId(121), ReferenceId(122), ReferenceId(123), ReferenceId(124), ReferenceId(125), ReferenceId(126), ReferenceId(127), ReferenceId(128), ReferenceId(129), ReferenceId(130), ReferenceId(131), ReferenceId(132), ReferenceId(133), ReferenceId(134), ReferenceId(135), ReferenceId(136), ReferenceId(137), ReferenceId(138), ReferenceId(139), ReferenceId(140), ReferenceId(141), ReferenceId(142), ReferenceId(143), ReferenceId(144), ReferenceId(145), ReferenceId(146), ReferenceId(147), ReferenceId(148), ReferenceId(149), ReferenceId(150), ReferenceId(151), ReferenceId(152), ReferenceId(153), ReferenceId(154), ReferenceId(155), ReferenceId(156)]
+after transform: SymbolId(92): [ReferenceId(150), ReferenceId(151), ReferenceId(152), ReferenceId(153), ReferenceId(154), ReferenceId(155), ReferenceId(156), ReferenceId(157), ReferenceId(158), ReferenceId(159), ReferenceId(160), ReferenceId(161), ReferenceId(162), ReferenceId(163), ReferenceId(164), ReferenceId(165), ReferenceId(166), ReferenceId(167), ReferenceId(168), ReferenceId(169), ReferenceId(170), ReferenceId(171), ReferenceId(172), ReferenceId(173), ReferenceId(174), ReferenceId(175), ReferenceId(176), ReferenceId(177), ReferenceId(178), ReferenceId(179), ReferenceId(180), ReferenceId(181), ReferenceId(182), ReferenceId(183), ReferenceId(184), ReferenceId(185), ReferenceId(186), ReferenceId(187), ReferenceId(188), ReferenceId(189), ReferenceId(190), ReferenceId(191), ReferenceId(192), ReferenceId(193), ReferenceId(194), ReferenceId(195), ReferenceId(196), ReferenceId(197), ReferenceId(198), ReferenceId(199), ReferenceId(200), ReferenceId(201), ReferenceId(202), ReferenceId(203), ReferenceId(204), ReferenceId(205), ReferenceId(206), ReferenceId(207), ReferenceId(208)]
 rebuilt        : SymbolId(2): [ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(48), ReferenceId(49), ReferenceId(50), ReferenceId(51), ReferenceId(52), ReferenceId(53), ReferenceId(54), ReferenceId(55), ReferenceId(56), ReferenceId(57), ReferenceId(58), ReferenceId(59), ReferenceId(60), ReferenceId(61), ReferenceId(62), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(66)]
 Symbol flags mismatch for "Comments":
 after transform: SymbolId(31): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Comments":
-after transform: SymbolId(31): [ReferenceId(85), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(90), ReferenceId(91), ReferenceId(92), ReferenceId(93), ReferenceId(174)]
+after transform: SymbolId(31): [ReferenceId(85), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(90), ReferenceId(91), ReferenceId(92), ReferenceId(93), ReferenceId(226)]
 rebuilt        : SymbolId(3): [ReferenceId(83), ReferenceId(214), ReferenceId(215), ReferenceId(216), ReferenceId(217), ReferenceId(218), ReferenceId(219), ReferenceId(220)]
+Symbol flags mismatch for "A":
+after transform: SymbolId(39): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(39): Span { start: 717, end: 718 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "A":
+after transform: SymbolId(39): [Span { start: 905, end: 906 }]
+rebuilt        : SymbolId(5): []
+Symbol flags mismatch for "B":
+after transform: SymbolId(40): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(40): Span { start: 739, end: 740 }
+rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
+Symbol flags mismatch for "C":
+after transform: SymbolId(41): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "C":
+after transform: SymbolId(41): Span { start: 765, end: 766 }
+rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
 Symbol flags mismatch for "E":
 after transform: SymbolId(42): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(42): []
-rebuilt        : SymbolId(11): [ReferenceId(91)]
+Symbol flags mismatch for "B":
+after transform: SymbolId(45): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(45): Span { start: 927, end: 928 }
+rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
+Symbol flags mismatch for "C":
+after transform: SymbolId(46): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "C":
+after transform: SymbolId(46): Span { start: 953, end: 954 }
+rebuilt        : SymbolId(16): Span { start: 0, end: 0 }
+Symbol flags mismatch for "A1":
+after transform: SymbolId(50): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(19): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A1":
+after transform: SymbolId(50): Span { start: 1114, end: 1116 }
+rebuilt        : SymbolId(19): Span { start: 0, end: 0 }
+Symbol flags mismatch for "B":
+after transform: SymbolId(51): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(21): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(51): Span { start: 1137, end: 1138 }
+rebuilt        : SymbolId(21): Span { start: 0, end: 0 }
+Symbol flags mismatch for "C":
+after transform: SymbolId(52): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(23): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "C":
+after transform: SymbolId(52): Span { start: 1163, end: 1164 }
+rebuilt        : SymbolId(23): Span { start: 0, end: 0 }
+Symbol flags mismatch for "A2":
+after transform: SymbolId(56): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(26): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A2":
+after transform: SymbolId(56): Span { start: 1292, end: 1294 }
+rebuilt        : SymbolId(26): Span { start: 0, end: 0 }
+Symbol flags mismatch for "B":
+after transform: SymbolId(57): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(28): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(57): Span { start: 1315, end: 1316 }
+rebuilt        : SymbolId(28): Span { start: 0, end: 0 }
+Symbol flags mismatch for "C":
+after transform: SymbolId(58): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(30): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "C":
+after transform: SymbolId(58): Span { start: 1341, end: 1342 }
+rebuilt        : SymbolId(30): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "C":
+after transform: SymbolId(58): [Span { start: 1524, end: 1525 }]
+rebuilt        : SymbolId(30): []
 Reference symbol mismatch for "Enum1":
 after transform: SymbolId(0) "Enum1"
 rebuilt        : SymbolId(2) "Enum1"
@@ -4362,20 +3888,17 @@ rebuilt        : SymbolId(2) "Enum1"
 Reference symbol mismatch for "Enum1":
 after transform: SymbolId(0) "Enum1"
 rebuilt        : SymbolId(2) "Enum1"
-Reference symbol mismatch for "A":
-after transform: SymbolId(39) "A"
-rebuilt        : SymbolId(5) "A"
 Reference symbol mismatch for "E":
 after transform: SymbolId(47) "E"
 rebuilt        : <None>
-Reference symbol mismatch for "A":
-after transform: SymbolId(39) "A"
-rebuilt        : SymbolId(5) "A"
-Reference symbol mismatch for "A":
-after transform: SymbolId(39) "A"
-rebuilt        : SymbolId(5) "A"
 Reference symbol mismatch for "E":
 after transform: SymbolId(47) "E"
+rebuilt        : <None>
+Reference symbol mismatch for "E":
+after transform: SymbolId(47) "E"
+rebuilt        : <None>
+Reference symbol mismatch for "E":
+after transform: SymbolId(53) "E"
 rebuilt        : <None>
 Reference symbol mismatch for "E":
 after transform: SymbolId(53) "E"
@@ -4389,15 +3912,9 @@ rebuilt        : <None>
 Reference symbol mismatch for "E":
 after transform: SymbolId(59) "E"
 rebuilt        : <None>
-Reference symbol mismatch for "A":
-after transform: SymbolId(39) "A"
-rebuilt        : SymbolId(5) "A"
-Reference symbol mismatch for "A1":
-after transform: SymbolId(50) "A1"
-rebuilt        : SymbolId(19) "A1"
-Reference symbol mismatch for "A2":
-after transform: SymbolId(56) "A2"
-rebuilt        : SymbolId(26) "A2"
+Reference symbol mismatch for "E":
+after transform: SymbolId(59) "E"
+rebuilt        : <None>
 Reference symbol mismatch for "I":
 after transform: SymbolId(63) "I"
 rebuilt        : SymbolId(35) "I"
@@ -4416,15 +3933,6 @@ rebuilt        : SymbolId(37) "I2"
 Reference symbol mismatch for "I2":
 after transform: SymbolId(65) "I2"
 rebuilt        : SymbolId(37) "I2"
-Reference symbol mismatch for "A":
-after transform: SymbolId(39) "A"
-rebuilt        : SymbolId(5) "A"
-Reference symbol mismatch for "A":
-after transform: SymbolId(39) "A"
-rebuilt        : SymbolId(5) "A"
-Reference symbol mismatch for "A":
-after transform: SymbolId(39) "A"
-rebuilt        : SymbolId(5) "A"
 Unresolved references mismatch:
 after transform: ["A", "A0"]
 rebuilt        : ["E"]
@@ -4516,38 +4024,18 @@ after transform: SymbolId(1): [ReferenceId(3), ReferenceId(6)]
 rebuilt        : SymbolId(1): []
 
 tasks/coverage/typescript/tests/cases/compiler/constructorArgWithGenericCallSignature.ts
-semantic error: Missing SymbolId: "Test"
-Missing SymbolId: "_Test"
-Missing ReferenceId: "_Test"
-Missing ReferenceId: "MyClass"
-Missing ReferenceId: "_Test"
-Missing ReferenceId: "F"
-Missing ReferenceId: "Test"
-Missing ReferenceId: "Test"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(7), SymbolId(8)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(6), SymbolId(7)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(3), SymbolId(5), SymbolId(9)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(5)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4)]
-Symbol reference IDs mismatch for "MyClass":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Symbol reference IDs mismatch for "F":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(4): [ReferenceId(3)]
-Reference symbol mismatch for "Test":
-after transform: SymbolId(0) "Test"
-rebuilt        : SymbolId(0) "Test"
-Reference symbol mismatch for "Test":
-after transform: SymbolId(0) "Test"
-rebuilt        : SymbolId(0) "Test"
+Symbol flags mismatch for "Test":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Test":
+after transform: SymbolId(0): Span { start: 7, end: 11 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["Test"]
 rebuilt        : []
@@ -5350,32 +4838,21 @@ after transform: ["DocumentEventMap", "Partial", "ReadonlyArray", "Record", "Req
 rebuilt        : ["bar", "console", "document", "makeCompleteLookupMapping", "r1", "r2", "undefined", "xx"]
 
 tasks/coverage/typescript/tests/cases/compiler/covariance1.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "XX"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "f"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(2), SymbolId(5), SymbolId(7), SymbolId(8), SymbolId(9)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(6), SymbolId(7)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4)]
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "XX":
-after transform: SymbolId(2): [ReferenceId(6)]
+after transform: SymbolId(2): [ReferenceId(6), ReferenceId(10)]
 rebuilt        : SymbolId(2): [ReferenceId(2)]
-Symbol reference IDs mismatch for "f":
-after transform: SymbolId(5): [ReferenceId(4), ReferenceId(7)]
-rebuilt        : SymbolId(4): [ReferenceId(4), ReferenceId(5), ReferenceId(7)]
 
 tasks/coverage/typescript/tests/cases/compiler/crashInGetTextOfComputedPropertyName.ts
 semantic error: Scope children mismatch:
@@ -5564,62 +5041,32 @@ after transform: ["module"]
 rebuilt        : ["Foo", "module"]
 
 tasks/coverage/typescript/tests/cases/compiler/declFileExportImportChain.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing SymbolId: "m2"
-Missing SymbolId: "_m2"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "c1"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(4)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Symbol reference IDs mismatch for "c1":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Reference symbol mismatch for "m1":
-after transform: SymbolId(0) "m1"
-rebuilt        : SymbolId(0) "m1"
+semantic error: Symbol flags mismatch for "m1":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(0): Span { start: 7, end: 9 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "m2":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m2":
+after transform: SymbolId(1): Span { start: 30, end: 32 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/declFileExportImportChain2.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing SymbolId: "m2"
-Missing SymbolId: "_m2"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "c1"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(4)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Symbol reference IDs mismatch for "c1":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Reference symbol mismatch for "m1":
-after transform: SymbolId(0) "m1"
-rebuilt        : SymbolId(0) "m1"
+semantic error: Symbol flags mismatch for "m1":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(0): Span { start: 7, end: 9 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "m2":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m2":
+after transform: SymbolId(1): Span { start: 30, end: 32 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/declFileForClassWithMultipleBaseClasses.ts
 semantic error: Scope children mismatch:
@@ -5691,249 +5138,138 @@ after transform: SymbolId(7): [ReferenceId(0), ReferenceId(6), ReferenceId(8)]
 rebuilt        : SymbolId(3): []
 
 tasks/coverage/typescript/tests/cases/compiler/declFileGenericType.ts
-semantic error: Missing SymbolId: "C"
-Missing SymbolId: "_C"
-Missing ReferenceId: "_C"
-Missing ReferenceId: "A"
-Missing ReferenceId: "_C"
-Missing ReferenceId: "B"
-Missing ReferenceId: "_C"
-Missing ReferenceId: "F"
-Missing ReferenceId: "_C"
-Missing ReferenceId: "F2"
-Missing ReferenceId: "_C"
-Missing ReferenceId: "F3"
-Missing ReferenceId: "_C"
-Missing ReferenceId: "F4"
-Missing ReferenceId: "_C"
-Missing ReferenceId: "F5"
-Missing ReferenceId: "_C"
-Missing ReferenceId: "F6"
-Missing ReferenceId: "_C"
-Missing ReferenceId: "D"
-Missing ReferenceId: "C"
-Missing ReferenceId: "C"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(27), SymbolId(28), SymbolId(29), SymbolId(30), SymbolId(32), SymbolId(33), SymbolId(35)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(12), ScopeId(13), ScopeId(14)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(12), ScopeId(13)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(4), SymbolId(7), SymbolId(10), SymbolId(13), SymbolId(16), SymbolId(18), SymbolId(21), SymbolId(36)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6), SymbolId(8), SymbolId(10), SymbolId(12), SymbolId(13), SymbolId(15)]
+Symbol flags mismatch for "C":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "C":
+after transform: SymbolId(0): Span { start: 14, end: 15 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(1): [ReferenceId(1), ReferenceId(9), ReferenceId(16)]
+after transform: SymbolId(1): [ReferenceId(1), ReferenceId(9), ReferenceId(16), ReferenceId(43)]
 rebuilt        : SymbolId(2): [ReferenceId(1)]
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(3): [ReferenceId(2), ReferenceId(10), ReferenceId(17)]
+after transform: SymbolId(3): [ReferenceId(2), ReferenceId(10), ReferenceId(17), ReferenceId(45)]
 rebuilt        : SymbolId(3): [ReferenceId(3)]
 Symbol flags mismatch for "F":
 after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "F":
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(4): [ReferenceId(5)]
 Symbol flags mismatch for "F2":
 after transform: SymbolId(7): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "F2":
-after transform: SymbolId(7): []
-rebuilt        : SymbolId(6): [ReferenceId(7)]
 Symbol flags mismatch for "F3":
 after transform: SymbolId(10): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "F3":
-after transform: SymbolId(10): []
-rebuilt        : SymbolId(8): [ReferenceId(9)]
 Symbol flags mismatch for "F4":
 after transform: SymbolId(13): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "F4":
-after transform: SymbolId(13): []
-rebuilt        : SymbolId(10): [ReferenceId(11)]
 Symbol flags mismatch for "F5":
 after transform: SymbolId(16): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(12): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "F5":
-after transform: SymbolId(16): []
-rebuilt        : SymbolId(12): [ReferenceId(13)]
 Symbol flags mismatch for "F6":
 after transform: SymbolId(18): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(13): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "F6":
-after transform: SymbolId(18): []
-rebuilt        : SymbolId(13): [ReferenceId(15)]
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(21): []
-rebuilt        : SymbolId(15): [ReferenceId(18)]
-Reference symbol mismatch for "C":
-after transform: SymbolId(0) "C"
-rebuilt        : SymbolId(0) "C"
-Reference symbol mismatch for "C":
-after transform: SymbolId(0) "C"
-rebuilt        : SymbolId(0) "C"
-Reference symbol mismatch for "C":
-after transform: SymbolId(0) "C"
-rebuilt        : SymbolId(0) "C"
-Reference symbol mismatch for "C":
-after transform: SymbolId(0) "C"
-rebuilt        : SymbolId(0) "C"
-Reference symbol mismatch for "C":
-after transform: SymbolId(0) "C"
-rebuilt        : SymbolId(0) "C"
-Reference symbol mismatch for "C":
-after transform: SymbolId(0) "C"
-rebuilt        : SymbolId(0) "C"
-Reference symbol mismatch for "C":
-after transform: SymbolId(0) "C"
-rebuilt        : SymbolId(0) "C"
-Reference symbol mismatch for "C":
-after transform: SymbolId(0) "C"
-rebuilt        : SymbolId(0) "C"
-Reference symbol mismatch for "C":
-after transform: SymbolId(0) "C"
-rebuilt        : SymbolId(0) "C"
 Unresolved references mismatch:
 after transform: ["Array", "C"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/declFileGenericType2.ts
-semantic error: Missing SymbolId: "templa"
-Missing SymbolId: "_templa2"
-Missing SymbolId: "dom"
-Missing SymbolId: "_dom2"
-Missing SymbolId: "mvc"
-Missing SymbolId: "_mvc2"
-Missing ReferenceId: "_mvc2"
-Missing ReferenceId: "AbstractElementController"
-Missing ReferenceId: "mvc"
-Missing ReferenceId: "mvc"
-Missing ReferenceId: "_dom2"
-Missing ReferenceId: "_dom2"
-Missing ReferenceId: "dom"
-Missing ReferenceId: "dom"
-Missing ReferenceId: "_templa2"
-Missing ReferenceId: "_templa2"
-Missing ReferenceId: "templa"
-Missing ReferenceId: "templa"
-Missing SymbolId: "_templa3"
-Missing SymbolId: "dom"
-Missing SymbolId: "_dom3"
-Missing SymbolId: "mvc"
-Missing SymbolId: "_mvc3"
-Missing SymbolId: "composite"
-Missing SymbolId: "_composite"
-Missing ReferenceId: "_composite"
-Missing ReferenceId: "AbstractCompositeElementController"
-Missing ReferenceId: "composite"
-Missing ReferenceId: "composite"
-Missing ReferenceId: "_mvc3"
-Missing ReferenceId: "_mvc3"
-Missing ReferenceId: "mvc"
-Missing ReferenceId: "mvc"
-Missing ReferenceId: "_dom3"
-Missing ReferenceId: "_dom3"
-Missing ReferenceId: "dom"
-Missing ReferenceId: "dom"
-Missing ReferenceId: "_templa3"
-Missing ReferenceId: "_templa3"
-Missing ReferenceId: "templa"
-Missing ReferenceId: "templa"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(35)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["_defineProperty", "templa"]
+rebuilt        : ScopeId(0): ["_defineProperty"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(10), ScopeId(15), ScopeId(19), ScopeId(24)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(19): [SymbolId(16), SymbolId(28)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
 Scope flags mismatch:
 after transform: ScopeId(19): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(20): [SymbolId(17), SymbolId(29)]
-rebuilt        : ScopeId(2): [SymbolId(4), SymbolId(5)]
 Scope flags mismatch:
 after transform: ScopeId(20): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(21): [SymbolId(18), SymbolId(30)]
-rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
 Scope flags mismatch:
 after transform: ScopeId(21): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(24): [SymbolId(20), SymbolId(31)]
-rebuilt        : ScopeId(6): [SymbolId(8), SymbolId(9)]
 Scope flags mismatch:
 after transform: ScopeId(24): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(25): [SymbolId(21), SymbolId(32)]
-rebuilt        : ScopeId(7): [SymbolId(10), SymbolId(11)]
 Scope flags mismatch:
 after transform: ScopeId(25): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(26): [SymbolId(22), SymbolId(33)]
-rebuilt        : ScopeId(8): [SymbolId(12), SymbolId(13)]
 Scope flags mismatch:
 after transform: ScopeId(26): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(8): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(27): [SymbolId(23), SymbolId(34)]
-rebuilt        : ScopeId(9): [SymbolId(14), SymbolId(15)]
 Scope flags mismatch:
 after transform: ScopeId(27): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(9): ScopeFlags(Function)
-Symbol reference IDs mismatch for "AbstractElementController":
-after transform: SymbolId(18): []
-rebuilt        : SymbolId(7): [ReferenceId(3)]
-Symbol reference IDs mismatch for "AbstractCompositeElementController":
-after transform: SymbolId(23): []
-rebuilt        : SymbolId(15): [ReferenceId(17)]
+Symbol flags mismatch for "dom":
+after transform: SymbolId(16): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "dom":
+after transform: SymbolId(16): Span { start: 643, end: 646 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "mvc":
+after transform: SymbolId(17): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "mvc":
+after transform: SymbolId(17): Span { start: 647, end: 650 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
+Symbol flags mismatch for "dom":
+after transform: SymbolId(20): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "dom":
+after transform: SymbolId(20): Span { start: 913, end: 916 }
+rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
+Symbol flags mismatch for "mvc":
+after transform: SymbolId(21): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "mvc":
+after transform: SymbolId(21): Span { start: 917, end: 920 }
+rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
+Symbol flags mismatch for "composite":
+after transform: SymbolId(22): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "composite":
+after transform: SymbolId(22): Span { start: 921, end: 930 }
+rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
 Reference symbol mismatch for "templa":
-after transform: <None>
-rebuilt        : SymbolId(1) "templa"
+after transform: SymbolId(0) "templa"
+rebuilt        : <None>
 Reference symbol mismatch for "templa":
-after transform: <None>
-rebuilt        : SymbolId(1) "templa"
+after transform: SymbolId(0) "templa"
+rebuilt        : <None>
+Reference symbol mismatch for "templa":
+after transform: SymbolId(0) "templa"
+rebuilt        : <None>
+Reference symbol mismatch for "templa":
+after transform: SymbolId(0) "templa"
+rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["IElementController", "mvc", "require", "templa"]
-rebuilt        : ["require"]
+rebuilt        : ["require", "templa"]
+Unresolved reference IDs mismatch for "templa":
+after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(7), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(15), ReferenceId(16), ReferenceId(18), ReferenceId(19)]
+rebuilt        : [ReferenceId(1), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(30), ReferenceId(31)]
 
 tasks/coverage/typescript/tests/cases/compiler/declFileImportChainInExportAssignment.ts
-semantic error: Missing SymbolId: "m"
-Missing SymbolId: "_m"
-Missing SymbolId: "c"
-Missing SymbolId: "_c"
-Missing ReferenceId: "_c"
-Missing ReferenceId: "c"
-Missing ReferenceId: "c"
-Missing ReferenceId: "c"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "m"
-Missing ReferenceId: "m"
-Missing SymbolId: "a"
+semantic error: Missing SymbolId: "a"
 Missing SymbolId: "b"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Reference symbol mismatch for "m":
-after transform: SymbolId(0) "m"
-rebuilt        : SymbolId(0) "m"
+Symbol flags mismatch for "m":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "c":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "c":
+after transform: SymbolId(1): Span { start: 29, end: 30 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Reference symbol mismatch for "a":
 after transform: SymbolId(3) "a"
 rebuilt        : SymbolId(5) "a"
@@ -5987,80 +5323,53 @@ after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), Sc
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17)]
 
 tasks/coverage/typescript/tests/cases/compiler/declFileModuleAssignmentInObjectLiteralProperty.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "c"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(2)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Reference symbol mismatch for "m1":
-after transform: SymbolId(0) "m1"
-rebuilt        : SymbolId(0) "m1"
-Reference symbol mismatch for "m1":
-after transform: SymbolId(0) "m1"
-rebuilt        : SymbolId(0) "m1"
+Symbol flags mismatch for "m1":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(0): Span { start: 7, end: 9 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/declFileModuleContinuation.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A2"
-Missing SymbolId: "B"
-Missing SymbolId: "_B"
-Missing SymbolId: "C"
-Missing SymbolId: "_C2"
-Missing ReferenceId: "_C2"
-Missing ReferenceId: "W"
-Missing ReferenceId: "C"
-Missing ReferenceId: "C"
-Missing ReferenceId: "_B"
-Missing ReferenceId: "_B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "_A2"
-Missing ReferenceId: "_A2"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A"]
+rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(3), SymbolId(8)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(4), SymbolId(9)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(5), SymbolId(10)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Symbol reference IDs mismatch for "W":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(6): [ReferenceId(1)]
-Unresolved references mismatch:
-after transform: ["A"]
-rebuilt        : []
+Symbol flags mismatch for "B":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(3): Span { start: 56, end: 57 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
+Symbol flags mismatch for "C":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "C":
+after transform: SymbolId(4): Span { start: 58, end: 59 }
+rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
+Reference symbol mismatch for "A":
+after transform: SymbolId(0) "A"
+rebuilt        : <None>
+Reference symbol mismatch for "A":
+after transform: SymbolId(0) "A"
+rebuilt        : <None>
+Unresolved reference IDs mismatch for "A":
+after transform: [ReferenceId(0)]
+rebuilt        : [ReferenceId(10), ReferenceId(11)]
 
 tasks/coverage/typescript/tests/cases/compiler/declFileModuleWithPropertyOfTypeModule.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -6082,47 +5391,21 @@ after transform: ["Array"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationArrayType.ts
-semantic error: Missing SymbolId: "m"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "c"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "g"
-Missing ReferenceId: "m"
-Missing ReferenceId: "m"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(17)]
-rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol reference IDs mismatch for "c":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(12), ReferenceId(13), ReferenceId(14)]
 rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7), ReferenceId(14), ReferenceId(15)]
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(3): [ReferenceId(1)]
-Symbol reference IDs mismatch for "g":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(4): [ReferenceId(3)]
+Symbol flags mismatch for "m":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m":
+after transform: SymbolId(1): Span { start: 19, end: 20 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "g":
 after transform: SymbolId(5): [ReferenceId(6), ReferenceId(7), ReferenceId(8)]
 rebuilt        : SymbolId(5): [ReferenceId(10), ReferenceId(11)]
-Reference symbol mismatch for "m":
-after transform: SymbolId(1) "m"
-rebuilt        : SymbolId(1) "m"
-Reference symbol mismatch for "m":
-after transform: SymbolId(1) "m"
-rebuilt        : SymbolId(1) "m"
-Reference symbol mismatch for "m":
-after transform: SymbolId(1) "m"
-rebuilt        : SymbolId(1) "m"
-Reference symbol mismatch for "m":
-after transform: SymbolId(1) "m"
-rebuilt        : SymbolId(1) "m"
 Unresolved references mismatch:
 after transform: ["m"]
 rebuilt        : []
@@ -6133,41 +5416,21 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationTupleType.ts
-semantic error: Missing SymbolId: "m"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "c"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "g"
-Missing ReferenceId: "m"
-Missing ReferenceId: "m"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(11)]
-rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol reference IDs mismatch for "c":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(7), ReferenceId(10)]
 rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(11)]
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(3): [ReferenceId(1)]
-Symbol reference IDs mismatch for "g":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(4): [ReferenceId(3)]
+Symbol flags mismatch for "m":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m":
+after transform: SymbolId(1): Span { start: 19, end: 20 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "g":
 after transform: SymbolId(5): [ReferenceId(5), ReferenceId(8)]
 rebuilt        : SymbolId(5): [ReferenceId(9)]
-Reference symbol mismatch for "m":
-after transform: SymbolId(1) "m"
-rebuilt        : SymbolId(1) "m"
-Reference symbol mismatch for "m":
-after transform: SymbolId(1) "m"
-rebuilt        : SymbolId(1) "m"
 Unresolved references mismatch:
 after transform: ["m"]
 rebuilt        : []
@@ -6177,21 +5440,9 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationTypeLiteral.ts
-semantic error: Missing SymbolId: "m"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "c"
-Missing ReferenceId: "m"
-Missing ReferenceId: "m"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(7)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(5), SymbolId(6), SymbolId(7)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(4), SymbolId(8)]
-rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
@@ -6201,350 +5452,159 @@ rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch for "g":
 after transform: SymbolId(1): [ReferenceId(1), ReferenceId(7), ReferenceId(8)]
 rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
+Symbol flags mismatch for "m":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m":
+after transform: SymbolId(3): Span { start: 34, end: 35 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["m"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationTypeQuery.ts
-semantic error: Missing SymbolId: "m"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "c"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "g"
-Missing ReferenceId: "m"
-Missing ReferenceId: "m"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(15)]
-rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol reference IDs mismatch for "c":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7)]
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(3): [ReferenceId(1)]
-Symbol reference IDs mismatch for "g":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(4): [ReferenceId(3)]
+Symbol flags mismatch for "m":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m":
+after transform: SymbolId(1): Span { start: 19, end: 20 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "m":
+after transform: SymbolId(1): [ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(16), ReferenceId(17)]
+rebuilt        : SymbolId(1): [ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(9), ReferenceId(12), ReferenceId(13)]
 Symbol reference IDs mismatch for "g":
 after transform: SymbolId(5): [ReferenceId(6), ReferenceId(7), ReferenceId(8)]
 rebuilt        : SymbolId(5): [ReferenceId(10), ReferenceId(11)]
-Reference symbol mismatch for "m":
-after transform: SymbolId(1) "m"
-rebuilt        : SymbolId(1) "m"
-Reference symbol mismatch for "m":
-after transform: SymbolId(1) "m"
-rebuilt        : SymbolId(1) "m"
-Reference symbol mismatch for "m":
-after transform: SymbolId(1) "m"
-rebuilt        : SymbolId(1) "m"
-Reference symbol mismatch for "m":
-after transform: SymbolId(1) "m"
-rebuilt        : SymbolId(1) "m"
 
 tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationTypeReference.ts
-semantic error: Missing SymbolId: "m"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "c"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "g"
-Missing ReferenceId: "m"
-Missing ReferenceId: "m"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(15)]
-rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol reference IDs mismatch for "c":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7)]
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(3): [ReferenceId(1)]
-Symbol reference IDs mismatch for "g":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(4): [ReferenceId(3)]
+Symbol flags mismatch for "m":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m":
+after transform: SymbolId(1): Span { start: 19, end: 20 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "g":
 after transform: SymbolId(5): [ReferenceId(6), ReferenceId(7), ReferenceId(8)]
 rebuilt        : SymbolId(5): [ReferenceId(10), ReferenceId(11)]
-Reference symbol mismatch for "m":
-after transform: SymbolId(1) "m"
-rebuilt        : SymbolId(1) "m"
-Reference symbol mismatch for "m":
-after transform: SymbolId(1) "m"
-rebuilt        : SymbolId(1) "m"
-Reference symbol mismatch for "m":
-after transform: SymbolId(1) "m"
-rebuilt        : SymbolId(1) "m"
-Reference symbol mismatch for "m":
-after transform: SymbolId(1) "m"
-rebuilt        : SymbolId(1) "m"
 Unresolved references mismatch:
 after transform: ["m"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationUnionType.ts
-semantic error: Missing SymbolId: "m"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "c"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "g"
-Missing ReferenceId: "m"
-Missing ReferenceId: "m"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(12)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(11)]
-rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(5)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol reference IDs mismatch for "c":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(8), ReferenceId(11), ReferenceId(14)]
 rebuilt        : SymbolId(1): [ReferenceId(11), ReferenceId(13), ReferenceId(17), ReferenceId(20)]
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(4)]
-Symbol reference IDs mismatch for "g":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(5): [ReferenceId(7)]
+Symbol flags mismatch for "m":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m":
+after transform: SymbolId(1): Span { start: 42, end: 43 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "g":
 after transform: SymbolId(5): [ReferenceId(6), ReferenceId(9), ReferenceId(12)]
 rebuilt        : SymbolId(6): [ReferenceId(15), ReferenceId(18)]
-Reference symbol mismatch for "m":
-after transform: SymbolId(1) "m"
-rebuilt        : SymbolId(2) "m"
-Reference symbol mismatch for "m":
-after transform: SymbolId(1) "m"
-rebuilt        : SymbolId(2) "m"
-Reference symbol mismatch for "m":
-after transform: SymbolId(1) "m"
-rebuilt        : SymbolId(2) "m"
-Reference symbol mismatch for "m":
-after transform: SymbolId(1) "m"
-rebuilt        : SymbolId(2) "m"
 Unresolved references mismatch:
 after transform: ["m", "require"]
 rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts
-semantic error: Missing SymbolId: "m"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "public1"
-Missing SymbolId: "m2"
-Missing SymbolId: "_m2"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "public2"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "c"
-Missing ReferenceId: "m"
-Missing ReferenceId: "m"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(15)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(7)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(4), SymbolId(16)]
-rebuilt        : ScopeId(4): [SymbolId(5), SymbolId(6)]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
+Symbol flags mismatch for "m":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "private1":
 after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6)]
 rebuilt        : SymbolId(2): [ReferenceId(6), ReferenceId(7)]
 Symbol reference IDs mismatch for "public1":
-after transform: SymbolId(2): [ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13)]
+after transform: SymbolId(2): [ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(22)]
 rebuilt        : SymbolId(3): [ReferenceId(1), ReferenceId(8), ReferenceId(9)]
-Symbol reference IDs mismatch for "public2":
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(6): [ReferenceId(3)]
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(7): [ReferenceId(13)]
-Reference symbol mismatch for "m2":
-after transform: SymbolId(3) "m2"
-rebuilt        : SymbolId(4) "m2"
-Reference symbol mismatch for "m2":
-after transform: SymbolId(3) "m2"
-rebuilt        : SymbolId(4) "m2"
+Symbol flags mismatch for "m2":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m2":
+after transform: SymbolId(3): Span { start: 84, end: 86 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["m2"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorParameterOfFunction.ts
-semantic error: Missing SymbolId: "m"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "public1"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "foo3"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "foo4"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "foo13"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "foo14"
-Missing SymbolId: "m2"
-Missing SymbolId: "_m2"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "public2"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "foo113"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "foo114"
-Missing ReferenceId: "m"
-Missing ReferenceId: "m"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(7), SymbolId(9), SymbolId(11), SymbolId(13), SymbolId(15), SymbolId(17), SymbolId(19), SymbolId(21), SymbolId(23), SymbolId(25), SymbolId(27), SymbolId(29)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6), SymbolId(8), SymbolId(10), SymbolId(12), SymbolId(14), SymbolId(16), SymbolId(18), SymbolId(20), SymbolId(23), SymbolId(25), SymbolId(27), SymbolId(29)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(12): [SymbolId(20), SymbolId(30)]
-rebuilt        : ScopeId(12): [SymbolId(21), SymbolId(22)]
 Scope flags mismatch:
 after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(12): ScopeFlags(Function)
+Symbol flags mismatch for "m":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "private1":
 after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3)]
 rebuilt        : SymbolId(2): [ReferenceId(2), ReferenceId(5)]
 Symbol reference IDs mismatch for "public1":
-after transform: SymbolId(2): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7)]
+after transform: SymbolId(2): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(13)]
 rebuilt        : SymbolId(3): [ReferenceId(1), ReferenceId(8), ReferenceId(11)]
-Symbol reference IDs mismatch for "foo3":
-after transform: SymbolId(7): []
-rebuilt        : SymbolId(8): [ReferenceId(4)]
-Symbol reference IDs mismatch for "foo4":
-after transform: SymbolId(9): []
-rebuilt        : SymbolId(10): [ReferenceId(7)]
-Symbol reference IDs mismatch for "foo13":
-after transform: SymbolId(15): []
-rebuilt        : SymbolId(16): [ReferenceId(10)]
-Symbol reference IDs mismatch for "foo14":
-after transform: SymbolId(17): []
-rebuilt        : SymbolId(18): [ReferenceId(13)]
-Symbol reference IDs mismatch for "public2":
-after transform: SymbolId(20): []
-rebuilt        : SymbolId(22): [ReferenceId(15)]
-Symbol reference IDs mismatch for "foo113":
-after transform: SymbolId(25): []
-rebuilt        : SymbolId(27): [ReferenceId(20)]
-Symbol reference IDs mismatch for "foo114":
-after transform: SymbolId(27): []
-rebuilt        : SymbolId(29): [ReferenceId(23)]
-Reference symbol mismatch for "m2":
-after transform: SymbolId(19) "m2"
-rebuilt        : SymbolId(20) "m2"
-Reference symbol mismatch for "m2":
-after transform: SymbolId(19) "m2"
-rebuilt        : SymbolId(20) "m2"
+Symbol flags mismatch for "m2":
+after transform: SymbolId(19): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m2":
+after transform: SymbolId(19): Span { start: 534, end: 536 }
+rebuilt        : SymbolId(20): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["m2"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorReturnTypeOfFunction.ts
-semantic error: Missing SymbolId: "m"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "public1"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "foo3"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "foo4"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "foo13"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "foo14"
-Missing SymbolId: "m2"
-Missing SymbolId: "_m2"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "public2"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "foo113"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "foo114"
-Missing ReferenceId: "m"
-Missing ReferenceId: "m"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(12): [SymbolId(12), SymbolId(18)]
-rebuilt        : ScopeId(12): [SymbolId(13), SymbolId(14)]
 Scope flags mismatch:
 after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(12): ScopeFlags(Function)
+Symbol flags mismatch for "m":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "private1":
 after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3)]
 rebuilt        : SymbolId(2): [ReferenceId(2), ReferenceId(5)]
 Symbol reference IDs mismatch for "public1":
-after transform: SymbolId(2): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7)]
+after transform: SymbolId(2): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(13)]
 rebuilt        : SymbolId(3): [ReferenceId(1), ReferenceId(8), ReferenceId(11)]
-Symbol reference IDs mismatch for "foo3":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(6): [ReferenceId(4)]
-Symbol reference IDs mismatch for "foo4":
-after transform: SymbolId(6): []
-rebuilt        : SymbolId(7): [ReferenceId(7)]
-Symbol reference IDs mismatch for "foo13":
-after transform: SymbolId(9): []
-rebuilt        : SymbolId(10): [ReferenceId(10)]
-Symbol reference IDs mismatch for "foo14":
-after transform: SymbolId(10): []
-rebuilt        : SymbolId(11): [ReferenceId(13)]
-Symbol reference IDs mismatch for "public2":
-after transform: SymbolId(12): []
-rebuilt        : SymbolId(14): [ReferenceId(15)]
-Symbol reference IDs mismatch for "foo113":
-after transform: SymbolId(15): []
-rebuilt        : SymbolId(17): [ReferenceId(20)]
-Symbol reference IDs mismatch for "foo114":
-after transform: SymbolId(16): []
-rebuilt        : SymbolId(18): [ReferenceId(23)]
-Reference symbol mismatch for "m2":
-after transform: SymbolId(11) "m2"
-rebuilt        : SymbolId(12) "m2"
-Reference symbol mismatch for "m2":
-after transform: SymbolId(11) "m2"
-rebuilt        : SymbolId(12) "m2"
+Symbol flags mismatch for "m2":
+after transform: SymbolId(11): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m2":
+after transform: SymbolId(11): Span { start: 613, end: 615 }
+rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["m2"]
 rebuilt        : []
@@ -6607,21 +5667,7 @@ after transform: SymbolId(8): [ReferenceId(8), ReferenceId(9), ReferenceId(10)]
 rebuilt        : SymbolId(4): [ReferenceId(3)]
 
 tasks/coverage/typescript/tests/cases/compiler/declFileTypeofInAnonymousType.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "c"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "e"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(10)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Bindings mismatch:
@@ -6630,36 +5676,15 @@ rebuilt        : ScopeId(3): ["e"]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(0x0)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol flags mismatch for "m1":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(0): Span { start: 7, end: 9 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "e":
 after transform: SymbolId(2): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "e":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(3): [ReferenceId(10)]
-Reference symbol mismatch for "m1":
-after transform: SymbolId(0) "m1"
-rebuilt        : SymbolId(0) "m1"
-Reference symbol mismatch for "m1":
-after transform: SymbolId(0) "m1"
-rebuilt        : SymbolId(0) "m1"
-Reference symbol mismatch for "m1":
-after transform: SymbolId(0) "m1"
-rebuilt        : SymbolId(0) "m1"
-Reference symbol mismatch for "m1":
-after transform: SymbolId(0) "m1"
-rebuilt        : SymbolId(0) "m1"
-Reference symbol mismatch for "m1":
-after transform: SymbolId(0) "m1"
-rebuilt        : SymbolId(0) "m1"
-Reference symbol mismatch for "m1":
-after transform: SymbolId(0) "m1"
-rebuilt        : SymbolId(0) "m1"
-Reference symbol mismatch for "m1":
-after transform: SymbolId(0) "m1"
-rebuilt        : SymbolId(0) "m1"
 Unresolved references mismatch:
 after transform: ["m1"]
 rebuilt        : []
@@ -6669,224 +5694,142 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/declFileWithClassNameConflictingWithClassReferredByExtendsClause.ts
-semantic error: Missing SymbolId: "X"
-Missing SymbolId: "_X"
-Missing SymbolId: "Y"
-Missing SymbolId: "_Y"
-Missing SymbolId: "base"
-Missing SymbolId: "_base"
-Missing ReferenceId: "_base"
-Missing ReferenceId: "W"
-Missing ReferenceId: "base"
-Missing ReferenceId: "base"
-Missing ReferenceId: "_Y"
-Missing ReferenceId: "_Y"
-Missing ReferenceId: "Y"
-Missing ReferenceId: "Y"
-Missing ReferenceId: "_X"
-Missing ReferenceId: "_X"
-Missing ReferenceId: "X"
-Missing ReferenceId: "X"
-Missing SymbolId: "_X2"
-Missing SymbolId: "Y"
-Missing SymbolId: "_Y2"
-Missing SymbolId: "base"
-Missing SymbolId: "_base2"
-Missing SymbolId: "Z"
-Missing SymbolId: "_Z"
-Missing ReferenceId: "_Z"
-Missing ReferenceId: "W"
-Missing ReferenceId: "Z"
-Missing ReferenceId: "Z"
-Missing ReferenceId: "_base2"
-Missing ReferenceId: "_base2"
-Missing ReferenceId: "base"
-Missing ReferenceId: "base"
-Missing ReferenceId: "_Y2"
-Missing ReferenceId: "_Y2"
-Missing ReferenceId: "Y"
-Missing ReferenceId: "Y"
-Missing ReferenceId: "_X2"
-Missing ReferenceId: "_X2"
-Missing ReferenceId: "X"
-Missing ReferenceId: "X"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "X", "_defineProperty"]
 rebuilt        : ScopeId(0): ["X", "_defineProperty"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(9)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(5), SymbolId(13)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(6), SymbolId(14)]
-rebuilt        : ScopeId(2): [SymbolId(4), SymbolId(5)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(7): [SymbolId(7), SymbolId(15)]
-rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
 Scope flags mismatch:
 after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(9): [SymbolId(8), SymbolId(16)]
-rebuilt        : ScopeId(6): [SymbolId(9), SymbolId(10)]
 Scope flags mismatch:
 after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(10): [SymbolId(9), SymbolId(17)]
-rebuilt        : ScopeId(7): [SymbolId(11), SymbolId(12)]
 Scope flags mismatch:
 after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(11): [SymbolId(10), SymbolId(18)]
-rebuilt        : ScopeId(8): [SymbolId(13), SymbolId(14)]
 Scope flags mismatch:
 after transform: ScopeId(11): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(8): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(12): [SymbolId(11), SymbolId(19)]
-rebuilt        : ScopeId(9): [SymbolId(15), SymbolId(16)]
 Scope flags mismatch:
 after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(9): ScopeFlags(Function)
-Symbol reference IDs mismatch for "W":
-after transform: SymbolId(7): []
-rebuilt        : SymbolId(7): [ReferenceId(5)]
-Symbol reference IDs mismatch for "W":
-after transform: SymbolId(11): []
-rebuilt        : SymbolId(16): [ReferenceId(20)]
-Reference symbol mismatch for "X":
-after transform: SymbolId(4) "X"
-rebuilt        : SymbolId(1) "X"
+Symbol flags mismatch for "X":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "X":
+after transform: SymbolId(4): Span { start: 82, end: 83 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "X":
+after transform: SymbolId(4): [Span { start: 172, end: 173 }]
+rebuilt        : SymbolId(1): []
+Symbol flags mismatch for "Y":
+after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Y":
+after transform: SymbolId(5): Span { start: 84, end: 85 }
+rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
+Symbol flags mismatch for "base":
+after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "base":
+after transform: SymbolId(6): Span { start: 86, end: 90 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Y":
+after transform: SymbolId(8): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Y":
+after transform: SymbolId(8): Span { start: 174, end: 175 }
+rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
+Symbol flags mismatch for "base":
+after transform: SymbolId(9): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "base":
+after transform: SymbolId(9): Span { start: 176, end: 180 }
+rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Z":
+after transform: SymbolId(10): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Z":
+after transform: SymbolId(10): Span { start: 181, end: 182 }
+rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/declFileWithExtendsClauseThatHasItsContainerNameConflict.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing SymbolId: "B"
-Missing SymbolId: "_B"
-Missing ReferenceId: "_B"
-Missing ReferenceId: "EventManager"
-Missing ReferenceId: "B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Missing SymbolId: "_A2"
-Missing SymbolId: "B"
-Missing SymbolId: "_B2"
-Missing SymbolId: "C"
-Missing SymbolId: "_C"
-Missing ReferenceId: "_C"
-Missing ReferenceId: "ContextMenu"
-Missing ReferenceId: "C"
-Missing ReferenceId: "C"
-Missing ReferenceId: "_B2"
-Missing ReferenceId: "_B2"
-Missing ReferenceId: "B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "_A2"
-Missing ReferenceId: "_A2"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(14)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["A", "_defineProperty"]
+rebuilt        : ScopeId(0): ["_defineProperty"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(8)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(4), SymbolId(9)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(5), SymbolId(10)]
-rebuilt        : ScopeId(2): [SymbolId(4), SymbolId(5)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(8): [SymbolId(6), SymbolId(11)]
-rebuilt        : ScopeId(5): [SymbolId(6), SymbolId(7)]
 Scope flags mismatch:
 after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(9): [SymbolId(7), SymbolId(12)]
-rebuilt        : ScopeId(6): [SymbolId(8), SymbolId(9)]
 Scope flags mismatch:
 after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(10): [SymbolId(8), SymbolId(13)]
-rebuilt        : ScopeId(7): [SymbolId(10), SymbolId(11)]
 Scope flags mismatch:
 after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
-Symbol reference IDs mismatch for "EventManager":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(5): [ReferenceId(3)]
-Symbol reference IDs mismatch for "ContextMenu":
-after transform: SymbolId(8): []
-rebuilt        : SymbolId(11): [ReferenceId(14)]
+Symbol flags mismatch for "B":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(4): Span { start: 55, end: 56 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "B":
+after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(6): Span { start: 130, end: 131 }
+rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
+Symbol flags mismatch for "C":
+after transform: SymbolId(7): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "C":
+after transform: SymbolId(7): Span { start: 132, end: 133 }
+rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
+Reference symbol mismatch for "A":
+after transform: SymbolId(0) "A"
+rebuilt        : <None>
+Reference symbol mismatch for "A":
+after transform: SymbolId(0) "A"
+rebuilt        : <None>
+Reference symbol mismatch for "A":
+after transform: SymbolId(0) "A"
+rebuilt        : <None>
+Reference symbol mismatch for "A":
+after transform: SymbolId(0) "A"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: ["EventManager", "require"]
+rebuilt        : ["A", "EventManager", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause1.ts
-semantic error: Missing SymbolId: "X"
-Missing SymbolId: "_X2"
-Missing SymbolId: "A"
-Missing SymbolId: "_A2"
-Missing SymbolId: "B"
-Missing SymbolId: "_B"
-Missing SymbolId: "C"
-Missing SymbolId: "_C2"
-Missing ReferenceId: "_C2"
-Missing ReferenceId: "W"
-Missing ReferenceId: "C"
-Missing ReferenceId: "C"
-Missing ReferenceId: "_B"
-Missing ReferenceId: "_B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "_A2"
-Missing ReferenceId: "_A2"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "_X2"
-Missing ReferenceId: "_X2"
-Missing ReferenceId: "X"
-Missing ReferenceId: "X"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["X"]
+rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(4), SymbolId(12)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(5), SymbolId(13)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(7): [SymbolId(6), SymbolId(14)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
 Scope flags mismatch:
 after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
@@ -6899,167 +5842,147 @@ rebuilt        : ScopeId(4): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(8): [ScopeId(9), ScopeId(10)]
 rebuilt        : ScopeId(4): [ScopeId(5)]
-Symbol reference IDs mismatch for "W":
-after transform: SymbolId(8): []
-rebuilt        : SymbolId(8): [ReferenceId(1)]
-Unresolved references mismatch:
-after transform: ["X"]
-rebuilt        : []
+Symbol flags mismatch for "A":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(4): Span { start: 57, end: 58 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
+Symbol flags mismatch for "B":
+after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(5): Span { start: 59, end: 60 }
+rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
+Symbol flags mismatch for "C":
+after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "C":
+after transform: SymbolId(6): Span { start: 61, end: 62 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
+Reference symbol mismatch for "X":
+after transform: SymbolId(0) "X"
+rebuilt        : <None>
+Reference symbol mismatch for "X":
+after transform: SymbolId(0) "X"
+rebuilt        : <None>
+Unresolved reference IDs mismatch for "X":
+after transform: [ReferenceId(0)]
+rebuilt        : [ReferenceId(14), ReferenceId(15)]
 
 tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause2.ts
-semantic error: Missing SymbolId: "X"
-Missing SymbolId: "_X2"
-Missing SymbolId: "A"
-Missing SymbolId: "_A2"
-Missing SymbolId: "B"
-Missing SymbolId: "_B"
-Missing SymbolId: "C"
-Missing SymbolId: "_C2"
-Missing ReferenceId: "_C2"
-Missing ReferenceId: "W"
-Missing ReferenceId: "C"
-Missing ReferenceId: "C"
-Missing ReferenceId: "_B"
-Missing ReferenceId: "_B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "_A2"
-Missing ReferenceId: "_A2"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "_X2"
-Missing ReferenceId: "_X2"
-Missing ReferenceId: "X"
-Missing ReferenceId: "X"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["X"]
+rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(10)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(4), SymbolId(15)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(5), SymbolId(16)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(7): [SymbolId(6), SymbolId(17)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
 Scope flags mismatch:
 after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(8): [SymbolId(7), SymbolId(18)]
-rebuilt        : ScopeId(4): [SymbolId(7), SymbolId(8)]
 Scope flags mismatch:
 after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
-Symbol reference IDs mismatch for "W":
-after transform: SymbolId(7): []
-rebuilt        : SymbolId(8): [ReferenceId(1)]
+Symbol flags mismatch for "A":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(4): Span { start: 57, end: 58 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
+Symbol flags mismatch for "B":
+after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(5): Span { start: 59, end: 60 }
+rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
+Symbol flags mismatch for "C":
+after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "C":
+after transform: SymbolId(6): Span { start: 61, end: 62 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
+Reference symbol mismatch for "X":
+after transform: SymbolId(0) "X"
+rebuilt        : <None>
+Reference symbol mismatch for "X":
+after transform: SymbolId(0) "X"
+rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["A"]
-rebuilt        : []
+rebuilt        : ["X"]
 
 tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause3.ts
-semantic error: Missing SymbolId: "X"
-Missing SymbolId: "_X2"
-Missing SymbolId: "A"
-Missing SymbolId: "_A2"
-Missing SymbolId: "B"
-Missing SymbolId: "_B"
-Missing SymbolId: "C"
-Missing SymbolId: "_C2"
-Missing ReferenceId: "_C2"
-Missing ReferenceId: "W"
-Missing ReferenceId: "C"
-Missing ReferenceId: "C"
-Missing ReferenceId: "_B"
-Missing ReferenceId: "_B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "_A2"
-Missing ReferenceId: "_A2"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "_X2"
-Missing ReferenceId: "_X2"
-Missing ReferenceId: "X"
-Missing ReferenceId: "X"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["X"]
+rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(10)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(4), SymbolId(15)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(5), SymbolId(16)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(7): [SymbolId(6), SymbolId(17)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
 Scope flags mismatch:
 after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(8): [SymbolId(7), SymbolId(18)]
-rebuilt        : ScopeId(4): [SymbolId(7), SymbolId(8)]
 Scope flags mismatch:
 after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
-Symbol reference IDs mismatch for "W":
-after transform: SymbolId(7): []
-rebuilt        : SymbolId(8): [ReferenceId(1)]
-Unresolved references mismatch:
-after transform: ["X"]
-rebuilt        : []
+Symbol flags mismatch for "A":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(4): Span { start: 57, end: 58 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
+Symbol flags mismatch for "B":
+after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(5): Span { start: 59, end: 60 }
+rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
+Symbol flags mismatch for "C":
+after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "C":
+after transform: SymbolId(6): Span { start: 61, end: 62 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
+Reference symbol mismatch for "X":
+after transform: SymbolId(0) "X"
+rebuilt        : <None>
+Reference symbol mismatch for "X":
+after transform: SymbolId(0) "X"
+rebuilt        : <None>
+Unresolved reference IDs mismatch for "X":
+after transform: [ReferenceId(0)]
+rebuilt        : [ReferenceId(14), ReferenceId(15)]
 
 tasks/coverage/typescript/tests/cases/compiler/declInput-2.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "E"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "D"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(9)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5), SymbolId(8)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(10), ReferenceId(11)]
 rebuilt        : SymbolId(3): [ReferenceId(10)]
 Symbol reference IDs mismatch for "E":
-after transform: SymbolId(2): [ReferenceId(2), ReferenceId(5)]
+after transform: SymbolId(2): [ReferenceId(2), ReferenceId(5), ReferenceId(13)]
 rebuilt        : SymbolId(4): [ReferenceId(2)]
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(5): [ReferenceId(12)]
 
 tasks/coverage/typescript/tests/cases/compiler/declInput.ts
 semantic error: Bindings mismatch:
@@ -7090,32 +6013,21 @@ after transform: SymbolId(1): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/declInput4.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "E"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "D"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(8)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5), SymbolId(7)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "E":
-after transform: SymbolId(2): [ReferenceId(0), ReferenceId(2)]
+after transform: SymbolId(2): [ReferenceId(0), ReferenceId(2), ReferenceId(6)]
 rebuilt        : SymbolId(4): [ReferenceId(2)]
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(5): [ReferenceId(8)]
 
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitAliasExportStar.ts
 semantic error: Scope children mismatch:
@@ -7335,15 +6247,7 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(6)]
 rebuilt        : SymbolId(1): [ReferenceId(4), ReferenceId(6)]
 
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitEnumReferenceViaImportEquals.ts
-semantic error: Missing SymbolId: "Translation"
-Missing SymbolId: "_Translation"
-Missing ReferenceId: "_Translation"
-Missing ReferenceId: "Translation"
-Missing ReferenceId: "Translation"
-Bindings mismatch:
-after transform: ScopeId(0): []
-rebuilt        : ScopeId(0): ["Translation"]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
@@ -7354,16 +6258,25 @@ after transform: ScopeId(2): [ScopeId(3)]
 rebuilt        : ScopeId(1): []
 Symbol flags mismatch for "TranslationKeyEnum":
 after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable | TypeAlias)
-rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable)
 Symbol span mismatch for "TranslationKeyEnum":
 after transform: SymbolId(1): Span { start: 129, end: 147 }
-rebuilt        : SymbolId(2): Span { start: 198, end: 216 }
+rebuilt        : SymbolId(1): Span { start: 198, end: 216 }
 Symbol reference IDs mismatch for "TranslationKeyEnum":
 after transform: SymbolId(1): [ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(2): []
+rebuilt        : SymbolId(1): []
 Symbol redeclarations mismatch for "TranslationKeyEnum":
 after transform: SymbolId(1): [Span { start: 198, end: 216 }]
-rebuilt        : SymbolId(2): []
+rebuilt        : SymbolId(1): []
+Reference symbol mismatch for "Translation":
+after transform: SymbolId(0) "Translation"
+rebuilt        : <None>
+Reference symbol mismatch for "Translation":
+after transform: SymbolId(0) "Translation"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["Translation"]
 
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitExactOptionalPropertyTypesNodeNotReused.ts
 semantic error: Scope children mismatch:
@@ -7439,37 +6352,18 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), Sc
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
 
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends5.ts
-semantic error: Missing SymbolId: "Test"
-Missing SymbolId: "_Test"
-Missing ReferenceId: "_Test"
-Missing ReferenceId: "SomeClass"
-Missing ReferenceId: "_Test"
-Missing ReferenceId: "Derived"
-Missing ReferenceId: "_Test"
-Missing ReferenceId: "getClass"
-Missing ReferenceId: "Test"
-Missing ReferenceId: "Test"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
-Symbol reference IDs mismatch for "SomeClass":
-after transform: SymbolId(2): [ReferenceId(4)]
-rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(5)]
-Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(3): [ReferenceId(4)]
-Symbol reference IDs mismatch for "getClass":
-after transform: SymbolId(4): [ReferenceId(1)]
-rebuilt        : SymbolId(4): [ReferenceId(2), ReferenceId(7)]
+Symbol flags mismatch for "Test":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Test":
+after transform: SymbolId(0): Span { start: 10, end: 14 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitFirstTypeArgumentGenericFunctionType.ts
 semantic error: Symbol reference IDs mismatch for "X":
@@ -7705,24 +6599,12 @@ after transform: ScopeId(0): ["PluginConfig"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflicts.ts
-semantic error: Missing SymbolId: "f"
-Missing SymbolId: "_f"
-Missing ReferenceId: "_f"
-Missing ReferenceId: "c"
-Missing ReferenceId: "f"
-Missing ReferenceId: "f"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Reference symbol mismatch for "f":
-after transform: SymbolId(0) "f"
-rebuilt        : SymbolId(0) "f"
+semantic error: Symbol flags mismatch for "f":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "f":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflicts2.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -7741,27 +6623,21 @@ tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflictsWithA
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitNamespaceMergedWithInterfaceNestedFunction.ts
-semantic error: Missing SymbolId: "Bar"
-Missing SymbolId: "_Bar"
-Missing ReferenceId: "_Bar"
-Missing ReferenceId: "biz"
-Missing ReferenceId: "Bar"
-Missing ReferenceId: "Bar"
-Bindings mismatch:
-after transform: ScopeId(0): []
-rebuilt        : ScopeId(0): ["Bar"]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(2), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 Symbol flags mismatch for "biz":
 after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | Function)
-rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "biz":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
+rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
+Reference symbol mismatch for "Bar":
+after transform: SymbolId(1) "Bar"
+rebuilt        : <None>
+Reference symbol mismatch for "Bar":
+after transform: SymbolId(1) "Bar"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["Bar"]
 
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitNestedAnonymousMappedType.ts
 semantic error: Scope children mismatch:
@@ -8217,20 +7093,15 @@ after transform: ["Error", "undefined"]
 rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/declarationFunctionTypeNonlocalShouldNotBeAnError.ts
-semantic error: Missing SymbolId: "foo"
-Missing SymbolId: "_foo"
-Missing ReferenceId: "_foo"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "foo"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "foo":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "foo":
+after transform: SymbolId(0): Span { start: 10, end: 13 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/declarationImportTypeAliasInferredAndEmittable.ts
 semantic error: Bindings mismatch:
@@ -8606,23 +7477,18 @@ after transform: ScopeId(2): [ScopeId(3)]
 rebuilt        : ScopeId(1): []
 
 tasks/coverage/typescript/tests/cases/compiler/defaultDeclarationEmitShadowedNamedCorrectly.ts
-semantic error: Missing SymbolId: "Something"
-Missing SymbolId: "_Something"
-Missing ReferenceId: "_Something"
-Missing ReferenceId: "Something"
-Missing ReferenceId: "Something"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(9), SymbolId(10), SymbolId(14)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(5)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
 Scope children mismatch:
 after transform: ScopeId(2): [ScopeId(3)]
 rebuilt        : ScopeId(1): []
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(11), SymbolId(12), SymbolId(13)]
-rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7), SymbolId(8)]
+Symbol flags mismatch for "Something":
+after transform: SymbolId(10): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Something":
+after transform: SymbolId(10): Span { start: 294, end: 303 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/defaultNamedExportWithType1.ts
 semantic error: Bindings mismatch:
@@ -9312,45 +8178,27 @@ Namespaces exporting non-const are not supported by Babel. Change to const or se
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/dottedNamesInSystem.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing SymbolId: "B"
-Missing SymbolId: "_B"
-Missing SymbolId: "C"
-Missing SymbolId: "_C"
-Missing ReferenceId: "_C"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "C"
-Missing ReferenceId: "C"
-Missing ReferenceId: "_B"
-Missing ReferenceId: "_B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(4)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(7)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(3), SymbolId(7)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
+semantic error: Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 17, end: 18 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "B":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(1): Span { start: 19, end: 20 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "C":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "C":
+after transform: SymbolId(2): Span { start: 21, end: 22 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol flags mismatch for "foo":
 after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(6): [ReferenceId(1)]
-Reference symbol mismatch for "A":
-after transform: SymbolId(0) "A"
-rebuilt        : SymbolId(0) "A"
 
 tasks/coverage/typescript/tests/cases/compiler/dottedSymbolResolution1.ts
 semantic error: Scope children mismatch:
@@ -9369,58 +8217,30 @@ after transform: SymbolId(1): [ReferenceId(3), ReferenceId(10)]
 rebuilt        : SymbolId(1): [ReferenceId(6)]
 
 tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreEnumEmit.ts
-semantic error: Missing SymbolId: "_Foo"
-Missing ReferenceId: "_Foo"
-Missing ReferenceId: "___call"
-Missing ReferenceId: "Foo"
-Missing ReferenceId: "Foo"
-Missing SymbolId: "_Bar"
-Missing ReferenceId: "_Bar"
-Missing ReferenceId: "__call"
-Missing ReferenceId: "Bar"
-Missing ReferenceId: "Bar"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["(Anonymous class)", "(Anonymous function)", "Foo", "__a", "__call"]
 rebuilt        : ScopeId(1): ["Foo"]
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(0x0)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(5), SymbolId(9)]
-rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3)]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(7), SymbolId(10)]
-rebuilt        : ScopeId(5): [SymbolId(5), SymbolId(6)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(0): [ReferenceId(9)]
-rebuilt        : SymbolId(0): [ReferenceId(9), ReferenceId(12), ReferenceId(13)]
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 117, end: 120 }]
 rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "___call":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(3): [ReferenceId(11)]
 Symbol flags mismatch for "Bar":
 after transform: SymbolId(6): SymbolFlags(FunctionScopedVariable | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "Bar":
-after transform: SymbolId(6): []
-rebuilt        : SymbolId(4): [ReferenceId(16), ReferenceId(17)]
 Symbol redeclarations mismatch for "Bar":
 after transform: SymbolId(6): [Span { start: 235, end: 238 }]
 rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "__call":
-after transform: SymbolId(7): []
-rebuilt        : SymbolId(6): [ReferenceId(15)]
 
 tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreMappedTypes.ts
 semantic error: Scope children mismatch:
@@ -9473,76 +8293,60 @@ tasks/coverage/typescript/tests/cases/compiler/duplicateAnonymousInners1.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/duplicateAnonymousModuleClasses.ts
-semantic error: Missing SymbolId: "F"
-Missing SymbolId: "_F"
-Missing ReferenceId: "F"
-Missing ReferenceId: "F"
-Missing SymbolId: "_F2"
-Missing ReferenceId: "F"
-Missing ReferenceId: "F"
-Missing SymbolId: "Foo"
-Missing SymbolId: "_Foo"
-Missing ReferenceId: "Foo"
-Missing ReferenceId: "Foo"
-Missing SymbolId: "_Foo2"
-Missing ReferenceId: "Foo"
-Missing ReferenceId: "Foo"
-Missing SymbolId: "Gar"
-Missing SymbolId: "_Gar"
-Missing SymbolId: "Foo"
-Missing SymbolId: "_Foo3"
-Missing ReferenceId: "Foo"
-Missing ReferenceId: "Foo"
-Missing SymbolId: "_Foo4"
-Missing ReferenceId: "Foo"
-Missing ReferenceId: "Foo"
-Missing ReferenceId: "Gar"
-Missing ReferenceId: "Gar"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(6)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(10)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(10)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(2), SymbolId(11)]
-rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(4), SymbolId(12)]
-rebuilt        : ScopeId(5): [SymbolId(6), SymbolId(7)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(7): [SymbolId(5), SymbolId(13)]
-rebuilt        : ScopeId(7): [SymbolId(8), SymbolId(9)]
 Scope flags mismatch:
 after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(9): [SymbolId(7), SymbolId(14)]
-rebuilt        : ScopeId(9): [SymbolId(11), SymbolId(12)]
 Scope flags mismatch:
 after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(9): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(10): [SymbolId(8), SymbolId(15)]
-rebuilt        : ScopeId(10): [SymbolId(13), SymbolId(14)]
 Scope flags mismatch:
 after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(10): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(12): [SymbolId(9), SymbolId(16)]
-rebuilt        : ScopeId(12): [SymbolId(15), SymbolId(16)]
 Scope flags mismatch:
 after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(12): ScopeFlags(Function)
+Symbol flags mismatch for "F":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "F":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "F":
+after transform: SymbolId(0): [Span { start: 50, end: 51 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch for "Foo":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Foo":
+after transform: SymbolId(3): Span { start: 126, end: 129 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "Foo":
+after transform: SymbolId(3): [Span { start: 171, end: 174 }]
+rebuilt        : SymbolId(5): []
+Symbol flags mismatch for "Gar":
+after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Gar":
+after transform: SymbolId(6): Span { start: 249, end: 252 }
+rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Foo":
+after transform: SymbolId(7): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Foo":
+after transform: SymbolId(7): Span { start: 266, end: 269 }
+rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "Foo":
+after transform: SymbolId(7): [Span { start: 327, end: 330 }]
+rebuilt        : SymbolId(12): []
 
 tasks/coverage/typescript/tests/cases/compiler/duplicateConstructSignature.ts
 semantic error: Scope children mismatch:
@@ -9565,24 +8369,15 @@ after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierShouldNotShortCircuitBaseTypeBinding.ts
-semantic error: Missing SymbolId: "Shapes"
-Missing SymbolId: "_Shapes"
-Missing ReferenceId: "_Shapes"
-Missing ReferenceId: "Point"
-Missing ReferenceId: "Shapes"
-Missing ReferenceId: "Shapes"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(1)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol flags mismatch for "Shapes":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Shapes":
+after transform: SymbolId(1): Span { start: 42, end: 48 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/duplicateOverloadInTypeAugmentation1.ts
 semantic error: Scope children mismatch:
@@ -9622,19 +8417,15 @@ after transform: ["M"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/duplicateVariablesByScope.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(5)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(8)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 71, end: 72 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/dynamicNames.ts
 semantic error: Scope children mismatch:
@@ -9726,42 +8517,24 @@ after transform: []
 rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/compiler/emitMemberAccessExpression.ts
-semantic error: Missing SymbolId: "Microsoft"
-Missing SymbolId: "_Microsoft"
-Missing SymbolId: "PeopleAtWork"
-Missing SymbolId: "_PeopleAtWork"
-Missing SymbolId: "Model"
-Missing SymbolId: "_Model"
-Missing ReferenceId: "_Model"
-Missing ReferenceId: "_Person"
-Missing ReferenceId: "Model"
-Missing ReferenceId: "Model"
-Missing ReferenceId: "_PeopleAtWork"
-Missing ReferenceId: "_PeopleAtWork"
-Missing ReferenceId: "PeopleAtWork"
-Missing ReferenceId: "PeopleAtWork"
-Missing ReferenceId: "_Microsoft"
-Missing ReferenceId: "_Microsoft"
-Missing ReferenceId: "Microsoft"
-Missing ReferenceId: "Microsoft"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(7)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(3), SymbolId(8)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
-Symbol reference IDs mismatch for "_Person":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(6): [ReferenceId(2)]
-Reference symbol mismatch for "Model":
-after transform: SymbolId(2) "Model"
-rebuilt        : SymbolId(4) "Model"
+semantic error: Symbol flags mismatch for "Microsoft":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Microsoft":
+after transform: SymbolId(0): Span { start: 82, end: 91 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "PeopleAtWork":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "PeopleAtWork":
+after transform: SymbolId(1): Span { start: 92, end: 104 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Model":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Model":
+after transform: SymbolId(2): Span { start: 105, end: 110 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/emitTopOfFileTripleSlashCommentOnNotEmittedNodeIfRemoveCommentsIsFalse.ts
 semantic error: Bindings mismatch:
@@ -12039,19 +10812,15 @@ after transform: ScopeId(10): [ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14
 rebuilt        : ScopeId(10): [ScopeId(11), ScopeId(12)]
 
 tasks/coverage/typescript/tests/cases/compiler/es6ClassTest3.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/es6ClassTest4.ts
 semantic error: Scope children mismatch:
@@ -12196,21 +10965,12 @@ after transform: ScopeId(0): ["a", "a1", "a11", "aaaa", "b", "bbbb", "m", "x", "
 rebuilt        : ScopeId(0): ["a", "a1", "a11", "b", "m", "x", "x1", "x11", "xxxx", "y", "z", "z1", "z111", "z2", "z3"]
 
 tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportInIndirectExportAssignment.ts
-semantic error: Missing SymbolId: "a"
-Missing SymbolId: "_a"
-Missing ReferenceId: "_a"
-Missing ReferenceId: "c"
-Missing ReferenceId: "a"
-Missing ReferenceId: "a"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
+semantic error: Symbol flags mismatch for "a":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "a":
+after transform: SymbolId(0): Span { start: 14, end: 15 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportWithTypesAndValues.ts
 semantic error: Scope children mismatch:
@@ -12223,85 +10983,35 @@ after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/es6ModuleClassDeclaration.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "c3"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Missing SymbolId: "m2"
-Missing SymbolId: "_m2"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "c3"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m2"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(5), SymbolId(10)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(7)]
-Binding symbols mismatch:
-after transform: ScopeId(13): [SymbolId(3), SymbolId(4), SymbolId(8)]
-rebuilt        : ScopeId(13): [SymbolId(4), SymbolId(5), SymbolId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(26): [SymbolId(6), SymbolId(7), SymbolId(9)]
-rebuilt        : ScopeId(26): [SymbolId(8), SymbolId(9), SymbolId(10)]
-Symbol reference IDs mismatch for "c3":
-after transform: SymbolId(3): [ReferenceId(4), ReferenceId(25), ReferenceId(27)]
-rebuilt        : SymbolId(5): [ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(30)]
-Symbol reference IDs mismatch for "c3":
-after transform: SymbolId(6): [ReferenceId(8), ReferenceId(37), ReferenceId(39)]
-rebuilt        : SymbolId(9): [ReferenceId(37), ReferenceId(39), ReferenceId(41), ReferenceId(50)]
-Reference symbol mismatch for "m1":
-after transform: SymbolId(2) "m1"
-rebuilt        : SymbolId(3) "m1"
+semantic error: Symbol flags mismatch for "m1":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(2): Span { start: 538, end: 540 }
+rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
+Symbol flags mismatch for "m2":
+after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m2":
+after transform: SymbolId(5): Span { start: 1240, end: 1242 }
+rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/es6ModuleConst.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Missing SymbolId: "m2"
-Missing SymbolId: "_m2"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m2"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(13)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(14)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(20)]
-rebuilt        : ScopeId(1): [SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(21)]
-rebuilt        : ScopeId(2): [SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21)]
-Reference symbol mismatch for "m1":
-after transform: SymbolId(6) "m1"
-rebuilt        : SymbolId(6) "m1"
-Reference symbol mismatch for "m1":
-after transform: SymbolId(6) "m1"
-rebuilt        : SymbolId(6) "m1"
+semantic error: Symbol flags mismatch for "m1":
+after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(6): Span { start: 116, end: 118 }
+rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
+Symbol flags mismatch for "m2":
+after transform: SymbolId(13): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m2":
+after transform: SymbolId(13): Span { start: 245, end: 247 }
+rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/es6ModuleConstEnumDeclaration.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "e3"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Missing SymbolId: "m2"
-Missing SymbolId: "_m2"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "e5"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m2"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(23)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(16)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["a", "b", "c", "e1"]
 rebuilt        : ScopeId(1): ["e1"]
 Scope flags mismatch:
@@ -12313,9 +11023,6 @@ rebuilt        : ScopeId(2): ["e2"]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(11), SymbolId(15), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(37)]
-rebuilt        : ScopeId(3): [SymbolId(7), SymbolId(8), SymbolId(10), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15)]
 Bindings mismatch:
 after transform: ScopeId(4): ["a", "b", "c", "e3"]
 rebuilt        : ScopeId(4): ["e3"]
@@ -12328,9 +11035,6 @@ rebuilt        : ScopeId(5): ["e4"]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(5): ScopeFlags(StrictMode | Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(24), SymbolId(28), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(38)]
-rebuilt        : ScopeId(6): [SymbolId(17), SymbolId(18), SymbolId(20), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26)]
 Bindings mismatch:
 after transform: ScopeId(7): ["a", "b", "c", "e5"]
 rebuilt        : ScopeId(7): ["e5"]
@@ -12349,45 +11053,33 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "e2":
 after transform: SymbolId(4): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch for "m1":
+after transform: SymbolId(10): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(10): Span { start: 125, end: 127 }
+rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol flags mismatch for "e3":
 after transform: SymbolId(11): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "e3":
-after transform: SymbolId(11): [ReferenceId(4)]
-rebuilt        : SymbolId(8): [ReferenceId(25), ReferenceId(35)]
 Symbol flags mismatch for "e4":
 after transform: SymbolId(15): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
+Symbol flags mismatch for "m2":
+after transform: SymbolId(23): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m2":
+after transform: SymbolId(23): Span { start: 338, end: 340 }
+rebuilt        : SymbolId(16): Span { start: 0, end: 0 }
 Symbol flags mismatch for "e5":
 after transform: SymbolId(24): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "e5":
-after transform: SymbolId(24): [ReferenceId(8)]
-rebuilt        : SymbolId(18): [ReferenceId(47), ReferenceId(57)]
 Symbol flags mismatch for "e6":
 after transform: SymbolId(28): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
-Reference symbol mismatch for "m1":
-after transform: SymbolId(10) "m1"
-rebuilt        : SymbolId(6) "m1"
 
 tasks/coverage/typescript/tests/cases/compiler/es6ModuleConstEnumDeclaration2.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "e3"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Missing SymbolId: "m2"
-Missing SymbolId: "_m2"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "e5"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m2"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(23)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(16)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["a", "b", "c", "e1"]
 rebuilt        : ScopeId(1): ["e1"]
 Scope flags mismatch:
@@ -12399,9 +11091,6 @@ rebuilt        : ScopeId(2): ["e2"]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(11), SymbolId(15), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(37)]
-rebuilt        : ScopeId(3): [SymbolId(7), SymbolId(8), SymbolId(10), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15)]
 Bindings mismatch:
 after transform: ScopeId(4): ["a", "b", "c", "e3"]
 rebuilt        : ScopeId(4): ["e3"]
@@ -12414,9 +11103,6 @@ rebuilt        : ScopeId(5): ["e4"]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(5): ScopeFlags(StrictMode | Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(24), SymbolId(28), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(38)]
-rebuilt        : ScopeId(6): [SymbolId(17), SymbolId(18), SymbolId(20), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26)]
 Bindings mismatch:
 after transform: ScopeId(7): ["a", "b", "c", "e5"]
 rebuilt        : ScopeId(7): ["e5"]
@@ -12435,45 +11121,33 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "e2":
 after transform: SymbolId(4): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch for "m1":
+after transform: SymbolId(10): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(10): Span { start: 125, end: 127 }
+rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol flags mismatch for "e3":
 after transform: SymbolId(11): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "e3":
-after transform: SymbolId(11): [ReferenceId(4)]
-rebuilt        : SymbolId(8): [ReferenceId(25), ReferenceId(35)]
 Symbol flags mismatch for "e4":
 after transform: SymbolId(15): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
+Symbol flags mismatch for "m2":
+after transform: SymbolId(23): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m2":
+after transform: SymbolId(23): Span { start: 338, end: 340 }
+rebuilt        : SymbolId(16): Span { start: 0, end: 0 }
 Symbol flags mismatch for "e5":
 after transform: SymbolId(24): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "e5":
-after transform: SymbolId(24): [ReferenceId(8)]
-rebuilt        : SymbolId(18): [ReferenceId(47), ReferenceId(57)]
 Symbol flags mismatch for "e6":
 after transform: SymbolId(28): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
-Reference symbol mismatch for "m1":
-after transform: SymbolId(10) "m1"
-rebuilt        : SymbolId(6) "m1"
 
 tasks/coverage/typescript/tests/cases/compiler/es6ModuleEnumDeclaration.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "e3"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Missing SymbolId: "m2"
-Missing SymbolId: "_m2"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "e5"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m2"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(23)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(16)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["a", "b", "c", "e1"]
 rebuilt        : ScopeId(1): ["e1"]
 Scope flags mismatch:
@@ -12485,9 +11159,6 @@ rebuilt        : ScopeId(2): ["e2"]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(11), SymbolId(15), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(37)]
-rebuilt        : ScopeId(3): [SymbolId(7), SymbolId(8), SymbolId(10), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15)]
 Bindings mismatch:
 after transform: ScopeId(4): ["a", "b", "c", "e3"]
 rebuilt        : ScopeId(4): ["e3"]
@@ -12500,9 +11171,6 @@ rebuilt        : ScopeId(5): ["e4"]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(5): ScopeFlags(StrictMode | Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(24), SymbolId(28), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(38)]
-rebuilt        : ScopeId(6): [SymbolId(17), SymbolId(18), SymbolId(20), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26)]
 Bindings mismatch:
 after transform: ScopeId(7): ["a", "b", "c", "e5"]
 rebuilt        : ScopeId(7): ["e5"]
@@ -12521,71 +11189,56 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "e2":
 after transform: SymbolId(4): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch for "m1":
+after transform: SymbolId(10): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(10): Span { start: 113, end: 115 }
+rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol flags mismatch for "e3":
 after transform: SymbolId(11): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "e3":
-after transform: SymbolId(11): [ReferenceId(4)]
-rebuilt        : SymbolId(8): [ReferenceId(25), ReferenceId(35)]
 Symbol flags mismatch for "e4":
 after transform: SymbolId(15): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
+Symbol flags mismatch for "m2":
+after transform: SymbolId(23): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m2":
+after transform: SymbolId(23): Span { start: 314, end: 316 }
+rebuilt        : SymbolId(16): Span { start: 0, end: 0 }
 Symbol flags mismatch for "e5":
 after transform: SymbolId(24): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "e5":
-after transform: SymbolId(24): [ReferenceId(8)]
-rebuilt        : SymbolId(18): [ReferenceId(47), ReferenceId(57)]
 Symbol flags mismatch for "e6":
 after transform: SymbolId(28): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
-Reference symbol mismatch for "m1":
-after transform: SymbolId(10) "m1"
-rebuilt        : SymbolId(6) "m1"
 
 tasks/coverage/typescript/tests/cases/compiler/es6ModuleFunctionDeclaration.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "foo3"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Missing SymbolId: "m2"
-Missing SymbolId: "_m2"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "foo3"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m2"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(5)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(8)]
-rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(6), SymbolId(7), SymbolId(9)]
-rebuilt        : ScopeId(6): [SymbolId(7), SymbolId(8), SymbolId(9)]
+semantic error: Symbol flags mismatch for "m1":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(2): Span { start: 76, end: 78 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "foo3":
 after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "foo3":
-after transform: SymbolId(3): [ReferenceId(4)]
-rebuilt        : SymbolId(4): [ReferenceId(3), ReferenceId(6)]
 Symbol flags mismatch for "foo4":
 after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch for "m2":
+after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m2":
+after transform: SymbolId(5): Span { start: 200, end: 202 }
+rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol flags mismatch for "foo3":
 after transform: SymbolId(6): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "foo3":
-after transform: SymbolId(6): [ReferenceId(8)]
-rebuilt        : SymbolId(8): [ReferenceId(11), ReferenceId(14)]
 Symbol flags mismatch for "foo4":
 after transform: SymbolId(7): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
-Reference symbol mismatch for "m1":
-after transform: SymbolId(2) "m1"
-rebuilt        : SymbolId(2) "m1"
 
 tasks/coverage/typescript/tests/cases/compiler/es6ModuleInternalImport.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -12869,26 +11522,18 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/exportDeclarationForModuleOrEnumWithMemberOfSameName.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(2)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 67, end: 68 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
 after transform: SymbolId(2): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
-Reference symbol mismatch for "A":
-after transform: SymbolId(0) "A"
-rebuilt        : SymbolId(0) "A"
 
 tasks/coverage/typescript/tests/cases/compiler/exportDeclarationsInAmbientNamespaces.ts
 semantic error: Bindings mismatch:
@@ -12938,39 +11583,18 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/exportDefaultProperty.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "B"
-Missing SymbolId: "_B"
-Missing ReferenceId: "_B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(3), SymbolId(5)]
-rebuilt        : ScopeId(4): [SymbolId(4), SymbolId(5)]
+semantic error: Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 10, end: 11 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
 after transform: SymbolId(1): SymbolFlags(Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(Class)
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(3), ReferenceId(4)]
 Symbol redeclarations mismatch for "B":
 after transform: SymbolId(1): [Span { start: 84, end: 85 }]
 rebuilt        : SymbolId(2): []
-Reference symbol mismatch for "A":
-after transform: SymbolId(0) "A"
-rebuilt        : SymbolId(0) "A"
 
 tasks/coverage/typescript/tests/cases/compiler/exportDefaultProperty2.ts
 semantic error: Scope children mismatch:
@@ -13038,39 +11662,18 @@ after transform: ["proxy"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/exportEqualsProperty.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "B"
-Missing SymbolId: "_B"
-Missing ReferenceId: "_B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(3), SymbolId(5)]
-rebuilt        : ScopeId(4): [SymbolId(4), SymbolId(5)]
+semantic error: Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 10, end: 11 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
 after transform: SymbolId(1): SymbolFlags(Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(Class)
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(3), ReferenceId(4)]
 Symbol redeclarations mismatch for "B":
 after transform: SymbolId(1): [Span { start: 84, end: 85 }]
 rebuilt        : SymbolId(2): []
-Reference symbol mismatch for "A":
-after transform: SymbolId(0) "A"
-rebuilt        : SymbolId(0) "A"
 
 tasks/coverage/typescript/tests/cases/compiler/exportEqualsProperty2.ts
 semantic error: Scope children mismatch:
@@ -13093,58 +11696,13 @@ tasks/coverage/typescript/tests/cases/compiler/exportImportAndClodule.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/exportImportCanSubstituteConstEnumForValue.ts
-semantic error: Missing SymbolId: "MsPortalFx"
-Missing SymbolId: "_MsPortalFx"
-Missing SymbolId: "ViewModels"
-Missing SymbolId: "_ViewModels"
-Missing SymbolId: "Dialogs"
-Missing SymbolId: "_Dialogs"
-Missing ReferenceId: "_Dialogs"
-Missing ReferenceId: "DialogResult"
-Missing ReferenceId: "_Dialogs"
-Missing ReferenceId: "someExportedFunction"
-Missing ReferenceId: "_Dialogs"
-Missing ReferenceId: "MessageBoxButtons"
-Missing ReferenceId: "Dialogs"
-Missing ReferenceId: "Dialogs"
-Missing ReferenceId: "_ViewModels"
-Missing ReferenceId: "_ViewModels"
-Missing ReferenceId: "ViewModels"
-Missing ReferenceId: "ViewModels"
-Missing ReferenceId: "_MsPortalFx"
-Missing ReferenceId: "_MsPortalFx"
-Missing ReferenceId: "MsPortalFx"
-Missing ReferenceId: "MsPortalFx"
-Missing SymbolId: "_MsPortalFx2"
-Missing SymbolId: "ViewModels"
-Missing SymbolId: "_ViewModels2"
-Missing SymbolId: "DialogButtons"
-Missing ReferenceId: "_ViewModels2"
-Missing ReferenceId: "SomeUsagesOfTheseConsts"
-Missing ReferenceId: "ViewModels"
-Missing ReferenceId: "ViewModels"
-Missing ReferenceId: "_MsPortalFx2"
-Missing ReferenceId: "_MsPortalFx2"
-Missing ReferenceId: "MsPortalFx"
-Missing ReferenceId: "MsPortalFx"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(27)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+semantic error: Missing SymbolId: "DialogButtons"
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(28)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(3), SymbolId(12), SymbolId(13), SymbolId(29)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6), SymbolId(8), SymbolId(9)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
@@ -13163,9 +11721,6 @@ rebuilt        : ScopeId(6): ["MessageBoxButtons"]
 Scope flags mismatch:
 after transform: ScopeId(7): ScopeFlags(0x0)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(8): [SymbolId(20), SymbolId(30)]
-rebuilt        : ScopeId(7): [SymbolId(11), SymbolId(12)]
 Scope flags mismatch:
 after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
@@ -13175,24 +11730,39 @@ rebuilt        : ScopeId(8): ["DialogButtons", "SomeUsagesOfTheseConsts", "_View
 Scope flags mismatch:
 after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(8): ScopeFlags(Function)
+Symbol flags mismatch for "MsPortalFx":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "MsPortalFx":
+after transform: SymbolId(0): Span { start: 7, end: 17 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "MsPortalFx":
+after transform: SymbolId(0): [Span { start: 526, end: 536 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch for "ViewModels":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "ViewModels":
+after transform: SymbolId(1): Span { start: 18, end: 28 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Dialogs":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Dialogs":
+after transform: SymbolId(2): Span { start: 29, end: 36 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol flags mismatch for "DialogResult":
 after transform: SymbolId(3): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "DialogResult":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(6): [ReferenceId(16)]
-Symbol reference IDs mismatch for "someExportedFunction":
-after transform: SymbolId(12): []
-rebuilt        : SymbolId(8): [ReferenceId(18)]
 Symbol flags mismatch for "MessageBoxButtons":
 after transform: SymbolId(13): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "MessageBoxButtons":
-after transform: SymbolId(13): []
-rebuilt        : SymbolId(9): [ReferenceId(33)]
-Symbol reference IDs mismatch for "SomeUsagesOfTheseConsts":
-after transform: SymbolId(24): []
-rebuilt        : SymbolId(15): [ReferenceId(52)]
+Symbol flags mismatch for "ViewModels":
+after transform: SymbolId(20): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "ViewModels":
+after transform: SymbolId(20): Span { start: 537, end: 547 }
+rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
 Reference symbol mismatch for "ReExportedEnum":
 after transform: SymbolId(21) "ReExportedEnum"
 rebuilt        : <None>
@@ -13380,61 +11950,30 @@ after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/extBaseClass1.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "B"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "C"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Missing SymbolId: "_M2"
-Missing ReferenceId: "_M2"
-Missing ReferenceId: "C2"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Missing SymbolId: "N"
-Missing SymbolId: "_N"
-Missing ReferenceId: "_N"
-Missing ReferenceId: "C3"
-Missing ReferenceId: "N"
-Missing ReferenceId: "N"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(9)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(7)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(3), SymbolId(7)]
-rebuilt        : ScopeId(5): [SymbolId(5), SymbolId(6)]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(5), SymbolId(8)]
-rebuilt        : ScopeId(7): [SymbolId(8), SymbolId(9)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): [ReferenceId(0)]
-rebuilt        : SymbolId(3): [ReferenceId(3), ReferenceId(4)]
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(6)]
-Symbol reference IDs mismatch for "C2":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(6): [ReferenceId(11)]
-Symbol reference IDs mismatch for "C3":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(9): [ReferenceId(16)]
-Reference symbol mismatch for "M":
-after transform: SymbolId(0) "M"
-rebuilt        : SymbolId(1) "M"
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "M":
+after transform: SymbolId(0): [Span { start: 104, end: 105 }]
+rebuilt        : SymbolId(1): []
+Symbol flags mismatch for "N":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N":
+after transform: SymbolId(4): Span { start: 156, end: 157 }
+rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/extendAndImplementTheSameBaseType.ts
 semantic error: Symbol reference IDs mismatch for "C":
@@ -13548,74 +12087,50 @@ after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/fakeInfinity2.ts
-semantic error: Missing SymbolId: "X"
-Missing SymbolId: "_X"
-Missing ReferenceId: "_X"
-Missing ReferenceId: "f"
-Missing ReferenceId: "X"
-Missing ReferenceId: "X"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(7)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(5)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "Foo"]
 rebuilt        : ScopeId(1): ["Foo"]
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(6), SymbolId(8)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope children mismatch:
 after transform: ScopeId(2): [ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(2): [ScopeId(3)]
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol flags mismatch for "X":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "X":
+after transform: SymbolId(3): Span { start: 62, end: 63 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "f":
 after transform: SymbolId(6): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "f":
-after transform: SymbolId(6): []
-rebuilt        : SymbolId(4): [ReferenceId(9)]
-Reference symbol mismatch for "X":
-after transform: SymbolId(3) "X"
-rebuilt        : SymbolId(2) "X"
 
 tasks/coverage/typescript/tests/cases/compiler/fakeInfinity3.ts
-semantic error: Missing SymbolId: "X"
-Missing SymbolId: "_X"
-Missing ReferenceId: "_X"
-Missing ReferenceId: "f"
-Missing ReferenceId: "X"
-Missing ReferenceId: "X"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(7), SymbolId(8)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(5), SymbolId(6)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "Foo"]
 rebuilt        : ScopeId(1): ["Foo"]
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(6), SymbolId(9)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope children mismatch:
 after transform: ScopeId(2): [ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(2): [ScopeId(3)]
 Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol flags mismatch for "X":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "X":
+after transform: SymbolId(3): Span { start: 62, end: 63 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "f":
 after transform: SymbolId(6): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "f":
-after transform: SymbolId(6): []
-rebuilt        : SymbolId(4): [ReferenceId(9)]
-Reference symbol mismatch for "X":
-after transform: SymbolId(3) "X"
-rebuilt        : SymbolId(2) "X"
 
 tasks/coverage/typescript/tests/cases/compiler/fallFromLastCase1.ts
 semantic error: Scope children mismatch:
@@ -13628,37 +12143,27 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), Sc
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 
 tasks/coverage/typescript/tests/cases/compiler/fatArrowSelf.ts
-semantic error: Missing SymbolId: "Events"
-Missing SymbolId: "_Events"
-Missing ReferenceId: "_Events"
-Missing ReferenceId: "EventEmitter"
-Missing ReferenceId: "Events"
-Missing ReferenceId: "Events"
-Missing SymbolId: "Consumer"
-Missing SymbolId: "_Consumer"
-Missing ReferenceId: "Consumer"
-Missing ReferenceId: "Consumer"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(5)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(2), SymbolId(9)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(6), SymbolId(10)]
-rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
-Symbol reference IDs mismatch for "EventEmitter":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol flags mismatch for "Events":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Events":
+after transform: SymbolId(0): Span { start: 7, end: 13 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Consumer":
+after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Consumer":
+after transform: SymbolId(5): Span { start: 217, end: 225 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["Events"]
 rebuilt        : []
@@ -13737,19 +12242,15 @@ after transform: ["AsyncIterable", "Iterable", "arguments", "require"]
 rebuilt        : ["arguments", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/forInModule.ts
-semantic error: Missing SymbolId: "Foo"
-Missing SymbolId: "_Foo"
-Missing ReferenceId: "Foo"
-Missing ReferenceId: "Foo"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "Foo":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Foo":
+after transform: SymbolId(0): Span { start: 7, end: 10 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/forLoopEndingMultilineComments.ts
 semantic error: Bindings mismatch:
@@ -13860,30 +12361,18 @@ after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/funcdecl.ts
-semantic error: Missing SymbolId: "m2"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m2"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(8), SymbolId(9), SymbolId(13), SymbolId(14), SymbolId(16), SymbolId(17), SymbolId(22), SymbolId(23), SymbolId(26), SymbolId(27), SymbolId(30), SymbolId(33), SymbolId(35), SymbolId(36), SymbolId(38), SymbolId(45)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(8), SymbolId(9), SymbolId(13), SymbolId(14), SymbolId(16), SymbolId(17), SymbolId(22), SymbolId(23), SymbolId(26), SymbolId(27), SymbolId(30), SymbolId(31), SymbolId(33), SymbolId(34), SymbolId(36), SymbolId(41)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(14), ScopeId(15)]
-Binding symbols mismatch:
-after transform: ScopeId(14): [SymbolId(39), SymbolId(46)]
-rebuilt        : ScopeId(12): [SymbolId(37), SymbolId(38)]
 Scope flags mismatch:
 after transform: ScopeId(14): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(12): ScopeFlags(Function)
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(39): []
-rebuilt        : SymbolId(38): [ReferenceId(15)]
-Reference symbol mismatch for "m2":
-after transform: SymbolId(38) "m2"
-rebuilt        : SymbolId(36) "m2"
+Symbol flags mismatch for "m2":
+after transform: SymbolId(38): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(36): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m2":
+after transform: SymbolId(38): Span { start: 1207, end: 1209 }
+rebuilt        : SymbolId(36): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["Object"]
 rebuilt        : []
@@ -13894,27 +12383,15 @@ after transform: ["ArrayLike"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/functionCall5.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "c1"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(3), SymbolId(5)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(4), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol reference IDs mismatch for "c1":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(3): [ReferenceId(3)]
-Reference symbol mismatch for "m1":
-after transform: SymbolId(0) "m1"
-rebuilt        : SymbolId(1) "m1"
+Symbol flags mismatch for "m1":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(0): Span { start: 7, end: 9 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["m1", "require"]
 rebuilt        : ["require"]
@@ -13965,82 +12442,47 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/functionInIfStatementInModule.ts
-semantic error: Missing SymbolId: "Midori"
-Missing SymbolId: "_Midori"
-Missing ReferenceId: "Midori"
-Missing ReferenceId: "Midori"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "Midori":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Midori":
+after transform: SymbolId(0): Span { start: 9, end: 15 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/functionMergedWithModule.ts
-semantic error: Missing SymbolId: "_foo"
-Missing SymbolId: "Bar"
-Missing SymbolId: "_Bar"
-Missing ReferenceId: "_Bar"
-Missing ReferenceId: "f"
-Missing ReferenceId: "Bar"
-Missing ReferenceId: "Bar"
-Missing ReferenceId: "_foo"
-Missing ReferenceId: "_foo"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "foo"
-Missing SymbolId: "_foo2"
-Missing SymbolId: "Baz"
-Missing SymbolId: "_Baz"
-Missing ReferenceId: "_Baz"
-Missing ReferenceId: "g"
-Missing ReferenceId: "Baz"
-Missing ReferenceId: "Baz"
-Missing ReferenceId: "_foo2"
-Missing ReferenceId: "_foo2"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "foo"
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(3), SymbolId(7)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(4), SymbolId(8)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(5), SymbolId(9)]
-rebuilt        : ScopeId(5): [SymbolId(7), SymbolId(8)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(6), SymbolId(10)]
-rebuilt        : ScopeId(6): [SymbolId(9), SymbolId(10)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 Symbol flags mismatch for "foo":
 after transform: SymbolId(0): SymbolFlags(FunctionScopedVariable | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(0): []
-rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7), ReferenceId(15), ReferenceId(16)]
 Symbol redeclarations mismatch for "foo":
 after transform: SymbolId(0): [Span { start: 56, end: 59 }, Span { start: 108, end: 111 }]
 rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "f":
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(6): [ReferenceId(1)]
-Symbol reference IDs mismatch for "g":
-after transform: SymbolId(6): []
-rebuilt        : SymbolId(10): [ReferenceId(10)]
+Symbol flags mismatch for "Bar":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Bar":
+after transform: SymbolId(3): Span { start: 60, end: 63 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Baz":
+after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Baz":
+after transform: SymbolId(5): Span { start: 112, end: 115 }
+rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/functionOverloads10.ts
 semantic error: Scope children mismatch:
@@ -14220,22 +12662,18 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/functionTypeArgumentArrayAssignment.ts
-semantic error: Missing SymbolId: "test"
-Missing SymbolId: "_test"
-Missing ReferenceId: "test"
-Missing ReferenceId: "test"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(3), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
+Symbol flags mismatch for "test":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "test":
+after transform: SymbolId(0): Span { start: 7, end: 11 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/functionsWithImplicitReturnTypeAssignableToUndefined.ts
 semantic error: Scope children mismatch:
@@ -14268,27 +12706,18 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/generativeRecursionWithTypeOf.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "f"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(7)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(4), SymbolId(6)]
-rebuilt        : ScopeId(4): [SymbolId(4), SymbolId(5)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(0): [ReferenceId(1)]
 rebuilt        : SymbolId(1): []
-Symbol reference IDs mismatch for "f":
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(5): [ReferenceId(4)]
+Symbol flags mismatch for "M":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(3): Span { start: 66, end: 67 }
+rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "x":
 after transform: SymbolId(5): [ReferenceId(2), ReferenceId(3)]
 rebuilt        : SymbolId(6): [ReferenceId(2)]
@@ -14360,196 +12789,134 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(6)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
 
 tasks/coverage/typescript/tests/cases/compiler/genericCallbacksAndClassHierarchy.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "C1"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "A"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "B"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "D"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(17)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(3), SymbolId(5), SymbolId(7), SymbolId(9), SymbolId(16)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(7)]
-Symbol reference IDs mismatch for "C1":
-after transform: SymbolId(3): [ReferenceId(3)]
-rebuilt        : SymbolId(3): [ReferenceId(3), ReferenceId(7)]
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(5): [ReferenceId(4), ReferenceId(8), ReferenceId(11), ReferenceId(17)]
+after transform: SymbolId(5): [ReferenceId(4), ReferenceId(8), ReferenceId(11), ReferenceId(17), ReferenceId(22)]
 rebuilt        : SymbolId(4): [ReferenceId(6)]
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(7): [ReferenceId(6)]
+after transform: SymbolId(7): [ReferenceId(6), ReferenceId(24)]
 rebuilt        : SymbolId(5): [ReferenceId(9)]
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(9): []
-rebuilt        : SymbolId(6): [ReferenceId(15)]
 
 tasks/coverage/typescript/tests/cases/compiler/genericClassImplementingGenericInterfaceFromAnotherModule.ts
-semantic error: Missing SymbolId: "bar"
-Missing SymbolId: "_bar"
-Missing ReferenceId: "_bar"
-Missing ReferenceId: "Foo"
-Missing ReferenceId: "bar"
-Missing ReferenceId: "bar"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["bar", "foo"]
 rebuilt        : ScopeId(0): ["bar"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(4), SymbolId(7)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol flags mismatch for "bar":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "bar":
+after transform: SymbolId(3): Span { start: 55, end: 58 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["foo"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/genericClassPropertyInheritanceSpecialization.ts
-semantic error: Missing SymbolId: "Portal"
-Missing SymbolId: "_Portal"
-Missing SymbolId: "Controls"
-Missing SymbolId: "_Controls"
-Missing SymbolId: "Validators"
-Missing SymbolId: "_Validators"
-Missing ReferenceId: "_Validators"
-Missing ReferenceId: "Validator"
-Missing ReferenceId: "Validators"
-Missing ReferenceId: "Validators"
-Missing ReferenceId: "_Controls"
-Missing ReferenceId: "_Controls"
-Missing ReferenceId: "Controls"
-Missing ReferenceId: "Controls"
-Missing ReferenceId: "_Portal"
-Missing ReferenceId: "_Portal"
-Missing ReferenceId: "Portal"
-Missing ReferenceId: "Portal"
-Missing SymbolId: "PortalFx"
-Missing SymbolId: "_PortalFx"
-Missing SymbolId: "ViewModels"
-Missing SymbolId: "_ViewModels"
-Missing SymbolId: "Controls"
-Missing SymbolId: "_Controls2"
-Missing SymbolId: "Validators"
-Missing SymbolId: "_Validators2"
-Missing ReferenceId: "_Validators2"
-Missing ReferenceId: "Validator"
-Missing ReferenceId: "Validators"
-Missing ReferenceId: "Validators"
-Missing ReferenceId: "_Controls2"
-Missing ReferenceId: "_Controls2"
-Missing ReferenceId: "Controls"
-Missing ReferenceId: "Controls"
-Missing ReferenceId: "_ViewModels"
-Missing ReferenceId: "_ViewModels"
-Missing ReferenceId: "ViewModels"
-Missing ReferenceId: "ViewModels"
-Missing ReferenceId: "_PortalFx"
-Missing ReferenceId: "_PortalFx"
-Missing ReferenceId: "PortalFx"
-Missing ReferenceId: "PortalFx"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Portal", "PortalFx", "ViewModel", "_defineProperty", "ko"]
 rebuilt        : ScopeId(0): ["Portal", "PortalFx", "ViewModel", "_defineProperty"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(7), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(31), ScopeId(37), ScopeId(38)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(8), ScopeId(14)]
-Binding symbols mismatch:
-after transform: ScopeId(24): [SymbolId(11), SymbolId(28)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
 Scope flags mismatch:
 after transform: ScopeId(24): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(25): [SymbolId(12), SymbolId(29)]
-rebuilt        : ScopeId(2): [SymbolId(4), SymbolId(5)]
 Scope flags mismatch:
 after transform: ScopeId(25): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(26): [SymbolId(13), SymbolId(30)]
-rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
 Scope flags mismatch:
 after transform: ScopeId(26): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(31): [SymbolId(18), SymbolId(31)]
-rebuilt        : ScopeId(8): [SymbolId(11), SymbolId(12)]
 Scope flags mismatch:
 after transform: ScopeId(31): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(8): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(32): [SymbolId(19), SymbolId(32)]
-rebuilt        : ScopeId(9): [SymbolId(13), SymbolId(14)]
 Scope flags mismatch:
 after transform: ScopeId(32): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(9): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(33): [SymbolId(20), SymbolId(33)]
-rebuilt        : ScopeId(10): [SymbolId(15), SymbolId(16)]
 Scope flags mismatch:
 after transform: ScopeId(33): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(10): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(34): [SymbolId(21), SymbolId(34)]
-rebuilt        : ScopeId(11): [SymbolId(17), SymbolId(18)]
 Scope flags mismatch:
 after transform: ScopeId(34): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(11): ScopeFlags(Function)
-Symbol reference IDs mismatch for "Validator":
-after transform: SymbolId(13): []
-rebuilt        : SymbolId(7): [ReferenceId(6)]
-Symbol reference IDs mismatch for "Validator":
-after transform: SymbolId(21): []
-rebuilt        : SymbolId(18): [ReferenceId(20)]
-Reference symbol mismatch for "Portal":
-after transform: SymbolId(10) "Portal"
-rebuilt        : SymbolId(1) "Portal"
+Symbol flags mismatch for "Portal":
+after transform: SymbolId(10): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Portal":
+after transform: SymbolId(10): Span { start: 1075, end: 1081 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Controls":
+after transform: SymbolId(11): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Controls":
+after transform: SymbolId(11): Span { start: 1082, end: 1090 }
+rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Validators":
+after transform: SymbolId(12): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Validators":
+after transform: SymbolId(12): Span { start: 1091, end: 1101 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
+Symbol flags mismatch for "PortalFx":
+after transform: SymbolId(17): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "PortalFx":
+after transform: SymbolId(17): Span { start: 1491, end: 1499 }
+rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
+Symbol flags mismatch for "ViewModels":
+after transform: SymbolId(18): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "ViewModels":
+after transform: SymbolId(18): Span { start: 1500, end: 1510 }
+rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Controls":
+after transform: SymbolId(19): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Controls":
+after transform: SymbolId(19): Span { start: 1511, end: 1519 }
+rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Validators":
+after transform: SymbolId(20): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Validators":
+after transform: SymbolId(20): Span { start: 1520, end: 1530 }
+rebuilt        : SymbolId(16): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["PortalFx", "ko", "require"]
 rebuilt        : ["ko", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/genericClassWithStaticFactory.ts
-semantic error: Missing SymbolId: "Editor"
-Missing SymbolId: "_Editor"
-Missing ReferenceId: "_Editor"
-Missing ReferenceId: "List"
-Missing ReferenceId: "_Editor"
-Missing ReferenceId: "ListFactory"
-Missing ReferenceId: "Editor"
-Missing ReferenceId: "Editor"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(29)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(19), SymbolId(28)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(20)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "Editor":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Editor":
+after transform: SymbolId(0): Span { start: 7, end: 13 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "List":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(10), ReferenceId(18), ReferenceId(28), ReferenceId(46), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(61), ReferenceId(63), ReferenceId(72), ReferenceId(74), ReferenceId(82), ReferenceId(86), ReferenceId(88), ReferenceId(90), ReferenceId(98), ReferenceId(100), ReferenceId(102), ReferenceId(110), ReferenceId(112)]
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(10), ReferenceId(18), ReferenceId(28), ReferenceId(46), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(61), ReferenceId(63), ReferenceId(72), ReferenceId(74), ReferenceId(82), ReferenceId(86), ReferenceId(88), ReferenceId(90), ReferenceId(98), ReferenceId(100), ReferenceId(102), ReferenceId(110), ReferenceId(112), ReferenceId(122)]
 rebuilt        : SymbolId(3): [ReferenceId(56), ReferenceId(57), ReferenceId(63)]
 Symbol reference IDs mismatch for "ListFactory":
-after transform: SymbolId(19): [ReferenceId(4), ReferenceId(7)]
+after transform: SymbolId(19): [ReferenceId(4), ReferenceId(7), ReferenceId(124)]
 rebuilt        : SymbolId(20): [ReferenceId(6), ReferenceId(78)]
 
 tasks/coverage/typescript/tests/cases/compiler/genericClasses0.ts
@@ -14576,32 +12943,15 @@ after transform: SymbolId(0): [ReferenceId(4), ReferenceId(10), ReferenceId(12),
 rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(10)]
 
 tasks/coverage/typescript/tests/cases/compiler/genericClassesInModule.ts
-semantic error: Missing SymbolId: "Foo"
-Missing SymbolId: "_Foo"
-Missing ReferenceId: "_Foo"
-Missing ReferenceId: "B"
-Missing ReferenceId: "_Foo"
-Missing ReferenceId: "A"
-Missing ReferenceId: "Foo"
-Missing ReferenceId: "Foo"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(4)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(3): [ReferenceId(3)]
-Reference symbol mismatch for "Foo":
-after transform: SymbolId(0) "Foo"
-rebuilt        : SymbolId(0) "Foo"
+Symbol flags mismatch for "Foo":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Foo":
+after transform: SymbolId(0): Span { start: 7, end: 10 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["Foo"]
 rebuilt        : []
@@ -14631,132 +12981,104 @@ after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes.ts
-semantic error: Missing SymbolId: "EndGate"
-Missing SymbolId: "_EndGate"
-Missing SymbolId: "Tweening"
-Missing SymbolId: "_Tweening"
-Missing ReferenceId: "_Tweening"
-Missing ReferenceId: "Tween"
-Missing ReferenceId: "Tweening"
-Missing ReferenceId: "Tweening"
-Missing ReferenceId: "_EndGate"
-Missing ReferenceId: "_EndGate"
-Missing ReferenceId: "EndGate"
-Missing ReferenceId: "EndGate"
-Missing SymbolId: "_EndGate2"
-Missing SymbolId: "Tweening"
-Missing SymbolId: "_Tweening2"
-Missing ReferenceId: "_Tweening2"
-Missing ReferenceId: "NumberTween"
-Missing ReferenceId: "Tweening"
-Missing ReferenceId: "Tweening"
-Missing ReferenceId: "_EndGate2"
-Missing ReferenceId: "_EndGate2"
-Missing ReferenceId: "EndGate"
-Missing ReferenceId: "EndGate"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(14)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["EndGate", "_defineProperty"]
+rebuilt        : ScopeId(0): ["_defineProperty"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(9)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(3), SymbolId(10)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(4), SymbolId(11)]
-rebuilt        : ScopeId(2): [SymbolId(4), SymbolId(5)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(9): [SymbolId(7), SymbolId(12)]
-rebuilt        : ScopeId(5): [SymbolId(7), SymbolId(8)]
 Scope flags mismatch:
 after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(10): [SymbolId(8), SymbolId(13)]
-rebuilt        : ScopeId(6): [SymbolId(9), SymbolId(10)]
 Scope flags mismatch:
 after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
-Symbol reference IDs mismatch for "Tween":
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(5): [ReferenceId(4)]
-Symbol reference IDs mismatch for "NumberTween":
-after transform: SymbolId(8): []
-rebuilt        : SymbolId(10): [ReferenceId(14)]
+Symbol flags mismatch for "Tweening":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Tweening":
+after transform: SymbolId(3): Span { start: 154, end: 162 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Tweening":
+after transform: SymbolId(7): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Tweening":
+after transform: SymbolId(7): Span { start: 343, end: 351 }
+rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
+Reference symbol mismatch for "EndGate":
+after transform: SymbolId(0) "EndGate"
+rebuilt        : <None>
+Reference symbol mismatch for "EndGate":
+after transform: SymbolId(0) "EndGate"
+rebuilt        : <None>
+Reference symbol mismatch for "EndGate":
+after transform: SymbolId(0) "EndGate"
+rebuilt        : <None>
+Reference symbol mismatch for "EndGate":
+after transform: SymbolId(0) "EndGate"
+rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["EndGate", "ICloneable", "Tween", "require"]
-rebuilt        : ["Tween", "require"]
+rebuilt        : ["EndGate", "Tween", "require"]
+Unresolved reference IDs mismatch for "EndGate":
+after transform: [ReferenceId(0)]
+rebuilt        : [ReferenceId(9), ReferenceId(10), ReferenceId(19), ReferenceId(20)]
 
 tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes2.ts
-semantic error: Missing SymbolId: "EndGate"
-Missing SymbolId: "_EndGate2"
-Missing SymbolId: "Tweening"
-Missing SymbolId: "_Tweening"
-Missing ReferenceId: "_Tweening"
-Missing ReferenceId: "Tween"
-Missing ReferenceId: "Tweening"
-Missing ReferenceId: "Tweening"
-Missing ReferenceId: "_EndGate2"
-Missing ReferenceId: "_EndGate2"
-Missing ReferenceId: "EndGate"
-Missing ReferenceId: "EndGate"
-Missing SymbolId: "_EndGate3"
-Missing SymbolId: "Tweening"
-Missing SymbolId: "_Tweening2"
-Missing ReferenceId: "_Tweening2"
-Missing ReferenceId: "NumberTween"
-Missing ReferenceId: "Tweening"
-Missing ReferenceId: "Tweening"
-Missing ReferenceId: "_EndGate3"
-Missing ReferenceId: "_EndGate3"
-Missing ReferenceId: "EndGate"
-Missing ReferenceId: "EndGate"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(15)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["EndGate", "_defineProperty"]
+rebuilt        : ScopeId(0): ["_defineProperty"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(9)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(3), SymbolId(11)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(4), SymbolId(12)]
-rebuilt        : ScopeId(2): [SymbolId(4), SymbolId(5)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(9): [SymbolId(7), SymbolId(13)]
-rebuilt        : ScopeId(5): [SymbolId(7), SymbolId(8)]
 Scope flags mismatch:
 after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(10): [SymbolId(8), SymbolId(14)]
-rebuilt        : ScopeId(6): [SymbolId(9), SymbolId(10)]
 Scope flags mismatch:
 after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
-Symbol reference IDs mismatch for "Tween":
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(5): [ReferenceId(4)]
-Symbol reference IDs mismatch for "NumberTween":
-after transform: SymbolId(8): []
-rebuilt        : SymbolId(10): [ReferenceId(14)]
+Symbol flags mismatch for "Tweening":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Tweening":
+after transform: SymbolId(3): Span { start: 146, end: 154 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Tweening":
+after transform: SymbolId(7): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Tweening":
+after transform: SymbolId(7): Span { start: 334, end: 342 }
+rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
+Reference symbol mismatch for "EndGate":
+after transform: SymbolId(0) "EndGate"
+rebuilt        : <None>
+Reference symbol mismatch for "EndGate":
+after transform: SymbolId(0) "EndGate"
+rebuilt        : <None>
+Reference symbol mismatch for "EndGate":
+after transform: SymbolId(0) "EndGate"
+rebuilt        : <None>
+Reference symbol mismatch for "EndGate":
+after transform: SymbolId(0) "EndGate"
+rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["EndGate", "ICloneable", "Tween", "require"]
-rebuilt        : ["Tween", "require"]
+rebuilt        : ["EndGate", "Tween", "require"]
+Unresolved reference IDs mismatch for "EndGate":
+after transform: [ReferenceId(0)]
+rebuilt        : [ReferenceId(9), ReferenceId(10), ReferenceId(19), ReferenceId(20)]
 
 tasks/coverage/typescript/tests/cases/compiler/genericConstructSignatureInInterface.ts
 semantic error: Scope children mismatch:
@@ -14918,101 +13240,62 @@ after transform: ["require"]
 rebuilt        : ["params", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/genericOfACloduleType1.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "C"
-Missing SymbolId: "_C"
-Missing ReferenceId: "_C"
-Missing ReferenceId: "X"
-Missing ReferenceId: "C"
-Missing ReferenceId: "C"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(7)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(8)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(4), SymbolId(6), SymbolId(8)]
-rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(7)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(5), SymbolId(9)]
-rebuilt        : ScopeId(6): [SymbolId(5), SymbolId(6)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
+Symbol flags mismatch for "M":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(3): Span { start: 45, end: 46 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "C":
 after transform: SymbolId(4): SymbolFlags(Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(Class)
 Symbol reference IDs mismatch for "C":
-after transform: SymbolId(4): [ReferenceId(3)]
+after transform: SymbolId(4): [ReferenceId(3), ReferenceId(8), ReferenceId(11), ReferenceId(13)]
 rebuilt        : SymbolId(4): [ReferenceId(2), ReferenceId(5), ReferenceId(6)]
 Symbol redeclarations mismatch for "C":
 after transform: SymbolId(4): [Span { start: 100, end: 101 }]
 rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "X":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(6): [ReferenceId(4)]
 Unresolved references mismatch:
 after transform: ["M"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/genericOfACloduleType2.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "C"
-Missing SymbolId: "_C"
-Missing ReferenceId: "_C"
-Missing ReferenceId: "X"
-Missing ReferenceId: "C"
-Missing ReferenceId: "C"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Missing SymbolId: "N"
-Missing SymbolId: "_N"
-Missing ReferenceId: "N"
-Missing ReferenceId: "N"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(7)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(8)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(4), SymbolId(6), SymbolId(9)]
-rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(7)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(5), SymbolId(10)]
-rebuilt        : ScopeId(6): [SymbolId(5), SymbolId(6)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(8): [SymbolId(8), SymbolId(11)]
-rebuilt        : ScopeId(8): [SymbolId(9), SymbolId(10)]
 Scope flags mismatch:
 after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(8): ScopeFlags(Function)
+Symbol flags mismatch for "M":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(3): Span { start: 45, end: 46 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "C":
 after transform: SymbolId(4): SymbolFlags(Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(Class)
 Symbol reference IDs mismatch for "C":
-after transform: SymbolId(4): [ReferenceId(3)]
+after transform: SymbolId(4): [ReferenceId(3), ReferenceId(8), ReferenceId(11), ReferenceId(13)]
 rebuilt        : SymbolId(4): [ReferenceId(2), ReferenceId(5), ReferenceId(6)]
 Symbol redeclarations mismatch for "C":
 after transform: SymbolId(4): [Span { start: 100, end: 101 }]
 rebuilt        : SymbolId(4): []
-Symbol reference IDs mismatch for "X":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(6): [ReferenceId(4)]
+Symbol flags mismatch for "N":
+after transform: SymbolId(7): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N":
+after transform: SymbolId(7): Span { start: 217, end: 218 }
+rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["M"]
 rebuilt        : []
@@ -15045,23 +13328,7 @@ after transform: SymbolId(1): [ReferenceId(4)]
 rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/compiler/genericRecursiveImplicitConstructorErrors2.ts
-semantic error: Missing SymbolId: "TypeScript2"
-Missing SymbolId: "_TypeScript"
-Missing ReferenceId: "_TypeScript"
-Missing ReferenceId: "PullSymbolVisibility"
-Missing ReferenceId: "_TypeScript"
-Missing ReferenceId: "PullSymbol"
-Missing ReferenceId: "_TypeScript"
-Missing ReferenceId: "PullTypeSymbol"
-Missing ReferenceId: "TypeScript2"
-Missing ReferenceId: "TypeScript2"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(4), SymbolId(7), SymbolId(18), SymbolId(22)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(9)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
@@ -15073,17 +13340,20 @@ rebuilt        : ScopeId(2): ["PullSymbolVisibility"]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(0x0)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch for "TypeScript2":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "TypeScript2":
+after transform: SymbolId(0): Span { start: 7, end: 18 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "PullSymbolVisibility":
 after transform: SymbolId(4): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "PullSymbolVisibility":
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(2): [ReferenceId(6)]
 Symbol reference IDs mismatch for "PullSymbol":
-after transform: SymbolId(7): [ReferenceId(1), ReferenceId(8)]
+after transform: SymbolId(7): [ReferenceId(1), ReferenceId(8), ReferenceId(12)]
 rebuilt        : SymbolId(4): [ReferenceId(9), ReferenceId(10)]
 Symbol reference IDs mismatch for "PullTypeSymbol":
-after transform: SymbolId(18): [ReferenceId(3)]
+after transform: SymbolId(18): [ReferenceId(3), ReferenceId(14)]
 rebuilt        : SymbolId(9): [ReferenceId(12)]
 
 tasks/coverage/typescript/tests/cases/compiler/genericReversingTypeParameters.ts
@@ -15225,27 +13495,21 @@ after transform: SymbolId(1): [Span { start: 724, end: 731 }]
 rebuilt        : SymbolId(4): []
 
 tasks/coverage/typescript/tests/cases/compiler/getAccessorWithImpliedReturnTypeAndFunctionClassMerge.ts
-semantic error: Missing SymbolId: "MyModule"
-Missing SymbolId: "_MyModule"
-Missing ReferenceId: "_MyModule"
-Missing ReferenceId: "MyClass"
-Missing ReferenceId: "MyModule"
-Missing ReferenceId: "MyModule"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["MyModule", "_"]
 rebuilt        : ScopeId(0): ["MyModule"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(8)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(8): [SymbolId(14), SymbolId(16)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 Scope flags mismatch:
 after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol reference IDs mismatch for "MyClass":
-after transform: SymbolId(14): []
-rebuilt        : SymbolId(2): [ReferenceId(2)]
+Symbol flags mismatch for "MyModule":
+after transform: SymbolId(13): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "MyModule":
+after transform: SymbolId(13): Span { start: 435, end: 443 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["Array", "_"]
 rebuilt        : []
@@ -15274,27 +13538,15 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(8), ScopeId(16), ScopeId(17)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(9), ScopeId(18)]
 
 tasks/coverage/typescript/tests/cases/compiler/global.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "f"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol reference IDs mismatch for "f":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(3)]
-Reference symbol mismatch for "M":
-after transform: SymbolId(0) "M"
-rebuilt        : SymbolId(0) "M"
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/globalFunctionAugmentationOverload.ts
 semantic error: Scope children mismatch:
@@ -15476,67 +13728,41 @@ after transform: SymbolId(39): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(32): SymbolFlags(BlockScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/importAliasAnExternalModuleInsideAnInternalModule.ts
-semantic error: Missing SymbolId: "m"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "m"
-Missing ReferenceId: "m"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+semantic error: Symbol flags mismatch for "m":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m":
+after transform: SymbolId(0): Span { start: 14, end: 15 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "foo":
 after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/importAliasFromNamespace.ts
-semantic error: Missing SymbolId: "My"
-Missing SymbolId: "_My"
-Missing SymbolId: "Internal"
-Missing SymbolId: "_Internal"
-Missing ReferenceId: "_Internal"
-Missing ReferenceId: "getThing"
-Missing ReferenceId: "_Internal"
-Missing ReferenceId: "WhichThing"
-Missing ReferenceId: "Internal"
-Missing ReferenceId: "Internal"
-Missing ReferenceId: "_My"
-Missing ReferenceId: "_My"
-Missing ReferenceId: "My"
-Missing ReferenceId: "My"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(3), SymbolId(8)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4), SymbolId(5)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(4): ["A", "B", "C", "WhichThing"]
 rebuilt        : ScopeId(4): ["WhichThing"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "My":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "My":
+after transform: SymbolId(0): Span { start: 10, end: 12 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Internal":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Internal":
+after transform: SymbolId(1): Span { start: 13, end: 21 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "getThing":
 after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "getThing":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
 Symbol flags mismatch for "WhichThing":
 after transform: SymbolId(3): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "WhichThing":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(5): [ReferenceId(10)]
 
 tasks/coverage/typescript/tests/cases/compiler/importAliasWithDottedName.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -15717,63 +13943,39 @@ after transform: ["T", "theme"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/import_reference-exported-alias.ts
-semantic error: Missing SymbolId: "App"
-Missing SymbolId: "_App"
-Missing SymbolId: "Services"
-Missing SymbolId: "_Services"
-Missing ReferenceId: "_Services"
-Missing ReferenceId: "UserServices"
-Missing ReferenceId: "Services"
-Missing ReferenceId: "Services"
-Missing ReferenceId: "_App"
-Missing ReferenceId: "_App"
-Missing ReferenceId: "App"
-Missing ReferenceId: "App"
-Missing SymbolId: "Mod"
+semantic error: Missing SymbolId: "Mod"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(5)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Symbol reference IDs mismatch for "UserServices":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Reference symbol mismatch for "App":
-after transform: SymbolId(0) "App"
-rebuilt        : SymbolId(0) "App"
+Symbol flags mismatch for "App":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "App":
+after transform: SymbolId(0): Span { start: 7, end: 10 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Services":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Services":
+after transform: SymbolId(1): Span { start: 31, end: 39 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Reference symbol mismatch for "Mod":
 after transform: SymbolId(3) "Mod"
 rebuilt        : SymbolId(5) "Mod"
 
 tasks/coverage/typescript/tests/cases/compiler/import_reference-to-type-alias.ts
-semantic error: Missing SymbolId: "App"
-Missing SymbolId: "_App"
-Missing SymbolId: "Services"
-Missing SymbolId: "_Services"
-Missing ReferenceId: "_Services"
-Missing ReferenceId: "UserServices"
-Missing ReferenceId: "Services"
-Missing ReferenceId: "Services"
-Missing ReferenceId: "_App"
-Missing ReferenceId: "_App"
-Missing ReferenceId: "App"
-Missing ReferenceId: "App"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(4)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Symbol reference IDs mismatch for "UserServices":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
+semantic error: Symbol flags mismatch for "App":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "App":
+after transform: SymbolId(0): Span { start: 14, end: 17 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Services":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Services":
+after transform: SymbolId(1): Span { start: 38, end: 46 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/import_unneeded-require-when-referenecing-aliased-type-throug-array.ts
 semantic error: Bindings mismatch:
@@ -15801,48 +14003,30 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/importedAliasesInTypePositions.ts
-semantic error: Missing SymbolId: "elaborate"
-Missing SymbolId: "_elaborate"
-Missing SymbolId: "nested"
-Missing SymbolId: "_nested"
-Missing SymbolId: "mod"
-Missing SymbolId: "_mod"
-Missing SymbolId: "name"
-Missing SymbolId: "_name"
-Missing ReferenceId: "_name"
-Missing ReferenceId: "ReferredTo"
-Missing ReferenceId: "name"
-Missing ReferenceId: "name"
-Missing ReferenceId: "_mod"
-Missing ReferenceId: "_mod"
-Missing ReferenceId: "mod"
-Missing ReferenceId: "mod"
-Missing ReferenceId: "_nested"
-Missing ReferenceId: "_nested"
-Missing ReferenceId: "nested"
-Missing ReferenceId: "nested"
-Missing ReferenceId: "_elaborate"
-Missing ReferenceId: "_elaborate"
-Missing ReferenceId: "elaborate"
-Missing ReferenceId: "elaborate"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(3), SymbolId(7)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(4), SymbolId(8)]
-rebuilt        : ScopeId(4): [SymbolId(7), SymbolId(8)]
-Symbol reference IDs mismatch for "ReferredTo":
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(8): [ReferenceId(1)]
+semantic error: Symbol flags mismatch for "elaborate":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "elaborate":
+after transform: SymbolId(0): Span { start: 14, end: 23 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "nested":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "nested":
+after transform: SymbolId(1): Span { start: 24, end: 30 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "mod":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "mod":
+after transform: SymbolId(2): Span { start: 31, end: 34 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
+Symbol flags mismatch for "name":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "name":
+after transform: SymbolId(3): Span { start: 35, end: 39 }
+rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/importedModuleClassNameClash.ts
 semantic error: Bindings mismatch:
@@ -15984,22 +14168,18 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/indexIntoEnum.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(0x0)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "E":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
@@ -16563,67 +14743,24 @@ after transform: ["Date"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/inheritanceOfGenericConstructorMethod2.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "C1"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "C2"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Missing SymbolId: "N"
-Missing SymbolId: "_N"
-Missing ReferenceId: "_N"
-Missing ReferenceId: "D1"
-Missing ReferenceId: "_N"
-Missing ReferenceId: "D2"
-Missing ReferenceId: "N"
-Missing ReferenceId: "N"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(12)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(5), SymbolId(6), SymbolId(13)]
-rebuilt        : ScopeId(4): [SymbolId(5), SymbolId(6), SymbolId(7)]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
-Symbol reference IDs mismatch for "C1":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Symbol reference IDs mismatch for "C2":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(3): [ReferenceId(3)]
-Symbol reference IDs mismatch for "D1":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(6): [ReferenceId(8)]
-Symbol reference IDs mismatch for "D2":
-after transform: SymbolId(6): []
-rebuilt        : SymbolId(7): [ReferenceId(11)]
-Reference symbol mismatch for "M":
-after transform: SymbolId(0) "M"
-rebuilt        : SymbolId(0) "M"
-Reference symbol mismatch for "M":
-after transform: SymbolId(0) "M"
-rebuilt        : SymbolId(0) "M"
-Reference symbol mismatch for "M":
-after transform: SymbolId(0) "M"
-rebuilt        : SymbolId(0) "M"
-Reference symbol mismatch for "N":
-after transform: SymbolId(4) "N"
-rebuilt        : SymbolId(4) "N"
-Reference symbol mismatch for "N":
-after transform: SymbolId(4) "N"
-rebuilt        : SymbolId(4) "N"
-Reference symbol mismatch for "N":
-after transform: SymbolId(4) "N"
-rebuilt        : SymbolId(4) "N"
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "N":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N":
+after transform: SymbolId(4): Span { start: 69, end: 70 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticMembersCompatible.ts
 semantic error: Symbol reference IDs mismatch for "a":
@@ -16700,23 +14837,7 @@ after transform: SymbolId(5): [ReferenceId(0), ReferenceId(1), ReferenceId(2), R
 rebuilt        : SymbolId(1): []
 
 tasks/coverage/typescript/tests/cases/compiler/innerAliases2.ts
-semantic error: Missing SymbolId: "_provider"
-Missing SymbolId: "_provider2"
-Missing ReferenceId: "_provider2"
-Missing ReferenceId: "UsefulClass"
-Missing ReferenceId: "_provider"
-Missing ReferenceId: "_provider"
-Missing SymbolId: "consumer"
-Missing SymbolId: "_consumer"
-Missing SymbolId: "provider"
-Missing ReferenceId: "consumer"
-Missing ReferenceId: "consumer"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(2)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+semantic error: Missing SymbolId: "provider"
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
@@ -16726,59 +14847,41 @@ rebuilt        : ScopeId(4): [SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7)
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
-Symbol reference IDs mismatch for "UsefulClass":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Reference symbol mismatch for "_provider":
-after transform: SymbolId(0) "_provider"
-rebuilt        : SymbolId(0) "_provider"
+Symbol flags mismatch for "_provider":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "_provider":
+after transform: SymbolId(0): Span { start: 7, end: 16 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "consumer":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "consumer":
+after transform: SymbolId(2): Span { start: 171, end: 179 }
+rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Reference symbol mismatch for "provider":
 after transform: SymbolId(3) "provider"
 rebuilt        : SymbolId(5) "provider"
 
 tasks/coverage/typescript/tests/cases/compiler/innerBoundLambdaEmit.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "Foo"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["M"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/innerExtern.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing SymbolId: "B"
-Missing SymbolId: "_B"
-Missing ReferenceId: "_B"
-Missing ReferenceId: "C"
-Missing ReferenceId: "B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(7)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["B", "BB", "_A"]
 rebuilt        : ScopeId(1): ["B", "_A"]
 Scope flags mismatch:
@@ -16787,35 +14890,32 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(4), SymbolId(6)]
-rebuilt        : ScopeId(2): [SymbolId(4), SymbolId(5)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(5): [ReferenceId(4)]
+Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
+Symbol flags mismatch for "B":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(3): Span { start: 95, end: 96 }
+rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/innerFunc.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "tungsten"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(2)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(3), SymbolId(5)]
-rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Symbol reference IDs mismatch for "tungsten":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(4): [ReferenceId(3)]
+Symbol flags mismatch for "M":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(2): Span { start: 82, end: 83 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/innerOverloads.ts
 semantic error: Scope children mismatch:
@@ -16889,22 +14989,21 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/instantiateContextualTypes.ts
-semantic error: Missing SymbolId: "N1"
-Missing SymbolId: "_N"
-Missing ReferenceId: "N1"
-Missing ReferenceId: "N1"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Interesting", "N1", "NON_VOID_ACTION", "VOID_ACTION", "_defineProperty", "defaultState", "fn", "handlers", "obj", "outerBoxOfString", "x", "xx"]
 rebuilt        : ScopeId(0): ["Interesting", "N1", "NON_VOID_ACTION", "VOID_ACTION", "_defineProperty", "defaultState", "fn", "obj", "xx"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(24), ScopeId(25), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(12), ScopeId(13), ScopeId(23), ScopeId(24), ScopeId(25)]
-Binding symbols mismatch:
-after transform: ScopeId(25): [SymbolId(60), SymbolId(86)]
-rebuilt        : ScopeId(8): [SymbolId(15), SymbolId(16)]
 Scope children mismatch:
 after transform: ScopeId(25): [ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36), ScopeId(37)]
 rebuilt        : ScopeId(8): [ScopeId(9), ScopeId(10), ScopeId(11)]
+Symbol flags mismatch for "N1":
+after transform: SymbolId(46): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N1":
+after transform: SymbolId(46): Span { start: 1772, end: 1774 }
+rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 Reference symbol mismatch for "handlers":
 after transform: SymbolId(6) "handlers"
 rebuilt        : <None>
@@ -16958,22 +15057,7 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), Sc
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces0.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing SymbolId: "B"
-Missing SymbolId: "_B"
-Missing ReferenceId: "_B"
-Missing ReferenceId: "createB"
-Missing ReferenceId: "B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["_A"]
 rebuilt        : ScopeId(1): ["B", "_A"]
 Scope flags mismatch:
@@ -16982,114 +15066,85 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(4)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(5)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Symbol reference IDs mismatch for "createB":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Reference symbol mismatch for "A":
-after transform: SymbolId(0) "A"
-rebuilt        : SymbolId(0) "A"
+Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "B":
+after transform: SymbolId(1): SymbolFlags(Interface | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(1): Span { start: 30, end: 31 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "B":
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(5), ReferenceId(7)]
+rebuilt        : SymbolId(2): [ReferenceId(2), ReferenceId(3)]
+Symbol redeclarations mismatch for "B":
+after transform: SymbolId(1): [Span { start: 136, end: 137 }]
+rebuilt        : SymbolId(2): []
 Unresolved references mismatch:
 after transform: ["A"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces1.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing SymbolId: "B"
-Missing SymbolId: "_B"
-Missing ReferenceId: "_B"
-Missing ReferenceId: "createB"
-Missing ReferenceId: "B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
-Bindings mismatch:
-after transform: ScopeId(1): ["_A"]
-rebuilt        : ScopeId(1): ["B", "_A"]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(2), SymbolId(5)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Symbol reference IDs mismatch for "createB":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Reference symbol mismatch for "A":
-after transform: SymbolId(0) "A"
-rebuilt        : SymbolId(0) "A"
+Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Reference symbol mismatch for "B":
+after transform: SymbolId(1) "B"
+rebuilt        : <None>
+Reference symbol mismatch for "B":
+after transform: SymbolId(1) "B"
+rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["A"]
-rebuilt        : []
+rebuilt        : ["B"]
 
 tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces2.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing SymbolId: "B"
-Missing SymbolId: "_B"
-Missing ReferenceId: "_B"
-Missing ReferenceId: "createB"
-Missing ReferenceId: "B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
-Bindings mismatch:
-after transform: ScopeId(1): ["_A"]
-rebuilt        : ScopeId(1): ["B", "_A"]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(2), SymbolId(5)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Symbol reference IDs mismatch for "createB":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
+Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Reference symbol mismatch for "B":
+after transform: SymbolId(1) "B"
+rebuilt        : <None>
+Reference symbol mismatch for "B":
+after transform: SymbolId(1) "B"
+rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["A"]
-rebuilt        : []
+rebuilt        : ["B"]
 
 tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces3.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing SymbolId: "B"
-Missing SymbolId: "_B"
-Missing ReferenceId: "_B"
-Missing ReferenceId: "createB"
-Missing ReferenceId: "B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["_A"]
 rebuilt        : ScopeId(1): ["B", "_A"]
 Scope flags mismatch:
@@ -17098,36 +15153,33 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(4)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(5)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Symbol reference IDs mismatch for "createB":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
+Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "B":
+after transform: SymbolId(1): SymbolFlags(Interface | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(1): Span { start: 23, end: 24 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "B":
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(4), ReferenceId(5)]
+rebuilt        : SymbolId(2): [ReferenceId(2), ReferenceId(3)]
+Symbol redeclarations mismatch for "B":
+after transform: SymbolId(1): [Span { start: 129, end: 130 }]
+rebuilt        : SymbolId(2): []
 Unresolved references mismatch:
 after transform: ["A"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces4.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing SymbolId: "B"
-Missing SymbolId: "_B"
-Missing ReferenceId: "_B"
-Missing ReferenceId: "createB"
-Missing ReferenceId: "B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["_A"]
 rebuilt        : ScopeId(1): ["B", "_A"]
 Scope flags mismatch:
@@ -17136,56 +15188,50 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(4)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(5)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Symbol reference IDs mismatch for "createB":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Reference symbol mismatch for "A":
-after transform: SymbolId(0) "A"
-rebuilt        : SymbolId(0) "A"
+Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "B":
+after transform: SymbolId(1): SymbolFlags(Interface | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(1): Span { start: 30, end: 31 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "B":
+after transform: SymbolId(1): [Span { start: 134, end: 135 }]
+rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces5.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing SymbolId: "B"
-Missing SymbolId: "_B"
-Missing ReferenceId: "_B"
-Missing ReferenceId: "createB"
-Missing ReferenceId: "B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
-Bindings mismatch:
-after transform: ScopeId(1): ["_A"]
-rebuilt        : ScopeId(1): ["B", "_A"]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(2), SymbolId(5)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Symbol reference IDs mismatch for "createB":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Reference symbol mismatch for "A":
-after transform: SymbolId(0) "A"
-rebuilt        : SymbolId(0) "A"
+Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Reference symbol mismatch for "B":
+after transform: SymbolId(1) "B"
+rebuilt        : <None>
+Reference symbol mismatch for "B":
+after transform: SymbolId(1) "B"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["B"]
 
 tasks/coverage/typescript/tests/cases/compiler/interface0.ts
 semantic error: Scope children mismatch:
@@ -17294,30 +15340,27 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), Sc
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(8), ScopeId(10), ScopeId(12)]
 
 tasks/coverage/typescript/tests/cases/compiler/interfaceInReopenedModule.ts
-semantic error: Missing SymbolId: "m"
-Missing SymbolId: "_m2"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "n"
-Missing ReferenceId: "m"
-Missing ReferenceId: "m"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(5)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["_defineProperty", "m"]
+rebuilt        : ScopeId(0): ["_defineProperty"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(2): [ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
-Symbol reference IDs mismatch for "n":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(3): [ReferenceId(3)]
+Reference symbol mismatch for "m":
+after transform: SymbolId(0) "m"
+rebuilt        : <None>
+Reference symbol mismatch for "m":
+after transform: SymbolId(0) "m"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: ["require"]
+rebuilt        : ["m", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/interfaceInheritance2.ts
 semantic error: Scope children mismatch:
@@ -17375,49 +15418,31 @@ tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideLocalModu
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideTopLevelModuleWithExport.ts
-semantic error: Missing SymbolId: "x"
-Missing SymbolId: "_x"
-Missing ReferenceId: "_x"
-Missing ReferenceId: "c"
-Missing ReferenceId: "x"
-Missing ReferenceId: "x"
-Missing SymbolId: "xc"
+semantic error: Missing SymbolId: "xc"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4), SymbolId(5)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5), SymbolId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(2)]
-Reference symbol mismatch for "x":
-after transform: SymbolId(0) "x"
-rebuilt        : SymbolId(0) "x"
+Symbol flags mismatch for "x":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "x":
+after transform: SymbolId(0): Span { start: 14, end: 15 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Reference symbol mismatch for "xc":
 after transform: SymbolId(3) "xc"
 rebuilt        : SymbolId(4) "xc"
 
 tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideTopLevelModuleWithoutExport.ts
-semantic error: Missing SymbolId: "x"
-Missing SymbolId: "_x"
-Missing ReferenceId: "_x"
-Missing ReferenceId: "c"
-Missing ReferenceId: "x"
-Missing ReferenceId: "x"
-Missing SymbolId: "xc"
+semantic error: Missing SymbolId: "xc"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4), SymbolId(5)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5), SymbolId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(2)]
-Reference symbol mismatch for "x":
-after transform: SymbolId(0) "x"
-rebuilt        : SymbolId(0) "x"
+Symbol flags mismatch for "x":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "x":
+after transform: SymbolId(0): Span { start: 14, end: 15 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Reference symbol mismatch for "xc":
 after transform: SymbolId(3) "xc"
 rebuilt        : SymbolId(4) "xc"
@@ -17432,67 +15457,49 @@ tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideLocalModul
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideTopLevelModuleWithExport.ts
-semantic error: Missing SymbolId: "a"
-Missing SymbolId: "_a"
-Missing ReferenceId: "_a"
-Missing ReferenceId: "weekend"
-Missing ReferenceId: "a"
-Missing ReferenceId: "a"
-Missing SymbolId: "b"
+semantic error: Missing SymbolId: "b"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(6)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 Bindings mismatch:
 after transform: ScopeId(2): ["Friday", "Saturday", "Sunday", "weekend"]
 rebuilt        : ScopeId(2): ["weekend"]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "a":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "a":
+after transform: SymbolId(0): Span { start: 14, end: 15 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "weekend":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "weekend":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(8)]
-Reference symbol mismatch for "a":
-after transform: SymbolId(0) "a"
-rebuilt        : SymbolId(0) "a"
 Reference symbol mismatch for "b":
 after transform: SymbolId(5) "b"
 rebuilt        : SymbolId(4) "b"
 
 tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideTopLevelModuleWithoutExport.ts
-semantic error: Missing SymbolId: "a"
-Missing SymbolId: "_a"
-Missing ReferenceId: "_a"
-Missing ReferenceId: "weekend"
-Missing ReferenceId: "a"
-Missing ReferenceId: "a"
-Missing SymbolId: "b"
+semantic error: Missing SymbolId: "b"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(6)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 Bindings mismatch:
 after transform: ScopeId(2): ["Friday", "Saturday", "Sunday", "weekend"]
 rebuilt        : ScopeId(2): ["weekend"]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "a":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "a":
+after transform: SymbolId(0): Span { start: 14, end: 15 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "weekend":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "weekend":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(8)]
-Reference symbol mismatch for "a":
-after transform: SymbolId(0) "a"
-rebuilt        : SymbolId(0) "a"
 Reference symbol mismatch for "b":
 after transform: SymbolId(5) "b"
 rebuilt        : SymbolId(4) "b"
@@ -17509,28 +15516,19 @@ tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideLocalM
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideTopLevelModuleWithExport.ts
-semantic error: Missing SymbolId: "a"
-Missing SymbolId: "_a"
-Missing ReferenceId: "_a"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "a"
-Missing ReferenceId: "a"
-Missing SymbolId: "b"
+semantic error: Missing SymbolId: "b"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4), SymbolId(5)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5), SymbolId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Symbol flags mismatch for "a":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "a":
+after transform: SymbolId(0): Span { start: 14, end: 15 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "foo":
 after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(2)]
-Reference symbol mismatch for "a":
-after transform: SymbolId(0) "a"
-rebuilt        : SymbolId(0) "a"
 Reference symbol mismatch for "b":
 after transform: SymbolId(3) "b"
 rebuilt        : SymbolId(4) "b"
@@ -17539,28 +15537,19 @@ after transform: SymbolId(3) "b"
 rebuilt        : SymbolId(4) "b"
 
 tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideTopLevelModuleWithoutExport.ts
-semantic error: Missing SymbolId: "a"
-Missing SymbolId: "_a"
-Missing ReferenceId: "_a"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "a"
-Missing ReferenceId: "a"
-Missing SymbolId: "b"
+semantic error: Missing SymbolId: "b"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4), SymbolId(5)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5), SymbolId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Symbol flags mismatch for "a":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "a":
+after transform: SymbolId(0): Span { start: 14, end: 15 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "foo":
 after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(2)]
-Reference symbol mismatch for "a":
-after transform: SymbolId(0) "a"
-rebuilt        : SymbolId(0) "a"
 Reference symbol mismatch for "b":
 after transform: SymbolId(3) "b"
 rebuilt        : SymbolId(4) "b"
@@ -17578,67 +15567,43 @@ tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleIns
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideTopLevelModuleWithExport.ts
-semantic error: Missing SymbolId: "a"
-Missing SymbolId: "_a"
-Missing SymbolId: "b"
-Missing SymbolId: "_b"
-Missing ReferenceId: "_b"
-Missing ReferenceId: "c"
-Missing ReferenceId: "b"
-Missing ReferenceId: "b"
-Missing ReferenceId: "_a"
-Missing ReferenceId: "_a"
-Missing ReferenceId: "a"
-Missing ReferenceId: "a"
-Missing SymbolId: "b"
+semantic error: Missing SymbolId: "b"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Reference symbol mismatch for "a":
-after transform: SymbolId(0) "a"
-rebuilt        : SymbolId(0) "a"
+Symbol flags mismatch for "a":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "a":
+after transform: SymbolId(0): Span { start: 14, end: 15 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "b":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "b":
+after transform: SymbolId(1): Span { start: 36, end: 37 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Reference symbol mismatch for "b":
 after transform: SymbolId(3) "b"
 rebuilt        : SymbolId(5) "b"
 
 tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideTopLevelModuleWithoutExport.ts
-semantic error: Missing SymbolId: "a"
-Missing SymbolId: "_a"
-Missing SymbolId: "b"
-Missing SymbolId: "_b"
-Missing ReferenceId: "_b"
-Missing ReferenceId: "c"
-Missing ReferenceId: "b"
-Missing ReferenceId: "b"
-Missing ReferenceId: "_a"
-Missing ReferenceId: "_a"
-Missing ReferenceId: "a"
-Missing ReferenceId: "a"
-Missing SymbolId: "b"
+semantic error: Missing SymbolId: "b"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Reference symbol mismatch for "a":
-after transform: SymbolId(0) "a"
-rebuilt        : SymbolId(0) "a"
+Symbol flags mismatch for "a":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "a":
+after transform: SymbolId(0): Span { start: 14, end: 15 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "b":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "b":
+after transform: SymbolId(1): Span { start: 36, end: 37 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Reference symbol mismatch for "b":
 after transform: SymbolId(3) "b"
 rebuilt        : SymbolId(5) "b"
@@ -17743,11 +15708,7 @@ after transform: SymbolId(0): [Span { start: 38, end: 39 }]
 rebuilt        : SymbolId(1): []
 
 tasks/coverage/typescript/tests/cases/compiler/internalImportUnInstantiatedModuleNotReferencingInstanceNoConflict.ts
-semantic error: Missing SymbolId: "B"
-Missing SymbolId: "_B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "B"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A", "B"]
 rebuilt        : ScopeId(0): ["B"]
 Scope children mismatch:
@@ -17759,6 +15720,12 @@ rebuilt        : ScopeId(1): ["A", "_B"]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "B":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(2): Span { start: 58, end: 59 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "A":
 after transform: SymbolId(3): [ReferenceId(0)]
 rebuilt        : SymbolId(2): []
@@ -17809,25 +15776,9 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/intersectionTypeNormalization.ts
-semantic error: Missing SymbolId: "enums"
-Missing SymbolId: "_enums"
-Missing ReferenceId: "_enums"
-Missing ReferenceId: "A"
-Missing ReferenceId: "_enums"
-Missing ReferenceId: "B"
-Missing ReferenceId: "_enums"
-Missing ReferenceId: "C"
-Missing ReferenceId: "enums"
-Missing ReferenceId: "enums"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(7), SymbolId(13), SymbolId(20), SymbolId(25), SymbolId(27), SymbolId(49)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(13)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(26), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(7)]
-Binding symbols mismatch:
-after transform: ScopeId(26): [SymbolId(28), SymbolId(35), SymbolId(40), SymbolId(53)]
-rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7), SymbolId(9), SymbolId(11)]
 Scope flags mismatch:
 after transform: ScopeId(26): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
@@ -17852,23 +15803,29 @@ rebuilt        : ScopeId(6): ["C"]
 Scope flags mismatch:
 after transform: ScopeId(29): ScopeFlags(0x0)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
+Symbol flags mismatch for "enums":
+after transform: SymbolId(27): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "enums":
+after transform: SymbolId(27): Span { start: 1443, end: 1448 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "A":
 after transform: SymbolId(28): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 Symbol reference IDs mismatch for "A":
-after transform: SymbolId(28): [ReferenceId(100)]
+after transform: SymbolId(28): [ReferenceId(100), ReferenceId(112)]
 rebuilt        : SymbolId(7): [ReferenceId(17)]
 Symbol flags mismatch for "B":
 after transform: SymbolId(35): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
 Symbol reference IDs mismatch for "B":
-after transform: SymbolId(35): [ReferenceId(101)]
+after transform: SymbolId(35): [ReferenceId(101), ReferenceId(114)]
 rebuilt        : SymbolId(9): [ReferenceId(28)]
 Symbol flags mismatch for "C":
 after transform: SymbolId(40): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
 Symbol reference IDs mismatch for "C":
-after transform: SymbolId(40): [ReferenceId(102)]
+after transform: SymbolId(40): [ReferenceId(102), ReferenceId(116)]
 rebuilt        : SymbolId(11): [ReferenceId(39)]
 Unresolved references mismatch:
 after transform: ["enums"]
@@ -17998,145 +15955,51 @@ after transform: ["Windows"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/isDeclarationVisibleNodeKinds.ts
-semantic error: Missing SymbolId: "schema"
-Missing SymbolId: "_schema"
-Missing ReferenceId: "_schema"
-Missing ReferenceId: "createValidator1"
-Missing ReferenceId: "schema"
-Missing ReferenceId: "schema"
-Missing SymbolId: "_schema2"
-Missing ReferenceId: "_schema2"
-Missing ReferenceId: "createValidator2"
-Missing ReferenceId: "schema"
-Missing ReferenceId: "schema"
-Missing SymbolId: "_schema3"
-Missing ReferenceId: "_schema3"
-Missing ReferenceId: "createValidator3"
-Missing ReferenceId: "schema"
-Missing ReferenceId: "schema"
-Missing SymbolId: "_schema4"
-Missing ReferenceId: "_schema4"
-Missing ReferenceId: "createValidator4"
-Missing ReferenceId: "schema"
-Missing ReferenceId: "schema"
-Missing SymbolId: "_schema5"
-Missing ReferenceId: "_schema5"
-Missing ReferenceId: "createValidator5"
-Missing ReferenceId: "schema"
-Missing ReferenceId: "schema"
-Missing SymbolId: "_schema6"
-Missing ReferenceId: "_schema6"
-Missing ReferenceId: "createValidator6"
-Missing ReferenceId: "schema"
-Missing ReferenceId: "schema"
-Missing SymbolId: "_schema7"
-Missing ReferenceId: "_schema7"
-Missing ReferenceId: "createValidator7"
-Missing ReferenceId: "schema"
-Missing ReferenceId: "schema"
-Missing SymbolId: "_schema8"
-Missing ReferenceId: "_schema8"
-Missing ReferenceId: "createValidator8"
-Missing ReferenceId: "schema"
-Missing ReferenceId: "schema"
-Missing SymbolId: "_schema9"
-Missing ReferenceId: "_schema9"
-Missing ReferenceId: "T"
-Missing ReferenceId: "schema"
-Missing ReferenceId: "schema"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(29)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(4), SymbolId(30)]
-rebuilt        : ScopeId(3): [SymbolId(4), SymbolId(5)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(7), SymbolId(31)]
-rebuilt        : ScopeId(5): [SymbolId(7), SymbolId(8)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(6): [ScopeId(7)]
 rebuilt        : ScopeId(6): []
-Binding symbols mismatch:
-after transform: ScopeId(8): [SymbolId(10), SymbolId(32)]
-rebuilt        : ScopeId(7): [SymbolId(10), SymbolId(11)]
 Scope flags mismatch:
 after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(9): [ScopeId(10)]
 rebuilt        : ScopeId(8): []
-Binding symbols mismatch:
-after transform: ScopeId(11): [SymbolId(13), SymbolId(33)]
-rebuilt        : ScopeId(9): [SymbolId(13), SymbolId(14)]
 Scope flags mismatch:
 after transform: ScopeId(11): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(9): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(12): [ScopeId(13)]
 rebuilt        : ScopeId(10): []
-Binding symbols mismatch:
-after transform: ScopeId(14): [SymbolId(16), SymbolId(34)]
-rebuilt        : ScopeId(11): [SymbolId(16), SymbolId(17)]
 Scope flags mismatch:
 after transform: ScopeId(14): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(11): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(16): [SymbolId(19), SymbolId(35)]
-rebuilt        : ScopeId(13): [SymbolId(19), SymbolId(20)]
 Scope flags mismatch:
 after transform: ScopeId(16): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(13): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(18): [SymbolId(22), SymbolId(36)]
-rebuilt        : ScopeId(15): [SymbolId(22), SymbolId(23)]
 Scope flags mismatch:
 after transform: ScopeId(18): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(15): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(20): [SymbolId(25), SymbolId(37)]
-rebuilt        : ScopeId(17): [SymbolId(25), SymbolId(26)]
 Scope flags mismatch:
 after transform: ScopeId(20): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(17): ScopeFlags(Function)
-Symbol reference IDs mismatch for "createValidator1":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(2)]
-Symbol reference IDs mismatch for "createValidator2":
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(5): [ReferenceId(7)]
-Symbol reference IDs mismatch for "createValidator3":
-after transform: SymbolId(7): []
-rebuilt        : SymbolId(8): [ReferenceId(12)]
-Symbol reference IDs mismatch for "createValidator4":
-after transform: SymbolId(10): []
-rebuilt        : SymbolId(11): [ReferenceId(17)]
-Symbol reference IDs mismatch for "createValidator5":
-after transform: SymbolId(13): []
-rebuilt        : SymbolId(14): [ReferenceId(22)]
-Symbol reference IDs mismatch for "createValidator6":
-after transform: SymbolId(16): []
-rebuilt        : SymbolId(17): [ReferenceId(27)]
-Symbol reference IDs mismatch for "createValidator7":
-after transform: SymbolId(19): []
-rebuilt        : SymbolId(20): [ReferenceId(32)]
-Symbol reference IDs mismatch for "createValidator8":
-after transform: SymbolId(22): []
-rebuilt        : SymbolId(23): [ReferenceId(37)]
-Symbol reference IDs mismatch for "T":
-after transform: SymbolId(25): []
-rebuilt        : SymbolId(26): [ReferenceId(42)]
+Symbol flags mismatch for "schema":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "schema":
+after transform: SymbolId(0): Span { start: 25, end: 31 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "schema":
+after transform: SymbolId(0): [Span { start: 168, end: 174 }, Span { start: 309, end: 315 }, Span { start: 464, end: 470 }, Span { start: 613, end: 619 }, Span { start: 756, end: 762 }, Span { start: 908, end: 914 }, Span { start: 1055, end: 1061 }, Span { start: 1187, end: 1193 }]
+rebuilt        : SymbolId(0): []
 Unresolved references mismatch:
 after transform: ["Array", "undefined"]
 rebuilt        : ["undefined"]
@@ -18390,38 +16253,24 @@ after transform: ScopeId(0): ["React", "_jsxFileName", "_reactJsxRuntime"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxEmitWithAttributes.ts
-semantic error: Missing SymbolId: "Element"
-Missing SymbolId: "_Element"
-Missing ReferenceId: "_Element"
-Missing ReferenceId: "isElement"
-Missing ReferenceId: "_Element"
-Missing ReferenceId: "createElement"
-Missing ReferenceId: "Element"
-Missing ReferenceId: "Element"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Element", "JSX", "createElement", "toCamelCase"]
 rebuilt        : ScopeId(0): ["Element", "createElement", "toCamelCase"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(7), ScopeId(10)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(7): [SymbolId(3), SymbolId(5), SymbolId(10)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4)]
+Symbol flags mismatch for "Element":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Element":
+after transform: SymbolId(2): Span { start: 358, end: 365 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "isElement":
 after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "isElement":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(2): [ReferenceId(3)]
 Symbol flags mismatch for "createElement":
 after transform: SymbolId(5): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "createElement":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(4): [ReferenceId(5)]
-Reference symbol mismatch for "Element":
-after transform: SymbolId(2) "Element"
-rebuilt        : SymbolId(0) "Element"
 Unresolved references mismatch:
 after transform: ["JSX", "undefined"]
 rebuilt        : ["undefined"]
@@ -18445,38 +16294,24 @@ after transform: ScopeId(0): ["_jsxFileName", "h"]
 rebuilt        : ScopeId(0): ["_jsxFileName"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxFactoryIdentifier.ts
-semantic error: Missing SymbolId: "Element"
-Missing SymbolId: "_Element"
-Missing ReferenceId: "_Element"
-Missing ReferenceId: "isElement"
-Missing ReferenceId: "_Element"
-Missing ReferenceId: "createElement"
-Missing ReferenceId: "Element"
-Missing ReferenceId: "Element"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Element", "JSX", "createElement", "toCamelCase"]
 rebuilt        : ScopeId(0): ["Element", "createElement", "toCamelCase"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(7), ScopeId(10)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(7): [SymbolId(3), SymbolId(5), SymbolId(10)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4)]
+Symbol flags mismatch for "Element":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Element":
+after transform: SymbolId(2): Span { start: 358, end: 365 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "isElement":
 after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "isElement":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(2): [ReferenceId(3)]
 Symbol flags mismatch for "createElement":
 after transform: SymbolId(5): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "createElement":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(4): [ReferenceId(5)]
-Reference symbol mismatch for "Element":
-after transform: SymbolId(2) "Element"
-rebuilt        : SymbolId(0) "Element"
 Unresolved references mismatch:
 after transform: ["JSX", "undefined"]
 rebuilt        : ["undefined"]
@@ -18490,38 +16325,24 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxFactoryQualifiedName.ts
-semantic error: Missing SymbolId: "Element"
-Missing SymbolId: "_Element"
-Missing ReferenceId: "_Element"
-Missing ReferenceId: "isElement"
-Missing ReferenceId: "_Element"
-Missing ReferenceId: "createElement"
-Missing ReferenceId: "Element"
-Missing ReferenceId: "Element"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Element", "JSX", "createElement", "toCamelCase"]
 rebuilt        : ScopeId(0): ["Element", "createElement", "toCamelCase"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(7), ScopeId(10)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(7): [SymbolId(3), SymbolId(5), SymbolId(10)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4)]
+Symbol flags mismatch for "Element":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Element":
+after transform: SymbolId(2): Span { start: 358, end: 365 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "isElement":
 after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "isElement":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(2): [ReferenceId(3)]
 Symbol flags mismatch for "createElement":
 after transform: SymbolId(5): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "createElement":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(4): [ReferenceId(5)]
-Reference symbol mismatch for "Element":
-after transform: SymbolId(2) "Element"
-rebuilt        : SymbolId(0) "Element"
 Unresolved references mismatch:
 after transform: ["JSX", "undefined"]
 rebuilt        : ["undefined"]
@@ -18807,19 +16628,15 @@ tasks/coverage/typescript/tests/cases/compiler/letDeclarations2.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/letKeepNamesOfTopLevelItems.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(4), SymbolId(5)]
-rebuilt        : ScopeId(2): [SymbolId(4), SymbolId(5)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch for "A":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(3): Span { start: 45, end: 46 }
+rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/libdtsFix.ts
 semantic error: Scope children mismatch:
@@ -18832,46 +16649,20 @@ after transform: ["RegExpExecArray"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/listFailure.ts
-semantic error: Missing SymbolId: "Editor"
-Missing SymbolId: "_Editor"
-Missing ReferenceId: "_Editor"
-Missing ReferenceId: "Buffer"
-Missing ReferenceId: "_Editor"
-Missing ReferenceId: "ListRemoveEntry"
-Missing ReferenceId: "_Editor"
-Missing ReferenceId: "ListMakeHead"
-Missing ReferenceId: "_Editor"
-Missing ReferenceId: "ListMakeEntry"
-Missing ReferenceId: "_Editor"
-Missing ReferenceId: "Line"
-Missing ReferenceId: "Editor"
-Missing ReferenceId: "Editor"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(19)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(5), SymbolId(8), SymbolId(10), SymbolId(13), SymbolId(17), SymbolId(18)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(7), SymbolId(9), SymbolId(10), SymbolId(12), SymbolId(15)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol reference IDs mismatch for "Buffer":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(3): [ReferenceId(7)]
-Symbol reference IDs mismatch for "ListRemoveEntry":
-after transform: SymbolId(5): [ReferenceId(31)]
-rebuilt        : SymbolId(7): [ReferenceId(10), ReferenceId(18)]
-Symbol reference IDs mismatch for "ListMakeHead":
-after transform: SymbolId(8): [ReferenceId(0)]
-rebuilt        : SymbolId(9): [ReferenceId(2), ReferenceId(12)]
-Symbol reference IDs mismatch for "ListMakeEntry":
-after transform: SymbolId(10): [ReferenceId(25)]
-rebuilt        : SymbolId(10): [ReferenceId(14), ReferenceId(16)]
+Symbol flags mismatch for "Editor":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Editor":
+after transform: SymbolId(0): Span { start: 7, end: 13 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "List":
 after transform: SymbolId(13): [ReferenceId(2), ReferenceId(4), ReferenceId(10), ReferenceId(12), ReferenceId(15), ReferenceId(18), ReferenceId(20), ReferenceId(23), ReferenceId(27), ReferenceId(29)]
 rebuilt        : SymbolId(12): []
 Symbol reference IDs mismatch for "Line":
-after transform: SymbolId(17): [ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(7)]
+after transform: SymbolId(17): [ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(41)]
 rebuilt        : SymbolId(15): [ReferenceId(3), ReferenceId(20)]
 
 tasks/coverage/typescript/tests/cases/compiler/literalWideningWithCompoundLikeAssignments.ts
@@ -18932,25 +16723,7 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/localImportNameVsGlobalName.ts
-semantic error: Missing SymbolId: "Keyboard"
-Missing SymbolId: "_Keyboard"
-Missing ReferenceId: "_Keyboard"
-Missing ReferenceId: "Key"
-Missing ReferenceId: "Keyboard"
-Missing ReferenceId: "Keyboard"
-Missing SymbolId: "App"
-Missing SymbolId: "_App"
-Missing SymbolId: "Key"
-Missing ReferenceId: "_App"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "App"
-Missing ReferenceId: "App"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(6)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(10)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+semantic error: Missing SymbolId: "Key"
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
@@ -18966,18 +16739,21 @@ rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6), SymbolId(7)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch for "Keyboard":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Keyboard":
+after transform: SymbolId(0): Span { start: 7, end: 15 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Key":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "Key":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(10)]
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(8): [ReferenceId(2), ReferenceId(4), ReferenceId(6)]
-rebuilt        : SymbolId(7): [ReferenceId(15), ReferenceId(16), ReferenceId(18), ReferenceId(20)]
-Reference symbol mismatch for "Keyboard":
-after transform: SymbolId(0) "Keyboard"
-rebuilt        : SymbolId(0) "Keyboard"
+Symbol flags mismatch for "App":
+after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "App":
+after transform: SymbolId(6): Span { start: 72, end: 75 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Reference symbol mismatch for "Key":
 after transform: SymbolId(7) "Key"
 rebuilt        : SymbolId(6) "Key"
@@ -19299,283 +17075,186 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen.ts
-semantic error: Missing SymbolId: "X"
-Missing SymbolId: "_X"
-Missing SymbolId: "Y"
-Missing SymbolId: "_Y"
-Missing ReferenceId: "Y"
-Missing ReferenceId: "Y"
-Missing ReferenceId: "_X"
-Missing ReferenceId: "_X"
-Missing ReferenceId: "X"
-Missing ReferenceId: "X"
-Missing SymbolId: "_X2"
-Missing SymbolId: "Y"
-Missing SymbolId: "_Y2"
-Missing ReferenceId: "_Y2"
-Missing ReferenceId: "B"
-Missing ReferenceId: "Y"
-Missing ReferenceId: "Y"
-Missing ReferenceId: "_X2"
-Missing ReferenceId: "_X2"
-Missing ReferenceId: "X"
-Missing ReferenceId: "X"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(7)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(4), SymbolId(8)]
-rebuilt        : ScopeId(5): [SymbolId(6), SymbolId(7)]
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(5), SymbolId(9)]
-rebuilt        : ScopeId(6): [SymbolId(8), SymbolId(9)]
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(9): [ReferenceId(8)]
+semantic error: Symbol flags mismatch for "X":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "X":
+after transform: SymbolId(0): Span { start: 14, end: 15 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "X":
+after transform: SymbolId(0): [Span { start: 163, end: 164 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch for "Y":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Y":
+after transform: SymbolId(1): Span { start: 36, end: 37 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Y":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Y":
+after transform: SymbolId(4): Span { start: 185, end: 186 }
+rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen2.ts
-semantic error: Missing SymbolId: "my"
-Missing SymbolId: "_my"
-Missing SymbolId: "data"
-Missing SymbolId: "_data"
-Missing SymbolId: "foo"
-Missing SymbolId: "_foo"
-Missing ReferenceId: "_foo"
-Missing ReferenceId: "buz"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "_data"
-Missing ReferenceId: "_data"
-Missing ReferenceId: "data"
-Missing ReferenceId: "data"
-Missing ReferenceId: "_my"
-Missing ReferenceId: "_my"
-Missing ReferenceId: "my"
-Missing ReferenceId: "my"
-Missing SymbolId: "_my2"
-Missing SymbolId: "data"
-Missing SymbolId: "_data2"
-Missing ReferenceId: "data"
-Missing ReferenceId: "data"
-Missing ReferenceId: "_my2"
-Missing ReferenceId: "_my2"
-Missing ReferenceId: "my"
-Missing ReferenceId: "my"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(8)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(3), SymbolId(9)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(4), SymbolId(10)]
-rebuilt        : ScopeId(5): [SymbolId(7), SymbolId(8)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(5), SymbolId(11)]
-rebuilt        : ScopeId(6): [SymbolId(9), SymbolId(10)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
-Symbol reference IDs mismatch for "buz":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(6): [ReferenceId(1)]
+Symbol flags mismatch for "my":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "my":
+after transform: SymbolId(0): Span { start: 7, end: 9 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "my":
+after transform: SymbolId(0): [Span { start: 60, end: 62 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch for "data":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "data":
+after transform: SymbolId(1): Span { start: 10, end: 14 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "foo":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "foo":
+after transform: SymbolId(2): Span { start: 15, end: 18 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
+Symbol flags mismatch for "data":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "data":
+after transform: SymbolId(4): Span { start: 63, end: 67 }
+rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen3.ts
-semantic error: Missing SymbolId: "my"
-Missing SymbolId: "_my"
-Missing SymbolId: "data"
-Missing SymbolId: "_data"
-Missing ReferenceId: "_data"
-Missing ReferenceId: "buz"
-Missing ReferenceId: "data"
-Missing ReferenceId: "data"
-Missing ReferenceId: "_my"
-Missing ReferenceId: "_my"
-Missing ReferenceId: "my"
-Missing ReferenceId: "my"
-Missing SymbolId: "_my2"
-Missing SymbolId: "data"
-Missing SymbolId: "_data2"
-Missing SymbolId: "foo"
-Missing SymbolId: "_foo"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "_data2"
-Missing ReferenceId: "_data2"
-Missing ReferenceId: "data"
-Missing ReferenceId: "data"
-Missing ReferenceId: "_my2"
-Missing ReferenceId: "_my2"
-Missing ReferenceId: "my"
-Missing ReferenceId: "my"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(8)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(9)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(3), SymbolId(10)]
-rebuilt        : ScopeId(4): [SymbolId(5), SymbolId(6)]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(4), SymbolId(11)]
-rebuilt        : ScopeId(5): [SymbolId(7), SymbolId(8)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(5), SymbolId(12)]
-rebuilt        : ScopeId(6): [SymbolId(9), SymbolId(10)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
-Symbol reference IDs mismatch for "buz":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
+Symbol flags mismatch for "my":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "my":
+after transform: SymbolId(0): Span { start: 7, end: 9 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "my":
+after transform: SymbolId(0): [Span { start: 56, end: 58 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch for "data":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "data":
+after transform: SymbolId(1): Span { start: 10, end: 14 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "data":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "data":
+after transform: SymbolId(3): Span { start: 59, end: 63 }
+rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
+Symbol flags mismatch for "foo":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "foo":
+after transform: SymbolId(4): Span { start: 64, end: 67 }
+rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen4.ts
-semantic error: Missing SymbolId: "superContain"
-Missing SymbolId: "_superContain"
-Missing SymbolId: "contain"
-Missing SymbolId: "_contain"
-Missing SymbolId: "my"
-Missing SymbolId: "_my"
-Missing SymbolId: "buz"
-Missing SymbolId: "_buz"
-Missing SymbolId: "data"
-Missing SymbolId: "_data"
-Missing ReferenceId: "_data"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "data"
-Missing ReferenceId: "data"
-Missing ReferenceId: "_buz"
-Missing ReferenceId: "_buz"
-Missing ReferenceId: "buz"
-Missing ReferenceId: "buz"
-Missing ReferenceId: "_my"
-Missing ReferenceId: "_my"
-Missing ReferenceId: "my"
-Missing ReferenceId: "my"
-Missing ReferenceId: "_contain"
-Missing ReferenceId: "_contain"
-Missing SymbolId: "_my2"
-Missing SymbolId: "buz"
-Missing SymbolId: "_buz2"
-Missing SymbolId: "data"
-Missing SymbolId: "_data2"
-Missing ReferenceId: "_data2"
-Missing ReferenceId: "bar"
-Missing ReferenceId: "data"
-Missing ReferenceId: "data"
-Missing ReferenceId: "_buz2"
-Missing ReferenceId: "_buz2"
-Missing ReferenceId: "buz"
-Missing ReferenceId: "buz"
-Missing ReferenceId: "_my2"
-Missing ReferenceId: "_my2"
-Missing ReferenceId: "my"
-Missing ReferenceId: "my"
-Missing ReferenceId: "_contain"
-Missing ReferenceId: "_contain"
-Missing ReferenceId: "contain"
-Missing ReferenceId: "contain"
-Missing ReferenceId: "_superContain"
-Missing ReferenceId: "_superContain"
-Missing ReferenceId: "superContain"
-Missing ReferenceId: "superContain"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(13)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(14)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(3), SymbolId(15)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(4), SymbolId(16)]
-rebuilt        : ScopeId(4): [SymbolId(7), SymbolId(8)]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(5), SymbolId(17)]
-rebuilt        : ScopeId(5): [SymbolId(9), SymbolId(10)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(7): [SymbolId(6), SymbolId(18)]
-rebuilt        : ScopeId(7): [SymbolId(11), SymbolId(12)]
 Scope flags mismatch:
 after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(8): [SymbolId(7), SymbolId(19)]
-rebuilt        : ScopeId(8): [SymbolId(13), SymbolId(14)]
 Scope flags mismatch:
 after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(8): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(9): [SymbolId(8), SymbolId(20)]
-rebuilt        : ScopeId(9): [SymbolId(15), SymbolId(16)]
 Scope flags mismatch:
 after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(9): ScopeFlags(Function)
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(10): [ReferenceId(1)]
-Symbol reference IDs mismatch for "bar":
-after transform: SymbolId(8): []
-rebuilt        : SymbolId(16): [ReferenceId(16)]
+Symbol flags mismatch for "superContain":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "superContain":
+after transform: SymbolId(0): Span { start: 7, end: 19 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "contain":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "contain":
+after transform: SymbolId(1): Span { start: 40, end: 47 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "my":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "my":
+after transform: SymbolId(2): Span { start: 72, end: 74 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "my":
+after transform: SymbolId(2): [Span { start: 202, end: 204 }]
+rebuilt        : SymbolId(4): []
+Symbol flags mismatch for "buz":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "buz":
+after transform: SymbolId(3): Span { start: 75, end: 78 }
+rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
+Symbol flags mismatch for "data":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "data":
+after transform: SymbolId(4): Span { start: 107, end: 111 }
+rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
+Symbol flags mismatch for "buz":
+after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "buz":
+after transform: SymbolId(6): Span { start: 205, end: 208 }
+rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
+Symbol flags mismatch for "data":
+after transform: SymbolId(7): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "data":
+after transform: SymbolId(7): Span { start: 237, end: 241 }
+rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen5.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -19609,34 +17288,21 @@ after transform: ["PropertyDecorator"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/metadataOfClassFromModule.ts
-semantic error: Missing SymbolId: "MyModule"
-Missing SymbolId: "_MyModule"
-Missing ReferenceId: "_MyModule"
-Missing ReferenceId: "inject"
-Missing ReferenceId: "_MyModule"
-Missing ReferenceId: "Leg"
-Missing ReferenceId: "_MyModule"
-Missing ReferenceId: "Person"
-Missing ReferenceId: "MyModule"
-Missing ReferenceId: "MyModule"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(7)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(4), SymbolId(5), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(6), SymbolId(7)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "MyModule":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "MyModule":
+after transform: SymbolId(0): Span { start: 7, end: 15 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "inject":
-after transform: SymbolId(1): [ReferenceId(0)]
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(3)]
 rebuilt        : SymbolId(3): [ReferenceId(2)]
 Symbol reference IDs mismatch for "Leg":
-after transform: SymbolId(4): [ReferenceId(1)]
+after transform: SymbolId(4): [ReferenceId(1), ReferenceId(5)]
 rebuilt        : SymbolId(6): [ReferenceId(4)]
-Symbol reference IDs mismatch for "Person":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(7): [ReferenceId(7)]
 
 tasks/coverage/typescript/tests/cases/compiler/metadataOfEventAlias.ts
 semantic error: Scope children mismatch:
@@ -19694,19 +17360,7 @@ after transform: ScopeId(0): ["Class1", "Class2", "decorate"]
 rebuilt        : ScopeId(0): ["Class2", "decorate"]
 
 tasks/coverage/typescript/tests/cases/compiler/methodContainingLocalFunction.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "exhibitBug"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "E"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(8), SymbolId(14), SymbolId(19), SymbolId(23)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(6), SymbolId(10), SymbolId(14), SymbolId(19)]
-Binding symbols mismatch:
-after transform: ScopeId(13): [SymbolId(20), SymbolId(27)]
-rebuilt        : ScopeId(13): [SymbolId(15), SymbolId(16)]
+semantic error: Missing ReferenceId: "E"
 Scope flags mismatch:
 after transform: ScopeId(13): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(13): ScopeFlags(Function)
@@ -19716,14 +17370,17 @@ rebuilt        : ScopeId(16): ["E"]
 Scope flags mismatch:
 after transform: ScopeId(16): ScopeFlags(0x0)
 rebuilt        : ScopeId(16): ScopeFlags(Function)
-Symbol reference IDs mismatch for "exhibitBug":
-after transform: SymbolId(20): []
-rebuilt        : SymbolId(16): [ReferenceId(11)]
+Symbol flags mismatch for "M":
+after transform: SymbolId(19): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(19): Span { start: 758, end: 759 }
+rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 Symbol flags mismatch for "E":
 after transform: SymbolId(23): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(19): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "E":
-after transform: SymbolId(28): [ReferenceId(14), ReferenceId(15), ReferenceId(16)]
+after transform: SymbolId(28): [ReferenceId(18), ReferenceId(19), ReferenceId(20)]
 rebuilt        : SymbolId(20): [ReferenceId(14), ReferenceId(15), ReferenceId(17), ReferenceId(18)]
 Symbol reference IDs mismatch for "localFunction":
 after transform: SymbolId(25): [ReferenceId(13)]
@@ -19848,12 +17505,93 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(5), ScopeId(7), Sc
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(6), ScopeId(8)]
 
 tasks/coverage/typescript/tests/cases/compiler/mixingFunctionAndAmbientModule1.ts
-semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
-Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+semantic error: Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(1): [ScopeId(2)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Scope children mismatch:
+after transform: ScopeId(4): [ScopeId(5), ScopeId(6), ScopeId(7)]
+rebuilt        : ScopeId(3): [ScopeId(4)]
+Bindings mismatch:
+after transform: ScopeId(8): ["My", "_C"]
+rebuilt        : ScopeId(5): ["_C"]
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Scope children mismatch:
+after transform: ScopeId(8): [ScopeId(9), ScopeId(10)]
+rebuilt        : ScopeId(5): []
+Bindings mismatch:
+after transform: ScopeId(11): ["My", "_D"]
+rebuilt        : ScopeId(6): ["_D"]
+Scope flags mismatch:
+after transform: ScopeId(11): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Scope children mismatch:
+after transform: ScopeId(11): [ScopeId(12), ScopeId(13), ScopeId(14)]
+rebuilt        : ScopeId(6): []
+Bindings mismatch:
+after transform: ScopeId(15): ["My", "_E"]
+rebuilt        : ScopeId(7): ["_E"]
+Scope flags mismatch:
+after transform: ScopeId(15): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
+Scope children mismatch:
+after transform: ScopeId(15): [ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19)]
+rebuilt        : ScopeId(7): []
+Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "My":
+after transform: SymbolId(1): SymbolFlags(FunctionScopedVariable | NameSpaceModule | Ambient)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol span mismatch for "My":
+after transform: SymbolId(1): Span { start: 30, end: 32 }
+rebuilt        : SymbolId(2): Span { start: 84, end: 86 }
+Symbol redeclarations mismatch for "My":
+after transform: SymbolId(1): [Span { start: 84, end: 86 }]
+rebuilt        : SymbolId(2): []
+Symbol flags mismatch for "B":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(4): Span { start: 112, end: 113 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
+Symbol flags mismatch for "My":
+after transform: SymbolId(5): SymbolFlags(FunctionScopedVariable | NameSpaceModule | Ambient)
+rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
+Symbol span mismatch for "My":
+after transform: SymbolId(5): Span { start: 135, end: 137 }
+rebuilt        : SymbolId(6): Span { start: 218, end: 220 }
+Symbol redeclarations mismatch for "My":
+after transform: SymbolId(5): [Span { start: 218, end: 220 }]
+rebuilt        : SymbolId(6): []
+Symbol flags mismatch for "C":
+after transform: SymbolId(9): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "C":
+after transform: SymbolId(9): Span { start: 243, end: 244 }
+rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
+Symbol flags mismatch for "D":
+after transform: SymbolId(13): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "D":
+after transform: SymbolId(13): Span { start: 354, end: 355 }
+rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
+Symbol flags mismatch for "E":
+after transform: SymbolId(18): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "E":
+after transform: SymbolId(18): Span { start: 499, end: 500 }
+rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/modFunctionCrash.ts
 semantic error: Bindings mismatch:
@@ -19909,42 +17647,9 @@ after transform: SymbolId(0) "a"
 rebuilt        : SymbolId(0) "a"
 
 tasks/coverage/typescript/tests/cases/compiler/moduleAliasInterface.ts
-semantic error: Missing SymbolId: "_modes"
-Missing SymbolId: "_modes2"
-Missing ReferenceId: "_modes2"
-Missing ReferenceId: "Mode"
-Missing ReferenceId: "_modes"
-Missing ReferenceId: "_modes"
-Missing SymbolId: "editor"
-Missing SymbolId: "_editor"
-Missing ReferenceId: "editor"
-Missing ReferenceId: "editor"
-Missing SymbolId: "editor2"
-Missing SymbolId: "_editor2"
-Missing SymbolId: "Foo"
-Missing SymbolId: "_Foo"
-Missing ReferenceId: "_Foo"
-Missing ReferenceId: "Bar"
-Missing ReferenceId: "Foo"
-Missing ReferenceId: "Foo"
-Missing ReferenceId: "editor2"
-Missing ReferenceId: "editor2"
-Missing SymbolId: "A1"
-Missing SymbolId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "A1C1"
-Missing ReferenceId: "A1"
-Missing ReferenceId: "A1"
-Missing SymbolId: "B1"
-Missing SymbolId: "_B"
-Missing ReferenceId: "B1"
-Missing ReferenceId: "B1"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["A1", "B1", "_modes", "editor", "editor2", "modesOuter"]
 rebuilt        : ScopeId(0): ["A1", "B1", "_modes", "editor", "editor2"]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(2), SymbolId(28)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
@@ -19957,21 +17662,12 @@ rebuilt        : ScopeId(3): ["Bug", "_editor", "i"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(8): [SymbolId(12), SymbolId(13), SymbolId(16), SymbolId(18), SymbolId(30)]
-rebuilt        : ScopeId(7): [SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(16), SymbolId(19)]
 Scope flags mismatch:
 after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(11): [SymbolId(17), SymbolId(31)]
-rebuilt        : ScopeId(10): [SymbolId(17), SymbolId(18)]
 Scope flags mismatch:
 after transform: ScopeId(11): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(10): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(15): [SymbolId(23), SymbolId(32)]
-rebuilt        : ScopeId(14): [SymbolId(23), SymbolId(24)]
 Scope flags mismatch:
 after transform: ScopeId(15): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(14): ScopeFlags(Function)
@@ -19984,15 +17680,48 @@ rebuilt        : ScopeId(16): ["_B", "c", "i"]
 Scope flags mismatch:
 after transform: ScopeId(18): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(16): ScopeFlags(Function)
-Symbol reference IDs mismatch for "Mode":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Symbol reference IDs mismatch for "Bar":
-after transform: SymbolId(17): []
-rebuilt        : SymbolId(18): [ReferenceId(7)]
-Symbol reference IDs mismatch for "A1C1":
-after transform: SymbolId(23): []
-rebuilt        : SymbolId(24): [ReferenceId(13)]
+Symbol flags mismatch for "_modes":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "_modes":
+after transform: SymbolId(0): Span { start: 7, end: 13 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "_modes":
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(5), ReferenceId(16), ReferenceId(17)]
+rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
+Symbol flags mismatch for "editor":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "editor":
+after transform: SymbolId(3): Span { start: 165, end: 171 }
+rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
+Symbol flags mismatch for "editor2":
+after transform: SymbolId(11): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "editor2":
+after transform: SymbolId(11): Span { start: 493, end: 500 }
+rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Foo":
+after transform: SymbolId(16): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Foo":
+after transform: SymbolId(16): Span { start: 685, end: 688 }
+rebuilt        : SymbolId(16): Span { start: 0, end: 0 }
+Symbol flags mismatch for "A1":
+after transform: SymbolId(21): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(22): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A1":
+after transform: SymbolId(21): Span { start: 799, end: 801 }
+rebuilt        : SymbolId(22): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "A1":
+after transform: SymbolId(21): [ReferenceId(11), ReferenceId(28), ReferenceId(29)]
+rebuilt        : SymbolId(22): [ReferenceId(14), ReferenceId(15)]
+Symbol flags mismatch for "B1":
+after transform: SymbolId(24): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(25): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B1":
+after transform: SymbolId(24): Span { start: 868, end: 870 }
+rebuilt        : SymbolId(25): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["Foo"]
 rebuilt        : []
@@ -20306,98 +18035,51 @@ after transform: ScopeId(0): ["ISpinButton"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/moduleMemberWithoutTypeAnnotation1.ts
-semantic error: Missing SymbolId: "TypeScript"
-Missing SymbolId: "_TypeScript"
-Missing SymbolId: "Parser"
-Missing SymbolId: "_Parser"
-Missing ReferenceId: "Parser"
-Missing ReferenceId: "Parser"
-Missing ReferenceId: "_TypeScript"
-Missing ReferenceId: "_TypeScript"
-Missing ReferenceId: "TypeScript"
-Missing ReferenceId: "TypeScript"
-Missing SymbolId: "_TypeScript2"
-Missing ReferenceId: "_TypeScript2"
-Missing ReferenceId: "PositionedElement"
-Missing ReferenceId: "_TypeScript2"
-Missing ReferenceId: "PositionedToken"
-Missing ReferenceId: "TypeScript"
-Missing ReferenceId: "TypeScript"
-Missing SymbolId: "_TypeScript3"
-Missing ReferenceId: "_TypeScript3"
-Missing ReferenceId: "SyntaxNode"
-Missing ReferenceId: "TypeScript"
-Missing ReferenceId: "TypeScript"
-Missing SymbolId: "_TypeScript4"
-Missing SymbolId: "Syntax"
-Missing SymbolId: "_Syntax"
-Missing ReferenceId: "_Syntax"
-Missing ReferenceId: "childIndex"
-Missing ReferenceId: "_Syntax"
-Missing ReferenceId: "VariableWidthTokenWithTrailingTrivia"
-Missing ReferenceId: "Syntax"
-Missing ReferenceId: "Syntax"
-Missing ReferenceId: "_TypeScript4"
-Missing ReferenceId: "_TypeScript4"
-Missing ReferenceId: "TypeScript"
-Missing ReferenceId: "TypeScript"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(24)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(25)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(5), SymbolId(7), SymbolId(26)]
-rebuilt        : ScopeId(5): [SymbolId(5), SymbolId(6), SymbolId(8)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(10)]
 rebuilt        : ScopeId(5): [ScopeId(6), ScopeId(8)]
-Binding symbols mismatch:
-after transform: ScopeId(12): [SymbolId(11), SymbolId(27)]
-rebuilt        : ScopeId(10): [SymbolId(12), SymbolId(13)]
 Scope flags mismatch:
 after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(10): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(16): [SymbolId(18), SymbolId(28)]
-rebuilt        : ScopeId(14): [SymbolId(20), SymbolId(21)]
 Scope flags mismatch:
 after transform: ScopeId(16): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(14): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(17): [SymbolId(19), SymbolId(20), SymbolId(29)]
-rebuilt        : ScopeId(15): [SymbolId(22), SymbolId(23), SymbolId(24)]
 Scope flags mismatch:
 after transform: ScopeId(17): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(15): ScopeFlags(Function)
+Symbol flags mismatch for "TypeScript":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "TypeScript":
+after transform: SymbolId(0): Span { start: 7, end: 17 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "TypeScript":
+after transform: SymbolId(0): [Span { start: 146, end: 156 }, Span { start: 535, end: 545 }, Span { start: 879, end: 889 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch for "Parser":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Parser":
+after transform: SymbolId(1): Span { start: 18, end: 24 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "PositionedElement":
-after transform: SymbolId(5): [ReferenceId(3)]
+after transform: SymbolId(5): [ReferenceId(3), ReferenceId(19)]
 rebuilt        : SymbolId(6): [ReferenceId(8)]
-Symbol reference IDs mismatch for "PositionedToken":
-after transform: SymbolId(7): []
-rebuilt        : SymbolId(8): [ReferenceId(10)]
-Symbol reference IDs mismatch for "SyntaxNode":
-after transform: SymbolId(11): []
-rebuilt        : SymbolId(13): [ReferenceId(15)]
-Symbol reference IDs mismatch for "childIndex":
-after transform: SymbolId(19): []
-rebuilt        : SymbolId(23): [ReferenceId(19)]
-Symbol reference IDs mismatch for "VariableWidthTokenWithTrailingTrivia":
-after transform: SymbolId(20): []
-rebuilt        : SymbolId(24): [ReferenceId(24)]
+Symbol flags mismatch for "Syntax":
+after transform: SymbolId(18): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(21): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Syntax":
+after transform: SymbolId(18): Span { start: 890, end: 896 }
+rebuilt        : SymbolId(21): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["ISyntaxToken", "PositionedElement", "PositionedToken", "Syntax", "SyntaxNode"]
 rebuilt        : ["PositionedToken", "Syntax"]
@@ -20409,33 +18091,21 @@ tasks/coverage/typescript/tests/cases/compiler/moduleMemberWithoutTypeAnnotation
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/moduleMerge.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Missing SymbolId: "_A2"
-Missing ReferenceId: "_A2"
-Missing ReferenceId: "B"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(2), SymbolId(4)]
-rebuilt        : ScopeId(4): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(3)]
+Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 101, end: 102 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "A":
+after transform: SymbolId(0): [Span { start: 227, end: 228 }]
+rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/moduleMergeConstructor.ts
 semantic error: Symbol reference IDs mismatch for "foo":
@@ -20443,19 +18113,15 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/moduleNoEmit.ts
-semantic error: Missing SymbolId: "Foo"
-Missing SymbolId: "_Foo"
-Missing ReferenceId: "Foo"
-Missing ReferenceId: "Foo"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1)]
-rebuilt        : ScopeId(1): [SymbolId(1)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "Foo":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Foo":
+after transform: SymbolId(0): Span { start: 7, end: 10 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/moduleNodeImportRequireEmit.ts
 semantic error: Missing SymbolId: "foo"
@@ -20519,81 +18185,47 @@ after transform: SymbolId(0): [Span { start: 19, end: 20 }]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/moduleReopenedTypeOtherBlock.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "C1"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Missing SymbolId: "_M2"
-Missing ReferenceId: "_M2"
-Missing ReferenceId: "C2"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(3), SymbolId(5)]
-rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Symbol reference IDs mismatch for "C1":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Symbol reference IDs mismatch for "C2":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(4): [ReferenceId(5)]
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "M":
+after transform: SymbolId(0): [Span { start: 82, end: 83 }]
+rebuilt        : SymbolId(0): []
 Unresolved references mismatch:
 after transform: ["I"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/moduleReopenedTypeSameBlock.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "C1"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Missing SymbolId: "_M2"
-Missing ReferenceId: "_M2"
-Missing ReferenceId: "C2"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(3), SymbolId(5)]
-rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(3): [ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(3): [ScopeId(4)]
-Symbol reference IDs mismatch for "C1":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Symbol reference IDs mismatch for "C2":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(4): [ReferenceId(5)]
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "M":
+after transform: SymbolId(0): [Span { start: 40, end: 41 }]
+rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/moduleResolutionAsTypeReferenceDirective.ts
 semantic error: Bindings mismatch:
@@ -20794,74 +18426,33 @@ after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/moduleScopingBug.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing SymbolId: "X"
-Missing SymbolId: "_X"
-Missing ReferenceId: "X"
-Missing ReferenceId: "X"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(6), SymbolId(8)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(7)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(7), SymbolId(9)]
-rebuilt        : ScopeId(5): [SymbolId(8), SymbolId(9)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "X":
+after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "X":
+after transform: SymbolId(6): Span { start: 207, end: 208 }
+rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt.ts
-semantic error: Missing SymbolId: "Z"
-Missing SymbolId: "_Z"
-Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "bar"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "_Z"
-Missing ReferenceId: "_Z"
-Missing ReferenceId: "Z"
-Missing ReferenceId: "Z"
-Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing SymbolId: "M"
-Missing SymbolId: "_M2"
-Missing SymbolId: "M"
-Missing ReferenceId: "_M2"
-Missing ReferenceId: "bar"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+semantic error: Missing SymbolId: "M"
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(8)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(4), SymbolId(9)]
-rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7)]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
@@ -20871,62 +18462,41 @@ rebuilt        : ScopeId(5): [SymbolId(8), SymbolId(9), SymbolId(10)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
-Symbol reference IDs mismatch for "bar":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Symbol reference IDs mismatch for "bar":
-after transform: SymbolId(6): []
-rebuilt        : SymbolId(10): [ReferenceId(10)]
-Reference symbol mismatch for "Z":
-after transform: SymbolId(0) "Z"
-rebuilt        : SymbolId(0) "Z"
+Symbol flags mismatch for "Z":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Z":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "M":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(1): Span { start: 9, end: 10 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "A":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(3): Span { start: 75, end: 76 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
+Symbol flags mismatch for "M":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(4): Span { start: 77, end: 78 }
+rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 Reference symbol mismatch for "M":
 after transform: SymbolId(5) "M"
 rebuilt        : SymbolId(9) "M"
 
 tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt2.ts
-semantic error: Missing SymbolId: "Z"
-Missing SymbolId: "_Z"
-Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "bar"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "_Z"
-Missing ReferenceId: "_Z"
-Missing ReferenceId: "Z"
-Missing ReferenceId: "Z"
-Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing SymbolId: "M"
-Missing SymbolId: "_M2"
-Missing ReferenceId: "_M2"
-Missing ReferenceId: "bar"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(8)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(4), SymbolId(9)]
-rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7)]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
@@ -20936,60 +18506,48 @@ rebuilt        : ScopeId(5): ["_M2", "bar"]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
-Symbol reference IDs mismatch for "bar":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Symbol reference IDs mismatch for "bar":
-after transform: SymbolId(6): []
-rebuilt        : SymbolId(9): [ReferenceId(9)]
+Symbol flags mismatch for "Z":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Z":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "Z":
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(8), ReferenceId(9)]
+rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7)]
+Symbol flags mismatch for "M":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(1): Span { start: 9, end: 10 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "A":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(3): Span { start: 75, end: 76 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
+Symbol flags mismatch for "M":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(4): Span { start: 77, end: 78 }
+rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "M":
+after transform: SymbolId(4): [ReferenceId(12), ReferenceId(14)]
+rebuilt        : SymbolId(7): [ReferenceId(10), ReferenceId(11), ReferenceId(12)]
 Reference symbol mismatch for "M":
 after transform: SymbolId(5) "M"
 rebuilt        : SymbolId(7) "M"
 
 tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt4.ts
-semantic error: Missing SymbolId: "Z"
-Missing SymbolId: "_Z"
-Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "bar"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "_Z"
-Missing ReferenceId: "_Z"
-Missing ReferenceId: "Z"
-Missing ReferenceId: "Z"
-Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing SymbolId: "M"
-Missing SymbolId: "_M2"
-Missing SymbolId: "M"
-Missing ReferenceId: "_M2"
-Missing ReferenceId: "bar"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+semantic error: Missing SymbolId: "M"
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(8)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(4), SymbolId(9)]
-rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7)]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
@@ -21002,62 +18560,41 @@ rebuilt        : ScopeId(5): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(5): [ScopeId(6), ScopeId(7)]
 rebuilt        : ScopeId(5): [ScopeId(6)]
-Symbol reference IDs mismatch for "bar":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Symbol reference IDs mismatch for "bar":
-after transform: SymbolId(6): []
-rebuilt        : SymbolId(10): [ReferenceId(10)]
-Reference symbol mismatch for "Z":
-after transform: SymbolId(0) "Z"
-rebuilt        : SymbolId(0) "Z"
+Symbol flags mismatch for "Z":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Z":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "M":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(1): Span { start: 9, end: 10 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "A":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(3): Span { start: 75, end: 76 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
+Symbol flags mismatch for "M":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(4): Span { start: 77, end: 78 }
+rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 Reference symbol mismatch for "M":
 after transform: SymbolId(5) "M"
 rebuilt        : SymbolId(9) "M"
 
 tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt6.ts
-semantic error: Missing SymbolId: "Z"
-Missing SymbolId: "_Z"
-Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "bar"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "_Z"
-Missing ReferenceId: "_Z"
-Missing ReferenceId: "Z"
-Missing ReferenceId: "Z"
-Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing SymbolId: "M"
-Missing SymbolId: "_M2"
-Missing ReferenceId: "_M2"
-Missing ReferenceId: "bar"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(8)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(4), SymbolId(9)]
-rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7)]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
@@ -21067,12 +18604,33 @@ rebuilt        : ScopeId(5): ["_M2", "bar"]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
-Symbol reference IDs mismatch for "bar":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Symbol reference IDs mismatch for "bar":
-after transform: SymbolId(6): []
-rebuilt        : SymbolId(9): [ReferenceId(9)]
+Symbol flags mismatch for "Z":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Z":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "Z":
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(7), ReferenceId(8)]
+rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7)]
+Symbol flags mismatch for "M":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(1): Span { start: 9, end: 10 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "A":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(3): Span { start: 75, end: 76 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
+Symbol flags mismatch for "M":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(4): Span { start: 77, end: 78 }
+rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/moduleSymbolMerging.ts
 semantic error: Bindings mismatch:
@@ -21095,19 +18653,18 @@ Namespaces exporting non-const are not supported by Babel. Change to const or se
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/moduleWithTryStatement1.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(2)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "M":
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2)]
+rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 Reference symbol mismatch for "M":
 after transform: <None>
 rebuilt        : SymbolId(0) "M"
@@ -21219,48 +18776,32 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/nameCollisionWithBlockScopedVariable1.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "C"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Missing SymbolId: "_M2"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(4)]
-rebuilt        : ScopeId(3): [SymbolId(3)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "M":
+after transform: SymbolId(0): [Span { start: 43, end: 44 }]
+rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/namedFunctionExpressionInModule.ts
-semantic error: Missing SymbolId: "Variables"
-Missing SymbolId: "_Variables"
-Missing ReferenceId: "Variables"
-Missing ReferenceId: "Variables"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "Variables":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Variables":
+after transform: SymbolId(0): Span { start: 7, end: 16 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/namespaces1.ts
 semantic error: Bindings mismatch:
@@ -21274,39 +18815,24 @@ after transform: ["X"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/namespaces2.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing SymbolId: "B"
-Missing SymbolId: "_B"
-Missing ReferenceId: "_B"
-Missing ReferenceId: "C"
-Missing ReferenceId: "B"
-Missing ReferenceId: "B"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(5)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Reference symbol mismatch for "A":
-after transform: SymbolId(0) "A"
-rebuilt        : SymbolId(0) "A"
+Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "B":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(1): Span { start: 29, end: 30 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["A"]
 rebuilt        : []
@@ -21714,29 +19240,24 @@ after transform: ["Array"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/nestedModulePrivateAccess.ts
-semantic error: Missing SymbolId: "a"
-Missing SymbolId: "_a"
-Missing SymbolId: "b"
-Missing SymbolId: "_b"
-Missing ReferenceId: "b"
-Missing ReferenceId: "b"
-Missing ReferenceId: "a"
-Missing ReferenceId: "a"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(3), SymbolId(5)]
-rebuilt        : ScopeId(2): [SymbolId(4), SymbolId(5)]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch for "a":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "a":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "b":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "b":
+after transform: SymbolId(2): Span { start: 45, end: 46 }
+rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/nestedObjectRest.ts
 semantic error: Bindings mismatch:
@@ -21759,24 +19280,15 @@ after transform: SymbolId(8): ScopeId(2)
 rebuilt        : SymbolId(8): ScopeId(0)
 
 tasks/coverage/typescript/tests/cases/compiler/nestedSelf.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "C"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(4)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(3): [ReferenceId(4)]
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/nestedSuperCallEmit.ts
 semantic error: Unresolved reference IDs mismatch for "Error":
@@ -21814,19 +19326,15 @@ after transform: SymbolId(14): [ReferenceId(6), ReferenceId(11), ReferenceId(13)
 rebuilt        : SymbolId(5): []
 
 tasks/coverage/typescript/tests/cases/compiler/newArrays.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(4)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "Foo":
 after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2)]
 rebuilt        : SymbolId(3): []
@@ -22698,37 +20206,29 @@ after transform: SymbolId(5): [ReferenceId(1)]
 rebuilt        : SymbolId(5): []
 
 tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOverNonCTLambdas.ts
-semantic error: Missing SymbolId: "Bugs"
-Missing SymbolId: "_Bugs"
-Missing ReferenceId: "Bugs"
-Missing ReferenceId: "Bugs"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(9), SymbolId(11)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(10), SymbolId(12)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(14)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "Bugs":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Bugs":
+after transform: SymbolId(0): Span { start: 7, end: 11 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOverNonCTObjectLit.ts
-semantic error: Missing SymbolId: "Bugs"
-Missing SymbolId: "_Bugs"
-Missing ReferenceId: "Bugs"
-Missing ReferenceId: "Bugs"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(4), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
+Symbol flags mismatch for "Bugs":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Bugs":
+after transform: SymbolId(0): Span { start: 7, end: 11 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/overloadResolutionWithAny.ts
 semantic error: Unresolved references mismatch:
@@ -23098,141 +20598,36 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/privacyAccessorDeclFile.ts
-semantic error: Missing SymbolId: "publicModule"
-Missing SymbolId: "_publicModule"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClass"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassWithWithPrivateGetAccessorTypes"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassWithWithPublicGetAccessorTypes"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassWithWithPrivateSetAccessorTypes"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassWithWithPublicSetAccessorTypes"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassWithPrivateModuleGetAccessorTypes"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassWithPrivateModuleSetAccessorTypes"
-Missing ReferenceId: "publicModule"
-Missing ReferenceId: "publicModule"
-Missing SymbolId: "privateModule"
-Missing SymbolId: "_privateModule"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClass"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClassWithWithPrivateGetAccessorTypes"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClassWithWithPublicGetAccessorTypes"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClassWithWithPrivateSetAccessorTypes"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClassWithWithPublicSetAccessorTypes"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClassWithPrivateModuleGetAccessorTypes"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClassWithPrivateModuleSetAccessorTypes"
-Missing ReferenceId: "privateModule"
-Missing ReferenceId: "privateModule"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(11), SymbolId(16), SymbolId(21), SymbolId(26), SymbolId(27), SymbolId(30), SymbolId(31), SymbolId(34), SymbolId(69)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(11), SymbolId(16), SymbolId(21), SymbolId(26), SymbolId(27), SymbolId(30), SymbolId(31), SymbolId(34), SymbolId(70)]
-Binding symbols mismatch:
-after transform: ScopeId(75): [SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(46), SymbolId(51), SymbolId(56), SymbolId(61), SymbolId(62), SymbolId(65), SymbolId(66), SymbolId(104)]
-rebuilt        : ScopeId(75): [SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(42), SymbolId(47), SymbolId(52), SymbolId(57), SymbolId(62), SymbolId(63), SymbolId(66), SymbolId(67)]
-Binding symbols mismatch:
-after transform: ScopeId(150): [SymbolId(70), SymbolId(71), SymbolId(72), SymbolId(73), SymbolId(74), SymbolId(75), SymbolId(76), SymbolId(81), SymbolId(86), SymbolId(91), SymbolId(96), SymbolId(97), SymbolId(100), SymbolId(101), SymbolId(105)]
-rebuilt        : ScopeId(150): [SymbolId(71), SymbolId(72), SymbolId(73), SymbolId(74), SymbolId(75), SymbolId(76), SymbolId(77), SymbolId(78), SymbolId(83), SymbolId(88), SymbolId(93), SymbolId(98), SymbolId(99), SymbolId(102), SymbolId(103)]
-Symbol reference IDs mismatch for "privateClass":
+semantic error: Symbol reference IDs mismatch for "privateClass":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35), ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43)]
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11)]
 Symbol reference IDs mismatch for "publicClass":
 after transform: SymbolId(1): [ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47)]
 rebuilt        : SymbolId(1): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15)]
+Symbol flags mismatch for "publicModule":
+after transform: SymbolId(34): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(34): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "publicModule":
+after transform: SymbolId(34): Span { start: 5395, end: 5407 }
+rebuilt        : SymbolId(34): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "privateClass":
 after transform: SymbolId(35): [ReferenceId(60), ReferenceId(61), ReferenceId(62), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(80), ReferenceId(81), ReferenceId(82), ReferenceId(83), ReferenceId(92), ReferenceId(93), ReferenceId(94), ReferenceId(95), ReferenceId(100), ReferenceId(101), ReferenceId(102), ReferenceId(103)]
 rebuilt        : SymbolId(36): [ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37)]
 Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(36): [ReferenceId(68), ReferenceId(69), ReferenceId(70), ReferenceId(71), ReferenceId(72), ReferenceId(73), ReferenceId(74), ReferenceId(75), ReferenceId(84), ReferenceId(85), ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(90), ReferenceId(91), ReferenceId(96), ReferenceId(97), ReferenceId(98), ReferenceId(99), ReferenceId(104), ReferenceId(105), ReferenceId(106), ReferenceId(107)]
+after transform: SymbolId(36): [ReferenceId(68), ReferenceId(69), ReferenceId(70), ReferenceId(71), ReferenceId(72), ReferenceId(73), ReferenceId(74), ReferenceId(75), ReferenceId(84), ReferenceId(85), ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(90), ReferenceId(91), ReferenceId(96), ReferenceId(97), ReferenceId(98), ReferenceId(99), ReferenceId(104), ReferenceId(105), ReferenceId(106), ReferenceId(107), ReferenceId(181)]
 rebuilt        : SymbolId(37): [ReferenceId(21), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(41)]
-Symbol reference IDs mismatch for "publicClassWithWithPrivateGetAccessorTypes":
-after transform: SymbolId(37): []
-rebuilt        : SymbolId(38): [ReferenceId(27)]
-Symbol reference IDs mismatch for "publicClassWithWithPublicGetAccessorTypes":
-after transform: SymbolId(38): []
-rebuilt        : SymbolId(39): [ReferenceId(33)]
-Symbol reference IDs mismatch for "publicClassWithWithPrivateSetAccessorTypes":
-after transform: SymbolId(41): []
-rebuilt        : SymbolId(42): [ReferenceId(43)]
-Symbol reference IDs mismatch for "publicClassWithWithPublicSetAccessorTypes":
-after transform: SymbolId(46): []
-rebuilt        : SymbolId(47): [ReferenceId(45)]
-Symbol reference IDs mismatch for "publicClassWithPrivateModuleGetAccessorTypes":
-after transform: SymbolId(61): []
-rebuilt        : SymbolId(62): [ReferenceId(49)]
-Symbol reference IDs mismatch for "publicClassWithPrivateModuleSetAccessorTypes":
-after transform: SymbolId(62): []
-rebuilt        : SymbolId(63): [ReferenceId(51)]
+Symbol flags mismatch for "privateModule":
+after transform: SymbolId(69): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(70): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "privateModule":
+after transform: SymbolId(69): Span { start: 11550, end: 11563 }
+rebuilt        : SymbolId(70): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "privateClass":
 after transform: SymbolId(70): [ReferenceId(120), ReferenceId(121), ReferenceId(122), ReferenceId(123), ReferenceId(124), ReferenceId(125), ReferenceId(126), ReferenceId(127), ReferenceId(136), ReferenceId(137), ReferenceId(138), ReferenceId(139), ReferenceId(140), ReferenceId(141), ReferenceId(142), ReferenceId(143), ReferenceId(152), ReferenceId(153), ReferenceId(154), ReferenceId(155), ReferenceId(160), ReferenceId(161), ReferenceId(162), ReferenceId(163)]
 rebuilt        : SymbolId(72): [ReferenceId(58), ReferenceId(59), ReferenceId(60), ReferenceId(61), ReferenceId(70), ReferenceId(71), ReferenceId(72), ReferenceId(73)]
 Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(71): [ReferenceId(128), ReferenceId(129), ReferenceId(130), ReferenceId(131), ReferenceId(132), ReferenceId(133), ReferenceId(134), ReferenceId(135), ReferenceId(144), ReferenceId(145), ReferenceId(146), ReferenceId(147), ReferenceId(148), ReferenceId(149), ReferenceId(150), ReferenceId(151), ReferenceId(156), ReferenceId(157), ReferenceId(158), ReferenceId(159), ReferenceId(164), ReferenceId(165), ReferenceId(166), ReferenceId(167)]
+after transform: SymbolId(71): [ReferenceId(128), ReferenceId(129), ReferenceId(130), ReferenceId(131), ReferenceId(132), ReferenceId(133), ReferenceId(134), ReferenceId(135), ReferenceId(144), ReferenceId(145), ReferenceId(146), ReferenceId(147), ReferenceId(148), ReferenceId(149), ReferenceId(150), ReferenceId(151), ReferenceId(156), ReferenceId(157), ReferenceId(158), ReferenceId(159), ReferenceId(164), ReferenceId(165), ReferenceId(166), ReferenceId(167), ReferenceId(197)]
 rebuilt        : SymbolId(73): [ReferenceId(57), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77)]
-Symbol reference IDs mismatch for "publicClassWithWithPrivateGetAccessorTypes":
-after transform: SymbolId(72): []
-rebuilt        : SymbolId(74): [ReferenceId(63)]
-Symbol reference IDs mismatch for "publicClassWithWithPublicGetAccessorTypes":
-after transform: SymbolId(73): []
-rebuilt        : SymbolId(75): [ReferenceId(69)]
-Symbol reference IDs mismatch for "publicClassWithWithPrivateSetAccessorTypes":
-after transform: SymbolId(76): []
-rebuilt        : SymbolId(78): [ReferenceId(79)]
-Symbol reference IDs mismatch for "publicClassWithWithPublicSetAccessorTypes":
-after transform: SymbolId(81): []
-rebuilt        : SymbolId(83): [ReferenceId(81)]
-Symbol reference IDs mismatch for "publicClassWithPrivateModuleGetAccessorTypes":
-after transform: SymbolId(96): []
-rebuilt        : SymbolId(98): [ReferenceId(85)]
-Symbol reference IDs mismatch for "publicClassWithPrivateModuleSetAccessorTypes":
-after transform: SymbolId(97): []
-rebuilt        : SymbolId(99): [ReferenceId(87)]
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(69) "privateModule"
-rebuilt        : SymbolId(70) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(69) "privateModule"
-rebuilt        : SymbolId(70) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(69) "privateModule"
-rebuilt        : SymbolId(70) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(69) "privateModule"
-rebuilt        : SymbolId(70) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(69) "privateModule"
-rebuilt        : SymbolId(70) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(69) "privateModule"
-rebuilt        : SymbolId(70) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(69) "privateModule"
-rebuilt        : SymbolId(70) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(69) "privateModule"
-rebuilt        : SymbolId(70) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(69) "privateModule"
-rebuilt        : SymbolId(70) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(69) "privateModule"
-rebuilt        : SymbolId(70) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(69) "privateModule"
-rebuilt        : SymbolId(70) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(69) "privateModule"
-rebuilt        : SymbolId(70) "privateModule"
 Unresolved references mismatch:
 after transform: ["privateModule"]
 rebuilt        : []
@@ -23254,59 +20649,38 @@ after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/privacyCheckAnonymousFunctionParameter.ts
-semantic error: Missing SymbolId: "Query"
-Missing SymbolId: "_Query"
-Missing ReferenceId: "_Query"
-Missing ReferenceId: "fromDoWhile"
-Missing ReferenceId: "Query"
-Missing ReferenceId: "Query"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(4), SymbolId(7), SymbolId(9)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(5)]
+Symbol flags mismatch for "Query":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Query":
+after transform: SymbolId(3): Span { start: 86, end: 91 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol flags mismatch for "fromDoWhile":
 after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "fromDoWhile":
-after transform: SymbolId(4): [ReferenceId(4)]
-rebuilt        : SymbolId(3): [ReferenceId(1), ReferenceId(2)]
 Symbol flags mismatch for "fromOrderBy":
 after transform: SymbolId(7): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(5): SymbolFlags(FunctionScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/privacyCheckAnonymousFunctionParameter2.ts
-semantic error: Missing SymbolId: "Q"
-Missing SymbolId: "_Q"
-Missing ReferenceId: "_Q"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "Q"
-Missing ReferenceId: "Q"
-Missing SymbolId: "_Q2"
-Missing ReferenceId: "Q"
-Missing ReferenceId: "Q"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(4), SymbolId(8)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(7), SymbolId(9)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
+Symbol flags mismatch for "Q":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Q":
+after transform: SymbolId(3): Span { start: 92, end: 93 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "Q":
+after transform: SymbolId(3): [Span { start: 190, end: 191 }]
+rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "foo":
 after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(3): [ReferenceId(2)]
 Symbol flags mismatch for "bar":
 after transform: SymbolId(7): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
@@ -23375,201 +20749,56 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/privacyClass.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "m1_c_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "m1_C3_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "m1_C4_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "m1_C7_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "m1_C8_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "m1_C11_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "m1_C12_public"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Missing SymbolId: "m2"
-Missing SymbolId: "_m2"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "m2_c_public"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "m2_C3_public"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "m2_C4_public"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "m2_C7_public"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "m2_C8_public"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "m2_C11_public"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "m2_C12_public"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m2"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(17), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(42), SymbolId(43), SymbolId(44), SymbolId(45), SymbolId(46), SymbolId(47), SymbolId(48), SymbolId(49)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(16), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(42), SymbolId(43), SymbolId(44), SymbolId(45)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(19), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(17), ScopeId(33), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(50)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15)]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16)]
-Binding symbols mismatch:
-after transform: ScopeId(19): [SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(27), SymbolId(28), SymbolId(29), SymbolId(30), SymbolId(31), SymbolId(32), SymbolId(33), SymbolId(51)]
-rebuilt        : ScopeId(17): [SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(27), SymbolId(28), SymbolId(29), SymbolId(30), SymbolId(31)]
 Scope children mismatch:
 after transform: ScopeId(19): [ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36)]
 rebuilt        : ScopeId(17): [ScopeId(18), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32)]
-Symbol reference IDs mismatch for "m1_c_public":
-after transform: SymbolId(3): [ReferenceId(0), ReferenceId(2), ReferenceId(8), ReferenceId(14)]
-rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(14), ReferenceId(16)]
-Symbol reference IDs mismatch for "m1_C3_public":
-after transform: SymbolId(7): []
-rebuilt        : SymbolId(6): [ReferenceId(6)]
-Symbol reference IDs mismatch for "m1_C4_public":
-after transform: SymbolId(8): []
-rebuilt        : SymbolId(7): [ReferenceId(9)]
-Symbol reference IDs mismatch for "m1_C7_public":
-after transform: SymbolId(11): []
-rebuilt        : SymbolId(10): [ReferenceId(11)]
-Symbol reference IDs mismatch for "m1_C8_public":
-after transform: SymbolId(12): []
-rebuilt        : SymbolId(11): [ReferenceId(13)]
-Symbol reference IDs mismatch for "m1_C11_public":
-after transform: SymbolId(15): []
-rebuilt        : SymbolId(14): [ReferenceId(18)]
-Symbol reference IDs mismatch for "m1_C12_public":
-after transform: SymbolId(16): []
-rebuilt        : SymbolId(15): [ReferenceId(21)]
-Symbol reference IDs mismatch for "m2_c_public":
-after transform: SymbolId(20): [ReferenceId(20), ReferenceId(22), ReferenceId(28), ReferenceId(34)]
-rebuilt        : SymbolId(18): [ReferenceId(25), ReferenceId(26), ReferenceId(28), ReferenceId(38), ReferenceId(40)]
-Symbol reference IDs mismatch for "m2_C3_public":
-after transform: SymbolId(24): []
-rebuilt        : SymbolId(22): [ReferenceId(30)]
-Symbol reference IDs mismatch for "m2_C4_public":
-after transform: SymbolId(25): []
-rebuilt        : SymbolId(23): [ReferenceId(33)]
-Symbol reference IDs mismatch for "m2_C7_public":
-after transform: SymbolId(28): []
-rebuilt        : SymbolId(26): [ReferenceId(35)]
-Symbol reference IDs mismatch for "m2_C8_public":
-after transform: SymbolId(29): []
-rebuilt        : SymbolId(27): [ReferenceId(37)]
-Symbol reference IDs mismatch for "m2_C11_public":
-after transform: SymbolId(32): []
-rebuilt        : SymbolId(30): [ReferenceId(42)]
-Symbol reference IDs mismatch for "m2_C12_public":
-after transform: SymbolId(33): []
-rebuilt        : SymbolId(31): [ReferenceId(45)]
+Symbol flags mismatch for "m1":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(0): Span { start: 14, end: 16 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "m2":
+after transform: SymbolId(17): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m2":
+after transform: SymbolId(17): Span { start: 1045, end: 1047 }
+rebuilt        : SymbolId(16): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/privacyClassImplementsClauseDeclFile.ts
-semantic error: Missing SymbolId: "publicModule"
-Missing SymbolId: "_publicModule"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassImplementingPublicInterfaceInModule"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassImplementingPrivateInterfaceInModule"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassImplementingFromPrivateModuleInterface"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassImplementingPrivateAndPublicInterface"
-Missing ReferenceId: "publicModule"
-Missing ReferenceId: "publicModule"
-Missing SymbolId: "privateModule"
-Missing SymbolId: "_privateModule"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClassImplementingPublicInterfaceInModule"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClassImplementingPrivateInterfaceInModule"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClassImplementingFromPrivateModuleInterface"
-Missing ReferenceId: "privateModule"
-Missing ReferenceId: "privateModule"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(10), SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(9), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(11), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(9), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(27)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8)]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
-Binding symbols mismatch:
-after transform: ScopeId(11): [SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(28)]
-rebuilt        : ScopeId(9): [SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16)]
 Scope children mismatch:
 after transform: ScopeId(11): [ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19)]
 rebuilt        : ScopeId(9): [ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15)]
-Symbol reference IDs mismatch for "publicClassImplementingPublicInterfaceInModule":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Symbol reference IDs mismatch for "publicClassImplementingPrivateInterfaceInModule":
-after transform: SymbolId(6): []
-rebuilt        : SymbolId(5): [ReferenceId(3)]
-Symbol reference IDs mismatch for "publicClassImplementingFromPrivateModuleInterface":
-after transform: SymbolId(8): []
-rebuilt        : SymbolId(7): [ReferenceId(5)]
-Symbol reference IDs mismatch for "publicClassImplementingPrivateAndPublicInterface":
-after transform: SymbolId(9): []
-rebuilt        : SymbolId(8): [ReferenceId(7)]
-Symbol reference IDs mismatch for "publicClassImplementingPublicInterfaceInModule":
-after transform: SymbolId(15): []
-rebuilt        : SymbolId(13): [ReferenceId(11)]
-Symbol reference IDs mismatch for "publicClassImplementingPrivateInterfaceInModule":
-after transform: SymbolId(16): []
-rebuilt        : SymbolId(14): [ReferenceId(13)]
-Symbol reference IDs mismatch for "publicClassImplementingFromPrivateModuleInterface":
-after transform: SymbolId(18): []
-rebuilt        : SymbolId(16): [ReferenceId(15)]
+Symbol flags mismatch for "publicModule":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "publicModule":
+after transform: SymbolId(0): Span { start: 14, end: 26 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "privateModule":
+after transform: SymbolId(10): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "privateModule":
+after transform: SymbolId(10): Span { start: 1050, end: 1063 }
+rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["privateModule"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/privacyFunc.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "C1_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "C3_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "C5_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "C7_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "f2_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "f4_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "f6_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "f8_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "f10_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "f12_public"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(43), SymbolId(44), SymbolId(49), SymbolId(51), SymbolId(53), SymbolId(54)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(40), SymbolId(41), SymbolId(45), SymbolId(47), SymbolId(49), SymbolId(50)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(11), SymbolId(19), SymbolId(21), SymbolId(23), SymbolId(25), SymbolId(27), SymbolId(29), SymbolId(31), SymbolId(33), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(42), SymbolId(55)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(10), SymbolId(16), SymbolId(18), SymbolId(20), SymbolId(22), SymbolId(24), SymbolId(26), SymbolId(28), SymbolId(30), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
@@ -23581,39 +20810,18 @@ rebuilt        : ScopeId(19): [ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23
 Scope children mismatch:
 after transform: ScopeId(58): [ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66)]
 rebuilt        : ScopeId(54): [ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61)]
+Symbol flags mismatch for "m1":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(0): Span { start: 7, end: 9 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C1_public":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(7), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(18), ReferenceId(20), ReferenceId(21), ReferenceId(24), ReferenceId(25), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(36), ReferenceId(37), ReferenceId(40), ReferenceId(41), ReferenceId(44), ReferenceId(45), ReferenceId(48), ReferenceId(49), ReferenceId(50), ReferenceId(51)]
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(7), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(18), ReferenceId(20), ReferenceId(21), ReferenceId(24), ReferenceId(25), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(36), ReferenceId(37), ReferenceId(40), ReferenceId(41), ReferenceId(44), ReferenceId(45), ReferenceId(48), ReferenceId(49), ReferenceId(50), ReferenceId(51), ReferenceId(71)]
 rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(7), ReferenceId(12), ReferenceId(13), ReferenceId(16), ReferenceId(17), ReferenceId(28), ReferenceId(29), ReferenceId(36), ReferenceId(37)]
 Symbol reference IDs mismatch for "C2_private":
 after transform: SymbolId(2): [ReferenceId(1), ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(9), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(19), ReferenceId(22), ReferenceId(23), ReferenceId(26), ReferenceId(27), ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35), ReferenceId(38), ReferenceId(39), ReferenceId(42), ReferenceId(43), ReferenceId(46), ReferenceId(47), ReferenceId(52), ReferenceId(53), ReferenceId(54), ReferenceId(55)]
 rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(9), ReferenceId(14), ReferenceId(15), ReferenceId(18), ReferenceId(19), ReferenceId(32), ReferenceId(33), ReferenceId(40), ReferenceId(41)]
-Symbol reference IDs mismatch for "C3_public":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(4): [ReferenceId(11)]
-Symbol reference IDs mismatch for "C5_public":
-after transform: SymbolId(19): []
-rebuilt        : SymbolId(16): [ReferenceId(21)]
-Symbol reference IDs mismatch for "C7_public":
-after transform: SymbolId(23): []
-rebuilt        : SymbolId(20): [ReferenceId(23)]
-Symbol reference IDs mismatch for "f2_public":
-after transform: SymbolId(29): []
-rebuilt        : SymbolId(26): [ReferenceId(25)]
-Symbol reference IDs mismatch for "f4_public":
-after transform: SymbolId(33): []
-rebuilt        : SymbolId(30): [ReferenceId(27)]
-Symbol reference IDs mismatch for "f6_public":
-after transform: SymbolId(36): []
-rebuilt        : SymbolId(33): [ReferenceId(31)]
-Symbol reference IDs mismatch for "f8_public":
-after transform: SymbolId(38): []
-rebuilt        : SymbolId(35): [ReferenceId(35)]
-Symbol reference IDs mismatch for "f10_public":
-after transform: SymbolId(40): []
-rebuilt        : SymbolId(37): [ReferenceId(39)]
-Symbol reference IDs mismatch for "f12_public":
-after transform: SymbolId(42): []
-rebuilt        : SymbolId(39): [ReferenceId(43)]
 Symbol reference IDs mismatch for "C6_public":
 after transform: SymbolId(43): [ReferenceId(56), ReferenceId(57), ReferenceId(58), ReferenceId(59), ReferenceId(60), ReferenceId(61), ReferenceId(62), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(68), ReferenceId(69)]
 rebuilt        : SymbolId(40): [ReferenceId(46), ReferenceId(47), ReferenceId(48), ReferenceId(49), ReferenceId(50), ReferenceId(51)]
@@ -23635,57 +20843,12 @@ after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/privacyFunctionParameterDeclFile.ts
-semantic error: Missing SymbolId: "publicModule"
-Missing SymbolId: "_publicModule"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClass"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassWithWithPrivateParmeterTypes"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassWithWithPublicParmeterTypes"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicFunctionWithPrivateParmeterTypes"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicFunctionWithPublicParmeterTypes"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassWithPrivateModuleParameterTypes"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicFunctionWithPrivateModuleParameterTypes"
-Missing ReferenceId: "publicModule"
-Missing ReferenceId: "publicModule"
-Missing SymbolId: "privateModule"
-Missing SymbolId: "_privateModule"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClass"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClassWithWithPrivateParmeterTypes"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClassWithWithPublicParmeterTypes"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicFunctionWithPrivateParmeterTypes"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicFunctionWithPublicParmeterTypes"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClassWithPrivateModuleParameterTypes"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicFunctionWithPrivateModuleParameterTypes"
-Missing ReferenceId: "privateModule"
-Missing ReferenceId: "privateModule"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(6), SymbolId(14), SymbolId(22), SymbolId(30), SymbolId(38), SymbolId(40), SymbolId(42), SymbolId(44), SymbolId(51), SymbolId(57), SymbolId(61), SymbolId(67), SymbolId(70), SymbolId(141)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(10), SymbolId(18), SymbolId(26), SymbolId(34), SymbolId(36), SymbolId(38), SymbolId(40), SymbolId(42), SymbolId(48), SymbolId(50), SymbolId(56), SymbolId(58), SymbolId(118)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(9), ScopeId(12), ScopeId(15), ScopeId(21), ScopeId(27), ScopeId(33), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(50), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(59), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(130)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(9), ScopeId(15), ScopeId(21), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(35), ScopeId(36), ScopeId(40), ScopeId(41), ScopeId(82)]
-Binding symbols mismatch:
-after transform: ScopeId(65): [SymbolId(71), SymbolId(72), SymbolId(77), SymbolId(85), SymbolId(93), SymbolId(101), SymbolId(109), SymbolId(111), SymbolId(113), SymbolId(115), SymbolId(122), SymbolId(128), SymbolId(132), SymbolId(138), SymbolId(212)]
-rebuilt        : ScopeId(41): [SymbolId(59), SymbolId(60), SymbolId(61), SymbolId(62), SymbolId(70), SymbolId(78), SymbolId(86), SymbolId(94), SymbolId(96), SymbolId(98), SymbolId(100), SymbolId(102), SymbolId(108), SymbolId(110), SymbolId(116)]
 Scope children mismatch:
 after transform: ScopeId(65): [ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(71), ScopeId(74), ScopeId(77), ScopeId(80), ScopeId(86), ScopeId(92), ScopeId(98), ScopeId(104), ScopeId(105), ScopeId(106), ScopeId(107), ScopeId(108), ScopeId(109), ScopeId(110), ScopeId(111), ScopeId(112), ScopeId(115), ScopeId(119), ScopeId(120), ScopeId(121), ScopeId(124), ScopeId(128), ScopeId(129)]
 rebuilt        : ScopeId(41): [ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(50), ScopeId(56), ScopeId(62), ScopeId(68), ScopeId(69), ScopeId(70), ScopeId(71), ScopeId(72), ScopeId(76), ScopeId(77), ScopeId(81)]
-Binding symbols mismatch:
-after transform: ScopeId(130): [SymbolId(142), SymbolId(143), SymbolId(148), SymbolId(156), SymbolId(164), SymbolId(172), SymbolId(180), SymbolId(182), SymbolId(184), SymbolId(186), SymbolId(193), SymbolId(199), SymbolId(203), SymbolId(209), SymbolId(213)]
-rebuilt        : ScopeId(82): [SymbolId(119), SymbolId(120), SymbolId(121), SymbolId(122), SymbolId(130), SymbolId(138), SymbolId(146), SymbolId(154), SymbolId(156), SymbolId(158), SymbolId(160), SymbolId(162), SymbolId(168), SymbolId(170), SymbolId(176)]
 Scope children mismatch:
 after transform: ScopeId(130): [ScopeId(131), ScopeId(132), ScopeId(133), ScopeId(136), ScopeId(139), ScopeId(142), ScopeId(145), ScopeId(151), ScopeId(157), ScopeId(163), ScopeId(169), ScopeId(170), ScopeId(171), ScopeId(172), ScopeId(173), ScopeId(174), ScopeId(175), ScopeId(176), ScopeId(177), ScopeId(180), ScopeId(184), ScopeId(185), ScopeId(186), ScopeId(189), ScopeId(193), ScopeId(194)]
 rebuilt        : ScopeId(82): [ScopeId(83), ScopeId(84), ScopeId(85), ScopeId(91), ScopeId(97), ScopeId(103), ScopeId(109), ScopeId(110), ScopeId(111), ScopeId(112), ScopeId(113), ScopeId(117), ScopeId(118), ScopeId(122)]
@@ -23695,87 +20858,63 @@ rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch for "publicClass":
 after transform: SymbolId(1): [ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(32), ReferenceId(33), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(49), ReferenceId(51), ReferenceId(53), ReferenceId(55), ReferenceId(57), ReferenceId(59), ReferenceId(69), ReferenceId(71)]
 rebuilt        : SymbolId(1): []
+Symbol flags mismatch for "publicModule":
+after transform: SymbolId(70): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(58): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "publicModule":
+after transform: SymbolId(70): Span { start: 4743, end: 4755 }
+rebuilt        : SymbolId(58): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "privateClass":
 after transform: SymbolId(71): [ReferenceId(80), ReferenceId(82), ReferenceId(84), ReferenceId(90), ReferenceId(91), ReferenceId(92), ReferenceId(93), ReferenceId(94), ReferenceId(100), ReferenceId(101), ReferenceId(102), ReferenceId(103), ReferenceId(104), ReferenceId(105), ReferenceId(106), ReferenceId(114), ReferenceId(115), ReferenceId(116), ReferenceId(117), ReferenceId(118), ReferenceId(119), ReferenceId(120), ReferenceId(128), ReferenceId(130), ReferenceId(132), ReferenceId(134)]
 rebuilt        : SymbolId(60): []
 Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(72): [ReferenceId(81), ReferenceId(83), ReferenceId(85), ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(95), ReferenceId(96), ReferenceId(97), ReferenceId(98), ReferenceId(99), ReferenceId(107), ReferenceId(108), ReferenceId(109), ReferenceId(110), ReferenceId(111), ReferenceId(112), ReferenceId(113), ReferenceId(121), ReferenceId(122), ReferenceId(123), ReferenceId(124), ReferenceId(125), ReferenceId(126), ReferenceId(127), ReferenceId(129), ReferenceId(131), ReferenceId(133), ReferenceId(135), ReferenceId(137), ReferenceId(139), ReferenceId(149), ReferenceId(151)]
+after transform: SymbolId(72): [ReferenceId(81), ReferenceId(83), ReferenceId(85), ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(95), ReferenceId(96), ReferenceId(97), ReferenceId(98), ReferenceId(99), ReferenceId(107), ReferenceId(108), ReferenceId(109), ReferenceId(110), ReferenceId(111), ReferenceId(112), ReferenceId(113), ReferenceId(121), ReferenceId(122), ReferenceId(123), ReferenceId(124), ReferenceId(125), ReferenceId(126), ReferenceId(127), ReferenceId(129), ReferenceId(131), ReferenceId(133), ReferenceId(135), ReferenceId(137), ReferenceId(139), ReferenceId(149), ReferenceId(151), ReferenceId(241)]
 rebuilt        : SymbolId(61): [ReferenceId(13)]
-Symbol reference IDs mismatch for "publicClassWithWithPrivateParmeterTypes":
-after transform: SymbolId(77): []
-rebuilt        : SymbolId(62): [ReferenceId(17)]
-Symbol reference IDs mismatch for "publicClassWithWithPublicParmeterTypes":
-after transform: SymbolId(85): []
-rebuilt        : SymbolId(70): [ReferenceId(21)]
 Symbol flags mismatch for "publicFunctionWithPrivateParmeterTypes":
 after transform: SymbolId(109): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(94): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicFunctionWithPrivateParmeterTypes":
-after transform: SymbolId(109): []
-rebuilt        : SymbolId(94): [ReferenceId(27)]
 Symbol flags mismatch for "publicFunctionWithPublicParmeterTypes":
 after transform: SymbolId(111): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(96): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicFunctionWithPublicParmeterTypes":
-after transform: SymbolId(111): []
-rebuilt        : SymbolId(96): [ReferenceId(29)]
 Symbol flags mismatch for "privateFunctionWithPrivateParmeterTypes":
 after transform: SymbolId(113): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(98): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "privateFunctionWithPublicParmeterTypes":
 after transform: SymbolId(115): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(100): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicClassWithPrivateModuleParameterTypes":
-after transform: SymbolId(122): []
-rebuilt        : SymbolId(102): [ReferenceId(33)]
 Symbol flags mismatch for "publicFunctionWithPrivateModuleParameterTypes":
 after transform: SymbolId(128): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(108): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicFunctionWithPrivateModuleParameterTypes":
-after transform: SymbolId(128): []
-rebuilt        : SymbolId(108): [ReferenceId(35)]
 Symbol flags mismatch for "privateFunctionWithPrivateModuleParameterTypes":
 after transform: SymbolId(138): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(116): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch for "privateModule":
+after transform: SymbolId(141): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(118): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "privateModule":
+after transform: SymbolId(141): Span { start: 9961, end: 9974 }
+rebuilt        : SymbolId(118): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "privateClass":
 after transform: SymbolId(142): [ReferenceId(160), ReferenceId(162), ReferenceId(164), ReferenceId(170), ReferenceId(171), ReferenceId(172), ReferenceId(173), ReferenceId(174), ReferenceId(180), ReferenceId(181), ReferenceId(182), ReferenceId(183), ReferenceId(184), ReferenceId(185), ReferenceId(186), ReferenceId(194), ReferenceId(195), ReferenceId(196), ReferenceId(197), ReferenceId(198), ReferenceId(199), ReferenceId(200), ReferenceId(208), ReferenceId(210), ReferenceId(212), ReferenceId(214)]
 rebuilt        : SymbolId(120): []
 Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(143): [ReferenceId(161), ReferenceId(163), ReferenceId(165), ReferenceId(166), ReferenceId(167), ReferenceId(168), ReferenceId(169), ReferenceId(175), ReferenceId(176), ReferenceId(177), ReferenceId(178), ReferenceId(179), ReferenceId(187), ReferenceId(188), ReferenceId(189), ReferenceId(190), ReferenceId(191), ReferenceId(192), ReferenceId(193), ReferenceId(201), ReferenceId(202), ReferenceId(203), ReferenceId(204), ReferenceId(205), ReferenceId(206), ReferenceId(207), ReferenceId(209), ReferenceId(211), ReferenceId(213), ReferenceId(215), ReferenceId(217), ReferenceId(219), ReferenceId(229), ReferenceId(231)]
+after transform: SymbolId(143): [ReferenceId(161), ReferenceId(163), ReferenceId(165), ReferenceId(166), ReferenceId(167), ReferenceId(168), ReferenceId(169), ReferenceId(175), ReferenceId(176), ReferenceId(177), ReferenceId(178), ReferenceId(179), ReferenceId(187), ReferenceId(188), ReferenceId(189), ReferenceId(190), ReferenceId(191), ReferenceId(192), ReferenceId(193), ReferenceId(201), ReferenceId(202), ReferenceId(203), ReferenceId(204), ReferenceId(205), ReferenceId(206), ReferenceId(207), ReferenceId(209), ReferenceId(211), ReferenceId(213), ReferenceId(215), ReferenceId(217), ReferenceId(219), ReferenceId(229), ReferenceId(231), ReferenceId(257)]
 rebuilt        : SymbolId(121): [ReferenceId(41)]
-Symbol reference IDs mismatch for "publicClassWithWithPrivateParmeterTypes":
-after transform: SymbolId(148): []
-rebuilt        : SymbolId(122): [ReferenceId(45)]
-Symbol reference IDs mismatch for "publicClassWithWithPublicParmeterTypes":
-after transform: SymbolId(156): []
-rebuilt        : SymbolId(130): [ReferenceId(49)]
 Symbol flags mismatch for "publicFunctionWithPrivateParmeterTypes":
 after transform: SymbolId(180): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(154): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicFunctionWithPrivateParmeterTypes":
-after transform: SymbolId(180): []
-rebuilt        : SymbolId(154): [ReferenceId(55)]
 Symbol flags mismatch for "publicFunctionWithPublicParmeterTypes":
 after transform: SymbolId(182): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(156): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicFunctionWithPublicParmeterTypes":
-after transform: SymbolId(182): []
-rebuilt        : SymbolId(156): [ReferenceId(57)]
 Symbol flags mismatch for "privateFunctionWithPrivateParmeterTypes":
 after transform: SymbolId(184): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(158): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "privateFunctionWithPublicParmeterTypes":
 after transform: SymbolId(186): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(160): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicClassWithPrivateModuleParameterTypes":
-after transform: SymbolId(193): []
-rebuilt        : SymbolId(162): [ReferenceId(61)]
 Symbol flags mismatch for "publicFunctionWithPrivateModuleParameterTypes":
 after transform: SymbolId(199): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(168): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicFunctionWithPrivateModuleParameterTypes":
-after transform: SymbolId(199): []
-rebuilt        : SymbolId(168): [ReferenceId(63)]
 Symbol flags mismatch for "privateFunctionWithPrivateModuleParameterTypes":
 after transform: SymbolId(209): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(176): SymbolFlags(FunctionScopedVariable)
@@ -23784,69 +20923,12 @@ after transform: ["privateModule"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/privacyFunctionReturnTypeDeclFile.ts
-semantic error: Missing SymbolId: "publicModule"
-Missing SymbolId: "_publicModule"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClass"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassWithWithPrivateParmeterTypes"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassWithWithPublicParmeterTypes"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicFunctionWithPrivateParmeterTypes"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicFunctionWithPublicParmeterTypes"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicFunctionWithPrivateParmeterTypes1"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicFunctionWithPublicParmeterTypes1"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassWithPrivateModuleParameterTypes"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicFunctionWithPrivateModuleParameterTypes"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicFunctionWithPrivateModuleParameterTypes1"
-Missing ReferenceId: "publicModule"
-Missing ReferenceId: "publicModule"
-Missing SymbolId: "privateModule"
-Missing SymbolId: "_privateModule"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClass"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClassWithWithPrivateParmeterTypes"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClassWithWithPublicParmeterTypes"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicFunctionWithPrivateParmeterTypes"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicFunctionWithPublicParmeterTypes"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicFunctionWithPrivateParmeterTypes1"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicFunctionWithPublicParmeterTypes1"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClassWithPrivateModuleParameterTypes"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicFunctionWithPrivateModuleParameterTypes"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicFunctionWithPrivateModuleParameterTypes1"
-Missing ReferenceId: "privateModule"
-Missing ReferenceId: "privateModule"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(53)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(42)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(9), ScopeId(12), ScopeId(15), ScopeId(24), ScopeId(33), ScopeId(42), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(66), ScopeId(71), ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(77), ScopeId(82), ScopeId(83), ScopeId(84), ScopeId(85), ScopeId(170)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(12), ScopeId(21), ScopeId(30), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47), ScopeId(52), ScopeId(53), ScopeId(54), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(122)]
-Binding symbols mismatch:
-after transform: ScopeId(85): [SymbolId(27), SymbolId(28), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(42), SymbolId(43), SymbolId(44), SymbolId(46), SymbolId(47), SymbolId(48), SymbolId(50), SymbolId(51), SymbolId(52), SymbolId(80)]
-rebuilt        : ScopeId(61): [SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(27), SymbolId(28), SymbolId(29), SymbolId(30), SymbolId(31), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(40), SymbolId(41)]
 Scope children mismatch:
 after transform: ScopeId(85): [ScopeId(86), ScopeId(87), ScopeId(88), ScopeId(91), ScopeId(94), ScopeId(97), ScopeId(100), ScopeId(109), ScopeId(118), ScopeId(127), ScopeId(136), ScopeId(137), ScopeId(138), ScopeId(139), ScopeId(140), ScopeId(141), ScopeId(142), ScopeId(143), ScopeId(144), ScopeId(145), ScopeId(146), ScopeId(147), ScopeId(148), ScopeId(151), ScopeId(156), ScopeId(157), ScopeId(158), ScopeId(159), ScopeId(162), ScopeId(167), ScopeId(168), ScopeId(169)]
 rebuilt        : ScopeId(61): [ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(73), ScopeId(82), ScopeId(91), ScopeId(100), ScopeId(101), ScopeId(102), ScopeId(103), ScopeId(104), ScopeId(105), ScopeId(106), ScopeId(107), ScopeId(108), ScopeId(113), ScopeId(114), ScopeId(115), ScopeId(120), ScopeId(121)]
-Binding symbols mismatch:
-after transform: ScopeId(170): [SymbolId(54), SymbolId(55), SymbolId(60), SymbolId(61), SymbolId(62), SymbolId(63), SymbolId(64), SymbolId(65), SymbolId(66), SymbolId(67), SymbolId(68), SymbolId(69), SymbolId(70), SymbolId(71), SymbolId(73), SymbolId(74), SymbolId(75), SymbolId(77), SymbolId(78), SymbolId(79), SymbolId(81)]
-rebuilt        : ScopeId(122): [SymbolId(43), SymbolId(44), SymbolId(45), SymbolId(46), SymbolId(47), SymbolId(48), SymbolId(49), SymbolId(50), SymbolId(51), SymbolId(52), SymbolId(53), SymbolId(54), SymbolId(55), SymbolId(56), SymbolId(57), SymbolId(58), SymbolId(59), SymbolId(60), SymbolId(61), SymbolId(62), SymbolId(63)]
 Scope children mismatch:
 after transform: ScopeId(170): [ScopeId(171), ScopeId(172), ScopeId(173), ScopeId(176), ScopeId(179), ScopeId(182), ScopeId(185), ScopeId(194), ScopeId(203), ScopeId(212), ScopeId(221), ScopeId(222), ScopeId(223), ScopeId(224), ScopeId(225), ScopeId(226), ScopeId(227), ScopeId(228), ScopeId(229), ScopeId(230), ScopeId(231), ScopeId(232), ScopeId(233), ScopeId(236), ScopeId(241), ScopeId(242), ScopeId(243), ScopeId(244), ScopeId(247), ScopeId(252), ScopeId(253), ScopeId(254)]
 rebuilt        : ScopeId(122): [ScopeId(123), ScopeId(124), ScopeId(125), ScopeId(134), ScopeId(143), ScopeId(152), ScopeId(161), ScopeId(162), ScopeId(163), ScopeId(164), ScopeId(165), ScopeId(166), ScopeId(167), ScopeId(168), ScopeId(169), ScopeId(174), ScopeId(175), ScopeId(176), ScopeId(181), ScopeId(182)]
@@ -23856,30 +20938,24 @@ rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), R
 Symbol reference IDs mismatch for "publicClass":
 after transform: SymbolId(1): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(49), ReferenceId(51), ReferenceId(53), ReferenceId(55), ReferenceId(57), ReferenceId(59)]
 rebuilt        : SymbolId(1): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(17), ReferenceId(19)]
+Symbol flags mismatch for "publicModule":
+after transform: SymbolId(26): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "publicModule":
+after transform: SymbolId(26): Span { start: 6483, end: 6495 }
+rebuilt        : SymbolId(20): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "privateClass":
 after transform: SymbolId(27): [ReferenceId(82), ReferenceId(83), ReferenceId(84), ReferenceId(85), ReferenceId(90), ReferenceId(91), ReferenceId(92), ReferenceId(93), ReferenceId(98), ReferenceId(99), ReferenceId(100), ReferenceId(101), ReferenceId(102), ReferenceId(103), ReferenceId(104), ReferenceId(105), ReferenceId(114), ReferenceId(115), ReferenceId(116), ReferenceId(117), ReferenceId(118), ReferenceId(119), ReferenceId(120), ReferenceId(121), ReferenceId(130), ReferenceId(132), ReferenceId(134), ReferenceId(136), ReferenceId(138), ReferenceId(140)]
 rebuilt        : SymbolId(22): [ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(52), ReferenceId(58)]
 Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(28): [ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(94), ReferenceId(95), ReferenceId(96), ReferenceId(97), ReferenceId(106), ReferenceId(107), ReferenceId(108), ReferenceId(109), ReferenceId(110), ReferenceId(111), ReferenceId(112), ReferenceId(113), ReferenceId(122), ReferenceId(123), ReferenceId(124), ReferenceId(125), ReferenceId(126), ReferenceId(127), ReferenceId(128), ReferenceId(129), ReferenceId(131), ReferenceId(133), ReferenceId(135), ReferenceId(137), ReferenceId(139), ReferenceId(141)]
+after transform: SymbolId(28): [ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(94), ReferenceId(95), ReferenceId(96), ReferenceId(97), ReferenceId(106), ReferenceId(107), ReferenceId(108), ReferenceId(109), ReferenceId(110), ReferenceId(111), ReferenceId(112), ReferenceId(113), ReferenceId(122), ReferenceId(123), ReferenceId(124), ReferenceId(125), ReferenceId(126), ReferenceId(127), ReferenceId(128), ReferenceId(129), ReferenceId(131), ReferenceId(133), ReferenceId(135), ReferenceId(137), ReferenceId(139), ReferenceId(141), ReferenceId(247)]
 rebuilt        : SymbolId(23): [ReferenceId(27), ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(55), ReferenceId(59)]
-Symbol reference IDs mismatch for "publicClassWithWithPrivateParmeterTypes":
-after transform: SymbolId(33): []
-rebuilt        : SymbolId(24): [ReferenceId(33)]
-Symbol reference IDs mismatch for "publicClassWithWithPublicParmeterTypes":
-after transform: SymbolId(34): []
-rebuilt        : SymbolId(25): [ReferenceId(39)]
 Symbol flags mismatch for "publicFunctionWithPrivateParmeterTypes":
 after transform: SymbolId(37): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(28): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicFunctionWithPrivateParmeterTypes":
-after transform: SymbolId(37): []
-rebuilt        : SymbolId(28): [ReferenceId(49)]
 Symbol flags mismatch for "publicFunctionWithPublicParmeterTypes":
 after transform: SymbolId(38): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(29): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicFunctionWithPublicParmeterTypes":
-after transform: SymbolId(38): []
-rebuilt        : SymbolId(29): [ReferenceId(51)]
 Symbol flags mismatch for "privateFunctionWithPrivateParmeterTypes":
 after transform: SymbolId(39): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(30): SymbolFlags(FunctionScopedVariable)
@@ -23889,66 +20965,45 @@ rebuilt        : SymbolId(31): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "publicFunctionWithPrivateParmeterTypes1":
 after transform: SymbolId(41): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(32): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicFunctionWithPrivateParmeterTypes1":
-after transform: SymbolId(41): []
-rebuilt        : SymbolId(32): [ReferenceId(54)]
 Symbol flags mismatch for "publicFunctionWithPublicParmeterTypes1":
 after transform: SymbolId(42): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(33): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicFunctionWithPublicParmeterTypes1":
-after transform: SymbolId(42): []
-rebuilt        : SymbolId(33): [ReferenceId(57)]
 Symbol flags mismatch for "privateFunctionWithPrivateParmeterTypes1":
 after transform: SymbolId(43): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(34): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "privateFunctionWithPublicParmeterTypes1":
 after transform: SymbolId(44): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(35): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicClassWithPrivateModuleParameterTypes":
-after transform: SymbolId(46): []
-rebuilt        : SymbolId(36): [ReferenceId(63)]
 Symbol flags mismatch for "publicFunctionWithPrivateModuleParameterTypes":
 after transform: SymbolId(47): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(37): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicFunctionWithPrivateModuleParameterTypes":
-after transform: SymbolId(47): []
-rebuilt        : SymbolId(37): [ReferenceId(65)]
 Symbol flags mismatch for "publicFunctionWithPrivateModuleParameterTypes1":
 after transform: SymbolId(48): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(38): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicFunctionWithPrivateModuleParameterTypes1":
-after transform: SymbolId(48): []
-rebuilt        : SymbolId(38): [ReferenceId(68)]
 Symbol flags mismatch for "privateFunctionWithPrivateModuleParameterTypes":
 after transform: SymbolId(51): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(40): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "privateFunctionWithPrivateModuleParameterTypes1":
 after transform: SymbolId(52): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(41): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch for "privateModule":
+after transform: SymbolId(53): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(42): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "privateModule":
+after transform: SymbolId(53): Span { start: 13824, end: 13837 }
+rebuilt        : SymbolId(42): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "privateClass":
 after transform: SymbolId(54): [ReferenceId(164), ReferenceId(165), ReferenceId(166), ReferenceId(167), ReferenceId(172), ReferenceId(173), ReferenceId(174), ReferenceId(175), ReferenceId(180), ReferenceId(181), ReferenceId(182), ReferenceId(183), ReferenceId(184), ReferenceId(185), ReferenceId(186), ReferenceId(187), ReferenceId(196), ReferenceId(197), ReferenceId(198), ReferenceId(199), ReferenceId(200), ReferenceId(201), ReferenceId(202), ReferenceId(203), ReferenceId(212), ReferenceId(214), ReferenceId(216), ReferenceId(218), ReferenceId(220), ReferenceId(222)]
 rebuilt        : SymbolId(44): [ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(88), ReferenceId(89), ReferenceId(90), ReferenceId(91), ReferenceId(100), ReferenceId(106)]
 Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(55): [ReferenceId(168), ReferenceId(169), ReferenceId(170), ReferenceId(171), ReferenceId(176), ReferenceId(177), ReferenceId(178), ReferenceId(179), ReferenceId(188), ReferenceId(189), ReferenceId(190), ReferenceId(191), ReferenceId(192), ReferenceId(193), ReferenceId(194), ReferenceId(195), ReferenceId(204), ReferenceId(205), ReferenceId(206), ReferenceId(207), ReferenceId(208), ReferenceId(209), ReferenceId(210), ReferenceId(211), ReferenceId(213), ReferenceId(215), ReferenceId(217), ReferenceId(219), ReferenceId(221), ReferenceId(223)]
+after transform: SymbolId(55): [ReferenceId(168), ReferenceId(169), ReferenceId(170), ReferenceId(171), ReferenceId(176), ReferenceId(177), ReferenceId(178), ReferenceId(179), ReferenceId(188), ReferenceId(189), ReferenceId(190), ReferenceId(191), ReferenceId(192), ReferenceId(193), ReferenceId(194), ReferenceId(195), ReferenceId(204), ReferenceId(205), ReferenceId(206), ReferenceId(207), ReferenceId(208), ReferenceId(209), ReferenceId(210), ReferenceId(211), ReferenceId(213), ReferenceId(215), ReferenceId(217), ReferenceId(219), ReferenceId(221), ReferenceId(223), ReferenceId(269)]
 rebuilt        : SymbolId(45): [ReferenceId(75), ReferenceId(82), ReferenceId(83), ReferenceId(84), ReferenceId(85), ReferenceId(92), ReferenceId(93), ReferenceId(94), ReferenceId(95), ReferenceId(103), ReferenceId(107)]
-Symbol reference IDs mismatch for "publicClassWithWithPrivateParmeterTypes":
-after transform: SymbolId(60): []
-rebuilt        : SymbolId(46): [ReferenceId(81)]
-Symbol reference IDs mismatch for "publicClassWithWithPublicParmeterTypes":
-after transform: SymbolId(61): []
-rebuilt        : SymbolId(47): [ReferenceId(87)]
 Symbol flags mismatch for "publicFunctionWithPrivateParmeterTypes":
 after transform: SymbolId(64): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(50): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicFunctionWithPrivateParmeterTypes":
-after transform: SymbolId(64): []
-rebuilt        : SymbolId(50): [ReferenceId(97)]
 Symbol flags mismatch for "publicFunctionWithPublicParmeterTypes":
 after transform: SymbolId(65): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(51): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicFunctionWithPublicParmeterTypes":
-after transform: SymbolId(65): []
-rebuilt        : SymbolId(51): [ReferenceId(99)]
 Symbol flags mismatch for "privateFunctionWithPrivateParmeterTypes":
 after transform: SymbolId(66): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(52): SymbolFlags(FunctionScopedVariable)
@@ -23958,144 +21013,56 @@ rebuilt        : SymbolId(53): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "publicFunctionWithPrivateParmeterTypes1":
 after transform: SymbolId(68): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(54): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicFunctionWithPrivateParmeterTypes1":
-after transform: SymbolId(68): []
-rebuilt        : SymbolId(54): [ReferenceId(102)]
 Symbol flags mismatch for "publicFunctionWithPublicParmeterTypes1":
 after transform: SymbolId(69): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(55): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicFunctionWithPublicParmeterTypes1":
-after transform: SymbolId(69): []
-rebuilt        : SymbolId(55): [ReferenceId(105)]
 Symbol flags mismatch for "privateFunctionWithPrivateParmeterTypes1":
 after transform: SymbolId(70): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(56): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "privateFunctionWithPublicParmeterTypes1":
 after transform: SymbolId(71): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(57): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicClassWithPrivateModuleParameterTypes":
-after transform: SymbolId(73): []
-rebuilt        : SymbolId(58): [ReferenceId(111)]
 Symbol flags mismatch for "publicFunctionWithPrivateModuleParameterTypes":
 after transform: SymbolId(74): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(59): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicFunctionWithPrivateModuleParameterTypes":
-after transform: SymbolId(74): []
-rebuilt        : SymbolId(59): [ReferenceId(113)]
 Symbol flags mismatch for "publicFunctionWithPrivateModuleParameterTypes1":
 after transform: SymbolId(75): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(60): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicFunctionWithPrivateModuleParameterTypes1":
-after transform: SymbolId(75): []
-rebuilt        : SymbolId(60): [ReferenceId(116)]
 Symbol flags mismatch for "privateFunctionWithPrivateModuleParameterTypes":
 after transform: SymbolId(78): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(62): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "privateFunctionWithPrivateModuleParameterTypes1":
 after transform: SymbolId(79): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(63): SymbolFlags(FunctionScopedVariable)
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(53) "privateModule"
-rebuilt        : SymbolId(42) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(53) "privateModule"
-rebuilt        : SymbolId(42) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(53) "privateModule"
-rebuilt        : SymbolId(42) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(53) "privateModule"
-rebuilt        : SymbolId(42) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(53) "privateModule"
-rebuilt        : SymbolId(42) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(53) "privateModule"
-rebuilt        : SymbolId(42) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(53) "privateModule"
-rebuilt        : SymbolId(42) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(53) "privateModule"
-rebuilt        : SymbolId(42) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(53) "privateModule"
-rebuilt        : SymbolId(42) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(53) "privateModule"
-rebuilt        : SymbolId(42) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(53) "privateModule"
-rebuilt        : SymbolId(42) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(53) "privateModule"
-rebuilt        : SymbolId(42) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(53) "privateModule"
-rebuilt        : SymbolId(42) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(53) "privateModule"
-rebuilt        : SymbolId(42) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(53) "privateModule"
-rebuilt        : SymbolId(42) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(53) "privateModule"
-rebuilt        : SymbolId(42) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(53) "privateModule"
-rebuilt        : SymbolId(42) "privateModule"
-Reference symbol mismatch for "privateModule":
-after transform: SymbolId(53) "privateModule"
-rebuilt        : SymbolId(42) "privateModule"
 Unresolved references mismatch:
 after transform: ["privateModule"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/privacyGetter.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "C1_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "C3_public"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Missing SymbolId: "m2"
-Missing SymbolId: "_m2"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "m2_C1_public"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "m2_C3_public"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m2"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(13), SymbolId(26), SymbolId(27), SymbolId(28), SymbolId(33)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(14), SymbolId(28), SymbolId(29), SymbolId(30), SymbolId(35)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(8), SymbolId(38)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(9)]
-Binding symbols mismatch:
-after transform: ScopeId(23): [SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(21), SymbolId(39)]
-rebuilt        : ScopeId(23): [SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(23)]
+semantic error: Symbol flags mismatch for "m1":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(0): Span { start: 14, end: 16 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C1_public":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12)]
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(55)]
 rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(8), ReferenceId(9)]
 Symbol reference IDs mismatch for "C2_private":
 after transform: SymbolId(2): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17)]
 rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(5), ReferenceId(10), ReferenceId(11)]
-Symbol reference IDs mismatch for "C3_public":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(4): [ReferenceId(7)]
+Symbol flags mismatch for "m2":
+after transform: SymbolId(13): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m2":
+after transform: SymbolId(13): Span { start: 1449, end: 1451 }
+rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "m2_C1_public":
-after transform: SymbolId(14): [ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30)]
+after transform: SymbolId(14): [ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(61)]
 rebuilt        : SymbolId(16): [ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(22), ReferenceId(23)]
 Symbol reference IDs mismatch for "m2_C2_private":
 after transform: SymbolId(15): [ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(31), ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35)]
 rebuilt        : SymbolId(17): [ReferenceId(18), ReferenceId(19), ReferenceId(24), ReferenceId(25)]
-Symbol reference IDs mismatch for "m2_C3_public":
-after transform: SymbolId(16): []
-rebuilt        : SymbolId(18): [ReferenceId(21)]
 Symbol reference IDs mismatch for "C5_private":
 after transform: SymbolId(26): [ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(44), ReferenceId(49), ReferenceId(50), ReferenceId(51), ReferenceId(52), ReferenceId(53)]
 rebuilt        : SymbolId(28): [ReferenceId(30), ReferenceId(31), ReferenceId(34), ReferenceId(35)]
@@ -24104,125 +21071,29 @@ after transform: SymbolId(27): [ReferenceId(36), ReferenceId(37), ReferenceId(38
 rebuilt        : SymbolId(29): [ReferenceId(28), ReferenceId(29), ReferenceId(32), ReferenceId(33)]
 
 tasks/coverage/typescript/tests/cases/compiler/privacyGloClass.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "m1_c_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "m1_C3_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "m1_C4_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "m1_C7_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "m1_C8_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "m1_C11_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "m1_C12_public"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(19), ScopeId(20), ScopeId(22), ScopeId(23), ScopeId(24)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(17), ScopeId(19), ScopeId(20), ScopeId(21)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(22)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15)]
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16)]
-Symbol reference IDs mismatch for "m1_c_public":
-after transform: SymbolId(3): [ReferenceId(0), ReferenceId(2), ReferenceId(8), ReferenceId(14)]
-rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2), ReferenceId(4), ReferenceId(14), ReferenceId(16)]
-Symbol reference IDs mismatch for "m1_C3_public":
-after transform: SymbolId(7): []
-rebuilt        : SymbolId(6): [ReferenceId(6)]
-Symbol reference IDs mismatch for "m1_C4_public":
-after transform: SymbolId(8): []
-rebuilt        : SymbolId(7): [ReferenceId(9)]
-Symbol reference IDs mismatch for "m1_C7_public":
-after transform: SymbolId(11): []
-rebuilt        : SymbolId(10): [ReferenceId(11)]
-Symbol reference IDs mismatch for "m1_C8_public":
-after transform: SymbolId(12): []
-rebuilt        : SymbolId(11): [ReferenceId(13)]
-Symbol reference IDs mismatch for "m1_C11_public":
-after transform: SymbolId(15): []
-rebuilt        : SymbolId(14): [ReferenceId(18)]
-Symbol reference IDs mismatch for "m1_C12_public":
-after transform: SymbolId(16): []
-rebuilt        : SymbolId(15): [ReferenceId(21)]
+Symbol flags mismatch for "m1":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(0): Span { start: 7, end: 9 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/privacyGloFunc.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "C1_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "C3_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "C5_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "C7_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "f2_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "f4_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "f6_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "f8_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "f10_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "f12_public"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Missing SymbolId: "m2"
-Missing SymbolId: "_m2"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "m2_C1_public"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "m2_C3_public"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "m2_C5_public"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "m2_C7_public"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "f2_public"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "f4_public"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "f6_public"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "f8_public"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "f10_public"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "f12_public"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m2"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(43), SymbolId(86), SymbolId(87), SymbolId(88), SymbolId(96), SymbolId(104), SymbolId(106), SymbolId(108), SymbolId(110), SymbolId(112), SymbolId(114), SymbolId(116), SymbolId(118), SymbolId(120), SymbolId(121), SymbolId(122), SymbolId(123), SymbolId(124), SymbolId(125), SymbolId(126), SymbolId(127)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(40), SymbolId(80), SymbolId(81), SymbolId(82), SymbolId(88), SymbolId(94), SymbolId(96), SymbolId(98), SymbolId(100), SymbolId(102), SymbolId(104), SymbolId(106), SymbolId(108), SymbolId(110), SymbolId(111), SymbolId(112), SymbolId(113), SymbolId(114), SymbolId(115), SymbolId(116), SymbolId(117)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(11), SymbolId(19), SymbolId(21), SymbolId(23), SymbolId(25), SymbolId(27), SymbolId(29), SymbolId(31), SymbolId(33), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(42), SymbolId(128)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(10), SymbolId(16), SymbolId(18), SymbolId(20), SymbolId(22), SymbolId(24), SymbolId(26), SymbolId(28), SymbolId(30), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20)]
 rebuilt        : ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
 Scope children mismatch:
 after transform: ScopeId(21): [ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36)]
 rebuilt        : ScopeId(19): [ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32)]
-Binding symbols mismatch:
-after transform: ScopeId(57): [SymbolId(44), SymbolId(45), SymbolId(46), SymbolId(54), SymbolId(62), SymbolId(64), SymbolId(66), SymbolId(68), SymbolId(70), SymbolId(72), SymbolId(74), SymbolId(76), SymbolId(78), SymbolId(79), SymbolId(80), SymbolId(81), SymbolId(82), SymbolId(83), SymbolId(84), SymbolId(85), SymbolId(129)]
-rebuilt        : ScopeId(53): [SymbolId(41), SymbolId(42), SymbolId(43), SymbolId(44), SymbolId(50), SymbolId(56), SymbolId(58), SymbolId(60), SymbolId(62), SymbolId(64), SymbolId(66), SymbolId(68), SymbolId(70), SymbolId(72), SymbolId(73), SymbolId(74), SymbolId(75), SymbolId(76), SymbolId(77), SymbolId(78), SymbolId(79)]
 Scope children mismatch:
 after transform: ScopeId(61): [ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69), ScopeId(70), ScopeId(71), ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(75), ScopeId(76)]
 rebuilt        : ScopeId(57): [ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66), ScopeId(67), ScopeId(68), ScopeId(69), ScopeId(70)]
@@ -24235,144 +21106,102 @@ rebuilt        : ScopeId(108): [ScopeId(109), ScopeId(110), ScopeId(111), ScopeI
 Scope children mismatch:
 after transform: ScopeId(132): [ScopeId(133), ScopeId(134), ScopeId(135), ScopeId(136), ScopeId(137), ScopeId(138), ScopeId(139), ScopeId(140), ScopeId(141), ScopeId(142), ScopeId(143), ScopeId(144), ScopeId(145), ScopeId(146), ScopeId(147)]
 rebuilt        : ScopeId(122): [ScopeId(123), ScopeId(124), ScopeId(125), ScopeId(126), ScopeId(127), ScopeId(128), ScopeId(129), ScopeId(130), ScopeId(131), ScopeId(132), ScopeId(133), ScopeId(134), ScopeId(135)]
+Symbol flags mismatch for "m1":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(0): Span { start: 14, end: 16 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C1_public":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(7), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(18), ReferenceId(20), ReferenceId(21), ReferenceId(24), ReferenceId(25), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(36), ReferenceId(37), ReferenceId(40), ReferenceId(41), ReferenceId(44), ReferenceId(45), ReferenceId(48), ReferenceId(49), ReferenceId(50), ReferenceId(51)]
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(7), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(18), ReferenceId(20), ReferenceId(21), ReferenceId(24), ReferenceId(25), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(36), ReferenceId(37), ReferenceId(40), ReferenceId(41), ReferenceId(44), ReferenceId(45), ReferenceId(48), ReferenceId(49), ReferenceId(50), ReferenceId(51), ReferenceId(169)]
 rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(6), ReferenceId(7), ReferenceId(12), ReferenceId(13), ReferenceId(16), ReferenceId(17), ReferenceId(28), ReferenceId(29), ReferenceId(36), ReferenceId(37)]
 Symbol reference IDs mismatch for "C2_private":
 after transform: SymbolId(2): [ReferenceId(1), ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(9), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(19), ReferenceId(22), ReferenceId(23), ReferenceId(26), ReferenceId(27), ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35), ReferenceId(38), ReferenceId(39), ReferenceId(42), ReferenceId(43), ReferenceId(46), ReferenceId(47), ReferenceId(52), ReferenceId(53), ReferenceId(54), ReferenceId(55)]
 rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(9), ReferenceId(14), ReferenceId(15), ReferenceId(18), ReferenceId(19), ReferenceId(32), ReferenceId(33), ReferenceId(40), ReferenceId(41)]
-Symbol reference IDs mismatch for "C3_public":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(4): [ReferenceId(11)]
-Symbol reference IDs mismatch for "C5_public":
-after transform: SymbolId(19): []
-rebuilt        : SymbolId(16): [ReferenceId(21)]
-Symbol reference IDs mismatch for "C7_public":
-after transform: SymbolId(23): []
-rebuilt        : SymbolId(20): [ReferenceId(23)]
 Symbol flags mismatch for "f1_public":
 after transform: SymbolId(27): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(24): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "f2_public":
 after transform: SymbolId(29): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(26): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "f2_public":
-after transform: SymbolId(29): []
-rebuilt        : SymbolId(26): [ReferenceId(25)]
 Symbol flags mismatch for "f3_public":
 after transform: SymbolId(31): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(28): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "f4_public":
 after transform: SymbolId(33): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(30): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "f4_public":
-after transform: SymbolId(33): []
-rebuilt        : SymbolId(30): [ReferenceId(27)]
 Symbol flags mismatch for "f5_public":
 after transform: SymbolId(35): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(32): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "f6_public":
 after transform: SymbolId(36): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(33): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "f6_public":
-after transform: SymbolId(36): []
-rebuilt        : SymbolId(33): [ReferenceId(31)]
 Symbol flags mismatch for "f7_public":
 after transform: SymbolId(37): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(34): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "f8_public":
 after transform: SymbolId(38): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(35): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "f8_public":
-after transform: SymbolId(38): []
-rebuilt        : SymbolId(35): [ReferenceId(35)]
 Symbol flags mismatch for "f9_private":
 after transform: SymbolId(39): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(36): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "f10_public":
 after transform: SymbolId(40): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(37): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "f10_public":
-after transform: SymbolId(40): []
-rebuilt        : SymbolId(37): [ReferenceId(39)]
 Symbol flags mismatch for "f11_private":
 after transform: SymbolId(41): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(38): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "f12_public":
 after transform: SymbolId(42): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(39): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "f12_public":
-after transform: SymbolId(42): []
-rebuilt        : SymbolId(39): [ReferenceId(43)]
+Symbol flags mismatch for "m2":
+after transform: SymbolId(43): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(40): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m2":
+after transform: SymbolId(43): Span { start: 3609, end: 3611 }
+rebuilt        : SymbolId(40): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "m2_C1_public":
-after transform: SymbolId(44): [ReferenceId(56), ReferenceId(58), ReferenceId(59), ReferenceId(62), ReferenceId(63), ReferenceId(66), ReferenceId(67), ReferenceId(68), ReferenceId(69), ReferenceId(74), ReferenceId(76), ReferenceId(77), ReferenceId(80), ReferenceId(81), ReferenceId(84), ReferenceId(85), ReferenceId(86), ReferenceId(87), ReferenceId(92), ReferenceId(93), ReferenceId(96), ReferenceId(97), ReferenceId(100), ReferenceId(101), ReferenceId(104), ReferenceId(105), ReferenceId(106), ReferenceId(107)]
+after transform: SymbolId(44): [ReferenceId(56), ReferenceId(58), ReferenceId(59), ReferenceId(62), ReferenceId(63), ReferenceId(66), ReferenceId(67), ReferenceId(68), ReferenceId(69), ReferenceId(74), ReferenceId(76), ReferenceId(77), ReferenceId(80), ReferenceId(81), ReferenceId(84), ReferenceId(85), ReferenceId(86), ReferenceId(87), ReferenceId(92), ReferenceId(93), ReferenceId(96), ReferenceId(97), ReferenceId(100), ReferenceId(101), ReferenceId(104), ReferenceId(105), ReferenceId(106), ReferenceId(107), ReferenceId(191)]
 rebuilt        : SymbolId(42): [ReferenceId(47), ReferenceId(48), ReferenceId(49), ReferenceId(52), ReferenceId(53), ReferenceId(58), ReferenceId(59), ReferenceId(62), ReferenceId(63), ReferenceId(74), ReferenceId(75), ReferenceId(82), ReferenceId(83)]
 Symbol reference IDs mismatch for "m2_C2_private":
 after transform: SymbolId(45): [ReferenceId(57), ReferenceId(60), ReferenceId(61), ReferenceId(64), ReferenceId(65), ReferenceId(70), ReferenceId(71), ReferenceId(72), ReferenceId(73), ReferenceId(75), ReferenceId(78), ReferenceId(79), ReferenceId(82), ReferenceId(83), ReferenceId(88), ReferenceId(89), ReferenceId(90), ReferenceId(91), ReferenceId(94), ReferenceId(95), ReferenceId(98), ReferenceId(99), ReferenceId(102), ReferenceId(103), ReferenceId(108), ReferenceId(109), ReferenceId(110), ReferenceId(111)]
 rebuilt        : SymbolId(43): [ReferenceId(50), ReferenceId(51), ReferenceId(54), ReferenceId(55), ReferenceId(60), ReferenceId(61), ReferenceId(64), ReferenceId(65), ReferenceId(78), ReferenceId(79), ReferenceId(86), ReferenceId(87)]
-Symbol reference IDs mismatch for "m2_C3_public":
-after transform: SymbolId(46): []
-rebuilt        : SymbolId(44): [ReferenceId(57)]
-Symbol reference IDs mismatch for "m2_C5_public":
-after transform: SymbolId(62): []
-rebuilt        : SymbolId(56): [ReferenceId(67)]
-Symbol reference IDs mismatch for "m2_C7_public":
-after transform: SymbolId(66): []
-rebuilt        : SymbolId(60): [ReferenceId(69)]
 Symbol flags mismatch for "f1_public":
 after transform: SymbolId(70): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(64): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "f2_public":
 after transform: SymbolId(72): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(66): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "f2_public":
-after transform: SymbolId(72): []
-rebuilt        : SymbolId(66): [ReferenceId(71)]
 Symbol flags mismatch for "f3_public":
 after transform: SymbolId(74): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(68): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "f4_public":
 after transform: SymbolId(76): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(70): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "f4_public":
-after transform: SymbolId(76): []
-rebuilt        : SymbolId(70): [ReferenceId(73)]
 Symbol flags mismatch for "f5_public":
 after transform: SymbolId(78): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(72): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "f6_public":
 after transform: SymbolId(79): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(73): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "f6_public":
-after transform: SymbolId(79): []
-rebuilt        : SymbolId(73): [ReferenceId(77)]
 Symbol flags mismatch for "f7_public":
 after transform: SymbolId(80): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(74): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "f8_public":
 after transform: SymbolId(81): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(75): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "f8_public":
-after transform: SymbolId(81): []
-rebuilt        : SymbolId(75): [ReferenceId(81)]
 Symbol flags mismatch for "f9_private":
 after transform: SymbolId(82): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(76): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "f10_public":
 after transform: SymbolId(83): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(77): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "f10_public":
-after transform: SymbolId(83): []
-rebuilt        : SymbolId(77): [ReferenceId(85)]
 Symbol flags mismatch for "f11_private":
 after transform: SymbolId(84): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(78): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "f12_public":
 after transform: SymbolId(85): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(79): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "f12_public":
-after transform: SymbolId(85): []
-rebuilt        : SymbolId(79): [ReferenceId(89)]
 Symbol reference IDs mismatch for "C5_private":
 after transform: SymbolId(86): [ReferenceId(112), ReferenceId(116), ReferenceId(117), ReferenceId(120), ReferenceId(121), ReferenceId(126), ReferenceId(127), ReferenceId(128), ReferenceId(129), ReferenceId(130), ReferenceId(134), ReferenceId(135), ReferenceId(138), ReferenceId(139), ReferenceId(144), ReferenceId(145), ReferenceId(146), ReferenceId(147), ReferenceId(150), ReferenceId(151), ReferenceId(152), ReferenceId(153), ReferenceId(158), ReferenceId(159), ReferenceId(164), ReferenceId(165), ReferenceId(166), ReferenceId(167)]
 rebuilt        : SymbolId(80): [ReferenceId(94), ReferenceId(95), ReferenceId(98), ReferenceId(99), ReferenceId(102), ReferenceId(103), ReferenceId(106), ReferenceId(107), ReferenceId(110), ReferenceId(111), ReferenceId(114), ReferenceId(115)]
@@ -24381,32 +21210,21 @@ after transform: SymbolId(87): [ReferenceId(113), ReferenceId(114), ReferenceId(
 rebuilt        : SymbolId(81): [ReferenceId(92), ReferenceId(93), ReferenceId(96), ReferenceId(97), ReferenceId(100), ReferenceId(101), ReferenceId(104), ReferenceId(105), ReferenceId(108), ReferenceId(109), ReferenceId(112), ReferenceId(113)]
 
 tasks/coverage/typescript/tests/cases/compiler/privacyGloGetter.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "C1_public"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "C3_public"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(13), SymbolId(14)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(14), SymbolId(15)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(8), SymbolId(17)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(9)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "m1":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(0): Span { start: 7, end: 9 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C1_public":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12)]
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(23)]
 rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(8), ReferenceId(9)]
 Symbol reference IDs mismatch for "C2_private":
 after transform: SymbolId(2): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17)]
 rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(5), ReferenceId(10), ReferenceId(11)]
-Symbol reference IDs mismatch for "C3_public":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(4): [ReferenceId(7)]
 Symbol reference IDs mismatch for "C6_public":
 after transform: SymbolId(13): [ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21)]
 rebuilt        : SymbolId(14): [ReferenceId(14), ReferenceId(15)]
@@ -24428,29 +21246,26 @@ Namespaces exporting non-const are not supported by Babel. Change to const or se
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/privacyGloInterface.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "C1_public"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C5_public", "m1", "m3"]
 rebuilt        : ScopeId(0): ["C5_public", "m1"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(23), ScopeId(25), ScopeId(30), ScopeId(41), ScopeId(43)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(18)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(14)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4)]
+Symbol flags mismatch for "m1":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(0): Span { start: 7, end: 9 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C1_public":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(22), ReferenceId(24), ReferenceId(26), ReferenceId(28), ReferenceId(30), ReferenceId(32), ReferenceId(34)]
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(22), ReferenceId(24), ReferenceId(26), ReferenceId(28), ReferenceId(30), ReferenceId(32), ReferenceId(34), ReferenceId(55)]
 rebuilt        : SymbolId(2): [ReferenceId(1)]
 Symbol reference IDs mismatch for "C2_private":
 after transform: SymbolId(2): [ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35)]
@@ -24498,44 +21313,38 @@ Namespaces exporting non-const are not supported by Babel. Change to const or se
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/privacyInterface.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "C1_public"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Missing SymbolId: "m2"
-Missing SymbolId: "_m2"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "C1_public"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m2"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C5_public", "C6_private", "m1", "m2", "m3", "m4"]
 rebuilt        : ScopeId(0): ["C5_public", "C6_private", "m1", "m2"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(23), ScopeId(45), ScopeId(47), ScopeId(48), ScopeId(57), ScopeId(66), ScopeId(77), ScopeId(88), ScopeId(90), ScopeId(92), ScopeId(93), ScopeId(94), ScopeId(95), ScopeId(96), ScopeId(97)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(9), ScopeId(11)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(40)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(14)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(23): [SymbolId(6), SymbolId(7), SymbolId(41)]
-rebuilt        : ScopeId(5): [SymbolId(5), SymbolId(6), SymbolId(7)]
 Scope children mismatch:
 after transform: ScopeId(23): [ScopeId(24), ScopeId(26), ScopeId(27), ScopeId(36)]
 rebuilt        : ScopeId(5): [ScopeId(6), ScopeId(8)]
+Symbol flags mismatch for "m1":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(0): Span { start: 14, end: 16 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C1_public":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(22), ReferenceId(24), ReferenceId(26), ReferenceId(28), ReferenceId(30), ReferenceId(32), ReferenceId(34)]
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(20), ReferenceId(22), ReferenceId(24), ReferenceId(26), ReferenceId(28), ReferenceId(30), ReferenceId(32), ReferenceId(34), ReferenceId(133)]
 rebuilt        : SymbolId(2): [ReferenceId(1)]
 Symbol reference IDs mismatch for "C2_private":
 after transform: SymbolId(2): [ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35)]
 rebuilt        : SymbolId(3): []
+Symbol flags mismatch for "m2":
+after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m2":
+after transform: SymbolId(5): Span { start: 1205, end: 1207 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C1_public":
-after transform: SymbolId(6): [ReferenceId(36), ReferenceId(38), ReferenceId(40), ReferenceId(42), ReferenceId(44), ReferenceId(46), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(54), ReferenceId(56), ReferenceId(58), ReferenceId(60), ReferenceId(62), ReferenceId(64), ReferenceId(66), ReferenceId(68), ReferenceId(70)]
+after transform: SymbolId(6): [ReferenceId(36), ReferenceId(38), ReferenceId(40), ReferenceId(42), ReferenceId(44), ReferenceId(46), ReferenceId(48), ReferenceId(50), ReferenceId(52), ReferenceId(54), ReferenceId(56), ReferenceId(58), ReferenceId(60), ReferenceId(62), ReferenceId(64), ReferenceId(66), ReferenceId(68), ReferenceId(70), ReferenceId(137)]
 rebuilt        : SymbolId(6): [ReferenceId(5)]
 Symbol reference IDs mismatch for "C2_private":
 after transform: SymbolId(7): [ReferenceId(37), ReferenceId(39), ReferenceId(41), ReferenceId(43), ReferenceId(45), ReferenceId(47), ReferenceId(49), ReferenceId(51), ReferenceId(53), ReferenceId(55), ReferenceId(57), ReferenceId(59), ReferenceId(61), ReferenceId(63), ReferenceId(65), ReferenceId(67), ReferenceId(69), ReferenceId(71)]
@@ -24642,61 +21451,12 @@ after transform: SymbolId(1): [ReferenceId(6), ReferenceId(7), ReferenceId(8), R
 rebuilt        : SymbolId(1): []
 
 tasks/coverage/typescript/tests/cases/compiler/privacyTypeParameterOfFunctionDeclFile.ts
-semantic error: Missing SymbolId: "publicModule"
-Missing SymbolId: "_publicModule"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClass"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassWithWithPrivateTypeParameters"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassWithWithPublicTypeParameters"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicFunctionWithPrivateTypeParameters"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicFunctionWithPublicTypeParameters"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassWithWithPublicTypeParametersWithoutExtends"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicFunctionWithPublicTypeParametersWithoutExtends"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassWithWithPrivateModuleTypeParameters"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicFunctionWithPrivateMopduleTypeParameters"
-Missing ReferenceId: "publicModule"
-Missing ReferenceId: "publicModule"
-Missing SymbolId: "privateModule"
-Missing SymbolId: "_privateModule"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClass"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClassWithWithPrivateTypeParameters"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClassWithWithPublicTypeParameters"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicFunctionWithPrivateTypeParameters"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicFunctionWithPublicTypeParameters"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClassWithWithPublicTypeParametersWithoutExtends"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicFunctionWithPublicTypeParametersWithoutExtends"
-Missing ReferenceId: "privateModule"
-Missing ReferenceId: "privateModule"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(18), SymbolId(23), SymbolId(28), SymbolId(33), SymbolId(38), SymbolId(40), SymbolId(42), SymbolId(44), SymbolId(54), SymbolId(59), SymbolId(64), SymbolId(66), SymbolId(72), SymbolId(75), SymbolId(81), SymbolId(84), SymbolId(86), SymbolId(173)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(38)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(6), ScopeId(9), ScopeId(12), ScopeId(15), ScopeId(20), ScopeId(25), ScopeId(30), ScopeId(35), ScopeId(36), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(42), ScopeId(45), ScopeId(50), ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(60), ScopeId(63), ScopeId(64), ScopeId(67), ScopeId(70), ScopeId(71), ScopeId(142)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(8), ScopeId(13), ScopeId(18), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(32), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(42), ScopeId(43), ScopeId(46), ScopeId(47), ScopeId(94)]
-Binding symbols mismatch:
-after transform: ScopeId(71): [SymbolId(87), SymbolId(88), SymbolId(105), SymbolId(110), SymbolId(115), SymbolId(120), SymbolId(125), SymbolId(127), SymbolId(129), SymbolId(131), SymbolId(141), SymbolId(146), SymbolId(151), SymbolId(153), SymbolId(159), SymbolId(162), SymbolId(168), SymbolId(171), SymbolId(242)]
-rebuilt        : ScopeId(47): [SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(27), SymbolId(28), SymbolId(29), SymbolId(30), SymbolId(31), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(37)]
 Scope children mismatch:
 after transform: ScopeId(71): [ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(77), ScopeId(80), ScopeId(83), ScopeId(86), ScopeId(91), ScopeId(96), ScopeId(101), ScopeId(106), ScopeId(107), ScopeId(108), ScopeId(109), ScopeId(110), ScopeId(113), ScopeId(116), ScopeId(121), ScopeId(126), ScopeId(127), ScopeId(128), ScopeId(131), ScopeId(134), ScopeId(135), ScopeId(138), ScopeId(141)]
 rebuilt        : ScopeId(47): [ScopeId(48), ScopeId(49), ScopeId(50), ScopeId(55), ScopeId(60), ScopeId(65), ScopeId(70), ScopeId(71), ScopeId(72), ScopeId(73), ScopeId(74), ScopeId(79), ScopeId(84), ScopeId(85), ScopeId(86), ScopeId(89), ScopeId(90), ScopeId(93)]
-Binding symbols mismatch:
-after transform: ScopeId(142): [SymbolId(174), SymbolId(175), SymbolId(192), SymbolId(197), SymbolId(202), SymbolId(207), SymbolId(212), SymbolId(214), SymbolId(216), SymbolId(218), SymbolId(228), SymbolId(233), SymbolId(238), SymbolId(240), SymbolId(243)]
-rebuilt        : ScopeId(94): [SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(42), SymbolId(43), SymbolId(44), SymbolId(45), SymbolId(46), SymbolId(47), SymbolId(48), SymbolId(49), SymbolId(50), SymbolId(51), SymbolId(52), SymbolId(53)]
 Scope children mismatch:
 after transform: ScopeId(142): [ScopeId(143), ScopeId(144), ScopeId(145), ScopeId(148), ScopeId(151), ScopeId(154), ScopeId(157), ScopeId(162), ScopeId(167), ScopeId(172), ScopeId(177), ScopeId(178), ScopeId(179), ScopeId(180), ScopeId(181), ScopeId(184), ScopeId(187), ScopeId(192), ScopeId(197), ScopeId(198)]
 rebuilt        : ScopeId(94): [ScopeId(95), ScopeId(96), ScopeId(97), ScopeId(102), ScopeId(107), ScopeId(112), ScopeId(117), ScopeId(118), ScopeId(119), ScopeId(120), ScopeId(121), ScopeId(126), ScopeId(131), ScopeId(132)]
@@ -24706,99 +21466,69 @@ rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch for "publicClass":
 after transform: SymbolId(1): [ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(41), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(48), ReferenceId(49)]
 rebuilt        : SymbolId(1): []
+Symbol flags mismatch for "publicModule":
+after transform: SymbolId(86): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "publicModule":
+after transform: SymbolId(86): Span { start: 4738, end: 4750 }
+rebuilt        : SymbolId(18): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "privateClass":
 after transform: SymbolId(87): [ReferenceId(68), ReferenceId(69), ReferenceId(70), ReferenceId(71), ReferenceId(72), ReferenceId(73), ReferenceId(80), ReferenceId(81), ReferenceId(82), ReferenceId(83), ReferenceId(84), ReferenceId(85), ReferenceId(92), ReferenceId(93), ReferenceId(94), ReferenceId(95), ReferenceId(100), ReferenceId(101), ReferenceId(102), ReferenceId(103), ReferenceId(108), ReferenceId(110)]
 rebuilt        : SymbolId(20): []
 Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(88): [ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(90), ReferenceId(91), ReferenceId(96), ReferenceId(97), ReferenceId(98), ReferenceId(99), ReferenceId(104), ReferenceId(105), ReferenceId(106), ReferenceId(107), ReferenceId(109), ReferenceId(111), ReferenceId(112), ReferenceId(113), ReferenceId(114), ReferenceId(115), ReferenceId(116), ReferenceId(117)]
+after transform: SymbolId(88): [ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(90), ReferenceId(91), ReferenceId(96), ReferenceId(97), ReferenceId(98), ReferenceId(99), ReferenceId(104), ReferenceId(105), ReferenceId(106), ReferenceId(107), ReferenceId(109), ReferenceId(111), ReferenceId(112), ReferenceId(113), ReferenceId(114), ReferenceId(115), ReferenceId(116), ReferenceId(117), ReferenceId(187)]
 rebuilt        : SymbolId(21): [ReferenceId(1)]
-Symbol reference IDs mismatch for "publicClassWithWithPrivateTypeParameters":
-after transform: SymbolId(105): []
-rebuilt        : SymbolId(22): [ReferenceId(3)]
-Symbol reference IDs mismatch for "publicClassWithWithPublicTypeParameters":
-after transform: SymbolId(110): []
-rebuilt        : SymbolId(23): [ReferenceId(5)]
 Symbol flags mismatch for "publicFunctionWithPrivateTypeParameters":
 after transform: SymbolId(125): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(26): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicFunctionWithPrivateTypeParameters":
-after transform: SymbolId(125): []
-rebuilt        : SymbolId(26): [ReferenceId(7)]
 Symbol flags mismatch for "publicFunctionWithPublicTypeParameters":
 after transform: SymbolId(127): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(27): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicFunctionWithPublicTypeParameters":
-after transform: SymbolId(127): []
-rebuilt        : SymbolId(27): [ReferenceId(9)]
 Symbol flags mismatch for "privateFunctionWithPrivateTypeParameters":
 after transform: SymbolId(129): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(28): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "privateFunctionWithPublicTypeParameters":
 after transform: SymbolId(131): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(29): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicClassWithWithPublicTypeParametersWithoutExtends":
-after transform: SymbolId(141): []
-rebuilt        : SymbolId(30): [ReferenceId(11)]
 Symbol flags mismatch for "publicFunctionWithPublicTypeParametersWithoutExtends":
 after transform: SymbolId(151): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(32): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicFunctionWithPublicTypeParametersWithoutExtends":
-after transform: SymbolId(151): []
-rebuilt        : SymbolId(32): [ReferenceId(13)]
 Symbol flags mismatch for "privateFunctionWithPublicTypeParametersWithoutExtends":
 after transform: SymbolId(153): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(33): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicClassWithWithPrivateModuleTypeParameters":
-after transform: SymbolId(159): []
-rebuilt        : SymbolId(34): [ReferenceId(15)]
 Symbol flags mismatch for "publicFunctionWithPrivateMopduleTypeParameters":
 after transform: SymbolId(162): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(35): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicFunctionWithPrivateMopduleTypeParameters":
-after transform: SymbolId(162): []
-rebuilt        : SymbolId(35): [ReferenceId(17)]
 Symbol flags mismatch for "privateFunctionWithPrivateMopduleTypeParameters":
 after transform: SymbolId(171): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(37): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch for "privateModule":
+after transform: SymbolId(173): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(38): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "privateModule":
+after transform: SymbolId(173): Span { start: 10023, end: 10036 }
+rebuilt        : SymbolId(38): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "privateClass":
 after transform: SymbolId(174): [ReferenceId(136), ReferenceId(137), ReferenceId(138), ReferenceId(139), ReferenceId(140), ReferenceId(141), ReferenceId(148), ReferenceId(149), ReferenceId(150), ReferenceId(151), ReferenceId(152), ReferenceId(153), ReferenceId(160), ReferenceId(161), ReferenceId(162), ReferenceId(163), ReferenceId(168), ReferenceId(169), ReferenceId(170), ReferenceId(171), ReferenceId(176), ReferenceId(178)]
 rebuilt        : SymbolId(40): []
 Symbol reference IDs mismatch for "publicClass":
-after transform: SymbolId(175): [ReferenceId(142), ReferenceId(143), ReferenceId(144), ReferenceId(145), ReferenceId(146), ReferenceId(147), ReferenceId(154), ReferenceId(155), ReferenceId(156), ReferenceId(157), ReferenceId(158), ReferenceId(159), ReferenceId(164), ReferenceId(165), ReferenceId(166), ReferenceId(167), ReferenceId(172), ReferenceId(173), ReferenceId(174), ReferenceId(175), ReferenceId(177), ReferenceId(179), ReferenceId(180), ReferenceId(181), ReferenceId(182), ReferenceId(183), ReferenceId(184), ReferenceId(185)]
+after transform: SymbolId(175): [ReferenceId(142), ReferenceId(143), ReferenceId(144), ReferenceId(145), ReferenceId(146), ReferenceId(147), ReferenceId(154), ReferenceId(155), ReferenceId(156), ReferenceId(157), ReferenceId(158), ReferenceId(159), ReferenceId(164), ReferenceId(165), ReferenceId(166), ReferenceId(167), ReferenceId(172), ReferenceId(173), ReferenceId(174), ReferenceId(175), ReferenceId(177), ReferenceId(179), ReferenceId(180), ReferenceId(181), ReferenceId(182), ReferenceId(183), ReferenceId(184), ReferenceId(185), ReferenceId(207)]
 rebuilt        : SymbolId(41): [ReferenceId(21)]
-Symbol reference IDs mismatch for "publicClassWithWithPrivateTypeParameters":
-after transform: SymbolId(192): []
-rebuilt        : SymbolId(42): [ReferenceId(23)]
-Symbol reference IDs mismatch for "publicClassWithWithPublicTypeParameters":
-after transform: SymbolId(197): []
-rebuilt        : SymbolId(43): [ReferenceId(25)]
 Symbol flags mismatch for "publicFunctionWithPrivateTypeParameters":
 after transform: SymbolId(212): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(46): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicFunctionWithPrivateTypeParameters":
-after transform: SymbolId(212): []
-rebuilt        : SymbolId(46): [ReferenceId(27)]
 Symbol flags mismatch for "publicFunctionWithPublicTypeParameters":
 after transform: SymbolId(214): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(47): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicFunctionWithPublicTypeParameters":
-after transform: SymbolId(214): []
-rebuilt        : SymbolId(47): [ReferenceId(29)]
 Symbol flags mismatch for "privateFunctionWithPrivateTypeParameters":
 after transform: SymbolId(216): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(48): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "privateFunctionWithPublicTypeParameters":
 after transform: SymbolId(218): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(49): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicClassWithWithPublicTypeParametersWithoutExtends":
-after transform: SymbolId(228): []
-rebuilt        : SymbolId(50): [ReferenceId(31)]
 Symbol flags mismatch for "publicFunctionWithPublicTypeParametersWithoutExtends":
 after transform: SymbolId(238): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(52): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "publicFunctionWithPublicTypeParametersWithoutExtends":
-after transform: SymbolId(238): []
-rebuilt        : SymbolId(52): [ReferenceId(33)]
 Symbol flags mismatch for "privateFunctionWithPublicTypeParametersWithoutExtends":
 after transform: SymbolId(240): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(53): SymbolFlags(FunctionScopedVariable)
@@ -24815,80 +21545,36 @@ after transform: SymbolId(1): [ReferenceId(4), ReferenceId(12)]
 rebuilt        : SymbolId(1): []
 
 tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfClassDeclFile.ts
-semantic error: Missing SymbolId: "publicModule"
-Missing SymbolId: "_publicModule"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassInPublicModule"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassWithPrivateTypeParameters"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassWithPublicTypeParameters"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassWithPublicTypeParametersWithoutExtends"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassWithTypeParametersFromPrivateModule"
-Missing ReferenceId: "publicModule"
-Missing ReferenceId: "publicModule"
-Missing SymbolId: "privateModule"
-Missing SymbolId: "_privateModule"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClassInPrivateModule"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClassWithPrivateTypeParameters"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClassWithPublicTypeParameters"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClassWithPublicTypeParametersWithoutExtends"
-Missing ReferenceId: "privateModule"
-Missing ReferenceId: "privateModule"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(5), SymbolId(8), SymbolId(11), SymbolId(14), SymbolId(17), SymbolId(20), SymbolId(23), SymbolId(26), SymbolId(53)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(6), SymbolId(8), SymbolId(10), SymbolId(12), SymbolId(14), SymbolId(16), SymbolId(18), SymbolId(38)]
-Binding symbols mismatch:
-after transform: ScopeId(19): [SymbolId(27), SymbolId(28), SymbolId(29), SymbolId(32), SymbolId(35), SymbolId(38), SymbolId(41), SymbolId(44), SymbolId(47), SymbolId(50), SymbolId(74)]
-rebuilt        : ScopeId(19): [SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(24), SymbolId(26), SymbolId(28), SymbolId(30), SymbolId(32), SymbolId(34), SymbolId(36)]
-Binding symbols mismatch:
-after transform: ScopeId(38): [SymbolId(54), SymbolId(55), SymbolId(56), SymbolId(59), SymbolId(62), SymbolId(65), SymbolId(68), SymbolId(71), SymbolId(75)]
-rebuilt        : ScopeId(38): [SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(42), SymbolId(44), SymbolId(46), SymbolId(48), SymbolId(50), SymbolId(52)]
-Symbol reference IDs mismatch for "privateClass":
+semantic error: Symbol reference IDs mismatch for "privateClass":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(8)]
 rebuilt        : SymbolId(0): []
 Symbol reference IDs mismatch for "publicClass":
 after transform: SymbolId(1): [ReferenceId(4), ReferenceId(12)]
 rebuilt        : SymbolId(1): []
+Symbol flags mismatch for "publicModule":
+after transform: SymbolId(26): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "publicModule":
+after transform: SymbolId(26): Span { start: 1169, end: 1181 }
+rebuilt        : SymbolId(18): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "privateClassInPublicModule":
 after transform: SymbolId(27): [ReferenceId(30), ReferenceId(38)]
 rebuilt        : SymbolId(20): []
 Symbol reference IDs mismatch for "publicClassInPublicModule":
-after transform: SymbolId(28): [ReferenceId(34), ReferenceId(42)]
+after transform: SymbolId(28): [ReferenceId(34), ReferenceId(42), ReferenceId(83)]
 rebuilt        : SymbolId(21): [ReferenceId(9)]
-Symbol reference IDs mismatch for "publicClassWithPrivateTypeParameters":
-after transform: SymbolId(29): []
-rebuilt        : SymbolId(22): [ReferenceId(12)]
-Symbol reference IDs mismatch for "publicClassWithPublicTypeParameters":
-after transform: SymbolId(32): []
-rebuilt        : SymbolId(24): [ReferenceId(15)]
-Symbol reference IDs mismatch for "publicClassWithPublicTypeParametersWithoutExtends":
-after transform: SymbolId(41): []
-rebuilt        : SymbolId(30): [ReferenceId(20)]
-Symbol reference IDs mismatch for "publicClassWithTypeParametersFromPrivateModule":
-after transform: SymbolId(47): []
-rebuilt        : SymbolId(34): [ReferenceId(24)]
+Symbol flags mismatch for "privateModule":
+after transform: SymbolId(53): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(38): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "privateModule":
+after transform: SymbolId(53): Span { start: 2605, end: 2618 }
+rebuilt        : SymbolId(38): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "privateClassInPrivateModule":
 after transform: SymbolId(54): [ReferenceId(60), ReferenceId(68)]
 rebuilt        : SymbolId(40): []
 Symbol reference IDs mismatch for "publicClassInPrivateModule":
-after transform: SymbolId(55): [ReferenceId(64), ReferenceId(72)]
+after transform: SymbolId(55): [ReferenceId(64), ReferenceId(72), ReferenceId(95)]
 rebuilt        : SymbolId(41): [ReferenceId(29)]
-Symbol reference IDs mismatch for "publicClassWithPrivateTypeParameters":
-after transform: SymbolId(56): []
-rebuilt        : SymbolId(42): [ReferenceId(32)]
-Symbol reference IDs mismatch for "publicClassWithPublicTypeParameters":
-after transform: SymbolId(59): []
-rebuilt        : SymbolId(44): [ReferenceId(35)]
-Symbol reference IDs mismatch for "publicClassWithPublicTypeParametersWithoutExtends":
-after transform: SymbolId(68): []
-rebuilt        : SymbolId(50): [ReferenceId(40)]
 Unresolved references mismatch:
 after transform: ["privateModule"]
 rebuilt        : []
@@ -24911,37 +21597,12 @@ after transform: SymbolId(4): [ReferenceId(3), ReferenceId(9), ReferenceId(11), 
 rebuilt        : SymbolId(3): []
 
 tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfInterfaceDeclFile.ts
-semantic error: Missing SymbolId: "publicModule"
-Missing SymbolId: "_publicModule"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassInPublicModule"
-Missing ReferenceId: "_publicModule"
-Missing ReferenceId: "publicClassInPublicModuleT"
-Missing ReferenceId: "publicModule"
-Missing ReferenceId: "publicModule"
-Missing SymbolId: "privateModule"
-Missing SymbolId: "_privateModule"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClassInPrivateModule"
-Missing ReferenceId: "_privateModule"
-Missing ReferenceId: "publicClassInPrivateModuleT"
-Missing ReferenceId: "privateModule"
-Missing ReferenceId: "privateModule"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(22), SymbolId(45)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(10)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(12), ScopeId(19), ScopeId(26), ScopeId(33), ScopeId(36), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(82)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(10)]
-Binding symbols mismatch:
-after transform: ScopeId(41): [SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(27), SymbolId(64)]
-rebuilt        : ScopeId(5): [SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9)]
 Scope children mismatch:
 after transform: ScopeId(41): [ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(53), ScopeId(60), ScopeId(67), ScopeId(74), ScopeId(77), ScopeId(80), ScopeId(81)]
 rebuilt        : ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-Binding symbols mismatch:
-after transform: ScopeId(82): [SymbolId(46), SymbolId(47), SymbolId(48), SymbolId(50), SymbolId(65)]
-rebuilt        : ScopeId(10): [SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15)]
 Scope children mismatch:
 after transform: ScopeId(82): [ScopeId(83), ScopeId(84), ScopeId(85), ScopeId(86), ScopeId(87), ScopeId(94), ScopeId(101), ScopeId(108), ScopeId(115), ScopeId(118)]
 rebuilt        : ScopeId(10): [ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14)]
@@ -24957,29 +21618,41 @@ rebuilt        : SymbolId(2): []
 Symbol reference IDs mismatch for "publicClassT":
 after transform: SymbolId(4): [ReferenceId(3), ReferenceId(9), ReferenceId(11), ReferenceId(16), ReferenceId(22), ReferenceId(24), ReferenceId(29), ReferenceId(35), ReferenceId(37), ReferenceId(42), ReferenceId(48), ReferenceId(50), ReferenceId(54), ReferenceId(58)]
 rebuilt        : SymbolId(3): []
+Symbol flags mismatch for "publicModule":
+after transform: SymbolId(22): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "publicModule":
+after transform: SymbolId(22): Span { start: 1973, end: 1985 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "privateClassInPublicModule":
 after transform: SymbolId(23): [ReferenceId(62), ReferenceId(68), ReferenceId(72), ReferenceId(81), ReferenceId(85), ReferenceId(88), ReferenceId(94), ReferenceId(98), ReferenceId(107), ReferenceId(111)]
 rebuilt        : SymbolId(6): []
 Symbol reference IDs mismatch for "publicClassInPublicModule":
-after transform: SymbolId(24): [ReferenceId(70), ReferenceId(74), ReferenceId(75), ReferenceId(83), ReferenceId(87), ReferenceId(96), ReferenceId(100), ReferenceId(101), ReferenceId(109), ReferenceId(113)]
+after transform: SymbolId(24): [ReferenceId(70), ReferenceId(74), ReferenceId(75), ReferenceId(83), ReferenceId(87), ReferenceId(96), ReferenceId(100), ReferenceId(101), ReferenceId(109), ReferenceId(113), ReferenceId(185)]
 rebuilt        : SymbolId(7): [ReferenceId(1)]
 Symbol reference IDs mismatch for "privateClassInPublicModuleT":
 after transform: SymbolId(25): [ReferenceId(67), ReferenceId(69), ReferenceId(80), ReferenceId(82), ReferenceId(93), ReferenceId(95), ReferenceId(106), ReferenceId(108)]
 rebuilt        : SymbolId(8): []
 Symbol reference IDs mismatch for "publicClassInPublicModuleT":
-after transform: SymbolId(27): [ReferenceId(65), ReferenceId(71), ReferenceId(73), ReferenceId(78), ReferenceId(84), ReferenceId(86), ReferenceId(91), ReferenceId(97), ReferenceId(99), ReferenceId(104), ReferenceId(110), ReferenceId(112), ReferenceId(116), ReferenceId(120)]
+after transform: SymbolId(27): [ReferenceId(65), ReferenceId(71), ReferenceId(73), ReferenceId(78), ReferenceId(84), ReferenceId(86), ReferenceId(91), ReferenceId(97), ReferenceId(99), ReferenceId(104), ReferenceId(110), ReferenceId(112), ReferenceId(116), ReferenceId(120), ReferenceId(187)]
 rebuilt        : SymbolId(9): [ReferenceId(3)]
+Symbol flags mismatch for "privateModule":
+after transform: SymbolId(45): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "privateModule":
+after transform: SymbolId(45): Span { start: 4805, end: 4818 }
+rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "privateClassInPrivateModule":
 after transform: SymbolId(46): [ReferenceId(124), ReferenceId(130), ReferenceId(134), ReferenceId(143), ReferenceId(147), ReferenceId(150), ReferenceId(156), ReferenceId(160), ReferenceId(169), ReferenceId(173)]
 rebuilt        : SymbolId(12): []
 Symbol reference IDs mismatch for "publicClassInPrivateModule":
-after transform: SymbolId(47): [ReferenceId(132), ReferenceId(136), ReferenceId(137), ReferenceId(145), ReferenceId(149), ReferenceId(158), ReferenceId(162), ReferenceId(163), ReferenceId(171), ReferenceId(175)]
+after transform: SymbolId(47): [ReferenceId(132), ReferenceId(136), ReferenceId(137), ReferenceId(145), ReferenceId(149), ReferenceId(158), ReferenceId(162), ReferenceId(163), ReferenceId(171), ReferenceId(175), ReferenceId(191)]
 rebuilt        : SymbolId(13): [ReferenceId(7)]
 Symbol reference IDs mismatch for "privateClassInPrivateModuleT":
 after transform: SymbolId(48): [ReferenceId(129), ReferenceId(131), ReferenceId(142), ReferenceId(144), ReferenceId(155), ReferenceId(157), ReferenceId(168), ReferenceId(170)]
 rebuilt        : SymbolId(14): []
 Symbol reference IDs mismatch for "publicClassInPrivateModuleT":
-after transform: SymbolId(50): [ReferenceId(127), ReferenceId(133), ReferenceId(135), ReferenceId(140), ReferenceId(146), ReferenceId(148), ReferenceId(153), ReferenceId(159), ReferenceId(161), ReferenceId(166), ReferenceId(172), ReferenceId(174), ReferenceId(178), ReferenceId(182)]
+after transform: SymbolId(50): [ReferenceId(127), ReferenceId(133), ReferenceId(135), ReferenceId(140), ReferenceId(146), ReferenceId(148), ReferenceId(153), ReferenceId(159), ReferenceId(161), ReferenceId(166), ReferenceId(172), ReferenceId(174), ReferenceId(178), ReferenceId(182), ReferenceId(193)]
 rebuilt        : SymbolId(15): [ReferenceId(9)]
 Unresolved references mismatch:
 after transform: ["privateModule"]
@@ -25008,24 +21681,15 @@ Namespaces exporting non-const are not supported by Babel. Change to const or se
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/privateInstanceVisibility.ts
-semantic error: Missing SymbolId: "Test"
-Missing SymbolId: "_Test"
-Missing ReferenceId: "_Test"
-Missing ReferenceId: "Example"
-Missing ReferenceId: "Test"
-Missing ReferenceId: "Test"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(8)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(7)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol reference IDs mismatch for "Example":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(3): [ReferenceId(4)]
+Symbol flags mismatch for "Test":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Test":
+after transform: SymbolId(0): Span { start: 7, end: 11 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(5): [ReferenceId(1)]
 rebuilt        : SymbolId(7): []
@@ -26236,48 +22900,35 @@ after transform: ["Object", "require"]
 rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/reboundBaseClassSymbol.ts
-semantic error: Missing SymbolId: "Foo"
-Missing SymbolId: "_Foo"
-Missing ReferenceId: "Foo"
-Missing ReferenceId: "Foo"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(1)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(2): [ScopeId(3)]
 rebuilt        : ScopeId(1): []
+Symbol flags mismatch for "Foo":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Foo":
+after transform: SymbolId(1): Span { start: 34, end: 37 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/rectype.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "f"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(2), SymbolId(4), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
-Symbol reference IDs mismatch for "f":
-after transform: SymbolId(2): [ReferenceId(3), ReferenceId(5), ReferenceId(7), ReferenceId(8), ReferenceId(10), ReferenceId(11), ReferenceId(12)]
-rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(9), ReferenceId(10)]
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveArrayNotCircular.ts
 semantic error: Scope children mismatch:
@@ -26339,32 +22990,15 @@ after transform: ["undefined"]
 rebuilt        : ["Base", "p", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveClassInstantiationsWithDefaultConstructors.ts
-semantic error: Missing SymbolId: "TypeScript2"
-Missing SymbolId: "_TypeScript"
-Missing ReferenceId: "_TypeScript"
-Missing ReferenceId: "MemberName"
-Missing ReferenceId: "_TypeScript"
-Missing ReferenceId: "MemberNameArray"
-Missing ReferenceId: "TypeScript2"
-Missing ReferenceId: "TypeScript2"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(5)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol reference IDs mismatch for "MemberName":
-after transform: SymbolId(1): [ReferenceId(0)]
-rebuilt        : SymbolId(3): [ReferenceId(3), ReferenceId(4)]
-Symbol reference IDs mismatch for "MemberNameArray":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(6)]
-Reference symbol mismatch for "TypeScript2":
-after transform: SymbolId(0) "TypeScript2"
-rebuilt        : SymbolId(1) "TypeScript2"
+Symbol flags mismatch for "TypeScript2":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "TypeScript2":
+after transform: SymbolId(0): Span { start: 7, end: 18 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveCloduleReference.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -26491,22 +23125,18 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveIdenticalOverloadResolution.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(2), SymbolId(4), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveInheritance2.ts
 semantic error: Bindings mismatch:
@@ -26529,27 +23159,15 @@ after transform: []
 rebuilt        : ["a", "b", "c"]
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveMods.ts
-semantic error: Missing SymbolId: "Foo"
-Missing SymbolId: "_Foo"
-Missing ReferenceId: "_Foo"
-Missing ReferenceId: "C"
-Missing ReferenceId: "Foo"
-Missing ReferenceId: "Foo"
-Missing SymbolId: "_Foo2"
-Missing ReferenceId: "Foo"
-Missing ReferenceId: "Foo"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(8)]
-rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(7)]
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
+semantic error: Symbol flags mismatch for "Foo":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Foo":
+after transform: SymbolId(0): Span { start: 14, end: 17 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "Foo":
+after transform: SymbolId(0): [Span { start: 56, end: 59 }]
+rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "Bar":
 after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
@@ -26671,67 +23289,47 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/recursivelySpecializedConstructorDeclaration.ts
-semantic error: Missing SymbolId: "MsPortal"
-Missing SymbolId: "_MsPortal"
-Missing SymbolId: "Controls"
-Missing SymbolId: "_Controls"
-Missing SymbolId: "Base"
-Missing SymbolId: "_Base"
-Missing SymbolId: "ItemList"
-Missing SymbolId: "_ItemList"
-Missing ReferenceId: "_ItemList"
-Missing ReferenceId: "ItemValue"
-Missing ReferenceId: "_ItemList"
-Missing ReferenceId: "ViewModel"
-Missing ReferenceId: "ItemList"
-Missing ReferenceId: "ItemList"
-Missing ReferenceId: "_Base"
-Missing ReferenceId: "_Base"
-Missing ReferenceId: "Base"
-Missing ReferenceId: "Base"
-Missing ReferenceId: "_Controls"
-Missing ReferenceId: "_Controls"
-Missing ReferenceId: "Controls"
-Missing ReferenceId: "Controls"
-Missing ReferenceId: "_MsPortal"
-Missing ReferenceId: "_MsPortal"
-Missing ReferenceId: "MsPortal"
-Missing ReferenceId: "MsPortal"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(11)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(12)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(3), SymbolId(13)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(6), SymbolId(9), SymbolId(14)]
-rebuilt        : ScopeId(4): [SymbolId(7), SymbolId(8), SymbolId(10)]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(4): [ScopeId(5), ScopeId(6), ScopeId(8)]
 rebuilt        : ScopeId(4): [ScopeId(5), ScopeId(7)]
-Symbol reference IDs mismatch for "ItemValue":
-after transform: SymbolId(6): [ReferenceId(3)]
-rebuilt        : SymbolId(8): [ReferenceId(1), ReferenceId(2)]
+Symbol flags mismatch for "MsPortal":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "MsPortal":
+after transform: SymbolId(0): Span { start: 7, end: 15 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Controls":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Controls":
+after transform: SymbolId(1): Span { start: 16, end: 24 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Base":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Base":
+after transform: SymbolId(2): Span { start: 25, end: 29 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
+Symbol flags mismatch for "ItemList":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "ItemList":
+after transform: SymbolId(3): Span { start: 30, end: 38 }
+rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "ViewModel":
-after transform: SymbolId(9): [ReferenceId(0)]
+after transform: SymbolId(9): [ReferenceId(0), ReferenceId(8)]
 rebuilt        : SymbolId(10): [ReferenceId(4)]
 
 tasks/coverage/typescript/tests/cases/compiler/redeclarationOfVarWithGenericType.ts
@@ -26823,21 +23421,12 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/requireEmitSemicolon.ts
-semantic error: Missing SymbolId: "Models"
-Missing SymbolId: "_Models"
-Missing ReferenceId: "_Models"
-Missing ReferenceId: "Person"
-Missing ReferenceId: "Models"
-Missing ReferenceId: "Models"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Symbol reference IDs mismatch for "Person":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
+semantic error: Symbol flags mismatch for "Models":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Models":
+after transform: SymbolId(0): Span { start: 14, end: 20 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFile.ts
 semantic error: Missing SymbolId: "b1"
@@ -27275,27 +23864,7 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), Sc
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/returnTypeParameterWithModules.ts
-semantic error: Missing SymbolId: "M1"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "reduce"
-Missing ReferenceId: "M1"
-Missing ReferenceId: "M1"
-Missing SymbolId: "M2"
-Missing SymbolId: "_M2"
-Missing SymbolId: "A"
-Missing ReferenceId: "_M2"
-Missing ReferenceId: "compose"
-Missing ReferenceId: "_M2"
-Missing ReferenceId: "compose2"
-Missing ReferenceId: "M2"
-Missing ReferenceId: "M2"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(6)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(16)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+semantic error: Missing SymbolId: "A"
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
@@ -27305,18 +23874,18 @@ rebuilt        : ScopeId(3): [SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Symbol reference IDs mismatch for "reduce":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(7)]
-Symbol reference IDs mismatch for "compose":
-after transform: SymbolId(8): []
-rebuilt        : SymbolId(9): [ReferenceId(15)]
-Symbol reference IDs mismatch for "compose2":
-after transform: SymbolId(9): [ReferenceId(11)]
-rebuilt        : SymbolId(10): [ReferenceId(13), ReferenceId(20)]
-Reference symbol mismatch for "M1":
-after transform: SymbolId(0) "M1"
-rebuilt        : SymbolId(0) "M1"
+Symbol flags mismatch for "M1":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M1":
+after transform: SymbolId(0): Span { start: 7, end: 9 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "M2":
+after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M2":
+after transform: SymbolId(6): Span { start: 149, end: 151 }
+rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Reference symbol mismatch for "A":
 after transform: SymbolId(7) "A"
 rebuilt        : SymbolId(8) "A"
@@ -27449,24 +24018,15 @@ after transform: ["f", "g", "h"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/separate1-2.ts
-semantic error: Missing SymbolId: "X"
-Missing SymbolId: "_X"
-Missing ReferenceId: "_X"
-Missing ReferenceId: "f"
-Missing ReferenceId: "X"
-Missing ReferenceId: "X"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol reference IDs mismatch for "f":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol flags mismatch for "X":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "X":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/shebangBeforeReferences.ts
 semantic error: Scope children mismatch:
@@ -27546,67 +24106,38 @@ after transform: []
 rebuilt        : ["x"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMap-Comments.ts
-semantic error: Missing SymbolId: "sas"
-Missing SymbolId: "_sas"
-Missing SymbolId: "tools"
-Missing SymbolId: "_tools"
-Missing ReferenceId: "_tools"
-Missing ReferenceId: "Test"
-Missing ReferenceId: "tools"
-Missing ReferenceId: "tools"
-Missing ReferenceId: "_sas"
-Missing ReferenceId: "_sas"
-Missing ReferenceId: "sas"
-Missing ReferenceId: "sas"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(5)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
-Symbol reference IDs mismatch for "Test":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(2)]
+Symbol flags mismatch for "sas":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "sas":
+after transform: SymbolId(0): Span { start: 7, end: 10 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "tools":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "tools":
+after transform: SymbolId(1): Span { start: 11, end: 16 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMap-FileWithComments.ts
-semantic error: Missing SymbolId: "Shapes"
-Missing SymbolId: "_Shapes"
-Missing ReferenceId: "_Shapes"
-Missing ReferenceId: "Point"
-Missing ReferenceId: "_Shapes"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "Shapes"
-Missing ReferenceId: "Shapes"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(1), SymbolId(8), SymbolId(9), SymbolId(12)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(10), SymbolId(11)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(2), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(10), SymbolId(11)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(7), SymbolId(8), SymbolId(9)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(2): [ReferenceId(8), ReferenceId(10)]
-rebuilt        : SymbolId(4): [ReferenceId(5), ReferenceId(7), ReferenceId(10)]
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(6): []
-rebuilt        : SymbolId(8): [ReferenceId(12)]
-Reference symbol mismatch for "Shapes":
-after transform: SymbolId(1) "Shapes"
-rebuilt        : SymbolId(1) "Shapes"
+Symbol flags mismatch for "Shapes":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Shapes":
+after transform: SymbolId(1): Span { start: 75, end: 81 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMap-InterfacePrecedingVariableDeclaration1.ts
 semantic error: Scope children mismatch:
@@ -27614,22 +24145,21 @@ after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMap-StringLiteralWithNewLine.ts
-semantic error: Missing SymbolId: "Foo"
-Missing SymbolId: "_Foo"
-Missing ReferenceId: "Foo"
-Missing ReferenceId: "Foo"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Foo", "window"]
 rebuilt        : ScopeId(0): ["Foo"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "Foo":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Foo":
+after transform: SymbolId(3): Span { start: 104, end: 107 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Reference symbol mismatch for "window":
 after transform: SymbolId(2) "window"
 rebuilt        : <None>
@@ -27638,43 +24168,32 @@ after transform: []
 rebuilt        : ["window"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapForFunctionInInternalModuleWithCommentPrecedingStatement01.ts
-semantic error: Missing SymbolId: "Q"
-Missing SymbolId: "_Q"
-Missing ReferenceId: "Q"
-Missing ReferenceId: "Q"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "Q":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Q":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationClasses.ts
-semantic error: Missing SymbolId: "Foo"
-Missing SymbolId: "_Foo"
-Missing SymbolId: "Bar"
-Missing SymbolId: "_Bar"
-Missing ReferenceId: "Bar"
-Missing ReferenceId: "Bar"
-Missing ReferenceId: "_Foo"
-Missing ReferenceId: "_Foo"
-Missing ReferenceId: "Foo"
-Missing ReferenceId: "Foo"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(15)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(4), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(13), SymbolId(14), SymbolId(16)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4), SymbolId(6), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(15), SymbolId(16)]
+Symbol flags mismatch for "Foo":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Foo":
+after transform: SymbolId(0): Span { start: 7, end: 10 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Bar":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Bar":
+after transform: SymbolId(1): Span { start: 11, end: 14 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "Greeter":
 after transform: SymbolId(2): [ReferenceId(0), ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(7), ReferenceId(13)]
 rebuilt        : SymbolId(4): [ReferenceId(1), ReferenceId(3), ReferenceId(6), ReferenceId(12)]
@@ -29175,29 +25694,17 @@ after transform: []
 rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationImport.ts
-semantic error: Missing SymbolId: "m"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "c"
-Missing ReferenceId: "m"
-Missing ReferenceId: "m"
-Missing SymbolId: "a"
+semantic error: Missing SymbolId: "a"
 Missing SymbolId: "b"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Reference symbol mismatch for "m":
-after transform: SymbolId(0) "m"
-rebuilt        : SymbolId(0) "m"
-Reference symbol mismatch for "m":
-after transform: SymbolId(0) "m"
-rebuilt        : SymbolId(0) "m"
+Symbol flags mismatch for "m":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m":
+after transform: SymbolId(0): Span { start: 14, end: 15 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Reference symbol mismatch for "a":
 after transform: SymbolId(2) "a"
 rebuilt        : SymbolId(3) "a"
@@ -29212,36 +25719,21 @@ tasks/coverage/typescript/tests/cases/compiler/sourceMapWithMultipleFilesWithFil
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/sourcemapValidationDuplicateNames.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "c"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Missing SymbolId: "_m2"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(3), SymbolId(5)]
-rebuilt        : ScopeId(3): [SymbolId(4), SymbolId(5)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Symbol reference IDs mismatch for "c":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(3): [ReferenceId(1)]
-Reference symbol mismatch for "m1":
-after transform: SymbolId(0) "m1"
-rebuilt        : SymbolId(0) "m1"
+Symbol flags mismatch for "m1":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(0): Span { start: 7, end: 9 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "m1":
+after transform: SymbolId(0): [Span { start: 64, end: 66 }]
+rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/specedNoStackBlown.ts
 semantic error: Scope children mismatch:
@@ -29257,27 +25749,15 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/specializationOfExportedClass.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "C"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Reference symbol mismatch for "M":
-after transform: SymbolId(0) "M"
-rebuilt        : SymbolId(0) "M"
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/specializationsShouldNotAffectEachOther.ts
 semantic error: Scope children mismatch:
@@ -29545,36 +26025,24 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/staticAnonymousTypeNotReferencingTypeParameter.ts
-semantic error: Missing SymbolId: "tessst"
-Missing SymbolId: "_tessst"
-Missing ReferenceId: "_tessst"
-Missing ReferenceId: "funkyFor"
-Missing ReferenceId: "tessst"
-Missing ReferenceId: "tessst"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5), SymbolId(13), SymbolId(24), SymbolId(124), SymbolId(131)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(4), SymbolId(5), SymbolId(11), SymbolId(19), SymbolId(102)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(6), ScopeId(12), ScopeId(14), ScopeId(55), ScopeId(56), ScopeId(57)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(6), ScopeId(12)]
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(14), SymbolId(130)]
-rebuilt        : ScopeId(6): [SymbolId(12), SymbolId(13)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 Symbol reference IDs mismatch for "ListWrapper2":
 after transform: SymbolId(5): [ReferenceId(5), ReferenceId(9), ReferenceId(12)]
 rebuilt        : SymbolId(5): [ReferenceId(7)]
-Symbol reference IDs mismatch for "funkyFor":
-after transform: SymbolId(14): []
-rebuilt        : SymbolId(13): [ReferenceId(24)]
+Symbol flags mismatch for "tessst":
+after transform: SymbolId(13): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "tessst":
+after transform: SymbolId(13): Span { start: 503, end: 509 }
+rebuilt        : SymbolId(11): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "ListWrapper":
 after transform: SymbolId(24): [ReferenceId(34), ReferenceId(37), ReferenceId(40), ReferenceId(44), ReferenceId(54), ReferenceId(59), ReferenceId(66), ReferenceId(72), ReferenceId(77), ReferenceId(80), ReferenceId(90), ReferenceId(93), ReferenceId(99), ReferenceId(107), ReferenceId(118), ReferenceId(126), ReferenceId(128), ReferenceId(130), ReferenceId(137), ReferenceId(147), ReferenceId(155), ReferenceId(161), ReferenceId(170), ReferenceId(173), ReferenceId(177), ReferenceId(200), ReferenceId(201)]
 rebuilt        : SymbolId(19): [ReferenceId(50), ReferenceId(133), ReferenceId(134)]
-Reference symbol mismatch for "tessst":
-after transform: SymbolId(13) "tessst"
-rebuilt        : SymbolId(11) "tessst"
 
 tasks/coverage/typescript/tests/cases/compiler/staticFieldWithInterfaceContext.ts
 semantic error: Bindings mismatch:
@@ -29726,27 +26194,18 @@ after transform: ["Required"]
 rebuilt        : ["someVal", "someVal2"]
 
 tasks/coverage/typescript/tests/cases/compiler/structural1.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "f"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(2), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
-Symbol reference IDs mismatch for "f":
-after transform: SymbolId(2): [ReferenceId(1)]
-rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2)]
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/structuralTypeInDeclareFileForModule.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -29855,29 +26314,15 @@ after transform: ["Number", "require"]
 rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/superAccessInFatArrow1.ts
-semantic error: Missing SymbolId: "test"
-Missing SymbolId: "_test"
-Missing ReferenceId: "_test"
-Missing ReferenceId: "A"
-Missing ReferenceId: "_test"
-Missing ReferenceId: "B"
-Missing ReferenceId: "test"
-Missing ReferenceId: "test"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(1): [ReferenceId(0)]
-rebuilt        : SymbolId(2): [ReferenceId(1), ReferenceId(2)]
-Symbol reference IDs mismatch for "B":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(3): [ReferenceId(4)]
+Symbol flags mismatch for "test":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "test":
+after transform: SymbolId(0): Span { start: 7, end: 11 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericType1.ts
 semantic error: Scope children mismatch:
@@ -29986,19 +26431,18 @@ after transform: ScopeId(0): [SymbolId(0)]
 rebuilt        : ScopeId(0): [SymbolId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/systemModule7.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 49, end: 50 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "M":
+after transform: SymbolId(0): [Span { start: 123, end: 124 }]
+rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/systemModuleAmbientDeclarations.ts
 semantic error: Bindings mismatch:
@@ -30015,16 +26459,7 @@ after transform: ["C", "Foo", "Promise"]
 rebuilt        : ["C", "E", "Foo", "Promise"]
 
 tasks/coverage/typescript/tests/cases/compiler/systemModuleConstEnums.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "NonTopLevelConstEnum"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(1), SymbolId(3), SymbolId(4)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(3)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
@@ -30033,9 +26468,6 @@ rebuilt        : ScopeId(1): ["TopLevelConstEnum"]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(5), SymbolId(7)]
-rebuilt        : ScopeId(3): [SymbolId(4), SymbolId(5)]
 Bindings mismatch:
 after transform: ScopeId(5): ["NonTopLevelConstEnum", "X"]
 rebuilt        : ScopeId(4): ["NonTopLevelConstEnum"]
@@ -30045,27 +26477,18 @@ rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "TopLevelConstEnum":
 after transform: SymbolId(1): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch for "M":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(4): Span { start: 165, end: 166 }
+rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol flags mismatch for "NonTopLevelConstEnum":
 after transform: SymbolId(5): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "NonTopLevelConstEnum":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(5): [ReferenceId(12)]
-Reference symbol mismatch for "M":
-after transform: SymbolId(4) "M"
-rebuilt        : SymbolId(3) "M"
 
 tasks/coverage/typescript/tests/cases/compiler/systemModuleConstEnumsSeparateCompilation.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "NonTopLevelConstEnum"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(1), SymbolId(3), SymbolId(4)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(3)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 Bindings mismatch:
@@ -30074,9 +26497,6 @@ rebuilt        : ScopeId(1): ["TopLevelConstEnum"]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(5), SymbolId(7)]
-rebuilt        : ScopeId(3): [SymbolId(4), SymbolId(5)]
 Bindings mismatch:
 after transform: ScopeId(5): ["NonTopLevelConstEnum", "X"]
 rebuilt        : ScopeId(4): ["NonTopLevelConstEnum"]
@@ -30086,156 +26506,96 @@ rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "TopLevelConstEnum":
 after transform: SymbolId(1): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch for "M":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(4): Span { start: 165, end: 166 }
+rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol flags mismatch for "NonTopLevelConstEnum":
 after transform: SymbolId(5): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "NonTopLevelConstEnum":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(5): [ReferenceId(12)]
-Reference symbol mismatch for "M":
-after transform: SymbolId(4) "M"
-rebuilt        : SymbolId(3) "M"
 
 tasks/coverage/typescript/tests/cases/compiler/systemModuleDeclarationMerging.ts
-semantic error: Missing SymbolId: "_F"
-Missing ReferenceId: "F"
-Missing ReferenceId: "F"
-Missing SymbolId: "_C"
-Missing ReferenceId: "C"
-Missing ReferenceId: "C"
-Missing SymbolId: "_E"
-Missing ReferenceId: "E"
-Missing ReferenceId: "E"
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(1), SymbolId(6)]
-rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(3), SymbolId(7)]
-rebuilt        : ScopeId(4): [SymbolId(4), SymbolId(5)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(5): ScopeFlags(StrictMode | Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(5), SymbolId(8)]
-rebuilt        : ScopeId(6): [SymbolId(8), SymbolId(9)]
 Symbol flags mismatch for "F":
 after transform: SymbolId(0): SymbolFlags(BlockScopedVariable | Function | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable | Function)
-Symbol reference IDs mismatch for "F":
-after transform: SymbolId(0): []
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 Symbol redeclarations mismatch for "F":
 after transform: SymbolId(0): [Span { start: 37, end: 38 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "C":
 after transform: SymbolId(2): SymbolFlags(Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(Class)
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(3): [ReferenceId(2), ReferenceId(3)]
 Symbol redeclarations mismatch for "C":
 after transform: SymbolId(2): [Span { start: 83, end: 84 }]
 rebuilt        : SymbolId(3): []
 Symbol flags mismatch for "E":
 after transform: SymbolId(4): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(6): [ReferenceId(5), ReferenceId(6)]
 Symbol redeclarations mismatch for "E":
 after transform: SymbolId(4): [Span { start: 128, end: 129 }]
 rebuilt        : SymbolId(6): []
 
 tasks/coverage/typescript/tests/cases/compiler/systemModuleNonTopLevelModuleMembers.ts
-semantic error: Missing SymbolId: "TopLevelModule"
-Missing SymbolId: "_TopLevelModule"
-Missing ReferenceId: "TopLevelModule"
-Missing ReferenceId: "TopLevelModule"
-Missing SymbolId: "TopLevelModule2"
-Missing SymbolId: "_TopLevelModule2"
-Missing ReferenceId: "_TopLevelModule2"
-Missing ReferenceId: "NonTopLevelClass"
-Missing SymbolId: "NonTopLevelModule"
-Missing SymbolId: "_NonTopLevelModule"
-Missing ReferenceId: "NonTopLevelModule"
-Missing ReferenceId: "NonTopLevelModule"
-Missing ReferenceId: "_TopLevelModule2"
-Missing ReferenceId: "_TopLevelModule2"
-Missing ReferenceId: "_TopLevelModule2"
-Missing ReferenceId: "NonTopLevelFunction"
-Missing ReferenceId: "_TopLevelModule2"
-Missing ReferenceId: "NonTopLevelEnum"
-Missing ReferenceId: "TopLevelModule2"
-Missing ReferenceId: "TopLevelModule2"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(4), SymbolId(6)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(4), SymbolId(5), SymbolId(7)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(13)]
-rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(4): ["E", "TopLevelEnum"]
 rebuilt        : ScopeId(4): ["TopLevelEnum"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(7), SymbolId(8), SymbolId(10), SymbolId(11), SymbolId(14)]
-rebuilt        : ScopeId(5): [SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(13), SymbolId(14)]
-Binding symbols mismatch:
-after transform: ScopeId(7): [SymbolId(9), SymbolId(15)]
-rebuilt        : ScopeId(7): [SymbolId(11), SymbolId(12)]
 Bindings mismatch:
 after transform: ScopeId(9): ["E", "NonTopLevelEnum"]
 rebuilt        : ScopeId(9): ["NonTopLevelEnum"]
 Scope flags mismatch:
 after transform: ScopeId(9): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(9): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "TopLevelModule":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "TopLevelModule":
+after transform: SymbolId(1): Span { start: 44, end: 58 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol flags mismatch for "TopLevelEnum":
 after transform: SymbolId(4): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "NonTopLevelClass":
-after transform: SymbolId(7): []
-rebuilt        : SymbolId(9): [ReferenceId(6)]
+Symbol flags mismatch for "TopLevelModule2":
+after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "TopLevelModule2":
+after transform: SymbolId(6): Span { start: 156, end: 171 }
+rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
+Symbol flags mismatch for "NonTopLevelModule":
+after transform: SymbolId(8): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "NonTopLevelModule":
+after transform: SymbolId(8): Span { start: 229, end: 246 }
+rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 Symbol flags mismatch for "NonTopLevelFunction":
 after transform: SymbolId(10): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(13): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "NonTopLevelFunction":
-after transform: SymbolId(10): []
-rebuilt        : SymbolId(13): [ReferenceId(12)]
 Symbol flags mismatch for "NonTopLevelEnum":
 after transform: SymbolId(11): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "NonTopLevelEnum":
-after transform: SymbolId(11): []
-rebuilt        : SymbolId(14): [ReferenceId(17)]
 
 tasks/coverage/typescript/tests/cases/compiler/systemNamespaceAliasEmit.ts
-semantic error: Missing SymbolId: "ns"
-Missing SymbolId: "_ns"
-Missing ReferenceId: "ns"
-Missing ReferenceId: "ns"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(2)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(2): ["AnEnum", "ONE", "TWO"]
 rebuilt        : ScopeId(2): ["AnEnum"]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "ns":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "ns":
+after transform: SymbolId(0): Span { start: 10, end: 12 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "AnEnum":
 after transform: SymbolId(2): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
-Reference symbol mismatch for "ns":
-after transform: SymbolId(0) "ns"
-rebuilt        : SymbolId(0) "ns"
-Reference symbol mismatch for "ns":
-after transform: SymbolId(0) "ns"
-rebuilt        : SymbolId(0) "ns"
 
 tasks/coverage/typescript/tests/cases/compiler/taggedPrimitiveNarrowing.ts
 semantic error: Scope children mismatch:
@@ -30256,16 +26616,12 @@ after transform: ["TemplateStringsArray"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/taggedTemplatesInModuleAndGlobal.ts
-semantic error: Missing SymbolId: "n"
-Missing SymbolId: "_n"
-Missing ReferenceId: "n"
-Missing ReferenceId: "n"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(4), SymbolId(5), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(5)]
+semantic error: Symbol flags mismatch for "n":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "n":
+after transform: SymbolId(0): Span { start: 10, end: 11 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "id":
 after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
@@ -30346,19 +26702,15 @@ after transform: ScopeId(0): ["Greeter", "_defineProperty", "format"]
 rebuilt        : ScopeId(0): ["Greeter", "_defineProperty"]
 
 tasks/coverage/typescript/tests/cases/compiler/testContainerList.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 35, end: 36 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/testTypings.ts
 semantic error: Scope children mismatch:
@@ -30387,27 +26739,15 @@ after transform: SymbolId(6): [ReferenceId(7), ReferenceId(8), ReferenceId(10), 
 rebuilt        : SymbolId(4): []
 
 tasks/coverage/typescript/tests/cases/compiler/thisInModuleFunction1.ts
-semantic error: Missing SymbolId: "bar"
-Missing SymbolId: "_bar"
-Missing ReferenceId: "_bar"
-Missing ReferenceId: "bar"
-Missing ReferenceId: "bar"
-Missing ReferenceId: "bar"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(2)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol reference IDs mismatch for "bar":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
-Reference symbol mismatch for "bar":
-after transform: SymbolId(0) "bar"
-rebuilt        : SymbolId(0) "bar"
+Symbol flags mismatch for "bar":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "bar":
+after transform: SymbolId(0): Span { start: 7, end: 10 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/thisInPropertyBoundDeclarations.ts
 semantic error: Symbol reference IDs mismatch for "Bug":
@@ -30445,19 +26785,15 @@ after transform: [ReferenceId(6), ReferenceId(9)]
 rebuilt        : [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/this_inside-object-literal-getters-and-setters.ts
-semantic error: Missing SymbolId: "ObjectLiteral"
-Missing SymbolId: "_ObjectLiteral"
-Missing ReferenceId: "ObjectLiteral"
-Missing ReferenceId: "ObjectLiteral"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "ObjectLiteral":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "ObjectLiteral":
+after transform: SymbolId(0): Span { start: 7, end: 20 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/tooFewArgumentsInGenericFunctionTypedArgument.ts
 semantic error: Scope children mismatch:
@@ -30967,43 +27303,23 @@ after transform: []
 rebuilt        : ["aIndex", "bIndex", "cIndex"]
 
 tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty7.ts
-semantic error: Missing SymbolId: "Foo"
-Missing SymbolId: "_Foo"
-Missing ReferenceId: "_Foo"
-Missing ReferenceId: "Foo"
-Missing ReferenceId: "Foo"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(4), SymbolId(5)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(3), SymbolId(4)]
-Reference symbol mismatch for "Foo":
-after transform: SymbolId(0) "Foo"
-rebuilt        : SymbolId(2) "Foo"
-Reference symbol mismatch for "Foo":
-after transform: SymbolId(0) "Foo"
-rebuilt        : SymbolId(2) "Foo"
+semantic error: Symbol flags mismatch for "Foo":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Foo":
+after transform: SymbolId(0): Span { start: 17, end: 20 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/typeGuardOnContainerTypeNoHang.ts
-semantic error: Missing SymbolId: "TypeGuards"
-Missing SymbolId: "_TypeGuards"
-Missing ReferenceId: "_TypeGuards"
-Missing ReferenceId: "IsObject"
-Missing ReferenceId: "TypeGuards"
-Missing ReferenceId: "TypeGuards"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+semantic error: Symbol flags mismatch for "TypeGuards":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "TypeGuards":
+after transform: SymbolId(0): Span { start: 17, end: 27 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "IsObject":
 after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "IsObject":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/typeInferenceCacheInvalidation.ts
 semantic error: Scope children mismatch:
@@ -31376,122 +27692,72 @@ after transform: ["Lib", "undefined"]
 rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/typeResolution.ts
-semantic error: Missing SymbolId: "TopLevelModule1"
-Missing SymbolId: "_TopLevelModule"
-Missing SymbolId: "SubModule1"
-Missing SymbolId: "_SubModule"
-Missing SymbolId: "SubSubModule1"
-Missing SymbolId: "_SubSubModule"
-Missing ReferenceId: "_SubSubModule"
-Missing ReferenceId: "ClassA"
-Missing ReferenceId: "_SubSubModule"
-Missing ReferenceId: "ClassB"
-Missing ReferenceId: "SubSubModule1"
-Missing ReferenceId: "SubSubModule1"
-Missing ReferenceId: "_SubModule"
-Missing ReferenceId: "_SubModule"
-Missing ReferenceId: "SubModule1"
-Missing ReferenceId: "SubModule1"
-Missing ReferenceId: "_TopLevelModule"
-Missing ReferenceId: "_TopLevelModule"
-Missing SymbolId: "SubModule2"
-Missing SymbolId: "_SubModule2"
-Missing SymbolId: "SubSubModule2"
-Missing SymbolId: "_SubSubModule2"
-Missing ReferenceId: "_SubSubModule2"
-Missing ReferenceId: "ClassA"
-Missing ReferenceId: "_SubSubModule2"
-Missing ReferenceId: "ClassB"
-Missing ReferenceId: "_SubSubModule2"
-Missing ReferenceId: "ClassC"
-Missing ReferenceId: "SubSubModule2"
-Missing ReferenceId: "SubSubModule2"
-Missing ReferenceId: "_SubModule2"
-Missing ReferenceId: "_SubModule2"
-Missing ReferenceId: "SubModule2"
-Missing ReferenceId: "SubModule2"
-Missing ReferenceId: "_TopLevelModule"
-Missing ReferenceId: "_TopLevelModule"
-Missing SymbolId: "NotExportedModule"
-Missing SymbolId: "_NotExportedModule"
-Missing ReferenceId: "_NotExportedModule"
-Missing ReferenceId: "ClassA"
-Missing ReferenceId: "NotExportedModule"
-Missing ReferenceId: "NotExportedModule"
-Missing ReferenceId: "TopLevelModule1"
-Missing ReferenceId: "TopLevelModule1"
-Missing SymbolId: "TopLevelModule2"
-Missing SymbolId: "_TopLevelModule2"
-Missing SymbolId: "SubModule3"
-Missing SymbolId: "_SubModule3"
-Missing ReferenceId: "_SubModule3"
-Missing ReferenceId: "ClassA"
-Missing ReferenceId: "SubModule3"
-Missing ReferenceId: "SubModule3"
-Missing ReferenceId: "_TopLevelModule2"
-Missing ReferenceId: "_TopLevelModule2"
-Missing ReferenceId: "TopLevelModule2"
-Missing ReferenceId: "TopLevelModule2"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(49)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(50)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(37), SymbolId(45), SymbolId(47), SymbolId(52)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(39), SymbolId(46), SymbolId(47)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(16), ScopeId(29), ScopeId(31), ScopeId(33)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(14), ScopeId(22), ScopeId(24)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(31), SymbolId(53)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4), SymbolId(33)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(3), SymbolId(13), SymbolId(25), SymbolId(54)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6), SymbolId(16), SymbolId(27)]
 Scope children mismatch:
 after transform: ScopeId(3): [ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(10)]
 rebuilt        : ScopeId(3): [ScopeId(4), ScopeId(6), ScopeId(8)]
-Binding symbols mismatch:
-after transform: ScopeId(16): [SymbolId(38), SymbolId(55)]
-rebuilt        : ScopeId(14): [SymbolId(40), SymbolId(41)]
 Scope children mismatch:
 after transform: ScopeId(16): [ScopeId(17), ScopeId(27)]
 rebuilt        : ScopeId(14): [ScopeId(15)]
-Binding symbols mismatch:
-after transform: ScopeId(17): [SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(56)]
-rebuilt        : ScopeId(15): [SymbolId(42), SymbolId(43), SymbolId(44), SymbolId(45)]
 Scope children mismatch:
 after transform: ScopeId(17): [ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26)]
 rebuilt        : ScopeId(15): [ScopeId(16), ScopeId(18), ScopeId(20)]
-Binding symbols mismatch:
-after transform: ScopeId(33): [SymbolId(48), SymbolId(57)]
-rebuilt        : ScopeId(24): [SymbolId(48), SymbolId(49)]
-Binding symbols mismatch:
-after transform: ScopeId(35): [SymbolId(50), SymbolId(58)]
-rebuilt        : ScopeId(26): [SymbolId(51), SymbolId(52)]
-Binding symbols mismatch:
-after transform: ScopeId(36): [SymbolId(51), SymbolId(59)]
-rebuilt        : ScopeId(27): [SymbolId(53), SymbolId(54)]
+Symbol flags mismatch for "TopLevelModule1":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "TopLevelModule1":
+after transform: SymbolId(0): Span { start: 14, end: 29 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "SubModule1":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "SubModule1":
+after transform: SymbolId(1): Span { start: 50, end: 60 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "SubSubModule1":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "SubSubModule1":
+after transform: SymbolId(2): Span { start: 85, end: 98 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "ClassA":
-after transform: SymbolId(3): [ReferenceId(0), ReferenceId(18)]
+after transform: SymbolId(3): [ReferenceId(0), ReferenceId(18), ReferenceId(55)]
 rebuilt        : SymbolId(6): [ReferenceId(10)]
 Symbol reference IDs mismatch for "ClassB":
-after transform: SymbolId(13): [ReferenceId(8), ReferenceId(26)]
+after transform: SymbolId(13): [ReferenceId(8), ReferenceId(26), ReferenceId(57)]
 rebuilt        : SymbolId(16): [ReferenceId(22)]
-Symbol reference IDs mismatch for "ClassA":
-after transform: SymbolId(39): []
-rebuilt        : SymbolId(43): [ReferenceId(40)]
-Symbol reference IDs mismatch for "ClassB":
-after transform: SymbolId(40): []
-rebuilt        : SymbolId(44): [ReferenceId(42)]
-Symbol reference IDs mismatch for "ClassC":
-after transform: SymbolId(41): []
-rebuilt        : SymbolId(45): [ReferenceId(44)]
-Symbol reference IDs mismatch for "ClassA":
-after transform: SymbolId(48): []
-rebuilt        : SymbolId(49): [ReferenceId(54)]
-Symbol reference IDs mismatch for "ClassA":
-after transform: SymbolId(51): []
-rebuilt        : SymbolId(54): [ReferenceId(60)]
+Symbol flags mismatch for "SubModule2":
+after transform: SymbolId(37): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(39): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "SubModule2":
+after transform: SymbolId(37): Span { start: 3617, end: 3627 }
+rebuilt        : SymbolId(39): Span { start: 0, end: 0 }
+Symbol flags mismatch for "SubSubModule2":
+after transform: SymbolId(38): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(41): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "SubSubModule2":
+after transform: SymbolId(38): Span { start: 3652, end: 3665 }
+rebuilt        : SymbolId(41): Span { start: 0, end: 0 }
+Symbol flags mismatch for "NotExportedModule":
+after transform: SymbolId(47): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(47): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "NotExportedModule":
+after transform: SymbolId(47): Span { start: 4231, end: 4248 }
+rebuilt        : SymbolId(47): Span { start: 0, end: 0 }
+Symbol flags mismatch for "TopLevelModule2":
+after transform: SymbolId(49): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(50): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "TopLevelModule2":
+after transform: SymbolId(49): Span { start: 4299, end: 4314 }
+rebuilt        : SymbolId(50): Span { start: 0, end: 0 }
+Symbol flags mismatch for "SubModule3":
+after transform: SymbolId(50): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(52): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "SubModule3":
+after transform: SymbolId(50): Span { start: 4335, end: 4345 }
+rebuilt        : SymbolId(52): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["SubModule1", "SubSubModule1", "TopLevelModule1", "TopLevelModule2"]
 rebuilt        : []
@@ -31833,28 +28099,21 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(9), ScopeId(10), ScopeId(11), 
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/unexportedInstanceClassVariables.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Missing SymbolId: "_M2"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(3), SymbolId(4), SymbolId(6)]
-rebuilt        : ScopeId(4): [SymbolId(4), SymbolId(5), SymbolId(6)]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "M":
+after transform: SymbolId(0): [Span { start: 61, end: 62 }]
+rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/unionCallMixedTypeParameterPresence.ts
 semantic error: Bindings mismatch:
@@ -32127,27 +28386,18 @@ after transform: ScopeId(0): ["Element", "FooComponent", "_jsxFileName"]
 rebuilt        : ScopeId(0): ["FooComponent", "_jsxFileName"]
 
 tasks/coverage/typescript/tests/cases/compiler/unusedInterfaceinNamespace4.ts
-semantic error: Missing SymbolId: "Validation"
-Missing SymbolId: "_Validation"
-Missing ReferenceId: "_Validation"
-Missing ReferenceId: "c1"
-Missing ReferenceId: "Validation"
-Missing ReferenceId: "Validation"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(4), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
-Symbol reference IDs mismatch for "c1":
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
+Symbol flags mismatch for "Validation":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Validation":
+after transform: SymbolId(0): Span { start: 10, end: 20 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/unusedInterfaceinNamespace5.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -32167,19 +28417,12 @@ after transform: []
 rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndParametersDeferred.ts
-semantic error: Missing SymbolId: "N"
-Missing SymbolId: "_N"
-Missing ReferenceId: "N"
-Missing ReferenceId: "N"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(5), SymbolId(7), SymbolId(9), SymbolId(10), SymbolId(13), SymbolId(14), SymbolId(17), SymbolId(23), SymbolId(29), SymbolId(32)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(7), SymbolId(9), SymbolId(10), SymbolId(13), SymbolId(14), SymbolId(17), SymbolId(23), SymbolId(29)]
-Binding symbols mismatch:
-after transform: ScopeId(43): [SymbolId(30), SymbolId(31)]
-rebuilt        : ScopeId(45): [SymbolId(30), SymbolId(31)]
-Reference symbol mismatch for "N":
-after transform: SymbolId(29) "N"
-rebuilt        : SymbolId(29) "N"
+semantic error: Symbol flags mismatch for "N":
+after transform: SymbolId(29): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(29): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N":
+after transform: SymbolId(29): Span { start: 2046, end: 2047 }
+rebuilt        : SymbolId(29): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndParametersOverloadSignatures.ts
 semantic error: Scope children mismatch:
@@ -32265,32 +28508,18 @@ after transform: []
 rebuilt        : ["a", "b"]
 
 tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration.ts
-semantic error: Missing SymbolId: "ts"
-Missing SymbolId: "_ts"
-Missing ReferenceId: "_ts"
-Missing ReferenceId: "printVersion"
-Missing ReferenceId: "_ts"
-Missing ReferenceId: "log"
-Missing ReferenceId: "ts"
-Missing ReferenceId: "ts"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
+semantic error: Symbol flags mismatch for "ts":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "ts":
+after transform: SymbolId(0): Span { start: 10, end: 12 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "printVersion":
 after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "printVersion":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(3)]
 Symbol flags mismatch for "log":
 after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "log":
-after transform: SymbolId(2): [ReferenceId(0)]
-rebuilt        : SymbolId(3): [ReferenceId(0), ReferenceId(5)]
 
 tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_classDecorators.2.ts
 semantic error: Bindings mismatch:
@@ -32678,66 +28907,45 @@ after transform: ScopeId(20): [ScopeId(21)]
 rebuilt        : ScopeId(6): []
 
 tasks/coverage/typescript/tests/cases/compiler/withExportDecl.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Missing SymbolId: "m3"
-Missing SymbolId: "_m2"
-Missing ReferenceId: "_m2"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "m3"
-Missing ReferenceId: "m3"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["anotherVar", "arrayVar", "deckareVarWithType", "declareVar2", "declaredVar", "eVar1", "eVar2", "eVar22", "eVar3", "eVar4", "eVar5", "exportedArrayVar", "exportedDeclaredVar", "exportedFunction", "exportedSimpleVar", "exportedVarWithInitialValue", "exportedWithComplicatedValue", "m1", "m2", "m3", "simpleFunction", "simpleVar", "varWithArrayType", "varWithInitialValue", "varWithSimpleType", "withComplicatedValue"]
 rebuilt        : ScopeId(0): ["anotherVar", "arrayVar", "eVar1", "eVar2", "eVar22", "eVar3", "eVar4", "eVar5", "exportedArrayVar", "exportedFunction", "exportedSimpleVar", "exportedVarWithInitialValue", "exportedWithComplicatedValue", "m1", "m3", "simpleFunction", "simpleVar", "varWithArrayType", "varWithInitialValue", "varWithSimpleType", "withComplicatedValue"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(18), SymbolId(29)]
-rebuilt        : ScopeId(3): [SymbolId(14), SymbolId(15)]
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(22), SymbolId(30)]
-rebuilt        : ScopeId(5): [SymbolId(17), SymbolId(18)]
+Symbol flags mismatch for "m1":
+after transform: SymbolId(17): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(13): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(17): Span { start: 843, end: 845 }
+rebuilt        : SymbolId(13): Span { start: 0, end: 0 }
 Symbol flags mismatch for "foo":
 after transform: SymbolId(18): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(15): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(18): []
-rebuilt        : SymbolId(15): [ReferenceId(3)]
+Symbol flags mismatch for "m3":
+after transform: SymbolId(21): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m3":
+after transform: SymbolId(21): Span { start: 980, end: 982 }
+rebuilt        : SymbolId(16): Span { start: 0, end: 0 }
 Symbol flags mismatch for "foo":
 after transform: SymbolId(22): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(18): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(22): []
-rebuilt        : SymbolId(18): [ReferenceId(8)]
-Reference symbol mismatch for "m1":
-after transform: SymbolId(17) "m1"
-rebuilt        : SymbolId(13) "m1"
 
 tasks/coverage/typescript/tests/cases/compiler/withImportDecl.ts
-semantic error: Missing SymbolId: "m1"
-Missing SymbolId: "_m"
-Missing ReferenceId: "_m"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Missing SymbolId: "m3"
+semantic error: Missing SymbolId: "m3"
 Bindings mismatch:
 after transform: ScopeId(0): ["anotherVar", "arrayVar", "b", "deckareVarWithType", "declareVar2", "declaredVar", "m1", "m3", "simpleFunction", "simpleVar", "varWithArrayType", "varWithInitialValue", "varWithSimpleType", "withComplicatedValue"]
 rebuilt        : ScopeId(0): ["anotherVar", "arrayVar", "b", "m1", "m3", "simpleFunction", "simpleVar", "varWithArrayType", "varWithInitialValue", "varWithSimpleType", "withComplicatedValue"]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(12), SymbolId(15)]
-rebuilt        : ScopeId(2): [SymbolId(9), SymbolId(10)]
+Symbol flags mismatch for "m1":
+after transform: SymbolId(11): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(11): Span { start: 504, end: 506 }
+rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 Symbol flags mismatch for "foo":
 after transform: SymbolId(12): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(12): []
-rebuilt        : SymbolId(10): [ReferenceId(1)]
 Reference symbol mismatch for "m3":
 after transform: SymbolId(13) "m3"
 rebuilt        : SymbolId(11) "m3"
@@ -32815,11 +29023,7 @@ after transform: SymbolId(0) "M"
 rebuilt        : SymbolId(0) "M"
 
 tasks/coverage/typescript/tests/cases/conformance/ambient/ambientInsideNonAmbient.ts
-semantic error: Missing SymbolId: "M2"
-Missing SymbolId: "_M2"
-Missing ReferenceId: "M2"
-Missing ReferenceId: "M2"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["M", "M2"]
 rebuilt        : ScopeId(0): ["M2"]
 Scope children mismatch:
@@ -32834,6 +29038,12 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(6): [ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
 rebuilt        : ScopeId(1): []
+Symbol flags mismatch for "M2":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M2":
+after transform: SymbolId(4): Span { start: 173, end: 175 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/ambient/ambientInsideNonAmbientExternalModule.ts
 semantic error: Bindings mismatch:
@@ -32884,21 +29094,12 @@ after transform: ["Promise", "arguments", "require", "someOtherFunction"]
 rebuilt        : ["arguments", "require", "someOtherFunction"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncAwait_es2017.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "f1"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "M", "_asyncToGenerator", "_f", "_f2", "_f3", "_f5", "f0", "f1", "f10", "f11", "f12", "f13", "f14", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "mp", "o", "p"]
 rebuilt        : ScopeId(0): ["C", "M", "_asyncToGenerator", "_f", "_f2", "_f3", "_f5", "f0", "f1", "f10", "f11", "f12", "f13", "f14", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "o"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(18), ScopeId(25), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43), ScopeId(45), ScopeId(47), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(60), ScopeId(61)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(16), ScopeId(19), ScopeId(22), ScopeId(25), ScopeId(28), ScopeId(31), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(53), ScopeId(57), ScopeId(58)]
-Binding symbols mismatch:
-after transform: ScopeId(25): [SymbolId(20), SymbolId(22), SymbolId(41)]
-rebuilt        : ScopeId(53): [SymbolId(34), SymbolId(35), SymbolId(36)]
 Scope flags mismatch:
 after transform: ScopeId(25): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(53): ScopeFlags(Function)
@@ -32908,12 +29109,15 @@ rebuilt        : ScopeId(54): ScopeFlags(Function)
 Scope flags mismatch:
 after transform: ScopeId(59): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(55): ScopeFlags(Function)
+Symbol flags mismatch for "M":
+after transform: SymbolId(19): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(33): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(19): Span { start: 913, end: 914 }
+rebuilt        : SymbolId(33): Span { start: 0, end: 0 }
 Symbol flags mismatch for "f1":
 after transform: SymbolId(20): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(35): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "f1":
-after transform: SymbolId(20): []
-rebuilt        : SymbolId(35): [ReferenceId(63)]
 Reference symbol mismatch for "p":
 after transform: SymbolId(2) "p"
 rebuilt        : <None>
@@ -33263,21 +29467,12 @@ after transform: [ReferenceId(0), ReferenceId(1)]
 rebuilt        : [ReferenceId(5)]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncAwait_es5.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "f1"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "M", "_asyncToGenerator", "_f", "_f2", "_f3", "_f5", "f0", "f1", "f10", "f11", "f12", "f13", "f14", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "mp", "o", "p"]
 rebuilt        : ScopeId(0): ["C", "M", "_asyncToGenerator", "_f", "_f2", "_f3", "_f5", "f0", "f1", "f10", "f11", "f12", "f13", "f14", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "o"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(18), ScopeId(25), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43), ScopeId(45), ScopeId(47), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(60), ScopeId(61)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(16), ScopeId(19), ScopeId(22), ScopeId(25), ScopeId(28), ScopeId(31), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(53), ScopeId(57), ScopeId(58)]
-Binding symbols mismatch:
-after transform: ScopeId(25): [SymbolId(20), SymbolId(22), SymbolId(41)]
-rebuilt        : ScopeId(53): [SymbolId(34), SymbolId(35), SymbolId(36)]
 Scope flags mismatch:
 after transform: ScopeId(25): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(53): ScopeFlags(Function)
@@ -33287,12 +29482,15 @@ rebuilt        : ScopeId(54): ScopeFlags(Function)
 Scope flags mismatch:
 after transform: ScopeId(59): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(55): ScopeFlags(Function)
+Symbol flags mismatch for "M":
+after transform: SymbolId(19): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(33): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(19): Span { start: 913, end: 914 }
+rebuilt        : SymbolId(33): Span { start: 0, end: 0 }
 Symbol flags mismatch for "f1":
 after transform: SymbolId(20): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(35): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "f1":
-after transform: SymbolId(20): []
-rebuilt        : SymbolId(35): [ReferenceId(63)]
 Reference symbol mismatch for "p":
 after transform: SymbolId(2) "p"
 rebuilt        : <None>
@@ -33315,24 +29513,15 @@ after transform: ScopeId(0): ["Task", "Test", "_asyncToGenerator"]
 rebuilt        : ScopeId(0): ["Test", "_asyncToGenerator"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncQualifiedReturnType_es5.ts
-semantic error: Missing SymbolId: "X"
-Missing SymbolId: "_X"
-Missing ReferenceId: "_X"
-Missing ReferenceId: "MyPromise"
-Missing ReferenceId: "X"
-Missing ReferenceId: "X"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(5), SymbolId(6)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(4), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol reference IDs mismatch for "MyPromise":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(3): [ReferenceId(3)]
+Symbol flags mismatch for "X":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "X":
+after transform: SymbolId(0): Span { start: 10, end: 11 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["Promise", "X", "arguments", "require"]
 rebuilt        : ["Promise", "arguments", "require"]
@@ -33682,21 +29871,12 @@ after transform: ["Promise", "arguments", "require", "someOtherFunction"]
 rebuilt        : ["arguments", "require", "someOtherFunction"]
 
 tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncAwait_es6.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "f1"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "M", "_asyncToGenerator", "_f", "_f2", "_f3", "_f5", "f0", "f1", "f10", "f11", "f12", "f13", "f14", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "mp", "o", "p"]
 rebuilt        : ScopeId(0): ["C", "M", "_asyncToGenerator", "_f", "_f2", "_f3", "_f5", "f0", "f1", "f10", "f11", "f12", "f13", "f14", "f3", "f4", "f5", "f6", "f7", "f8", "f9", "o"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(18), ScopeId(25), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(41), ScopeId(43), ScopeId(45), ScopeId(47), ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(60), ScopeId(61)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(16), ScopeId(19), ScopeId(22), ScopeId(25), ScopeId(28), ScopeId(31), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(40), ScopeId(53), ScopeId(57), ScopeId(58)]
-Binding symbols mismatch:
-after transform: ScopeId(25): [SymbolId(20), SymbolId(22), SymbolId(41)]
-rebuilt        : ScopeId(53): [SymbolId(34), SymbolId(35), SymbolId(36)]
 Scope flags mismatch:
 after transform: ScopeId(25): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(53): ScopeFlags(Function)
@@ -33706,12 +29886,15 @@ rebuilt        : ScopeId(54): ScopeFlags(Function)
 Scope flags mismatch:
 after transform: ScopeId(59): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(55): ScopeFlags(Function)
+Symbol flags mismatch for "M":
+after transform: SymbolId(19): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(33): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(19): Span { start: 913, end: 914 }
+rebuilt        : SymbolId(33): Span { start: 0, end: 0 }
 Symbol flags mismatch for "f1":
 after transform: SymbolId(20): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(35): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "f1":
-after transform: SymbolId(20): []
-rebuilt        : SymbolId(35): [ReferenceId(63)]
 Reference symbol mismatch for "p":
 after transform: SymbolId(2) "p"
 rebuilt        : <None>
@@ -34071,11 +30254,7 @@ after transform: [ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(10
 rebuilt        : [ReferenceId(10), ReferenceId(21), ReferenceId(30)]
 
 tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAndInterfaceWithSameName.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["M", "_defineProperty"]
 rebuilt        : ScopeId(0): ["C", "M", "_defineProperty"]
 Scope children mismatch:
@@ -34096,6 +30275,12 @@ rebuilt        : SymbolId(1): SymbolFlags(Class)
 Symbol redeclarations mismatch for "C":
 after transform: SymbolId(0): [Span { start: 35, end: 36 }]
 rebuilt        : SymbolId(1): []
+Symbol flags mismatch for "M":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(1): Span { start: 62, end: 63 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "D":
 after transform: SymbolId(2): SymbolFlags(Class | Interface)
 rebuilt        : SymbolId(4): SymbolFlags(Class)
@@ -34209,19 +30394,15 @@ after transform: SymbolId(4): [ReferenceId(12)]
 rebuilt        : SymbolId(5): []
 
 tasks/coverage/typescript/tests/cases/conformance/classes/classExpression.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(4)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(5), SymbolId(7)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch for "M":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(4): Span { start: 67, end: 68 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classWithStaticFieldInParameterBindingPattern.3.ts
 semantic error: Bindings mismatch:
@@ -34344,19 +30525,15 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(5), ReferenceId(6), R
 rebuilt        : SymbolId(1): [ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(16)]
 
 tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/genericSetterInClassType.ts
-semantic error: Missing SymbolId: "Generic"
-Missing SymbolId: "_Generic"
-Missing ReferenceId: "Generic"
-Missing ReferenceId: "Generic"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(10), SymbolId(11), SymbolId(12)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(4), SymbolId(5), SymbolId(8), SymbolId(9)]
-rebuilt        : ScopeId(1): [SymbolId(4), SymbolId(5), SymbolId(7), SymbolId(8), SymbolId(9)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "Generic":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Generic":
+after transform: SymbolId(0): Span { start: 7, end: 14 }
+rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/indexersInClassType.ts
 semantic error: Unresolved references mismatch:
@@ -34364,29 +30541,24 @@ after transform: ["Date", "Object", "require"]
 rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/classes/members/constructorFunctionTypes/constructorHasPrototypeProperty.ts
-semantic error: Missing SymbolId: "NonGeneric"
-Missing SymbolId: "_NonGeneric"
-Missing ReferenceId: "NonGeneric"
-Missing ReferenceId: "NonGeneric"
-Missing SymbolId: "Generic"
-Missing SymbolId: "_Generic"
-Missing ReferenceId: "Generic"
-Missing ReferenceId: "Generic"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(18)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(8)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(16)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6), SymbolId(7)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(6), SymbolId(9), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(17)]
-rebuilt        : ScopeId(6): [SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16)]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
+Symbol flags mismatch for "NonGeneric":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "NonGeneric":
+after transform: SymbolId(0): Span { start: 7, end: 17 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Generic":
+after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Generic":
+after transform: SymbolId(5): Span { start: 198, end: 205 }
+rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassIncludesInheritedMembers.ts
 semantic error: Symbol reference IDs mismatch for "Derived":
@@ -34916,79 +31088,66 @@ Classes may not have a static property named prototype
 Classes may not have a static property named prototype
 Classes may not have a static property named prototype
 Classes may not have a static property named prototype
-Missing SymbolId: "TestOnDefaultExportedClass_1"
-Missing SymbolId: "_TestOnDefaultExportedClass_"
-Missing ReferenceId: "TestOnDefaultExportedClass_1"
-Missing ReferenceId: "TestOnDefaultExportedClass_1"
-Missing SymbolId: "TestOnDefaultExportedClass_2"
-Missing SymbolId: "_TestOnDefaultExportedClass_2"
-Missing ReferenceId: "TestOnDefaultExportedClass_2"
-Missing ReferenceId: "TestOnDefaultExportedClass_2"
-Missing SymbolId: "TestOnDefaultExportedClass_3"
-Missing SymbolId: "_TestOnDefaultExportedClass_3"
-Missing ReferenceId: "TestOnDefaultExportedClass_3"
-Missing ReferenceId: "TestOnDefaultExportedClass_3"
-Missing SymbolId: "TestOnDefaultExportedClass_4"
-Missing SymbolId: "_TestOnDefaultExportedClass_4"
-Missing ReferenceId: "TestOnDefaultExportedClass_4"
-Missing ReferenceId: "TestOnDefaultExportedClass_4"
-Missing SymbolId: "TestOnDefaultExportedClass_5"
-Missing SymbolId: "_TestOnDefaultExportedClass_5"
-Missing ReferenceId: "TestOnDefaultExportedClass_5"
-Missing ReferenceId: "TestOnDefaultExportedClass_5"
-Missing SymbolId: "TestOnDefaultExportedClass_6"
-Missing SymbolId: "_TestOnDefaultExportedClass_6"
-Missing ReferenceId: "TestOnDefaultExportedClass_6"
-Missing ReferenceId: "TestOnDefaultExportedClass_6"
-Missing SymbolId: "TestOnDefaultExportedClass_7"
-Missing SymbolId: "_TestOnDefaultExportedClass_7"
-Missing ReferenceId: "TestOnDefaultExportedClass_7"
-Missing ReferenceId: "TestOnDefaultExportedClass_7"
-Missing SymbolId: "TestOnDefaultExportedClass_8"
-Missing SymbolId: "_TestOnDefaultExportedClass_8"
-Missing ReferenceId: "TestOnDefaultExportedClass_8"
-Missing ReferenceId: "TestOnDefaultExportedClass_8"
-Missing SymbolId: "TestOnDefaultExportedClass_9"
-Missing SymbolId: "_TestOnDefaultExportedClass_9"
-Missing ReferenceId: "TestOnDefaultExportedClass_9"
-Missing ReferenceId: "TestOnDefaultExportedClass_9"
-Missing SymbolId: "TestOnDefaultExportedClass_10"
-Missing SymbolId: "_TestOnDefaultExportedClass_10"
-Missing ReferenceId: "TestOnDefaultExportedClass_10"
-Missing ReferenceId: "TestOnDefaultExportedClass_10"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(27), SymbolId(28), SymbolId(29), SymbolId(30), SymbolId(31), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(43), SymbolId(44), SymbolId(46), SymbolId(47), SymbolId(49), SymbolId(50), SymbolId(52), SymbolId(53), SymbolId(55), SymbolId(56), SymbolId(58), SymbolId(59), SymbolId(61), SymbolId(62), SymbolId(64), SymbolId(65), SymbolId(67), SymbolId(68), SymbolId(70), SymbolId(81), SymbolId(82), SymbolId(83), SymbolId(84), SymbolId(85), SymbolId(86), SymbolId(87), SymbolId(88), SymbolId(89), SymbolId(90), SymbolId(91), SymbolId(92), SymbolId(93), SymbolId(94), SymbolId(95), SymbolId(96), SymbolId(97), SymbolId(98), SymbolId(99), SymbolId(100), SymbolId(101), SymbolId(102), SymbolId(103), SymbolId(104), SymbolId(105), SymbolId(106), SymbolId(107), SymbolId(108), SymbolId(109), SymbolId(110), SymbolId(111), SymbolId(112), SymbolId(113), SymbolId(114), SymbolId(115), SymbolId(116), SymbolId(117), SymbolId(118), SymbolId(119), SymbolId(120), SymbolId(121)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(27), SymbolId(28), SymbolId(29), SymbolId(30), SymbolId(31), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(42), SymbolId(43), SymbolId(44), SymbolId(45), SymbolId(46), SymbolId(47), SymbolId(48), SymbolId(49), SymbolId(50), SymbolId(51), SymbolId(52), SymbolId(53), SymbolId(54), SymbolId(55), SymbolId(56), SymbolId(57), SymbolId(58), SymbolId(59), SymbolId(60), SymbolId(61), SymbolId(62), SymbolId(63), SymbolId(64), SymbolId(65), SymbolId(66), SymbolId(67), SymbolId(68), SymbolId(69), SymbolId(70), SymbolId(71), SymbolId(72), SymbolId(73), SymbolId(74), SymbolId(75), SymbolId(76), SymbolId(77), SymbolId(78), SymbolId(79), SymbolId(80), SymbolId(81), SymbolId(82), SymbolId(85), SymbolId(86), SymbolId(89), SymbolId(90), SymbolId(93), SymbolId(94), SymbolId(97), SymbolId(98), SymbolId(101), SymbolId(102), SymbolId(105), SymbolId(106), SymbolId(109), SymbolId(110), SymbolId(113), SymbolId(114), SymbolId(117), SymbolId(118), SymbolId(121)]
-Binding symbols mismatch:
-after transform: ScopeId(81): [SymbolId(42), SymbolId(71)]
-rebuilt        : ScopeId(101): [SymbolId(83), SymbolId(84)]
-Binding symbols mismatch:
-after transform: ScopeId(84): [SymbolId(45), SymbolId(72)]
-rebuilt        : ScopeId(106): [SymbolId(87), SymbolId(88)]
-Binding symbols mismatch:
-after transform: ScopeId(91): [SymbolId(48), SymbolId(73)]
-rebuilt        : ScopeId(113): [SymbolId(91), SymbolId(92)]
-Binding symbols mismatch:
-after transform: ScopeId(94): [SymbolId(51), SymbolId(74)]
-rebuilt        : ScopeId(118): [SymbolId(95), SymbolId(96)]
-Binding symbols mismatch:
-after transform: ScopeId(101): [SymbolId(54), SymbolId(75)]
-rebuilt        : ScopeId(125): [SymbolId(99), SymbolId(100)]
-Binding symbols mismatch:
-after transform: ScopeId(104): [SymbolId(57), SymbolId(76)]
-rebuilt        : ScopeId(130): [SymbolId(103), SymbolId(104)]
-Binding symbols mismatch:
-after transform: ScopeId(111): [SymbolId(60), SymbolId(77)]
-rebuilt        : ScopeId(137): [SymbolId(107), SymbolId(108)]
-Binding symbols mismatch:
-after transform: ScopeId(114): [SymbolId(63), SymbolId(78)]
-rebuilt        : ScopeId(142): [SymbolId(111), SymbolId(112)]
-Binding symbols mismatch:
-after transform: ScopeId(121): [SymbolId(66), SymbolId(79)]
-rebuilt        : ScopeId(149): [SymbolId(115), SymbolId(116)]
-Binding symbols mismatch:
-after transform: ScopeId(124): [SymbolId(69), SymbolId(80)]
-rebuilt        : ScopeId(154): [SymbolId(119), SymbolId(120)]
+Symbol flags mismatch for "TestOnDefaultExportedClass_1":
+after transform: SymbolId(41): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(82): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "TestOnDefaultExportedClass_1":
+after transform: SymbolId(41): Span { start: 6217, end: 6245 }
+rebuilt        : SymbolId(82): Span { start: 0, end: 0 }
+Symbol flags mismatch for "TestOnDefaultExportedClass_2":
+after transform: SymbolId(44): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(86): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "TestOnDefaultExportedClass_2":
+after transform: SymbolId(44): Span { start: 6560, end: 6588 }
+rebuilt        : SymbolId(86): Span { start: 0, end: 0 }
+Symbol flags mismatch for "TestOnDefaultExportedClass_3":
+after transform: SymbolId(47): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(90): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "TestOnDefaultExportedClass_3":
+after transform: SymbolId(47): Span { start: 6901, end: 6929 }
+rebuilt        : SymbolId(90): Span { start: 0, end: 0 }
+Symbol flags mismatch for "TestOnDefaultExportedClass_4":
+after transform: SymbolId(50): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(94): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "TestOnDefaultExportedClass_4":
+after transform: SymbolId(50): Span { start: 7271, end: 7299 }
+rebuilt        : SymbolId(94): Span { start: 0, end: 0 }
+Symbol flags mismatch for "TestOnDefaultExportedClass_5":
+after transform: SymbolId(53): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(98): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "TestOnDefaultExportedClass_5":
+after transform: SymbolId(53): Span { start: 7642, end: 7670 }
+rebuilt        : SymbolId(98): Span { start: 0, end: 0 }
+Symbol flags mismatch for "TestOnDefaultExportedClass_6":
+after transform: SymbolId(56): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(102): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "TestOnDefaultExportedClass_6":
+after transform: SymbolId(56): Span { start: 7986, end: 8014 }
+rebuilt        : SymbolId(102): Span { start: 0, end: 0 }
+Symbol flags mismatch for "TestOnDefaultExportedClass_7":
+after transform: SymbolId(59): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(106): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "TestOnDefaultExportedClass_7":
+after transform: SymbolId(59): Span { start: 8328, end: 8356 }
+rebuilt        : SymbolId(106): Span { start: 0, end: 0 }
+Symbol flags mismatch for "TestOnDefaultExportedClass_8":
+after transform: SymbolId(62): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(110): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "TestOnDefaultExportedClass_8":
+after transform: SymbolId(62): Span { start: 8698, end: 8726 }
+rebuilt        : SymbolId(110): Span { start: 0, end: 0 }
+Symbol flags mismatch for "TestOnDefaultExportedClass_9":
+after transform: SymbolId(65): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(114): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "TestOnDefaultExportedClass_9":
+after transform: SymbolId(65): Span { start: 9069, end: 9097 }
+rebuilt        : SymbolId(114): Span { start: 0, end: 0 }
+Symbol flags mismatch for "TestOnDefaultExportedClass_10":
+after transform: SymbolId(68): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(118): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "TestOnDefaultExportedClass_10":
+after transform: SymbolId(68): Span { start: 9457, end: 9486 }
+rebuilt        : SymbolId(118): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["const"]
 rebuilt        : []
@@ -35319,27 +31478,18 @@ after transform: SymbolId(0): [ReferenceId(2), ReferenceId(5)]
 rebuilt        : SymbolId(1): [ReferenceId(3)]
 
 tasks/coverage/typescript/tests/cases/conformance/declarationEmit/classDoesNotDependOnPrivateMember.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "C"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(4)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(2), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(3): [ReferenceId(3)]
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/declarationEmit/leaveOptionalParameterAsWritten.ts
 semantic error: Scope children mismatch:
@@ -35827,21 +31977,12 @@ after transform: []
 rebuilt        : ["decorator"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorMetadataWithTypeOnlyImport2.ts
-semantic error: Missing SymbolId: "Services"
-Missing SymbolId: "_Services"
-Missing ReferenceId: "_Services"
-Missing ReferenceId: "Service"
-Missing ReferenceId: "Services"
-Missing ReferenceId: "Services"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Symbol reference IDs mismatch for "Service":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
+semantic error: Symbol flags mismatch for "Services":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Services":
+after transform: SymbolId(0): Span { start: 17, end: 25 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/legacyDecorators-contextualTypes.ts
 semantic error: Scope children mismatch:
@@ -36395,68 +32536,7 @@ after transform: ["Cat", "Dog"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/enums/enumMerging.ts
-semantic error: Missing SymbolId: "M1"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "EConst1"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "EConst1"
-Missing ReferenceId: "M1"
-Missing ReferenceId: "M1"
-Missing SymbolId: "M2"
-Missing SymbolId: "_M2"
-Missing ReferenceId: "_M2"
-Missing ReferenceId: "EComp2"
-Missing ReferenceId: "_M2"
-Missing ReferenceId: "EComp2"
-Missing ReferenceId: "M2"
-Missing ReferenceId: "M2"
-Missing SymbolId: "M3"
-Missing SymbolId: "_M3"
-Missing ReferenceId: "M3"
-Missing ReferenceId: "M3"
-Missing SymbolId: "M4"
-Missing SymbolId: "_M4"
-Missing ReferenceId: "_M4"
-Missing ReferenceId: "Color"
-Missing ReferenceId: "M4"
-Missing ReferenceId: "M4"
-Missing SymbolId: "M5"
-Missing SymbolId: "_M5"
-Missing ReferenceId: "_M5"
-Missing ReferenceId: "Color"
-Missing ReferenceId: "M5"
-Missing ReferenceId: "M5"
-Missing SymbolId: "M6"
-Missing SymbolId: "_M6"
-Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "Color"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "_M6"
-Missing ReferenceId: "_M6"
-Missing ReferenceId: "M6"
-Missing ReferenceId: "M6"
-Missing SymbolId: "_M7"
-Missing SymbolId: "A"
-Missing SymbolId: "_A2"
-Missing ReferenceId: "_A2"
-Missing ReferenceId: "Color"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "_M7"
-Missing ReferenceId: "_M7"
-Missing ReferenceId: "M6"
-Missing ReferenceId: "M6"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(16), SymbolId(25), SymbolId(32), SymbolId(37), SymbolId(42)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(9), SymbolId(15), SymbolId(20), SymbolId(24), SymbolId(27)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(8), SymbolId(15), SymbolId(52)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5), SymbolId(8)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Bindings mismatch:
@@ -36483,9 +32563,6 @@ rebuilt        : ScopeId(5): ["EConst1"]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(0x0)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(17), SymbolId(24), SymbolId(53)]
-rebuilt        : ScopeId(6): [SymbolId(10), SymbolId(11), SymbolId(14)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
@@ -36501,9 +32578,6 @@ rebuilt        : ScopeId(8): ["EComp2"]
 Scope flags mismatch:
 after transform: ScopeId(8): ScopeFlags(0x0)
 rebuilt        : ScopeId(8): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(9): [SymbolId(26), SymbolId(54)]
-rebuilt        : ScopeId(9): [SymbolId(16), SymbolId(17)]
 Scope flags mismatch:
 after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(9): ScopeFlags(Function)
@@ -36519,9 +32593,6 @@ rebuilt        : ScopeId(11): ["EInit"]
 Scope flags mismatch:
 after transform: ScopeId(11): ScopeFlags(0x0)
 rebuilt        : ScopeId(11): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(12): [SymbolId(33), SymbolId(55)]
-rebuilt        : ScopeId(12): [SymbolId(21), SymbolId(22)]
 Scope flags mismatch:
 after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(12): ScopeFlags(Function)
@@ -36543,9 +32614,6 @@ rebuilt        : ScopeId(15): ["Color"]
 Scope flags mismatch:
 after transform: ScopeId(15): ScopeFlags(0x0)
 rebuilt        : ScopeId(15): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(16): [SymbolId(43), SymbolId(57)]
-rebuilt        : ScopeId(16): [SymbolId(28), SymbolId(29)]
 Scope flags mismatch:
 after transform: ScopeId(16): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(16): ScopeFlags(Function)
@@ -36561,9 +32629,6 @@ rebuilt        : ScopeId(18): ["Color"]
 Scope flags mismatch:
 after transform: ScopeId(18): ScopeFlags(0x0)
 rebuilt        : ScopeId(18): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(19): [SymbolId(48), SymbolId(51), SymbolId(59)]
-rebuilt        : ScopeId(19): [SymbolId(32), SymbolId(33), SymbolId(36)]
 Scope flags mismatch:
 after transform: ScopeId(19): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(19): ScopeFlags(Function)
@@ -36579,6 +32644,12 @@ rebuilt        : ScopeId(21): ["Color"]
 Scope flags mismatch:
 after transform: ScopeId(21): ScopeFlags(0x0)
 rebuilt        : ScopeId(21): ScopeFlags(Function)
+Symbol flags mismatch for "M1":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M1":
+after transform: SymbolId(0): Span { start: 183, end: 185 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "EImpl1":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
@@ -36588,33 +32659,72 @@ rebuilt        : SymbolId(2): []
 Symbol flags mismatch for "EConst1":
 after transform: SymbolId(8): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "EConst1":
-after transform: SymbolId(8): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(45), ReferenceId(46)]
-rebuilt        : SymbolId(5): [ReferenceId(24), ReferenceId(25), ReferenceId(33), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(41)]
 Symbol redeclarations mismatch for "EConst1":
 after transform: SymbolId(8): [Span { start: 351, end: 358 }]
 rebuilt        : SymbolId(5): []
+Symbol flags mismatch for "M2":
+after transform: SymbolId(16): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M2":
+after transform: SymbolId(16): Span { start: 570, end: 572 }
+rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
 Symbol flags mismatch for "EComp2":
 after transform: SymbolId(17): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "EComp2":
-after transform: SymbolId(17): [ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(61), ReferenceId(62)]
-rebuilt        : SymbolId(11): [ReferenceId(52), ReferenceId(53), ReferenceId(61), ReferenceId(63), ReferenceId(64), ReferenceId(65), ReferenceId(66), ReferenceId(67), ReferenceId(68), ReferenceId(69)]
 Symbol redeclarations mismatch for "EComp2":
 after transform: SymbolId(17): [Span { start: 684, end: 690 }]
 rebuilt        : SymbolId(11): []
+Symbol flags mismatch for "M3":
+after transform: SymbolId(25): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(15): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M3":
+after transform: SymbolId(25): Span { start: 950, end: 952 }
+rebuilt        : SymbolId(15): Span { start: 0, end: 0 }
 Symbol flags mismatch for "EInit":
 after transform: SymbolId(26): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(17): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "EInit":
 after transform: SymbolId(26): [Span { start: 1009, end: 1014 }]
 rebuilt        : SymbolId(17): []
+Symbol flags mismatch for "M4":
+after transform: SymbolId(32): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M4":
+after transform: SymbolId(32): Span { start: 1103, end: 1105 }
+rebuilt        : SymbolId(20): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Color":
 after transform: SymbolId(33): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(22): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "Color":
-after transform: SymbolId(33): []
-rebuilt        : SymbolId(22): [ReferenceId(96)]
+Symbol flags mismatch for "M5":
+after transform: SymbolId(37): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(24): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M5":
+after transform: SymbolId(37): Span { start: 1160, end: 1162 }
+rebuilt        : SymbolId(24): Span { start: 0, end: 0 }
+Symbol flags mismatch for "M6":
+after transform: SymbolId(42): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(27): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M6":
+after transform: SymbolId(42): Span { start: 1218, end: 1220 }
+rebuilt        : SymbolId(27): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "M6":
+after transform: SymbolId(42): [Span { start: 1277, end: 1279 }]
+rebuilt        : SymbolId(27): []
+Symbol flags mismatch for "A":
+after transform: SymbolId(43): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(29): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(43): Span { start: 1221, end: 1222 }
+rebuilt        : SymbolId(29): Span { start: 0, end: 0 }
+Symbol flags mismatch for "A":
+after transform: SymbolId(48): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(33): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(48): Span { start: 1300, end: 1301 }
+rebuilt        : SymbolId(33): Span { start: 0, end: 0 }
+Reference symbol mismatch for "Color":
+after transform: SymbolId(38) "Color"
+rebuilt        : <None>
 Reference symbol mismatch for "Color":
 after transform: SymbolId(38) "Color"
 rebuilt        : <None>
@@ -36628,17 +32738,17 @@ Reference symbol mismatch for "Color":
 after transform: SymbolId(44) "Color"
 rebuilt        : <None>
 Reference symbol mismatch for "Color":
+after transform: SymbolId(44) "Color"
+rebuilt        : <None>
+Reference symbol mismatch for "Color":
 after transform: SymbolId(49) "Color"
 rebuilt        : <None>
 Reference symbol mismatch for "Color":
 after transform: SymbolId(49) "Color"
 rebuilt        : <None>
-Reference symbol mismatch for "A":
-after transform: SymbolId(48) "A"
-rebuilt        : SymbolId(33) "A"
-Reference symbol mismatch for "A":
-after transform: SymbolId(48) "A"
-rebuilt        : SymbolId(33) "A"
+Reference symbol mismatch for "Color":
+after transform: SymbolId(49) "Color"
+rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["Color"]
@@ -37064,50 +33174,35 @@ after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(6)
 rebuilt        : [ReferenceId(0), ReferenceId(4), ReferenceId(6)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty48.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty49.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty50.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(2), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty51.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["C", "Symbol", "_M"]
 rebuilt        : ScopeId(1): ["C", "_M"]
 Scope flags mismatch:
@@ -37116,39 +33211,37 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty55.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(2), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "M":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(1): Span { start: 48, end: 49 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["Symbol", "SymbolConstructor"]
 rebuilt        : ["Symbol"]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty56.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(2), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "M":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(1): Span { start: 48, end: 49 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty58.ts
 semantic error: Scope children mismatch:
@@ -37804,27 +33897,18 @@ after transform: ["Array", "TemplateStringsArray", "f", "g"]
 rebuilt        : ["f", "g", "obj"]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorInAmbientContext6.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "generator"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "generator":
 after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "generator":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads4.ts
 semantic error: Scope children mismatch:
@@ -37835,22 +33919,18 @@ after transform: ["Iterable"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads5.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(3), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "f":
 after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
@@ -38232,22 +34312,12 @@ after transform: []
 rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-commonjs-classNamespaceMerge.ts
-semantic error: Missing SymbolId: "_Example"
-Missing ReferenceId: "_Example"
-Missing ReferenceId: "Example"
-Missing ReferenceId: "Example"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Example", "deco"]
 rebuilt        : ScopeId(0): ["Example"]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(2), SymbolId(3)]
-rebuilt        : ScopeId(3): [SymbolId(1), SymbolId(2)]
 Symbol flags mismatch for "Example":
 after transform: SymbolId(1): SymbolFlags(Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
-Symbol reference IDs mismatch for "Example":
-after transform: SymbolId(1): [ReferenceId(1)]
-rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(4)]
 Symbol redeclarations mismatch for "Example":
 after transform: SymbolId(1): [Span { start: 93, end: 100 }]
 rebuilt        : SymbolId(0): []
@@ -40154,19 +36224,15 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/functions/typeOfThisInFunctionExpression.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(4), SymbolId(7), SymbolId(11), SymbolId(20)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(8), SymbolId(12)]
-Binding symbols mismatch:
-after transform: ScopeId(7): [SymbolId(12), SymbolId(14), SymbolId(16), SymbolId(19)]
-rebuilt        : ScopeId(8): [SymbolId(13), SymbolId(14), SymbolId(16), SymbolId(18)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(8): ScopeFlags(Function)
+Symbol flags mismatch for "M":
+after transform: SymbolId(11): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(11): Span { start: 383, end: 384 }
+rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/functions/voidParamAssignmentCompatibility.ts
 semantic error: Bindings mismatch:
@@ -41814,61 +37880,51 @@ after transform: ["Date", "Object", "require"]
 rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInFunctionAndModuleBlock.ts
-semantic error: Missing SymbolId: "m"
-Missing SymbolId: "_m"
-Missing SymbolId: "m2"
-Missing SymbolId: "_m2"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m"
-Missing ReferenceId: "m"
-Missing SymbolId: "m1"
-Missing SymbolId: "_m3"
-Missing SymbolId: "m2"
-Missing SymbolId: "_m4"
-Missing SymbolId: "m3"
-Missing SymbolId: "_m5"
-Missing ReferenceId: "m3"
-Missing ReferenceId: "m3"
-Missing ReferenceId: "_m4"
-Missing ReferenceId: "_m4"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m2"
-Missing ReferenceId: "m1"
-Missing ReferenceId: "m1"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(9), SymbolId(12), SymbolId(16), SymbolId(21), SymbolId(26)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(9), SymbolId(12), SymbolId(16), SymbolId(21), SymbolId(28)]
-Binding symbols mismatch:
-after transform: ScopeId(12): [SymbolId(22), SymbolId(23), SymbolId(32)]
-rebuilt        : ScopeId(12): [SymbolId(22), SymbolId(23), SymbolId(24)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(12): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(13): [SymbolId(24), SymbolId(25), SymbolId(33)]
-rebuilt        : ScopeId(13): [SymbolId(25), SymbolId(26), SymbolId(27)]
 Scope flags mismatch:
 after transform: ScopeId(13): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(13): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(16): [SymbolId(27), SymbolId(28), SymbolId(34)]
-rebuilt        : ScopeId(16): [SymbolId(29), SymbolId(30), SymbolId(31)]
 Scope flags mismatch:
 after transform: ScopeId(16): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(16): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(17): [SymbolId(29), SymbolId(35)]
-rebuilt        : ScopeId(17): [SymbolId(32), SymbolId(33)]
 Scope flags mismatch:
 after transform: ScopeId(17): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(17): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(18): [SymbolId(30), SymbolId(31), SymbolId(36)]
-rebuilt        : ScopeId(18): [SymbolId(34), SymbolId(35), SymbolId(36)]
 Scope flags mismatch:
 after transform: ScopeId(18): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(18): ScopeFlags(Function)
+Symbol flags mismatch for "m":
+after transform: SymbolId(21): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(21): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m":
+after transform: SymbolId(21): Span { start: 1652, end: 1653 }
+rebuilt        : SymbolId(21): Span { start: 0, end: 0 }
+Symbol flags mismatch for "m2":
+after transform: SymbolId(23): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(24): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m2":
+after transform: SymbolId(23): Span { start: 1705, end: 1707 }
+rebuilt        : SymbolId(24): Span { start: 0, end: 0 }
+Symbol flags mismatch for "m1":
+after transform: SymbolId(26): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(28): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m1":
+after transform: SymbolId(26): Span { start: 2016, end: 2018 }
+rebuilt        : SymbolId(28): Span { start: 0, end: 0 }
+Symbol flags mismatch for "m2":
+after transform: SymbolId(28): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(31): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m2":
+after transform: SymbolId(28): Span { start: 2070, end: 2072 }
+rebuilt        : SymbolId(31): Span { start: 0, end: 0 }
+Symbol flags mismatch for "m3":
+after transform: SymbolId(29): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(33): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m3":
+after transform: SymbolId(29): Span { start: 2073, end: 2075 }
+rebuilt        : SymbolId(33): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInModule.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -42015,19 +38071,15 @@ after transform: SymbolId(4): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/asiPreventsParsingAsAmbientExternalModule02.ts
-semantic error: Missing SymbolId: "container"
-Missing SymbolId: "_container"
-Missing ReferenceId: "container"
-Missing ReferenceId: "container"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(3)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "container":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "container":
+after transform: SymbolId(2): Span { start: 49, end: 58 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/commonJSImportAsPrimaryExpression.ts
 semantic error: Missing SymbolId: "foo"
@@ -42066,35 +38118,12 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/es6/es6modulekindWithES5Target12.ts
-semantic error: Missing SymbolId: "_C"
-Missing ReferenceId: "_C"
-Missing ReferenceId: "C"
-Missing ReferenceId: "C"
-Missing SymbolId: "_E"
-Missing ReferenceId: "_E"
-Missing ReferenceId: "E"
-Missing ReferenceId: "E"
-Missing SymbolId: "_E2"
-Missing ReferenceId: "_E2"
-Missing ReferenceId: "E"
-Missing ReferenceId: "E"
-Missing SymbolId: "_N2"
-Missing ReferenceId: "_N2"
-Missing ReferenceId: "N"
-Missing ReferenceId: "N"
-Missing SymbolId: "_F"
-Missing ReferenceId: "_F"
-Missing ReferenceId: "F"
-Missing ReferenceId: "F"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "E", "F", "N"]
 rebuilt        : ScopeId(0): ["C", "E", "F"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(1), SymbolId(11)]
-rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
 Bindings mismatch:
 after transform: ScopeId(3): ["E", "w"]
 rebuilt        : ScopeId(3): ["E"]
@@ -42107,45 +38136,30 @@ rebuilt        : ScopeId(4): ["E"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(5), SymbolId(12)]
-rebuilt        : ScopeId(5): [SymbolId(6), SymbolId(7)]
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(6), SymbolId(13)]
-rebuilt        : ScopeId(6): [SymbolId(8), SymbolId(9)]
-Binding symbols mismatch:
-after transform: ScopeId(8): [SymbolId(8), SymbolId(15)]
-rebuilt        : ScopeId(7): [SymbolId(10), SymbolId(11)]
-Binding symbols mismatch:
-after transform: ScopeId(10): [SymbolId(10), SymbolId(16)]
-rebuilt        : ScopeId(9): [SymbolId(13), SymbolId(14)]
 Symbol flags mismatch for "C":
 after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): []
-rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(2)]
 Symbol redeclarations mismatch for "C":
 after transform: SymbolId(0): [Span { start: 37, end: 38 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "E":
 after transform: SymbolId(2): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(2): [ReferenceId(6), ReferenceId(7)]
-rebuilt        : SymbolId(3): [ReferenceId(6), ReferenceId(10), ReferenceId(12), ReferenceId(13), ReferenceId(15), ReferenceId(16)]
 Symbol redeclarations mismatch for "E":
 after transform: SymbolId(2): [Span { start: 109, end: 110 }, Span { start: 143, end: 144 }, Span { start: 191, end: 192 }]
 rebuilt        : SymbolId(3): []
 Symbol flags mismatch for "F":
 after transform: SymbolId(9): SymbolFlags(BlockScopedVariable | Function | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable | Function)
-Symbol reference IDs mismatch for "F":
-after transform: SymbolId(9): []
-rebuilt        : SymbolId(12): [ReferenceId(21), ReferenceId(22)]
 Symbol redeclarations mismatch for "F":
 after transform: SymbolId(9): [Span { start: 336, end: 337 }]
 rebuilt        : SymbolId(12): []
+Reference symbol mismatch for "N":
+after transform: SymbolId(7) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(7) "N"
+rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["N"]
@@ -42176,19 +38190,18 @@ after transform: SymbolId(2): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/es6/es6modulekindWithES5Target7.ts
-semantic error: Missing SymbolId: "N"
-Missing SymbolId: "_N"
-Missing ReferenceId: "N"
-Missing ReferenceId: "N"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["N", "N2"]
 rebuilt        : ScopeId(0): ["N"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Symbol flags mismatch for "N":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N":
+after transform: SymbolId(0): Span { start: 17, end: 18 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/esnext/esnextmodulekindWithES5Target.ts
 semantic error: Scope children mismatch:
@@ -42201,35 +38214,12 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/esnext/esnextmodulekindWithES5Target12.ts
-semantic error: Missing SymbolId: "_C"
-Missing ReferenceId: "_C"
-Missing ReferenceId: "C"
-Missing ReferenceId: "C"
-Missing SymbolId: "_E"
-Missing ReferenceId: "_E"
-Missing ReferenceId: "E"
-Missing ReferenceId: "E"
-Missing SymbolId: "_E2"
-Missing ReferenceId: "_E2"
-Missing ReferenceId: "E"
-Missing ReferenceId: "E"
-Missing SymbolId: "_N2"
-Missing ReferenceId: "_N2"
-Missing ReferenceId: "N"
-Missing ReferenceId: "N"
-Missing SymbolId: "_F"
-Missing ReferenceId: "_F"
-Missing ReferenceId: "F"
-Missing ReferenceId: "F"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "E", "F", "N"]
 rebuilt        : ScopeId(0): ["C", "E", "F"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(1), SymbolId(11)]
-rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
 Bindings mismatch:
 after transform: ScopeId(3): ["E", "w"]
 rebuilt        : ScopeId(3): ["E"]
@@ -42242,45 +38232,30 @@ rebuilt        : ScopeId(4): ["E"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(5), SymbolId(12)]
-rebuilt        : ScopeId(5): [SymbolId(6), SymbolId(7)]
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(6), SymbolId(13)]
-rebuilt        : ScopeId(6): [SymbolId(8), SymbolId(9)]
-Binding symbols mismatch:
-after transform: ScopeId(8): [SymbolId(8), SymbolId(15)]
-rebuilt        : ScopeId(7): [SymbolId(10), SymbolId(11)]
-Binding symbols mismatch:
-after transform: ScopeId(10): [SymbolId(10), SymbolId(16)]
-rebuilt        : ScopeId(9): [SymbolId(13), SymbolId(14)]
 Symbol flags mismatch for "C":
 after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
-Symbol reference IDs mismatch for "C":
-after transform: SymbolId(0): []
-rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(2)]
 Symbol redeclarations mismatch for "C":
 after transform: SymbolId(0): [Span { start: 37, end: 38 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "E":
 after transform: SymbolId(2): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "E":
-after transform: SymbolId(2): [ReferenceId(6), ReferenceId(7)]
-rebuilt        : SymbolId(3): [ReferenceId(6), ReferenceId(10), ReferenceId(12), ReferenceId(13), ReferenceId(15), ReferenceId(16)]
 Symbol redeclarations mismatch for "E":
 after transform: SymbolId(2): [Span { start: 109, end: 110 }, Span { start: 143, end: 144 }, Span { start: 191, end: 192 }]
 rebuilt        : SymbolId(3): []
 Symbol flags mismatch for "F":
 after transform: SymbolId(9): SymbolFlags(BlockScopedVariable | Function | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable | Function)
-Symbol reference IDs mismatch for "F":
-after transform: SymbolId(9): []
-rebuilt        : SymbolId(12): [ReferenceId(21), ReferenceId(22)]
 Symbol redeclarations mismatch for "F":
 after transform: SymbolId(9): [Span { start: 336, end: 337 }]
 rebuilt        : SymbolId(12): []
+Reference symbol mismatch for "N":
+after transform: SymbolId(7) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(7) "N"
+rebuilt        : <None>
 Unresolved references mismatch:
 after transform: []
 rebuilt        : ["N"]
@@ -42311,19 +38286,18 @@ after transform: SymbolId(2): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/esnext/esnextmodulekindWithES5Target7.ts
-semantic error: Missing SymbolId: "N"
-Missing SymbolId: "_N"
-Missing ReferenceId: "N"
-Missing ReferenceId: "N"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["N", "N2"]
 rebuilt        : ScopeId(0): ["N"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Symbol flags mismatch for "N":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N":
+after transform: SymbolId(0): Span { start: 17, end: 18 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAmbientClassNameWithObject.ts
 semantic error: Scope children mismatch:
@@ -42639,21 +38613,12 @@ after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/nestedNamespace.ts
-semantic error: Missing SymbolId: "types"
-Missing SymbolId: "_types"
-Missing ReferenceId: "_types"
-Missing ReferenceId: "A"
-Missing ReferenceId: "types"
-Missing ReferenceId: "types"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
+semantic error: Symbol flags mismatch for "types":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "types":
+after transform: SymbolId(0): Span { start: 17, end: 22 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/preserveValueImports.ts
 semantic error: Scope children mismatch:
@@ -42809,17 +38774,7 @@ after transform: ["Iterator"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/generators/generatorYieldContextualType.ts
-semantic error: Missing SymbolId: "_Directive"
-Missing ReferenceId: "_Directive"
-Missing ReferenceId: "is"
-Missing ReferenceId: "Directive"
-Missing ReferenceId: "Directive"
-Missing SymbolId: "StepResult"
-Missing SymbolId: "_StepResult"
-Missing ReferenceId: "_StepResult"
-Missing ReferenceId: "StepResult"
-Missing ReferenceId: "StepResult"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Directive", "_wrapAsyncGenerator", "canPickStepContinue", "createPickStep", "showStep"]
 rebuilt        : ScopeId(0): ["Directive", "StepResult", "_wrapAsyncGenerator", "canPickStepContinue", "createPickStep", "showStep"]
 Scope children mismatch:
@@ -42831,15 +38786,9 @@ rebuilt        : ScopeId(3): ["Directive"]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(0x0)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(15), SymbolId(53)]
-rebuilt        : ScopeId(4): [SymbolId(5), SymbolId(6)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(15): [SymbolId(27), SymbolId(54)]
-rebuilt        : ScopeId(6): [SymbolId(9), SymbolId(10)]
 Scope flags mismatch:
 after transform: ScopeId(15): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
@@ -42847,20 +38796,26 @@ Symbol flags mismatch for "Directive":
 after transform: SymbolId(10): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Directive":
-after transform: SymbolId(10): [ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(51), ReferenceId(54), ReferenceId(64), ReferenceId(101)]
+after transform: SymbolId(10): [ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(51), ReferenceId(54), ReferenceId(64), ReferenceId(93), ReferenceId(94), ReferenceId(108)]
 rebuilt        : SymbolId(3): [ReferenceId(13), ReferenceId(15), ReferenceId(19), ReferenceId(20)]
 Symbol redeclarations mismatch for "Directive":
 after transform: SymbolId(10): [Span { start: 381, end: 390 }]
 rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "is":
-after transform: SymbolId(15): []
-rebuilt        : SymbolId(6): [ReferenceId(18)]
+Symbol flags mismatch for "StepResult":
+after transform: SymbolId(26): SymbolFlags(TypeAlias | NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "StepResult":
+after transform: SymbolId(26): Span { start: 1257, end: 1267 }
+rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "StepResult":
+after transform: SymbolId(26): [ReferenceId(25), ReferenceId(29), ReferenceId(36), ReferenceId(41), ReferenceId(46), ReferenceId(90), ReferenceId(96), ReferenceId(97)]
+rebuilt        : SymbolId(8): [ReferenceId(23), ReferenceId(24), ReferenceId(33)]
+Symbol redeclarations mismatch for "StepResult":
+after transform: SymbolId(26): [Span { start: 1321, end: 1331 }]
+rebuilt        : SymbolId(8): []
 Symbol reference IDs mismatch for "step":
 after transform: SymbolId(51): [ReferenceId(83), ReferenceId(84), ReferenceId(86)]
 rebuilt        : SymbolId(20): [ReferenceId(27), ReferenceId(29)]
-Reference symbol mismatch for "StepResult":
-after transform: SymbolId(26) "StepResult"
-rebuilt        : SymbolId(8) "StepResult"
 Unresolved references mismatch:
 after transform: ["AsyncGenerator", "Generator", "Partial", "Record", "Symbol", "f1", "f2", "require"]
 rebuilt        : ["Symbol", "f1", "f2", "require"]
@@ -42930,226 +38885,159 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergeThreeInterfaces.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(7): [SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(27)]
-rebuilt        : ScopeId(1): [SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17)]
 Scope flags mismatch:
 after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(7): [ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13)]
 rebuilt        : ScopeId(1): []
+Symbol flags mismatch for "M":
+after transform: SymbolId(13): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(13): Span { start: 474, end: 475 }
+rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergeThreeInterfaces2.ts
-semantic error: Missing SymbolId: "M2"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M2"
-Missing ReferenceId: "M2"
-Missing SymbolId: "_M2"
-Missing ReferenceId: "M2"
-Missing ReferenceId: "M2"
-Missing SymbolId: "_M3"
-Missing SymbolId: "M3"
-Missing SymbolId: "_M4"
-Missing ReferenceId: "M3"
-Missing ReferenceId: "M3"
-Missing ReferenceId: "_M3"
-Missing ReferenceId: "_M3"
-Missing ReferenceId: "M2"
-Missing ReferenceId: "M2"
-Missing SymbolId: "_M5"
-Missing SymbolId: "M3"
-Missing SymbolId: "_M6"
-Missing ReferenceId: "M3"
-Missing ReferenceId: "M3"
-Missing ReferenceId: "_M5"
-Missing ReferenceId: "_M5"
-Missing ReferenceId: "M2"
-Missing ReferenceId: "M2"
-Missing SymbolId: "_M7"
-Missing SymbolId: "M3"
-Missing SymbolId: "_M8"
-Missing ReferenceId: "M3"
-Missing ReferenceId: "M3"
-Missing ReferenceId: "_M7"
-Missing ReferenceId: "_M7"
-Missing ReferenceId: "M2"
-Missing ReferenceId: "M2"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(27)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2)]
 rebuilt        : ScopeId(1): []
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(28)]
-rebuilt        : ScopeId(2): [SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(3): [ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(2): []
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(10), SymbolId(29)]
-rebuilt        : ScopeId(3): [SymbolId(10), SymbolId(11)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(7): [SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(30)]
-rebuilt        : ScopeId(4): [SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15)]
 Scope flags mismatch:
 after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(7): [ScopeId(8)]
 rebuilt        : ScopeId(4): []
-Binding symbols mismatch:
-after transform: ScopeId(9): [SymbolId(15), SymbolId(31)]
-rebuilt        : ScopeId(5): [SymbolId(16), SymbolId(17)]
 Scope flags mismatch:
 after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(10): [SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(32)]
-rebuilt        : ScopeId(6): [SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22)]
 Scope flags mismatch:
 after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(10): [ScopeId(11)]
 rebuilt        : ScopeId(6): []
-Binding symbols mismatch:
-after transform: ScopeId(12): [SymbolId(21), SymbolId(33)]
-rebuilt        : ScopeId(7): [SymbolId(23), SymbolId(24)]
 Scope flags mismatch:
 after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(13): [SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(34)]
-rebuilt        : ScopeId(8): [SymbolId(25), SymbolId(26), SymbolId(27), SymbolId(28), SymbolId(29)]
 Scope flags mismatch:
 after transform: ScopeId(13): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(8): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(13): [ScopeId(14)]
 rebuilt        : ScopeId(8): []
+Symbol flags mismatch for "M2":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M2":
+after transform: SymbolId(0): Span { start: 113, end: 115 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "M2":
+after transform: SymbolId(0): [Span { start: 235, end: 237 }, Span { start: 518, end: 520 }, Span { start: 693, end: 695 }, Span { start: 892, end: 894 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch for "M3":
+after transform: SymbolId(10): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M3":
+after transform: SymbolId(10): Span { start: 541, end: 543 }
+rebuilt        : SymbolId(11): Span { start: 0, end: 0 }
+Symbol flags mismatch for "M3":
+after transform: SymbolId(15): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(17): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M3":
+after transform: SymbolId(15): Span { start: 716, end: 718 }
+rebuilt        : SymbolId(17): Span { start: 0, end: 0 }
+Symbol flags mismatch for "M3":
+after transform: SymbolId(21): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(24): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M3":
+after transform: SymbolId(21): Span { start: 915, end: 917 }
+rebuilt        : SymbolId(24): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergeTwoInterfaces.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21)]
-rebuilt        : ScopeId(1): [SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
 rebuilt        : ScopeId(1): []
+Symbol flags mismatch for "M":
+after transform: SymbolId(10): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(10): Span { start: 396, end: 397 }
+rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergeTwoInterfaces2.ts
-semantic error: Missing SymbolId: "M2"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M2"
-Missing ReferenceId: "M2"
-Missing SymbolId: "_M2"
-Missing ReferenceId: "M2"
-Missing ReferenceId: "M2"
-Missing SymbolId: "_M3"
-Missing SymbolId: "M3"
-Missing SymbolId: "_M4"
-Missing ReferenceId: "M3"
-Missing ReferenceId: "M3"
-Missing ReferenceId: "_M3"
-Missing ReferenceId: "_M3"
-Missing ReferenceId: "M2"
-Missing ReferenceId: "M2"
-Missing SymbolId: "_M5"
-Missing SymbolId: "M3"
-Missing SymbolId: "_M6"
-Missing ReferenceId: "M3"
-Missing ReferenceId: "M3"
-Missing ReferenceId: "_M5"
-Missing ReferenceId: "_M5"
-Missing ReferenceId: "M2"
-Missing ReferenceId: "M2"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(19)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2)]
 rebuilt        : ScopeId(1): []
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(20)]
-rebuilt        : ScopeId(2): [SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(3): [ScopeId(4)]
 rebuilt        : ScopeId(2): []
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(9), SymbolId(21)]
-rebuilt        : ScopeId(3): [SymbolId(9), SymbolId(10)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(22)]
-rebuilt        : ScopeId(4): [SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(6): [ScopeId(7)]
 rebuilt        : ScopeId(4): []
-Binding symbols mismatch:
-after transform: ScopeId(8): [SymbolId(14), SymbolId(23)]
-rebuilt        : ScopeId(5): [SymbolId(15), SymbolId(16)]
 Scope flags mismatch:
 after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(9): [SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(24)]
-rebuilt        : ScopeId(6): [SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20)]
 Scope flags mismatch:
 after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(9): [ScopeId(10)]
 rebuilt        : ScopeId(6): []
+Symbol flags mismatch for "M2":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M2":
+after transform: SymbolId(0): Span { start: 113, end: 115 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "M2":
+after transform: SymbolId(0): [Span { start: 234, end: 236 }, Span { start: 412, end: 414 }, Span { start: 586, end: 588 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch for "M3":
+after transform: SymbolId(9): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M3":
+after transform: SymbolId(9): Span { start: 435, end: 437 }
+rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
+Symbol flags mismatch for "M3":
+after transform: SymbolId(14): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M3":
+after transform: SymbolId(14): Span { start: 609, end: 611 }
+rebuilt        : SymbolId(16): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithConflictingPropertyNames2.ts
 semantic error: Bindings mismatch:
@@ -43165,19 +39053,9 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithMultipleBases.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(16)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7)]
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(7), SymbolId(9), SymbolId(14), SymbolId(15)]
-rebuilt        : ScopeId(7): [SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
@@ -43190,6 +39068,12 @@ rebuilt        : SymbolId(1): []
 Symbol reference IDs mismatch for "C2":
 after transform: SymbolId(1): [ReferenceId(1)]
 rebuilt        : SymbolId(2): []
+Symbol flags mismatch for "M":
+after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(6): Span { start: 412, end: 413 }
+rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(7): [ReferenceId(7)]
 rebuilt        : SymbolId(8): []
@@ -43198,19 +39082,9 @@ after transform: SymbolId(9): [ReferenceId(10)]
 rebuilt        : SymbolId(9): []
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithMultipleBases2.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(22)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(9), ScopeId(11)]
-Binding symbols mismatch:
-after transform: ScopeId(8): [SymbolId(9), SymbolId(11), SymbolId(13), SymbolId(15), SymbolId(20), SymbolId(21)]
-rebuilt        : ScopeId(11): [SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14)]
 Scope flags mismatch:
 after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(11): ScopeFlags(Function)
@@ -43229,6 +39103,12 @@ rebuilt        : SymbolId(3): []
 Symbol reference IDs mismatch for "C4":
 after transform: SymbolId(3): [ReferenceId(3)]
 rebuilt        : SymbolId(4): []
+Symbol flags mismatch for "M":
+after transform: SymbolId(8): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(8): Span { start: 509, end: 510 }
+rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(9): [ReferenceId(11)]
 rebuilt        : SymbolId(10): []
@@ -43268,40 +39148,32 @@ after transform: ["Date"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/twoMergedInterfacesWithDifferingOverloads2.ts
-semantic error: Missing SymbolId: "G"
-Missing SymbolId: "_G"
-Missing ReferenceId: "G"
-Missing ReferenceId: "G"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15)]
-rebuilt        : ScopeId(1): [SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(3): [ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(1): []
+Symbol flags mismatch for "G":
+after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "G":
+after transform: SymbolId(5): Span { start: 176, end: 177 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/asiPreventsParsingAsInterface03.ts
-semantic error: Missing SymbolId: "n"
-Missing SymbolId: "_n"
-Missing ReferenceId: "n"
-Missing ReferenceId: "n"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(3)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "n":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "n":
+after transform: SymbolId(2): Span { start: 45, end: 46 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/derivedInterfaceDoesNotHideBaseSignatures.ts
 semantic error: Scope children mismatch:
@@ -43380,55 +39252,20 @@ after transform: ["Object", "require"]
 rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/AmbientModuleAndNonAmbientClassWithSameNameAndCommonRoot.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "Point"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(3)]
+semantic error: Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithStaticFunctionAndNonExportedFunctionThatShareAName.ts
-semantic error: Missing SymbolId: "_Point"
-Missing ReferenceId: "Point"
-Missing ReferenceId: "Point"
-Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "Point"
-Missing SymbolId: "_Point2"
-Missing ReferenceId: "Point"
-Missing ReferenceId: "Point"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(4)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(3), SymbolId(9)]
-rebuilt        : ScopeId(4): [SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(5), SymbolId(10)]
-rebuilt        : ScopeId(6): [SymbolId(6), SymbolId(7)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(10): [SymbolId(8), SymbolId(11)]
-rebuilt        : ScopeId(10): [SymbolId(10), SymbolId(11)]
 Scope flags mismatch:
 after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(10): ScopeFlags(Function)
@@ -43436,54 +39273,34 @@ Symbol flags mismatch for "Point":
 after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(0): [ReferenceId(0)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3)]
 rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
 Symbol redeclarations mismatch for "Point":
 after transform: SymbolId(0): [Span { start: 135, end: 140 }]
 rebuilt        : SymbolId(0): []
+Symbol flags mismatch for "A":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(4): Span { start: 226, end: 227 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Point":
 after transform: SymbolId(5): SymbolFlags(Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(Class)
 Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(5): [ReferenceId(1)]
+after transform: SymbolId(5): [ReferenceId(1), ReferenceId(5), ReferenceId(6), ReferenceId(8)]
 rebuilt        : SymbolId(7): [ReferenceId(7), ReferenceId(8), ReferenceId(9)]
 Symbol redeclarations mismatch for "Point":
 after transform: SymbolId(5): [Span { start: 399, end: 404 }]
 rebuilt        : SymbolId(7): []
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithStaticVariableAndNonExportedVarThatShareAName.ts
-semantic error: Missing SymbolId: "_Point"
-Missing ReferenceId: "Point"
-Missing ReferenceId: "Point"
-Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "Point"
-Missing SymbolId: "_Point2"
-Missing ReferenceId: "Point"
-Missing ReferenceId: "Point"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(12)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(3), SymbolId(9)]
-rebuilt        : ScopeId(3): [SymbolId(4), SymbolId(5)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(5), SymbolId(10)]
-rebuilt        : ScopeId(4): [SymbolId(7), SymbolId(8)]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(7): [SymbolId(8), SymbolId(11)]
-rebuilt        : ScopeId(7): [SymbolId(11), SymbolId(12)]
 Scope flags mismatch:
 after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
@@ -43491,36 +39308,34 @@ Symbol flags mismatch for "Point":
 after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(Class)
 Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(14)]
 rebuilt        : SymbolId(1): [ReferenceId(4), ReferenceId(5), ReferenceId(6)]
 Symbol redeclarations mismatch for "Point":
 after transform: SymbolId(0): [Span { start: 124, end: 129 }]
 rebuilt        : SymbolId(1): []
+Symbol flags mismatch for "A":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(4): Span { start: 200, end: 201 }
+rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Point":
 after transform: SymbolId(5): SymbolFlags(Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(Class)
 Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(5): [ReferenceId(1), ReferenceId(8)]
+after transform: SymbolId(5): [ReferenceId(1), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(18)]
 rebuilt        : SymbolId(8): [ReferenceId(10), ReferenceId(12), ReferenceId(13), ReferenceId(14)]
 Symbol redeclarations mismatch for "Point":
 after transform: SymbolId(5): [Span { start: 362, end: 367 }]
 rebuilt        : SymbolId(8): []
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/EnumAndModuleWithSameNameAndCommonRoot.ts
-semantic error: Missing SymbolId: "_enumdule"
-Missing ReferenceId: "_enumdule"
-Missing ReferenceId: "Point"
-Missing ReferenceId: "enumdule"
-Missing ReferenceId: "enumdule"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["Blue", "Red", "enumdule"]
 rebuilt        : ScopeId(1): ["enumdule"]
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(0x0)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(3), SymbolId(8)]
-rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3)]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
@@ -43528,46 +39343,25 @@ Symbol flags mismatch for "enumdule":
 after transform: SymbolId(0): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "enumdule":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(8)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(5), ReferenceId(6), ReferenceId(12)]
 rebuilt        : SymbolId(0): [ReferenceId(5), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13)]
 Symbol redeclarations mismatch for "enumdule":
 after transform: SymbolId(0): [Span { start: 40, end: 48 }]
 rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(3): [ReferenceId(9)]
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/FunctionAndModuleWithSameNameAndDifferentCommonRoot.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "Point"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+semantic error: Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Point":
 after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ModuleAndEnumWithSameNameAndCommonRoot.ts
-semantic error: Missing SymbolId: "enumdule"
-Missing SymbolId: "_enumdule"
-Missing ReferenceId: "_enumdule"
-Missing ReferenceId: "Point"
-Missing ReferenceId: "enumdule"
-Missing ReferenceId: "enumdule"
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(8)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Bindings mismatch:
@@ -43576,119 +39370,86 @@ rebuilt        : ScopeId(4): ["enumdule"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(0x0)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
-Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(2): [ReferenceId(3)]
 Symbol flags mismatch for "enumdule":
 after transform: SymbolId(0): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
-rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable | BlockScopedVariable)
+rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch for "enumdule":
 after transform: SymbolId(0): Span { start: 7, end: 15 }
-rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(4): Span { start: 118, end: 126 }
 Symbol reference IDs mismatch for "enumdule":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(10)]
-rebuilt        : SymbolId(0): [ReferenceId(4), ReferenceId(5), ReferenceId(11), ReferenceId(12), ReferenceId(13)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(5), ReferenceId(6), ReferenceId(14)]
+rebuilt        : SymbolId(4): [ReferenceId(4), ReferenceId(5), ReferenceId(11), ReferenceId(12), ReferenceId(13)]
+Symbol redeclarations mismatch for "enumdule":
+after transform: SymbolId(0): [Span { start: 118, end: 126 }]
+rebuilt        : SymbolId(4): []
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedAndNonExportedClassesOfTheSameName.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "Point"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Missing SymbolId: "_A2"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Missing SymbolId: "X"
-Missing SymbolId: "_X"
-Missing SymbolId: "Y"
-Missing SymbolId: "_Y"
-Missing SymbolId: "Z"
-Missing SymbolId: "_Z"
-Missing ReferenceId: "_Z"
-Missing ReferenceId: "Line"
-Missing ReferenceId: "Z"
-Missing ReferenceId: "Z"
-Missing ReferenceId: "_Y"
-Missing ReferenceId: "_Y"
-Missing ReferenceId: "Y"
-Missing ReferenceId: "Y"
-Missing ReferenceId: "_X"
-Missing ReferenceId: "_X"
-Missing ReferenceId: "X"
-Missing ReferenceId: "X"
-Missing SymbolId: "_X2"
-Missing SymbolId: "Y"
-Missing SymbolId: "_Y2"
-Missing SymbolId: "Z"
-Missing SymbolId: "_Z2"
-Missing ReferenceId: "Z"
-Missing ReferenceId: "Z"
-Missing ReferenceId: "_Y2"
-Missing ReferenceId: "_Y2"
-Missing ReferenceId: "Y"
-Missing ReferenceId: "Y"
-Missing ReferenceId: "_X2"
-Missing ReferenceId: "_X2"
-Missing ReferenceId: "X"
-Missing ReferenceId: "X"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(4), SymbolId(5), SymbolId(12), SymbolId(21)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(7), SymbolId(8), SymbolId(21)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(13)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(2), SymbolId(14)]
-rebuilt        : ScopeId(4): [SymbolId(4), SymbolId(5)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(6), SymbolId(15)]
-rebuilt        : ScopeId(7): [SymbolId(9), SymbolId(10)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(7): [SymbolId(7), SymbolId(16)]
-rebuilt        : ScopeId(8): [SymbolId(11), SymbolId(12)]
 Scope flags mismatch:
 after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(8): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(8): [SymbolId(8), SymbolId(17)]
-rebuilt        : ScopeId(9): [SymbolId(13), SymbolId(14)]
 Scope flags mismatch:
 after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(9): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(10): [SymbolId(9), SymbolId(18)]
-rebuilt        : ScopeId(12): [SymbolId(15), SymbolId(16)]
 Scope flags mismatch:
 after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(12): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(11): [SymbolId(10), SymbolId(19)]
-rebuilt        : ScopeId(13): [SymbolId(17), SymbolId(18)]
 Scope flags mismatch:
 after transform: ScopeId(11): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(13): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(12): [SymbolId(11), SymbolId(20)]
-rebuilt        : ScopeId(14): [SymbolId(19), SymbolId(20)]
 Scope flags mismatch:
 after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(14): ScopeFlags(Function)
-Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(3): [ReferenceId(4)]
-Symbol reference IDs mismatch for "Line":
-after transform: SymbolId(8): []
-rebuilt        : SymbolId(14): [ReferenceId(13)]
+Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "A":
+after transform: SymbolId(0): [Span { start: 90, end: 91 }]
+rebuilt        : SymbolId(1): []
+Symbol flags mismatch for "X":
+after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "X":
+after transform: SymbolId(5): Span { start: 294, end: 295 }
+rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "X":
+after transform: SymbolId(5): [Span { start: 366, end: 367 }]
+rebuilt        : SymbolId(8): []
+Symbol flags mismatch for "Y":
+after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Y":
+after transform: SymbolId(6): Span { start: 296, end: 297 }
+rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Z":
+after transform: SymbolId(7): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Z":
+after transform: SymbolId(7): Span { start: 298, end: 299 }
+rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Y":
+after transform: SymbolId(9): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Y":
+after transform: SymbolId(9): Span { start: 388, end: 389 }
+rebuilt        : SymbolId(16): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Z":
+after transform: SymbolId(10): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Z":
+after transform: SymbolId(10): Span { start: 414, end: 415 }
+rebuilt        : SymbolId(18): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["A", "X", "require"]
 rebuilt        : ["require"]
@@ -43723,77 +39484,50 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesWithTheSameNameAndDifferentCommonRoot.ts
-semantic error: Missing SymbolId: "Root"
-Missing SymbolId: "_Root"
-Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing SymbolId: "Utils"
-Missing SymbolId: "_Utils"
-Missing ReferenceId: "_Utils"
-Missing ReferenceId: "mirror"
-Missing ReferenceId: "Utils"
-Missing ReferenceId: "Utils"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "_Root"
-Missing ReferenceId: "_Root"
-Missing ReferenceId: "Root"
-Missing ReferenceId: "Root"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(7)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(3), SymbolId(8)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(2): [ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(2): [ScopeId(3)]
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(4), SymbolId(9)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
+Symbol flags mismatch for "Root":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Root":
+after transform: SymbolId(0): Span { start: 7, end: 11 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "A":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(1): Span { start: 32, end: 33 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Utils":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Utils":
+after transform: SymbolId(3): Span { start: 148, end: 153 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol flags mismatch for "mirror":
 after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "mirror":
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(6): [ReferenceId(3)]
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesWithTheSameNameAndSameCommonRoot.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing SymbolId: "Utils"
-Missing SymbolId: "_Utils"
-Missing ReferenceId: "_Utils"
-Missing ReferenceId: "mirror"
-Missing ReferenceId: "Utils"
-Missing ReferenceId: "Utils"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(2), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(3), SymbolId(7)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Utils":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Utils":
+after transform: SymbolId(2): Span { start: 103, end: 108 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "mirror":
 after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "mirror":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(4): [ReferenceId(3)]
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/codeGeneration/exportCodeGen.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -43806,144 +39540,91 @@ tasks/coverage/typescript/tests/cases/conformance/internalModules/codeGeneration
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportClassWhichExtendsInterfaceWithInaccessibleType.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "Point2d"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(2), SymbolId(6)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(4)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
-Symbol reference IDs mismatch for "Point2d":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(2): [ReferenceId(3)]
+Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportClassWithAccessibleTypesInTypeParameterConstraintsClassHeritageListMemberTypeAnnotations.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportClassWithInaccessibleTypeInIndexerTypeAnnotations.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "points"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(4)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "Point":
 after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(3): []
-Symbol reference IDs mismatch for "points":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(4)]
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportClassWithInaccessibleTypeInTypeParameterConstraint.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportFunctionWithAccessibleTypesInParameterAndReturnTypeAnnotation.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "Point"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "Line"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "fromOrigin"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(8)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5), SymbolId(7)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(7)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(7)]
 rebuilt        : SymbolId(3): [ReferenceId(4)]
 Symbol reference IDs mismatch for "Line":
-after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4)]
+after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4), ReferenceId(9)]
 rebuilt        : SymbolId(4): [ReferenceId(8), ReferenceId(9)]
-Symbol reference IDs mismatch for "fromOrigin":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(7): [ReferenceId(12)]
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportFunctionWithInaccessibleTypesInParameterTypeAnnotation.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "Line"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "fromOrigin"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(8)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5), SymbolId(7)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(7)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "Point":
 after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 rebuilt        : SymbolId(3): []
 Symbol reference IDs mismatch for "Line":
-after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4)]
+after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4), ReferenceId(7)]
 rebuilt        : SymbolId(4): [ReferenceId(6), ReferenceId(7)]
-Symbol reference IDs mismatch for "fromOrigin":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(7): [ReferenceId(10)]
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportFunctionWithInaccessibleTypesInReturnTypeAnnotation.ts
-semantic error: Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "Point"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "fromOrigin"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(8)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5), SymbolId(7)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(7)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(7)]
 rebuilt        : SymbolId(3): [ReferenceId(4)]
 Symbol reference IDs mismatch for "Line":
 after transform: SymbolId(2): [ReferenceId(3), ReferenceId(4)]
 rebuilt        : SymbolId(4): [ReferenceId(7)]
-Symbol reference IDs mismatch for "fromOrigin":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(7): [ReferenceId(10)]
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportInterfaceWithAccessibleTypesInTypeParameterConstraintsClassHeritageListMemberTypeAnnotations.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -43987,24 +39668,9 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/importDeclarations/importAliasIdentifiers.ts
-semantic error: Missing SymbolId: "moduleA"
-Missing SymbolId: "_moduleA"
-Missing ReferenceId: "_moduleA"
-Missing ReferenceId: "Point"
-Missing ReferenceId: "moduleA"
-Missing ReferenceId: "moduleA"
-Missing SymbolId: "_clodule"
-Missing ReferenceId: "clodule"
-Missing ReferenceId: "clodule"
-Missing SymbolId: "_fundule"
-Missing ReferenceId: "fundule"
-Missing ReferenceId: "fundule"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["_defineProperty", "alias", "clodule", "clolias", "fundule", "funlias", "moduleA", "p"]
 rebuilt        : ScopeId(0): ["_defineProperty", "clodule", "fundule", "moduleA", "p"]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(12)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
@@ -44026,14 +39692,20 @@ rebuilt        : ScopeId(8): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(8): [ScopeId(9)]
 rebuilt        : ScopeId(8): []
-Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(1): []
-rebuilt        : SymbolId(3): [ReferenceId(4)]
+Symbol flags mismatch for "moduleA":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "moduleA":
+after transform: SymbolId(0): Span { start: 7, end: 14 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "moduleA":
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(13), ReferenceId(14)]
+rebuilt        : SymbolId(1): [ReferenceId(5), ReferenceId(6)]
 Symbol flags mismatch for "clodule":
 after transform: SymbolId(6): SymbolFlags(Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(Class)
 Symbol reference IDs mismatch for "clodule":
-after transform: SymbolId(6): [ReferenceId(4), ReferenceId(6)]
+after transform: SymbolId(6): [ReferenceId(4), ReferenceId(6), ReferenceId(15), ReferenceId(16)]
 rebuilt        : SymbolId(7): [ReferenceId(8), ReferenceId(9)]
 Symbol redeclarations mismatch for "clodule":
 after transform: SymbolId(6): [Span { start: 257, end: 264 }]
@@ -44054,7 +39726,7 @@ Symbol flags mismatch for "fundule":
 after transform: SymbolId(9): SymbolFlags(FunctionScopedVariable | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "fundule":
-after transform: SymbolId(9): [ReferenceId(8)]
+after transform: SymbolId(9): [ReferenceId(8), ReferenceId(17), ReferenceId(18)]
 rebuilt        : SymbolId(10): [ReferenceId(10), ReferenceId(11)]
 Symbol redeclarations mismatch for "fundule":
 after transform: SymbolId(9): [Span { start: 539, end: 546 }]
@@ -44082,19 +39754,15 @@ Namespaces exporting non-const are not supported by Babel. Change to const or se
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/asiPreventsParsingAsNamespace03.ts
-semantic error: Missing SymbolId: "container"
-Missing SymbolId: "_container"
-Missing ReferenceId: "container"
-Missing ReferenceId: "container"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(3)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "container":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "container":
+after transform: SymbolId(2): Span { start: 49, end: 58 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/asiPreventsParsingAsNamespace05.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -44605,30 +40273,21 @@ after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution.tsx
-semantic error: Missing SymbolId: "Dotted"
-Missing SymbolId: "_Dotted"
-Missing ReferenceId: "_Dotted"
-Missing ReferenceId: "Name"
-Missing ReferenceId: "Dotted"
-Missing ReferenceId: "Dotted"
-Bindings mismatch:
+semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Dotted", "JSX", "Other", "_jsxFileName", "_reactJsxRuntime", "a", "b", "d", "e", "foundFirst"]
 rebuilt        : ScopeId(0): ["Dotted", "Other", "_jsxFileName", "_reactJsxRuntime", "a", "b", "d", "e", "foundFirst"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(5), SymbolId(10)]
-rebuilt        : ScopeId(3): [SymbolId(5), SymbolId(6)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Symbol reference IDs mismatch for "Name":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(6): [ReferenceId(2)]
-Reference symbol mismatch for "Dotted":
-after transform: SymbolId(4) "Dotted"
-rebuilt        : SymbolId(4) "Dotted"
+Symbol flags mismatch for "Dotted":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Dotted":
+after transform: SymbolId(4): Span { start: 161, end: 167 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution13.tsx
 semantic error: Bindings mismatch:
@@ -45854,30 +41513,18 @@ after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/IncompleteMemberVariables/parserErrorRecovery_IncompleteMemberVariable1.ts
-semantic error: Missing SymbolId: "Shapes"
-Missing SymbolId: "_Shapes"
-Missing ReferenceId: "_Shapes"
-Missing ReferenceId: "Point"
-Missing ReferenceId: "Shapes"
-Missing ReferenceId: "Shapes"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(1), SymbolId(5), SymbolId(6), SymbolId(8)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(7), SymbolId(8)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(2), SymbolId(7), SymbolId(9)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(4)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Symbol reference IDs mismatch for "Point":
-after transform: SymbolId(2): [ReferenceId(9), ReferenceId(11)]
-rebuilt        : SymbolId(4): [ReferenceId(6), ReferenceId(8), ReferenceId(11)]
-Reference symbol mismatch for "Shapes":
-after transform: SymbolId(1) "Shapes"
-rebuilt        : SymbolId(1) "Shapes"
+Symbol flags mismatch for "Shapes":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Shapes":
+after transform: SymbolId(1): Span { start: 75, end: 81 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnPropertySignature2.ts
 semantic error: Scope children mismatch:
@@ -46330,23 +41977,9 @@ after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInitializer.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "A"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "F2"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(6), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(26), SymbolId(27), SymbolId(28), SymbolId(31)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(26), SymbolId(27), SymbolId(28)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(8), ScopeId(9)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(10), ScopeId(11)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(7), SymbolId(8), SymbolId(30)]
-rebuilt        : ScopeId(6): [SymbolId(6), SymbolId(7), SymbolId(8)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
@@ -46359,18 +41992,15 @@ rebuilt        : SymbolId(2): [ReferenceId(19)]
 Symbol reference IDs mismatch for "F":
 after transform: SymbolId(4): [ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25)]
 rebuilt        : SymbolId(3): [ReferenceId(21), ReferenceId(22)]
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(7): []
-rebuilt        : SymbolId(7): [ReferenceId(7)]
-Symbol reference IDs mismatch for "F2":
-after transform: SymbolId(8): []
-rebuilt        : SymbolId(8): [ReferenceId(10)]
-Reference symbol mismatch for "M":
-after transform: SymbolId(6) "M"
-rebuilt        : SymbolId(5) "M"
-Reference symbol mismatch for "M":
-after transform: SymbolId(6) "M"
-rebuilt        : SymbolId(5) "M"
+Symbol flags mismatch for "M":
+after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(6): Span { start: 198, end: 199 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "M":
+after transform: SymbolId(6): [ReferenceId(26), ReferenceId(27), ReferenceId(29), ReferenceId(30), ReferenceId(35), ReferenceId(36)]
+rebuilt        : SymbolId(5): [ReferenceId(11), ReferenceId(12), ReferenceId(23), ReferenceId(24)]
 Unresolved references mismatch:
 after transform: ["Date", "M", "Object", "require", "undefined"]
 rebuilt        : ["Date", "Object", "require", "undefined"]
@@ -46382,44 +42012,21 @@ after transform: [ReferenceId(10), ReferenceId(11)]
 rebuilt        : [ReferenceId(14)]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/everyTypeWithInitializer.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "A"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "F2"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(6), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(28)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(8)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(10)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(7), SymbolId(8), SymbolId(27)]
-rebuilt        : ScopeId(6): [SymbolId(6), SymbolId(7), SymbolId(8)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 Symbol reference IDs mismatch for "D":
 after transform: SymbolId(2): [ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(13)]
 rebuilt        : SymbolId(2): [ReferenceId(18)]
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(7): []
-rebuilt        : SymbolId(7): [ReferenceId(7)]
-Symbol reference IDs mismatch for "F2":
-after transform: SymbolId(8): []
-rebuilt        : SymbolId(8): [ReferenceId(10)]
-Reference symbol mismatch for "M":
-after transform: SymbolId(6) "M"
-rebuilt        : SymbolId(5) "M"
-Reference symbol mismatch for "M":
-after transform: SymbolId(6) "M"
-rebuilt        : SymbolId(5) "M"
-Reference symbol mismatch for "M":
-after transform: SymbolId(6) "M"
-rebuilt        : SymbolId(5) "M"
+Symbol flags mismatch for "M":
+after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(6): Span { start: 198, end: 199 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsInForAwaitOf.ts
 semantic error: Scope children mismatch:
@@ -46433,16 +42040,12 @@ after transform: ScopeId(2): [ScopeId(4)]
 rebuilt        : ScopeId(9): []
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.1.ts
-semantic error: Missing SymbolId: "N"
-Missing SymbolId: "_N"
-Missing ReferenceId: "N"
-Missing ReferenceId: "N"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(7), SymbolId(9), SymbolId(11), SymbolId(22), SymbolId(24), SymbolId(26), SymbolId(28), SymbolId(29), SymbolId(30), SymbolId(31), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(41), SymbolId(43), SymbolId(45), SymbolId(46), SymbolId(47), SymbolId(48), SymbolId(49), SymbolId(50)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(7), SymbolId(8), SymbolId(10), SymbolId(12), SymbolId(13), SymbolId(15), SymbolId(17), SymbolId(28), SymbolId(30), SymbolId(32), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(41), SymbolId(42), SymbolId(43), SymbolId(44), SymbolId(45), SymbolId(46), SymbolId(47), SymbolId(49), SymbolId(51)]
-Binding symbols mismatch:
-after transform: ScopeId(37): [SymbolId(27), SymbolId(44)]
-rebuilt        : ScopeId(43): [SymbolId(33), SymbolId(34)]
+semantic error: Symbol flags mismatch for "N":
+after transform: SymbolId(26): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(32): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N":
+after transform: SymbolId(26): Span { start: 1385, end: 1386 }
+rebuilt        : SymbolId(32): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsDeclarationEmit.2.ts
 semantic error: Scope children mismatch:
@@ -46787,23 +42390,9 @@ after transform: ["Date"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/statements/forStatements/forStatements.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "A"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "F2"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(6), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(26), SymbolId(27), SymbolId(28), SymbolId(31)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(26), SymbolId(27), SymbolId(28)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(8), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(39), ScopeId(41), ScopeId(43)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(10), ScopeId(12), ScopeId(14), ScopeId(16), ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26), ScopeId(28), ScopeId(30), ScopeId(32), ScopeId(34), ScopeId(36), ScopeId(38), ScopeId(41), ScopeId(43), ScopeId(45)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(7), SymbolId(8), SymbolId(30)]
-rebuilt        : ScopeId(6): [SymbolId(6), SymbolId(7), SymbolId(8)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
@@ -46816,18 +42405,15 @@ rebuilt        : SymbolId(2): [ReferenceId(19)]
 Symbol reference IDs mismatch for "F":
 after transform: SymbolId(4): [ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25)]
 rebuilt        : SymbolId(3): [ReferenceId(21), ReferenceId(22)]
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(7): []
-rebuilt        : SymbolId(7): [ReferenceId(7)]
-Symbol reference IDs mismatch for "F2":
-after transform: SymbolId(8): []
-rebuilt        : SymbolId(8): [ReferenceId(10)]
-Reference symbol mismatch for "M":
-after transform: SymbolId(6) "M"
-rebuilt        : SymbolId(5) "M"
-Reference symbol mismatch for "M":
-after transform: SymbolId(6) "M"
-rebuilt        : SymbolId(5) "M"
+Symbol flags mismatch for "M":
+after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(6): Span { start: 198, end: 199 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "M":
+after transform: SymbolId(6): [ReferenceId(26), ReferenceId(27), ReferenceId(29), ReferenceId(30), ReferenceId(35), ReferenceId(36)]
+rebuilt        : SymbolId(5): [ReferenceId(11), ReferenceId(12), ReferenceId(23), ReferenceId(24)]
 Unresolved references mismatch:
 after transform: ["Date", "M", "Object", "require", "undefined"]
 rebuilt        : ["Date", "Object", "require", "undefined"]
@@ -46905,47 +42491,21 @@ after transform: [ReferenceId(1), ReferenceId(2)]
 rebuilt        : [ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/statements/throwStatements/throwStatements.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "A"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "F2"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(6), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(30)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(8), ScopeId(9), ScopeId(10)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(10), ScopeId(11), ScopeId(12)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(7), SymbolId(8), SymbolId(29)]
-rebuilt        : ScopeId(6): [SymbolId(6), SymbolId(7), SymbolId(8)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 Symbol reference IDs mismatch for "D":
 after transform: SymbolId(2): [ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(21), ReferenceId(42)]
 rebuilt        : SymbolId(2): [ReferenceId(26), ReferenceId(46)]
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(7): []
-rebuilt        : SymbolId(7): [ReferenceId(7)]
-Symbol reference IDs mismatch for "F2":
-after transform: SymbolId(8): []
-rebuilt        : SymbolId(8): [ReferenceId(10)]
-Reference symbol mismatch for "M":
-after transform: SymbolId(6) "M"
-rebuilt        : SymbolId(5) "M"
-Reference symbol mismatch for "M":
-after transform: SymbolId(6) "M"
-rebuilt        : SymbolId(5) "M"
-Reference symbol mismatch for "M":
-after transform: SymbolId(6) "M"
-rebuilt        : SymbolId(5) "M"
-Reference symbol mismatch for "M":
-after transform: SymbolId(6) "M"
-rebuilt        : SymbolId(5) "M"
+Symbol flags mismatch for "M":
+after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(6): Span { start: 212, end: 213 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/types/any/assignEveryTypeToAny.ts
 semantic error: Scope children mismatch:
@@ -48685,19 +44245,18 @@ after transform: SymbolId(10): [ReferenceId(4)]
 rebuilt        : SymbolId(6): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofModuleWithoutExports.ts
-semantic error: Missing SymbolId: "M"
-Missing SymbolId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(5)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(4)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "M":
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
+rebuilt        : SymbolId(1): [ReferenceId(2), ReferenceId(3)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofThisWithImplicitThis.ts
 semantic error: Unresolved references mismatch:
@@ -48891,60 +44450,50 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), Sc
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads01.ts
-semantic error: Missing SymbolId: "Consts1"
-Missing SymbolId: "_Consts"
-Missing ReferenceId: "Consts1"
-Missing ReferenceId: "Consts1"
-Missing SymbolId: "Consts2"
-Missing SymbolId: "_Consts2"
-Missing ReferenceId: "Consts2"
-Missing ReferenceId: "Consts2"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(8), SymbolId(10), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(13), ScopeId(14)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(13): [SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(29)]
-rebuilt        : ScopeId(5): [SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6)]
 Scope flags mismatch:
 after transform: ScopeId(13): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(14): [SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(27), SymbolId(28), SymbolId(30)]
-rebuilt        : ScopeId(6): [SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22)]
 Scope flags mismatch:
 after transform: ScopeId(14): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
+Symbol flags mismatch for "Consts1":
+after transform: SymbolId(10): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Consts1":
+after transform: SymbolId(10): Span { start: 807, end: 814 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Consts2":
+after transform: SymbolId(21): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Consts2":
+after transform: SymbolId(21): Span { start: 1271, end: 1278 }
+rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads02.ts
-semantic error: Missing SymbolId: "Consts1"
-Missing SymbolId: "_Consts"
-Missing ReferenceId: "Consts1"
-Missing ReferenceId: "Consts1"
-Missing SymbolId: "Consts2"
-Missing SymbolId: "_Consts2"
-Missing ReferenceId: "Consts2"
-Missing ReferenceId: "Consts2"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(7), SymbolId(9), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(12), ScopeId(13)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(6)]
-Binding symbols mismatch:
-after transform: ScopeId(12): [SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(28)]
-rebuilt        : ScopeId(5): [SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6)]
 Scope flags mismatch:
 after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(13): [SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(27), SymbolId(29)]
-rebuilt        : ScopeId(6): [SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22)]
 Scope flags mismatch:
 after transform: ScopeId(13): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
+Symbol flags mismatch for "Consts1":
+after transform: SymbolId(9): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Consts1":
+after transform: SymbolId(9): Span { start: 745, end: 752 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Consts2":
+after transform: SymbolId(20): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Consts2":
+after transform: SymbolId(20): Span { start: 1178, end: 1185 }
+rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads03.ts
 semantic error: Scope children mismatch:
@@ -49222,19 +44771,15 @@ after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/asiPreventsParsingAsTypeAlias02.ts
-semantic error: Missing SymbolId: "container"
-Missing SymbolId: "_container"
-Missing ReferenceId: "container"
-Missing ReferenceId: "container"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(4)]
-rebuilt        : ScopeId(1): [SymbolId(4)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "container":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "container":
+after transform: SymbolId(3): Span { start: 42, end: 51 }
+rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/builtinIteratorReturn.ts
 semantic error: Bindings mismatch:
@@ -49524,41 +45069,36 @@ after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembers.ts
-semantic error: Missing SymbolId: "SimpleTypes"
-Missing SymbolId: "_SimpleTypes"
-Missing ReferenceId: "SimpleTypes"
-Missing ReferenceId: "SimpleTypes"
-Missing SymbolId: "ObjectTypes"
-Missing SymbolId: "_ObjectTypes"
-Missing ReferenceId: "ObjectTypes"
-Missing ReferenceId: "ObjectTypes"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(13), SymbolId(28)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(13)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(26)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(27)]
-rebuilt        : ScopeId(6): [SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(6): [ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
 rebuilt        : ScopeId(6): [ScopeId(7), ScopeId(9)]
+Symbol flags mismatch for "SimpleTypes":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "SimpleTypes":
+after transform: SymbolId(0): Span { start: 146, end: 157 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "S":
 after transform: SymbolId(1): [ReferenceId(0)]
 rebuilt        : SymbolId(3): []
 Symbol reference IDs mismatch for "T":
 after transform: SymbolId(2): [ReferenceId(1)]
 rebuilt        : SymbolId(4): []
+Symbol flags mismatch for "ObjectTypes":
+after transform: SymbolId(13): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(13): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "ObjectTypes":
+after transform: SymbolId(13): Span { start: 700, end: 711 }
+rebuilt        : SymbolId(13): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "S":
 after transform: SymbolId(14): [ReferenceId(42), ReferenceId(44)]
 rebuilt        : SymbolId(15): []
@@ -49834,25 +45374,9 @@ after transform: [ReferenceId(1), ReferenceId(8), ReferenceId(9)]
 rebuilt        : [ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/heterogeneousArrayLiterals.ts
-semantic error: Missing SymbolId: "_Derived"
-Missing ReferenceId: "Derived"
-Missing ReferenceId: "Derived"
-Missing SymbolId: "WithContextualType"
-Missing SymbolId: "_WithContextualType"
-Missing ReferenceId: "WithContextualType"
-Missing ReferenceId: "WithContextualType"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(30), SymbolId(35), SymbolId(46), SymbolId(61), SymbolId(76), SymbolId(94)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(18), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(34), SymbolId(40), SymbolId(49), SymbolId(62), SymbolId(75)]
-Binding symbols mismatch:
-after transform: ScopeId(15): [SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(27), SymbolId(28), SymbolId(29), SymbolId(92)]
-rebuilt        : ScopeId(18): [SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(27), SymbolId(28), SymbolId(29), SymbolId(30), SymbolId(31), SymbolId(32), SymbolId(33)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(15): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(18): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(29): [SymbolId(31), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(93)]
-rebuilt        : ScopeId(32): [SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39)]
 Scope flags mismatch:
 after transform: ScopeId(29): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(32): ScopeFlags(Function)
@@ -49863,7 +45387,7 @@ Symbol flags mismatch for "Derived":
 after transform: SymbolId(15): SymbolFlags(Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(16): SymbolFlags(Class)
 Symbol reference IDs mismatch for "Derived":
-after transform: SymbolId(15): [ReferenceId(4), ReferenceId(30), ReferenceId(31), ReferenceId(48), ReferenceId(69), ReferenceId(70)]
+after transform: SymbolId(15): [ReferenceId(4), ReferenceId(30), ReferenceId(31), ReferenceId(48), ReferenceId(69), ReferenceId(70), ReferenceId(116), ReferenceId(117)]
 rebuilt        : SymbolId(16): [ReferenceId(30), ReferenceId(31)]
 Symbol redeclarations mismatch for "Derived":
 after transform: SymbolId(15): [Span { start: 842, end: 849 }]
@@ -49871,6 +45395,12 @@ rebuilt        : SymbolId(16): []
 Symbol reference IDs mismatch for "Derived2":
 after transform: SymbolId(16): [ReferenceId(5)]
 rebuilt        : SymbolId(18): []
+Symbol flags mismatch for "WithContextualType":
+after transform: SymbolId(30): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(34): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "WithContextualType":
+after transform: SymbolId(30): Span { start: 1461, end: 1479 }
+rebuilt        : SymbolId(34): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/equalityWithUnionTypes01.ts
 semantic error: Scope children mismatch:
@@ -50018,22 +45548,18 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures.ts
-semantic error: Missing SymbolId: "CallSignature"
-Missing SymbolId: "_CallSignature"
-Missing ReferenceId: "CallSignature"
-Missing ReferenceId: "CallSignature"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(3), SymbolId(5), SymbolId(10), SymbolId(13), SymbolId(16)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(6), SymbolId(9)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
+Symbol flags mismatch for "CallSignature":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "CallSignature":
+after transform: SymbolId(0): Span { start: 7, end: 20 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures2.ts
 semantic error: Scope children mismatch:
@@ -50053,35 +45579,24 @@ after transform: ["Array", "Date", "Object", "foo1", "foo10", "foo11", "foo12", 
 rebuilt        : ["foo1", "foo10", "foo11", "foo12", "foo13", "foo14", "foo15", "foo16", "foo17", "foo18", "foo2", "foo3", "foo4", "foo5", "foo6", "foo7", "foo8", "foo9", "require"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignatures3.ts
-semantic error: Missing SymbolId: "Errors"
-Missing SymbolId: "_Errors"
-Missing ReferenceId: "Errors"
-Missing ReferenceId: "Errors"
-Missing SymbolId: "WithGenericSignaturesInBaseType"
-Missing SymbolId: "_WithGenericSignaturesInBaseType"
-Missing ReferenceId: "WithGenericSignaturesInBaseType"
-Missing ReferenceId: "WithGenericSignaturesInBaseType"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(113), SymbolId(130)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(81)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(24), SymbolId(28), SymbolId(33), SymbolId(38), SymbolId(44), SymbolId(47), SymbolId(48), SymbolId(49), SymbolId(50), SymbolId(56), SymbolId(60), SymbolId(61), SymbolId(62), SymbolId(63), SymbolId(66), SymbolId(68), SymbolId(69), SymbolId(70), SymbolId(71), SymbolId(75), SymbolId(78), SymbolId(79), SymbolId(80), SymbolId(81), SymbolId(84), SymbolId(88), SymbolId(89), SymbolId(90), SymbolId(91), SymbolId(94), SymbolId(96), SymbolId(97), SymbolId(98), SymbolId(99), SymbolId(102), SymbolId(103), SymbolId(104), SymbolId(105), SymbolId(108), SymbolId(109), SymbolId(112), SymbolId(128)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6), SymbolId(8), SymbolId(10), SymbolId(12), SymbolId(15), SymbolId(18), SymbolId(21), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(27), SymbolId(31), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(40), SymbolId(42), SymbolId(43), SymbolId(44), SymbolId(45), SymbolId(48), SymbolId(51), SymbolId(52), SymbolId(53), SymbolId(54), SymbolId(57), SymbolId(60), SymbolId(61), SymbolId(62), SymbolId(63), SymbolId(65), SymbolId(67), SymbolId(68), SymbolId(69), SymbolId(70), SymbolId(72), SymbolId(73), SymbolId(74), SymbolId(75), SymbolId(77), SymbolId(78), SymbolId(80)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(31), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42), ScopeId(43), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(47)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(17), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33)]
-Binding symbols mismatch:
-after transform: ScopeId(48): [SymbolId(117), SymbolId(120), SymbolId(124), SymbolId(127), SymbolId(129)]
-rebuilt        : ScopeId(34): [SymbolId(82), SymbolId(83), SymbolId(85), SymbolId(86), SymbolId(88)]
 Scope flags mismatch:
 after transform: ScopeId(48): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(34): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(48): [ScopeId(49), ScopeId(50), ScopeId(51), ScopeId(52), ScopeId(53), ScopeId(54)]
 rebuilt        : ScopeId(34): [ScopeId(35), ScopeId(36)]
+Symbol flags mismatch for "Errors":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Errors":
+after transform: SymbolId(0): Span { start: 168, end: 174 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "Base":
 after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(16), ReferenceId(17), ReferenceId(19), ReferenceId(22), ReferenceId(33), ReferenceId(39), ReferenceId(50), ReferenceId(57), ReferenceId(59), ReferenceId(67), ReferenceId(74), ReferenceId(76), ReferenceId(78), ReferenceId(89), ReferenceId(90), ReferenceId(101), ReferenceId(109), ReferenceId(117), ReferenceId(119), ReferenceId(136)]
 rebuilt        : SymbolId(3): [ReferenceId(2), ReferenceId(8)]
@@ -50091,6 +45606,12 @@ rebuilt        : SymbolId(4): [ReferenceId(5)]
 Symbol reference IDs mismatch for "Derived2":
 after transform: SymbolId(3): [ReferenceId(7), ReferenceId(24), ReferenceId(36), ReferenceId(52), ReferenceId(60), ReferenceId(111), ReferenceId(115)]
 rebuilt        : SymbolId(6): []
+Symbol flags mismatch for "WithGenericSignaturesInBaseType":
+after transform: SymbolId(113): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(81): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "WithGenericSignaturesInBaseType":
+after transform: SymbolId(113): Span { start: 4321, end: 4352 }
+rebuilt        : SymbolId(81): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["Array", "foo10", "foo11", "foo12", "foo15", "foo16", "foo17", "foo2", "foo3", "foo7", "foo8", "require"]
 rebuilt        : ["foo10", "foo11", "foo12", "foo15", "foo16", "foo17", "foo2", "foo3", "foo7", "foo8", "require"]
@@ -50110,22 +45631,18 @@ after transform: SymbolId(2): [ReferenceId(41)]
 rebuilt        : SymbolId(4): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures.ts
-semantic error: Missing SymbolId: "ConstructSignature"
-Missing SymbolId: "_ConstructSignature"
-Missing ReferenceId: "ConstructSignature"
-Missing ReferenceId: "ConstructSignature"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(7), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7), SymbolId(8), SymbolId(9)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(1): []
+Symbol flags mismatch for "ConstructSignature":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "ConstructSignature":
+after transform: SymbolId(0): Span { start: 7, end: 25 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures2.ts
 semantic error: Scope children mismatch:
@@ -50145,35 +45662,24 @@ after transform: ["Array", "Date", "Object", "foo1", "foo10", "foo11", "foo12", 
 rebuilt        : ["foo1", "foo10", "foo11", "foo12", "foo13", "foo14", "foo15", "foo16", "foo17", "foo18", "foo2", "foo3", "foo4", "foo5", "foo6", "foo7", "foo8", "foo9", "require"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures3.ts
-semantic error: Missing SymbolId: "Errors"
-Missing SymbolId: "_Errors"
-Missing ReferenceId: "Errors"
-Missing ReferenceId: "Errors"
-Missing SymbolId: "WithGenericSignaturesInBaseType"
-Missing SymbolId: "_WithGenericSignaturesInBaseType"
-Missing ReferenceId: "WithGenericSignaturesInBaseType"
-Missing ReferenceId: "WithGenericSignaturesInBaseType"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(73), SymbolId(87)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(53)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(27), SymbolId(30), SymbolId(31), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(42), SymbolId(43), SymbolId(44), SymbolId(45), SymbolId(46), SymbolId(47), SymbolId(48), SymbolId(49), SymbolId(50), SymbolId(51), SymbolId(52), SymbolId(53), SymbolId(54), SymbolId(55), SymbolId(56), SymbolId(57), SymbolId(58), SymbolId(59), SymbolId(60), SymbolId(61), SymbolId(62), SymbolId(63), SymbolId(64), SymbolId(65), SymbolId(66), SymbolId(67), SymbolId(68), SymbolId(69), SymbolId(70), SymbolId(71), SymbolId(72), SymbolId(85)]
-rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(6), SymbolId(8), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(27), SymbolId(28), SymbolId(29), SymbolId(30), SymbolId(31), SymbolId(32), SymbolId(33), SymbolId(34), SymbolId(35), SymbolId(36), SymbolId(37), SymbolId(38), SymbolId(39), SymbolId(40), SymbolId(41), SymbolId(42), SymbolId(43), SymbolId(44), SymbolId(45), SymbolId(46), SymbolId(47), SymbolId(48), SymbolId(49), SymbolId(50), SymbolId(51), SymbolId(52)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(27), ScopeId(28), ScopeId(35)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(8)]
-Binding symbols mismatch:
-after transform: ScopeId(36): [SymbolId(77), SymbolId(79), SymbolId(83), SymbolId(84), SymbolId(86)]
-rebuilt        : ScopeId(10): [SymbolId(54), SymbolId(55), SymbolId(56), SymbolId(57), SymbolId(58)]
 Scope flags mismatch:
 after transform: ScopeId(36): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(10): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(36): [ScopeId(37), ScopeId(38), ScopeId(39), ScopeId(40)]
 rebuilt        : ScopeId(10): []
+Symbol flags mismatch for "Errors":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Errors":
+after transform: SymbolId(0): Span { start: 168, end: 174 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "Base":
 after transform: SymbolId(1): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(6), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(16), ReferenceId(17), ReferenceId(19), ReferenceId(22), ReferenceId(33), ReferenceId(39), ReferenceId(51), ReferenceId(58), ReferenceId(60), ReferenceId(68), ReferenceId(75), ReferenceId(77), ReferenceId(79), ReferenceId(90), ReferenceId(91), ReferenceId(102), ReferenceId(110), ReferenceId(118), ReferenceId(120), ReferenceId(137)]
 rebuilt        : SymbolId(3): [ReferenceId(2), ReferenceId(8)]
@@ -50183,6 +45689,12 @@ rebuilt        : SymbolId(4): [ReferenceId(5)]
 Symbol reference IDs mismatch for "Derived2":
 after transform: SymbolId(3): [ReferenceId(7), ReferenceId(24), ReferenceId(36), ReferenceId(53), ReferenceId(61), ReferenceId(112), ReferenceId(116)]
 rebuilt        : SymbolId(6): []
+Symbol flags mismatch for "WithGenericSignaturesInBaseType":
+after transform: SymbolId(73): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(53): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "WithGenericSignaturesInBaseType":
+after transform: SymbolId(73): Span { start: 4469, end: 4500 }
+rebuilt        : SymbolId(53): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["Array", "foo10", "foo11", "foo12", "foo15", "foo16", "foo17", "foo2", "foo3", "foo7", "foo8", "require"]
 rebuilt        : ["foo10", "foo11", "foo12", "foo15", "foo16", "foo17", "foo2", "foo3", "foo7", "foo8", "require"]
@@ -50227,25 +45739,21 @@ after transform: SymbolId(1): [ReferenceId(3), ReferenceId(6), ReferenceId(9)]
 rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembersOptionality.ts
-semantic error: Missing SymbolId: "TwoLevels"
-Missing SymbolId: "_TwoLevels"
-Missing ReferenceId: "TwoLevels"
-Missing ReferenceId: "TwoLevels"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(9), SymbolId(10), SymbolId(11), SymbolId(12)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3)]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Binding symbols mismatch:
-after transform: ScopeId(10): [SymbolId(19), SymbolId(20), SymbolId(21), SymbolId(22)]
-rebuilt        : ScopeId(1): [SymbolId(4), SymbolId(5), SymbolId(6), SymbolId(7)]
 Scope flags mismatch:
 after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(10): [ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16)]
 rebuilt        : ScopeId(1): []
+Symbol flags mismatch for "TwoLevels":
+after transform: SymbolId(12): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "TwoLevels":
+after transform: SymbolId(12): Span { start: 1157, end: 1166 }
+rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithObjectMembersOptionality3.ts
 semantic error: Scope children mismatch:
@@ -51327,29 +46835,12 @@ after transform: ["Date"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithOverloadedConstructorTypedArguments.ts
-semantic error: Missing SymbolId: "NonGenericParameter"
-Missing SymbolId: "_NonGenericParameter"
-Missing ReferenceId: "NonGenericParameter"
-Missing ReferenceId: "NonGenericParameter"
-Missing SymbolId: "GenericParameter"
-Missing SymbolId: "_GenericParameter"
-Missing ReferenceId: "GenericParameter"
-Missing ReferenceId: "GenericParameter"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(8)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(8)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(5), SymbolId(7), SymbolId(36)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(7)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(9), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(17), SymbolId(18), SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(27), SymbolId(28), SymbolId(31), SymbolId(34), SymbolId(35), SymbolId(37)]
-rebuilt        : ScopeId(3): [SymbolId(9), SymbolId(10), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(18), SymbolId(19), SymbolId(20), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(27)]
 Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
@@ -51365,59 +46856,49 @@ rebuilt        : ScopeId(5): []
 Scope children mismatch:
 after transform: ScopeId(17): [ScopeId(18), ScopeId(19)]
 rebuilt        : ScopeId(6): []
+Symbol flags mismatch for "NonGenericParameter":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "NonGenericParameter":
+after transform: SymbolId(0): Span { start: 193, end: 212 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "a":
 after transform: SymbolId(1): [ReferenceId(0), ReferenceId(3)]
 rebuilt        : SymbolId(2): [ReferenceId(2)]
+Symbol flags mismatch for "GenericParameter":
+after transform: SymbolId(8): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "GenericParameter":
+after transform: SymbolId(8): Span { start: 457, end: 473 }
+rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithOverloadedFunctionTypedArguments.ts
-semantic error: Missing SymbolId: "NonGenericParameter"
-Missing SymbolId: "_NonGenericParameter"
-Missing ReferenceId: "NonGenericParameter"
-Missing ReferenceId: "NonGenericParameter"
-Missing SymbolId: "GenericParameter"
-Missing SymbolId: "_GenericParameter"
-Missing ReferenceId: "GenericParameter"
-Missing ReferenceId: "GenericParameter"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(10)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(10)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(5), SymbolId(8), SymbolId(41)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(5), SymbolId(6), SymbolId(8)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(11), SymbolId(14), SymbolId(16), SymbolId(18), SymbolId(19), SymbolId(22), SymbolId(24), SymbolId(27), SymbolId(31), SymbolId(35), SymbolId(37), SymbolId(40), SymbolId(42)]
-rebuilt        : ScopeId(5): [SymbolId(11), SymbolId(12), SymbolId(14), SymbolId(16), SymbolId(17), SymbolId(18), SymbolId(20), SymbolId(22), SymbolId(24), SymbolId(27), SymbolId(30), SymbolId(32), SymbolId(34)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
+Symbol flags mismatch for "NonGenericParameter":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "NonGenericParameter":
+after transform: SymbolId(0): Span { start: 193, end: 212 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "a":
 after transform: SymbolId(1): [ReferenceId(0), ReferenceId(3)]
 rebuilt        : SymbolId(2): [ReferenceId(2)]
+Symbol flags mismatch for "GenericParameter":
+after transform: SymbolId(10): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "GenericParameter":
+after transform: SymbolId(10): Span { start: 452, end: 468 }
+rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericClassWithObjectTypeArgsAndConstraints.ts
-semantic error: Missing SymbolId: "Class"
-Missing SymbolId: "_Class"
-Missing ReferenceId: "Class"
-Missing ReferenceId: "Class"
-Missing SymbolId: "Interface"
-Missing SymbolId: "_Interface"
-Missing ReferenceId: "Interface"
-Missing ReferenceId: "Interface"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(4), SymbolId(23), SymbolId(38)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(20)]
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(5), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(22), SymbolId(36)]
-rebuilt        : ScopeId(7): [SymbolId(5), SymbolId(6), SymbolId(10), SymbolId(11), SymbolId(12), SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(19)]
-Scope flags mismatch:
+semantic error: Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
-Binding symbols mismatch:
-after transform: ScopeId(9): [SymbolId(27), SymbolId(28), SymbolId(29), SymbolId(30), SymbolId(31), SymbolId(35), SymbolId(37)]
-rebuilt        : ScopeId(12): [SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(25), SymbolId(26), SymbolId(27)]
 Scope flags mismatch:
 after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(12): ScopeFlags(Function)
@@ -51433,12 +46914,24 @@ rebuilt        : SymbolId(2): []
 Symbol reference IDs mismatch for "X":
 after transform: SymbolId(2): [ReferenceId(1), ReferenceId(3), ReferenceId(7), ReferenceId(9), ReferenceId(20), ReferenceId(22), ReferenceId(34), ReferenceId(36), ReferenceId(39), ReferenceId(41), ReferenceId(52), ReferenceId(54)]
 rebuilt        : SymbolId(3): [ReferenceId(6), ReferenceId(7), ReferenceId(23), ReferenceId(24)]
+Symbol flags mismatch for "Class":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Class":
+after transform: SymbolId(4): Span { start: 214, end: 219 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "G":
 after transform: SymbolId(5): [ReferenceId(11)]
 rebuilt        : SymbolId(6): []
 Symbol reference IDs mismatch for "G2":
 after transform: SymbolId(16): [ReferenceId(26)]
 rebuilt        : SymbolId(15): []
+Symbol flags mismatch for "Interface":
+after transform: SymbolId(23): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Interface":
+after transform: SymbolId(23): Span { start: 749, end: 758 }
+rebuilt        : SymbolId(20): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes1.ts
 semantic error: Bindings mismatch:

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -2231,448 +2231,368 @@ after transform: [ReferenceId(1), ReferenceId(5)]
 rebuilt        : [ReferenceId(0)]
 
 * namespace/clobber-class/input.ts
-Missing SymbolId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): []
-rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(2)]
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 22, end: 23 }]
 rebuilt        : SymbolId(0): []
 
 * namespace/clobber-enum/input.ts
-Missing SymbolId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
 Bindings mismatch:
 after transform: ScopeId(1): ["A", "C"]
 rebuilt        : ScopeId(1): ["A"]
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(3)]
-rebuilt        : ScopeId(2): [SymbolId(2), SymbolId(3)]
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): [ReferenceId(3)]
-rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(5), ReferenceId(6)]
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 30, end: 31 }]
 rebuilt        : SymbolId(0): []
 
 * namespace/clobber-export/input.ts
-Missing SymbolId: "_N"
-Missing ReferenceId: "N"
-Missing ReferenceId: "N"
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2)]
 Symbol flags mismatch for "N":
 after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
-Symbol reference IDs mismatch for "N":
-after transform: SymbolId(0): [ReferenceId(0)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 Symbol redeclarations mismatch for "N":
 after transform: SymbolId(0): [Span { start: 35, end: 36 }]
 rebuilt        : SymbolId(0): []
 
 * namespace/contentious-names/input.ts
-Missing SymbolId: "N"
-Missing SymbolId: "_N"
-Missing SymbolId: "N"
-Missing SymbolId: "_N2"
-Missing ReferenceId: "N"
-Missing ReferenceId: "N"
-Missing SymbolId: "constructor"
-Missing SymbolId: "_constructor"
-Missing ReferenceId: "constructor"
-Missing ReferenceId: "constructor"
-Missing SymbolId: "length"
-Missing SymbolId: "_length"
-Missing ReferenceId: "length"
-Missing ReferenceId: "length"
-Missing SymbolId: "concat"
-Missing SymbolId: "_concat"
-Missing ReferenceId: "concat"
-Missing ReferenceId: "concat"
-Missing SymbolId: "copyWithin"
-Missing SymbolId: "_copyWithin"
-Missing ReferenceId: "copyWithin"
-Missing ReferenceId: "copyWithin"
-Missing SymbolId: "fill"
-Missing SymbolId: "_fill"
-Missing ReferenceId: "fill"
-Missing ReferenceId: "fill"
-Missing SymbolId: "find"
-Missing SymbolId: "_find"
-Missing ReferenceId: "find"
-Missing ReferenceId: "find"
-Missing SymbolId: "findIndex"
-Missing SymbolId: "_findIndex"
-Missing ReferenceId: "findIndex"
-Missing ReferenceId: "findIndex"
-Missing SymbolId: "lastIndexOf"
-Missing SymbolId: "_lastIndexOf"
-Missing ReferenceId: "lastIndexOf"
-Missing ReferenceId: "lastIndexOf"
-Missing SymbolId: "pop"
-Missing SymbolId: "_pop"
-Missing ReferenceId: "pop"
-Missing ReferenceId: "pop"
-Missing SymbolId: "push"
-Missing SymbolId: "_push"
-Missing ReferenceId: "push"
-Missing ReferenceId: "push"
-Missing SymbolId: "reverse"
-Missing SymbolId: "_reverse"
-Missing ReferenceId: "reverse"
-Missing ReferenceId: "reverse"
-Missing SymbolId: "shift"
-Missing SymbolId: "_shift"
-Missing ReferenceId: "shift"
-Missing ReferenceId: "shift"
-Missing SymbolId: "unshift"
-Missing SymbolId: "_unshift"
-Missing ReferenceId: "unshift"
-Missing ReferenceId: "unshift"
-Missing SymbolId: "slice"
-Missing SymbolId: "_slice"
-Missing ReferenceId: "slice"
-Missing ReferenceId: "slice"
-Missing SymbolId: "sort"
-Missing SymbolId: "_sort"
-Missing ReferenceId: "sort"
-Missing ReferenceId: "sort"
-Missing SymbolId: "splice"
-Missing SymbolId: "_splice"
-Missing ReferenceId: "splice"
-Missing ReferenceId: "splice"
-Missing SymbolId: "includes"
-Missing SymbolId: "_includes"
-Missing ReferenceId: "includes"
-Missing ReferenceId: "includes"
-Missing SymbolId: "indexOf"
-Missing SymbolId: "_indexOf"
-Missing ReferenceId: "indexOf"
-Missing ReferenceId: "indexOf"
-Missing SymbolId: "join"
-Missing SymbolId: "_join"
-Missing ReferenceId: "join"
-Missing ReferenceId: "join"
-Missing SymbolId: "keys"
-Missing SymbolId: "_keys"
-Missing ReferenceId: "keys"
-Missing ReferenceId: "keys"
-Missing SymbolId: "entries"
-Missing SymbolId: "_entries"
-Missing ReferenceId: "entries"
-Missing ReferenceId: "entries"
-Missing SymbolId: "values"
-Missing SymbolId: "_values"
-Missing ReferenceId: "values"
-Missing ReferenceId: "values"
-Missing SymbolId: "forEach"
-Missing SymbolId: "_forEach"
-Missing ReferenceId: "forEach"
-Missing ReferenceId: "forEach"
-Missing SymbolId: "filter"
-Missing SymbolId: "_filter"
-Missing ReferenceId: "filter"
-Missing ReferenceId: "filter"
-Missing SymbolId: "map"
-Missing SymbolId: "_map"
-Missing ReferenceId: "map"
-Missing ReferenceId: "map"
-Missing SymbolId: "every"
-Missing SymbolId: "_every"
-Missing ReferenceId: "every"
-Missing ReferenceId: "every"
-Missing SymbolId: "some"
-Missing SymbolId: "_some"
-Missing ReferenceId: "some"
-Missing ReferenceId: "some"
-Missing SymbolId: "reduce"
-Missing SymbolId: "_reduce"
-Missing ReferenceId: "reduce"
-Missing ReferenceId: "reduce"
-Missing SymbolId: "reduceRight"
-Missing SymbolId: "_reduceRight"
-Missing ReferenceId: "reduceRight"
-Missing ReferenceId: "reduceRight"
-Missing SymbolId: "toLocaleString"
-Missing SymbolId: "_toLocaleString"
-Missing ReferenceId: "toLocaleString"
-Missing ReferenceId: "toLocaleString"
-Missing SymbolId: "toString"
-Missing SymbolId: "_toString"
-Missing ReferenceId: "toString"
-Missing ReferenceId: "toString"
-Missing SymbolId: "flat"
-Missing SymbolId: "_flat"
-Missing ReferenceId: "flat"
-Missing ReferenceId: "flat"
-Missing SymbolId: "flatMap"
-Missing SymbolId: "_flatMap"
-Missing ReferenceId: "flatMap"
-Missing ReferenceId: "flatMap"
-Missing ReferenceId: "N"
-Missing ReferenceId: "N"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(5), SymbolId(7), SymbolId(9), SymbolId(11), SymbolId(13), SymbolId(15), SymbolId(17), SymbolId(19), SymbolId(21), SymbolId(23), SymbolId(25), SymbolId(27), SymbolId(29), SymbolId(31), SymbolId(33), SymbolId(35), SymbolId(37), SymbolId(39), SymbolId(41), SymbolId(43), SymbolId(45), SymbolId(47), SymbolId(49), SymbolId(51), SymbolId(53), SymbolId(55), SymbolId(57), SymbolId(59), SymbolId(61), SymbolId(63), SymbolId(65), SymbolId(67), SymbolId(69)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5), SymbolId(8), SymbolId(11), SymbolId(14), SymbolId(17), SymbolId(20), SymbolId(23), SymbolId(26), SymbolId(29), SymbolId(32), SymbolId(35), SymbolId(38), SymbolId(41), SymbolId(44), SymbolId(47), SymbolId(50), SymbolId(53), SymbolId(56), SymbolId(59), SymbolId(62), SymbolId(65), SymbolId(68), SymbolId(71), SymbolId(74), SymbolId(77), SymbolId(80), SymbolId(83), SymbolId(86), SymbolId(89), SymbolId(92), SymbolId(95), SymbolId(98), SymbolId(101)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(70)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(4), SymbolId(71)]
-rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(6), SymbolId(72)]
-rebuilt        : ScopeId(4): [SymbolId(9), SymbolId(10)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(8), SymbolId(73)]
-rebuilt        : ScopeId(5): [SymbolId(12), SymbolId(13)]
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(10), SymbolId(74)]
-rebuilt        : ScopeId(6): [SymbolId(15), SymbolId(16)]
-Binding symbols mismatch:
-after transform: ScopeId(7): [SymbolId(12), SymbolId(75)]
-rebuilt        : ScopeId(7): [SymbolId(18), SymbolId(19)]
-Binding symbols mismatch:
-after transform: ScopeId(8): [SymbolId(14), SymbolId(76)]
-rebuilt        : ScopeId(8): [SymbolId(21), SymbolId(22)]
-Binding symbols mismatch:
-after transform: ScopeId(9): [SymbolId(16), SymbolId(77)]
-rebuilt        : ScopeId(9): [SymbolId(24), SymbolId(25)]
-Binding symbols mismatch:
-after transform: ScopeId(10): [SymbolId(18), SymbolId(78)]
-rebuilt        : ScopeId(10): [SymbolId(27), SymbolId(28)]
-Binding symbols mismatch:
-after transform: ScopeId(11): [SymbolId(20), SymbolId(79)]
-rebuilt        : ScopeId(11): [SymbolId(30), SymbolId(31)]
-Binding symbols mismatch:
-after transform: ScopeId(12): [SymbolId(22), SymbolId(80)]
-rebuilt        : ScopeId(12): [SymbolId(33), SymbolId(34)]
-Binding symbols mismatch:
-after transform: ScopeId(13): [SymbolId(24), SymbolId(81)]
-rebuilt        : ScopeId(13): [SymbolId(36), SymbolId(37)]
-Binding symbols mismatch:
-after transform: ScopeId(14): [SymbolId(26), SymbolId(82)]
-rebuilt        : ScopeId(14): [SymbolId(39), SymbolId(40)]
-Binding symbols mismatch:
-after transform: ScopeId(15): [SymbolId(28), SymbolId(83)]
-rebuilt        : ScopeId(15): [SymbolId(42), SymbolId(43)]
-Binding symbols mismatch:
-after transform: ScopeId(16): [SymbolId(30), SymbolId(84)]
-rebuilt        : ScopeId(16): [SymbolId(45), SymbolId(46)]
-Binding symbols mismatch:
-after transform: ScopeId(17): [SymbolId(32), SymbolId(85)]
-rebuilt        : ScopeId(17): [SymbolId(48), SymbolId(49)]
-Binding symbols mismatch:
-after transform: ScopeId(18): [SymbolId(34), SymbolId(86)]
-rebuilt        : ScopeId(18): [SymbolId(51), SymbolId(52)]
-Binding symbols mismatch:
-after transform: ScopeId(19): [SymbolId(36), SymbolId(87)]
-rebuilt        : ScopeId(19): [SymbolId(54), SymbolId(55)]
-Binding symbols mismatch:
-after transform: ScopeId(20): [SymbolId(38), SymbolId(88)]
-rebuilt        : ScopeId(20): [SymbolId(57), SymbolId(58)]
-Binding symbols mismatch:
-after transform: ScopeId(21): [SymbolId(40), SymbolId(89)]
-rebuilt        : ScopeId(21): [SymbolId(60), SymbolId(61)]
-Binding symbols mismatch:
-after transform: ScopeId(22): [SymbolId(42), SymbolId(90)]
-rebuilt        : ScopeId(22): [SymbolId(63), SymbolId(64)]
-Binding symbols mismatch:
-after transform: ScopeId(23): [SymbolId(44), SymbolId(91)]
-rebuilt        : ScopeId(23): [SymbolId(66), SymbolId(67)]
-Binding symbols mismatch:
-after transform: ScopeId(24): [SymbolId(46), SymbolId(92)]
-rebuilt        : ScopeId(24): [SymbolId(69), SymbolId(70)]
-Binding symbols mismatch:
-after transform: ScopeId(25): [SymbolId(48), SymbolId(93)]
-rebuilt        : ScopeId(25): [SymbolId(72), SymbolId(73)]
-Binding symbols mismatch:
-after transform: ScopeId(26): [SymbolId(50), SymbolId(94)]
-rebuilt        : ScopeId(26): [SymbolId(75), SymbolId(76)]
-Binding symbols mismatch:
-after transform: ScopeId(27): [SymbolId(52), SymbolId(95)]
-rebuilt        : ScopeId(27): [SymbolId(78), SymbolId(79)]
-Binding symbols mismatch:
-after transform: ScopeId(28): [SymbolId(54), SymbolId(96)]
-rebuilt        : ScopeId(28): [SymbolId(81), SymbolId(82)]
-Binding symbols mismatch:
-after transform: ScopeId(29): [SymbolId(56), SymbolId(97)]
-rebuilt        : ScopeId(29): [SymbolId(84), SymbolId(85)]
-Binding symbols mismatch:
-after transform: ScopeId(30): [SymbolId(58), SymbolId(98)]
-rebuilt        : ScopeId(30): [SymbolId(87), SymbolId(88)]
-Binding symbols mismatch:
-after transform: ScopeId(31): [SymbolId(60), SymbolId(99)]
-rebuilt        : ScopeId(31): [SymbolId(90), SymbolId(91)]
-Binding symbols mismatch:
-after transform: ScopeId(32): [SymbolId(62), SymbolId(100)]
-rebuilt        : ScopeId(32): [SymbolId(93), SymbolId(94)]
-Binding symbols mismatch:
-after transform: ScopeId(33): [SymbolId(64), SymbolId(101)]
-rebuilt        : ScopeId(33): [SymbolId(96), SymbolId(97)]
-Binding symbols mismatch:
-after transform: ScopeId(34): [SymbolId(66), SymbolId(102)]
-rebuilt        : ScopeId(34): [SymbolId(99), SymbolId(100)]
-Binding symbols mismatch:
-after transform: ScopeId(35): [SymbolId(68), SymbolId(103)]
-rebuilt        : ScopeId(35): [SymbolId(102), SymbolId(103)]
+Symbol flags mismatch for "N":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N":
+after transform: SymbolId(0): Span { start: 10, end: 11 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "N":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N":
+after transform: SymbolId(1): Span { start: 26, end: 27 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "constructor":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "constructor":
+after transform: SymbolId(3): Span { start: 50, end: 61 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
+Symbol flags mismatch for "length":
+after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "length":
+after transform: SymbolId(5): Span { start: 84, end: 90 }
+rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
+Symbol flags mismatch for "concat":
+after transform: SymbolId(7): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "concat":
+after transform: SymbolId(7): Span { start: 113, end: 119 }
+rebuilt        : SymbolId(11): Span { start: 0, end: 0 }
+Symbol flags mismatch for "copyWithin":
+after transform: SymbolId(9): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "copyWithin":
+after transform: SymbolId(9): Span { start: 142, end: 152 }
+rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
+Symbol flags mismatch for "fill":
+after transform: SymbolId(11): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(17): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "fill":
+after transform: SymbolId(11): Span { start: 175, end: 179 }
+rebuilt        : SymbolId(17): Span { start: 0, end: 0 }
+Symbol flags mismatch for "find":
+after transform: SymbolId(13): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "find":
+after transform: SymbolId(13): Span { start: 202, end: 206 }
+rebuilt        : SymbolId(20): Span { start: 0, end: 0 }
+Symbol flags mismatch for "findIndex":
+after transform: SymbolId(15): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(23): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "findIndex":
+after transform: SymbolId(15): Span { start: 229, end: 238 }
+rebuilt        : SymbolId(23): Span { start: 0, end: 0 }
+Symbol flags mismatch for "lastIndexOf":
+after transform: SymbolId(17): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(26): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "lastIndexOf":
+after transform: SymbolId(17): Span { start: 261, end: 272 }
+rebuilt        : SymbolId(26): Span { start: 0, end: 0 }
+Symbol flags mismatch for "pop":
+after transform: SymbolId(19): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(29): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "pop":
+after transform: SymbolId(19): Span { start: 295, end: 298 }
+rebuilt        : SymbolId(29): Span { start: 0, end: 0 }
+Symbol flags mismatch for "push":
+after transform: SymbolId(21): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(32): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "push":
+after transform: SymbolId(21): Span { start: 321, end: 325 }
+rebuilt        : SymbolId(32): Span { start: 0, end: 0 }
+Symbol flags mismatch for "reverse":
+after transform: SymbolId(23): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(35): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "reverse":
+after transform: SymbolId(23): Span { start: 348, end: 355 }
+rebuilt        : SymbolId(35): Span { start: 0, end: 0 }
+Symbol flags mismatch for "shift":
+after transform: SymbolId(25): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(38): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "shift":
+after transform: SymbolId(25): Span { start: 378, end: 383 }
+rebuilt        : SymbolId(38): Span { start: 0, end: 0 }
+Symbol flags mismatch for "unshift":
+after transform: SymbolId(27): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(41): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "unshift":
+after transform: SymbolId(27): Span { start: 406, end: 413 }
+rebuilt        : SymbolId(41): Span { start: 0, end: 0 }
+Symbol flags mismatch for "slice":
+after transform: SymbolId(29): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(44): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "slice":
+after transform: SymbolId(29): Span { start: 436, end: 441 }
+rebuilt        : SymbolId(44): Span { start: 0, end: 0 }
+Symbol flags mismatch for "sort":
+after transform: SymbolId(31): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(47): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "sort":
+after transform: SymbolId(31): Span { start: 464, end: 468 }
+rebuilt        : SymbolId(47): Span { start: 0, end: 0 }
+Symbol flags mismatch for "splice":
+after transform: SymbolId(33): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(50): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "splice":
+after transform: SymbolId(33): Span { start: 491, end: 497 }
+rebuilt        : SymbolId(50): Span { start: 0, end: 0 }
+Symbol flags mismatch for "includes":
+after transform: SymbolId(35): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(53): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "includes":
+after transform: SymbolId(35): Span { start: 520, end: 528 }
+rebuilt        : SymbolId(53): Span { start: 0, end: 0 }
+Symbol flags mismatch for "indexOf":
+after transform: SymbolId(37): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(56): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "indexOf":
+after transform: SymbolId(37): Span { start: 551, end: 558 }
+rebuilt        : SymbolId(56): Span { start: 0, end: 0 }
+Symbol flags mismatch for "join":
+after transform: SymbolId(39): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(59): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "join":
+after transform: SymbolId(39): Span { start: 581, end: 585 }
+rebuilt        : SymbolId(59): Span { start: 0, end: 0 }
+Symbol flags mismatch for "keys":
+after transform: SymbolId(41): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(62): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "keys":
+after transform: SymbolId(41): Span { start: 608, end: 612 }
+rebuilt        : SymbolId(62): Span { start: 0, end: 0 }
+Symbol flags mismatch for "entries":
+after transform: SymbolId(43): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(65): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "entries":
+after transform: SymbolId(43): Span { start: 635, end: 642 }
+rebuilt        : SymbolId(65): Span { start: 0, end: 0 }
+Symbol flags mismatch for "values":
+after transform: SymbolId(45): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(68): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "values":
+after transform: SymbolId(45): Span { start: 665, end: 671 }
+rebuilt        : SymbolId(68): Span { start: 0, end: 0 }
+Symbol flags mismatch for "forEach":
+after transform: SymbolId(47): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(71): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "forEach":
+after transform: SymbolId(47): Span { start: 694, end: 701 }
+rebuilt        : SymbolId(71): Span { start: 0, end: 0 }
+Symbol flags mismatch for "filter":
+after transform: SymbolId(49): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(74): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "filter":
+after transform: SymbolId(49): Span { start: 724, end: 730 }
+rebuilt        : SymbolId(74): Span { start: 0, end: 0 }
+Symbol flags mismatch for "map":
+after transform: SymbolId(51): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(77): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "map":
+after transform: SymbolId(51): Span { start: 753, end: 756 }
+rebuilt        : SymbolId(77): Span { start: 0, end: 0 }
+Symbol flags mismatch for "every":
+after transform: SymbolId(53): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(80): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "every":
+after transform: SymbolId(53): Span { start: 779, end: 784 }
+rebuilt        : SymbolId(80): Span { start: 0, end: 0 }
+Symbol flags mismatch for "some":
+after transform: SymbolId(55): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(83): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "some":
+after transform: SymbolId(55): Span { start: 807, end: 811 }
+rebuilt        : SymbolId(83): Span { start: 0, end: 0 }
+Symbol flags mismatch for "reduce":
+after transform: SymbolId(57): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(86): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "reduce":
+after transform: SymbolId(57): Span { start: 834, end: 840 }
+rebuilt        : SymbolId(86): Span { start: 0, end: 0 }
+Symbol flags mismatch for "reduceRight":
+after transform: SymbolId(59): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(89): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "reduceRight":
+after transform: SymbolId(59): Span { start: 863, end: 874 }
+rebuilt        : SymbolId(89): Span { start: 0, end: 0 }
+Symbol flags mismatch for "toLocaleString":
+after transform: SymbolId(61): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(92): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "toLocaleString":
+after transform: SymbolId(61): Span { start: 897, end: 911 }
+rebuilt        : SymbolId(92): Span { start: 0, end: 0 }
+Symbol flags mismatch for "toString":
+after transform: SymbolId(63): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(95): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "toString":
+after transform: SymbolId(63): Span { start: 934, end: 942 }
+rebuilt        : SymbolId(95): Span { start: 0, end: 0 }
+Symbol flags mismatch for "flat":
+after transform: SymbolId(65): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(98): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "flat":
+after transform: SymbolId(65): Span { start: 965, end: 969 }
+rebuilt        : SymbolId(98): Span { start: 0, end: 0 }
+Symbol flags mismatch for "flatMap":
+after transform: SymbolId(67): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(101): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "flatMap":
+after transform: SymbolId(67): Span { start: 992, end: 999 }
+rebuilt        : SymbolId(101): Span { start: 0, end: 0 }
 
 * namespace/declare/input.ts
-Missing SymbolId: "N"
-Missing SymbolId: "_N"
-Missing ReferenceId: "N"
-Missing ReferenceId: "N"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
 Bindings mismatch:
 after transform: ScopeId(1): ["B", "_N", "e", "v"]
 rebuilt        : ScopeId(1): ["_N"]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(1): []
+Symbol flags mismatch for "N":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N":
+after transform: SymbolId(0): Span { start: 17, end: 18 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 * namespace/declare-global-nested-namespace/input.ts
-Missing SymbolId: "X"
-Missing SymbolId: "_X"
-Missing ReferenceId: "X"
-Missing ReferenceId: "X"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(2), SymbolId(4)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3)]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(3), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Symbol flags mismatch for "X":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "X":
+after transform: SymbolId(2): Span { start: 70, end: 71 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 * namespace/empty-removed/input.ts
-Missing SymbolId: "a"
-Missing SymbolId: "_a"
-Missing SymbolId: "c"
-Missing SymbolId: "_c"
-Missing ReferenceId: "c"
-Missing ReferenceId: "c"
-Missing ReferenceId: "a"
-Missing ReferenceId: "a"
-Missing SymbolId: "WithTypes"
-Missing SymbolId: "_WithTypes"
-Missing SymbolId: "d"
-Missing SymbolId: "_d2"
-Missing ReferenceId: "d"
-Missing ReferenceId: "d"
-Missing ReferenceId: "WithTypes"
-Missing ReferenceId: "WithTypes"
-Missing SymbolId: "WithValues"
-Missing SymbolId: "_WithValues"
-Missing SymbolId: "a"
-Missing SymbolId: "_a3"
-Missing ReferenceId: "a"
-Missing ReferenceId: "a"
-Missing SymbolId: "b"
-Missing SymbolId: "_b3"
-Missing ReferenceId: "b"
-Missing ReferenceId: "b"
-Missing SymbolId: "c"
-Missing SymbolId: "_c3"
-Missing ReferenceId: "c"
-Missing ReferenceId: "c"
-Missing SymbolId: "d"
-Missing SymbolId: "_d3"
-Missing ReferenceId: "d"
-Missing ReferenceId: "d"
-Missing SymbolId: "e"
-Missing SymbolId: "_e2"
-Missing ReferenceId: "e"
-Missing ReferenceId: "e"
-Missing ReferenceId: "WithValues"
-Missing ReferenceId: "WithValues"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(6), SymbolId(14)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5), SymbolId(9)]
 Bindings mismatch:
 after transform: ScopeId(1): ["_a", "b", "c", "d"]
 rebuilt        : ScopeId(1): ["_a", "c"]
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(3), SymbolId(26)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 Bindings mismatch:
 after transform: ScopeId(6): ["_WithTypes", "a", "b", "c", "d"]
 rebuilt        : ScopeId(3): ["_WithTypes", "d"]
 Scope children mismatch:
 after transform: ScopeId(6): [ScopeId(7), ScopeId(9), ScopeId(11), ScopeId(12)]
 rebuilt        : ScopeId(3): [ScopeId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(12): [SymbolId(33)]
-rebuilt        : ScopeId(4): [SymbolId(8)]
 Scope children mismatch:
 after transform: ScopeId(12): [ScopeId(13)]
 rebuilt        : ScopeId(4): []
-Binding symbols mismatch:
-after transform: ScopeId(14): [SymbolId(15), SymbolId(17), SymbolId(19), SymbolId(21), SymbolId(23), SymbolId(34)]
-rebuilt        : ScopeId(5): [SymbolId(10), SymbolId(11), SymbolId(14), SymbolId(18), SymbolId(21), SymbolId(24)]
-Binding symbols mismatch:
-after transform: ScopeId(15): [SymbolId(16), SymbolId(35)]
-rebuilt        : ScopeId(6): [SymbolId(12), SymbolId(13)]
-Binding symbols mismatch:
-after transform: ScopeId(17): [SymbolId(18), SymbolId(36)]
-rebuilt        : ScopeId(8): [SymbolId(15), SymbolId(16)]
 Scope flags mismatch:
 after transform: ScopeId(18): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(9): ScopeFlags(StrictMode | Function)
-Binding symbols mismatch:
-after transform: ScopeId(19): [SymbolId(20), SymbolId(37)]
-rebuilt        : ScopeId(10): [SymbolId(19), SymbolId(20)]
-Binding symbols mismatch:
-after transform: ScopeId(21): [SymbolId(22), SymbolId(38)]
-rebuilt        : ScopeId(12): [SymbolId(22), SymbolId(23)]
-Binding symbols mismatch:
-after transform: ScopeId(22): [SymbolId(39)]
-rebuilt        : ScopeId(13): [SymbolId(25)]
+Symbol flags mismatch for "a":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "a":
+after transform: SymbolId(0): Span { start: 10, end: 11 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "a":
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4), ReferenceId(5)]
+rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
+Symbol flags mismatch for "c":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "c":
+after transform: SymbolId(2): Span { start: 43, end: 44 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "WithTypes":
+after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "WithTypes":
+after transform: SymbolId(6): Span { start: 107, end: 116 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
+Symbol flags mismatch for "d":
+after transform: SymbolId(13): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "d":
+after transform: SymbolId(13): Span { start: 224, end: 225 }
+rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
+Symbol flags mismatch for "WithValues":
+after transform: SymbolId(14): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "WithValues":
+after transform: SymbolId(14): Span { start: 262, end: 272 }
+rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
+Symbol flags mismatch for "a":
+after transform: SymbolId(15): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "a":
+after transform: SymbolId(15): Span { start: 287, end: 288 }
+rebuilt        : SymbolId(11): Span { start: 0, end: 0 }
+Symbol flags mismatch for "b":
+after transform: SymbolId(17): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "b":
+after transform: SymbolId(17): Span { start: 316, end: 317 }
+rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
 after transform: SymbolId(18): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
+Symbol flags mismatch for "c":
+after transform: SymbolId(19): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "c":
+after transform: SymbolId(19): Span { start: 344, end: 345 }
+rebuilt        : SymbolId(18): Span { start: 0, end: 0 }
 Symbol flags mismatch for "C":
 after transform: SymbolId(20): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(20): SymbolFlags(FunctionScopedVariable)
+Symbol flags mismatch for "d":
+after transform: SymbolId(21): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(21): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "d":
+after transform: SymbolId(21): Span { start: 378, end: 379 }
+rebuilt        : SymbolId(21): Span { start: 0, end: 0 }
+Symbol flags mismatch for "e":
+after transform: SymbolId(23): SymbolFlags(NameSpaceModule)
+rebuilt        : SymbolId(24): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "e":
+after transform: SymbolId(23): Span { start: 402, end: 403 }
+rebuilt        : SymbolId(24): Span { start: 0, end: 0 }
 
 * namespace/export/input.ts
-Missing SymbolId: "N"
-Missing SymbolId: "_N"
-Missing ReferenceId: "N"
-Missing ReferenceId: "N"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Symbol flags mismatch for "N":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N":
+after transform: SymbolId(0): Span { start: 17, end: 18 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 * namespace/export-type-only/input.ts
 Bindings mismatch:
@@ -2686,102 +2606,55 @@ after transform: ["Platform"]
 rebuilt        : []
 
 * namespace/module-nested/input.ts
-Missing SymbolId: "src"
-Missing SymbolId: "_src"
-Missing SymbolId: "ns1"
-Missing SymbolId: "_ns"
-Missing ReferenceId: "_ns"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "ns1"
-Missing ReferenceId: "ns1"
-Missing ReferenceId: "_src"
-Missing ReferenceId: "_src"
-Missing SymbolId: "ns2"
-Missing SymbolId: "_ns2"
-Missing ReferenceId: "_ns2"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "ns2"
-Missing ReferenceId: "ns2"
-Missing ReferenceId: "_src"
-Missing ReferenceId: "_src"
-Missing ReferenceId: "src"
-Missing ReferenceId: "src"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(4), SymbolId(7)]
-rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7)]
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(7): [ReferenceId(7)]
+Symbol flags mismatch for "src":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "src":
+after transform: SymbolId(0): Span { start: 7, end: 10 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "ns1":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "ns1":
+after transform: SymbolId(1): Span { start: 32, end: 35 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "ns2":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "ns2":
+after transform: SymbolId(3): Span { start: 113, end: 116 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 
 * namespace/module-nested-export/input.ts
-Missing SymbolId: "src"
-Missing SymbolId: "_src"
-Missing SymbolId: "ns1"
-Missing SymbolId: "_ns"
-Missing ReferenceId: "_ns"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "ns1"
-Missing ReferenceId: "ns1"
-Missing ReferenceId: "_src"
-Missing ReferenceId: "_src"
-Missing SymbolId: "ns2"
-Missing SymbolId: "_ns2"
-Missing ReferenceId: "_ns2"
-Missing ReferenceId: "foo"
-Missing ReferenceId: "ns2"
-Missing ReferenceId: "ns2"
-Missing ReferenceId: "_src"
-Missing ReferenceId: "_src"
-Missing ReferenceId: "src"
-Missing ReferenceId: "src"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(5)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(6)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(4), SymbolId(7)]
-rebuilt        : ScopeId(4): [SymbolId(6), SymbolId(7)]
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
-Symbol reference IDs mismatch for "foo":
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(7): [ReferenceId(7)]
+Symbol flags mismatch for "src":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "src":
+after transform: SymbolId(0): Span { start: 14, end: 17 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "ns1":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "ns1":
+after transform: SymbolId(1): Span { start: 39, end: 42 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "ns2":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "ns2":
+after transform: SymbolId(3): Span { start: 120, end: 123 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 
 * namespace/multiple/input.ts
-Missing SymbolId: "N"
-Missing SymbolId: "_N"
-Missing ReferenceId: "N"
-Missing ReferenceId: "N"
-Missing SymbolId: "_N2"
-Missing ReferenceId: "N"
-Missing ReferenceId: "N"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(4)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
+Symbol flags mismatch for "N":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N":
+after transform: SymbolId(0): Span { start: 10, end: 11 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "N":
+after transform: SymbolId(0): [Span { start: 33, end: 34 }]
+rebuilt        : SymbolId(0): []
 
 * namespace/mutable-fail/input.ts
 
@@ -2807,62 +2680,12 @@ rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
 
 
 * namespace/nested/input.ts
-Missing SymbolId: "_A"
-Missing SymbolId: "C"
-Missing SymbolId: "_C"
-Missing ReferenceId: "_C"
-Missing ReferenceId: "G"
-Missing ReferenceId: "_C"
-Missing ReferenceId: "C"
-Missing ReferenceId: "C"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "_A"
-Missing SymbolId: "_M"
-Missing ReferenceId: "_M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "M"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "D"
-Missing SymbolId: "_D"
-Missing ReferenceId: "_D"
-Missing ReferenceId: "H"
-Missing ReferenceId: "D"
-Missing ReferenceId: "D"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "_A"
-Missing SymbolId: "_F"
-Missing ReferenceId: "F"
-Missing ReferenceId: "F"
-Missing SymbolId: "G"
-Missing SymbolId: "_G"
-Missing ReferenceId: "G"
-Missing ReferenceId: "G"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(1), SymbolId(4), SymbolId(6), SymbolId(12), SymbolId(14), SymbolId(16), SymbolId(18)]
-rebuilt        : ScopeId(2): [SymbolId(1), SymbolId(2), SymbolId(6), SymbolId(9), SymbolId(14), SymbolId(17), SymbolId(20)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(2), SymbolId(3), SymbolId(19)]
-rebuilt        : ScopeId(3): [SymbolId(3), SymbolId(4), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(5), SymbolId(20)]
-rebuilt        : ScopeId(6): [SymbolId(7), SymbolId(8)]
-Binding symbols mismatch:
-after transform: ScopeId(8): [SymbolId(7), SymbolId(8), SymbolId(21)]
-rebuilt        : ScopeId(8): [SymbolId(10), SymbolId(11), SymbolId(12)]
 Bindings mismatch:
 after transform: ScopeId(9): ["H", "I", "J", "K"]
 rebuilt        : ScopeId(9): ["H"]
 Scope flags mismatch:
 after transform: ScopeId(9): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(9): ScopeFlags(StrictMode | Function)
-Binding symbols mismatch:
-after transform: ScopeId(11): [SymbolId(13), SymbolId(22)]
-rebuilt        : ScopeId(11): [SymbolId(15), SymbolId(16)]
-Binding symbols mismatch:
-after transform: ScopeId(12): [SymbolId(15), SymbolId(23)]
-rebuilt        : ScopeId(12): [SymbolId(18), SymbolId(19)]
 Bindings mismatch:
 after transform: ScopeId(13): ["L", "M"]
 rebuilt        : ScopeId(13): ["L"]
@@ -2872,65 +2695,47 @@ rebuilt        : ScopeId(13): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
-Symbol reference IDs mismatch for "A":
-after transform: SymbolId(0): []
-rebuilt        : SymbolId(0): [ReferenceId(33), ReferenceId(34)]
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 22, end: 23 }]
 rebuilt        : SymbolId(0): []
-Symbol reference IDs mismatch for "G":
-after transform: SymbolId(2): []
-rebuilt        : SymbolId(4): [ReferenceId(1)]
+Symbol flags mismatch for "C":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "C":
+after transform: SymbolId(1): Span { start: 45, end: 46 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M":
 after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Function | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "M":
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(6): [ReferenceId(9), ReferenceId(10)]
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(4): [Span { start: 129, end: 130 }]
 rebuilt        : SymbolId(6): []
 Symbol flags mismatch for "D":
 after transform: SymbolId(6): SymbolFlags(BlockScopedVariable | Function | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(9): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "D":
-after transform: SymbolId(6): []
-rebuilt        : SymbolId(9): [ReferenceId(12), ReferenceId(22), ReferenceId(23)]
 Symbol redeclarations mismatch for "D":
 after transform: SymbolId(6): [Span { start: 207, end: 208 }]
 rebuilt        : SymbolId(9): []
 Symbol flags mismatch for "H":
 after transform: SymbolId(8): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "H":
-after transform: SymbolId(8): []
-rebuilt        : SymbolId(12): [ReferenceId(21)]
 Symbol flags mismatch for "F":
 after transform: SymbolId(12): SymbolFlags(Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(Class)
-Symbol reference IDs mismatch for "F":
-after transform: SymbolId(12): []
-rebuilt        : SymbolId(14): [ReferenceId(26), ReferenceId(27)]
 Symbol redeclarations mismatch for "F":
 after transform: SymbolId(12): [Span { start: 325, end: 326 }]
 rebuilt        : SymbolId(14): []
+Symbol flags mismatch for "G":
+after transform: SymbolId(14): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(17): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "G":
+after transform: SymbolId(14): Span { start: 350, end: 351 }
+rebuilt        : SymbolId(17): Span { start: 0, end: 0 }
 Symbol flags mismatch for "L":
 after transform: SymbolId(16): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
-Reference symbol mismatch for "C":
-after transform: SymbolId(1) "C"
-rebuilt        : SymbolId(2) "C"
 
 * namespace/nested-namespace/input.ts
-Missing SymbolId: "A"
-Missing SymbolId: "_A"
-Missing ReferenceId: "_A"
-Missing ReferenceId: "G"
-Missing ReferenceId: "A"
-Missing ReferenceId: "A"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
 Bindings mismatch:
 after transform: ScopeId(1): ["B", "G", "_A"]
 rebuilt        : ScopeId(1): ["G", "_A"]
@@ -2943,149 +2748,93 @@ rebuilt        : ScopeId(2): ["G"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 17, end: 18 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "G":
 after transform: SymbolId(3): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "G":
-after transform: SymbolId(3): []
-rebuilt        : SymbolId(2): [ReferenceId(4)]
 
 * namespace/nested-shorthand/input.ts
-Missing SymbolId: "X"
-Missing SymbolId: "_X"
-Missing SymbolId: "Y"
-Missing SymbolId: "_Y"
-Missing ReferenceId: "_Y"
-Missing ReferenceId: "Y"
-Missing ReferenceId: "Y"
-Missing ReferenceId: "_X"
-Missing ReferenceId: "_X"
-Missing ReferenceId: "X"
-Missing ReferenceId: "X"
-Missing SymbolId: "proj"
-Missing SymbolId: "_proj"
-Missing SymbolId: "data"
-Missing SymbolId: "_data"
-Missing SymbolId: "util"
-Missing SymbolId: "_util"
-Missing SymbolId: "api"
-Missing SymbolId: "_api"
-Missing ReferenceId: "_api"
-Missing ReferenceId: "api"
-Missing ReferenceId: "api"
-Missing ReferenceId: "_util"
-Missing ReferenceId: "_util"
-Missing ReferenceId: "util"
-Missing ReferenceId: "util"
-Missing ReferenceId: "_data"
-Missing ReferenceId: "_data"
-Missing ReferenceId: "data"
-Missing ReferenceId: "data"
-Missing ReferenceId: "_proj"
-Missing ReferenceId: "_proj"
-Missing ReferenceId: "proj"
-Missing ReferenceId: "proj"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(3)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(8)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(9)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(4), SymbolId(10)]
-rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
-Binding symbols mismatch:
-after transform: ScopeId(4): [SymbolId(5), SymbolId(11)]
-rebuilt        : ScopeId(4): [SymbolId(8), SymbolId(9)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(6), SymbolId(12)]
-rebuilt        : ScopeId(5): [SymbolId(10), SymbolId(11)]
-Binding symbols mismatch:
-after transform: ScopeId(6): [SymbolId(7), SymbolId(13)]
-rebuilt        : ScopeId(6): [SymbolId(12), SymbolId(13)]
+Symbol flags mismatch for "X":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "X":
+after transform: SymbolId(0): Span { start: 10, end: 11 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Y":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Y":
+after transform: SymbolId(1): Span { start: 12, end: 13 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "proj":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "proj":
+after transform: SymbolId(3): Span { start: 51, end: 55 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
+Symbol flags mismatch for "data":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "data":
+after transform: SymbolId(4): Span { start: 56, end: 60 }
+rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
+Symbol flags mismatch for "util":
+after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "util":
+after transform: SymbolId(5): Span { start: 61, end: 65 }
+rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
+Symbol flags mismatch for "api":
+after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "api":
+after transform: SymbolId(6): Span { start: 66, end: 69 }
+rebuilt        : SymbolId(11): Span { start: 0, end: 0 }
 
 * namespace/same-name/input.ts
-Missing SymbolId: "N"
-Missing SymbolId: "_N2"
-Missing SymbolId: "_N7"
-Missing SymbolId: "_N4"
-Missing ReferenceId: "_N7"
-Missing ReferenceId: "_N7"
-Missing SymbolId: "N"
-Missing SymbolId: "_N6"
-Missing ReferenceId: "_N6"
-Missing ReferenceId: "_N3"
-Missing ReferenceId: "N"
-Missing ReferenceId: "N"
-Missing ReferenceId: "_N2"
-Missing ReferenceId: "_N2"
-Missing SymbolId: "_N8"
-Missing ReferenceId: "_N8"
-Missing ReferenceId: "_N5"
-Missing ReferenceId: "N"
-Missing ReferenceId: "N"
-Missing ReferenceId: "_N2"
-Missing ReferenceId: "_N2"
-Missing SymbolId: "_N9"
-Missing ReferenceId: "_N9"
-Missing ReferenceId: "_N"
-Missing ReferenceId: "N"
-Missing ReferenceId: "N"
-Missing ReferenceId: "_N2"
-Missing ReferenceId: "_N2"
-Missing ReferenceId: "N"
-Missing ReferenceId: "N"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(7)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5)]
-Binding symbols mismatch:
-after transform: ScopeId(2): [SymbolId(2), SymbolId(8)]
-rebuilt        : ScopeId(2): [SymbolId(3), SymbolId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(3): [SymbolId(4), SymbolId(9)]
-rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(5), SymbolId(10)]
-rebuilt        : ScopeId(5): [SymbolId(8), SymbolId(9)]
-Binding symbols mismatch:
-after transform: ScopeId(7): [SymbolId(6), SymbolId(11)]
-rebuilt        : ScopeId(7): [SymbolId(10), SymbolId(11)]
 Scope flags mismatch:
 after transform: ScopeId(8): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(8): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "N":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N":
+after transform: SymbolId(0): Span { start: 10, end: 11 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol flags mismatch for "_N7":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "_N7":
+after transform: SymbolId(1): Span { start: 26, end: 29 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "N":
+after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N":
+after transform: SymbolId(3): Span { start: 59, end: 60 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "N":
+after transform: SymbolId(3): [Span { start: 115, end: 116 }, Span { start: 166, end: 167 }]
+rebuilt        : SymbolId(5): []
 Symbol flags mismatch for "_N3":
 after transform: SymbolId(4): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(7): SymbolFlags(FunctionScopedVariable)
-Symbol reference IDs mismatch for "_N3":
-after transform: SymbolId(4): []
-rebuilt        : SymbolId(7): [ReferenceId(3)]
-Symbol reference IDs mismatch for "_N5":
-after transform: SymbolId(5): []
-rebuilt        : SymbolId(9): [ReferenceId(9)]
 Symbol flags mismatch for "_N":
 after transform: SymbolId(6): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
-Symbol reference IDs mismatch for "_N":
-after transform: SymbolId(6): []
-rebuilt        : SymbolId(11): [ReferenceId(16)]
 
 * namespace/undeclared/input.ts
-Missing SymbolId: "N"
-Missing SymbolId: "_N"
-Missing ReferenceId: "N"
-Missing ReferenceId: "N"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0)]
-rebuilt        : ScopeId(0): [SymbolId(0)]
-Binding symbols mismatch:
-after transform: ScopeId(1): [SymbolId(1), SymbolId(2)]
-rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Symbol flags mismatch for "N":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N":
+after transform: SymbolId(0): Span { start: 10, end: 11 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 * optimize-const-enums/custom-values/input.ts
 x Output mismatch

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -121,23 +121,21 @@ after transform: SymbolId(5): [ReferenceId(3), ReferenceId(4), ReferenceId(5), R
 rebuilt        : SymbolId(2): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(8)]
 
 * export-elimination/input.ts
-Missing SymbolId: "Name"
-Missing SymbolId: "_Name"
-Missing ReferenceId: "_Name"
-Missing ReferenceId: "Name"
-Missing ReferenceId: "Name"
 Bindings mismatch:
 after transform: ScopeId(0): ["Bar", "Foo", "Func", "Im", "Name", "Ok"]
 rebuilt        : ScopeId(0): ["Bar", "Foo", "Func", "Im", "Name", "Ok", "T"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
-Binding symbols mismatch:
-after transform: ScopeId(5): [SymbolId(8), SymbolId(10)]
-rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch for "Name":
+after transform: SymbolId(7): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Name":
+after transform: SymbolId(7): Span { start: 116, end: 120 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "T":
 after transform: SymbolId(9): SymbolFlags(FunctionScopedVariable | TypeAlias)
 rebuilt        : SymbolId(8): SymbolFlags(FunctionScopedVariable)
@@ -150,9 +148,6 @@ rebuilt        : SymbolId(8): [ReferenceId(9)]
 Symbol redeclarations mismatch for "T":
 after transform: SymbolId(9): [Span { start: 226, end: 227 }]
 rebuilt        : SymbolId(8): []
-Reference symbol mismatch for "Name":
-after transform: SymbolId(7) "Name"
-rebuilt        : SymbolId(5) "Name"
 
 * exports/type-and-non-type/input.ts
 Scope children mismatch:
@@ -160,18 +155,7 @@ after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 * namespace/import-=/input.ts
-Missing SymbolId: "N1"
-Missing SymbolId: "_N"
-Missing ReferenceId: "N1"
-Missing ReferenceId: "N1"
-Missing SymbolId: "N2"
-Missing SymbolId: "_N2"
 Missing SymbolId: "X"
-Missing ReferenceId: "N2"
-Missing ReferenceId: "N2"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(4)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(4)]
 Bindings mismatch:
 after transform: ScopeId(1): ["V", "X", "_N"]
 rebuilt        : ScopeId(1): ["V", "_N"]
@@ -187,24 +171,25 @@ rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol reference IDs mismatch for "A":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(2)]
+Symbol flags mismatch for "N1":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N1":
+after transform: SymbolId(1): Span { start: 31, end: 33 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
+Symbol flags mismatch for "N2":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N2":
+after transform: SymbolId(4): Span { start: 130, end: 132 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Reference symbol mismatch for "X":
 after transform: SymbolId(5) "X"
 rebuilt        : SymbolId(6) "X"
 
 * namespace/preserve-import-=/input.ts
-Missing SymbolId: "N1"
-Missing SymbolId: "_N"
 Missing SymbolId: "Foo"
-Missing ReferenceId: "N1"
-Missing ReferenceId: "N1"
-Missing SymbolId: "N2"
-Missing SymbolId: "_N2"
 Missing SymbolId: "Foo"
-Missing ReferenceId: "N2"
-Missing ReferenceId: "N2"
-Binding symbols mismatch:
-after transform: ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(4)]
-rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(1), SymbolId(5)]
 Binding symbols mismatch:
 after transform: ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(7)]
 rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3), SymbolId(4)]
@@ -217,6 +202,18 @@ rebuilt        : ScopeId(2): [SymbolId(6), SymbolId(7), SymbolId(8)]
 Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch for "N1":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N1":
+after transform: SymbolId(1): Span { start: 34, end: 36 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
+Symbol flags mismatch for "N2":
+after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N2":
+after transform: SymbolId(4): Span { start: 145, end: 147 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 
 * preserve-import-=/input.js
 Missing SymbolId: "Foo"


### PR DESCRIPTION
I did a few things in this PR,

1. Remove `names` which store the declarations name used for checking re-declaration. (We can use SymbolTable to do it now.)
2. Correct semantic data for namespace transform
3. Simplify code