### PR TITLE
test(transformer): handle more exec tests

### DIFF
--- a/tasks/transform_conformance/snapshots/babel_exec.snap.md
+++ b/tasks/transform_conformance/snapshots/babel_exec.snap.md
@@ -2,7 +2,7 @@ commit: 54a8389f
 
 node: v22.12.0
 
-Passed: 291 of 374 (77.81%)
+Passed: 318 of 406 (78.33%)
 
 Failures:
 
@@ -181,6 +181,11 @@ ReferenceError: _Foo_brand is not defined
     at new Foo (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-loose-assignment-exec.test.js:8:38)
     at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-loose-assignment-exec.test.js:15:9
 
+./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-loose-async-exec.test.js
+ReferenceError: _Cl_brand is not defined
+    at new Cl (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-loose-async-exec.test.js:8:38)
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-loose-async-exec.test.js:17:9
+
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-loose-before-fields-exec.test.js
 ReferenceError: _Cl_brand is not defined
     at new Cl (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-loose-before-fields-exec.test.js:10:38)
@@ -220,6 +225,11 @@ ReferenceError: _Foo_brand is not defined
     at new Foo (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-privateFieldsAsProperties-assignment-exec.test.js:8:38)
     at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-privateFieldsAsProperties-assignment-exec.test.js:15:9
 
+./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-privateFieldsAsProperties-async-exec.test.js
+ReferenceError: _Cl_brand is not defined
+    at new Cl (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-privateFieldsAsProperties-async-exec.test.js:8:38)
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-privateFieldsAsProperties-async-exec.test.js:17:9
+
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-privateFieldsAsProperties-before-fields-exec.test.js
 ReferenceError: _Cl_brand is not defined
     at new Cl (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-privateFieldsAsProperties-before-fields-exec.test.js:11:38)
@@ -249,6 +259,11 @@ ReferenceError: _Cl_brand is not defined
 ReferenceError: _Sub_brand is not defined
     at new Sub (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-privateFieldsAsProperties-super-exec.test.js:16:38)
     at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-privateFieldsAsProperties-super-exec.test.js:29:9
+
+./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-privateFieldsAsSymbols-async-exec.test.js
+ReferenceError: _Cl_brand is not defined
+    at new Cl (./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-privateFieldsAsSymbols-async-exec.test.js:8:38)
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-method-privateFieldsAsSymbols-async-exec.test.js:17:9
 
 ./fixtures/babel/babel-plugin-transform-private-methods-test-fixtures-private-static-method-loose-basic-exec.test.js
 TypeError: attempted to use private field on non-instance
@@ -435,6 +450,14 @@ AssertionError: expected true to be false // Object.is equality
 ./fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-to-native-fields-static-shadow-exec.test.js
 AssertionError: expected 2 to be 5 // Object.is equality
     at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-private-property-in-object-test-fixtures-to-native-fields-static-shadow-exec.test.js:18:25
+
+./fixtures/babel/babel-plugin-transform-react-jsx-source-test-fixtures-react-source-basic-sample-exec.test.js
+ReferenceError: transformAsync is not defined
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-react-jsx-source-test-fixtures-react-source-basic-sample-exec.test.js:4:16
+
+./fixtures/babel/babel-plugin-transform-react-jsx-source-test-fixtures-react-source-with-source-exec.test.js
+ReferenceError: transformAsync is not defined
+    at ./tasks/transform_conformance/fixtures/babel/babel-plugin-transform-react-jsx-source-test-fixtures-react-source-with-source-exec.test.js:4:16
 
 ./fixtures/babel/babel-preset-env-test-fixtures-plugins-integration-issue-15170-exec.test.js
 AssertionError: expected [Function] to not throw an error but 'ReferenceError: x is not defined' was thrown

--- a/tasks/transform_conformance/src/driver.rs
+++ b/tasks/transform_conformance/src/driver.rs
@@ -4,6 +4,7 @@ use oxc::{
     ast::ast::Program,
     codegen::{CodegenOptions, CodegenReturn},
     diagnostics::OxcDiagnostic,
+    parser::ParseOptions,
     span::SourceType,
     transformer::{TransformOptions, TransformerReturn},
     CompilerInterface,
@@ -12,12 +13,20 @@ use oxc_tasks_transform_checker::check_semantic_after_transform;
 
 pub struct Driver {
     check_semantic: bool,
+    allow_return_outside_function: bool,
     options: TransformOptions,
     printed: String,
     errors: Vec<OxcDiagnostic>,
 }
 
 impl CompilerInterface for Driver {
+    fn parse_options(&self) -> ParseOptions {
+        ParseOptions {
+            allow_return_outside_function: self.allow_return_outside_function,
+            ..Default::default()
+        }
+    }
+
     fn transform_options(&self) -> Option<&TransformOptions> {
         Some(&self.options)
     }
@@ -61,8 +70,18 @@ impl CompilerInterface for Driver {
 }
 
 impl Driver {
-    pub fn new(check_semantic: bool, options: TransformOptions) -> Self {
-        Self { check_semantic, options, printed: String::new(), errors: vec![] }
+    pub fn new(
+        check_semantic: bool,
+        allow_return_outside_function: bool,
+        options: TransformOptions,
+    ) -> Self {
+        Self {
+            check_semantic,
+            allow_return_outside_function,
+            options,
+            printed: String::new(),
+            errors: vec![],
+        }
     }
 
     pub fn errors(&mut self) -> Vec<OxcDiagnostic> {


### PR DESCRIPTION
Some of Babel's exec tests contain a return statement at top level, in order to return a Promise.

e.g. https://github.com/babel/babel/blob/ad572fd1a1615f53c4e3b85941760bdb1a1aefd9/packages/babel-plugin-transform-private-methods/test/fixtures/private-method-loose/async/exec.js

These test files could not be parsed due to illegal position of `return`, and the tests were silently excluded.

This PR:

1. Includes those tests by passing `allow_return_outside_function: true` option to parser for exec tests.
2. Includes a "transform error" message in snapshot for any exec tests which produce errors in parser/transformer.
