### PR TITLE
chore(coverage): bump babel submodule

### DIFF
--- a/.github/actions/clone-submodules/action.yml
+++ b/.github/actions/clone-submodules/action.yml
@@ -17,7 +17,7 @@ runs:
         show-progress: false
         repository: babel/babel
         path: tasks/coverage/babel
-        ref: 54a8389fa31ce4fd18b0335b05832dc1ad3cc21f
+        ref: acbc09a87016778c1551ab5e7162fdd0e70b6663
 
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       with:

--- a/justfile
+++ b/justfile
@@ -37,7 +37,7 @@ ready:
 # Make sure to update `.github/actions/clone-submodules/action.yml` too
 submodules:
   just clone-submodule tasks/coverage/test262 https://github.com/tc39/test262.git c4317b0cb578d3fe7940f65b27162638efb9b34d
-  just clone-submodule tasks/coverage/babel https://github.com/babel/babel.git 54a8389fa31ce4fd18b0335b05832dc1ad3cc21f
+  just clone-submodule tasks/coverage/babel https://github.com/babel/babel.git acbc09a87016778c1551ab5e7162fdd0e70b6663
   just clone-submodule tasks/coverage/typescript https://github.com/microsoft/TypeScript.git d85767abfd83880cea17cea70f9913e9c4496dcc
   just clone-submodule tasks/prettier_conformance/prettier https://github.com/prettier/prettier.git 37fd1774d13ef68abcc03775ceef0a91f87a57d7
   just update-transformer-fixtures

--- a/tasks/coverage/snapshots/codegen_babel.snap
+++ b/tasks/coverage/snapshots/codegen_babel.snap
@@ -1,5 +1,5 @@
-commit: 54a8389f
+commit: acbc09a8
 
 codegen_babel Summary:
-AST Parsed     : 2218/2218 (100.00%)
-Positive Passed: 2218/2218 (100.00%)
+AST Parsed     : 2292/2292 (100.00%)
+Positive Passed: 2292/2292 (100.00%)

--- a/tasks/coverage/snapshots/minifier_babel.snap
+++ b/tasks/coverage/snapshots/minifier_babel.snap
@@ -1,4 +1,4 @@
-commit: 54a8389f
+commit: acbc09a8
 
 minifier_babel Summary:
 AST Parsed     : 1732/1732 (100.00%)

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -1,9 +1,9 @@
-commit: 54a8389f
+commit: acbc09a8
 
 parser_babel Summary:
-AST Parsed     : 2205/2218 (99.41%)
-Positive Passed: 2184/2218 (98.47%)
-Negative Passed: 1523/1634 (93.21%)
+AST Parsed     : 2277/2292 (99.35%)
+Positive Passed: 2256/2292 (98.43%)
+Negative Passed: 1541/1662 (92.72%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/annex-b/enabled/3.1-sloppy-labeled-functions-if-body/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/invalid-fn-decl-labeled-inside-if/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/invalid-fn-decl-labeled-inside-loop/input.js
@@ -31,6 +31,8 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/top-level-await-module/inside-class-property/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/es2015-generator/generator-parameter-binding-property-reserved/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0276/input.js
+Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/class-private-property/typescript-invalid-abstract/input.ts
+Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/class-private-property/typescript-invalid-abstract-babel-7/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/flow/expect-plugin/export-interface/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/flow/expect-plugin/export-type/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-fragment/input.js
@@ -95,22 +97,30 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/ty
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/tsx/invalid-gt-arrow-like/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/call-optional-chain-invalid/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/empty-function/input.ts
+Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/empty-function-babel-7/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/empty-interface-extends/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/empty-interface-extends-babel-7/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/empty-interface-implements/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/empty-interface-implements-babel-7/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/empty-new/input.ts
+Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/empty-new-babel-7/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/empty-superclass/input.ts
+Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/empty-superclass-babel-7/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/empty-tsx/input.ts
+Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/empty-tsx-babel-7/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/empty-type-import/input.ts
+Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/empty-type-import-babel-7/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/empty-type-ref/input.ts
+Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/empty-type-ref-babel-7/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-property-access/input.ts
+Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-property-access-babel-7/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-only-import-export-specifiers/export-invalid-type-in-type/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-only-import-export-specifiers/import-invalid-type-in-type/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/const-type-parameters-invalid/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/const-type-parameters-invalid-babel-7/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/import-type-declaration-error/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/import-type-dynamic-errors/input.ts
+Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/import-type-dynamic-errors-babel-7/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/intrinsic-keyword-error/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-labeled-invalid-optional/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/tuple-optional-invalid/input.ts
@@ -599,10 +609,25 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·                 ─┬
    ·                  ╰── `{` expected
    ╰────
+Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/class-heritage-babel-7/input.ts
+
+  × Expected `{` but found `<<`
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/class-heritage-babel-7/input.ts:1:17]
+ 1 │ (class extends f<<T>(v: T) => void> {});
+   ·                 ─┬
+   ·                  ╰── `{` expected
+   ╰────
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/jsx-opening-element/input.tsx
 
   × Unexpected token
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/jsx-opening-element/input.tsx:1:11]
+ 1 │ <Component<<T>(v: T) => void> />
+   ·           ──
+   ╰────
+Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/jsx-opening-element-babel-7/input.tsx
+
+  × Unexpected token
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/jsx-opening-element-babel-7/input.tsx:1:11]
  1 │ <Component<<T>(v: T) => void> />
    ·           ──
    ╰────
