### PR TITLE
fix(transformer/class-static-blocks): static block converted to IIFE use span of original block

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/static_block_and_prop_init.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/static_block_and_prop_init.rs
@@ -7,7 +7,6 @@ use oxc_ast::{
     ast::*,
     visit::{walk_mut, VisitMut},
 };
-use oxc_span::SPAN;
 use oxc_syntax::scope::{ScopeFlags, ScopeId};
 use oxc_traverse::TraverseCtx;
 
@@ -90,7 +89,7 @@ impl<'a> ClassProperties<'a, '_> {
         let outer_scope_id = ctx.current_scope_id();
         ctx.scopes_mut().change_parent_id(scope_id, Some(outer_scope_id));
 
-        wrap_statements_in_arrow_function_iife(ctx.ast.move_vec(stmts), scope_id, SPAN, ctx)
+        wrap_statements_in_arrow_function_iife(ctx.ast.move_vec(stmts), scope_id, block.span, ctx)
     }
 
     fn convert_static_block_with_single_expression_to_expression(

--- a/crates/oxc_transformer/src/es2022/class_static_block.rs
+++ b/crates/oxc_transformer/src/es2022/class_static_block.rs
@@ -159,7 +159,7 @@ impl ClassStaticBlock {
         // Always strict mode since we're in a class.
         *ctx.scopes_mut().get_flags_mut(scope_id) =
             ScopeFlags::Function | ScopeFlags::Arrow | ScopeFlags::StrictMode;
-        wrap_statements_in_arrow_function_iife(ctx.ast.move_vec(stmts), scope_id, SPAN, ctx)
+        wrap_statements_in_arrow_function_iife(ctx.ast.move_vec(stmts), scope_id, block.span, ctx)
     }
 
     /// Convert static block to expression which will be value of private field,


### PR DESCRIPTION
Fix spans in class static blocks and class properties transforms. When a static block is converted to an IIFE, the IIFE should take the span of the static block.