### PR TITLE
refactor(linter): move finishing default diagnostic message to `GraphicalReporter`

### DIFF
--- a/apps/oxlint/src/output_formatter/checkstyle.rs
+++ b/apps/oxlint/src/output_formatter/checkstyle.rs
@@ -66,7 +66,7 @@ fn format_checkstyle(diagnostics: &[Error]) -> String {
          format!(r#"<file name="{filename}">{messages}</file>"#)
      }).collect::<Vec<_>>().join(" ");
     format!(
-        r#"<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3">{messages}</checkstyle>"#
+        "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\">{messages}</checkstyle>\n"
     )
 }
 
@@ -148,6 +148,6 @@ mod test {
         let second_result = reporter.finish(&DiagnosticResult::default());
 
         assert!(second_result.is_some());
-        assert_eq!(second_result.unwrap(), "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"file://test.ts\"><error line=\"1\" column=\"1\" severity=\"warning\" message=\"error message\" source=\"\" /></file></checkstyle>");
+        assert_eq!(second_result.unwrap(), "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"file://test.ts\"><error line=\"1\" column=\"1\" severity=\"warning\" message=\"error message\" source=\"\" /></file></checkstyle>\n");
     }
 }

--- a/apps/oxlint/src/output_formatter/json.rs
+++ b/apps/oxlint/src/output_formatter/json.rs
@@ -76,7 +76,7 @@ fn format_json(diagnostics: &mut Vec<Error>) -> String {
         })
         .collect::<Vec<_>>()
         .join(",\n");
-    format!("[\n{messages}\n]")
+    format!("[\n{messages}\n]\n")
 }
 
 #[cfg(test)]
@@ -108,7 +108,7 @@ mod test {
         assert!(second_result.is_some());
         assert_eq!(
             second_result.unwrap(),
-            "[\n\t{\"message\": \"error message\",\"severity\": \"warning\",\"causes\": [],\"filename\": \"file://test.ts\",\"labels\": [{\"span\": {\"offset\": 0,\"length\": 8}}],\"related\": []}\n]"
+            "[\n\t{\"message\": \"error message\",\"severity\": \"warning\",\"causes\": [],\"filename\": \"file://test.ts\",\"labels\": [{\"span\": {\"offset\": 0,\"length\": 8}}],\"related\": []}\n]\n"
         );
     }
 }

--- a/apps/oxlint/src/output_formatter/mod.rs
+++ b/apps/oxlint/src/output_formatter/mod.rs
@@ -7,6 +7,7 @@ mod unix;
 
 use std::io::{BufWriter, Stdout, Write};
 use std::str::FromStr;
+use std::time::Duration;
 
 use checkstyle::CheckStyleOutputFormatter;
 use github::GithubOutputFormatter;
@@ -45,19 +46,45 @@ impl FromStr for OutputFormat {
     }
 }
 
+/// Some extra lint information, which can be outputted
+/// at the end of the command
+pub struct LintCommandInfo {
+    /// The number of files that were linted.
+    pub number_of_files: usize,
+    /// The number of lint rules that were run.
+    pub number_of_rules: usize,
+    /// The used CPU threads count
+    pub threads_count: usize,
+    /// Some reporters want to output the duration it took to finished the task
+    pub start_time: Duration,
+}
+
+/// An Interface for the different output formats.
+/// The Formatter is then managed by [`OutputFormatter`].
 trait InternalFormatter {
+    /// Print all available rules by oxlint
+    /// Some Formatter do not know how to output the rules in the style,
+    /// instead you should print out that this combination of flags is not supported.
+    /// Example: "flag --rules with flag --format=checkstyle is not allowed"
     fn all_rules(&mut self, writer: &mut dyn Write);
 
+    /// At the end of the Lint command the Formatter can output extra information.
+    fn lint_command_info(&self, _lint_command_info: &LintCommandInfo) -> Option<String> {
+        None
+    }
+
+    /// oxlint words with [`DiagnosticService`](oxc_diagnostics::DiagnosticService),
+    /// which uses a own reporter to output to stdout.
     fn get_diagnostic_reporter(&self) -> Box<dyn DiagnosticReporter>;
 }
 
 pub struct OutputFormatter {
-    internal_formatter: Box<dyn InternalFormatter>,
+    internal: Box<dyn InternalFormatter>,
 }
 
 impl OutputFormatter {
     pub fn new(format: OutputFormat) -> Self {
-        Self { internal_formatter: Self::get_internal_formatter(format) }
+        Self { internal: Self::get_internal_formatter(format) }
     }
 
     fn get_internal_formatter(format: OutputFormat) -> Box<dyn InternalFormatter> {
@@ -71,11 +98,20 @@ impl OutputFormatter {
         }
     }
 
+    /// Print all available rules by oxlint
+    /// See [`InternalFormatter::all_rules`] for more details.
     pub fn all_rules(&mut self, writer: &mut BufWriter<Stdout>) {
-        self.internal_formatter.all_rules(writer);
+        self.internal.all_rules(writer);
     }
 
+    /// At the end of the Lint command we may output extra information.
+    pub fn lint_command_info(&self, lint_command_info: &LintCommandInfo) -> Option<String> {
+        self.internal.lint_command_info(lint_command_info)
+    }
+
+    /// Returns the [`DiagnosticReporter`] which then will be used by [`DiagnosticService`](oxc_diagnostics::DiagnosticService)
+    /// See [`InternalFormatter::get_diagnostic_reporter`] for more details.
     pub fn get_diagnostic_reporter(&self) -> Box<dyn DiagnosticReporter> {
-        self.internal_formatter.get_diagnostic_reporter()
+        self.internal.get_diagnostic_reporter()
     }
 }