@@ -11564,6 +11589,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  2 │ func<T>(a: T);
    ╰────
 
+  × Expected `,` but found `:`
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/cast/parameter-typecast-babel-7/input.ts:1:7]
+ 1 │ func(a: T);
+   ·       ┬
+   ·       ╰── `,` expected
+ 2 │ func<T>(a: T);
+   ╰────
+
   × TS(1244): Abstract methods can only appear within an abstract class.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/abstract-method-in-non-abstract-class-1/input.ts:2:12]
  1 │ class Foo {
@@ -12254,6 +12287,16 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
 
   × Identifier `A` has already been declared
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-class-enum-babel-7/input.ts:1:7]
+ 1 │ class A {}
+   ·       ┬
+   ·       ╰── `A` has already been declared here
+ 2 │ enum A {}
+   ·      ┬
+   ·      ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `A` has already been declared
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-class-type/input.ts:1:7]
  1 │ class A {}
    ·       ┬
@@ -12274,7 +12317,27 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
 
   × Identifier `X` has already been declared
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-constenum-enum-babel-7/input.ts:1:12]
+ 1 │ const enum X {}
+   ·            ┬
+   ·            ╰── `X` has already been declared here
+ 2 │ enum X {}
+   ·      ┬
+   ·      ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `X` has already been declared
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-enum-class/input.ts:1:6]
+ 1 │ enum X {}
+   ·      ┬
+   ·      ╰── `X` has already been declared here
+ 2 │ class X {}
+   ·       ┬
+   ·       ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `X` has already been declared
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-enum-class-babel-7/input.ts:1:6]
  1 │ enum X {}
    ·      ┬
    ·      ╰── `X` has already been declared here
@@ -12293,8 +12356,28 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·            ╰── It can not be redeclared here
    ╰────
 
+  × Identifier `X` has already been declared
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-enum-constenum-babel-7/input.ts:1:6]
+ 1 │ enum X {}
+   ·      ┬
+   ·      ╰── `X` has already been declared here
+ 2 │ const enum X {}
+   ·            ┬
+   ·            ╰── It can not be redeclared here
+   ╰────
+
   × Identifier `Foo` has already been declared
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-enum-function/input.ts:1:6]
+ 1 │ enum Foo {}
+   ·      ─┬─
+   ·       ╰── `Foo` has already been declared here
+ 2 │ function Foo() {}
+   ·          ─┬─
+   ·           ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `Foo` has already been declared
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-enum-function-babel-7/input.ts:1:6]
  1 │ enum Foo {}
    ·      ─┬─
    ·       ╰── `Foo` has already been declared here
@@ -12313,6 +12396,16 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·           ╰── It can not be redeclared here
    ╰────
 
+  × Identifier `X` has already been declared
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-enum-interface-babel-7/input.ts:1:6]
+ 1 │ enum X {}
+   ·      ┬
+   ·      ╰── `X` has already been declared here
+ 2 │ interface X {}
+   ·           ┬
+   ·           ╰── It can not be redeclared here
+   ╰────
+
   × Identifier `Foo` has already been declared
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-enum-let/input.ts:1:6]
  1 │ enum Foo {}
@@ -12323,8 +12416,28 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·      ╰── It can not be redeclared here
    ╰────
 
+  × Identifier `Foo` has already been declared
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-enum-let-babel-7/input.ts:1:6]
+ 1 │ enum Foo {}
+   ·      ─┬─
+   ·       ╰── `Foo` has already been declared here
+ 2 │ let Foo;
+   ·     ─┬─
+   ·      ╰── It can not be redeclared here
+   ╰────
+
   × Identifier `X` has already been declared
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-enum-type/input.ts:1:6]
+ 1 │ enum X {}
+   ·      ┬
+   ·      ╰── `X` has already been declared here
+ 2 │ type X = number;
+   ·      ┬
+   ·      ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `X` has already been declared
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-enum-type-babel-7/input.ts:1:6]
  1 │ enum X {}
    ·      ┬
    ·      ╰── `X` has already been declared here
@@ -12344,7 +12457,27 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
 
   × Identifier `Foo` has already been declared
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-enum-var-babel-7/input.ts:1:6]
+ 1 │ enum Foo {}
+   ·      ─┬─
+   ·       ╰── `Foo` has already been declared here
+ 2 │ let Foo;
+   ·     ─┬─
+   ·      ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `Foo` has already been declared
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-function-enum/input.ts:1:10]
+ 1 │ function Foo() {}
+   ·          ─┬─
+   ·           ╰── `Foo` has already been declared here
+ 2 │ enum Foo {}
+   ·      ─┬─
+   ·       ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `Foo` has already been declared
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-function-enum-babel-7/input.ts:1:10]
  1 │ function Foo() {}
    ·          ─┬─
    ·           ╰── `Foo` has already been declared here
@@ -12373,8 +12506,28 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·      ╰── It can not be redeclared here
    ╰────
 
