### PR TITLE
refactor(span): derive `Copy` on `Atom`

### DIFF
--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -233,7 +233,7 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn use_strict_directive(self) -> Directive<'a> {
         let use_strict = Atom::from("use strict");
-        self.directive(SPAN, self.string_literal(SPAN, use_strict.clone(), None), use_strict)
+        self.directive(SPAN, self.string_literal(SPAN, use_strict, None), use_strict)
     }
 
     /* ---------- Functions ---------- */

--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -406,7 +406,7 @@ impl<'a> PropertyKey<'a> {
     #[allow(missing_docs)]
     pub fn private_name(&self) -> Option<Atom<'a>> {
         match self {
-            Self::PrivateIdentifier(ident) => Some(ident.name.clone()),
+            Self::PrivateIdentifier(ident) => Some(ident.name),
             _ => None,
         }
     }
@@ -451,7 +451,7 @@ impl<'a> TemplateLiteral<'a> {
 
     /// Get single quasi from `template`
     pub fn quasi(&self) -> Option<Atom<'a>> {
-        self.quasis.first().and_then(|quasi| quasi.value.cooked.clone())
+        self.quasis.first().and_then(|quasi| quasi.value.cooked)
     }
 }
 
@@ -548,13 +548,13 @@ impl<'a> ComputedMemberExpression<'a> {
     #[allow(missing_docs)]
     pub fn static_property_name(&self) -> Option<Atom<'a>> {
         match &self.expression {
-            Expression::StringLiteral(lit) => Some(lit.value.clone()),
+            Expression::StringLiteral(lit) => Some(lit.value),
             Expression::TemplateLiteral(lit)
                 if lit.expressions.is_empty() && lit.quasis.len() == 1 =>
             {
-                Some(lit.quasis[0].value.raw.clone())
+                Some(lit.quasis[0].value.raw)
             }
-            Expression::RegExpLiteral(lit) => lit.raw.clone(),
+            Expression::RegExpLiteral(lit) => lit.raw,
             _ => None,
         }
     }
@@ -953,7 +953,7 @@ impl<'a> BindingPatternKind<'a> {
     #[allow(missing_docs)]
     pub fn get_identifier(&self) -> Option<Atom<'a>> {
         match self {
-            Self::BindingIdentifier(ident) => Some(ident.name.clone()),
+            Self::BindingIdentifier(ident) => Some(ident.name),
             Self::AssignmentPattern(assign) => assign.left.get_identifier(),
             _ => None,
         }
@@ -1026,7 +1026,7 @@ impl<'a> Function<'a> {
     /// Returns this [`Function`]'s name, if it has one.
     #[inline]
     pub fn name(&self) -> Option<Atom<'a>> {
-        self.id.as_ref().map(|id| id.name.clone())
+        self.id.as_ref().map(|id| id.name)
     }
 
     /// Get the [`SymbolId`] this [`Function`] is bound to.
@@ -1176,7 +1176,7 @@ impl<'a> Class<'a> {
     /// Returns this [`Class`]'s name, if it has one.
     #[inline]
     pub fn name(&self) -> Option<Atom<'a>> {
-        self.id.as_ref().map(|id| id.name.clone())
+        self.id.as_ref().map(|id| id.name)
     }
 
     /// `true` if this [`Class`] is an expression.
@@ -1487,8 +1487,8 @@ impl<'a> ImportAttributeKey<'a> {
     #[allow(missing_docs)]
     pub fn as_atom(&self) -> Atom<'a> {
         match self {
-            Self::Identifier(identifier) => identifier.name.clone(),
-            Self::StringLiteral(literal) => literal.value.clone(),
+            Self::Identifier(identifier) => identifier.name,
+            Self::StringLiteral(literal) => literal.value,
         }
     }
 }
@@ -1543,17 +1543,17 @@ impl<'a> ModuleExportName<'a> {
     #[allow(missing_docs)]
     pub fn name(&self) -> Atom<'a> {
         match self {
-            Self::IdentifierName(identifier) => identifier.name.clone(),
-            Self::IdentifierReference(identifier) => identifier.name.clone(),
-            Self::StringLiteral(literal) => literal.value.clone(),
+            Self::IdentifierName(identifier) => identifier.name,
+            Self::IdentifierReference(identifier) => identifier.name,
+            Self::StringLiteral(literal) => literal.value,
         }
     }
 
     #[allow(missing_docs)]
     pub fn identifier_name(&self) -> Option<Atom<'a>> {
         match self {
-            Self::IdentifierName(identifier) => Some(identifier.name.clone()),
-            Self::IdentifierReference(identifier) => Some(identifier.name.clone()),
+            Self::IdentifierName(identifier) => Some(identifier.name),
+            Self::IdentifierReference(identifier) => Some(identifier.name),
             Self::StringLiteral(_) => None,
         }
     }

--- a/crates/oxc_ast/src/ast_impl/jsx.rs
+++ b/crates/oxc_ast/src/ast_impl/jsx.rs
@@ -37,8 +37,8 @@ impl<'a> JSXElementName<'a> {
     #[allow(missing_docs)]
     pub fn get_identifier_name(&self) -> Option<Atom<'a>> {
         match self {
-            Self::Identifier(id) => Some(id.as_ref().name.clone()),
-            Self::IdentifierReference(id) => Some(id.as_ref().name.clone()),
+            Self::Identifier(id) => Some(id.as_ref().name),
+            Self::IdentifierReference(id) => Some(id.as_ref().name),
             _ => None,
         }
     }

--- a/crates/oxc_ast/src/ast_impl/ts.rs
+++ b/crates/oxc_ast/src/ast_impl/ts.rs
@@ -14,8 +14,8 @@ impl<'a> TSEnumMemberName<'a> {
     /// Get the name of this enum member.
     pub fn static_name(&self) -> Atom<'a> {
         match self {
-            Self::Identifier(ident) => ident.name.clone(),
-            Self::String(lit) => lit.value.clone(),
+            Self::Identifier(ident) => ident.name,
+            Self::String(lit) => lit.value,
         }
     }
 }
@@ -211,8 +211,8 @@ impl<'a> TSModuleDeclarationName<'a> {
     /// Get the static name of this module declaration name.
     pub fn name(&self) -> Atom<'a> {
         match self {
-            Self::Identifier(ident) => ident.name.clone(),
-            Self::StringLiteral(lit) => lit.value.clone(),
+            Self::Identifier(ident) => ident.name,
+            Self::StringLiteral(lit) => lit.value,
         }
     }
 }

--- a/crates/oxc_ast/src/ast_kind_impl.rs
+++ b/crates/oxc_ast/src/ast_kind_impl.rs
@@ -67,10 +67,10 @@ impl<'a> AstKind<'a> {
 
     pub fn identifier_name(self) -> Option<Atom<'a>> {
         match self {
-            Self::BindingIdentifier(ident) => Some(ident.name.clone()),
-            Self::IdentifierReference(ident) => Some(ident.name.clone()),
-            Self::LabelIdentifier(ident) => Some(ident.name.clone()),
-            Self::IdentifierName(ident) => Some(ident.name.clone()),
+            Self::BindingIdentifier(ident) => Some(ident.name),
+            Self::IdentifierReference(ident) => Some(ident.name),
+            Self::LabelIdentifier(ident) => Some(ident.name),
+            Self::IdentifierName(ident) => Some(ident.name),
             _ => None,
         }
     }

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -307,7 +307,7 @@ impl Serialize for JSXElementName<'_> {
         match self {
             Self::Identifier(ident) => ident.serialize(serializer),
             Self::IdentifierReference(ident) => {
-                JSXIdentifier { span: ident.span, name: ident.name.clone() }.serialize(serializer)
+                JSXIdentifier { span: ident.span, name: ident.name }.serialize(serializer)
             }
             Self::NamespacedName(name) => name.serialize(serializer),
             Self::MemberExpression(expr) => expr.serialize(serializer),
@@ -322,7 +322,7 @@ impl Serialize for JSXMemberExpressionObject<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match self {
             Self::IdentifierReference(ident) => {
-                JSXIdentifier { span: ident.span, name: ident.name.clone() }.serialize(serializer)
+                JSXIdentifier { span: ident.span, name: ident.name }.serialize(serializer)
             }
             Self::MemberExpression(expr) => expr.serialize(serializer),
             Self::ThisExpression(expr) => {

--- a/crates/oxc_isolated_declarations/src/enum.rs
+++ b/crates/oxc_isolated_declarations/src/enum.rs
@@ -48,7 +48,7 @@ impl<'a> IsolatedDeclarations<'a> {
                     TSEnumMemberName::Identifier(id) => &id.name,
                     TSEnumMemberName::String(str) => &str.value,
                 };
-                prev_members.insert(member_name.clone(), value.clone());
+                prev_members.insert(*member_name, value.clone());
             }
 
             let member = self.ast.ts_enum_member(

--- a/crates/oxc_isolated_declarations/src/lib.rs
+++ b/crates/oxc_isolated_declarations/src/lib.rs
@@ -450,7 +450,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         return false;
                     }
                 } else {
-                    last_function_name = Some(name.clone());
+                    last_function_name = Some(*name);
                 }
                 true
             }
