### PR TITLE
fix(linter/no-unused-vars): false positives when variable and type have same name

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -1083,7 +1083,10 @@ fn test_namespaces() {
 
 #[test]
 fn test_type_aliases() {
-    let pass = vec!["type Foo = string; export default Foo;"];
+    let pass = vec![
+        "type Foo = string; export default Foo;",
+        "const a = { hello: 'world' }; export type a = typeof a;",
+    ];
 
     let fail = vec![
         // usages within own declaration do not count

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
@@ -291,7 +291,9 @@ impl<'a> Symbol<'_, 'a> {
                 | AstKind::ExportNamedDeclaration(_)
                 | AstKind::ExportDefaultDeclaration(_)
                 | AstKind::ExportAllDeclaration(_)
-                | AstKind::Program(_) => {
+                | AstKind::Program(_)
+                // It refers to value bindings, not types
+                | AstKind::TSTypeQuery(_) => {
                     return false;
                 }
 


### PR DESCRIPTION
close: #8236