### PR TITLE
chore(linter): update doc comment to reflect existance of `stylish` formatter

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -185,7 +185,7 @@ pub struct WarningOptions {
 /// Output
 #[derive(Debug, Clone, Bpaf)]
 pub struct OutputOptions {
-    /// Use a specific output format (default, json, unix, checkstyle, github)
+    /// Use a specific output format (default, json, unix, checkstyle, github, stylish)
     #[bpaf(long, short, fallback(OutputFormat::Default), hide_usage)]
     pub format: OutputFormat,
 }

--- a/tasks/website/src/linter/snapshots/cli.snap
+++ b/tasks/website/src/linter/snapshots/cli.snap
@@ -1,7 +1,6 @@
 ---
 source: tasks/website/src/linter/cli.rs
 expression: snapshot
-snapshot_kind: text
 ---
 ## Usage
  **`oxlint`** \[**`-c`**=_`<./oxlintrc.json>`_\] \[_`PATH`_\]...
@@ -111,7 +110,7 @@ Arguments:
 
 ## Output
 - **`-f`**, **`--format`**=_`ARG`_ &mdash; 
-  Use a specific output format (default, json, unix, checkstyle, github)
+  Use a specific output format (default, json, unix, checkstyle, github, stylish)
 
 
 

--- a/tasks/website/src/linter/snapshots/cli_terminal.snap
+++ b/tasks/website/src/linter/snapshots/cli_terminal.snap
@@ -1,7 +1,6 @@
 ---
 source: tasks/website/src/linter/cli.rs
 expression: snapshot
-snapshot_kind: text
 ---
 Usage: [-c=<./oxlintrc.json>] [PATH]...
 
@@ -68,7 +67,8 @@ Handle Warnings
                               your project
 
 Output
-    -f, --format=ARG          Use a specific output format (default, json, unix, checkstyle, github)
+    -f, --format=ARG          Use a specific output format (default, json, unix, checkstyle, github,
+                              stylish)
 
 Miscellaneous
         --silent              Do not display any diagnostics


### PR DESCRIPTION
after:
```
Output
    -f, --format=ARG          Use a specific output format (default, json, unix, checkstyle, github,
                              stylish)
```