### PR TITLE
feat(linter): added support to run in Node.JS legacy versions

### DIFF
--- a/npm/oxlint/bin/oxlint
+++ b/npm/oxlint/bin/oxlint
@@ -20,8 +20,7 @@ const isMuslFromFilesystem = () => {
   const { readFileSync } = require("fs");
   try {
     return readFileSync("/usr/bin/ldd", "utf-8").includes("musl");
-  } catch(error) {
-    console.error(error);
+  } catch(_error) {
     return null;
   }
 };
@@ -99,18 +98,17 @@ let binPath = (
 ) || null;
 
 if (binPath) {
-  const newEnvObject = Object.assign({}, env, {
-    JS_RUNTIME_VERSION: version,
-    JS_RUNTIME_NAME: release.name,
-    NODE_PACKAGE_MANAGER: detectPackageManager(),
-  });
   const result = require("child_process").spawnSync(
     require.resolve(binPath),
     process.argv.slice(2),
     {
       shell: false,
       stdio: "inherit",
-      env: newEnvObject
+      env: Object.assign({}, env, {
+        JS_RUNTIME_VERSION: version,
+        JS_RUNTIME_NAME: release.name,
+        NODE_PACKAGE_MANAGER: detectPackageManager(),
+      }),
     }
   );
 

--- a/npm/oxlint/bin/oxlint
+++ b/npm/oxlint/bin/oxlint
@@ -20,7 +20,8 @@ const isMuslFromFilesystem = () => {
   const { readFileSync } = require("fs");
   try {
     return readFileSync("/usr/bin/ldd", "utf-8").includes("musl");
-  } catch {
+  } catch(error) {
+    console.error(error);
     return null;
   }
 };
@@ -91,25 +92,25 @@ const PLATFORMS = {
 };
 
 let binPath = (
-  PLATFORMS && 
-  PLATFORMS[platform] && 
-  PLATFORMS[platform][arch] && 
+  PLATFORMS &&
+  PLATFORMS[platform] &&
+  PLATFORMS[platform][arch] &&
   PLATFORMS[platform][arch][isMusl() ? "musl" : "gnu"]
 ) || null;
 
 if (binPath) {
+  const newEnvObject = Object.assign({}, env, {
+    JS_RUNTIME_VERSION: version,
+    JS_RUNTIME_NAME: release.name,
+    NODE_PACKAGE_MANAGER: detectPackageManager(),
+  });
   const result = require("child_process").spawnSync(
     require.resolve(binPath),
     process.argv.slice(2),
     {
       shell: false,
       stdio: "inherit",
-      env: {
-        ...env,
-        JS_RUNTIME_VERSION: version,
-        JS_RUNTIME_NAME: release.name,
-        NODE_PACKAGE_MANAGER: detectPackageManager(),
-      },
+      env: newEnvObject
     }
   );
 

--- a/npm/oxlint/package.json
+++ b/npm/oxlint/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/sponsors/Boshen"
   },
   "engines": {
-    "node": ">=14.*"
+    "node": ">=8.*"
   },
   "files": [
     "bin/oxlint",


### PR DESCRIPTION
With a few adjustments It is possible to run _oxlint_ in projects which use legacy **Node.js** versions, such as **8.x.x**. Basically this is possible by removing spread operator in 'binpath' environment assemble and changing a catch command to inform an error variable.

Without this modification, we got always this error:

```
node_modules/oxlint/bin/oxlint:23
  } catch {
          ^

SyntaxError: Unexpected token {
    at createScript (vm.js:74:10)
    at Object.runInThisContext (vm.js:116:10)
    at Module._compile (module.js:533:28)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
    at Function.Module.runMain (module.js:605:10)
    at startup (bootstrap_node.js:158:16)
    at bootstrap_node.js:575:3
```