### PR TITLE
fix(isolated-declarations): import statement disappears when import binding is referenced in nested `typeof`

### DIFF
--- a/crates/oxc_isolated_declarations/src/scope.rs
+++ b/crates/oxc_isolated_declarations/src/scope.rs
@@ -110,10 +110,16 @@ impl<'a> Visit<'a> for ScopeTree<'a> {
         }
     }
 
+    // `typeof Value` or `typeof Value<Parameters>`
     fn visit_ts_type_query(&mut self, ty: &TSTypeQuery<'a>) {
         if let Some(type_name) = ty.expr_name.as_ts_type_name() {
             let ident = TSTypeName::get_identifier_reference(type_name);
             self.add_reference(ident.name.clone(), KindFlags::Value);
+            // `typeof Type<Parameters>`
+            //              ^^^^^^^^^^^
+            if let Some(type_parameters) = &ty.type_parameters {
+                self.visit_ts_type_parameter_instantiation(type_parameters);
+            }
         } else {
             walk_ts_type_query(self, ty);
         }

--- a/crates/oxc_isolated_declarations/tests/fixtures/typeof.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/typeof.ts
@@ -1,0 +1,4 @@
+import { ModA } from 'mod';
+import { Variable } from 'constant';
+
+export const Export: typeof ModA<typeof Variable> = 0;

--- a/crates/oxc_isolated_declarations/tests/snapshots/typeof.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/typeof.snap
@@ -1,0 +1,10 @@
+---
+source: crates/oxc_isolated_declarations/tests/mod.rs
+input_file: crates/oxc_isolated_declarations/tests/fixtures/typeof.ts
+---
+```
+==================== .D.TS ====================
+
+import { ModA } from "mod";
+import { Variable } from "constant";
+export declare const Export: typeof ModA<typeof Variable>;


### PR DESCRIPTION
close: #8474

