### PR TITLE
perf(lexer): peak 2 bytes after `!`

### DIFF
--- a/crates/oxc_parser/src/lexer/byte_handlers.rs
+++ b/crates/oxc_parser/src/lexer/byte_handlers.rs
@@ -210,14 +210,28 @@ ascii_byte_handler!(LIN(lexer) {
 // !
 ascii_byte_handler!(EXL(lexer) {
     lexer.consume_char();
-    if lexer.next_ascii_byte_eq(b'=') {
-        if lexer.next_ascii_byte_eq(b'=') {
-            Kind::Neq2
-        } else {
-            Kind::Neq
+    if let Some(next_2_bytes) = lexer.peek_2_bytes() {
+        match next_2_bytes[0] {
+            b'=' => {
+                if next_2_bytes[1] == b'=' {
+                    lexer.consume_2_chars();
+                    Kind::Neq2
+                } else {
+                    lexer.consume_char();
+                    Kind::Neq
+                }
+            }
+            _ => Kind::Bang
         }
     } else {
-        Kind::Bang
+        // At EOF, or only 1 byte left
+        match lexer.peek_byte() {
+            Some(b'=') => {
+                lexer.consume_char();
+                Kind::Neq
+            }
+            _ => Kind::Bang
+        }
     }
 });
 


### PR DESCRIPTION
`!==` and `!=` is very frequent.

<img width="845" alt="image" src="https://github.com/user-attachments/assets/91ff20fc-ae1c-4fb9-9444-4eb90d8e95f3" />

Picked this up while profiling.