### PR TITLE
refactor(ast): rename `#[estree(with)]` to `#[estree(via)]`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -2196,7 +2196,7 @@ pub struct ImportExpression<'a> {
 pub struct ImportDeclaration<'a> {
     pub span: Span,
     /// `None` for `import 'foo'`, `Some([])` for `import {} from 'foo'`
-    #[estree(with = "OptionVecDefault", type = "Array<ImportDeclarationSpecifier>")]
+    #[estree(via = "OptionVecDefault", type = "Array<ImportDeclarationSpecifier>")]
     pub specifiers: Option<Vec<'a, ImportDeclarationSpecifier<'a>>>,
     pub source: StringLiteral<'a>,
     pub phase: Option<ImportPhase>,

--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -142,7 +142,7 @@ fn serialize_struct(def: &StructDef, schema: &Schema) -> TokenStream {
                     }
                 )?;
             });
-        } else if let Some(with) = &field.markers.derive_attributes.estree.with {
+        } else if let Some(with) = &field.markers.derive_attributes.estree.via {
             let with_ident = with.to_ident();
             fields.push(quote! {
                 map.serialize_entry(

--- a/tasks/ast_tools/src/markers.rs
+++ b/tasks/ast_tools/src/markers.rs
@@ -227,7 +227,7 @@ pub struct ESTreeFieldAttribute {
     pub rename: Option<String>,
     pub typescript_type: Option<String>,
     pub append_to: Option<String>,
-    pub with: Option<String>,
+    pub via: Option<String>,
 }
 
 impl Parse for ESTreeFieldAttribute {
@@ -237,7 +237,7 @@ impl Parse for ESTreeFieldAttribute {
         let mut rename = None;
         let mut typescript_type = None;
         let mut append_to = None;
-        let mut with = None;
+        let mut via = None;
 
         loop {
             let is_type = input.peek(Token![type]);
@@ -283,10 +283,10 @@ impl Parse for ESTreeFieldAttribute {
                         "Duplicate estree(append_to)"
                     );
                 }
-                "with" => {
+                "via" => {
                     input.parse::<Token![=]>()?;
                     assert!(
-                        with.replace(input.parse::<LitStr>()?.value()).is_none(),
+                        via.replace(input.parse::<LitStr>()?.value()).is_none(),
                         "Duplicate estree(with)"
                     );
                 }
@@ -299,7 +299,7 @@ impl Parse for ESTreeFieldAttribute {
                 break;
             }
         }
-        Ok(Self { flatten, skip, rename, typescript_type, append_to, with })
+        Ok(Self { flatten, skip, rename, typescript_type, append_to, via })
     }
 }
 


### PR DESCRIPTION
Follow-on after #8560. Rename `#[estree(with)]` attr introduced in #8560 for struct fields to `#[estree(via)]`. This is to match the attr which does the same thing on struct itself. e.g.:

https://github.com/oxc-project/oxc/blob/869bc73e67e46f8b7d4b18dda76d75df499a5d62/crates/oxc_ast/src/ast/literal.rs#L23-L29