### PR TITLE
fix(linter): can't disable `no-nested-ternary` rule anymore

### DIFF
--- a/apps/oxlint/fixtures/two_rules_with_same_name/.oxlintrc.json
+++ b/apps/oxlint/fixtures/two_rules_with_same_name/.oxlintrc.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    "oxc",
+    "unicorn"
+  ],
+  "rules": {
+    "eslint/no-nested-ternary": "off",
+    "unicorn/no-nested-ternary": "off"
+  }
+}

--- a/apps/oxlint/fixtures/two_rules_with_same_name/test.js
+++ b/apps/oxlint/fixtures/two_rules_with_same_name/test.js
@@ -1,0 +1,1 @@
+console.log(bar ? baz : qux === quxx ? bing : bam);

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -825,6 +825,13 @@ mod test {
     }
 
     #[test]
+    fn test_two_rules_with_same_name_from_different_plugin_names() {
+        // Issue: <https://github.com/oxc-project/oxc/issues/8485>
+        let args = &["-c", ".oxlintrc.json", "test.js"];
+        Tester::new().with_cwd("fixtures/two_rules_with_same_name".into()).test_and_snapshot(args);
+    }
+
+    #[test]
     fn test_adjust_ignore_patterns() {
         let base = PathBuf::from("/project/root");
         let path = PathBuf::from("/project/root/src");

--- a/apps/oxlint/src/snapshots/fixtures__two_rules_with_same_name_-c .oxlintrc.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__two_rules_with_same_name_-c .oxlintrc.json test.js@oxlint.snap
@@ -1,0 +1,12 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: -c .oxlintrc.json test.js
+working directory: fixtures/two_rules_with_same_name
+----------
+Found 0 warnings and 0 errors.
+Finished in <variable>ms on 1 file with 74 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -504,18 +504,4 @@ mod test {
             assert_eq!(rule.severity, AllowWarnDeny::Warn, "{config:?}");
         }
     }
-
-    #[test]
-    fn test_two_rules_with_same_name_and_different_plugin_names() {
-        // Issue: <https://github.com/oxc-project/oxc/issues/8485>
-        let configs =
-            [json!({ "eslint/no-nested-ternary": "off", "unicorn/no-nested-ternary": "off" })];
-
-        for config in &configs {
-            let mut rules = RuleSet::default();
-            r#override(&mut rules, config);
-
-            assert_eq!(rules.len(), 0, "{config:?}");
-        }
-    }
 }

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -110,28 +110,43 @@ impl OxlintRules {
                     }
                 }
                 _ => {
-                    // For overlapping rule names, use the "error" one
-                    // "no-loss-of-precision": "off",
-                    // "@typescript-eslint/no-loss-of-precision": "error"
-                    if let Some(rule_config) =
-                        rule_configs.iter().find(|r| r.severity.is_warn_deny())
-                    {
-                        let config = rule_config.config.clone().unwrap_or_default();
+                    let rules = rules_for_override
+                        .iter()
+                        .filter_map(|r| {
+                            if r.name() == *name {
+                                Some((r.plugin_name(), r))
+                            } else {
+                                None
+                            }
+                        })
+                        .collect::<FxHashMap<_, _>>();
 
-                        if let Some(rule) = rules_for_override.iter().find(|r| r.name() == *name) {
-                            rules_to_replace
-                                .push(RuleWithSeverity::new(rule.read_json(config), rule.severity));
-                        }
-                        // If the given rule is not found in the rule list (for example, if all rules are disabled),
-                        // then look it up in the entire rules list and add it.
-                        else if let Some(rule) = all_rules.iter().find(|r| r.name() == *name) {
-                            rules_to_replace.push(RuleWithSeverity::new(
-                                rule.read_json(config),
-                                rule_config.severity,
-                            ));
-                        }
-                    } else if rule_configs.iter().all(|r| r.severity.is_allow()) {
-                        if let Some(rule) = rules_for_override.iter().find(|r| r.name() == *name) {
+                    for rule_config in rule_configs {
+                        let (rule_name, plugin_name) = transform_rule_and_plugin_name(
+                            &rule_config.rule_name,
+                            &rule_config.plugin_name,
+                        );
+
+                        if rule_config.severity.is_warn_deny() {
+                            let config = rule_config.config.clone().unwrap_or_default();
+                            if let Some(rule) = rules.get(&plugin_name) {
+                                rules_to_replace.push(RuleWithSeverity::new(
+                                    rule.read_json(config),
+                                    rule.severity,
+                                ));
+                            }
+                            // If the given rule is not found in the rule list (for example, if all rules are disabled),
+                            // then look it up in the entire rules list and add it.
+                            else if let Some(rule) = all_rules
+                                .iter()
+                                .find(|r| r.name() == rule_name && r.plugin_name() == plugin_name)
+                            {
+                                rules_to_replace.push(RuleWithSeverity::new(
+                                    rule.read_json(config),
+                                    rule_config.severity,
+                                ));
+                            }
+                        } else if let Some(&rule) = rules.get(&plugin_name) {
                             rules_to_remove.push(rule.clone());
                         }
                     }
@@ -152,17 +167,12 @@ fn transform_rule_and_plugin_name<'a>(
     rule_name: &'a str,
     plugin_name: &'a str,
 ) -> (&'a str, &'a str) {
-    if plugin_name == "vitest" && is_jest_rule_adapted_to_vitest(rule_name) {
-        return (rule_name, "jest");
-    }
-
-    if plugin_name == "typescript" && is_eslint_rule_adapted_to_typescript(rule_name) {
-        return (rule_name, "eslint");
-    }
-
-    if plugin_name == "unicorn" && rule_name == "no-negated-condition" {
-        return ("no-negated-condition", "eslint");
-    }
+    let plugin_name = match plugin_name {
+        "vitest" if is_jest_rule_adapted_to_vitest(rule_name) => "jest",
+        "unicorn" if rule_name == "no-negated-condition" => "eslint",
+        "typescript" if is_eslint_rule_adapted_to_typescript(rule_name) => "eslint",
+        _ => plugin_name,
+    };
 
     (rule_name, plugin_name)
 }
@@ -492,6 +502,20 @@ mod test {
             let rule = rules.iter().next().unwrap();
             assert_eq!(rule.name(), "no-unused-vars", "{config:?}");
             assert_eq!(rule.severity, AllowWarnDeny::Warn, "{config:?}");
+        }
+    }
+
+    #[test]
+    fn test_two_rules_with_same_name_and_different_plugin_names() {
+        // Issue: <https://github.com/oxc-project/oxc/issues/8485>
+        let configs =
+            [json!({ "eslint/no-nested-ternary": "off", "unicorn/no-nested-ternary": "off" })];
+
+        for config in &configs {
+            let mut rules = RuleSet::default();
+            r#override(&mut rules, config);
+
+            assert_eq!(rules.len(), 0, "{config:?}");
         }
     }
 }


### PR DESCRIPTION
closes #8485 

Since we currently support two rules with the same `rule_name` but different `plugin_names`, some of the original logic is no longer applicable. As a result, I have made some adjustments.