+  × Identifier `X` has already been declared
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-interface-enum-babel-7/input.ts:1:11]
+ 1 │ interface X {}
+   ·           ┬
+   ·           ╰── `X` has already been declared here
+ 2 │ enum X {}
+   ·      ┬
+   ·      ╰── It can not be redeclared here
+   ╰────
+
   × Identifier `Foo` has already been declared
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-let-enum/input.ts:1:5]
+ 1 │ let Foo;
+   ·     ─┬─
+   ·      ╰── `Foo` has already been declared here
+ 2 │ enum Foo {}
+   ·      ─┬─
+   ·       ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `Foo` has already been declared
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-let-enum-babel-7/input.ts:1:5]
  1 │ let Foo;
    ·     ─┬─
    ·      ╰── `Foo` has already been declared here
@@ -12395,6 +12548,16 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
 
   × Identifier `A` has already been declared
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-type-enum/input.ts:1:6]
+ 1 │ type A = number;
+   ·      ┬
+   ·      ╰── `A` has already been declared here
+ 2 │ enum A {}
+   ·      ┬
+   ·      ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `A` has already been declared
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-type-enum-babel-7/input.ts:1:6]
  1 │ type A = number;
    ·      ┬
    ·      ╰── `A` has already been declared here
@@ -12425,6 +12588,16 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
 
   × Identifier `Foo` has already been declared
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-var-enum/input.ts:1:5]
+ 1 │ let Foo;
+   ·     ─┬─
+   ·      ╰── `Foo` has already been declared here
+ 2 │ enum Foo {}
+   ·      ─┬─
+   ·       ╰── It can not be redeclared here
+   ╰────
+
+  × Identifier `Foo` has already been declared
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-var-enum-babel-7/input.ts:1:5]
  1 │ let Foo;
    ·     ─┬─
    ·      ╰── `Foo` has already been declared here
@@ -12515,6 +12688,13 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/type-arguments/new-without-arguments-missing-semicolon/input.ts:1:9]
+ 1 │ new A<T> if (0);
+   ·         ▲
+   ╰────
+  help: Try insert a semicolon here
+
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/type-arguments/new-without-arguments-missing-semicolon-babel-7/input.ts:1:9]
  1 │ new A<T> if (0);
    ·         ▲
    ╰────
@@ -12630,6 +12810,12 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·            ────────
    ╰────
 
+  × TS(1354): 'readonly' type modifier is only permitted on array and tuple literal types.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/read-only-4-babel-7/input.ts:1:12]
+ 1 │ type T33 = readonly Array<string>;  // Error
+   ·            ────────
+   ╰────
+
   × Expected `,` but found `:`
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/tuple-invalid-label-1/input.ts:1:14]
  1 │ type T = [x.y: A];
@@ -12639,6 +12825,13 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
 
   × Expected `,` but found `:`
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/tuple-invalid-label-2/input.ts:1:15]
+ 1 │ type T = [x<y>: A];
+   ·               ┬
+   ·               ╰── `,` expected
+   ╰────
+
+  × Expected `,` but found `:`
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/tuple-invalid-label-2-babel-7/input.ts:1:15]
  1 │ type T = [x<y>: A];
    ·               ┬
    ·               ╰── `,` expected

--- a/tasks/coverage/snapshots/prettier_babel.snap
+++ b/tasks/coverage/snapshots/prettier_babel.snap
@@ -1,4 +1,4 @@
-commit: 12619ffe
+commit: acbc09a8
 
 prettier_babel Summary:
 AST Parsed     : 2101/2101 (100.00%)

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -1,8 +1,8 @@
-commit: 54a8389f
+commit: acbc09a8
 
 semantic_babel Summary:
-AST Parsed     : 2218/2218 (100.00%)
-Positive Passed: 1893/2218 (85.35%)
+AST Parsed     : 2292/2292 (100.00%)
+Positive Passed: 1908/2292 (83.25%)
 tasks/coverage/babel/packages/babel-parser/test/fixtures/annex-b/enabled/3.3-function-in-if-body/input.js
 semantic error: Symbol scope ID mismatch for "f":
 after transform: SymbolId(0): ScopeId(4294967294)
@@ -103,12 +103,32 @@ semantic error: Symbol scope ID mismatch for "a":
 after transform: SymbolId(0): ScopeId(4294967294)
 rebuilt        : SymbolId(0): ScopeId(4294967294)
 
-tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/class-method/typescript/input.js
+tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/class-method/typescript/input.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2)]
+rebuilt        : ScopeId(1): []
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/class-method/typescript-babel-7/input.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2)]
+rebuilt        : ScopeId(1): []
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/class-private-method/typescript-invalid-abstract/input.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2)]
+rebuilt        : ScopeId(1): []
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/class-private-method/typescript-invalid-abstract-babel-7/input.ts
 semantic error: Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2)]
 rebuilt        : ScopeId(1): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/class-private-property/typescript/input.js
+semantic error: Unresolved references mismatch:
+after transform: ["Array", "WeakMap", "foo", "require"]
+rebuilt        : ["WeakMap", "foo", "require"]
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/class-private-property/typescript-babel-7/input.js
 semantic error: Unresolved references mismatch:
 after transform: ["Array", "WeakMap", "foo", "require"]
 rebuilt        : ["WeakMap", "foo", "require"]
