### PR TITLE
refactor(allocator)!: remove `Vec::into_string`

### DIFF
--- a/crates/oxc_allocator/src/vec.rs
+++ b/crates/oxc_allocator/src/vec.rs
@@ -19,9 +19,8 @@ use allocator_api2::vec::Vec as InnerVec;
 use bumpalo::Bump;
 #[cfg(any(feature = "serialize", test))]
 use serde::{ser::SerializeSeq, Serialize, Serializer};
-use simdutf8::basic::Utf8Error;
 
-use crate::{Allocator, Box, String};
+use crate::{Allocator, Box};
 
 /// A `Vec` without [`Drop`], which stores its data in the arena allocator.
 ///
@@ -206,29 +205,6 @@ impl<'alloc, T> Vec<'alloc, T> {
         // unique ownership of the data (no aliasing).
         // `ptr` was created from a `&mut [T]`.
         unsafe { Box::from_non_null(ptr) }
-    }
-}
-
-impl<'alloc> Vec<'alloc, u8> {
-    /// Convert `Vec<u8>` into [`String`].
-    ///
-    /// # Errors
-    /// Returns [`Err`] if the `Vec` does not comprise a valid UTF-8 string.
-    pub fn into_string(self) -> Result<String<'alloc>, Utf8Error> {
-        String::from_utf8(self)
-    }
-
-    /// Convert `Vec<u8>` into [`String`], without checking bytes comprise a valid UTF-8 string.
-    ///
-    /// Does not copy the contents of the `Vec`, converts in place. This is a zero-cost operation.
-    ///
-    /// # SAFETY
-    /// Caller must ensure this `Vec<u8>` comprises a valid UTF-8 string.
-    #[expect(clippy::missing_safety_doc, clippy::unnecessary_safety_comment)]
-    #[inline(always)] // `#[inline(always)]` because this is a no-op at runtime
-    pub unsafe fn into_string_unchecked(self) -> String<'alloc> {
-        // SAFETY: Caller guarantees vec comprises a valid UTF-8 string.
-        String::from_utf8_unchecked(self)
     }
 }
 

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -7,7 +7,7 @@ use base64::{
 use rustc_hash::FxHashMap;
 use sha1::{Digest, Sha1};
 
-use oxc_allocator::{Address, CloneIn, GetAddress, Vec as ArenaVec};
+use oxc_allocator::{Address, CloneIn, GetAddress, String as ArenaString, Vec as ArenaVec};
 use oxc_ast::{ast::*, match_expression, AstBuilder, NONE};
 use oxc_semantic::{Reference, ReferenceFlags, ScopeFlags, ScopeId, SymbolFlags};
 use oxc_span::{Atom, GetSpan, SPAN};
@@ -555,7 +555,7 @@ impl<'a> ReactRefresh<'a, '_> {
             let mut hashed_key = ArenaVec::from_array_in([0; ENCODED_LEN], ctx.ast.allocator);
             let encoded_bytes = BASE64_STANDARD.encode_slice(hash, &mut hashed_key).unwrap();
             debug_assert_eq!(encoded_bytes, ENCODED_LEN);
-            let hashed_key = hashed_key.into_string().unwrap();
+            let hashed_key = ArenaString::from_utf8(hashed_key).unwrap();
             Atom::from(hashed_key)
         };
 


### PR DESCRIPTION
We can use `String::from_utf8` instead (introduced in #8568). This matches `std::str::String`s method.