### PR TITLE
docs(allocator): improve docs for `Allocator`

### DIFF
--- a/crates/oxc_allocator/src/clone_in.rs
+++ b/crates/oxc_allocator/src/clone_in.rs
@@ -8,6 +8,9 @@ use crate::{Allocator, Box, Vec};
 /// It'd only differ in the lifetime, Here's an example:
 ///
 /// ```
+/// # use oxc_allocator::{Allocator, CloneIn, Vec};
+/// # struct Struct<'a> {a: Vec<'a, u8>, b: u8}
+///
 /// impl<'old_alloc, 'new_alloc> CloneIn<'new_alloc> for Struct<'old_alloc> {
 ///     type Cloned = Struct<'new_alloc>;
 ///     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {


### PR DESCRIPTION
Improve docs for `Allocator`:

1. Explain how allocator works.
2. Demonstrate how to achieve good performance by re-using `Allocator`s.

Also fix the doc test for `CloneIn`.