@@ -124,7 +144,33 @@ Symbol flags mismatch for "A":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/enum-babel-7/input.js
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["A", "a", "r"]
+rebuilt        : ScopeId(1): ["A"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(0x0)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/import/input.js
+semantic error: Unresolved references mismatch:
+after transform: ["Y", "foo"]
+rebuilt        : []
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/import-babel-7/input.js
+semantic error: Unresolved references mismatch:
+after transform: ["Y", "foo"]
+rebuilt        : []
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/import-with-options/input.js
+semantic error: Unresolved references mismatch:
+after transform: ["Y", "foo"]
+rebuilt        : []
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/import-with-options-babel-7/input.js
 semantic error: Unresolved references mismatch:
 after transform: ["Y", "foo"]
 rebuilt        : []
@@ -158,6 +204,11 @@ semantic error: Unresolved references mismatch:
 after transform: ["T", "foo"]
 rebuilt        : ["foo"]
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/estree/typescript/optional-chaining-babel-7/input.js
+semantic error: Unresolved references mismatch:
+after transform: ["T", "foo"]
+rebuilt        : ["foo"]
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-ts-type-param-no-flow/input.js
 semantic error: Expected `<` but found `EOF`
 
@@ -180,6 +231,11 @@ after transform: ["v"]
 rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/async-generic-false-positive/input.ts
+semantic error: Unresolved references mismatch:
+after transform: ["T", "async"]
+rebuilt        : ["async"]
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/async-generic-false-positive-babel-7/input.ts
 semantic error: Unresolved references mismatch:
 after transform: ["T", "async"]
 rebuilt        : ["async"]
@@ -297,6 +353,14 @@ Unresolved references mismatch:
 after transform: ["B", "Promise"]
 rebuilt        : ["B"]
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/async-optional-method-babel-7/input.js
+semantic error: Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2)]
+rebuilt        : ScopeId(1): []
+Unresolved references mismatch:
+after transform: ["B", "Promise"]
+rebuilt        : ["B"]
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/constructor/input.ts
 semantic error: Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
@@ -314,6 +378,11 @@ after transform: ["a"]
 rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/expression-extends/input.ts
+semantic error: Unresolved references mismatch:
+after transform: ["T", "f"]
+rebuilt        : ["f"]
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/expression-extends-babel-7/input.ts
 semantic error: Unresolved references mismatch:
 after transform: ["T", "f"]
 rebuilt        : ["f"]
@@ -339,6 +408,11 @@ after transform: ["T", "X"]
 rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/extends/input.ts
+semantic error: Unresolved references mismatch:
+after transform: ["T", "f"]
+rebuilt        : ["f"]
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/extends-babel-7/input.ts
 semantic error: Unresolved references mismatch:
 after transform: ["T", "f"]
 rebuilt        : ["f"]
