### PR TITLE
refactor(traverse): harden soundness of `Traverse` and document safety invariants better

### DIFF
--- a/crates/oxc_traverse/scripts/lib/walk.mjs
+++ b/crates/oxc_traverse/scripts/lib/walk.mjs
@@ -42,9 +42,24 @@ export default function generateWalkFunctionsCode(types) {
 
     use crate::{ancestor::{self, AncestorType}, Ancestor, Traverse, TraverseCtx};
 
+    /// Walk AST with \`Traverse\` impl.
+    ///
+    /// SAFETY:
+    /// * \`program\` must be a pointer to a valid \`Program\` which has lifetime \`'a\`
+    ///   (\`Program<'a>\`).
+    /// * \`ctx\` must contain a \`TraverseAncestry<'a>\` with single \`Ancestor::None\` on its stack.
+    #[inline]
+    pub(crate) unsafe fn walk_ast<'a, Tr: Traverse<'a>>(
+      traverser: &mut Tr,
+      program: *mut Program<'a>,
+      ctx: &mut TraverseCtx<'a>,
+    ) {
+      walk_program(traverser, program, ctx);
+    }
+
     ${walkMethods}
 
-    pub(crate) unsafe fn walk_statements<'a, Tr: Traverse<'a>>(
+    unsafe fn walk_statements<'a, Tr: Traverse<'a>>(
       traverser: &mut Tr,
       stmts: *mut Vec<'a, Statement<'a>>,
       ctx: &mut TraverseCtx<'a>
@@ -254,7 +269,7 @@ function generateWalkForStruct(type, types) {
 
   const typeSnakeName = camelToSnake(type.name);
   return `
-    pub(crate) unsafe fn walk_${typeSnakeName}<'a, Tr: Traverse<'a>>(
+    unsafe fn walk_${typeSnakeName}<'a, Tr: Traverse<'a>>(
       traverser: &mut Tr,
       node: *mut ${type.rawName},
       ctx: &mut TraverseCtx<'a>
@@ -319,7 +334,7 @@ function generateWalkForEnum(type, types) {
 
   const typeSnakeName = camelToSnake(type.name);
   return `
-    pub(crate) unsafe fn walk_${typeSnakeName}<'a, Tr: Traverse<'a>>(
+    unsafe fn walk_${typeSnakeName}<'a, Tr: Traverse<'a>>(
       traverser: &mut Tr,
       node: *mut ${type.rawName},
       ctx: &mut TraverseCtx<'a>

--- a/crates/oxc_traverse/src/context/ancestry.rs
+++ b/crates/oxc_traverse/src/context/ancestry.rs
@@ -147,6 +147,7 @@ impl<'a> TraverseAncestry<'a> {
     /// # SAFETY
     /// This method must not be public outside this crate, or consumer could break safety invariants.
     #[inline]
+    #[must_use] // `PopToken` must be passed to `pop_stack` to pop this entry off the stack again
     pub(crate) fn push_stack(&mut self, ancestor: Ancestor<'a, 'static>) -> PopToken {
         self.stack.push(ancestor);
 

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -25,7 +25,22 @@ use crate::{
     Ancestor, Traverse, TraverseCtx,
 };
 
-pub(crate) unsafe fn walk_program<'a, Tr: Traverse<'a>>(
+/// Walk AST with `Traverse` impl.
+///
+/// SAFETY:
+/// * `program` must be a pointer to a valid `Program` which has lifetime `'a`
+///   (`Program<'a>`).
+/// * `ctx` must contain a `TraverseAncestry<'a>` with single `Ancestor::None` on its stack.
+#[inline]
+pub(crate) unsafe fn walk_ast<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    program: *mut Program<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    walk_program(traverser, program, ctx);
+}
+
+unsafe fn walk_program<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut Program<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -67,7 +82,7 @@ pub(crate) unsafe fn walk_program<'a, Tr: Traverse<'a>>(
     traverser.exit_program(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut Expression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -190,7 +205,7 @@ pub(crate) unsafe fn walk_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_identifier_name<'a, Tr: Traverse<'a>>(
+unsafe fn walk_identifier_name<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut IdentifierName<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -199,7 +214,7 @@ pub(crate) unsafe fn walk_identifier_name<'a, Tr: Traverse<'a>>(
     traverser.exit_identifier_name(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_identifier_reference<'a, Tr: Traverse<'a>>(
+unsafe fn walk_identifier_reference<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut IdentifierReference<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -208,7 +223,7 @@ pub(crate) unsafe fn walk_identifier_reference<'a, Tr: Traverse<'a>>(
     traverser.exit_identifier_reference(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_binding_identifier<'a, Tr: Traverse<'a>>(
+unsafe fn walk_binding_identifier<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut BindingIdentifier<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -217,7 +232,7 @@ pub(crate) unsafe fn walk_binding_identifier<'a, Tr: Traverse<'a>>(
     traverser.exit_binding_identifier(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_label_identifier<'a, Tr: Traverse<'a>>(
+unsafe fn walk_label_identifier<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut LabelIdentifier<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -226,7 +241,7 @@ pub(crate) unsafe fn walk_label_identifier<'a, Tr: Traverse<'a>>(
     traverser.exit_label_identifier(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_this_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_this_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ThisExpression,
     ctx: &mut TraverseCtx<'a>,
@@ -235,7 +250,7 @@ pub(crate) unsafe fn walk_this_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_this_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_array_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_array_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ArrayExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -253,7 +268,7 @@ pub(crate) unsafe fn walk_array_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_array_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_array_expression_element<'a, Tr: Traverse<'a>>(
+unsafe fn walk_array_expression_element<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ArrayExpressionElement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -312,7 +327,7 @@ pub(crate) unsafe fn walk_array_expression_element<'a, Tr: Traverse<'a>>(
     traverser.exit_array_expression_element(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_elision<'a, Tr: Traverse<'a>>(
+unsafe fn walk_elision<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut Elision,
     ctx: &mut TraverseCtx<'a>,
@@ -321,7 +336,7 @@ pub(crate) unsafe fn walk_elision<'a, Tr: Traverse<'a>>(
     traverser.exit_elision(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_object_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_object_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ObjectExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -339,7 +354,7 @@ pub(crate) unsafe fn walk_object_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_object_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_object_property_kind<'a, Tr: Traverse<'a>>(
+unsafe fn walk_object_property_kind<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ObjectPropertyKind<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -356,7 +371,7 @@ pub(crate) unsafe fn walk_object_property_kind<'a, Tr: Traverse<'a>>(
     traverser.exit_object_property_kind(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_object_property<'a, Tr: Traverse<'a>>(
+unsafe fn walk_object_property<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ObjectProperty<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -380,7 +395,7 @@ pub(crate) unsafe fn walk_object_property<'a, Tr: Traverse<'a>>(
     traverser.exit_object_property(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_property_key<'a, Tr: Traverse<'a>>(
+unsafe fn walk_property_key<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut PropertyKey<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -439,7 +454,7 @@ pub(crate) unsafe fn walk_property_key<'a, Tr: Traverse<'a>>(
     traverser.exit_property_key(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_template_literal<'a, Tr: Traverse<'a>>(
+unsafe fn walk_template_literal<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TemplateLiteral<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -463,7 +478,7 @@ pub(crate) unsafe fn walk_template_literal<'a, Tr: Traverse<'a>>(
     traverser.exit_template_literal(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_tagged_template_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_tagged_template_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TaggedTemplateExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -495,7 +510,7 @@ pub(crate) unsafe fn walk_tagged_template_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_tagged_template_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_template_element<'a, Tr: Traverse<'a>>(
+unsafe fn walk_template_element<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TemplateElement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -504,7 +519,7 @@ pub(crate) unsafe fn walk_template_element<'a, Tr: Traverse<'a>>(
     traverser.exit_template_element(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_member_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_member_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut MemberExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -524,7 +539,7 @@ pub(crate) unsafe fn walk_member_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_member_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_computed_member_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_computed_member_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ComputedMemberExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -550,7 +565,7 @@ pub(crate) unsafe fn walk_computed_member_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_computed_member_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_static_member_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_static_member_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut StaticMemberExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -575,7 +590,7 @@ pub(crate) unsafe fn walk_static_member_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_static_member_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_private_field_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_private_field_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut PrivateFieldExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -600,7 +615,7 @@ pub(crate) unsafe fn walk_private_field_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_private_field_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_call_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_call_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut CallExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -631,7 +646,7 @@ pub(crate) unsafe fn walk_call_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_call_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_new_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_new_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut NewExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -662,7 +677,7 @@ pub(crate) unsafe fn walk_new_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_new_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_meta_property<'a, Tr: Traverse<'a>>(
+unsafe fn walk_meta_property<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut MetaProperty<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -687,7 +702,7 @@ pub(crate) unsafe fn walk_meta_property<'a, Tr: Traverse<'a>>(
     traverser.exit_meta_property(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_spread_element<'a, Tr: Traverse<'a>>(
+unsafe fn walk_spread_element<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut SpreadElement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -705,7 +720,7 @@ pub(crate) unsafe fn walk_spread_element<'a, Tr: Traverse<'a>>(
     traverser.exit_spread_element(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_argument<'a, Tr: Traverse<'a>>(
+unsafe fn walk_argument<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut Argument<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -761,7 +776,7 @@ pub(crate) unsafe fn walk_argument<'a, Tr: Traverse<'a>>(
     traverser.exit_argument(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_update_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_update_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut UpdateExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -780,7 +795,7 @@ pub(crate) unsafe fn walk_update_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_update_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_unary_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_unary_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut UnaryExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -798,7 +813,7 @@ pub(crate) unsafe fn walk_unary_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_unary_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_binary_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_binary_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut BinaryExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -822,7 +837,7 @@ pub(crate) unsafe fn walk_binary_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_binary_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_private_in_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_private_in_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut PrivateInExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -847,7 +862,7 @@ pub(crate) unsafe fn walk_private_in_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_private_in_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_logical_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_logical_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut LogicalExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -871,7 +886,7 @@ pub(crate) unsafe fn walk_logical_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_logical_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_conditional_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_conditional_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ConditionalExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -902,7 +917,7 @@ pub(crate) unsafe fn walk_conditional_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_conditional_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_assignment_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_assignment_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut AssignmentExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -926,7 +941,7 @@ pub(crate) unsafe fn walk_assignment_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_assignment_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_assignment_target<'a, Tr: Traverse<'a>>(
+unsafe fn walk_assignment_target<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut AssignmentTarget<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -952,7 +967,7 @@ pub(crate) unsafe fn walk_assignment_target<'a, Tr: Traverse<'a>>(
     traverser.exit_assignment_target(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_simple_assignment_target<'a, Tr: Traverse<'a>>(
+unsafe fn walk_simple_assignment_target<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut SimpleAssignmentTarget<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -986,7 +1001,7 @@ pub(crate) unsafe fn walk_simple_assignment_target<'a, Tr: Traverse<'a>>(
     traverser.exit_simple_assignment_target(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_assignment_target_pattern<'a, Tr: Traverse<'a>>(
+unsafe fn walk_assignment_target_pattern<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut AssignmentTargetPattern<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1003,7 +1018,7 @@ pub(crate) unsafe fn walk_assignment_target_pattern<'a, Tr: Traverse<'a>>(
     traverser.exit_assignment_target_pattern(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_array_assignment_target<'a, Tr: Traverse<'a>>(
+unsafe fn walk_array_assignment_target<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ArrayAssignmentTarget<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1029,7 +1044,7 @@ pub(crate) unsafe fn walk_array_assignment_target<'a, Tr: Traverse<'a>>(
     traverser.exit_array_assignment_target(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_object_assignment_target<'a, Tr: Traverse<'a>>(
+unsafe fn walk_object_assignment_target<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ObjectAssignmentTarget<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1054,7 +1069,7 @@ pub(crate) unsafe fn walk_object_assignment_target<'a, Tr: Traverse<'a>>(
     traverser.exit_object_assignment_target(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_assignment_target_rest<'a, Tr: Traverse<'a>>(
+unsafe fn walk_assignment_target_rest<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut AssignmentTargetRest<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1073,7 +1088,7 @@ pub(crate) unsafe fn walk_assignment_target_rest<'a, Tr: Traverse<'a>>(
     traverser.exit_assignment_target_rest(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_assignment_target_maybe_default<'a, Tr: Traverse<'a>>(
+unsafe fn walk_assignment_target_maybe_default<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut AssignmentTargetMaybeDefault<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1100,7 +1115,7 @@ pub(crate) unsafe fn walk_assignment_target_maybe_default<'a, Tr: Traverse<'a>>(
     traverser.exit_assignment_target_maybe_default(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_assignment_target_with_default<'a, Tr: Traverse<'a>>(
+unsafe fn walk_assignment_target_with_default<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut AssignmentTargetWithDefault<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1126,7 +1141,7 @@ pub(crate) unsafe fn walk_assignment_target_with_default<'a, Tr: Traverse<'a>>(
     traverser.exit_assignment_target_with_default(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_assignment_target_property<'a, Tr: Traverse<'a>>(
+unsafe fn walk_assignment_target_property<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut AssignmentTargetProperty<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1143,7 +1158,7 @@ pub(crate) unsafe fn walk_assignment_target_property<'a, Tr: Traverse<'a>>(
     traverser.exit_assignment_target_property(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_assignment_target_property_identifier<'a, Tr: Traverse<'a>>(
+unsafe fn walk_assignment_target_property_identifier<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut AssignmentTargetPropertyIdentifier<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1169,7 +1184,7 @@ pub(crate) unsafe fn walk_assignment_target_property_identifier<'a, Tr: Traverse
     traverser.exit_assignment_target_property_identifier(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_assignment_target_property_property<'a, Tr: Traverse<'a>>(
+unsafe fn walk_assignment_target_property_property<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut AssignmentTargetPropertyProperty<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1195,7 +1210,7 @@ pub(crate) unsafe fn walk_assignment_target_property_property<'a, Tr: Traverse<'
     traverser.exit_assignment_target_property_property(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_sequence_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_sequence_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut SequenceExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1213,7 +1228,7 @@ pub(crate) unsafe fn walk_sequence_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_sequence_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_super<'a, Tr: Traverse<'a>>(
+unsafe fn walk_super<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut Super,
     ctx: &mut TraverseCtx<'a>,
@@ -1222,7 +1237,7 @@ pub(crate) unsafe fn walk_super<'a, Tr: Traverse<'a>>(
     traverser.exit_super(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_await_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_await_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut AwaitExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1240,7 +1255,7 @@ pub(crate) unsafe fn walk_await_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_await_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_chain_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_chain_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ChainExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1258,7 +1273,7 @@ pub(crate) unsafe fn walk_chain_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_chain_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_chain_element<'a, Tr: Traverse<'a>>(
+unsafe fn walk_chain_element<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ChainElement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1280,7 +1295,7 @@ pub(crate) unsafe fn walk_chain_element<'a, Tr: Traverse<'a>>(
     traverser.exit_chain_element(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_parenthesized_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_parenthesized_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ParenthesizedExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1299,7 +1314,7 @@ pub(crate) unsafe fn walk_parenthesized_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_parenthesized_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_statement<'a, Tr: Traverse<'a>>(
+unsafe fn walk_statement<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut Statement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1380,7 +1395,7 @@ pub(crate) unsafe fn walk_statement<'a, Tr: Traverse<'a>>(
     traverser.exit_statement(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_directive<'a, Tr: Traverse<'a>>(
+unsafe fn walk_directive<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut Directive<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1398,7 +1413,7 @@ pub(crate) unsafe fn walk_directive<'a, Tr: Traverse<'a>>(
     traverser.exit_directive(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_hashbang<'a, Tr: Traverse<'a>>(
+unsafe fn walk_hashbang<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut Hashbang<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1407,7 +1422,7 @@ pub(crate) unsafe fn walk_hashbang<'a, Tr: Traverse<'a>>(
     traverser.exit_hashbang(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_block_statement<'a, Tr: Traverse<'a>>(
+unsafe fn walk_block_statement<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut BlockStatement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1435,7 +1450,7 @@ pub(crate) unsafe fn walk_block_statement<'a, Tr: Traverse<'a>>(
     traverser.exit_block_statement(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_declaration<'a, Tr: Traverse<'a>>(
+unsafe fn walk_declaration<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut Declaration<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1468,7 +1483,7 @@ pub(crate) unsafe fn walk_declaration<'a, Tr: Traverse<'a>>(
     traverser.exit_declaration(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_variable_declaration<'a, Tr: Traverse<'a>>(
+unsafe fn walk_variable_declaration<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut VariableDeclaration<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1486,7 +1501,7 @@ pub(crate) unsafe fn walk_variable_declaration<'a, Tr: Traverse<'a>>(
     traverser.exit_variable_declaration(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_variable_declarator<'a, Tr: Traverse<'a>>(
+unsafe fn walk_variable_declarator<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut VariableDeclarator<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1510,7 +1525,7 @@ pub(crate) unsafe fn walk_variable_declarator<'a, Tr: Traverse<'a>>(
     traverser.exit_variable_declarator(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_empty_statement<'a, Tr: Traverse<'a>>(
+unsafe fn walk_empty_statement<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut EmptyStatement,
     ctx: &mut TraverseCtx<'a>,
@@ -1519,7 +1534,7 @@ pub(crate) unsafe fn walk_empty_statement<'a, Tr: Traverse<'a>>(
     traverser.exit_empty_statement(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_expression_statement<'a, Tr: Traverse<'a>>(
+unsafe fn walk_expression_statement<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ExpressionStatement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1537,7 +1552,7 @@ pub(crate) unsafe fn walk_expression_statement<'a, Tr: Traverse<'a>>(
     traverser.exit_expression_statement(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_if_statement<'a, Tr: Traverse<'a>>(
+unsafe fn walk_if_statement<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut IfStatement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1566,7 +1581,7 @@ pub(crate) unsafe fn walk_if_statement<'a, Tr: Traverse<'a>>(
     traverser.exit_if_statement(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_do_while_statement<'a, Tr: Traverse<'a>>(
+unsafe fn walk_do_while_statement<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut DoWhileStatement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1590,7 +1605,7 @@ pub(crate) unsafe fn walk_do_while_statement<'a, Tr: Traverse<'a>>(
     traverser.exit_do_while_statement(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_while_statement<'a, Tr: Traverse<'a>>(
+unsafe fn walk_while_statement<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut WhileStatement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1614,7 +1629,7 @@ pub(crate) unsafe fn walk_while_statement<'a, Tr: Traverse<'a>>(
     traverser.exit_while_statement(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_for_statement<'a, Tr: Traverse<'a>>(
+unsafe fn walk_for_statement<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ForStatement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1658,7 +1673,7 @@ pub(crate) unsafe fn walk_for_statement<'a, Tr: Traverse<'a>>(
     traverser.exit_for_statement(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_for_statement_init<'a, Tr: Traverse<'a>>(
+unsafe fn walk_for_statement_init<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ForStatementInit<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1716,7 +1731,7 @@ pub(crate) unsafe fn walk_for_statement_init<'a, Tr: Traverse<'a>>(
     traverser.exit_for_statement_init(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_for_in_statement<'a, Tr: Traverse<'a>>(
+unsafe fn walk_for_in_statement<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ForInStatement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1753,7 +1768,7 @@ pub(crate) unsafe fn walk_for_in_statement<'a, Tr: Traverse<'a>>(
     traverser.exit_for_in_statement(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_for_statement_left<'a, Tr: Traverse<'a>>(
+unsafe fn walk_for_statement_left<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ForStatementLeft<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1780,7 +1795,7 @@ pub(crate) unsafe fn walk_for_statement_left<'a, Tr: Traverse<'a>>(
     traverser.exit_for_statement_left(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_for_of_statement<'a, Tr: Traverse<'a>>(
+unsafe fn walk_for_of_statement<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ForOfStatement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1817,7 +1832,7 @@ pub(crate) unsafe fn walk_for_of_statement<'a, Tr: Traverse<'a>>(
     traverser.exit_for_of_statement(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_continue_statement<'a, Tr: Traverse<'a>>(
+unsafe fn walk_continue_statement<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ContinueStatement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1835,7 +1850,7 @@ pub(crate) unsafe fn walk_continue_statement<'a, Tr: Traverse<'a>>(
     traverser.exit_continue_statement(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_break_statement<'a, Tr: Traverse<'a>>(
+unsafe fn walk_break_statement<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut BreakStatement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1853,7 +1868,7 @@ pub(crate) unsafe fn walk_break_statement<'a, Tr: Traverse<'a>>(
     traverser.exit_break_statement(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_return_statement<'a, Tr: Traverse<'a>>(
+unsafe fn walk_return_statement<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ReturnStatement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1871,7 +1886,7 @@ pub(crate) unsafe fn walk_return_statement<'a, Tr: Traverse<'a>>(
     traverser.exit_return_statement(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_with_statement<'a, Tr: Traverse<'a>>(
+unsafe fn walk_with_statement<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut WithStatement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1895,7 +1910,7 @@ pub(crate) unsafe fn walk_with_statement<'a, Tr: Traverse<'a>>(
     traverser.exit_with_statement(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_switch_statement<'a, Tr: Traverse<'a>>(
+unsafe fn walk_switch_statement<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut SwitchStatement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1926,7 +1941,7 @@ pub(crate) unsafe fn walk_switch_statement<'a, Tr: Traverse<'a>>(
     traverser.exit_switch_statement(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_switch_case<'a, Tr: Traverse<'a>>(
+unsafe fn walk_switch_case<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut SwitchCase<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1949,7 +1964,7 @@ pub(crate) unsafe fn walk_switch_case<'a, Tr: Traverse<'a>>(
     traverser.exit_switch_case(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_labeled_statement<'a, Tr: Traverse<'a>>(
+unsafe fn walk_labeled_statement<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut LabeledStatement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1973,7 +1988,7 @@ pub(crate) unsafe fn walk_labeled_statement<'a, Tr: Traverse<'a>>(
     traverser.exit_labeled_statement(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_throw_statement<'a, Tr: Traverse<'a>>(
+unsafe fn walk_throw_statement<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ThrowStatement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -1991,7 +2006,7 @@ pub(crate) unsafe fn walk_throw_statement<'a, Tr: Traverse<'a>>(
     traverser.exit_throw_statement(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_try_statement<'a, Tr: Traverse<'a>>(
+unsafe fn walk_try_statement<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TryStatement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2022,7 +2037,7 @@ pub(crate) unsafe fn walk_try_statement<'a, Tr: Traverse<'a>>(
     traverser.exit_try_statement(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_catch_clause<'a, Tr: Traverse<'a>>(
+unsafe fn walk_catch_clause<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut CatchClause<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2055,7 +2070,7 @@ pub(crate) unsafe fn walk_catch_clause<'a, Tr: Traverse<'a>>(
     traverser.exit_catch_clause(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_catch_parameter<'a, Tr: Traverse<'a>>(
+unsafe fn walk_catch_parameter<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut CatchParameter<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2073,7 +2088,7 @@ pub(crate) unsafe fn walk_catch_parameter<'a, Tr: Traverse<'a>>(
     traverser.exit_catch_parameter(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_debugger_statement<'a, Tr: Traverse<'a>>(
+unsafe fn walk_debugger_statement<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut DebuggerStatement,
     ctx: &mut TraverseCtx<'a>,
@@ -2082,7 +2097,7 @@ pub(crate) unsafe fn walk_debugger_statement<'a, Tr: Traverse<'a>>(
     traverser.exit_debugger_statement(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_binding_pattern<'a, Tr: Traverse<'a>>(
+unsafe fn walk_binding_pattern<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut BindingPattern<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2107,7 +2122,7 @@ pub(crate) unsafe fn walk_binding_pattern<'a, Tr: Traverse<'a>>(
     traverser.exit_binding_pattern(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_binding_pattern_kind<'a, Tr: Traverse<'a>>(
+unsafe fn walk_binding_pattern_kind<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut BindingPatternKind<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2130,7 +2145,7 @@ pub(crate) unsafe fn walk_binding_pattern_kind<'a, Tr: Traverse<'a>>(
     traverser.exit_binding_pattern_kind(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_assignment_pattern<'a, Tr: Traverse<'a>>(
+unsafe fn walk_assignment_pattern<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut AssignmentPattern<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2154,7 +2169,7 @@ pub(crate) unsafe fn walk_assignment_pattern<'a, Tr: Traverse<'a>>(
     traverser.exit_assignment_pattern(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_object_pattern<'a, Tr: Traverse<'a>>(
+unsafe fn walk_object_pattern<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ObjectPattern<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2178,7 +2193,7 @@ pub(crate) unsafe fn walk_object_pattern<'a, Tr: Traverse<'a>>(
     traverser.exit_object_pattern(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_binding_property<'a, Tr: Traverse<'a>>(
+unsafe fn walk_binding_property<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut BindingProperty<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2202,7 +2217,7 @@ pub(crate) unsafe fn walk_binding_property<'a, Tr: Traverse<'a>>(
     traverser.exit_binding_property(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_array_pattern<'a, Tr: Traverse<'a>>(
+unsafe fn walk_array_pattern<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ArrayPattern<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2228,7 +2243,7 @@ pub(crate) unsafe fn walk_array_pattern<'a, Tr: Traverse<'a>>(
     traverser.exit_array_pattern(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_binding_rest_element<'a, Tr: Traverse<'a>>(
+unsafe fn walk_binding_rest_element<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut BindingRestElement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2247,7 +2262,7 @@ pub(crate) unsafe fn walk_binding_rest_element<'a, Tr: Traverse<'a>>(
     traverser.exit_binding_rest_element(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_function<'a, Tr: Traverse<'a>>(
+unsafe fn walk_function<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut Function<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2308,7 +2323,7 @@ pub(crate) unsafe fn walk_function<'a, Tr: Traverse<'a>>(
     traverser.exit_function(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_formal_parameters<'a, Tr: Traverse<'a>>(
+unsafe fn walk_formal_parameters<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut FormalParameters<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2332,7 +2347,7 @@ pub(crate) unsafe fn walk_formal_parameters<'a, Tr: Traverse<'a>>(
     traverser.exit_formal_parameters(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_formal_parameter<'a, Tr: Traverse<'a>>(
+unsafe fn walk_formal_parameter<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut FormalParameter<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2356,7 +2371,7 @@ pub(crate) unsafe fn walk_formal_parameter<'a, Tr: Traverse<'a>>(
     traverser.exit_formal_parameter(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_function_body<'a, Tr: Traverse<'a>>(
+unsafe fn walk_function_body<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut FunctionBody<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2380,7 +2395,7 @@ pub(crate) unsafe fn walk_function_body<'a, Tr: Traverse<'a>>(
     traverser.exit_function_body(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_arrow_function_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_arrow_function_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ArrowFunctionExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2434,7 +2449,7 @@ pub(crate) unsafe fn walk_arrow_function_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_arrow_function_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_yield_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_yield_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut YieldExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2452,7 +2467,7 @@ pub(crate) unsafe fn walk_yield_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_yield_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_class<'a, Tr: Traverse<'a>>(
+unsafe fn walk_class<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut Class<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2515,7 +2530,7 @@ pub(crate) unsafe fn walk_class<'a, Tr: Traverse<'a>>(
     traverser.exit_class(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_class_body<'a, Tr: Traverse<'a>>(
+unsafe fn walk_class_body<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ClassBody<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2532,7 +2547,7 @@ pub(crate) unsafe fn walk_class_body<'a, Tr: Traverse<'a>>(
     traverser.exit_class_body(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_class_element<'a, Tr: Traverse<'a>>(
+unsafe fn walk_class_element<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ClassElement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2558,7 +2573,7 @@ pub(crate) unsafe fn walk_class_element<'a, Tr: Traverse<'a>>(
     traverser.exit_class_element(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_method_definition<'a, Tr: Traverse<'a>>(
+unsafe fn walk_method_definition<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut MethodDefinition<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2589,7 +2604,7 @@ pub(crate) unsafe fn walk_method_definition<'a, Tr: Traverse<'a>>(
     traverser.exit_method_definition(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_property_definition<'a, Tr: Traverse<'a>>(
+unsafe fn walk_property_definition<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut PropertyDefinition<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2626,7 +2641,7 @@ pub(crate) unsafe fn walk_property_definition<'a, Tr: Traverse<'a>>(
     traverser.exit_property_definition(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_private_identifier<'a, Tr: Traverse<'a>>(
+unsafe fn walk_private_identifier<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut PrivateIdentifier<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2635,7 +2650,7 @@ pub(crate) unsafe fn walk_private_identifier<'a, Tr: Traverse<'a>>(
     traverser.exit_private_identifier(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_static_block<'a, Tr: Traverse<'a>>(
+unsafe fn walk_static_block<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut StaticBlock<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2665,7 +2680,7 @@ pub(crate) unsafe fn walk_static_block<'a, Tr: Traverse<'a>>(
     traverser.exit_static_block(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_module_declaration<'a, Tr: Traverse<'a>>(
+unsafe fn walk_module_declaration<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ModuleDeclaration<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2694,7 +2709,7 @@ pub(crate) unsafe fn walk_module_declaration<'a, Tr: Traverse<'a>>(
     traverser.exit_module_declaration(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_accessor_property<'a, Tr: Traverse<'a>>(
+unsafe fn walk_accessor_property<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut AccessorProperty<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2731,7 +2746,7 @@ pub(crate) unsafe fn walk_accessor_property<'a, Tr: Traverse<'a>>(
     traverser.exit_accessor_property(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_import_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_import_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ImportExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2755,7 +2770,7 @@ pub(crate) unsafe fn walk_import_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_import_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_import_declaration<'a, Tr: Traverse<'a>>(
+unsafe fn walk_import_declaration<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ImportDeclaration<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2789,7 +2804,7 @@ pub(crate) unsafe fn walk_import_declaration<'a, Tr: Traverse<'a>>(
     traverser.exit_import_declaration(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_import_declaration_specifier<'a, Tr: Traverse<'a>>(
+unsafe fn walk_import_declaration_specifier<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ImportDeclarationSpecifier<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2809,7 +2824,7 @@ pub(crate) unsafe fn walk_import_declaration_specifier<'a, Tr: Traverse<'a>>(
     traverser.exit_import_declaration_specifier(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_import_specifier<'a, Tr: Traverse<'a>>(
+unsafe fn walk_import_specifier<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ImportSpecifier<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2833,7 +2848,7 @@ pub(crate) unsafe fn walk_import_specifier<'a, Tr: Traverse<'a>>(
     traverser.exit_import_specifier(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_import_default_specifier<'a, Tr: Traverse<'a>>(
+unsafe fn walk_import_default_specifier<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ImportDefaultSpecifier<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2852,7 +2867,7 @@ pub(crate) unsafe fn walk_import_default_specifier<'a, Tr: Traverse<'a>>(
     traverser.exit_import_default_specifier(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_import_namespace_specifier<'a, Tr: Traverse<'a>>(
+unsafe fn walk_import_namespace_specifier<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ImportNamespaceSpecifier<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2871,7 +2886,7 @@ pub(crate) unsafe fn walk_import_namespace_specifier<'a, Tr: Traverse<'a>>(
     traverser.exit_import_namespace_specifier(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_with_clause<'a, Tr: Traverse<'a>>(
+unsafe fn walk_with_clause<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut WithClause<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2896,7 +2911,7 @@ pub(crate) unsafe fn walk_with_clause<'a, Tr: Traverse<'a>>(
     traverser.exit_with_clause(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_import_attribute<'a, Tr: Traverse<'a>>(
+unsafe fn walk_import_attribute<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ImportAttribute<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2920,7 +2935,7 @@ pub(crate) unsafe fn walk_import_attribute<'a, Tr: Traverse<'a>>(
     traverser.exit_import_attribute(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_import_attribute_key<'a, Tr: Traverse<'a>>(
+unsafe fn walk_import_attribute_key<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ImportAttributeKey<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2937,7 +2952,7 @@ pub(crate) unsafe fn walk_import_attribute_key<'a, Tr: Traverse<'a>>(
     traverser.exit_import_attribute_key(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_export_named_declaration<'a, Tr: Traverse<'a>>(
+unsafe fn walk_export_named_declaration<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ExportNamedDeclaration<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -2976,7 +2991,7 @@ pub(crate) unsafe fn walk_export_named_declaration<'a, Tr: Traverse<'a>>(
     traverser.exit_export_named_declaration(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_export_default_declaration<'a, Tr: Traverse<'a>>(
+unsafe fn walk_export_default_declaration<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ExportDefaultDeclaration<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3002,7 +3017,7 @@ pub(crate) unsafe fn walk_export_default_declaration<'a, Tr: Traverse<'a>>(
     traverser.exit_export_default_declaration(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_export_all_declaration<'a, Tr: Traverse<'a>>(
+unsafe fn walk_export_all_declaration<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ExportAllDeclaration<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3034,7 +3049,7 @@ pub(crate) unsafe fn walk_export_all_declaration<'a, Tr: Traverse<'a>>(
     traverser.exit_export_all_declaration(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_export_specifier<'a, Tr: Traverse<'a>>(
+unsafe fn walk_export_specifier<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ExportSpecifier<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3058,7 +3073,7 @@ pub(crate) unsafe fn walk_export_specifier<'a, Tr: Traverse<'a>>(
     traverser.exit_export_specifier(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_export_default_declaration_kind<'a, Tr: Traverse<'a>>(
+unsafe fn walk_export_default_declaration_kind<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ExportDefaultDeclarationKind<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3122,7 +3137,7 @@ pub(crate) unsafe fn walk_export_default_declaration_kind<'a, Tr: Traverse<'a>>(
     traverser.exit_export_default_declaration_kind(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_module_export_name<'a, Tr: Traverse<'a>>(
+unsafe fn walk_module_export_name<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut ModuleExportName<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3142,7 +3157,7 @@ pub(crate) unsafe fn walk_module_export_name<'a, Tr: Traverse<'a>>(
     traverser.exit_module_export_name(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_jsx_element<'a, Tr: Traverse<'a>>(
+unsafe fn walk_jsx_element<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut JSXElement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3173,7 +3188,7 @@ pub(crate) unsafe fn walk_jsx_element<'a, Tr: Traverse<'a>>(
     traverser.exit_jsx_element(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_jsx_opening_element<'a, Tr: Traverse<'a>>(
+unsafe fn walk_jsx_opening_element<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut JSXOpeningElement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3204,7 +3219,7 @@ pub(crate) unsafe fn walk_jsx_opening_element<'a, Tr: Traverse<'a>>(
     traverser.exit_jsx_opening_element(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_jsx_closing_element<'a, Tr: Traverse<'a>>(
+unsafe fn walk_jsx_closing_element<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut JSXClosingElement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3222,7 +3237,7 @@ pub(crate) unsafe fn walk_jsx_closing_element<'a, Tr: Traverse<'a>>(
     traverser.exit_jsx_closing_element(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_jsx_fragment<'a, Tr: Traverse<'a>>(
+unsafe fn walk_jsx_fragment<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut JSXFragment<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3240,7 +3255,7 @@ pub(crate) unsafe fn walk_jsx_fragment<'a, Tr: Traverse<'a>>(
     traverser.exit_jsx_fragment(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_jsx_element_name<'a, Tr: Traverse<'a>>(
+unsafe fn walk_jsx_element_name<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut JSXElementName<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3266,7 +3281,7 @@ pub(crate) unsafe fn walk_jsx_element_name<'a, Tr: Traverse<'a>>(
     traverser.exit_jsx_element_name(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_jsx_namespaced_name<'a, Tr: Traverse<'a>>(
+unsafe fn walk_jsx_namespaced_name<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut JSXNamespacedName<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3290,7 +3305,7 @@ pub(crate) unsafe fn walk_jsx_namespaced_name<'a, Tr: Traverse<'a>>(
     traverser.exit_jsx_namespaced_name(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_jsx_member_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_jsx_member_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut JSXMemberExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3316,7 +3331,7 @@ pub(crate) unsafe fn walk_jsx_member_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_jsx_member_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_jsx_member_expression_object<'a, Tr: Traverse<'a>>(
+unsafe fn walk_jsx_member_expression_object<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut JSXMemberExpressionObject<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3336,7 +3351,7 @@ pub(crate) unsafe fn walk_jsx_member_expression_object<'a, Tr: Traverse<'a>>(
     traverser.exit_jsx_member_expression_object(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_jsx_expression_container<'a, Tr: Traverse<'a>>(
+unsafe fn walk_jsx_expression_container<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut JSXExpressionContainer<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3355,7 +3370,7 @@ pub(crate) unsafe fn walk_jsx_expression_container<'a, Tr: Traverse<'a>>(
     traverser.exit_jsx_expression_container(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_jsx_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_jsx_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut JSXExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3413,7 +3428,7 @@ pub(crate) unsafe fn walk_jsx_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_jsx_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_jsx_empty_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_jsx_empty_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut JSXEmptyExpression,
     ctx: &mut TraverseCtx<'a>,
@@ -3422,7 +3437,7 @@ pub(crate) unsafe fn walk_jsx_empty_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_jsx_empty_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_jsx_attribute_item<'a, Tr: Traverse<'a>>(
+unsafe fn walk_jsx_attribute_item<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut JSXAttributeItem<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3439,7 +3454,7 @@ pub(crate) unsafe fn walk_jsx_attribute_item<'a, Tr: Traverse<'a>>(
     traverser.exit_jsx_attribute_item(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_jsx_attribute<'a, Tr: Traverse<'a>>(
+unsafe fn walk_jsx_attribute<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut JSXAttribute<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3464,7 +3479,7 @@ pub(crate) unsafe fn walk_jsx_attribute<'a, Tr: Traverse<'a>>(
     traverser.exit_jsx_attribute(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_jsx_spread_attribute<'a, Tr: Traverse<'a>>(
+unsafe fn walk_jsx_spread_attribute<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut JSXSpreadAttribute<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3482,7 +3497,7 @@ pub(crate) unsafe fn walk_jsx_spread_attribute<'a, Tr: Traverse<'a>>(
     traverser.exit_jsx_spread_attribute(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_jsx_attribute_name<'a, Tr: Traverse<'a>>(
+unsafe fn walk_jsx_attribute_name<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut JSXAttributeName<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3499,7 +3514,7 @@ pub(crate) unsafe fn walk_jsx_attribute_name<'a, Tr: Traverse<'a>>(
     traverser.exit_jsx_attribute_name(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_jsx_attribute_value<'a, Tr: Traverse<'a>>(
+unsafe fn walk_jsx_attribute_value<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut JSXAttributeValue<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3522,7 +3537,7 @@ pub(crate) unsafe fn walk_jsx_attribute_value<'a, Tr: Traverse<'a>>(
     traverser.exit_jsx_attribute_value(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_jsx_identifier<'a, Tr: Traverse<'a>>(
+unsafe fn walk_jsx_identifier<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut JSXIdentifier<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3531,7 +3546,7 @@ pub(crate) unsafe fn walk_jsx_identifier<'a, Tr: Traverse<'a>>(
     traverser.exit_jsx_identifier(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_jsx_child<'a, Tr: Traverse<'a>>(
+unsafe fn walk_jsx_child<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut JSXChild<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3549,7 +3564,7 @@ pub(crate) unsafe fn walk_jsx_child<'a, Tr: Traverse<'a>>(
     traverser.exit_jsx_child(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_jsx_spread_child<'a, Tr: Traverse<'a>>(
+unsafe fn walk_jsx_spread_child<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut JSXSpreadChild<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3567,7 +3582,7 @@ pub(crate) unsafe fn walk_jsx_spread_child<'a, Tr: Traverse<'a>>(
     traverser.exit_jsx_spread_child(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_jsx_text<'a, Tr: Traverse<'a>>(
+unsafe fn walk_jsx_text<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut JSXText<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3576,7 +3591,7 @@ pub(crate) unsafe fn walk_jsx_text<'a, Tr: Traverse<'a>>(
     traverser.exit_jsx_text(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_boolean_literal<'a, Tr: Traverse<'a>>(
+unsafe fn walk_boolean_literal<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut BooleanLiteral,
     ctx: &mut TraverseCtx<'a>,
@@ -3585,7 +3600,7 @@ pub(crate) unsafe fn walk_boolean_literal<'a, Tr: Traverse<'a>>(
     traverser.exit_boolean_literal(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_null_literal<'a, Tr: Traverse<'a>>(
+unsafe fn walk_null_literal<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut NullLiteral,
     ctx: &mut TraverseCtx<'a>,
@@ -3594,7 +3609,7 @@ pub(crate) unsafe fn walk_null_literal<'a, Tr: Traverse<'a>>(
     traverser.exit_null_literal(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_numeric_literal<'a, Tr: Traverse<'a>>(
+unsafe fn walk_numeric_literal<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut NumericLiteral<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3603,7 +3618,7 @@ pub(crate) unsafe fn walk_numeric_literal<'a, Tr: Traverse<'a>>(
     traverser.exit_numeric_literal(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_string_literal<'a, Tr: Traverse<'a>>(
+unsafe fn walk_string_literal<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut StringLiteral<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3612,7 +3627,7 @@ pub(crate) unsafe fn walk_string_literal<'a, Tr: Traverse<'a>>(
     traverser.exit_string_literal(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_big_int_literal<'a, Tr: Traverse<'a>>(
+unsafe fn walk_big_int_literal<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut BigIntLiteral<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3621,7 +3636,7 @@ pub(crate) unsafe fn walk_big_int_literal<'a, Tr: Traverse<'a>>(
     traverser.exit_big_int_literal(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_reg_exp_literal<'a, Tr: Traverse<'a>>(
+unsafe fn walk_reg_exp_literal<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut RegExpLiteral<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3630,7 +3645,7 @@ pub(crate) unsafe fn walk_reg_exp_literal<'a, Tr: Traverse<'a>>(
     traverser.exit_reg_exp_literal(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_this_parameter<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_this_parameter<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSThisParameter<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3649,7 +3664,7 @@ pub(crate) unsafe fn walk_ts_this_parameter<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_this_parameter(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_enum_declaration<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_enum_declaration<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSEnumDeclaration<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3680,7 +3695,7 @@ pub(crate) unsafe fn walk_ts_enum_declaration<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_enum_declaration(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_enum_member<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_enum_member<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSEnumMember<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3703,7 +3718,7 @@ pub(crate) unsafe fn walk_ts_enum_member<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_enum_member(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_enum_member_name<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_enum_member_name<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSEnumMemberName<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3720,7 +3735,7 @@ pub(crate) unsafe fn walk_ts_enum_member_name<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_enum_member_name(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_type_annotation<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_type_annotation<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSTypeAnnotation<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3738,7 +3753,7 @@ pub(crate) unsafe fn walk_ts_type_annotation<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_type_annotation(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_literal_type<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_literal_type<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSLiteralType<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3756,7 +3771,7 @@ pub(crate) unsafe fn walk_ts_literal_type<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_literal_type(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_literal<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_literal<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSLiteral<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3789,7 +3804,7 @@ pub(crate) unsafe fn walk_ts_literal<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_literal(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_type<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_type<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSType<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3896,7 +3911,7 @@ pub(crate) unsafe fn walk_ts_type<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_type(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_conditional_type<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_conditional_type<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSConditionalType<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3939,7 +3954,7 @@ pub(crate) unsafe fn walk_ts_conditional_type<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_conditional_type(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_union_type<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_union_type<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSUnionType<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3958,7 +3973,7 @@ pub(crate) unsafe fn walk_ts_union_type<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_union_type(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_intersection_type<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_intersection_type<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSIntersectionType<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3976,7 +3991,7 @@ pub(crate) unsafe fn walk_ts_intersection_type<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_intersection_type(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_parenthesized_type<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_parenthesized_type<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSParenthesizedType<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -3995,7 +4010,7 @@ pub(crate) unsafe fn walk_ts_parenthesized_type<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_parenthesized_type(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_type_operator<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_type_operator<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSTypeOperator<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4013,7 +4028,7 @@ pub(crate) unsafe fn walk_ts_type_operator<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_type_operator(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_array_type<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_array_type<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSArrayType<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4031,7 +4046,7 @@ pub(crate) unsafe fn walk_ts_array_type<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_array_type(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_indexed_access_type<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_indexed_access_type<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSIndexedAccessType<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4055,7 +4070,7 @@ pub(crate) unsafe fn walk_ts_indexed_access_type<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_indexed_access_type(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_tuple_type<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_tuple_type<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSTupleType<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4073,7 +4088,7 @@ pub(crate) unsafe fn walk_ts_tuple_type<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_tuple_type(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_named_tuple_member<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_named_tuple_member<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSNamedTupleMember<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4098,7 +4113,7 @@ pub(crate) unsafe fn walk_ts_named_tuple_member<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_named_tuple_member(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_optional_type<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_optional_type<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSOptionalType<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4116,7 +4131,7 @@ pub(crate) unsafe fn walk_ts_optional_type<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_optional_type(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_rest_type<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_rest_type<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSRestType<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4134,7 +4149,7 @@ pub(crate) unsafe fn walk_ts_rest_type<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_rest_type(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_tuple_element<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_tuple_element<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSTupleElement<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4189,7 +4204,7 @@ pub(crate) unsafe fn walk_ts_tuple_element<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_tuple_element(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_any_keyword<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_any_keyword<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSAnyKeyword,
     ctx: &mut TraverseCtx<'a>,
@@ -4198,7 +4213,7 @@ pub(crate) unsafe fn walk_ts_any_keyword<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_any_keyword(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_string_keyword<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_string_keyword<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSStringKeyword,
     ctx: &mut TraverseCtx<'a>,
@@ -4207,7 +4222,7 @@ pub(crate) unsafe fn walk_ts_string_keyword<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_string_keyword(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_boolean_keyword<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_boolean_keyword<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSBooleanKeyword,
     ctx: &mut TraverseCtx<'a>,
@@ -4216,7 +4231,7 @@ pub(crate) unsafe fn walk_ts_boolean_keyword<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_boolean_keyword(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_number_keyword<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_number_keyword<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSNumberKeyword,
     ctx: &mut TraverseCtx<'a>,
@@ -4225,7 +4240,7 @@ pub(crate) unsafe fn walk_ts_number_keyword<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_number_keyword(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_never_keyword<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_never_keyword<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSNeverKeyword,
     ctx: &mut TraverseCtx<'a>,
@@ -4234,7 +4249,7 @@ pub(crate) unsafe fn walk_ts_never_keyword<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_never_keyword(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_intrinsic_keyword<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_intrinsic_keyword<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSIntrinsicKeyword,
     ctx: &mut TraverseCtx<'a>,
@@ -4243,7 +4258,7 @@ pub(crate) unsafe fn walk_ts_intrinsic_keyword<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_intrinsic_keyword(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_unknown_keyword<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_unknown_keyword<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSUnknownKeyword,
     ctx: &mut TraverseCtx<'a>,
@@ -4252,7 +4267,7 @@ pub(crate) unsafe fn walk_ts_unknown_keyword<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_unknown_keyword(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_null_keyword<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_null_keyword<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSNullKeyword,
     ctx: &mut TraverseCtx<'a>,
@@ -4261,7 +4276,7 @@ pub(crate) unsafe fn walk_ts_null_keyword<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_null_keyword(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_undefined_keyword<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_undefined_keyword<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSUndefinedKeyword,
     ctx: &mut TraverseCtx<'a>,
@@ -4270,7 +4285,7 @@ pub(crate) unsafe fn walk_ts_undefined_keyword<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_undefined_keyword(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_void_keyword<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_void_keyword<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSVoidKeyword,
     ctx: &mut TraverseCtx<'a>,
@@ -4279,7 +4294,7 @@ pub(crate) unsafe fn walk_ts_void_keyword<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_void_keyword(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_symbol_keyword<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_symbol_keyword<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSSymbolKeyword,
     ctx: &mut TraverseCtx<'a>,
@@ -4288,7 +4303,7 @@ pub(crate) unsafe fn walk_ts_symbol_keyword<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_symbol_keyword(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_this_type<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_this_type<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSThisType,
     ctx: &mut TraverseCtx<'a>,
@@ -4297,7 +4312,7 @@ pub(crate) unsafe fn walk_ts_this_type<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_this_type(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_object_keyword<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_object_keyword<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSObjectKeyword,
     ctx: &mut TraverseCtx<'a>,
@@ -4306,7 +4321,7 @@ pub(crate) unsafe fn walk_ts_object_keyword<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_object_keyword(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_big_int_keyword<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_big_int_keyword<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSBigIntKeyword,
     ctx: &mut TraverseCtx<'a>,
@@ -4315,7 +4330,7 @@ pub(crate) unsafe fn walk_ts_big_int_keyword<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_big_int_keyword(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_type_reference<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_type_reference<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSTypeReference<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4340,7 +4355,7 @@ pub(crate) unsafe fn walk_ts_type_reference<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_type_reference(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_type_name<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_type_name<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSTypeName<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4357,7 +4372,7 @@ pub(crate) unsafe fn walk_ts_type_name<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_type_name(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_qualified_name<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_qualified_name<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSQualifiedName<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4381,7 +4396,7 @@ pub(crate) unsafe fn walk_ts_qualified_name<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_qualified_name(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_type_parameter_instantiation<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_type_parameter_instantiation<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSTypeParameterInstantiation<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4400,7 +4415,7 @@ pub(crate) unsafe fn walk_ts_type_parameter_instantiation<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_type_parameter_instantiation(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_type_parameter<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_type_parameter<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSTypeParameter<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4430,7 +4445,7 @@ pub(crate) unsafe fn walk_ts_type_parameter<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_type_parameter(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_type_parameter_declaration<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_type_parameter_declaration<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSTypeParameterDeclaration<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4448,7 +4463,7 @@ pub(crate) unsafe fn walk_ts_type_parameter_declaration<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_type_parameter_declaration(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_type_alias_declaration<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_type_alias_declaration<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSTypeAliasDeclaration<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4489,7 +4504,7 @@ pub(crate) unsafe fn walk_ts_type_alias_declaration<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_type_alias_declaration(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_class_implements<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_class_implements<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSClassImplements<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4514,7 +4529,7 @@ pub(crate) unsafe fn walk_ts_class_implements<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_class_implements(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_interface_declaration<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_interface_declaration<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSInterfaceDeclaration<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4564,7 +4579,7 @@ pub(crate) unsafe fn walk_ts_interface_declaration<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_interface_declaration(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_interface_body<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_interface_body<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSInterfaceBody<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4582,7 +4597,7 @@ pub(crate) unsafe fn walk_ts_interface_body<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_interface_body(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_property_signature<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_property_signature<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSPropertySignature<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4607,7 +4622,7 @@ pub(crate) unsafe fn walk_ts_property_signature<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_property_signature(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_signature<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_signature<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSSignature<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4633,7 +4648,7 @@ pub(crate) unsafe fn walk_ts_signature<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_signature(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_index_signature<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_index_signature<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSIndexSignature<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4658,7 +4673,7 @@ pub(crate) unsafe fn walk_ts_index_signature<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_index_signature(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_call_signature_declaration<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_call_signature_declaration<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSCallSignatureDeclaration<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4698,7 +4713,7 @@ pub(crate) unsafe fn walk_ts_call_signature_declaration<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_call_signature_declaration(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_method_signature<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_method_signature<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSMethodSignature<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4751,7 +4766,7 @@ pub(crate) unsafe fn walk_ts_method_signature<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_method_signature(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_construct_signature_declaration<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_construct_signature_declaration<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSConstructSignatureDeclaration<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4792,7 +4807,7 @@ pub(crate) unsafe fn walk_ts_construct_signature_declaration<'a, Tr: Traverse<'a
     traverser.exit_ts_construct_signature_declaration(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_index_signature_name<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_index_signature_name<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSIndexSignatureName<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4811,7 +4826,7 @@ pub(crate) unsafe fn walk_ts_index_signature_name<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_index_signature_name(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_interface_heritage<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_interface_heritage<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSInterfaceHeritage<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4836,7 +4851,7 @@ pub(crate) unsafe fn walk_ts_interface_heritage<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_interface_heritage(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_type_predicate<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_type_predicate<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSTypePredicate<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4862,7 +4877,7 @@ pub(crate) unsafe fn walk_ts_type_predicate<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_type_predicate(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_type_predicate_name<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_type_predicate_name<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSTypePredicateName<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4877,7 +4892,7 @@ pub(crate) unsafe fn walk_ts_type_predicate_name<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_type_predicate_name(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_module_declaration<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_module_declaration<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSModuleDeclaration<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4916,7 +4931,7 @@ pub(crate) unsafe fn walk_ts_module_declaration<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_module_declaration(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_module_declaration_name<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_module_declaration_name<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSModuleDeclarationName<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4933,7 +4948,7 @@ pub(crate) unsafe fn walk_ts_module_declaration_name<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_module_declaration_name(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_module_declaration_body<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_module_declaration_body<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSModuleDeclarationBody<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4950,7 +4965,7 @@ pub(crate) unsafe fn walk_ts_module_declaration_body<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_module_declaration_body(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_module_block<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_module_block<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSModuleBlock<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4974,7 +4989,7 @@ pub(crate) unsafe fn walk_ts_module_block<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_module_block(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_type_literal<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_type_literal<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSTypeLiteral<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -4992,7 +5007,7 @@ pub(crate) unsafe fn walk_ts_type_literal<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_type_literal(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_infer_type<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_infer_type<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSInferType<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -5011,7 +5026,7 @@ pub(crate) unsafe fn walk_ts_infer_type<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_infer_type(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_type_query<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_type_query<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSTypeQuery<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -5036,7 +5051,7 @@ pub(crate) unsafe fn walk_ts_type_query<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_type_query(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_type_query_expr_name<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_type_query_expr_name<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSTypeQueryExprName<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -5053,7 +5068,7 @@ pub(crate) unsafe fn walk_ts_type_query_expr_name<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_type_query_expr_name(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_import_type<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_import_type<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSImportType<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -5090,7 +5105,7 @@ pub(crate) unsafe fn walk_ts_import_type<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_import_type(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_import_attributes<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_import_attributes<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSImportAttributes<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -5115,7 +5130,7 @@ pub(crate) unsafe fn walk_ts_import_attributes<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_import_attributes(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_import_attribute<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_import_attribute<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSImportAttribute<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -5140,7 +5155,7 @@ pub(crate) unsafe fn walk_ts_import_attribute<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_import_attribute(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_import_attribute_name<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_import_attribute_name<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSImportAttributeName<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -5157,7 +5172,7 @@ pub(crate) unsafe fn walk_ts_import_attribute_name<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_import_attribute_name(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_function_type<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_function_type<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSFunctionType<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -5196,7 +5211,7 @@ pub(crate) unsafe fn walk_ts_function_type<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_function_type(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_constructor_type<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_constructor_type<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSConstructorType<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -5229,7 +5244,7 @@ pub(crate) unsafe fn walk_ts_constructor_type<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_constructor_type(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_mapped_type<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_mapped_type<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSMappedType<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -5268,7 +5283,7 @@ pub(crate) unsafe fn walk_ts_mapped_type<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_mapped_type(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_template_literal_type<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_template_literal_type<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSTemplateLiteralType<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -5292,7 +5307,7 @@ pub(crate) unsafe fn walk_ts_template_literal_type<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_template_literal_type(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_as_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_as_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSAsExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -5316,7 +5331,7 @@ pub(crate) unsafe fn walk_ts_as_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_as_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_satisfies_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_satisfies_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSSatisfiesExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -5342,7 +5357,7 @@ pub(crate) unsafe fn walk_ts_satisfies_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_satisfies_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_type_assertion<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_type_assertion<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSTypeAssertion<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -5366,7 +5381,7 @@ pub(crate) unsafe fn walk_ts_type_assertion<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_type_assertion(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_import_equals_declaration<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_import_equals_declaration<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSImportEqualsDeclaration<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -5392,7 +5407,7 @@ pub(crate) unsafe fn walk_ts_import_equals_declaration<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_import_equals_declaration(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_module_reference<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_module_reference<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSModuleReference<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -5409,7 +5424,7 @@ pub(crate) unsafe fn walk_ts_module_reference<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_module_reference(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_external_module_reference<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_external_module_reference<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSExternalModuleReference<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -5428,7 +5443,7 @@ pub(crate) unsafe fn walk_ts_external_module_reference<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_external_module_reference(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_non_null_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_non_null_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSNonNullExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -5447,7 +5462,7 @@ pub(crate) unsafe fn walk_ts_non_null_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_non_null_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_decorator<'a, Tr: Traverse<'a>>(
+unsafe fn walk_decorator<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut Decorator<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -5465,7 +5480,7 @@ pub(crate) unsafe fn walk_decorator<'a, Tr: Traverse<'a>>(
     traverser.exit_decorator(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_export_assignment<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_export_assignment<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSExportAssignment<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -5483,7 +5498,7 @@ pub(crate) unsafe fn walk_ts_export_assignment<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_export_assignment(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_namespace_export_declaration<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_namespace_export_declaration<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSNamespaceExportDeclaration<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -5502,7 +5517,7 @@ pub(crate) unsafe fn walk_ts_namespace_export_declaration<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_namespace_export_declaration(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_ts_instantiation_expression<'a, Tr: Traverse<'a>>(
+unsafe fn walk_ts_instantiation_expression<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut TSInstantiationExpression<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -5528,7 +5543,7 @@ pub(crate) unsafe fn walk_ts_instantiation_expression<'a, Tr: Traverse<'a>>(
     traverser.exit_ts_instantiation_expression(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_js_doc_nullable_type<'a, Tr: Traverse<'a>>(
+unsafe fn walk_js_doc_nullable_type<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut JSDocNullableType<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -5546,7 +5561,7 @@ pub(crate) unsafe fn walk_js_doc_nullable_type<'a, Tr: Traverse<'a>>(
     traverser.exit_js_doc_nullable_type(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_js_doc_non_nullable_type<'a, Tr: Traverse<'a>>(
+unsafe fn walk_js_doc_non_nullable_type<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut JSDocNonNullableType<'a>,
     ctx: &mut TraverseCtx<'a>,
@@ -5565,7 +5580,7 @@ pub(crate) unsafe fn walk_js_doc_non_nullable_type<'a, Tr: Traverse<'a>>(
     traverser.exit_js_doc_non_nullable_type(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_js_doc_unknown_type<'a, Tr: Traverse<'a>>(
+unsafe fn walk_js_doc_unknown_type<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     node: *mut JSDocUnknownType,
     ctx: &mut TraverseCtx<'a>,
@@ -5574,7 +5589,7 @@ pub(crate) unsafe fn walk_js_doc_unknown_type<'a, Tr: Traverse<'a>>(
     traverser.exit_js_doc_unknown_type(&mut *node, ctx);
 }
 
-pub(crate) unsafe fn walk_statements<'a, Tr: Traverse<'a>>(
+unsafe fn walk_statements<'a, Tr: Traverse<'a>>(
     traverser: &mut Tr,
     stmts: *mut Vec<'a, Statement<'a>>,
     ctx: &mut TraverseCtx<'a>,


### PR DESCRIPTION
Harden soundness of `Traverse` by:

1. Not exposing `walk_*` methods outside of `walk.rs`.
2. Adding more debug assertions.
3. Adding `#[must_use]` to `TraverseAncestry::push_stack`, so we'll get a lint error if codegen-ed code pushes to `TraverseAncestry`'s stack and doesn't pop it off again.

Document the safety invariants better.
