### PR TITLE
fix(transformer/typescript): retain `TSImportEqualsDeclaration` when it is exported

### DIFF
--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -162,6 +162,12 @@ impl<'a> TypeScriptNamespace<'a, '_> {
                             continue;
                         }
                         match decl {
+                            Declaration::TSImportEqualsDeclaration(ref import_equals) => {
+                                let binding =
+                                    BoundIdentifier::from_binding_ident(&import_equals.id);
+                                new_stmts.push(Statement::from(decl));
+                                Self::add_declaration(&uid_binding, &binding, &mut new_stmts, ctx);
+                            }
                             Declaration::TSEnumDeclaration(ref enum_decl) => {
                                 let binding = BoundIdentifier::from_binding_ident(&enum_decl.id);
                                 new_stmts.push(Statement::from(decl));

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -334,15 +334,31 @@ after transform: ScopeId(3): [ScopeId(4), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(1): []
 
 tasks/coverage/typescript/tests/cases/compiler/acceptableAlias1.ts
-semantic error: Bindings mismatch:
+semantic error: Missing SymbolId: "X"
+Bindings mismatch:
 after transform: ScopeId(0): ["M", "r"]
-rebuilt        : ScopeId(0): []
+rebuilt        : ScopeId(0): ["M"]
+Bindings mismatch:
+after transform: ScopeId(1): ["N", "X", "_M"]
+rebuilt        : ScopeId(1): ["X", "_M"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
+after transform: ScopeId(1): [ScopeId(2)]
+rebuilt        : ScopeId(1): []
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Reference symbol mismatch for "X":
+after transform: SymbolId(2) "X"
+rebuilt        : SymbolId(2) "X"
 Unresolved references mismatch:
 after transform: ["M", "N"]
-rebuilt        : []
+rebuilt        : ["N"]
 
 tasks/coverage/typescript/tests/cases/compiler/accessorsEmit.ts
 semantic error: Symbol reference IDs mismatch for "Result":
@@ -365,21 +381,32 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/aliasInaccessibleModule.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["M"]
-rebuilt        : ScopeId(0): []
+semantic error: Missing SymbolId: "X"
+Bindings mismatch:
+after transform: ScopeId(1): ["N", "X", "_M"]
+rebuilt        : ScopeId(1): ["X", "_M"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["N"]
-rebuilt        : []
+after transform: ScopeId(1): [ScopeId(2)]
+rebuilt        : ScopeId(1): []
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Reference symbol mismatch for "X":
+after transform: SymbolId(2) "X"
+rebuilt        : SymbolId(2) "X"
 
 tasks/coverage/typescript/tests/cases/compiler/aliasInaccessibleModule2.ts
 semantic error: Missing SymbolId: "R"
-Bindings mismatch:
-after transform: ScopeId(1): ["N", "R", "X", "_M"]
-rebuilt        : ScopeId(1): ["N", "R", "_M"]
+Missing SymbolId: "X"
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(1), SymbolId(3), SymbolId(4), SymbolId(5)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2), SymbolId(5), SymbolId(6)]
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
@@ -398,6 +425,12 @@ rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "N":
 after transform: SymbolId(1): Span { start: 22, end: 23 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Reference symbol mismatch for "R":
+after transform: SymbolId(3) "R"
+rebuilt        : SymbolId(5) "R"
+Reference symbol mismatch for "X":
+after transform: SymbolId(4) "X"
+rebuilt        : SymbolId(6) "X"
 
 tasks/coverage/typescript/tests/cases/compiler/aliasOfGenericFunctionWithRestBehavedSameAsUnaliased.ts
 semantic error: Scope children mismatch:
@@ -2530,6 +2563,8 @@ semantic error: Missing SymbolId: "exports"
 Missing SymbolId: "require"
 Missing SymbolId: "exports"
 Missing SymbolId: "require"
+Missing SymbolId: "exports"
+Missing SymbolId: "require"
 Binding symbols mismatch:
 after transform: ScopeId(0): [SymbolId(0), SymbolId(2), SymbolId(3), SymbolId(4), SymbolId(7)]
 rebuilt        : ScopeId(0): [SymbolId(0), SymbolId(3), SymbolId(4), SymbolId(5), SymbolId(9)]
@@ -2542,9 +2577,9 @@ rebuilt        : ScopeId(3): [SymbolId(6), SymbolId(7), SymbolId(8)]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(4): ["_m2", "exports", "require"]
-rebuilt        : ScopeId(4): ["_m2"]
+Binding symbols mismatch:
+after transform: ScopeId(4): [SymbolId(8), SymbolId(9), SymbolId(12)]
+rebuilt        : ScopeId(4): [SymbolId(10), SymbolId(11), SymbolId(12)]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
@@ -2554,9 +2589,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "mOfGloalFile":
 after transform: SymbolId(0): Span { start: 7, end: 19 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "mOfGloalFile":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(9), ReferenceId(14), ReferenceId(15)]
-rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(9)]
 Symbol flags mismatch for "m1":
 after transform: SymbolId(4): SymbolFlags(NameSpaceModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
@@ -2583,10 +2615,16 @@ after transform: SymbolId(6) "require"
 rebuilt        : SymbolId(8) "require"
 Reference symbol mismatch for "exports":
 after transform: SymbolId(8) "exports"
-rebuilt        : SymbolId(3) "exports"
+rebuilt        : SymbolId(11) "exports"
 Reference symbol mismatch for "require":
 after transform: SymbolId(9) "require"
-rebuilt        : SymbolId(4) "require"
+rebuilt        : SymbolId(12) "require"
+Reference symbol mismatch for "exports":
+after transform: SymbolId(8) "exports"
+rebuilt        : SymbolId(11) "exports"
+Reference symbol mismatch for "require":
+after transform: SymbolId(9) "require"
+rebuilt        : SymbolId(12) "require"
 
 tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndUninstantiatedModule.ts
 semantic error: Bindings mismatch:
@@ -11696,7 +11734,9 @@ tasks/coverage/typescript/tests/cases/compiler/exportImportAndClodule.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/exportImportCanSubstituteConstEnumForValue.ts
-semantic error: Missing SymbolId: "DialogButtons"
+semantic error: Missing SymbolId: "ReExportedEnum"
+Missing SymbolId: "DialogButtons"
+Missing SymbolId: "Callback"
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
@@ -11724,9 +11764,9 @@ rebuilt        : ScopeId(6): ScopeFlags(Function)
 Scope flags mismatch:
 after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(9): ["Callback", "DialogButtons", "ReExportedEnum", "SomeUsagesOfTheseConsts", "_ViewModels2"]
-rebuilt        : ScopeId(8): ["DialogButtons", "SomeUsagesOfTheseConsts", "_ViewModels2"]
+Binding symbols mismatch:
+after transform: ScopeId(9): [SymbolId(21), SymbolId(22), SymbolId(23), SymbolId(24), SymbolId(31)]
+rebuilt        : ScopeId(8): [SymbolId(13), SymbolId(14), SymbolId(15), SymbolId(16), SymbolId(17)]
 Scope flags mismatch:
 after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(8): ScopeFlags(Function)
@@ -11765,16 +11805,19 @@ after transform: SymbolId(20): Span { start: 537, end: 547 }
 rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
 Reference symbol mismatch for "ReExportedEnum":
 after transform: SymbolId(21) "ReExportedEnum"
-rebuilt        : <None>
+rebuilt        : SymbolId(14) "ReExportedEnum"
+Reference symbol mismatch for "Callback":
+after transform: SymbolId(23) "Callback"
+rebuilt        : SymbolId(16) "Callback"
+Reference symbol mismatch for "ReExportedEnum":
+after transform: SymbolId(21) "ReExportedEnum"
+rebuilt        : SymbolId(14) "ReExportedEnum"
 Reference symbol mismatch for "DialogButtons":
 after transform: SymbolId(22) "DialogButtons"
-rebuilt        : SymbolId(14) "DialogButtons"
+rebuilt        : SymbolId(15) "DialogButtons"
 Unresolved references mismatch:
 after transform: ["Dialogs", "MsPortalFx", "console"]
-rebuilt        : ["Dialogs", "ReExportedEnum", "console"]
-Unresolved reference IDs mismatch for "Dialogs":
-after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
-rebuilt        : [ReferenceId(44)]
+rebuilt        : ["Dialogs", "console"]
 
 tasks/coverage/typescript/tests/cases/compiler/exportImportMultipleFiles.ts
 semantic error: Missing SymbolId: "math"
@@ -11786,15 +11829,31 @@ after transform: SymbolId(0) "math"
 rebuilt        : SymbolId(0) "math"
 
 tasks/coverage/typescript/tests/cases/compiler/exportImportNonInstantiatedModule.ts
-semantic error: Bindings mismatch:
+semantic error: Missing SymbolId: "A1"
+Bindings mismatch:
 after transform: ScopeId(0): ["A", "B", "x"]
-rebuilt        : ScopeId(0): ["x"]
+rebuilt        : ScopeId(0): ["B", "x"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
-rebuilt        : ScopeId(0): []
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Binding symbols mismatch:
+after transform: ScopeId(3): [SymbolId(3), SymbolId(6)]
+rebuilt        : ScopeId(1): [SymbolId(1), SymbolId(2)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "B":
+after transform: SymbolId(2): SymbolFlags(NameSpaceModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(2): Span { start: 58, end: 59 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Reference symbol mismatch for "A1":
+after transform: SymbolId(3) "A1"
+rebuilt        : SymbolId(2) "A1"
 Unresolved references mismatch:
 after transform: ["A", "B"]
-rebuilt        : []
+rebuilt        : ["A"]
 
 tasks/coverage/typescript/tests/cases/compiler/exportImportNonInstantiatedModule2.ts
 semantic error: Scope children mismatch:
@@ -18491,7 +18550,8 @@ after transform: SymbolId(5) "M"
 rebuilt        : SymbolId(9) "M"
 
 tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt2.ts
-semantic error: Scope flags mismatch:
+semantic error: Missing SymbolId: "M"
+Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope flags mismatch:
@@ -18500,9 +18560,9 @@ rebuilt        : ScopeId(2): ScopeFlags(Function)
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(5): ["M", "_M2", "bar"]
-rebuilt        : ScopeId(5): ["_M2", "bar"]
+Binding symbols mismatch:
+after transform: ScopeId(5): [SymbolId(5), SymbolId(6), SymbolId(10)]
+rebuilt        : ScopeId(5): [SymbolId(8), SymbolId(9), SymbolId(10)]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
@@ -18512,9 +18572,6 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Z":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "Z":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(8), ReferenceId(9)]
-rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7)]
 Symbol flags mismatch for "M":
 after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
@@ -18533,12 +18590,12 @@ rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(4): Span { start: 77, end: 78 }
 rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "M":
-after transform: SymbolId(4): [ReferenceId(12), ReferenceId(14)]
-rebuilt        : SymbolId(7): [ReferenceId(10), ReferenceId(11), ReferenceId(12)]
 Reference symbol mismatch for "M":
 after transform: SymbolId(5) "M"
-rebuilt        : SymbolId(7) "M"
+rebuilt        : SymbolId(9) "M"
+Reference symbol mismatch for "M":
+after transform: SymbolId(5) "M"
+rebuilt        : SymbolId(9) "M"
 
 tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt4.ts
 semantic error: Missing SymbolId: "M"

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 126/147
+Passed: 126/148
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -47,7 +47,7 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), R
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(10)]
 
 
-# babel-plugin-transform-typescript (2/13)
+# babel-plugin-transform-typescript (2/14)
 * class-property-definition/input.ts
 Unresolved references mismatch:
 after transform: ["const"]
@@ -153,6 +153,24 @@ rebuilt        : SymbolId(8): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
+
+* namespace/export-import-=/input.ts
+Missing SymbolId: "X"
+Binding symbols mismatch:
+after transform: ScopeId(1): [SymbolId(2), SymbolId(3)]
+rebuilt        : ScopeId(1): [SymbolId(2), SymbolId(3)]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "N1":
+after transform: SymbolId(1): SymbolFlags(NameSpaceModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N1":
+after transform: SymbolId(1): Span { start: 31, end: 33 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
+Reference symbol mismatch for "X":
+after transform: SymbolId(2) "X"
+rebuilt        : SymbolId(3) "X"
 
 * namespace/import-=/input.ts
 Missing SymbolId: "X"

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/namespace/export-import-=/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/namespace/export-import-=/input.ts
@@ -1,0 +1,4 @@
+import A from 'mod';
+namespace N1 {
+  export import X = A.B;
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/namespace/export-import-=/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/namespace/export-import-=/output.js
@@ -1,0 +1,7 @@
+import A from "mod";
+
+let N1;
+(function(_N) {
+  var X = A.B;
+  _N.X = X;
+})(N1 || (N1 = {}));


### PR DESCRIPTION
Related: #8458 

While doing #8459, I found that I forgot to retain `TSImportEqualsDeclaration` when it's exported.