@@ -449,6 +523,14 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/const/initializer-ambient-context-babel-7/input.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["N"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/declare/const/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["x", "y"]
@@ -514,7 +596,23 @@ Symbol flags mismatch for "E":
 after transform: SymbolId(0): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/const-babel-7/input.ts
+semantic error: Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "E":
+after transform: SymbolId(0): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/declare/input.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["E"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/declare-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E"]
 rebuilt        : ScopeId(0): []
@@ -530,7 +628,23 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/declare-const-babel-7/input.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["E"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/declare-new-line/input.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["E"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/declare-new-line-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["E"]
 rebuilt        : ScopeId(0): []
@@ -546,7 +660,23 @@ Symbol flags mismatch for "E":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/export-babel-7/input.ts
+semantic error: Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "E":
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/export-const/input.ts
+semantic error: Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "E":
+after transform: SymbolId(0): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/export-const-babel-7/input.ts
 semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
@@ -562,7 +692,26 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/export-declare-const-babel-7/input.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["E"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/members/input.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["A", "B", "E"]
+rebuilt        : ScopeId(1): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "E":
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/members-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["A", "B", "E"]
 rebuilt        : ScopeId(1): ["E"]
@@ -584,7 +733,29 @@ Symbol flags mismatch for "E":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/members-reserved-words-babel-7/input.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["E", "const", "default"]
+rebuilt        : ScopeId(1): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "E":
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/members-strings/input.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["E", "bar", "foo"]
+rebuilt        : ScopeId(1): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "E":
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/members-strings-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["E", "bar", "foo"]
 rebuilt        : ScopeId(1): ["E"]
@@ -606,7 +777,29 @@ Symbol flags mismatch for "E":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/members-trailing-comma-babel-7/input.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["A", "E"]
+rebuilt        : ScopeId(1): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "E":
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/members-trailing-comma-with-initializer/input.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["A", "E"]
+rebuilt        : ScopeId(1): ["E"]
+Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "E":
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/enum/members-trailing-comma-with-initializer-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(1): ["A", "E"]
 rebuilt        : ScopeId(1): ["E"]
@@ -626,6 +819,14 @@ after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/export/declare/input.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["M", "N", "_bar", "bar", "foo", "x"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
+rebuilt        : ScopeId(0): []
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/export/declare-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["M", "N", "_bar", "bar", "foo", "x"]
 rebuilt        : ScopeId(0): []
@@ -657,6 +858,20 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/export/export-value-declaration/input.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["C", "D", "E", "a", "b"]
+rebuilt        : ScopeId(0): ["C", "D", "a", "b"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "D":
+after transform: SymbolId(3): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/export/export-value-declaration-babel-7/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["C", "D", "E", "a", "b"]
 rebuilt        : ScopeId(0): ["C", "D", "a", "b"]
@@ -1036,6 +1251,9 @@ rebuilt        : ScopeId(0): []
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/head/input.ts
 semantic error: Ambient modules cannot be nested in other modules or namespaces.
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/head-babel-7/input.ts
+semantic error: Ambient modules cannot be nested in other modules or namespaces.
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/head-declare/input.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["M", "N", "m"]
@@ -1060,6 +1278,14 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): []
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/head-export-babel-7/input.ts
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["X"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
+rebuilt        : ScopeId(0): []
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/destructuring-in-function-type/input.ts
 semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
@@ -1076,6 +1302,17 @@ after transform: ["b", "c"]
 rebuilt        : ["c"]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/is-default-export/input.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "E":
+after transform: SymbolId(1): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/regression/is-default-export-babel-7/input.ts
 semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
@@ -1168,6 +1405,14 @@ Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/enum-block-scoped-babel-7/input.ts
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "Foo":
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export-declare-function-after/input.ts
 semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
@@ -1192,7 +1437,23 @@ Symbol flags mismatch for "Test":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export-enum-after-babel-7/input.ts
+semantic error: Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "Test":
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export-enum-before/input.ts
+semantic error: Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "Test":
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export-enum-before-babel-7/input.ts
 semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
@@ -1313,7 +1574,35 @@ Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 29, end: 32 }]
 rebuilt        : SymbolId(0): []
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-constenum-constenum-babel-7/input.ts
+semantic error: Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "Foo":
+after transform: SymbolId(0): SymbolFlags(ConstEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol redeclarations mismatch for "Foo":
+after transform: SymbolId(0): [Span { start: 29, end: 32 }]
+rebuilt        : SymbolId(0): []
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-enum-enum/input.ts
+semantic error: Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
+Symbol flags mismatch for "Foo":
+after transform: SymbolId(0): SymbolFlags(RegularEnum)
+rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
+Symbol redeclarations mismatch for "Foo":
+after transform: SymbolId(0): [Span { start: 17, end: 20 }]
+rebuilt        : SymbolId(0): []
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-enum-enum-babel-7/input.ts
 semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
@@ -1421,7 +1710,83 @@ Symbol redeclarations mismatch for "b":
 after transform: SymbolId(3): [Span { start: 170, end: 174 }]
 rebuilt        : SymbolId(3): []
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-import-let-babel-7/input.ts
+semantic error: Symbol flags mismatch for "Context":
+after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | Import)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Context":
+after transform: SymbolId(1): Span { start: 16, end: 23 }
+rebuilt        : SymbolId(1): Span { start: 104, end: 124 }
+Symbol reference IDs mismatch for "Context":
+after transform: SymbolId(1): [ReferenceId(0)]
+rebuilt        : SymbolId(1): []
+Symbol redeclarations mismatch for "Context":
+after transform: SymbolId(1): [Span { start: 104, end: 124 }]
+rebuilt        : SymbolId(1): []
+Symbol flags mismatch for "a":
+after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | Import)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "a":
+after transform: SymbolId(2): Span { start: 49, end: 50 }
+rebuilt        : SymbolId(2): Span { start: 156, end: 160 }
+Symbol reference IDs mismatch for "a":
+after transform: SymbolId(2): [ReferenceId(2)]
+rebuilt        : SymbolId(2): []
+Symbol redeclarations mismatch for "a":
+after transform: SymbolId(2): [Span { start: 156, end: 160 }]
+rebuilt        : SymbolId(2): []
+Symbol flags mismatch for "b":
+after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Import)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "b":
+after transform: SymbolId(3): Span { start: 81, end: 82 }
+rebuilt        : SymbolId(3): Span { start: 170, end: 174 }
+Symbol reference IDs mismatch for "b":
+after transform: SymbolId(3): [ReferenceId(3)]
+rebuilt        : SymbolId(3): []
+Symbol redeclarations mismatch for "b":
+after transform: SymbolId(3): [Span { start: 170, end: 174 }]
+rebuilt        : SymbolId(3): []
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-import-type-let/input.ts
+semantic error: Symbol flags mismatch for "Context":
+after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | TypeImport)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Context":
+after transform: SymbolId(1): Span { start: 21, end: 28 }
+rebuilt        : SymbolId(1): Span { start: 119, end: 139 }
+Symbol reference IDs mismatch for "Context":
+after transform: SymbolId(1): [ReferenceId(0)]
+rebuilt        : SymbolId(1): []
+Symbol redeclarations mismatch for "Context":
+after transform: SymbolId(1): [Span { start: 119, end: 139 }]
+rebuilt        : SymbolId(1): []
+Symbol flags mismatch for "a":
+after transform: SymbolId(2): SymbolFlags(BlockScopedVariable | TypeImport)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "a":
+after transform: SymbolId(2): Span { start: 59, end: 60 }
+rebuilt        : SymbolId(2): Span { start: 171, end: 175 }
+Symbol reference IDs mismatch for "a":
+after transform: SymbolId(2): [ReferenceId(2)]
+rebuilt        : SymbolId(2): []
+Symbol redeclarations mismatch for "a":
+after transform: SymbolId(2): [Span { start: 171, end: 175 }]
+rebuilt        : SymbolId(2): []
+Symbol flags mismatch for "b":
+after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | TypeImport)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "b":
+after transform: SymbolId(3): Span { start: 96, end: 97 }
+rebuilt        : SymbolId(3): Span { start: 185, end: 189 }
+Symbol reference IDs mismatch for "b":
+after transform: SymbolId(3): [ReferenceId(3)]
+rebuilt        : SymbolId(3): []
+Symbol redeclarations mismatch for "b":
+after transform: SymbolId(3): [Span { start: 185, end: 189 }]
+rebuilt        : SymbolId(3): []
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-import-type-let-babel-7/input.ts
 semantic error: Symbol flags mismatch for "Context":
 after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | TypeImport)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
