### PR TITLE
refactor(linter): improve `eslint/no-lone-blocks`

### DIFF
--- a/crates/oxc_linter/src/snapshots/eslint_no_lone_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_lone_blocks.snap
@@ -19,6 +19,12 @@ source: crates/oxc_linter/src/tester.rs
    ·        ──
    ╰────
 
+  ⚠ eslint(no-lone-blocks): Block is unnecessary.
+   ╭─[no_lone_blocks.tsx:1:19]
+ 1 │ function test() { { console.log(6); } }
+   ·                   ───────────────────
+   ╰────
+
   ⚠ eslint(no-lone-blocks): Nested block is redundant.
    ╭─[no_lone_blocks.tsx:1:19]
  1 │ if (foo) { bar(); {} baz(); }


### PR DESCRIPTION
The code `let mut lone_blocks = Vec::new();` is unnecessary because it will contain at most one element throughout its usage.

Additionally, special test cases has been added for when `parent_node.kind()` is `AstKind::FunctionBody(_)`.