### PR TITLE
feat(ast): derive `Clone` for `TemplateElement` and `TemplateElementValue`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -432,7 +432,7 @@ pub struct TaggedTemplateExpression<'a> {
 ///
 /// Represents a quasi element in a template literal.
 #[ast(visit)]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TemplateElement<'a> {
     pub span: Span,
@@ -442,7 +442,7 @@ pub struct TemplateElement<'a> {
 
 /// See [template-strings-cooked-vs-raw](https://exploringjs.com/js/book/ch_template-literals.html#template-strings-cooked-vs-raw)
 #[ast]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[generate_derive(CloneIn, ContentEq, ESTree)]
 #[estree(no_type)]
 pub struct TemplateElementValue<'a> {


### PR DESCRIPTION
In #8614, we need to duplicate the same template literal, and derive `Copy` and `Clone` to avoid using `CloneIn`.