### PR TITLE
refactor(span): rename `Atom::new_const` method

### DIFF
--- a/crates/oxc_span/src/atom.rs
+++ b/crates/oxc_span/src/atom.rs
@@ -22,14 +22,14 @@ pub struct Atom<'a>(&'a str);
 impl Atom<'static> {
     /// Get an [`Atom`] containing a static string.
     #[inline]
-    pub const fn r#static(s: &'static str) -> Self {
+    pub const fn new_const(s: &'static str) -> Self {
         Atom(s)
     }
 
     /// Get an [`Atom`] containing the empty string (`""`).
     #[inline]
     pub const fn empty() -> Self {
-        Self::r#static("")
+        Self::new_const("")
     }
 }
 


### PR DESCRIPTION
#8479 introduced `Atom::r#static` method. Rename it to `Atom::new_const`, to match `CompactStr::new_const` which does the same thing.