### PR TITLE
perf(mangler): reduce hash table lookups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,7 +1844,6 @@ dependencies = [
  "oxc_ast",
  "oxc_index",
  "oxc_semantic",
- "oxc_span",
  "rustc-hash",
 ]
 

--- a/crates/oxc_mangler/Cargo.toml
+++ b/crates/oxc_mangler/Cargo.toml
@@ -25,7 +25,6 @@ oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_index = { workspace = true }
 oxc_semantic = { workspace = true }
-oxc_span = { workspace = true }
 
 itertools = { workspace = true }
 rustc-hash = { workspace = true }


### PR DESCRIPTION
When getting the list of symbol names for slots, pre-prepare a single hash set of all unavailable symbol names. Then in the loop which generates symbol names, only 1 hash table lookup is required for each name.