@@ -1502,7 +1867,83 @@ Symbol redeclarations mismatch for "b":
 after transform: SymbolId(3): [Span { start: 185, end: 189 }]
 rebuilt        : SymbolId(3): []
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-import-type-var-babel-7/input.ts
+semantic error: Symbol flags mismatch for "Context":
+after transform: SymbolId(1): SymbolFlags(FunctionScopedVariable | TypeImport)
+rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
+Symbol span mismatch for "Context":
+after transform: SymbolId(1): Span { start: 21, end: 28 }
+rebuilt        : SymbolId(1): Span { start: 119, end: 139 }
+Symbol reference IDs mismatch for "Context":
+after transform: SymbolId(1): [ReferenceId(0)]
+rebuilt        : SymbolId(1): []
+Symbol redeclarations mismatch for "Context":
+after transform: SymbolId(1): [Span { start: 119, end: 139 }]
+rebuilt        : SymbolId(1): []
+Symbol flags mismatch for "a":
+after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable | TypeImport)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol span mismatch for "a":
+after transform: SymbolId(2): Span { start: 59, end: 60 }
+rebuilt        : SymbolId(2): Span { start: 171, end: 175 }
+Symbol reference IDs mismatch for "a":
+after transform: SymbolId(2): [ReferenceId(2)]
+rebuilt        : SymbolId(2): []
+Symbol redeclarations mismatch for "a":
+after transform: SymbolId(2): [Span { start: 171, end: 175 }]
+rebuilt        : SymbolId(2): []
+Symbol flags mismatch for "b":
+after transform: SymbolId(3): SymbolFlags(FunctionScopedVariable | TypeImport)
+rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
+Symbol span mismatch for "b":
+after transform: SymbolId(3): Span { start: 96, end: 97 }
+rebuilt        : SymbolId(3): Span { start: 185, end: 189 }
+Symbol reference IDs mismatch for "b":
+after transform: SymbolId(3): [ReferenceId(3)]
+rebuilt        : SymbolId(3): []
+Symbol redeclarations mismatch for "b":
+after transform: SymbolId(3): [Span { start: 185, end: 189 }]
+rebuilt        : SymbolId(3): []
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-import-var/input.ts
+semantic error: Symbol flags mismatch for "Context":
+after transform: SymbolId(1): SymbolFlags(FunctionScopedVariable | Import)
+rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
+Symbol span mismatch for "Context":
+after transform: SymbolId(1): Span { start: 16, end: 23 }
+rebuilt        : SymbolId(1): Span { start: 104, end: 124 }
+Symbol reference IDs mismatch for "Context":
+after transform: SymbolId(1): [ReferenceId(0)]
+rebuilt        : SymbolId(1): []
+Symbol redeclarations mismatch for "Context":
+after transform: SymbolId(1): [Span { start: 104, end: 124 }]
+rebuilt        : SymbolId(1): []
+Symbol flags mismatch for "a":
+after transform: SymbolId(2): SymbolFlags(FunctionScopedVariable | Import)
+rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
+Symbol span mismatch for "a":
+after transform: SymbolId(2): Span { start: 49, end: 50 }
+rebuilt        : SymbolId(2): Span { start: 156, end: 160 }
+Symbol reference IDs mismatch for "a":
+after transform: SymbolId(2): [ReferenceId(2)]
+rebuilt        : SymbolId(2): []
+Symbol redeclarations mismatch for "a":
+after transform: SymbolId(2): [Span { start: 156, end: 160 }]
+rebuilt        : SymbolId(2): []
+Symbol flags mismatch for "b":
+after transform: SymbolId(3): SymbolFlags(FunctionScopedVariable | Import)
+rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
+Symbol span mismatch for "b":
+after transform: SymbolId(3): Span { start: 81, end: 82 }
+rebuilt        : SymbolId(3): Span { start: 170, end: 174 }
+Symbol reference IDs mismatch for "b":
+after transform: SymbolId(3): [ReferenceId(3)]
+rebuilt        : SymbolId(3): []
+Symbol redeclarations mismatch for "b":
+after transform: SymbolId(3): [Span { start: 170, end: 174 }]
+rebuilt        : SymbolId(3): []
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/redeclaration-import-var-babel-7/input.ts
 semantic error: Symbol flags mismatch for "Context":
 after transform: SymbolId(1): SymbolFlags(FunctionScopedVariable | Import)
 rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
