### PR TITLE
ci(lint_rules): trigger on `utils/mod.rs` and on its workflow file

### DIFF
--- a/.github/workflows/lint_rules.yml
+++ b/.github/workflows/lint_rules.yml
@@ -5,7 +5,9 @@ on:
     branches:
       - main
     paths:
+      - ".github/workflows/lint_rules.yml"
       - "crates/oxc_linter/src/rules.rs"
+      - "crates/oxc_linter/src/utils/mod.rs" # here are the remaps for some plugins
       - "tasks/lint_rules/**"
 
 jobs:


### PR DESCRIPTION
The vitest rules documentation did not get updated after https://github.com/oxc-project/oxc/pull/8445

