### PR TITLE
feat(span): add `Atom::r#static`

### DIFF
--- a/crates/oxc_span/src/atom.rs
+++ b/crates/oxc_span/src/atom.rs
@@ -20,10 +20,16 @@ use crate::{cmp::ContentEq, hash::ContentHash, CompactStr};
 pub struct Atom<'a>(&'a str);
 
 impl Atom<'static> {
+    /// Get an [`Atom`] containing a static string.
+    #[inline]
+    pub const fn r#static(s: &'static str) -> Self {
+        Atom(s)
+    }
+
     /// Get an [`Atom`] containing the empty string (`""`).
     #[inline]
     pub const fn empty() -> Self {
-        Atom("")
+        Self::r#static("")
     }
 }
 


### PR DESCRIPTION
This allows

```rs
const TYPEOF_UNDEFINED: Atom<'static> = Atom::r#static("undefined");

#[derive(Clone, Copy)]
enum Value<'a> {
  /// Not `Atom<'a>`, which takes one more byte
  StringLiteral(&'a Atom<'a>),
  // ...
}

fn get_typeof<'a>(value: Value<'a>) -> Value<'a> {
  if ... {
    return Value::StringLiteral(&TYPEOF_UNDEFINED);
  }
}
```