@@ -1762,7 +2203,20 @@ semantic error: Unresolved references mismatch:
 after transform: ["D", "T"]
 rebuilt        : ["D"]
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/tsx/brace-is-block-babel-7/input.tsx
+semantic error: Unresolved references mismatch:
+after transform: ["D", "T"]
+rebuilt        : ["D"]
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/tsx/type-arguments/input.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): []
+Unresolved references mismatch:
+after transform: ["C", "T", "f"]
+rebuilt        : ["C", "f"]
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/tsx/type-arguments-babel-7/input.ts
 semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
@@ -1816,7 +2270,17 @@ semantic error: Unresolved references mismatch:
 after transform: ["T", "U", "f"]
 rebuilt        : ["f"]
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/call-babel-7/input.ts
+semantic error: Unresolved references mismatch:
+after transform: ["T", "U", "f"]
+rebuilt        : ["f"]
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/call-optional-chain/input.ts
+semantic error: Unresolved references mismatch:
+after transform: ["Q", "W", "f"]
+rebuilt        : ["f"]
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/call-optional-chain-babel-7/input.ts
 semantic error: Unresolved references mismatch:
 after transform: ["Q", "W", "f"]
 rebuilt        : ["f"]
@@ -1829,7 +2293,20 @@ Unresolved references mismatch:
 after transform: ["f", "true"]
 rebuilt        : ["f"]
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-asi-babel-7/input.ts
+semantic error: Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(8)]
+Unresolved references mismatch:
+after transform: ["f", "true"]
+rebuilt        : ["f"]
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-binary-operator/input.ts
+semantic error: Unresolved references mismatch:
+after transform: ["a", "b", "c"]
+rebuilt        : ["a", "c"]
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-binary-operator-babel-7/input.ts
 semantic error: Unresolved references mismatch:
 after transform: ["a", "b", "c"]
 rebuilt        : ["a", "c"]
@@ -1839,12 +2316,27 @@ semantic error: Unresolved references mismatch:
 after transform: ["a", "c"]
 rebuilt        : ["a"]
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-optional-chain-babel-7/input.ts
+semantic error: Unresolved references mismatch:
+after transform: ["a", "c"]
+rebuilt        : ["a"]
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/new/input.ts
 semantic error: Unresolved references mismatch:
 after transform: ["C", "T", "U"]
 rebuilt        : ["C"]
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/new-babel-7/input.ts
+semantic error: Unresolved references mismatch:
+after transform: ["C", "T", "U"]
+rebuilt        : ["C"]
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/new-false-positive-3/input.ts
+semantic error: Unresolved references mismatch:
+after transform: ["A", "B", "C"]
+rebuilt        : ["A", "C"]
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/new-false-positive-3-babel-7/input.ts
 semantic error: Unresolved references mismatch:
 after transform: ["A", "B", "C"]
 rebuilt        : ["A", "C"]
@@ -1859,12 +2351,32 @@ semantic error: Unresolved references mismatch:
 after transform: ["A", "T"]
 rebuilt        : ["A"]
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/new-without-arguments-asi-babel-7/input.ts
+semantic error: Unresolved references mismatch:
+after transform: ["A", "T"]
+rebuilt        : ["A"]
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/new-without-arguments-babel-7/input.ts
+semantic error: Unresolved references mismatch:
+after transform: ["A", "T"]
+rebuilt        : ["A"]
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/tagged-template/input.ts
 semantic error: Unresolved references mismatch:
 after transform: ["T", "f"]
 rebuilt        : ["f"]
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/tagged-template-babel-7/input.ts
+semantic error: Unresolved references mismatch:
+after transform: ["T", "f"]
+rebuilt        : ["f"]
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/tagged-template-no-asi/input.ts
+semantic error: Unresolved references mismatch:
+after transform: ["C", "T"]
+rebuilt        : ["C"]
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/tagged-template-no-asi-babel-7/input.ts
 semantic error: Unresolved references mismatch:
 after transform: ["C", "T"]
 rebuilt        : ["C"]
@@ -1877,7 +2389,13 @@ rebuilt        : ["f", "x"]
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/class-heritage/input.ts
 semantic error: Expected `{` but found `<<`
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/class-heritage-babel-7/input.ts
+semantic error: Expected `{` but found `<<`
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/jsx-opening-element/input.tsx
+semantic error: Unexpected token
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like/jsx-opening-element-babel-7/input.tsx
 semantic error: Unexpected token
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments-bit-shift-left-like-babel-7/after-bit-shift/input.ts
@@ -1970,6 +2488,11 @@ after transform: ScopeId(0): ["A", "B", "T", "Types"]
 rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/import-type-dynamic/input.ts
+semantic error: Unresolved references mismatch:
+after transform: ["Y", "foo"]
+rebuilt        : []
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/import-type-dynamic-babel-7/input.ts
 semantic error: Unresolved references mismatch:
 after transform: ["Y", "foo"]
 rebuilt        : []
