### PR TITLE
fix(transformer/arrow-functions): visit arguments to `super()` call

### DIFF
--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 54a8389f
 
-Passed: 129/151
+Passed: 130/152
 
 # All Passed:
 * babel-plugin-transform-class-static-block

--- a/tasks/transform_conformance/snapshots/oxc_exec.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc_exec.snap.md
@@ -2,7 +2,7 @@ commit: 54a8389f
 
 node: v22.12.0
 
-Passed: 3 of 5 (60.00%)
+Passed: 4 of 6 (66.67%)
 
 Failures:
 

--- a/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/class/this-after-super-in-super/exec.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/class/this-after-super-in-super/exec.js
@@ -1,0 +1,16 @@
+let f;
+
+class S {}
+
+class C extends S {
+  constructor(x) {
+    super(super(), this.x = x, f = async () => this);
+  }
+}
+
+try { new C(123) } catch {}
+
+return f().then((c) => {
+  expect(c).toBeInstanceOf(C);
+  expect(c.x).toBe(123);
+});

--- a/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/class/this-after-super-in-super/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/class/this-after-super-in-super/input.js
@@ -1,0 +1,9 @@
+let f;
+
+class S {}
+
+class C extends S {
+  constructor(x) {
+    super(super(), this.x = x, f = async () => this);
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/class/this-after-super-in-super/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-async-to-generator/test/fixtures/class/this-after-super-in-super/output.js
@@ -1,0 +1,17 @@
+let f;
+
+class S {}
+
+class C extends S {
+  constructor(x) {
+    var _this;
+    super(
+      (super(), _this = this),
+      this.x = x,
+      f = babelHelpers.asyncToGenerator(function* () {
+        return _this;
+      })
+    );
+    _this = this;
+  }
+}


### PR DESCRIPTION
Follow-on after #8482.

Fix an edge case in arrow functions transform when inserting `_this = this` after `super()`. It is possible (though bizarre) for `super()` to contain another `super()` call. This will throw an error when evaluating the outer `super()`, but it can still be observable in some cases.

```js
let f;
class S {}
class C extends S {
  constructor(x) {
    super(super(), this.x = x, f = async () => this);
  }
}

try { new C(123) } catch {}

const c = await f();
assert(c.x === 123);
```

So, before bailing out from searching for more `super()`s in class constructor, visit the `super()` call's arguments.