### PR TITLE
feat(linter): support `ignoreTypeOfTestName` for `jest/valid-title`

### DIFF
--- a/crates/oxc_linter/src/rules/jest/valid_title.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_title.rs
@@ -26,6 +26,7 @@ pub struct ValidTitle(Box<ValidTitleConfig>);
 
 #[derive(Debug, Default, Clone)]
 pub struct ValidTitleConfig {
+    ignore_type_of_test_name: bool,
     ignore_type_of_describe_name: bool,
     disallowed_words: Vec<CompactStr>,
     ignore_space: bool,
@@ -75,6 +76,17 @@ declare_oxc_lint!(
     /// describe('foo', () => {});
     /// it('bar', () => {});
     /// test('baz', () => {});
+    /// ```
+    ///
+    /// ### Options
+    /// interface Options {
+    ///     ignoreSpaces?: boolean;
+    ///     ignoreTypeOfTestName?: boolean;
+    ///     ignoreTypeOfDescribeName?: boolean;
+    ///     disallowedWords?: string[];
+    ///     mustNotMatch?: Partial<Record<'describe' | 'test' | 'it', string>> | string;
+    ///     mustMatch?: Partial<Record<'describe' | 'test' | 'it', string>> | string;
+    /// }
     ValidTitle,
     jest,
     correctness,
@@ -91,6 +103,7 @@ impl Rule for ValidTitle {
                 .unwrap_or_default()
         };
 
+        let ignore_type_of_test_name = get_as_bool("ignoreTypeOfTestName");
         let ignore_type_of_describe_name = get_as_bool("ignoreTypeOfDescribeName");
         let ignore_space = get_as_bool("ignoreSpaces");
         let disallowed_words = config
@@ -107,6 +120,7 @@ impl Rule for ValidTitle {
             .and_then(compile_matcher_patterns)
             .unwrap_or_default();
         Self(Box::new(ValidTitleConfig {
+            ignore_type_of_test_name,
             ignore_type_of_describe_name,
             disallowed_words,
             ignore_space,
@@ -146,8 +160,11 @@ impl ValidTitle {
             return;
         };
 
-        let need_report_describe_name = !(self.ignore_type_of_describe_name
-            && matches!(jest_fn_call.kind, JestFnKind::General(JestGeneralFnKind::Describe)));
+        let need_report_name = match jest_fn_call.kind {
+            JestFnKind::General(JestGeneralFnKind::Test) => !self.ignore_type_of_test_name,
+            JestFnKind::General(JestGeneralFnKind::Describe) => !self.ignore_type_of_describe_name,
+            _ => unreachable!(),
+        };
 
         match arg {
             Argument::StringLiteral(string_literal) => {
@@ -177,12 +194,12 @@ impl ValidTitle {
                 if does_binary_expression_contain_string_node(binary_expr) {
                     return;
                 }
-                if need_report_describe_name {
+                if need_report_name {
                     Message::TitleMustBeString.diagnostic(ctx, arg.span());
                 }
             }
             _ => {
-                if need_report_describe_name {
+                if need_report_name {
                     Message::TitleMustBeString.diagnostic(ctx, arg.span());
                 }
             }
@@ -567,6 +584,7 @@ fn test() {
             ",
             None,
         ),
+        ("it(abc, function () {})", Some(serde_json::json!([{ "ignoreTypeOfTestName": true }]))),
     ];
 
     let fail = vec![
@@ -908,6 +926,7 @@ fn test() {
             ",
             None,
         ),
+        ("it(abc, function () {})", None),
     ];
 
     let fix = vec![

--- a/crates/oxc_linter/src/snapshots/jest_valid_title.snap
+++ b/crates/oxc_linter/src/snapshots/jest_valid_title.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-snapshot_kind: text
 ---
   ⚠ eslint-plugin-jest(valid-title): "correct is not allowed in test title"
    ╭─[valid_title.tsx:1:6]
@@ -568,3 +567,10 @@ snapshot_kind: text
  4 │                 })
    ╰────
   help: "The function name has already contains the prefix, try remove the duplicate prefix"
+
+  ⚠ eslint-plugin-jest(valid-title): "Title must be a string"
+   ╭─[valid_title.tsx:1:4]
+ 1 │ it(abc, function () {})
+   ·    ───
+   ╰────
+  help: "Replace your title with a string"


### PR DESCRIPTION
closes #8531 

I'm not sure if we should support it because both `vitest` and `jest` have this issue