### PR TITLE
perf(semantic): use `oxc_allocator::HashMap` in `ScopeTree`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2034,7 +2034,6 @@ name = "oxc_semantic"
 version = "0.46.0"
 dependencies = [
  "assert-unchecked",
- "hashbrown 0.15.2",
  "insta",
  "itertools",
  "oxc_allocator",

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -30,7 +30,6 @@ oxc_span = { workspace = true }
 oxc_syntax = { workspace = true }
 
 assert-unchecked = { workspace = true }
-hashbrown = { workspace = true, features = ["allocator-api2"] }
 itertools = { workspace = true }
 phf = { workspace = true, features = ["macros"] }
 rustc-hash = { workspace = true }

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -712,8 +712,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         if self.scope.get_flags(parent_scope_id).is_catch_clause() {
             self.scope.cell.with_dependent_mut(|allocator, inner| {
                 if !inner.bindings[parent_scope_id].is_empty() {
-                    let mut parent_bindings =
-                        Bindings::with_hasher_in(rustc_hash::FxBuildHasher, allocator);
+                    let mut parent_bindings = Bindings::new_in(allocator);
                     mem::swap(&mut inner.bindings[parent_scope_id], &mut parent_bindings);
                     for &symbol_id in parent_bindings.values() {
                         self.symbols.set_scope_id(symbol_id, self.current_scope_id);


### PR DESCRIPTION
Use `oxc_allocator::HashMap` in `ScopeTree`, replacing `hashbrown::HashMap`. `oxc_allocator::HashMap` is non-drop, so it may reduce drop time of `ScopeTree` a little.