### PR TITLE
docs(lexer): fix doc comment

### DIFF
--- a/crates/oxc_parser/src/lexer/byte_handlers.rs
+++ b/crates/oxc_parser/src/lexer/byte_handlers.rs
@@ -108,7 +108,6 @@ macro_rules! byte_handler {
 ///     // SAFETY: This macro is only used for ASCII characters
 ///     unsafe {
 ///       use assert_unchecked::assert_unchecked;
-///       let s = lexer.current.chars.as_str();
 ///       assert_unchecked!(!lexer.source.is_eof());
 ///       assert_unchecked!(lexer.source.peek_byte_unchecked() < 128);
 ///     }


### PR DESCRIPTION
The comment showing expansion of `ascii_byte_handler!` macro was inaccurate.