### PR TITLE
refactor(transformer): move common utils functions to the root module

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -11,13 +11,17 @@ use oxc_traverse::{
     ast_operations::get_var_name_from_node, Ancestor, BoundIdentifier, TraverseCtx,
 };
 
-use crate::{common::helper_loader::Helper, TransformCtx};
+use crate::{
+    common::helper_loader::Helper,
+    utils::ast_builder::{create_bind_call, create_call_call, create_member_callee},
+    TransformCtx,
+};
 
 use super::{
     class_details::ResolvedGetSetPrivateProp,
     utils::{
-        create_assignment, create_bind_call, create_call_call, create_member_callee,
-        create_underscore_ident_name, debug_assert_expr_is_not_parenthesis_or_typescript_syntax,
+        create_assignment, create_underscore_ident_name,
+        debug_assert_expr_is_not_parenthesis_or_typescript_syntax,
     },
     ClassProperties, ResolvedPrivateProp,
 };

--- a/crates/oxc_transformer/src/es2022/class_properties/utils.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/utils.rs
@@ -3,7 +3,7 @@
 
 use std::path::PathBuf;
 
-use oxc_ast::{ast::*, NONE};
+use oxc_ast::ast::*;
 use oxc_span::SPAN;
 use oxc_syntax::reference::ReferenceFlags;
 use oxc_traverse::{BoundIdentifier, TraverseCtx};
@@ -80,38 +80,4 @@ pub(super) fn create_prototype_member<'a>(
     let property = ctx.ast.identifier_name(SPAN, Atom::from("prototype"));
     let static_member = ctx.ast.member_expression_static(SPAN, object, property, false);
     Expression::from(static_member)
-}
-
-/// `object` -> `object.call`.
-pub(super) fn create_member_callee<'a>(
-    object: Expression<'a>,
-    property: &'static str,
-    ctx: &mut TraverseCtx<'a>,
-) -> Expression<'a> {
-    let property = ctx.ast.identifier_name(SPAN, Atom::from(property));
-    Expression::from(ctx.ast.member_expression_static(SPAN, object, property, false))
-}
-
-/// `object` -> `object.bind(this)`.
-pub(super) fn create_bind_call<'a>(
-    callee: Expression<'a>,
-    this: Expression<'a>,
-    span: Span,
-    ctx: &mut TraverseCtx<'a>,
-) -> Expression<'a> {
-    let callee = create_member_callee(callee, "bind", ctx);
-    let arguments = ctx.ast.vec1(Argument::from(this));
-    ctx.ast.expression_call(span, callee, NONE, arguments, false)
-}
-
-/// `object` -> `object.call(...arguments)`.
-pub(super) fn create_call_call<'a>(
-    callee: Expression<'a>,
-    this: Expression<'a>,
-    span: Span,
-    ctx: &mut TraverseCtx<'a>,
-) -> Expression<'a> {
-    let callee = create_member_callee(callee, "call", ctx);
-    let arguments = ctx.ast.vec1(Argument::from(this));
-    ctx.ast.expression_call(span, callee, NONE, arguments, false)
 }

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -19,6 +19,7 @@ mod common;
 mod compiler_assumptions;
 mod context;
 mod options;
+mod utils;
 
 // Presets: <https://babel.dev/docs/presets>
 mod es2015;

--- a/crates/oxc_transformer/src/utils/ast_builder.rs
+++ b/crates/oxc_transformer/src/utils/ast_builder.rs
@@ -1,0 +1,37 @@
+use oxc_ast::{ast::*, NONE};
+use oxc_span::SPAN;
+use oxc_traverse::TraverseCtx;
+
+/// `object` -> `object.call`.
+pub(crate) fn create_member_callee<'a>(
+    object: Expression<'a>,
+    property: &'static str,
+    ctx: &mut TraverseCtx<'a>,
+) -> Expression<'a> {
+    let property = ctx.ast.identifier_name(SPAN, Atom::from(property));
+    Expression::from(ctx.ast.member_expression_static(SPAN, object, property, false))
+}
+
+/// `object` -> `object.bind(this)`.
+pub(crate) fn create_bind_call<'a>(
+    callee: Expression<'a>,
+    this: Expression<'a>,
+    span: Span,
+    ctx: &mut TraverseCtx<'a>,
+) -> Expression<'a> {
+    let callee = create_member_callee(callee, "bind", ctx);
+    let arguments = ctx.ast.vec1(Argument::from(this));
+    ctx.ast.expression_call(span, callee, NONE, arguments, false)
+}
+
+/// `object` -> `object.call(...arguments)`.
+pub(crate) fn create_call_call<'a>(
+    callee: Expression<'a>,
+    this: Expression<'a>,
+    span: Span,
+    ctx: &mut TraverseCtx<'a>,
+) -> Expression<'a> {
+    let callee = create_member_callee(callee, "call", ctx);
+    let arguments = ctx.ast.vec1(Argument::from(this));
+    ctx.ast.expression_call(span, callee, NONE, arguments, false)
+}

--- a/crates/oxc_transformer/src/utils/mod.rs
+++ b/crates/oxc_transformer/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod ast_builder;


### PR DESCRIPTION
These utils functions are very useful for other plugins, I am going to gradually move utils functions where in separate plugins into the root utils module. It also will include scope adjusting functions.