### PR TITLE
fix(isolated-declarations): unexpected error when global `Symbol` as property key

### DIFF
--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -32,8 +32,30 @@ impl<'a> IsolatedDeclarations<'a> {
         }
     }
 
-    pub(crate) fn report_property_key(&self, key: &PropertyKey<'a>, computed: bool) -> bool {
-        if computed && !self.is_literal_key(key) {
+    /// Check the property key whether it is a `Symbol.iterator` or `global.Symbol.iterator`
+    pub(crate) fn is_global_symbol(key: &PropertyKey<'a>) -> bool {
+        let PropertyKey::StaticMemberExpression(member) = key else {
+            return false;
+        };
+
+        // TODO: Unsupported checking if it is a global Symbol yet
+        match &member.object {
+            // `Symbol.iterator`
+            Expression::Identifier(ident) => ident.name == "Symbol",
+            // `global.Symbol.iterator`
+            Expression::StaticMemberExpression(expr) => {
+                expr.property.name == "Symbol"
+                    && matches!(
+                        &expr.object, Expression::Identifier(ident)
+                        if matches!(ident.name.as_str(), "window" | "globalThis")
+                    )
+            }
+            _ => false,
+        }
+    }
+
+    pub(crate) fn report_property_key(&self, key: &PropertyKey<'a>) -> bool {
+        if !self.is_literal_key(key) && !Self::is_global_symbol(key) {
             self.error(computed_property_name(key.span()));
             true
         } else {
@@ -367,7 +389,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         has_private_key = true;
                         continue;
                     }
-                    if self.report_property_key(&method.key, method.computed) {
+                    if method.computed && self.report_property_key(&method.key) {
                         continue;
                     }
 
@@ -462,7 +484,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         continue;
                     }
 
-                    if self.report_property_key(&property.key, property.computed) {
+                    if property.computed && self.report_property_key(&property.key) {
                         continue;
                     }
 
@@ -477,7 +499,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         continue;
                     }
 
-                    if self.report_property_key(&property.key, property.computed) {
+                    if property.computed && self.report_property_key(&property.key) {
                         return None;
                     }
 

--- a/crates/oxc_isolated_declarations/src/types.rs
+++ b/crates/oxc_isolated_declarations/src/types.rs
@@ -84,7 +84,7 @@ impl<'a> IsolatedDeclarations<'a> {
         let members =
             self.ast.vec_from_iter(expr.properties.iter().filter_map(|property| match property {
                 ObjectPropertyKind::ObjectProperty(object) => {
-                    if self.report_property_key(&object.key, object.computed) {
+                    if object.computed && self.report_property_key(&object.key) {
                         return None;
                     }
 

--- a/tasks/coverage/snapshots/transpile.snap
+++ b/tasks/coverage/snapshots/transpile.snap
@@ -96,10 +96,14 @@ export interface B {
 	[Math.random() > .5 ? "f1" : "f2"]: number;
 }
 export declare class C {
+	[Symbol.iterator]: number;
+	[globalThis.Symbol.toStringTag]: number;
 	[1]: number;
 	["2"]: number;
 }
 export declare const D: {
+	Symbol.iterator: number;
+	globalThis.Symbol.toStringTag: number;
 	1: number;
 	"2": number;
 };
@@ -197,24 +201,6 @@ export {};
 
   x TS9038: Computed property names on class or object literals cannot be
   | inferred with --isolatedDeclarations.
-    ,-[declarationComputedPropertyNames.d.ts:39:6]
- 38 |     [presentNs.a]: number = 1;
- 39 |     [Symbol.iterator]: number = 1;
-    :      ^^^^^^^^^^^^^^^
- 40 |     [globalThis.Symbol.toStringTag]: number = 1;
-    `----
-
-  x TS9038: Computed property names on class or object literals cannot be
-  | inferred with --isolatedDeclarations.
-    ,-[declarationComputedPropertyNames.d.ts:40:6]
- 39 |     [Symbol.iterator]: number = 1;
- 40 |     [globalThis.Symbol.toStringTag]: number = 1;
-    :      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- 41 |     [(globalThis.Symbol).unscopables]: number = 1;
-    `----
-
-  x TS9038: Computed property names on class or object literals cannot be
-  | inferred with --isolatedDeclarations.
     ,-[declarationComputedPropertyNames.d.ts:41:6]
  40 |     [globalThis.Symbol.toStringTag]: number = 1;
  41 |     [(globalThis.Symbol).unscopables]: number = 1;
@@ -274,24 +260,6 @@ export {};
  52 |     [presentNs.a]: 1,
     :      ^^^^^^^^^^^
  53 |     [Symbol.iterator]: 1,
-    `----
-
-  x TS9038: Computed property names on class or object literals cannot be
-  | inferred with --isolatedDeclarations.
-    ,-[declarationComputedPropertyNames.d.ts:53:6]
- 52 |     [presentNs.a]: 1,
- 53 |     [Symbol.iterator]: 1,
-    :      ^^^^^^^^^^^^^^^
- 54 |     [globalThis.Symbol.toStringTag]: 1,
-    `----
-
-  x TS9038: Computed property names on class or object literals cannot be
-  | inferred with --isolatedDeclarations.
-    ,-[declarationComputedPropertyNames.d.ts:54:6]
- 53 |     [Symbol.iterator]: 1,
- 54 |     [globalThis.Symbol.toStringTag]: 1,
-    :      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- 55 |     [(globalThis.Symbol).unscopables]: 1,
     `----
 
   x TS9038: Computed property names on class or object literals cannot be


### PR DESCRIPTION
close: #8469

No support to report errors for non-global `Symbol` yet, it is hard for the current architecture.