@@ -2095,7 +2618,17 @@ semantic error: Unresolved references mismatch:
 after transform: ["Array"]
 rebuilt        : []
 
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/reference-generic-babel-7/input.ts
+semantic error: Unresolved references mismatch:
+after transform: ["Array"]
+rebuilt        : []
+
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/reference-generic-nested/input.ts
+semantic error: Unresolved references mismatch:
+after transform: ["Array"]
+rebuilt        : []
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/reference-generic-nested-babel-7/input.ts
 semantic error: Unresolved references mismatch:
 after transform: ["Array"]
 rebuilt        : []
@@ -2184,6 +2717,11 @@ after transform: ["a"]
 rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/typeof-type-parameters/input.ts
+semantic error: Unresolved references mismatch:
+after transform: ["w", "y"]
+rebuilt        : []
+
+tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/types/typeof-type-parameters-babel-7/input.ts
 semantic error: Unresolved references mismatch:
 after transform: ["w", "y"]
 rebuilt        : []

--- a/tasks/coverage/snapshots/transformer_babel.snap
+++ b/tasks/coverage/snapshots/transformer_babel.snap
@@ -1,7 +1,7 @@
-commit: 54a8389f
+commit: acbc09a8
 
 transformer_babel Summary:
-AST Parsed     : 2218/2218 (100.00%)
-Positive Passed: 2216/2218 (99.91%)
+AST Parsed     : 2292/2292 (100.00%)
+Positive Passed: 2290/2292 (99.91%)
 Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-private-properties/await-in-private-property-in-async/input.js
 Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-properties/await-in-class-property-in-async/input.js

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1,6 +1,6 @@
-commit: 54a8389f
+commit: acbc09a8
 
-Passed: 688/1154
+Passed: 692/1168
 
 # All Passed:
 * babel-plugin-transform-logical-assignment-operators
@@ -915,7 +915,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-nullish-coalescing-operator (5/12)
+# babel-plugin-transform-nullish-coalescing-operator (9/24)
 * assumption-noDocumentAll/transform/input.js
 x Output mismatch
 
@@ -934,7 +934,31 @@ x Output mismatch
 * assumption-noDocumentAll/transform-static-refs-in-function/input.js
 x Output mismatch
 
+* assumption-pureGetters/logical-assignment/input.js
+x Output mismatch
+
+* assumption-pureGetters/logical-assignment-undeclared/input.js
+x Output mismatch
+
+* assumption-pureGetters/transform-in-default-param/input.js
+x Output mismatch
+
+* assumption-pureGetters/transform-static-refs-in-function/input.js
+x Output mismatch
+
+* nullish-coalescing/logical-assignment/input.js
+x Output mismatch
+
+* nullish-coalescing/logical-assignment-undeclared/input.js
+x Output mismatch
+
 * nullish-coalescing/transform-loose/input.js
+x Output mismatch
+
+* nullish-coalescing/transform-static-refs-in-function/input.js
+x Output mismatch
+
+* nullish-coalescing/undeclared/input.js
 x Output mismatch
 
 
@@ -1619,7 +1643,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-transform-typescript (49/157)
+# babel-plugin-transform-typescript (49/159)
 * cast/as-expression/input.ts
 Unresolved references mismatch:
 after transform: ["T", "x"]
@@ -1832,6 +1856,9 @@ after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 
 * enum/mix-references/input.ts
+x Output mismatch
+
+* enum/non-constant-member-reference/input.ts
 x Output mismatch
 
 * enum/non-foldable-constant/input.ts
@@ -2153,8 +2180,8 @@ rebuilt        : ScopeId(0): []
 
 * imports/only-remove-type-imports/input.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["H", "I", "I2", "J", "K1", "K2", "L1", "L2", "L3", "a", "b", "c2", "d", "d2", "e", "e4"]
-rebuilt        : ScopeId(0): ["L2", "a", "b", "c2", "d", "d2", "e", "e4"]
+after transform: ScopeId(0): ["H", "I", "I2", "J", "K1", "K2", "L1", "L2", "L3", "a", "b", "c2", "d", "d2", "e", "e4", "x"]
+rebuilt        : ScopeId(0): ["L2", "a", "b", "c2", "d", "d2", "e", "e4", "x"]
 
 * imports/property-signature/input.ts
 Bindings mismatch:
@@ -2848,6 +2875,9 @@ x Output mismatch
 x Output mismatch
 
 * optimize-const-enums/merged-exported/input.ts
+x Output mismatch
+
+* optimize-const-enums/namespace/input.ts
 x Output mismatch
 
 * regression/15768/input.ts

--- a/tasks/transform_conformance/snapshots/babel_exec.snap.md
+++ b/tasks/transform_conformance/snapshots/babel_exec.snap.md
@@ -1,4 +1,4 @@
-commit: 54a8389f
+commit: acbc09a8
 
 node: v22.12.0
 

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,4 +1,4 @@
-commit: 54a8389f
+commit: acbc09a8
 
 Passed: 130/152
 

--- a/tasks/transform_conformance/snapshots/oxc_exec.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc_exec.snap.md
@@ -1,4 +1,4 @@
-commit: 54a8389f
+commit: acbc09a8
 
 node: v22.12.0
 


### PR DESCRIPTION
Update babel submodule for conformance tests to latest HEAD.

The test fixtures include a new one for a bug fix which @branchseer intends to also apply to Oxc - https://github.com/babel/babel/pull/17050 (see #8342).