@@ -470,7 +470,7 @@ impl<'a> IsolatedDeclarations<'a> {
                             return false;
                         }
                     } else {
-                        last_function_name = Some(name.clone());
+                        last_function_name = Some(*name);
                     }
                     true
                 } else {
@@ -546,14 +546,14 @@ impl<'a> IsolatedDeclarations<'a> {
                             assignable_properties_for_namespace
                                 .entry(&ident.name)
                                 .or_default()
-                                .insert(id.name.clone());
+                                .insert(id.name);
                         }
                     }
                     Some(Declaration::TSEnumDeclaration(decl)) => {
                         assignable_properties_for_namespace
                             .entry(&ident.name)
                             .or_default()
-                            .insert(decl.id.name.clone());
+                            .insert(decl.id.name);
                     }
                     _ => {}
                 }
@@ -573,7 +573,7 @@ impl<'a> IsolatedDeclarations<'a> {
                     Some(Declaration::FunctionDeclaration(func)) => {
                         if func.body.is_some() {
                             if let Some(id) = func.id.as_ref() {
-                                can_expando_function_names.insert(id.name.clone());
+                                can_expando_function_names.insert(id.name);
                             }
                         }
                     }
@@ -583,7 +583,7 @@ impl<'a> IsolatedDeclarations<'a> {
                                 && declarator.init.as_ref().is_some_and(Expression::is_function)
                             {
                                 if let Some(name) = declarator.id.get_identifier() {
-                                    can_expando_function_names.insert(name.clone());
+                                    can_expando_function_names.insert(name);
                                 }
                             }
                         }
@@ -617,7 +617,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         {
                             if let Some(name) = declarator.id.get_identifier() {
                                 if self.scope.has_reference(&name) {
-                                    can_expando_function_names.insert(name.clone());
+                                    can_expando_function_names.insert(name);
                                 }
                             }
                         }

--- a/crates/oxc_isolated_declarations/src/module.rs
+++ b/crates/oxc_isolated_declarations/src/module.rs
@@ -78,7 +78,7 @@ impl<'a> IsolatedDeclarations<'a> {
             // declare const _default: Type
             let kind = VariableDeclarationKind::Const;
             let name = self.create_unique_name("_default");
-            let id = self.ast.binding_pattern_kind_binding_identifier(SPAN, &name);
+            let id = self.ast.binding_pattern_kind_binding_identifier(SPAN, name);
             let type_annotation = self
                 .infer_type_from_expression(expr)
                 .map(|ts_type| self.ast.ts_type_annotation(SPAN, ts_type));
@@ -97,7 +97,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 declarations,
                 self.is_declare(),
             ));
-            Some((Some(variable_statement), self.ast.expression_identifier_reference(SPAN, &name)))
+            Some((Some(variable_statement), self.ast.expression_identifier_reference(SPAN, name)))
         }
     }
 

