### PR TITLE
docs(allocator): reformat docs

### DIFF
--- a/crates/oxc_allocator/src/boxed.rs
+++ b/crates/oxc_allocator/src/boxed.rs
@@ -19,7 +19,7 @@ use crate::Allocator;
 
 /// A `Box` without [`Drop`], which stores its data in the arena allocator.
 ///
-/// ## No `Drop`s
+/// # No `Drop`s
 ///
 /// Objects allocated into Oxc memory arenas are never [`Dropped`](Drop). Memory is released in bulk
 /// when the allocator is dropped, without dropping the individual objects in the arena.
@@ -35,7 +35,7 @@ impl<T> Box<'_, T> {
     /// Take ownership of the value stored in this [`Box`], consuming the box in
     /// the process.
     ///
-    /// ## Example
+    /// # Examples
     /// ```
     /// use oxc_allocator::{Allocator, Box};
     ///
@@ -64,7 +64,7 @@ impl<T> Box<'_, T> {
     /// Put a `value` into a memory arena and get back a [`Box`] with ownership
     /// to the allocation.
     ///
-    /// ## Example
+    /// # Examples
     /// ```
     /// use oxc_allocator::{Allocator, Box};
     ///

--- a/crates/oxc_allocator/src/hash_map.rs
+++ b/crates/oxc_allocator/src/hash_map.rs
@@ -36,7 +36,7 @@ type FxHashMap<'alloc, K, V> = hashbrown::HashMap<K, V, FxBuildHasher, &'alloc B
 /// All APIs are the same, except create a [`HashMap`] with
 /// either [`new_in`](HashMap::new_in) or [`with_capacity_in`](HashMap::with_capacity_in).
 ///
-/// ## No `Drop`s
+/// # No `Drop`s
 ///
 /// Objects allocated into Oxc memory arenas are never [`Dropped`](Drop). Memory is released in bulk
 /// when the allocator is dropped, without dropping the individual objects in the arena.

--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -94,7 +94,7 @@ impl Allocator {
     /// # Panics
     /// Panics if reserving space for `T` fails.
     ///
-    /// # Example
+    /// # Examples
     /// ```
     /// use oxc_allocator::Allocator;
     ///
@@ -120,7 +120,7 @@ impl Allocator {
     /// # Panics
     /// Panics if reserving space for the string fails.
     ///
-    /// # Example
+    /// # Examples
     /// ```
     /// use oxc_allocator::Allocator;
     /// let allocator = Allocator::default();
@@ -145,8 +145,7 @@ impl Allocator {
     /// If this arena has allocated multiple chunks to bump allocate into, then the excess chunks
     /// are returned to the global allocator.
     ///
-    /// ## Example
-    ///
+    /// # Examples
     /// ```
     /// use oxc_allocator::Allocator;
     ///

--- a/crates/oxc_allocator/src/string.rs
+++ b/crates/oxc_allocator/src/string.rs
@@ -63,7 +63,6 @@ impl<'alloc> String<'alloc> {
     /// Construct a new [`String`] from a string slice.
     ///
     /// # Examples
-    ///
     /// ```
     /// use oxc_allocator::{Allocator, String};
     ///
@@ -126,9 +125,6 @@ impl<'alloc> String<'alloc> {
     /// nothing else uses the pointer after calling this function.
     ///
     /// # Examples
-    ///
-    /// Basic usage:
-    ///
     /// ```
     /// use std::mem;
     /// use oxc_allocator::{Allocator, String};
@@ -163,8 +159,7 @@ impl<'alloc> String<'alloc> {
     /// Convert this `String<'alloc>` into an `&'alloc str`. This is analogous to
     /// [`std::string::String::into_boxed_str`].
     ///
-    /// # Example
-    ///
+    /// # Examples
     /// ```
     /// use oxc_allocator::{Allocator, String};
     ///

--- a/crates/oxc_allocator/src/vec.rs
+++ b/crates/oxc_allocator/src/vec.rs
@@ -24,7 +24,7 @@ use crate::{Allocator, Box};
 
 /// A `Vec` without [`Drop`], which stores its data in the arena allocator.
 ///
-/// ## No `Drop`s
+/// # No `Drop`s
 ///
 /// Objects allocated into Oxc memory arenas are never [`Dropped`](Drop). Memory is released in bulk
 /// when the allocator is dropped, without dropping the individual objects in the arena.
@@ -48,7 +48,6 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// The vector will not allocate until elements are pushed onto it.
     ///
     /// # Examples
-    ///
     /// ```
     /// use oxc_allocator::{Allocator, Vec};
     ///
@@ -84,7 +83,6 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// Panics if the new capacity exceeds `isize::MAX` bytes.
     ///
     /// # Examples
-    ///
     /// ```
     /// use oxc_allocator::{Allocator, Vec};
     ///
@@ -147,7 +145,6 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// on stack and then copying to arena.
     ///
     /// # Examples
-    ///
     /// ```
     /// use oxc_allocator::{Allocator, Vec};
     ///
@@ -178,7 +175,6 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// The excess memory will be leaked in the arena (i.e. not reused by another allocation).
     ///
     /// # Examples
-    ///
     /// ```
     /// use oxc_allocator::{Allocator, Vec};
     ///


### PR DESCRIPTION
Make formatting of doc comments in `oxc_allocator` consistent.