### PR TITLE
docs(allocator): update docs for `Vec`

### DIFF
--- a/crates/oxc_allocator/src/vec.rs
+++ b/crates/oxc_allocator/src/vec.rs
@@ -22,8 +22,6 @@ use crate::{Allocator, Box, String};
 
 /// A `Vec` without [`Drop`], which stores its data in the arena allocator.
 ///
-/// Should only be used for storing AST types.
-///
 /// Must NOT be used to store types which have a [`Drop`] implementation.
 /// `T::drop` will NOT be called on the `Vec`'s contents when the `Vec` is dropped.
 /// If `T` owns memory outside of the arena, this will be a memory leak.


### PR DESCRIPTION
Remove line from `oxc_allocator::Vec` docs saying "Should only be used for storing AST types.". We are now using `Vec` in `Semantic` too, and there's no problem with that.