### PR TITLE
refactor(ast): align `#[estree(via)]` behavior

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -2196,7 +2196,7 @@ pub struct ImportExpression<'a> {
 pub struct ImportDeclaration<'a> {
     pub span: Span,
     /// `None` for `import 'foo'`, `Some([])` for `import {} from 'foo'`
-    #[estree(via = "OptionVecDefault", type = "Array<ImportDeclarationSpecifier>")]
+    #[estree(via = crate::serialize::OptionVecDefault, type = "Array<ImportDeclarationSpecifier>")]
     pub specifiers: Option<Vec<'a, ImportDeclarationSpecifier<'a>>>,
     pub source: StringLiteral<'a>,
     pub phase: Option<ImportPhase>,

--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -9,7 +9,6 @@ use crate::{
         serialize::{enum_variant_name, get_always_flatten_structs, get_type_tag},
         EnumDef, FieldDef, GetGenerics, GetIdent, Schema, StructDef, TypeDef,
     },
-    util::ToIdent,
 };
 
 use super::{define_derive, Derive};
@@ -142,12 +141,12 @@ fn serialize_struct(def: &StructDef, schema: &Schema) -> TokenStream {
                     }
                 )?;
             });
-        } else if let Some(with) = &field.markers.derive_attributes.estree.via {
-            let with_ident = with.to_ident();
+        } else if let Some(via) = &field.markers.derive_attributes.estree.via {
+            let via_tokens: TokenStream = via.parse().unwrap();
             fields.push(quote! {
                 map.serialize_entry(
                     #name,
-                    &crate::serialize::#with_ident(&self.#ident)
+                    &#via_tokens(&self.#ident)
                 )?;
             });
         } else {

--- a/tasks/ast_tools/src/markers.rs
+++ b/tasks/ast_tools/src/markers.rs
@@ -286,7 +286,7 @@ impl Parse for ESTreeFieldAttribute {
                 "via" => {
                     input.parse::<Token![=]>()?;
                     assert!(
-                        via.replace(input.parse::<LitStr>()?.value()).is_none(),
+                        via.replace(input.parse::<Path>()?.to_token_stream().to_string()).is_none(),
                         "Duplicate estree(with)"
                     );
                 }


### PR DESCRIPTION
Follow-on after #8564. Aligned the behavior of `#[estree(via)]` for fields with `#[estree(via)]` for structs.