### PR TITLE
fix(minifier): avoid minifing `String(a)` into `"" + a` for symbols

### DIFF
--- a/crates/oxc_minifier/src/ast_passes/peephole_substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_substitute_alternate_syntax.rs
@@ -866,8 +866,7 @@ impl<'a, 'b> PeepholeSubstituteAlternateSyntax {
                     None => Some(ctx.ast.expression_string_literal(span, "", None)),
                     // `String(a)` -> `'' + (a)`
                     Some(arg) => {
-                        if !arg.is_literal()
-                        {
+                        if !arg.is_literal() {
                             return None;
                         }
                         Some(ctx.ast.expression_binary(

--- a/crates/oxc_minifier/src/ast_passes/peephole_substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/ast_passes/peephole_substitute_alternate_syntax.rs
@@ -866,8 +866,7 @@ impl<'a, 'b> PeepholeSubstituteAlternateSyntax {
                     None => Some(ctx.ast.expression_string_literal(span, "", None)),
                     // `String(a)` -> `'' + (a)`
                     Some(arg) => {
-                        if !matches!(arg, Expression::Identifier(_) | Expression::CallExpression(_))
-                            && !arg.is_literal()
+                        if !arg.is_literal()
                         {
                             return None;
                         }
@@ -1972,6 +1971,8 @@ mod test {
         test("var a = String('hello')", "var a = '' + 'hello'");
         // Don't fold the existence check to preserve behavior
         test_same("var a = String?.('hello')");
+
+        test_same("var s = Symbol();var a = String(s);");
 
         test_same("var a = String('hello', bar());");
         test_same("var a = String({valueOf: function() { return 1; }});");

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -7,21 +7,21 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 
 287.63 kB  | 90.08 kB   | 90.07 kB   | 32.03 kB   | 31.95 kB   | jquery.js 
 
-342.15 kB  | 118.14 kB  | 118.14 kB  | 44.45 kB   | 44.37 kB   | vue.js    
+342.15 kB  | 118.19 kB  | 118.14 kB  | 44.45 kB   | 44.37 kB   | vue.js    
 
 544.10 kB  | 71.76 kB   | 72.48 kB   | 26.15 kB   | 26.20 kB   | lodash.js 
 
 555.77 kB  | 272.90 kB  | 270.13 kB  | 90.90 kB   | 90.80 kB   | d3.js     
 
-1.01 MB    | 460.15 kB  | 458.89 kB  | 126.77 kB  | 126.71 kB  | bundle.min.js
+1.01 MB    | 460.18 kB  | 458.89 kB  | 126.78 kB  | 126.71 kB  | bundle.min.js
 
-1.25 MB    | 652.88 kB  | 646.76 kB  | 163.54 kB  | 163.73 kB  | three.js  
+1.25 MB    | 652.90 kB  | 646.76 kB  | 163.54 kB  | 163.73 kB  | three.js  
 
-2.14 MB    | 724.05 kB  | 724.14 kB  | 179.94 kB  | 181.07 kB  | victory.js
+2.14 MB    | 724.06 kB  | 724.14 kB  | 179.94 kB  | 181.07 kB  | victory.js
 
 3.20 MB    | 1.01 MB    | 1.01 MB    | 332.01 kB  | 331.56 kB  | echarts.js
 
-6.69 MB    | 2.31 MB    | 2.31 MB    | 492.51 kB  | 488.28 kB  | antd.js   
+6.69 MB    | 2.31 MB    | 2.31 MB    | 492.53 kB  | 488.28 kB  | antd.js   
 
 10.95 MB   | 3.49 MB    | 3.49 MB    | 907.24 kB  | 915.50 kB  | typescript.js
 


### PR DESCRIPTION
We shouldn't change `String(a)` into `"" + a` if `a` can be a Symbol.
`String(Symbol())` does not throw an error, but `"" + Symbol()` does.

**References**
- [Spec of `ToString` (called for `"" + variable`)](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-tostring)
- [Spec of `String(a)`](https://tc39.es/ecma262/multipage/text-processing.html#sec-string-constructor-string-value)