--- a/crates/oxc_isolated_declarations/src/return_type.rs
+++ b/crates/oxc_isolated_declarations/src/return_type.rs
@@ -75,14 +75,14 @@ impl<'a> FunctionReturnType<'a> {
         if let Some((reference_name, is_value)) = match &expr_type {
             TSType::TSTypeReference(type_reference) => {
                 if let TSTypeName::IdentifierReference(ident) = &type_reference.type_name {
-                    Some((ident.name.clone(), false))
+                    Some((ident.name, false))
                 } else {
                     None
                 }
             }
             TSType::TSTypeQuery(query) => {
                 if let TSTypeQueryExprName::IdentifierReference(ident) = &query.expr_name {
-                    Some((ident.name.clone(), true))
+                    Some((ident.name, true))
                 } else {
                     None
                 }
@@ -132,13 +132,13 @@ impl<'a> Visit<'a> for FunctionReturnType<'a> {
 
     fn visit_binding_identifier(&mut self, ident: &BindingIdentifier<'a>) {
         if self.scope_depth == 0 {
-            self.value_bindings.push(ident.name.clone());
+            self.value_bindings.push(ident.name);
         }
     }
 
     fn visit_ts_type_alias_declaration(&mut self, decl: &TSTypeAliasDeclaration<'a>) {
         if self.scope_depth == 0 {
-            self.type_bindings.push(decl.id.name.clone());
+            self.type_bindings.push(decl.id.name);
         }
     }
 

--- a/crates/oxc_isolated_declarations/src/scope.rs
+++ b/crates/oxc_isolated_declarations/src/scope.rs
@@ -92,19 +92,19 @@ impl<'a> Visit<'a> for ScopeTree<'a> {
     }
 
     fn visit_identifier_reference(&mut self, ident: &IdentifierReference<'a>) {
-        self.add_reference(ident.name.clone(), KindFlags::Value);
+        self.add_reference(ident.name, KindFlags::Value);
     }
 
     fn visit_binding_pattern(&mut self, pattern: &BindingPattern<'a>) {
         if let BindingPatternKind::BindingIdentifier(ident) = &pattern.kind {
-            self.add_binding(ident.name.clone(), KindFlags::Value);
+            self.add_binding(ident.name, KindFlags::Value);
         }
         walk_binding_pattern(self, pattern);
     }
 
     fn visit_ts_type_name(&mut self, name: &TSTypeName<'a>) {
         if let TSTypeName::IdentifierReference(ident) = name {
-            self.add_reference(ident.name.clone(), KindFlags::Type);
+            self.add_reference(ident.name, KindFlags::Type);
         } else {
             walk_ts_type_name(self, name);
         }
@@ -114,7 +114,7 @@ impl<'a> Visit<'a> for ScopeTree<'a> {
     fn visit_ts_type_query(&mut self, ty: &TSTypeQuery<'a>) {
         if let Some(type_name) = ty.expr_name.as_ts_type_name() {
             let ident = TSTypeName::get_identifier_reference(type_name);
-            self.add_reference(ident.name.clone(), KindFlags::Value);
+            self.add_reference(ident.name, KindFlags::Value);
             // `typeof Type<Parameters>`
             //              ^^^^^^^^^^^
             if let Some(type_parameters) = &ty.type_parameters {
@@ -140,7 +140,7 @@ impl<'a> Visit<'a> for ScopeTree<'a> {
 
     fn visit_export_default_declaration(&mut self, decl: &ExportDefaultDeclaration<'a>) {
         if let ExportDefaultDeclarationKind::Identifier(ident) = &decl.declaration {
-            self.add_reference(ident.name.clone(), KindFlags::All);
+            self.add_reference(ident.name, KindFlags::All);
         } else {
             walk_export_default_declaration(self, decl);
         }
@@ -153,30 +153,30 @@ impl<'a> Visit<'a> for ScopeTree<'a> {
             }
             Declaration::FunctionDeclaration(decl) => {
                 if let Some(id) = decl.id.as_ref() {
-                    self.add_binding(id.name.clone(), KindFlags::Value);
+                    self.add_binding(id.name, KindFlags::Value);
                 }
             }
             Declaration::ClassDeclaration(decl) => {
                 if let Some(id) = decl.id.as_ref() {
-                    self.add_binding(id.name.clone(), KindFlags::Value);
+                    self.add_binding(id.name, KindFlags::Value);
                 }
             }
             Declaration::TSTypeAliasDeclaration(decl) => {
-                self.add_binding(decl.id.name.clone(), KindFlags::Type);
+                self.add_binding(decl.id.name, KindFlags::Type);
             }
             Declaration::TSInterfaceDeclaration(decl) => {
-                self.add_binding(decl.id.name.clone(), KindFlags::Type);
+                self.add_binding(decl.id.name, KindFlags::Type);
             }
             Declaration::TSEnumDeclaration(decl) => {
-                self.add_binding(decl.id.name.clone(), KindFlags::All);
+                self.add_binding(decl.id.name, KindFlags::All);
             }
             Declaration::TSModuleDeclaration(decl) => {
                 if let TSModuleDeclarationName::Identifier(ident) = &decl.id {
-                    self.add_binding(ident.name.clone(), KindFlags::All);
+                    self.add_binding(ident.name, KindFlags::All);
                 }
             }
             Declaration::TSImportEqualsDeclaration(decl) => {
-                self.add_binding(decl.id.name.clone(), KindFlags::Value);
+                self.add_binding(decl.id.name, KindFlags::Value);
             }
         }
         walk_declaration(self, declaration);

--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -308,7 +308,7 @@ pub fn extract_regex_flags<'a>(
         return None;
     }
     let flag_arg = match &args[1] {
-        Argument::StringLiteral(flag_arg) => flag_arg.value.clone(),
+        Argument::StringLiteral(flag_arg) => flag_arg.value,
         Argument::TemplateLiteral(template) if template.is_no_substitution_template() => {
             template.quasi().expect("no-substitution templates always have a quasi")
         }

--- a/crates/oxc_linter/src/rules/eslint/new_cap.rs
+++ b/crates/oxc_linter/src/rules/eslint/new_cap.rs
@@ -515,12 +515,12 @@ impl Rule for NewCap {
 
 fn extract_name_deep_from_expression(expression: &Expression) -> Option<CompactStr> {
     if let Some(identifier) = expression.get_identifier_reference() {
-        return Some(identifier.name.clone().into());
+        return Some(identifier.name.into());
     }
 
     match expression.without_parentheses() {
         Expression::StaticMemberExpression(expression) => {
-            let prop_name = expression.property.name.clone().into_compact_str();
+            let prop_name = expression.property.name.into_compact_str();
             let obj_name =
                 extract_name_deep_from_expression(expression.object.without_parentheses());
 
@@ -549,7 +549,7 @@ fn extract_name_deep_from_expression(expression: &Expression) -> Option<CompactS
                 extract_name_deep_from_expression(&non_null.expression)
             }
             ChainElement::StaticMemberExpression(expression) => {
-                let prop_name = expression.property.name.clone().into_compact_str();
+                let prop_name = expression.property.name.into_compact_str();
                 let obj_name =
                     extract_name_deep_from_expression(expression.object.without_parentheses());
 
@@ -586,19 +586,19 @@ fn get_computed_member_name(computed_member: &ComputedMemberExpression) -> Optio
         Expression::TemplateLiteral(lit) if lit.expressions.is_empty() && lit.quasis.len() == 1 => {
             Some(lit.quasis[0].value.raw.as_ref().into())
         }
-        Expression::RegExpLiteral(lit) => lit.raw.as_ref().map(|x| x.clone().into_compact_str()),
+        Expression::RegExpLiteral(lit) => lit.raw.as_ref().map(|x| (*x).into_compact_str()),
         _ => None,
     }
 }
 
 fn extract_name_from_expression(expression: &Expression) -> Option<CompactStr> {
     if let Some(identifier) = expression.get_identifier_reference() {
-        return Some(identifier.name.clone().into());
+        return Some(identifier.name.into());
     }
 
     match expression.without_parentheses() {
         Expression::StaticMemberExpression(expression) => {
-            Some(expression.property.name.clone().into_compact_str())
+            Some(expression.property.name.into_compact_str())
         }
         Expression::ComputedMemberExpression(expression) => get_computed_member_name(expression),
         Expression::ChainExpression(chain) => match &chain.expression {
@@ -607,7 +607,7 @@ fn extract_name_from_expression(expression: &Expression) -> Option<CompactStr> {
                 extract_name_from_expression(&non_null.expression)
             }
             ChainElement::StaticMemberExpression(expression) => {
-                Some(expression.property.name.clone().into_compact_str())
+                Some(expression.property.name.into_compact_str())
             }
             ChainElement::ComputedMemberExpression(expression) => {
                 get_computed_member_name(expression)

--- a/crates/oxc_linter/src/rules/eslint/no_magic_numbers.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_magic_numbers.rs
@@ -259,7 +259,7 @@ impl InternConfig<'_> {
                 }
             }
             AstKind::BigIntLiteral(bigint) => {
-                let big_int_string = bigint.raw.clone().into_string();
+                let big_int_string = bigint.raw.into_string();
                 if is_negative {
                     let raw = format!("-{big_int_string}");
 

--- a/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
+++ b/crates/oxc_linter/src/rules/nextjs/inline_script_id.rs
@@ -75,7 +75,7 @@ impl Rule for InlineScriptId {
                 match prop {
                     JSXAttributeItem::Attribute(attr) => {
                         if let JSXAttributeName::Identifier(ident) = &attr.name {
-                            prop_names_hash_set.insert(ident.name.clone());
+                            prop_names_hash_set.insert(ident.name);
                         }
                     }
                     JSXAttributeItem::SpreadAttribute(spread_attr) => {
@@ -85,7 +85,7 @@ impl Rule for InlineScriptId {
                             for prop in &obj_expr.properties {
                                 if let ObjectPropertyKind::ObjectProperty(obj_prop) = prop {
                                     if let PropertyKey::StaticIdentifier(ident) = &obj_prop.key {
-                                        prop_names_hash_set.insert(ident.name.clone());
+                                        prop_names_hash_set.insert(ident.name);
                                     }
                                 }
                             }

--- a/crates/oxc_linter/src/rules/nextjs/no_sync_scripts.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_sync_scripts.rs
@@ -53,13 +53,15 @@ impl Rule for NoSyncScripts {
             .filter_map(
                 |v| if let JSXAttributeItem::Attribute(v) = v { Some(&v.name) } else { None },
             )
-            .filter_map(|v| {
-                if let JSXAttributeName::Identifier(v) = v {
-                    Some(v.name.clone())
-                } else {
-                    None
-                }
-            })
+            .filter_map(
+                |v| {
+                    if let JSXAttributeName::Identifier(v) = v {
+                        Some(v.name)
+                    } else {
+                        None
+                    }
+                },
+            )
             .collect::<FxHashSet<_>>();
 
         if attributes_hs.contains("src")

--- a/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
@@ -728,7 +728,7 @@ fn analyze_property_chain<'a, 'b>(
     match expr {
         Expression::Identifier(ident) => Ok(Some(Dependency {
             span: ident.span(),
-            name: ident.name.clone(),
+            name: ident.name,
             reference_id: ident.reference_id(),
             chain: vec![],
             symbol_id: semantic.symbols().get_reference(ident.reference_id()).symbol_id(),
@@ -752,11 +752,11 @@ fn concat_members<'a, 'b>(
         return Ok(None);
     };
 
-    let new_chain = Vec::from([member_expr.property.name.clone()]);
+    let new_chain = Vec::from([member_expr.property.name]);
 
     Ok(Some(Dependency {
         span: member_expr.span,
-        name: source.name.clone(),
+        name: source.name,
         reference_id: source.reference_id,
         chain: [source.chain, new_chain].concat(),
         symbol_id: semantic.symbols().get_reference(source.reference_id).symbol_id(),
@@ -1050,9 +1050,9 @@ impl<'a> Visit<'a> for ExhaustiveDepsVisitor<'a, '_> {
                     if is_parent_call_expr {
                         self.found_dependencies.insert(source);
                     } else {
-                        let new_chain = Vec::from([it.property.name.clone()]);
+                        let new_chain = Vec::from([it.property.name]);
                         self.found_dependencies.insert(Dependency {
-                            name: source.name.clone(),
+                            name: source.name,
                             reference_id: source.reference_id,
                             span: source.span,
                             chain: [source.chain.clone(), new_chain].concat(),
@@ -1084,7 +1084,7 @@ impl<'a> Visit<'a> for ExhaustiveDepsVisitor<'a, '_> {
             return;
         }
         self.found_dependencies.insert(Dependency {
-            name: ident.name.clone(),
+            name: ident.name,
             reference_id: ident.reference_id(),
             span: ident.span,
             chain: vec![],

--- a/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
@@ -67,7 +67,7 @@ impl Rule for JsxNoDuplicateProps {
                 continue;
             };
 
-            if let Some(old_span) = props.insert(ident.name.clone(), ident.span) {
+            if let Some(old_span) = props.insert(ident.name, ident.span) {
                 ctx.diagnostic(jsx_no_duplicate_props_diagnostic(
                     ident.name.as_str(),
                     old_span,

--- a/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/explicit_length_check.rs
@@ -224,7 +224,7 @@ impl ExplicitLengthCheck {
             if need_paren { ")" } else { "" },
             if need_pad_end { " " } else { "" },
         );
-        let property = static_member_expr.property.name.clone();
+        let property = static_member_expr.property.name;
         let help = if auto_fix {
             None
         } else {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_node_protocol.rs
@@ -48,25 +48,23 @@ impl Rule for PreferNodeProtocol {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let string_lit_value_with_span = match node.kind() {
             AstKind::ImportExpression(import) => match import.source {
-                Expression::StringLiteral(ref str_lit) => {
-                    Some((str_lit.value.clone(), str_lit.span))
-                }
+                Expression::StringLiteral(ref str_lit) => Some((str_lit.value, str_lit.span)),
                 _ => None,
             },
             AstKind::TSImportEqualsDeclaration(import) => match &import.module_reference {
                 TSModuleReference::ExternalModuleReference(external) => {
-                    Some((external.expression.value.clone(), external.expression.span))
+                    Some((external.expression.value, external.expression.span))
                 }
                 _ => None,
             },
             AstKind::CallExpression(call) if !call.optional => {
-                call.common_js_require().map(|s| (s.value.clone(), s.span))
+                call.common_js_require().map(|s| (s.value, s.span))
             }
             AstKind::ModuleDeclaration(ModuleDeclaration::ImportDeclaration(import)) => {
-                Some((import.source.value.clone(), import.source.span))
+                Some((import.source.value, import.source.span))
             }
             AstKind::ModuleDeclaration(ModuleDeclaration::ExportNamedDeclaration(export)) => {
-                export.source.as_ref().map(|item| (item.value.clone(), item.span))
+                export.source.as_ref().map(|item| (item.value, item.span))
             }
             _ => None,
         };

--- a/crates/oxc_linter/src/utils/express.rs
+++ b/crates/oxc_linter/src/utils/express.rs
@@ -33,10 +33,10 @@ pub fn as_endpoint_registration<'a, 'n>(
     let first = call.arguments[0].as_expression()?;
     match first {
         Expression::StringLiteral(path) => {
-            Some((Some(path.value.clone()), &call.arguments.as_slice()[1..]))
+            Some((Some(path.value), &call.arguments.as_slice()[1..]))
         }
         Expression::TemplateLiteral(template) if template.is_no_substitution_template() => {
-            Some((template.quasi().clone(), &call.arguments.as_slice()[1..]))
+            Some((template.quasi(), &call.arguments.as_slice()[1..]))
         }
         _ => Some((None, call.arguments.as_slice())),
     }

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -317,7 +317,7 @@ impl Mangler {
                     itertools::Either::Right(decl.id().into_iter())
                 }
             })
-            .map(|id| (id.name.clone(), id.symbol_id()))
+            .map(|id| (id.name, id.symbol_id()))
             .collect()
     }
 }

--- a/crates/oxc_minifier/src/ast_passes/convert_to_dotted_properties.rs
+++ b/crates/oxc_minifier/src/ast_passes/convert_to_dotted_properties.rs
@@ -47,7 +47,7 @@ impl<'a> ConvertToDottedProperties {
         let MemberExpression::ComputedMemberExpression(e) = expr else { return };
         let Expression::StringLiteral(s) = &e.expression else { return };
         if is_identifier_name(&s.value) {
-            let property = ctx.ast.identifier_name(s.span, s.value.clone());
+            let property = ctx.ast.identifier_name(s.span, s.value);
             let object = ctx.ast.move_expression(&mut e.object);
             *expr = MemberExpression::StaticMemberExpression(
                 ctx.ast.alloc_static_member_expression(e.span, object, property, e.optional),

--- a/crates/oxc_minifier/src/ast_passes/peephole_fold_constants.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_fold_constants.rs
@@ -590,8 +590,7 @@ impl<'a, 'b> PeepholeFoldConstants {
                 // `Number("a")` -> `+"a"` -> `NaN`
                 // `Number("1")` -> `+"1"` -> `1`
                 Argument::StringLiteral(n) => {
-                    let argument =
-                        ctx.ast.expression_string_literal(n.span, n.value.clone(), n.raw.clone());
+                    let argument = ctx.ast.expression_string_literal(n.span, n.value, n.raw);
                     if let Some(n) = ctx.eval_to_number(&argument) {
                         n
                     } else {

--- a/crates/oxc_minifier/src/ast_passes/peephole_substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_substitute_alternate_syntax.rs
@@ -1141,9 +1141,7 @@ impl<'a, 'b> PeepholeSubstituteAlternateSyntax {
         }
         if is_identifier_name(value) {
             *computed = false;
-            *key = PropertyKey::StaticIdentifier(
-                ctx.ast.alloc_identifier_name(s.span, s.value.clone()),
-            );
+            *key = PropertyKey::StaticIdentifier(ctx.ast.alloc_identifier_name(s.span, s.value));
             self.changed = true;
             return;
         }

--- a/crates/oxc_minifier/src/keep_var.rs
+++ b/crates/oxc_minifier/src/keep_var.rs
@@ -43,7 +43,7 @@ impl<'a> Visit<'a> for KeepVar<'a> {
     fn visit_variable_declaration(&mut self, it: &VariableDeclaration<'a>) {
         if it.kind.is_var() {
             it.bound_names(&mut |ident| {
-                self.vars.push((ident.name.clone(), ident.span));
+                self.vars.push((ident.name, ident.span));
             });
             if it.has_init() {
                 self.all_hoisted = false;

--- a/crates/oxc_parser/src/js/binding.rs
+++ b/crates/oxc_parser/src/js/binding.rs
@@ -143,7 +143,7 @@ impl<'a> ParserImpl<'a> {
             if let PropertyKey::StaticIdentifier(ident) = &key {
                 shorthand = true;
                 let identifier =
-                    self.ast.binding_pattern_kind_binding_identifier(ident.span, &ident.name);
+                    self.ast.binding_pattern_kind_binding_identifier(ident.span, ident.name);
                 let left = self.ast.binding_pattern(identifier, NONE, false);
                 self.context(Context::In, Context::empty(), |p| p.parse_initializer(span, left))?
             } else {

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -473,7 +473,7 @@ impl<'a> ParserImpl<'a> {
             (imported, local)
         } else {
             let local = self.parse_binding_identifier()?;
-            (self.ast.module_export_name_identifier_name(local.span, local.name.clone()), local)
+            (self.ast.module_export_name_identifier_name(local.span, local.name), local)
         };
         Ok(self.ast.import_declaration_specifier_import_specifier(
             self.end_span(specifier_span),

--- a/crates/oxc_parser/src/js/object.rs
+++ b/crates/oxc_parser/src/js/object.rs
@@ -133,7 +133,7 @@ impl<'a> ParserImpl<'a> {
     fn parse_property_definition_shorthand(&mut self) -> Result<Box<'a, ObjectProperty<'a>>> {
         let span = self.start_span();
         let identifier = self.parse_identifier_reference()?;
-        let key = self.ast.alloc_identifier_name(identifier.span, identifier.name.clone());
+        let key = self.ast.alloc_identifier_name(identifier.span, identifier.name);
         // IdentifierReference ({ foo })
         let value = Expression::Identifier(self.alloc(identifier.clone()));
         // CoverInitializedName ({ foo = bar })

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -140,7 +140,7 @@ impl<'a> ParserImpl<'a> {
             // Section 14.13 Labelled Statement
             // Avoids lookahead for a labeled statement, which is on a hot path
             if self.eat(Kind::Colon) {
-                let label = self.ast.label_identifier(ident.span, ident.name.clone());
+                let label = self.ast.label_identifier(ident.span, ident.name);
                 let body = self.parse_statement_list_item(StatementContext::Label)?;
                 return Ok(self.ast.statement_labeled(self.end_span(span), label, body));
             }

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -149,7 +149,7 @@ impl<'a> ParserImpl<'a> {
         // <member.foo.bar />
         if self.at(Kind::Dot) {
             return self
-                .parse_jsx_member_expression(span, identifier)
+                .parse_jsx_member_expression(span, &identifier)
                 .map(JSXElementName::MemberExpression);
         }
 
@@ -184,7 +184,7 @@ impl<'a> ParserImpl<'a> {
     fn parse_jsx_member_expression(
         &mut self,
         span: Span,
-        object: JSXIdentifier<'a>,
+        object: &JSXIdentifier<'a>,
     ) -> Result<Box<'a, JSXMemberExpression<'a>>> {
         let mut object = if object.name == "this" {
             let object = self.ast.alloc_this_expression(object.span);

--- a/crates/oxc_parser/src/module_record.rs
+++ b/crates/oxc_parser/src/module_record.rs
@@ -68,7 +68,7 @@ impl<'a> ModuleRecordBuilder<'a> {
     fn add_module_request(&mut self, name: &Atom<'a>, requested_module: RequestedModule) {
         self.module_record
             .requested_modules
-            .entry(name.clone())
+            .entry(*name)
             .or_insert_with(|| oxc_allocator::Vec::new_in(self.allocator))
             .push(requested_module);
     }
@@ -94,7 +94,7 @@ impl<'a> ModuleRecordBuilder<'a> {
     }
 
     fn add_export_binding(&mut self, name: Atom<'a>, span: Span) {
-        if let Some(old_node) = self.module_record.exported_bindings.insert(name.clone(), span) {
+        if let Some(old_node) = self.module_record.exported_bindings.insert(name, span) {
             self.exported_bindings_duplicated.push(NameSpan::new(name, old_node));
         }
     }
@@ -206,7 +206,7 @@ impl<'a> ModuleRecordBuilder<'a> {
     }
 
     fn visit_import_declaration(&mut self, decl: &ImportDeclaration<'a>) {
-        let module_request = NameSpan::new(decl.source.value.clone(), decl.source.span);
+        let module_request = NameSpan::new(decl.source.value, decl.source.span);
 
         if let Some(specifiers) = &decl.specifiers {
             for specifier in specifiers {
@@ -216,17 +216,17 @@ impl<'a> ModuleRecordBuilder<'a> {
                             specifier.imported.name(),
                             specifier.imported.span(),
                         )),
-                        NameSpan::new(specifier.local.name.clone(), specifier.local.span),
+                        NameSpan::new(specifier.local.name, specifier.local.span),
                         decl.import_kind.is_type() || specifier.import_kind.is_type(),
                     ),
                     ImportDeclarationSpecifier::ImportNamespaceSpecifier(specifier) => (
                         ImportImportName::NamespaceObject,
-                        NameSpan::new(specifier.local.name.clone(), specifier.local.span),
+                        NameSpan::new(specifier.local.name, specifier.local.span),
                         decl.import_kind.is_type(),
                     ),
                     ImportDeclarationSpecifier::ImportDefaultSpecifier(specifier) => (
                         ImportImportName::Default(specifier.span),
-                        NameSpan::new(specifier.local.name.clone(), specifier.local.span),
+                        NameSpan::new(specifier.local.name, specifier.local.span),
                         decl.import_kind.is_type(),
                     ),
                 };
@@ -251,7 +251,7 @@ impl<'a> ModuleRecordBuilder<'a> {
     }
 
     fn visit_export_all_declaration(&mut self, decl: &ExportAllDeclaration<'a>) {
-        let module_request = NameSpan::new(decl.source.value.clone(), decl.source.span);
+        let module_request = NameSpan::new(decl.source.value, decl.source.span);
         let export_entry = ExportEntry {
             statement_span: decl.span,
             span: decl.span,
@@ -290,17 +290,17 @@ impl<'a> ModuleRecordBuilder<'a> {
 
         let local_name = match &decl.declaration {
             ExportDefaultDeclarationKind::Identifier(ident) => {
-                ExportLocalName::Default(NameSpan::new(ident.name.clone(), ident.span))
+                ExportLocalName::Default(NameSpan::new(ident.name, ident.span))
             }
             ExportDefaultDeclarationKind::FunctionDeclaration(func) => {
                 func.id.as_ref().map_or_else(
                     || ExportLocalName::Null,
-                    |id| ExportLocalName::Name(NameSpan::new(id.name.clone(), id.span)),
+                    |id| ExportLocalName::Name(NameSpan::new(id.name, id.span)),
                 )
             }
             ExportDefaultDeclarationKind::ClassDeclaration(class) => class.id.as_ref().map_or_else(
                 || ExportLocalName::Null,
-                |id| ExportLocalName::Name(NameSpan::new(id.name.clone(), id.span)),
+                |id| ExportLocalName::Name(NameSpan::new(id.name, id.span)),
             ),
             _ => ExportLocalName::Null,
         };
@@ -326,7 +326,7 @@ impl<'a> ModuleRecordBuilder<'a> {
         }
 
         let module_request =
-            decl.source.as_ref().map(|source| NameSpan::new(source.value.clone(), source.span));
+            decl.source.as_ref().map(|source| NameSpan::new(source.value, source.span));
 
         if let Some(module_request) = &module_request {
             self.add_module_request(
@@ -342,10 +342,8 @@ impl<'a> ModuleRecordBuilder<'a> {
 
         if let Some(d) = &decl.declaration {
             d.bound_names(&mut |ident| {
-                let export_name =
-                    ExportExportName::Name(NameSpan::new(ident.name.clone(), ident.span));
-                let local_name =
-                    ExportLocalName::Name(NameSpan::new(ident.name.clone(), ident.span));
+                let export_name = ExportExportName::Name(NameSpan::new(ident.name, ident.span));
+                let local_name = ExportLocalName::Name(NameSpan::new(ident.name, ident.span));
                 let export_entry = ExportEntry {
                     statement_span: decl.span,
                     span: d.span(),
@@ -356,18 +354,18 @@ impl<'a> ModuleRecordBuilder<'a> {
                     is_type: decl.export_kind.is_type(),
                 };
                 self.add_export_entry(export_entry);
-                self.add_export_binding(ident.name.clone(), ident.span);
+                self.add_export_binding(ident.name, ident.span);
             });
         }
 
         for specifier in &decl.specifiers {
             let export_name = ExportExportName::Name(NameSpan::new(
-                specifier.exported.name().clone(),
+                specifier.exported.name(),
                 specifier.exported.span(),
             ));
             let import_name = if module_request.is_some() {
                 ExportImportName::Name(NameSpan::new(
-                    specifier.local.name().clone(),
+                    specifier.local.name(),
                     specifier.local.span(),
                 ))
             } else {
@@ -376,10 +374,7 @@ impl<'a> ModuleRecordBuilder<'a> {
             let local_name = if module_request.is_some() {
                 ExportLocalName::Null
             } else {
-                ExportLocalName::Name(NameSpan::new(
-                    specifier.local.name().clone(),
-                    specifier.local.span(),
-                ))
+                ExportLocalName::Name(NameSpan::new(specifier.local.name(), specifier.local.span()))
             };
             let export_entry = ExportEntry {
                 statement_span: decl.span,
@@ -391,7 +386,7 @@ impl<'a> ModuleRecordBuilder<'a> {
                 is_type: specifier.export_kind.is_type() || decl.export_kind.is_type(),
             };
             self.add_export_entry(export_entry);
-            self.add_export_binding(specifier.exported.name().clone(), specifier.exported.span());
+            self.add_export_binding(specifier.exported.name(), specifier.exported.span());
         }
     }
 }

--- a/crates/oxc_regular_expression/src/parser/pattern_parser/state.rs
+++ b/crates/oxc_regular_expression/src/parser/pattern_parser/state.rs
@@ -128,7 +128,7 @@ fn parse_capturing_groups<'a>(
                 if reader.eat('>') {
                     let group_name = reader.atom(span_start, span_end);
 
-                    simplified.push(SimpleUnit::GroupName(group_name.clone()));
+                    simplified.push(SimpleUnit::GroupName(group_name));
                     // Check duplicates later
                     if let Some(last_span) = group_names.get(&group_name) {
                         let entry = may_duplicates.entry(group_name).or_default();
@@ -203,7 +203,7 @@ fn parse_capturing_groups<'a>(
         }
     }
 
-    Ok((num_of_left_capturing_parens, group_names.keys().cloned().collect()))
+    Ok((num_of_left_capturing_parens, group_names.keys().copied().collect()))
 }
 
 #[cfg(test)]

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -88,11 +88,7 @@ impl<'a> Binder<'a> for VariableDeclarator<'a> {
             // Finally, add the variable to all hoisted scopes
             // to support redeclaration checks when declaring variables with the same name later.
             for &scope_id in &var_scope_ids {
-                builder
-                    .hoisting_variables
-                    .entry(scope_id)
-                    .or_default()
-                    .insert(name.clone(), symbol_id);
+                builder.hoisting_variables.entry(scope_id).or_default().insert(*name, symbol_id);
             }
         });
     }
@@ -155,7 +151,7 @@ impl<'a> Binder<'a> for Function<'a> {
             if is_function_part_of_if_statement(self, builder) {
                 let symbol_id = builder.symbols.create_symbol(
                     ident.span,
-                    ident.name.clone().into(),
+                    ident.name.into(),
                     SymbolFlags::Function,
                     ScopeId::new(u32::MAX - 1), // Not bound to any scope.
                     builder.current_node_id,

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -2120,7 +2120,7 @@ impl<'a> SemanticBuilder<'a> {
     fn reference_identifier(&mut self, ident: &IdentifierReference<'a>) {
         let flags = self.resolve_reference_usages();
         let reference = Reference::new(self.current_node_id, flags);
-        let reference_id = self.declare_reference(ident.name.clone(), reference);
+        let reference_id = self.declare_reference(ident.name, reference);
         ident.reference_id.set(Some(reference_id));
     }
 

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -184,7 +184,7 @@ pub fn check_formal_parameters(params: &FormalParameters, ctx: &SemanticBuilder<
 fn check_duplicate_bound_names<'a, T: BoundNames<'a>>(bound_names: &T, ctx: &SemanticBuilder<'_>) {
     let mut idents: FxHashMap<Atom<'a>, Span> = FxHashMap::default();
     bound_names.bound_names(&mut |ident| {
-        if let Some(old_span) = idents.insert(ident.name.clone(), ident.span) {
+        if let Some(old_span) = idents.insert(ident.name, ident.span) {
             ctx.error(redeclaration(&ident.name, old_span, ident.span));
         }
     });

--- a/crates/oxc_span/src/atom.rs
+++ b/crates/oxc_span/src/atom.rs
@@ -14,7 +14,7 @@ use crate::{cmp::ContentEq, CompactStr};
 ///
 /// Use [CompactStr] with [Atom::to_compact_str] or [Atom::into_compact_str] for
 /// the lifetimeless form.
-#[derive(Clone, Eq)]
+#[derive(Clone, Copy, Eq)]
 #[cfg_attr(feature = "serialize", derive(Serialize))]
 #[cfg_attr(feature = "serialize", serde(transparent))]
 pub struct Atom<'a>(&'a str);

--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -1057,7 +1057,7 @@ impl<'a> ArrowFunctionConverter<'a> {
             ctx.symbols_mut().add_resolved_reference(binding.symbol_id, reference_id);
         }
 
-        ident.name = binding.name.clone();
+        ident.name = binding.name;
     }
 
     /// Transform the binding identifier for `arguments` if it's affected after transformation.
@@ -1081,7 +1081,7 @@ impl<'a> ArrowFunctionConverter<'a> {
             Self::rename_arguments_symbol(symbol_id, arguments_name, ctx);
             // Record the symbol ID as a renamed `arguments` variable.
             self.renamed_arguments_symbol_ids.insert(symbol_id);
-            BoundIdentifier::new(ident.name.clone(), symbol_id)
+            BoundIdentifier::new(ident.name, symbol_id)
         });
     }
 

--- a/crates/oxc_transformer/src/common/duplicate.rs
+++ b/crates/oxc_transformer/src/common/duplicate.rs
@@ -96,7 +96,7 @@ impl<'a> TransformCtx<'a> {
                     if !mutated_symbol_needs_temp_var || !ctx.symbols().symbol_is_mutated(symbol_id)
                     {
                         // Reading bound identifier cannot have side effects, so no need for temp var
-                        let binding = BoundIdentifier::new(ident.name.clone(), symbol_id);
+                        let binding = BoundIdentifier::new(ident.name, symbol_id);
                         let references = create_array(|| {
                             binding.create_spanned_read_expression(ident.span, ctx)
                         });

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -163,12 +163,11 @@ impl<'a> ExponentiationOperator<'a, '_> {
         let pow_left = if let Some(symbol_id) = reference.symbol_id() {
             // This variable is declared in scope so evaluating it multiple times can't trigger a getter.
             // No need for a temp var.
-            ctx.create_bound_ident_expr(SPAN, ident.name.clone(), symbol_id, ReferenceFlags::Read)
+            ctx.create_bound_ident_expr(SPAN, ident.name, symbol_id, ReferenceFlags::Read)
         } else {
             // Unbound reference. Could possibly trigger a getter so we need to only evaluate it once.
             // Assign to a temp var.
-            let reference =
-                ctx.create_unbound_ident_expr(SPAN, ident.name.clone(), ReferenceFlags::Read);
+            let reference = ctx.create_unbound_ident_expr(SPAN, ident.name, ReferenceFlags::Read);
             let binding = self.create_temp_var(reference, &mut temp_var_inits, ctx);
             binding.create_read_expression(ctx)
         };
@@ -245,8 +244,8 @@ impl<'a> ExponentiationOperator<'a, '_> {
         //                            ^^^^^^
         // ```
         let prop_span = member_expr.property.span;
-        let prop_name = member_expr.property.name.clone();
-        let prop = ctx.ast.expression_string_literal(prop_span, prop_name.clone(), None);
+        let prop_name = member_expr.property.name;
+        let prop = ctx.ast.expression_string_literal(prop_span, prop_name, None);
 
         // Complete 2nd member expression
         // ```
@@ -490,7 +489,7 @@ impl<'a> ExponentiationOperator<'a, '_> {
                     // No need for a temp var.
                     return ctx.create_bound_ident_expr(
                         SPAN,
-                        ident.name.clone(),
+                        ident.name,
                         symbol_id,
                         ReferenceFlags::Read,
                     );

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -362,7 +362,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
                 // `function foo() { ... }` -> `function foo() {} return foo;`
                 let reference = ctx.create_bound_ident_expr(
                     SPAN,
-                    id.name.clone(),
+                    id.name,
                     id.symbol_id(),
                     ReferenceFlags::Read,
                 );
@@ -560,7 +560,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
         match ctx.parent() {
             // infer `foo` from `const foo = async function() {}`
             Ancestor::VariableDeclaratorInit(declarator) => {
-                declarator.id().get_binding_identifier().map(|id| id.name.clone())
+                declarator.id().get_binding_identifier().map(|id| id.name)
             }
             // infer `foo` from `({ foo: async function() {} })`
             Ancestor::ObjectPropertyValue(property) if !*property.method() => {

--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -325,7 +325,7 @@ impl<'a> ObjectRestSpread<'a, '_> {
             ctx.ast.vec_from_iter(object_assignment_target.properties.iter_mut().filter_map(|e| {
                 match e {
                     AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(ident) => {
-                        let name = ident.binding.name.clone();
+                        let name = ident.binding.name;
                         let expr = ctx.ast.expression_string_literal(SPAN, name, None);
                         Some(ArrayExpressionElement::from(expr))
                     }
@@ -967,15 +967,15 @@ impl<'a> ObjectRestSpread<'a, '_> {
         match key {
             // `let { a, ... rest }`
             PropertyKey::StaticIdentifier(ident) => {
-                let name = ident.name.clone();
+                let name = ident.name;
                 let expr = ctx.ast.expression_string_literal(ident.span, name, None);
                 Some(ArrayExpressionElement::from(expr))
             }
             // `let { 'a', ... rest }`
             // `let { ['a'], ... rest }`
             PropertyKey::StringLiteral(lit) => {
-                let name = lit.value.clone();
-                let expr = ctx.ast.expression_string_literal(lit.span, name.clone(), None);
+                let name = lit.value;
+                let expr = ctx.ast.expression_string_literal(lit.span, name, None);
                 Some(ArrayExpressionElement::from(expr))
             }
             // `let { [`a`], ... rest }`

--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -91,7 +91,7 @@ impl<'a> NullishCoalescingOperator<'a, '_> {
                     // Check binding is not mutated.
                     // TODO(improve-on-babel): Remove this check. Whether binding is mutated or not is not relevant.
                     if ctx.symbols().get_resolved_references(symbol_id).all(|r| !r.is_write()) {
-                        let binding = BoundIdentifier::new(ident.name.clone(), symbol_id);
+                        let binding = BoundIdentifier::new(ident.name, symbol_id);
                         let ident_span = ident.span;
                         return Self::create_conditional_expression(
                             logical_expr.left,

--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -142,8 +142,7 @@ impl<'a> LogicalAssignmentOperators<'a, '_> {
         let symbol_id = reference.symbol_id();
         let left_expr = Expression::Identifier(ctx.alloc(ident.clone()));
 
-        let ident =
-            ctx.create_ident_reference(SPAN, ident.name.clone(), symbol_id, ReferenceFlags::Write);
+        let ident = ctx.create_ident_reference(SPAN, ident.name, symbol_id, ReferenceFlags::Write);
         let assign_target = AssignmentTarget::AssignmentTargetIdentifier(ctx.alloc(ident));
         (left_expr, assign_target)
     }

--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -89,7 +89,7 @@ impl<'a> ClassProperties<'a, '_> {
                         // Note: Current scope is outside class.
                         let binding = ctx.generate_uid_in_current_hoist_scope(&ident.name);
                         private_props.insert(
-                            ident.name.clone(),
+                            ident.name,
                             PrivateProp::new(binding, prop.r#static, None, false),
                         );
                     }
@@ -133,7 +133,7 @@ impl<'a> ClassProperties<'a, '_> {
                             SymbolFlags::FunctionScopedVariable,
                         );
 
-                        match private_props.entry(ident.name.clone()) {
+                        match private_props.entry(ident.name) {
                             Entry::Occupied(mut entry) => {
                                 // If there's already a binding for this private property,
                                 // it's a setter or getter, so store the binding in `binding2`.
@@ -156,7 +156,7 @@ impl<'a> ClassProperties<'a, '_> {
                     if let PropertyKey::PrivateIdentifier(ident) = &prop.key {
                         let dummy_binding = BoundIdentifier::new(Atom::empty(), SymbolId::new(0));
                         private_props.insert(
-                            ident.name.clone(),
+                            ident.name,
                             PrivateProp::new(dummy_binding, prop.r#static, None, true),
                         );
                     }
@@ -803,11 +803,7 @@ impl<'a> ClassProperties<'a, '_> {
         transform_ctx.helper_call_expr(
             Helper::ClassPrivateFieldLooseKey,
             SPAN,
-            ctx.ast.vec1(Argument::from(ctx.ast.expression_string_literal(
-                SPAN,
-                name.clone(),
-                None,
-            ))),
+            ctx.ast.vec1(Argument::from(ctx.ast.expression_string_literal(SPAN, *name, None))),
             ctx,
         )
     }

--- a/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
@@ -798,7 +798,7 @@ impl<'a> VisitMut<'a> for ConstructorSymbolRenamer<'a, '_> {
     fn visit_binding_identifier(&mut self, ident: &mut BindingIdentifier<'a>) {
         let symbol_id = ident.symbol_id();
         if let Some(new_name) = self.clashing_symbols.get(&symbol_id) {
-            ident.name = new_name.clone();
+            ident.name = *new_name;
         }
     }
 
@@ -806,7 +806,7 @@ impl<'a> VisitMut<'a> for ConstructorSymbolRenamer<'a, '_> {
         let reference_id = ident.reference_id();
         if let Some(symbol_id) = self.ctx.symbols().get_reference(reference_id).symbol_id() {
             if let Some(new_name) = self.clashing_symbols.get(&symbol_id) {
-                ident.name = new_name.clone();
+                ident.name = *new_name;
             }
         }
     }

--- a/crates/oxc_transformer/src/es2022/class_properties/instance_prop_init.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/instance_prop_init.rs
@@ -132,7 +132,7 @@ impl<'a> InstanceInitializerVisitor<'a, '_> {
         }
 
         // Record the symbol clash. Symbol in constructor needs to be renamed.
-        self.clashing_symbols.entry(constructor_symbol_id).or_insert(ident.name.clone());
+        self.clashing_symbols.entry(constructor_symbol_id).or_insert(ident.name);
     }
 }
 

--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -1095,7 +1095,7 @@ impl<'a> ClassProperties<'a, '_> {
             });
             let get_binding = get_binding.cloned();
             let set_binding = set_binding.cloned();
-            let private_name = field_expr.field.name.clone();
+            let private_name = field_expr.field.name;
 
             // Make 2 copies of `object`
             let (object1, object2) = self.duplicate_object(object, ctx);

--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -281,7 +281,7 @@ impl<'a> ClassProperties<'a, '_> {
     ) -> Expression<'a> {
         let key = match &mut prop.key {
             PropertyKey::StaticIdentifier(ident) => {
-                ctx.ast.expression_string_literal(ident.span, ident.name.clone(), None)
+                ctx.ast.expression_string_literal(ident.span, ident.name, None)
             }
             key @ match_expression!(PropertyKey) => {
                 let key = key.to_expression_mut();

--- a/crates/oxc_transformer/src/es2022/class_properties/static_block_and_prop_init.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/static_block_and_prop_init.rs
@@ -130,7 +130,7 @@ impl<'a> ClassProperties<'a, '_> {
 
         // Identifier is reference to class name. Rename it.
         let temp_binding = class_details.bindings.get_or_init_static_binding(ctx);
-        ident.name = temp_binding.name.clone();
+        ident.name = temp_binding.name;
 
         let symbols = ctx.symbols_mut();
         symbols.get_reference_mut(reference_id).set_symbol_id(temp_binding.symbol_id);

--- a/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
@@ -63,8 +63,7 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_, '_> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let property = &member.property;
-        let property =
-            ctx.ast.expression_string_literal(property.span, property.name.clone(), None);
+        let property = ctx.ast.expression_string_literal(property.span, property.name, None);
         self.create_super_prop_get(member.span, property, is_callee, ctx)
     }
 
@@ -211,11 +210,8 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_, '_> {
         };
         let AssignmentExpression { span, operator, right: value, left } = assign_expr.unbox();
         let AssignmentTarget::StaticMemberExpression(member) = left else { unreachable!() };
-        let property = ctx.ast.expression_string_literal(
-            member.property.span,
-            member.property.name.clone(),
-            None,
-        );
+        let property =
+            ctx.ast.expression_string_literal(member.property.span, member.property.name, None);
         *expr =
             self.transform_super_assignment_expression_impl(span, operator, property, value, ctx);
     }
@@ -382,11 +378,8 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_, '_> {
 
         let temp_var_name_base = get_var_name_from_node(member.as_ref());
 
-        let property = ctx.ast.expression_string_literal(
-            member.property.span,
-            member.property.name.clone(),
-            None,
-        );
+        let property =
+            ctx.ast.expression_string_literal(member.property.span, member.property.name, None);
 
         *expr = self.transform_super_update_expression_impl(
             &temp_var_name_base,

--- a/crates/oxc_transformer/src/jsx/display_name.rs
+++ b/crates/oxc_transformer/src/jsx/display_name.rs
@@ -81,10 +81,10 @@ impl<'a> Traverse<'a> for ReactDisplayName<'a, '_> {
                 // `foo = React.createClass({})`
                 Ancestor::AssignmentExpressionRight(assign_expr) => match assign_expr.left() {
                     AssignmentTarget::AssignmentTargetIdentifier(ident) => {
-                        break ident.name.clone();
+                        break ident.name;
                     }
                     AssignmentTarget::StaticMemberExpression(expr) => {
-                        break expr.property.name.clone();
+                        break expr.property.name;
                     }
                     // Babel does not handle computed member expressions e.g. `foo["bar"]`,
                     // so we diverge from Babel here, but that's probably an improvement
@@ -99,7 +99,7 @@ impl<'a> Traverse<'a> for ReactDisplayName<'a, '_> {
                 // `let foo = React.createClass({})`
                 Ancestor::VariableDeclaratorInit(declarator) => {
                     if let BindingPatternKind::BindingIdentifier(ident) = &declarator.id().kind {
-                        break ident.name.clone();
+                        break ident.name;
                     }
                     return;
                 }

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -187,8 +187,7 @@ impl<'a, 'ctx> AutomaticScriptBindings<'a, 'ctx> {
         if self.require_jsx.is_none() {
             let var_name =
                 if self.is_development { "reactJsxDevRuntime" } else { "reactJsxRuntime" };
-            let id =
-                self.add_require_statement(var_name, self.jsx_runtime_importer.clone(), false, ctx);
+            let id = self.add_require_statement(var_name, self.jsx_runtime_importer, false, ctx);
             self.require_jsx = Some(id);
         };
         self.require_jsx.as_ref().unwrap().create_read_reference(ctx)
@@ -291,7 +290,7 @@ impl<'a, 'ctx> AutomaticModuleBindings<'a, 'ctx> {
         name: &'static str,
         ctx: &mut TraverseCtx<'a>,
     ) -> BoundIdentifier<'a> {
-        self.add_import_statement(name, self.jsx_runtime_importer.clone(), ctx)
+        self.add_import_statement(name, self.jsx_runtime_importer, ctx)
     }
 
     fn add_import_statement(
@@ -365,20 +364,20 @@ impl<'a> Pragma<'a> {
     fn create_expression(&self, ctx: &mut TraverseCtx<'a>) -> Expression<'a> {
         let (object, parts) = match self {
             Self::Double(first, second) => {
-                let object = get_read_identifier_reference(SPAN, first.clone(), ctx);
+                let object = get_read_identifier_reference(SPAN, *first, ctx);
                 return Expression::from(ctx.ast.member_expression_static(
                     SPAN,
                     object,
-                    ctx.ast.identifier_name(SPAN, second.clone()),
+                    ctx.ast.identifier_name(SPAN, *second),
                     false,
                 ));
             }
             Self::Single(single) => {
-                return get_read_identifier_reference(SPAN, single.clone(), ctx);
+                return get_read_identifier_reference(SPAN, *single, ctx);
             }
             Self::Multiple(parts) => {
                 let mut parts = parts.iter();
-                let first = parts.next().unwrap().clone();
+                let first = *parts.next().unwrap();
                 let object = get_read_identifier_reference(SPAN, first, ctx);
                 (object, parts)
             }
@@ -398,7 +397,7 @@ impl<'a> Pragma<'a> {
 
         let mut expr = object;
         for item in parts {
-            let name = ctx.ast.identifier_name(SPAN, item.clone());
+            let name = ctx.ast.identifier_name(SPAN, *item);
             expr = ctx.ast.member_expression_static(SPAN, expr, name, false).into();
         }
         expr
@@ -770,7 +769,7 @@ impl<'a> JsxImpl<'a, '_> {
     ) -> Expression<'a> {
         match name {
             JSXElementName::Identifier(ident) => {
-                ctx.ast.expression_string_literal(ident.span, ident.name.clone(), None)
+                ctx.ast.expression_string_literal(ident.span, ident.name, None)
             }
             JSXElementName::IdentifierReference(ident) => {
                 Expression::Identifier(ctx.alloc(ident.as_ref().clone()))
@@ -852,7 +851,7 @@ impl<'a> JsxImpl<'a, '_> {
             }
             JSXMemberExpressionObject::ThisExpression(expr) => ctx.ast.expression_this(expr.span),
         };
-        let property = ctx.ast.identifier_name(expr.property.span, expr.property.name.clone());
+        let property = ctx.ast.identifier_name(expr.property.span, expr.property.name);
         ctx.ast.member_expression_static(expr.span, object, property, false).into()
     }
 
@@ -915,7 +914,7 @@ impl<'a> JsxImpl<'a, '_> {
     fn get_attribute_name(name: &JSXAttributeName<'a>, ctx: &TraverseCtx<'a>) -> PropertyKey<'a> {
         match name {
             JSXAttributeName::Identifier(ident) => {
-                let name = ident.name.clone();
+                let name = ident.name;
                 if ident.name.contains('-') {
                     PropertyKey::from(ctx.ast.expression_string_literal(ident.span, name, None))
                 } else {

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -71,7 +71,7 @@ impl<'a> RefreshIdentifierResolver<'a> {
                 let reference_id = ctx.create_unbound_reference(&ident.name, ReferenceFlags::Read);
                 Expression::Identifier(ctx.ast.alloc_identifier_reference_with_reference_id(
                     ident.span,
-                    ident.name.clone(),
+                    ident.name,
                     reference_id,
                 ))
             }
@@ -80,7 +80,7 @@ impl<'a> RefreshIdentifierResolver<'a> {
                 let ident =
                     Expression::Identifier(ctx.ast.alloc_identifier_reference_with_reference_id(
                         ident.span,
-                        ident.name.clone(),
+                        ident.name,
                         reference_id,
                     ));
                 Expression::from(ctx.ast.member_expression_static(
@@ -312,8 +312,8 @@ impl<'a> Traverse<'a> for ReactRefresh<'a, '_> {
         }
 
         let hook_name = match &call_expr.callee {
-            Expression::Identifier(ident) => ident.name.clone(),
-            Expression::StaticMemberExpression(ref member) => member.property.name.clone(),
+            Expression::Identifier(ident) => ident.name,
+            Expression::StaticMemberExpression(ref member) => member.property.name,
             _ => return,
         };
 
@@ -324,10 +324,10 @@ impl<'a> Traverse<'a> for ReactRefresh<'a, '_> {
         if !is_builtin_hook(&hook_name) {
             // Check if a corresponding binding exists where we emit the signature.
             let (binding_name, is_member_expression) = match &call_expr.callee {
-                Expression::Identifier(ident) => (Some(ident.name.clone()), false),
+                Expression::Identifier(ident) => (Some(ident.name), false),
                 Expression::StaticMemberExpression(member) => {
                     if let Expression::Identifier(object) = &member.object {
-                        (Some(object.name.clone()), true)
+                        (Some(object.name), true)
                     } else {
                         (None, false)
                     }
@@ -355,7 +355,7 @@ impl<'a> Traverse<'a> for ReactRefresh<'a, '_> {
                                 expr = Expression::from(ctx.ast.member_expression_static(
                                     SPAN,
                                     expr,
-                                    ctx.ast.identifier_name(SPAN, hook_name.clone()),
+                                    ctx.ast.identifier_name(SPAN, hook_name),
                                     false,
                                 ));
                             }
@@ -516,13 +516,9 @@ impl<'a> ReactRefresh<'a, '_> {
         id: &BindingIdentifier<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {
-        let left = self.create_registration(id.name.clone(), ctx);
-        let right = ctx.create_bound_ident_expr(
-            SPAN,
-            id.name.clone(),
-            id.symbol_id(),
-            ReferenceFlags::Read,
-        );
+        let left = self.create_registration(id.name, ctx);
+        let right =
+            ctx.create_bound_ident_expr(SPAN, id.name, id.symbol_id(), ReferenceFlags::Read);
         let expr = ctx.ast.expression_assignment(SPAN, AssignmentOperator::Assign, left, right);
         ctx.ast.statement_expression(SPAN, expr)
     }

--- a/crates/oxc_transformer/src/plugins/inject_global_variables.rs
+++ b/crates/oxc_transformer/src/plugins/inject_global_variables.rs
@@ -254,7 +254,7 @@ impl<'a> InjectGlobalVariables<'a> {
                             .push((dot_define.parts[0].clone(), dot_define.value.clone()));
                         self.ast.atom(dot_define.value.as_str())
                     });
-                    let value_atom = value_atom.clone();
+                    let value_atom = *value_atom;
 
                     let value = self.ast.expression_identifier_reference(SPAN, value_atom);
                     *expr = value;

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -331,7 +331,7 @@ impl<'a> Traverse<'a> for TypeScriptAnnotations<'a, '_> {
                     if let Some(id) = param.pattern.get_binding_identifier() {
                         self.assignments.push(Assignment {
                             span: id.span,
-                            name: id.name.clone(),
+                            name: id.name,
                             symbol_id: id.symbol_id(),
                         });
                     }
@@ -560,7 +560,7 @@ impl<'a> Traverse<'a> for TypeScriptAnnotations<'a, '_> {
         // NB: Namespace transform happens in `enter_program` visitor, and replaces retained
         // namespaces with functions. This visitor is called after, by which time any remaining
         // namespaces need to be deleted.
-        self.type_identifier_names.insert(decl.id.name().clone());
+        self.type_identifier_names.insert(decl.id.name());
     }
 }
 
@@ -637,11 +637,7 @@ impl<'a> Assignment<'a> {
     // Creates `this.name = name`
     fn create_this_property_assignment(&self, ctx: &mut TraverseCtx<'a>) -> Statement<'a> {
         let reference_id = ctx.create_bound_reference(self.symbol_id, ReferenceFlags::Read);
-        let id = ctx.ast.identifier_reference_with_reference_id(
-            self.span,
-            self.name.clone(),
-            reference_id,
-        );
+        let id = ctx.ast.identifier_reference_with_reference_id(self.span, self.name, reference_id);
 
         ctx.ast.statement_expression(
             SPAN,
@@ -651,7 +647,7 @@ impl<'a> Assignment<'a> {
                 SimpleAssignmentTarget::from(ctx.ast.member_expression_static(
                     SPAN,
                     ctx.ast.expression_this(SPAN),
-                    ctx.ast.identifier_name(self.span, &self.name),
+                    ctx.ast.identifier_name(self.span, self.name),
                     false,
                 ))
                 .into(),

--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -328,7 +328,7 @@ impl<'a> TypeScriptNamespace<'a, '_> {
                     AssignmentTarget::from(ctx.ast.member_expression_static(
                         SPAN,
                         parent_binding.create_read_expression(ctx),
-                        ctx.ast.identifier_name(SPAN, binding.name.clone()),
+                        ctx.ast.identifier_name(SPAN, binding.name),
                         false,
                     ))
                 } else {
@@ -347,7 +347,7 @@ impl<'a> TypeScriptNamespace<'a, '_> {
             if let Some(parent_binding) = parent_binding {
                 let assign_left = binding.create_write_target(ctx);
                 let assign_right = {
-                    let property = ctx.ast.identifier_name(SPAN, binding.name.clone());
+                    let property = ctx.ast.identifier_name(SPAN, binding.name);
                     let logical_left = ctx.ast.member_expression_static(
                         SPAN,
                         parent_binding.create_read_expression(ctx),
@@ -392,7 +392,7 @@ impl<'a> TypeScriptNamespace<'a, '_> {
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
         let object = object_binding.create_read_expression(ctx);
-        let property = ctx.ast.identifier_name(SPAN, &value_binding.name);
+        let property = ctx.ast.identifier_name(SPAN, value_binding.name);
         let left = ctx.ast.member_expression_static(SPAN, object, property, false);
         let left = AssignmentTarget::from(left);
         let right = value_binding.create_read_expression(ctx);

--- a/crates/oxc_traverse/src/context/bound_identifier.rs
+++ b/crates/oxc_traverse/src/context/bound_identifier.rs
@@ -53,17 +53,17 @@ impl<'a> BoundIdentifier<'a> {
 
     /// Create `BoundIdentifier` from a `BindingIdentifier`
     pub fn from_binding_ident(ident: &BindingIdentifier<'a>) -> Self {
-        Self { name: ident.name.clone(), symbol_id: ident.symbol_id() }
+        Self { name: ident.name, symbol_id: ident.symbol_id() }
     }
 
     /// Convert `BoundIdentifier` to `MaybeBoundIdentifier`
     pub fn to_maybe_bound_identifier(&self) -> MaybeBoundIdentifier<'a> {
-        MaybeBoundIdentifier::new(self.name.clone(), Some(self.symbol_id))
+        MaybeBoundIdentifier::new(self.name, Some(self.symbol_id))
     }
 
     /// Create `BindingIdentifier` for this binding
     pub fn create_binding_identifier(&self, ctx: &TraverseCtx<'a>) -> BindingIdentifier<'a> {
-        ctx.ast.binding_identifier_with_symbol_id(SPAN, self.name.clone(), self.symbol_id)
+        ctx.ast.binding_identifier_with_symbol_id(SPAN, self.name, self.symbol_id)
     }
 
     /// Create `BindingPattern` for this binding
@@ -281,7 +281,7 @@ impl<'a> BoundIdentifier<'a> {
         flags: ReferenceFlags,
         ctx: &mut TraverseCtx<'a>,
     ) -> IdentifierReference<'a> {
-        ctx.create_bound_ident_reference(span, self.name.clone(), self.symbol_id, flags)
+        ctx.create_bound_ident_reference(span, self.name, self.symbol_id, flags)
     }
 
     /// Create `Expression::Identifier` referencing this binding, with specified `Span` and `ReferenceFlags`

--- a/crates/oxc_traverse/src/context/maybe_bound_identifier.rs
+++ b/crates/oxc_traverse/src/context/maybe_bound_identifier.rs
@@ -45,14 +45,14 @@ impl<'a> MaybeBoundIdentifier<'a> {
         ctx: &TraverseCtx<'a>,
     ) -> Self {
         let symbol_id = ctx.symbols().get_reference(ident.reference_id()).symbol_id();
-        Self { name: ident.name.clone(), symbol_id }
+        Self { name: ident.name, symbol_id }
     }
 
     /// Convert `MaybeBoundIdentifier` to `BoundIdentifier`.
     ///
     /// Returns `None` if symbol is not bound.
     pub fn to_bound_identifier(&self) -> Option<BoundIdentifier<'a>> {
-        self.symbol_id.map(|symbol_id| BoundIdentifier::new(self.name.clone(), symbol_id))
+        self.symbol_id.map(|symbol_id| BoundIdentifier::new(self.name, symbol_id))
     }
 
     // --- Read only ---
@@ -263,7 +263,7 @@ impl<'a> MaybeBoundIdentifier<'a> {
         flags: ReferenceFlags,
         ctx: &mut TraverseCtx<'a>,
     ) -> IdentifierReference<'a> {
-        ctx.create_ident_reference(span, self.name.clone(), self.symbol_id, flags)
+        ctx.create_ident_reference(span, self.name, self.symbol_id, flags)
     }
 
     /// Create `Expression::Identifier` referencing this binding, with specified `Span` and `ReferenceFlags`

--- a/tasks/transform_checker/src/lib.rs
+++ b/tasks/transform_checker/src/lib.rs
@@ -674,7 +674,7 @@ impl<'a> Visit<'a> for SemanticIdsCollector<'a, '_> {
         let reference_id = ident.reference_id.get();
         self.reference_ids.push(reference_id);
         if reference_id.is_some() {
-            self.reference_names.push(ident.name.clone());
+            self.reference_names.push(ident.name);
         } else {
             self.errors.push(format!("Missing ReferenceId: {:?}", ident.name));
         }


### PR DESCRIPTION
Follow up from https://github.com/oxc-project/oxc/pull/8543#discussion_r1918592423

> I agree. https://github.com/oxc-project/oxc/issues/8606

> Originally we were considering some form of interning and reference-counting, so we didn't make it Copy to leave the door open for that. But now all strings are stored in the arena anyway, so even if we did decide to intern strings, reference-counting would be irrelevant - our bump allocator doesn't allow freeing individual allocations anyway.

Most of the changes are done automatically by `just fix` (`cargo clippy --fix` && `cargo fmt --all`). See the commit list for the manual edits.