### PR TITLE
feat(minifier): compress `typeof foo === 'object' && foo !== null` to `typeof foo == 'object' && !!foo`

### DIFF
--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -1,27 +1,27 @@
            | Oxc        | ESBuild    | Oxc        | ESBuild    |
 Original   | minified   | minified   | gzip       | gzip       | Fixture
 -------------------------------------------------------------------------------------
-72.14 kB   | 23.70 kB   | 23.70 kB   | 8.60 kB    | 8.54 kB    | react.development.js
+72.14 kB   | 23.67 kB   | 23.70 kB   | 8.60 kB    | 8.54 kB    | react.development.js
 
 173.90 kB  | 59.79 kB   | 59.82 kB   | 19.41 kB   | 19.33 kB   | moment.js 
 
-287.63 kB  | 90.08 kB   | 90.07 kB   | 32.03 kB   | 31.95 kB   | jquery.js 
+287.63 kB  | 90.08 kB   | 90.07 kB   | 32.02 kB   | 31.95 kB   | jquery.js 
 
 342.15 kB  | 118.19 kB  | 118.14 kB  | 44.45 kB   | 44.37 kB   | vue.js    
 
-544.10 kB  | 71.76 kB   | 72.48 kB   | 26.15 kB   | 26.20 kB   | lodash.js 
+544.10 kB  | 71.75 kB   | 72.48 kB   | 26.15 kB   | 26.20 kB   | lodash.js 
 
-555.77 kB  | 272.90 kB  | 270.13 kB  | 90.90 kB   | 90.80 kB   | d3.js     
+555.77 kB  | 272.89 kB  | 270.13 kB  | 90.90 kB   | 90.80 kB   | d3.js     
 
-1.01 MB    | 460.18 kB  | 458.89 kB  | 126.78 kB  | 126.71 kB  | bundle.min.js
+1.01 MB    | 460.18 kB  | 458.89 kB  | 126.77 kB  | 126.71 kB  | bundle.min.js
 
 1.25 MB    | 652.90 kB  | 646.76 kB  | 163.54 kB  | 163.73 kB  | three.js  
 
-2.14 MB    | 724.06 kB  | 724.14 kB  | 179.94 kB  | 181.07 kB  | victory.js
+2.14 MB    | 724.01 kB  | 724.14 kB  | 179.94 kB  | 181.07 kB  | victory.js
 
-3.20 MB    | 1.01 MB    | 1.01 MB    | 332.00 kB  | 331.56 kB  | echarts.js
+3.20 MB    | 1.01 MB    | 1.01 MB    | 332.01 kB  | 331.56 kB  | echarts.js
 
 6.69 MB    | 2.31 MB    | 2.31 MB    | 491.99 kB  | 488.28 kB  | antd.js   
 
-10.95 MB   | 3.48 MB    | 3.49 MB    | 905.39 kB  | 915.50 kB  | typescript.js
+10.95 MB   | 3.48 MB    | 3.49 MB    | 905.37 kB  | 915.50 kB  | typescript.js
 


### PR DESCRIPTION
If `typeof foo == 'object'`, then `foo` is guaranteed to be an object or null. In that case, `foo !== null` can be replaced with `!!foo` because objects return `true` for `!!foo` and null returns `false` for it.

**References**
- [Spec of `typeof`](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-typeof-operator)
- [Spec of `!`](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-logical-not-operator)
- [Spec of `ToBoolean`](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-toboolean)
