### PR TITLE
fix(linter): fix github `endColumn` output

### DIFF
--- a/apps/oxlint/src/output_formatter/checkstyle.rs
+++ b/apps/oxlint/src/output_formatter/checkstyle.rs
@@ -51,14 +51,14 @@ fn format_checkstyle(diagnostics: &[Error]) -> String {
          let messages = infos
              .iter()
              .fold(String::new(), |mut acc, info| {
-                 let Info { line, column, message, severity, rule_id, .. } = info;
+                 let Info { start, message, severity, rule_id, .. } = info;
                  let severity = match severity {
                      Severity::Error => "error",
                      _ => "warning",
                  };
                  let message = rule_id.as_ref().map_or_else(|| xml_escape(message), |rule_id| Cow::Owned(format!("{} ({rule_id})", xml_escape(message))));
                  let source = rule_id.as_ref().map_or_else(|| Cow::Borrowed(""), |rule_id| Cow::Owned(format!("eslint.rules.{rule_id}")));
-                 let line = format!(r#"<error line="{line}" column="{column}" severity="{severity}" message="{message}" source="{source}" />"#);
+                 let line = format!(r#"<error line="{}" column="{}" severity="{severity}" message="{message}" source="{source}" />"#, start.line, start.column);
                  acc.push_str(&line);
                  acc
              });

--- a/apps/oxlint/src/output_formatter/github.rs
+++ b/apps/oxlint/src/output_formatter/github.rs
@@ -35,7 +35,7 @@ impl DiagnosticReporter for GithubReporter {
 }
 
 fn format_github(diagnostic: &Error) -> String {
-    let Info { line, column, filename, message, severity, rule_id } = Info::new(diagnostic);
+    let Info { start, end, filename, message, severity, rule_id } = Info::new(diagnostic);
     let severity = match severity {
         Severity::Error => "error",
         Severity::Warning | miette::Severity::Advice => "warning",
@@ -44,7 +44,11 @@ fn format_github(diagnostic: &Error) -> String {
     let filename = escape_property(&filename);
     let message = escape_data(&message);
     format!(
-        "::{severity} file={filename},line={line},endLine={line},col={column},endColumn={column},title={title}::{message}\n"
+        "::{severity} file={filename},line={},endLine={},col={},endColumn={},title={title}::{message}\n",
+        start.line,
+        end.line,
+        start.column,
+        end.column
     )
 }
 
@@ -108,6 +112,6 @@ mod test {
         let result = reporter.render_error(error);
 
         assert!(result.is_some());
-        assert_eq!(result.unwrap(), "::warning file=file%3A//test.ts,line=1,endLine=1,col=1,endColumn=1,title=oxlint::error message\n");
+        assert_eq!(result.unwrap(), "::warning file=file%3A//test.ts,line=1,endLine=1,col=1,endColumn=9,title=oxlint::error message\n");
     }
 }

--- a/apps/oxlint/src/output_formatter/stylish.rs
+++ b/apps/oxlint/src/output_formatter/stylish.rs
@@ -49,7 +49,7 @@ fn format_stylish(diagnostics: &[Error]) -> String {
     let mut grouped: FxHashMap<String, Vec<&Error>> = FxHashMap::default();
     let mut sorted = diagnostics.iter().collect::<Vec<_>>();
 
-    sorted.sort_by_key(|diagnostic| Info::new(diagnostic).line);
+    sorted.sort_by_key(|diagnostic| Info::new(diagnostic).start.line);
 
     for diagnostic in sorted {
         let info = Info::new(diagnostic);

--- a/apps/oxlint/src/output_formatter/unix.rs
+++ b/apps/oxlint/src/output_formatter/unix.rs
@@ -45,14 +45,14 @@ impl DiagnosticReporter for UnixReporter {
 
 /// <https://github.com/fregante/eslint-formatters/tree/ae1fd9748596447d1fd09625c33d9e7ba9a3d06d/packages/eslint-formatter-unix>
 fn format_unix(diagnostic: &Error) -> String {
-    let Info { line, column, filename, message, severity, rule_id } = Info::new(diagnostic);
+    let Info { start, end: _, filename, message, severity, rule_id } = Info::new(diagnostic);
     let severity = match severity {
         Severity::Error => "Error",
         _ => "Warning",
     };
     let rule_id =
         rule_id.map_or_else(|| Cow::Borrowed(""), |rule_id| Cow::Owned(format!("/{rule_id}")));
-    format!("{filename}:{line}:{column}: {message} [{severity}{rule_id}]\n")
+    format!("{filename}:{}:{}: {message} [{severity}{rule_id}]\n", start.line, start.column)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
added `start` and `end` for `Info`, so every reporter can use both if they want.
Then end calculation is a bit hacky, but i looks like it works.