### PR TITLE
ci(lint): run clippy in release mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,7 @@ jobs:
           cache-key: clippy
           components: clippy
       - run: cargo lint -- -D warnings
+      - run: cargo lint --profile dev-no-debug-assertions -- -D warnings
       - name: Check Char and Byte Offset
         run: |
           npm i @ast-grep/cli -g

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -247,3 +247,10 @@ codegen-units = 256 # Compile faster
 lto = "thin" # Faster compile time with thin LTO
 debug-assertions = true # Make sure `debug_assert!`s pass
 overflow-checks = true # Catch arithmetic overflow errors
+
+# Profile for linting with release mode-like settings.
+# Catches lint errors which only appear in release mode.
+# `cargo lint --profile dev-no-debug-assertions` is about 35% faster than `cargo lint --release`.
+[profile.dev-no-debug-assertions]
+inherits = "dev"
+debug-assertions = false


### PR DESCRIPTION
CI Clippy task catch lint errors which only appear in release mode (e.g. the one fixed in #8539).

Add a profile for this. `cargo clippy --profile dev-no-debug-assertions` is about 35% faster than `cargo clippy --release` (and is slightly faster than plain `cargo clippy`) but catches the same problems.

This slows down the Clippy CI task, but it still remains faster than running conformance, so I don't think it's likely to slow down CI overall.