--- a/apps/oxlint/src/result.rs
+++ b/apps/oxlint/src/result.rs
@@ -1,7 +1,6 @@
 use std::{
     path::PathBuf,
     process::{ExitCode, Termination},
-    time::Duration,
 };
 
 #[derive(Debug)]
@@ -17,22 +16,14 @@ pub enum CliRunResult {
 /// A summary of a complete linter run.
 #[derive(Debug, Default)]
 pub struct LintResult {
-    /// The total time it took to run the linter.
-    pub duration: Duration,
-    /// The number of lint rules that were run.
-    pub number_of_rules: usize,
     /// The number of files that were linted.
     pub number_of_files: usize,
     /// The number of warnings that were found.
     pub number_of_warnings: usize,
     /// The number of errors that were found.
     pub number_of_errors: usize,
-    /// Whether or not the maximum number of warnings was exceeded.
-    pub max_warnings_exceeded: bool,
-    /// Whether or not warnings should be treated as errors (from `--deny-warnings` for example)
-    pub deny_warnings: bool,
-    /// Whether or not to print a summary of the results
-    pub print_summary: bool,
+    /// The exit unix code for, in general 0 or 1 (from `--deny-warnings` or `--max-warnings` for example)
+    pub exit_code: ExitCode,
 }
 
 impl Termination for CliRunResult {
@@ -49,47 +40,11 @@ impl Termination for CliRunResult {
                 ExitCode::from(1)
             }
             Self::LintResult(LintResult {
-                duration,
-                number_of_rules,
-                number_of_files,
-                number_of_warnings,
-                number_of_errors,
-                max_warnings_exceeded,
-                deny_warnings,
-                print_summary,
-            }) => {
-                if print_summary {
-                    let threads = rayon::current_num_threads();
-                    let number_of_diagnostics = number_of_warnings + number_of_errors;
-
-                    if number_of_diagnostics > 0 {
-                        println!();
-                    }
-
-                    let time = Self::get_execution_time(&duration);
-                    let s = if number_of_files == 1 { "" } else { "s" };
-                    println!(
-                        "Finished in {time} on {number_of_files} file{s} with {number_of_rules} rules using {threads} threads."
-                    );
-
-                    if max_warnings_exceeded {
-                        println!(
-                            "Exceeded maximum number of warnings. Found {number_of_warnings}."
-                        );
-                        return ExitCode::from(1);
-                    }
-
-                    println!(
-                        "Found {number_of_warnings} warning{} and {number_of_errors} error{}.",
-                        if number_of_warnings == 1 { "" } else { "s" },
-                        if number_of_errors == 1 { "" } else { "s" }
-                    );
-                }
-
-                let exit_code =
-                    u8::from((number_of_warnings > 0 && deny_warnings) || number_of_errors > 0);
-                ExitCode::from(exit_code)
-            }
+                number_of_files: _,    // ToDo: only for tests, make snapshots
+                number_of_warnings: _, // ToDo: only for tests, make snapshots
+                number_of_errors: _,
+                exit_code,
+            }) => exit_code,
             Self::PrintConfigResult { config_file } => {
                 println!("{config_file}");
                 ExitCode::from(0)
@@ -98,17 +53,6 @@ impl Termination for CliRunResult {
                 println!("{message}");
                 ExitCode::from(0)
             }
-        }
-    }
-}
-
-impl CliRunResult {
-    fn get_execution_time(duration: &Duration) -> String {
-        let ms = duration.as_millis();
-        if ms < 1000 {
-            format!("{ms}ms")
-        } else {
-            format!("{:.1}s", duration.as_secs_f64())
         }
     }
 }

--- a/crates/oxc_diagnostics/src/service.rs
+++ b/crates/oxc_diagnostics/src/service.rs
@@ -220,7 +220,7 @@ impl DiagnosticService {
     }
 
     fn check_for_writer_error(error: std::io::Error) -> Result<(), std::io::Error> {
-        // Do not panic when the process is skill (e.g. piping into `less`).
+        // Do not panic when the process is killed (e.g. piping into `less`).
         if matches!(error.kind(), ErrorKind::Interrupted | ErrorKind::BrokenPipe) {
             Ok(())
         } else {


### PR DESCRIPTION
Now every lint output is owned by is right OutputFormatter and his DiagnosticReporter 🥳 
Next step is to setup a snapshot Tester, so I can remove the ToDos.

Reorded some lines so the outfor is now for: `cargo run -p oxlint -- test.js --max-warnings=2`
```
Found 4 warnings and 0 errors.
Exceeded maximum number of warnings. Found 4.
Finished in 5ms on 1 file with 97 rules using 24 threads.
```

and for `cargo run -p oxlint -- test.js`

```
Found 4 warnings and 0 errors.
Finished in 5ms on 1 file with 97 rules using 24 threads.
```

The output time and warnings/error count wil be always printed. 