### PR TITLE
feat(minifier): replace `Number.*_SAFE_INTEGER`/`Number.EPSILON`

### DIFF
--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -15,13 +15,13 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 
 1.01 MB    | 460.16 kB  | 458.89 kB  | 126.78 kB  | 126.71 kB  | bundle.min.js
 
-1.25 MB    | 652.85 kB  | 646.76 kB  | 163.53 kB  | 163.73 kB  | three.js  
+1.25 MB    | 652.68 kB  | 646.76 kB  | 163.48 kB  | 163.73 kB  | three.js  
 
-2.14 MB    | 723.96 kB  | 724.14 kB  | 179.91 kB  | 181.07 kB  | victory.js
+2.14 MB    | 723.85 kB  | 724.14 kB  | 179.88 kB  | 181.07 kB  | victory.js
 
 3.20 MB    | 1.01 MB    | 1.01 MB    | 331.98 kB  | 331.56 kB  | echarts.js
 
-6.69 MB    | 2.31 MB    | 2.31 MB    | 491.94 kB  | 488.28 kB  | antd.js   
+6.69 MB    | 2.31 MB    | 2.31 MB    | 491.91 kB  | 488.28 kB  | antd.js   
 
 10.95 MB   | 3.48 MB    | 3.49 MB    | 905.29 kB  | 915.50 kB  | typescript.js
 


### PR DESCRIPTION
The value of `Number.*_SAFE_INTEGER`, `Number.EPSILON` are constants as they cannot be changed. This PR replaces them with `2**53-1` / `-(2**53-1)` / `2**-52` for ES2016+. For ES2015, `Number.EPSILON` is not changed but `Number.*_SAFE_INTEGER`s are replaced with `9007199254740991` / `-9007199254740991`.

**Reference**
- Spec of [`Number.MAX_SAFE_INTEGER`](https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.max_safe_integer)
- Spec of [`Number.MIN_SAFE_INTEGER`](https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.min_safe_integer)
- Spec of [`Number.EPSILON`](https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.epsilon)

### Additional Information
- [`Number.MIN_VALUE`](https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.min_value) cannot be replaced as the value depends on the runtime
- [`Number.MAX_VALUE`](https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-number.max_value) can be replaced but I didn't come up with a shorter representation that does not lack precision

