### PR TITLE
refactor(span)!: remove `PartialEq` impl for `&Atom`

### DIFF
--- a/crates/oxc_span/src/atom.rs
+++ b/crates/oxc_span/src/atom.rs
@@ -184,12 +184,6 @@ impl PartialEq<Atom<'_>> for Cow<'_, str> {
     }
 }
 
-impl PartialEq<&Atom<'_>> for Cow<'_, str> {
-    fn eq(&self, other: &&Atom<'_>) -> bool {
-        self.as_ref() == other.as_str()
-    }
-}
-
 impl ContentEq for Atom<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         self == other


### PR DESCRIPTION
Remove this unnecessary impl. It's pretty odd to have a method which takes an `&&Atom` (which is essentially a `&&&str`).
