### PR TITLE
refactor(transformer): move `create_prototype_member` to utils module

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
@@ -6,12 +6,9 @@ use oxc_ast::ast::*;
 use oxc_span::SPAN;
 use oxc_traverse::{ast_operations::get_var_name_from_node, TraverseCtx};
 
-use crate::Helper;
+use crate::{utils::ast_builder::create_prototype_member, Helper};
 
-use super::{
-    utils::{create_assignment, create_prototype_member},
-    ClassProperties,
-};
+use super::{utils::create_assignment, ClassProperties};
 
 #[derive(Debug)]
 pub(super) enum ClassPropertiesSuperConverterMode {

--- a/crates/oxc_transformer/src/es2022/class_properties/utils.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/utils.rs
@@ -71,13 +71,3 @@ pub(super) fn debug_assert_expr_is_not_parenthesis_or_typescript_syntax(
         "Should not be: {expr:?} in {path:?}",
     );
 }
-
-/// `object` -> `object.prototype`.
-pub(super) fn create_prototype_member<'a>(
-    object: Expression<'a>,
-    ctx: &mut TraverseCtx<'a>,
-) -> Expression<'a> {
-    let property = ctx.ast.identifier_name(SPAN, Atom::from("prototype"));
-    let static_member = ctx.ast.member_expression_static(SPAN, object, property, false);
-    Expression::from(static_member)
-}

--- a/crates/oxc_transformer/src/utils/ast_builder.rs
+++ b/crates/oxc_transformer/src/utils/ast_builder.rs
@@ -71,3 +71,13 @@ pub(crate) fn wrap_statements_in_arrow_function_iife<'a>(
         ));
     ctx.ast.expression_call(span, arrow, NONE, ctx.ast.vec(), false)
 }
+
+/// `object` -> `object.prototype`.
+pub(crate) fn create_prototype_member<'a>(
+    object: Expression<'a>,
+    ctx: &mut TraverseCtx<'a>,
+) -> Expression<'a> {
+    let property = ctx.ast.identifier_name(SPAN, Atom::from("prototype"));
+    let static_member = ctx.ast.member_expression_static(SPAN, object, property, false);
+    Expression::from(static_member)
+}


### PR DESCRIPTION
This function can also used in #8614, so move it.