### PR TITLE
chore(transformer): add legacy decorator tests that come from `TypeScript`

### DIFF
--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: acbc09a8
 
-Passed: 135/157
+Passed: 135/219
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -316,6 +316,269 @@ x Output mismatch
 x Output mismatch
 
 * refresh/react-refresh/supports-typescript-namespace-syntax/input.tsx
+x Output mismatch
+
+
+# legacy-decorators (0/62)
+* typescript/accessor/decoratorOnClassAccessor1/input.ts
+x Output mismatch
+
+* typescript/accessor/decoratorOnClassAccessor2/input.ts
+x Output mismatch
+
+* typescript/accessor/decoratorOnClassAccessor3/input.ts
+
+  x Expected a semicolon or an implicit semicolon after a statement, but found
+  | none
+   ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor3/input.ts:6:11]
+ 5 | class C {
+ 6 |     public @dec get accessor() { return 1; }
+   :           ^
+ 7 | }
+   `----
+  help: Try insert a semicolon here
+
+
+* typescript/accessor/decoratorOnClassAccessor4/input.ts
+x Output mismatch
+
+* typescript/accessor/decoratorOnClassAccessor5/input.ts
+x Output mismatch
+
+* typescript/accessor/decoratorOnClassAccessor6/input.ts
+
+  x Expected a semicolon or an implicit semicolon after a statement, but found
+  | none
+   ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor6/input.ts:6:11]
+ 5 | class C {
+ 6 |     public @dec set accessor(value: number) { }
+   :           ^
+ 7 | }
+   `----
+  help: Try insert a semicolon here
+
+
+* typescript/accessor/decoratorOnClassAccessor7/input.ts
+x Output mismatch
+
+* typescript/accessor/decoratorOnClassAccessor8/input.ts
+x Output mismatch
+
+* typescript/constructableDecoratorOnClass01/input.ts
+x Output mismatch
+
+* typescript/constructor/decoratorOnClassConstructor1/input.ts
+x Output mismatch
+
+* typescript/constructor/decoratorOnClassConstructor4/input.ts
+x Output mismatch
+
+* typescript/constructor/parameter/decoratorOnClassConstructorParameter1/input.ts
+x Output mismatch
+
+* typescript/constructor/parameter/decoratorOnClassConstructorParameter4/input.ts
+
+  x Expected `,` but found `@`
+   ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructor/parameter/decoratorOnClassConstructorParameter4/input.ts:6:24]
+ 5 | class C {
+ 6 |     constructor(public @dec p: number) {}
+   :                        |
+   :                        `-- `,` expected
+ 7 | }
+   `----
+
+
+* typescript/constructor/parameter/decoratorOnClassConstructorParameter5/input.ts
+x Output mismatch
+
+* typescript/decoratedBlockScopedClass1/input.ts
+x Output mismatch
+
+* typescript/decoratedBlockScopedClass2/input.ts
+x Output mismatch
+
+* typescript/decoratedBlockScopedClass3/input.ts
+x Output mismatch
+
+* typescript/decoratedClassExportsCommonJS1/input.ts
+x Output mismatch
+
+* typescript/decoratedClassExportsCommonJS2/input.ts
+x Output mismatch
+
+* typescript/decoratedClassExportsSystem1/input.ts
+x Output mismatch
+
+* typescript/decoratedClassExportsSystem2/input.ts
+x Output mismatch
+
+* typescript/decoratorChecksFunctionBodies/input.ts
+x Output mismatch
+
+* typescript/decoratorOnClass1/input.ts
+x Output mismatch
+
+* typescript/decoratorOnClass2/input.ts
+x Output mismatch
+
+* typescript/decoratorOnClass3/input.ts
+x Output mismatch
+
+* typescript/decoratorOnClass4/input.ts
+x Output mismatch
+
+* typescript/decoratorOnClass5/input.ts
+x Output mismatch
+
+* typescript/decoratorOnClass8/input.ts
+x Output mismatch
+
+* typescript/decoratorOnClass9/input.ts
+x Output mismatch
+
+* typescript/method/decoratorOnClassMethod1/input.ts
+x Output mismatch
+
+* typescript/method/decoratorOnClassMethod10/input.ts
+x Output mismatch
+
+* typescript/method/decoratorOnClassMethod11/input.ts
+x Output mismatch
+
+* typescript/method/decoratorOnClassMethod12/input.ts
+x Output mismatch
+
+* typescript/method/decoratorOnClassMethod13/input.ts
+x Output mismatch
+
+* typescript/method/decoratorOnClassMethod14/input.ts
+x Output mismatch
+
+* typescript/method/decoratorOnClassMethod15/input.ts
+x Output mismatch
+
+* typescript/method/decoratorOnClassMethod16/input.ts
+x Output mismatch
+
+* typescript/method/decoratorOnClassMethod17/input.ts
+
+  x Expected a semicolon or an implicit semicolon after a statement, but found
+  | none
+   ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod17/input.ts:7:17]
+ 6 | class Foo {
+ 7 |     private prop @decorator
+   :                 ^
+ 8 |     foo() {
+   `----
+  help: Try insert a semicolon here
+
+
+* typescript/method/decoratorOnClassMethod18/input.ts
+x Output mismatch
+
+* typescript/method/decoratorOnClassMethod19/input.ts
+x Output mismatch
+
+* typescript/method/decoratorOnClassMethod2/input.ts
+x Output mismatch
+
+* typescript/method/decoratorOnClassMethod3/input.ts
+
+  x Expected a semicolon or an implicit semicolon after a statement, but found
+  | none
+   ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod3/input.ts:6:11]
+ 5 | class C {
+ 6 |     public @dec method() {}
+   :           ^
+ 7 | }
+   `----
+  help: Try insert a semicolon here
+
+
+* typescript/method/decoratorOnClassMethod4/input.ts
+x Output mismatch
+
+* typescript/method/decoratorOnClassMethod5/input.ts
+x Output mismatch
+
+* typescript/method/decoratorOnClassMethod6/input.ts
+x Output mismatch
+
+* typescript/method/decoratorOnClassMethod7/input.ts
+x Output mismatch
+
+* typescript/method/decoratorOnClassMethod8/input.ts
+x Output mismatch
+
+* typescript/method/decoratorOnClassMethodOverload1/input.ts
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Scope children mismatch:
+after transform: ScopeId(2): [ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(1): [ScopeId(2)]
+Unresolved references mismatch:
+after transform: ["TypedPropertyDescriptor", "dec"]
+rebuilt        : []
+
+* typescript/method/decoratorOnClassMethodOverload2/input.ts
+x Output mismatch
+
+* typescript/method/parameter/decoratorOnClassMethodParameter1/input.ts
+x Output mismatch
+
+* typescript/method/parameter/decoratorOnClassMethodParameter2/input.ts
+x Output mismatch
+
+* typescript/method/parameter/decoratorOnClassMethodParameter3/input.ts
+x Output mismatch
+
+* typescript/method/parameter/decoratorOnClassMethodThisParameter/input.ts
+
+  x Identifier expected. 'this' is a reserved word that cannot be used here.
+   ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/parameter/decoratorOnClassMethodThisParameter/input.ts:6:17]
+ 5 | class C {
+ 6 |     method(@dec this: C) {}
+   :                 ^^^^
+ 7 | }
+   `----
+
+
+* typescript/property/decoratorOnClassProperty1/input.ts
+x Output mismatch
+
+* typescript/property/decoratorOnClassProperty10/input.ts
+x Output mismatch
+
+* typescript/property/decoratorOnClassProperty11/input.ts
+x Output mismatch
+
+* typescript/property/decoratorOnClassProperty12/input.ts
+x Output mismatch
+
+* typescript/property/decoratorOnClassProperty13/input.ts
+x Output mismatch
+
+* typescript/property/decoratorOnClassProperty2/input.ts
+x Output mismatch
+
+* typescript/property/decoratorOnClassProperty3/input.ts
+
+  x Expected a semicolon or an implicit semicolon after a statement, but found
+  | none
+   ,-[tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty3/input.ts:6:11]
+ 5 | class C {
+ 6 |     public @dec prop;
+   :           ^
+ 7 | }
+   `----
+  help: Try insert a semicolon here
+
+
+* typescript/property/decoratorOnClassProperty6/input.ts
+x Output mismatch
+
+* typescript/property/decoratorOnClassProperty7/input.ts
 x Output mismatch
 
 

--- a/tasks/transform_conformance/src/constants.rs
+++ b/tasks/transform_conformance/src/constants.rs
@@ -59,6 +59,8 @@ pub const PLUGINS: &[&str] = &[
 
     // RegExp tests ported from esbuild + a few additions
     "regexp",
+    // Legacy decorators, tests almost ported from TypeScript
+    "legacy-decorators",
 ];
 
 pub const PLUGINS_NOT_SUPPORTED_YET: &[&str] = &[

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/options.json
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/options.json
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "transform-legacy-decorator"
+  ]
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor1/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor1/input.ts
@@ -1,0 +1,7 @@
+// @target:es5
+// @experimentaldecorators: true
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+class C {
+    @dec get accessor() { return 1; }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor1/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor1/output.js
@@ -1,0 +1,6 @@
+class C {
+    get accessor() { return 1; }
+}
+babelHelpers.decorate([
+    dec
+], C.prototype, "accessor", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor2/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor2/input.ts
@@ -1,0 +1,7 @@
+// @target:es5
+// @experimentaldecorators: true
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+class C {
+    @dec public get accessor() { return 1; }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor2/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor2/output.js
@@ -1,0 +1,6 @@
+class C {
+    get accessor() { return 1; }
+}
+babelHelpers.decorate([
+    dec
+], C.prototype, "accessor", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor3/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor3/input.ts
@@ -1,0 +1,7 @@
+// @target:es5
+// @experimentaldecorators: true
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+class C {
+    public @dec get accessor() { return 1; }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor3/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor3/output.js
@@ -1,0 +1,7 @@
+class C {
+    public;
+    get accessor() { return 1; }
+}
+babelHelpers.decorate([
+    dec
+], C.prototype, "accessor", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor4/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor4/input.ts
@@ -1,0 +1,7 @@
+// @target:es5
+// @experimentaldecorators: true
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+class C {
+    @dec set accessor(value: number) { }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor4/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor4/output.js
@@ -1,0 +1,6 @@
+class C {
+    set accessor(value) { }
+}
+babelHelpers.decorate([
+    dec
+], C.prototype, "accessor", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor5/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor5/input.ts
@@ -1,0 +1,7 @@
+// @target:es5
+// @experimentaldecorators: true
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+class C {
+    @dec public set accessor(value: number) { }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor5/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor5/output.js
@@ -1,0 +1,6 @@
+class C {
+    set accessor(value) { }
+}
+babelHelpers.decorate([
+    dec
+], C.prototype, "accessor", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor6/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor6/input.ts
@@ -1,0 +1,7 @@
+// @target:es5
+// @experimentaldecorators: true
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+class C {
+    public @dec set accessor(value: number) { }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor6/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor6/output.js
@@ -1,0 +1,7 @@
+class C {
+    public;
+    set accessor(value) { }
+}
+babelHelpers.decorate([
+    dec
+], C.prototype, "accessor", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor7/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor7/input.ts
@@ -1,0 +1,34 @@
+// @target:es5
+// @experimentaldecorators: true
+declare function dec1<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+declare function dec2<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+class A {
+    @dec1 get x() { return 0; }
+    set x(value: number) { }
+}
+
+class B {
+    get x() { return 0; }
+    @dec2 set x(value: number) { }
+}
+
+class C {
+    @dec1 set x(value: number) { }
+    get x() { return 0; }
+}
+
+class D {
+    set x(value: number) { }
+    @dec2 get x() { return 0; }
+}
+
+class E {
+    @dec1 get x() { return 0; }
+    @dec2 set x(value: number) { }
+}
+
+class F {
+    @dec1 set x(value: number) { }
+    @dec2 get x() { return 0; }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor7/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor7/output.js
@@ -1,0 +1,42 @@
+class A {
+    get x() { return 0; }
+    set x(value) { }
+}
+babelHelpers.decorate([
+    dec1
+], A.prototype, "x", null);
+class B {
+    get x() { return 0; }
+    set x(value) { }
+}
+babelHelpers.decorate([
+    dec2
+], B.prototype, "x", null);
+class C {
+    set x(value) { }
+    get x() { return 0; }
+}
+babelHelpers.decorate([
+    dec1
+], C.prototype, "x", null);
+class D {
+    set x(value) { }
+    get x() { return 0; }
+}
+babelHelpers.decorate([
+    dec2
+], D.prototype, "x", null);
+class E {
+    get x() { return 0; }
+    set x(value) { }
+}
+babelHelpers.decorate([
+    dec1
+], E.prototype, "x", null);
+class F {
+    set x(value) { }
+    get x() { return 0; }
+}
+babelHelpers.decorate([
+    dec1
+], F.prototype, "x", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor8/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor8/input.ts
@@ -1,0 +1,32 @@
+// @target:es5
+// @experimentaldecorators: true
+// @emitdecoratormetadata: true
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+class A {
+    @dec get x() { return 0; }
+    set x(value: number) { }
+}
+
+class B {
+    get x() { return 0; }
+    @dec set x(value: number) { }
+}
+
+class C {
+    @dec set x(value: number) { }
+    get x() { return 0; }
+}
+
+class D {
+    set x(value: number) { }
+    @dec get x() { return 0; }
+}
+
+class E {
+    @dec get x() { return 0; }
+}
+
+class F {
+    @dec set x(value: number) { }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor8/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/decoratorOnClassAccessor8/output.js
@@ -1,0 +1,52 @@
+class A {
+    get x() { return 0; }
+    set x(value) { }
+}
+babelHelpers.decorate([
+    dec,
+    __metadata("design:type", Number),
+    __metadata("design:paramtypes", [Number])
+], A.prototype, "x", null);
+class B {
+    get x() { return 0; }
+    set x(value) { }
+}
+babelHelpers.decorate([
+    dec,
+    __metadata("design:type", Number),
+    __metadata("design:paramtypes", [Number])
+], B.prototype, "x", null);
+class C {
+    set x(value) { }
+    get x() { return 0; }
+}
+babelHelpers.decorate([
+    dec,
+    __metadata("design:type", Number),
+    __metadata("design:paramtypes", [Number])
+], C.prototype, "x", null);
+class D {
+    set x(value) { }
+    get x() { return 0; }
+}
+babelHelpers.decorate([
+    dec,
+    __metadata("design:type", Number),
+    __metadata("design:paramtypes", [Number])
+], D.prototype, "x", null);
+class E {
+    get x() { return 0; }
+}
+babelHelpers.decorate([
+    dec,
+    __metadata("design:type", Object),
+    __metadata("design:paramtypes", [])
+], E.prototype, "x", null);
+class F {
+    set x(value) { }
+}
+babelHelpers.decorate([
+    dec,
+    __metadata("design:type", Number),
+    __metadata("design:paramtypes", [Number])
+], F.prototype, "x", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/options.json
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/accessor/options.json
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "transform-legacy-decorator"
+  ]
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructableDecoratorOnClass01/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructableDecoratorOnClass01/input.ts
@@ -1,0 +1,8 @@
+// @experimentalDecorators: true
+
+class CtorDtor {}
+
+@CtorDtor
+class C {
+
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructableDecoratorOnClass01/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructableDecoratorOnClass01/output.js
@@ -1,0 +1,8 @@
+// @experimentalDecorators: true
+class CtorDtor {
+}
+let C = class C {
+};
+C = babelHelpers.decorate([
+    CtorDtor
+], C);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructor/decoratorOnClassConstructor1/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructor/decoratorOnClassConstructor1/input.ts
@@ -1,0 +1,7 @@
+// @target:es5
+// @experimentaldecorators: true
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+class C {
+    @dec constructor() {}
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructor/decoratorOnClassConstructor1/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructor/decoratorOnClassConstructor1/output.js
@@ -1,0 +1,3 @@
+class C {
+    constructor() { }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructor/decoratorOnClassConstructor4/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructor/decoratorOnClassConstructor4/input.ts
@@ -1,0 +1,18 @@
+﻿// @target: es5
+// @module: commonjs
+// @experimentaldecorators: true
+// @emitdecoratormetadata: true
+declare var dec: any;
+
+@dec
+class A {
+}
+
+@dec
+class B {
+    constructor(x: number) {}
+}
+
+@dec
+class C extends A {
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructor/decoratorOnClassConstructor4/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructor/decoratorOnClassConstructor4/output.js
@@ -1,0 +1,17 @@
+let A = class A {
+};
+A = babelHelpers.decorate([
+    dec
+], A);
+let B = class B {
+    constructor(x) { }
+};
+B = babelHelpers.decorate([
+    dec,
+    __metadata("design:paramtypes", [Number])
+], B);
+let C = class C extends A {
+};
+C = babelHelpers.decorate([
+    dec
+], C);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructor/options.json
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructor/options.json
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "transform-legacy-decorator"
+  ]
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructor/parameter/decoratorOnClassConstructorParameter1/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructor/parameter/decoratorOnClassConstructorParameter1/input.ts
@@ -1,0 +1,7 @@
+// @target:es5
+// @experimentaldecorators: true
+declare function dec(target: Function, propertyKey: string | symbol, parameterIndex: number): void;
+
+class C {
+    constructor(@dec p: number) {}
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructor/parameter/decoratorOnClassConstructorParameter1/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructor/parameter/decoratorOnClassConstructorParameter1/output.js
@@ -1,0 +1,6 @@
+let C = class C {
+    constructor(p) { }
+};
+C = babelHelpers.decorate([
+    babelHelpers.decorateParam(0, dec)
+], C);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructor/parameter/decoratorOnClassConstructorParameter4/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructor/parameter/decoratorOnClassConstructorParameter4/input.ts
@@ -1,0 +1,7 @@
+// @target:es5
+// @experimentaldecorators: true
+declare function dec(target: Function, propertyKey: string | symbol, parameterIndex: number): void;
+
+class C {
+    constructor(public @dec p: number) {}
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructor/parameter/decoratorOnClassConstructorParameter4/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructor/parameter/decoratorOnClassConstructorParameter4/output.js
@@ -1,0 +1,6 @@
+let C = class C {
+    constructor(public, p) { }
+};
+C = babelHelpers.decorate([
+    babelHelpers.decorateParam(1, dec)
+], C);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructor/parameter/decoratorOnClassConstructorParameter5/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructor/parameter/decoratorOnClassConstructorParameter5/input.ts
@@ -1,0 +1,15 @@
+// @target: es2018
+// @experimentalDecorators: true
+// @noEmitHelpers: true
+// @noTypesAndSymbols: true
+
+// https://github.com/microsoft/TypeScript/issues/44931
+interface IFoo { }
+declare const IFoo: any;
+class BulkEditPreviewProvider {
+    static readonly Schema = 'vscode-bulkeditpreview';
+    static emptyPreview = { scheme: BulkEditPreviewProvider.Schema };
+    constructor(
+        @IFoo private readonly _modeService: IFoo,
+    ) { }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructor/parameter/decoratorOnClassConstructorParameter5/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructor/parameter/decoratorOnClassConstructorParameter5/output.js
@@ -1,0 +1,17 @@
+// @target: es2018
+// @experimentalDecorators: true
+// @noEmitHelpers: true
+// @noTypesAndSymbols: true
+var BulkEditPreviewProvider_1;
+let BulkEditPreviewProvider = class BulkEditPreviewProvider {
+    static { BulkEditPreviewProvider_1 = this; }
+    _modeService;
+    static Schema = 'vscode-bulkeditpreview';
+    static emptyPreview = { scheme: BulkEditPreviewProvider_1.Schema };
+    constructor(_modeService) {
+        this._modeService = _modeService;
+    }
+};
+BulkEditPreviewProvider = BulkEditPreviewProvider_1 = babelHelpers.decorate([
+    babelHelpers.decorateParam(0, IFoo)
+], BulkEditPreviewProvider);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructor/parameter/options.json
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/constructor/parameter/options.json
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "transform-legacy-decorator"
+  ]
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedBlockScopedClass1/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedBlockScopedClass1/input.ts
@@ -1,0 +1,16 @@
+// @target: es5
+// @experimentaldecorators: true
+// @emitDecoratorMetadata: true
+// @filename: a.ts
+
+function decorator() {
+    return (target: new (...args: any[]) => any) => {}
+}
+
+@decorator()
+class Foo {
+    public static func(): Foo {
+        return new Foo();
+    }
+}
+Foo.func();

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedBlockScopedClass1/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedBlockScopedClass1/output.js
@@ -1,0 +1,17 @@
+// @target: es5
+// @experimentaldecorators: true
+// @emitDecoratorMetadata: true
+// @filename: a.ts
+var Foo_1;
+function decorator() {
+    return (target) => { };
+}
+let Foo = Foo_1 = class Foo {
+    static func() {
+        return new Foo_1();
+    }
+};
+Foo = Foo_1 = babelHelpers.decorate([
+    decorator()
+], Foo);
+Foo.func();

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedBlockScopedClass2/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedBlockScopedClass2/input.ts
@@ -1,0 +1,19 @@
+// @target: es5
+// @experimentaldecorators: true
+// @emitDecoratorMetadata: true
+// @filename: a.ts
+
+function decorator() {
+    return (target: new (...args: any[]) => any) => {}
+}
+
+try {
+    @decorator()
+    class Foo {
+        public static func(): Foo {
+            return new Foo();
+        }
+    }
+    Foo.func();
+}
+catch (e) {}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedBlockScopedClass2/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedBlockScopedClass2/output.js
@@ -1,0 +1,20 @@
+// @target: es5
+// @experimentaldecorators: true
+// @emitDecoratorMetadata: true
+// @filename: a.ts
+var Foo_1;
+function decorator() {
+    return (target) => { };
+}
+try {
+    let Foo = Foo_1 = class Foo {
+        static func() {
+            return new Foo_1();
+        }
+    };
+    Foo = Foo_1 = babelHelpers.decorate([
+        decorator()
+    ], Foo);
+    Foo.func();
+}
+catch (e) { }

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedBlockScopedClass3/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedBlockScopedClass3/input.ts
@@ -1,0 +1,27 @@
+// @target: es5
+// @experimentaldecorators: true
+// @emitDecoratorMetadata: true
+// @filename: a.ts
+
+function decorator() {
+    return (target: new (...args: any[]) => any) => {}
+}
+
+@decorator()
+class Foo {
+    public static func(): Foo {
+        return new Foo();
+    }
+}
+Foo.func();
+
+try {
+    @decorator()
+    class Foo {
+        public static func(): Foo {
+            return new Foo();
+        }
+    }
+    Foo.func();
+}
+catch (e) {}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedBlockScopedClass3/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedBlockScopedClass3/output.js
@@ -1,0 +1,29 @@
+// @target: es5
+// @experimentaldecorators: true
+// @emitDecoratorMetadata: true
+// @filename: a.ts
+var Foo_1, Foo_2;
+function decorator() {
+    return (target) => { };
+}
+let Foo = Foo_1 = class Foo {
+    static func() {
+        return new Foo_1();
+    }
+};
+Foo = Foo_1 = babelHelpers.decorate([
+    decorator()
+], Foo);
+Foo.func();
+try {
+    let Foo = Foo_2 = class Foo {
+        static func() {
+            return new Foo_2();
+        }
+    };
+    Foo = Foo_2 = babelHelpers.decorate([
+        decorator()
+    ], Foo);
+    Foo.func();
+}
+catch (e) { }

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedClassExportsCommonJS1/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedClassExportsCommonJS1/input.ts
@@ -1,0 +1,13 @@
+// @target: es6
+// @experimentaldecorators: true
+// @emitDecoratorMetadata: true
+// @module: commonjs
+// @filename: a.ts
+
+declare function forwardRef(x: any): any;
+declare var Something: any;
+@Something({ v: () => Testing123 })
+export class Testing123 {
+    static prop0: string;
+    static prop1 = Testing123.prop0;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedClassExportsCommonJS1/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedClassExportsCommonJS1/output.js
@@ -1,0 +1,15 @@
+// @target: es6
+// @experimentaldecorators: true
+// @emitDecoratorMetadata: true
+// @module: commonjs
+// @filename: a.ts
+var Testing123_1;
+let Testing123 = class Testing123 {
+    static { Testing123_1 = this; }
+    static prop0;
+    static prop1 = Testing123_1.prop0;
+};
+Testing123 = Testing123_1 = babelHelpers.decorate([
+    Something({ v: () => Testing123 })
+], Testing123);
+export { Testing123 };

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedClassExportsCommonJS2/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedClassExportsCommonJS2/input.ts
@@ -1,0 +1,10 @@
+// @target: es6
+// @experimentaldecorators: true
+// @emitDecoratorMetadata: true
+// @module: commonjs
+// @filename: a.ts
+
+declare function forwardRef(x: any): any;
+declare var Something: any;
+@Something({ v: () => Testing123 })
+export class Testing123 { }

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedClassExportsCommonJS2/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedClassExportsCommonJS2/output.js
@@ -1,0 +1,11 @@
+// @target: es6
+// @experimentaldecorators: true
+// @emitDecoratorMetadata: true
+// @module: commonjs
+// @filename: a.ts
+let Testing123 = class Testing123 {
+};
+Testing123 = babelHelpers.decorate([
+    Something({ v: () => Testing123 })
+], Testing123);
+export { Testing123 };

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedClassExportsSystem1/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedClassExportsSystem1/input.ts
@@ -1,0 +1,13 @@
+// @target: es6
+// @experimentaldecorators: true
+// @emitDecoratorMetadata: true
+// @module: system
+// @filename: a.ts
+
+declare function forwardRef(x: any): any;
+declare var Something: any;
+@Something({ v: () => Testing123 })
+export class Testing123 {
+    static prop0: string;
+    static prop1 = Testing123.prop0;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedClassExportsSystem1/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedClassExportsSystem1/output.js
@@ -1,0 +1,15 @@
+// @target: es6
+// @experimentaldecorators: true
+// @emitDecoratorMetadata: true
+// @module: system
+// @filename: a.ts
+var Testing123_1;
+let Testing123 = class Testing123 {
+    static { Testing123_1 = this; }
+    static prop0;
+    static prop1 = Testing123_1.prop0;
+};
+Testing123 = Testing123_1 = babelHelpers.decorate([
+    Something({ v: () => Testing123 })
+], Testing123);
+export { Testing123 };

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedClassExportsSystem2/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedClassExportsSystem2/input.ts
@@ -1,0 +1,10 @@
+// @target: es6
+// @experimentaldecorators: true
+// @emitDecoratorMetadata: true
+// @module: system
+// @filename: a.ts
+
+declare function forwardRef(x: any): any;
+declare var Something: any;
+@Something({ v: () => Testing123 })
+export class Testing123 { }

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedClassExportsSystem2/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratedClassExportsSystem2/output.js
@@ -1,0 +1,11 @@
+// @target: es6
+// @experimentaldecorators: true
+// @emitDecoratorMetadata: true
+// @module: system
+// @filename: a.ts
+let Testing123 = class Testing123 {
+};
+Testing123 = babelHelpers.decorate([
+    Something({ v: () => Testing123 })
+], Testing123);
+export { Testing123 };

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorChecksFunctionBodies/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorChecksFunctionBodies/input.ts
@@ -1,0 +1,17 @@
+// @target:es5
+// @experimentaldecorators: true
+
+// from #2971
+function func(s: string): void {
+}
+
+class A {
+    @((x, p, d) => {
+        var a = 3;
+        func(a);
+        return d;
+    })
+    m() {
+
+    }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorChecksFunctionBodies/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorChecksFunctionBodies/output.js
@@ -1,0 +1,16 @@
+// @target:es5
+// @experimentaldecorators: true
+// from #2971
+function func(s) {
+}
+class A {
+    m() {
+    }
+}
+babelHelpers.decorate([
+    ((x, p, d) => {
+        var a = 3;
+        func(a);
+        return d;
+    })
+], A.prototype, "m", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass1/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass1/input.ts
@@ -1,0 +1,7 @@
+// @target:es5
+// @experimentaldecorators: true
+declare function dec<T>(target: T): T;
+
+@dec
+class C {
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass1/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass1/output.js
@@ -1,0 +1,5 @@
+let C = class C {
+};
+C = babelHelpers.decorate([
+    dec
+], C);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass2/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass2/input.ts
@@ -1,0 +1,8 @@
+// @target:es5
+// @module: commonjs
+// @experimentaldecorators: true
+declare function dec<T>(target: T): T;
+
+@dec
+export class C {
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass2/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass2/output.js
@@ -1,0 +1,6 @@
+let C = class C {
+};
+C = babelHelpers.decorate([
+    dec
+], C);
+export { C };

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass3/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass3/input.ts
@@ -1,0 +1,9 @@
+// @target:es5
+// @module: commonjs
+// @experimentaldecorators: true
+declare function dec<T>(target: T): T;
+
+export
+@dec
+class C {
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass3/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass3/output.js
@@ -1,0 +1,6 @@
+let C = class C {
+};
+C = babelHelpers.decorate([
+    dec
+], C);
+export { C };

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass4/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass4/input.ts
@@ -1,0 +1,7 @@
+// @target:es5
+// @experimentaldecorators: true
+declare function dec(): <T>(target: T) => T;
+
+@dec()
+class C {
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass4/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass4/output.js
@@ -1,0 +1,5 @@
+let C = class C {
+};
+C = babelHelpers.decorate([
+    dec()
+], C);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass5/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass5/input.ts
@@ -1,0 +1,7 @@
+// @target:es5
+// @experimentaldecorators: true
+declare function dec(): <T>(target: T) => T;
+
+@dec()
+class C {
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass5/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass5/output.js
@@ -1,0 +1,5 @@
+let C = class C {
+};
+C = babelHelpers.decorate([
+    dec()
+], C);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass8/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass8/input.ts
@@ -1,0 +1,7 @@
+// @target:es5
+// @experimentaldecorators: true
+declare function dec(): (target: Function, paramIndex: number) => void;
+
+@dec()
+class C {
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass8/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass8/output.js
@@ -1,0 +1,5 @@
+let C = class C {
+};
+C = babelHelpers.decorate([
+    dec()
+], C);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass9/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass9/input.ts
@@ -1,0 +1,15 @@
+// @target:es5
+// @experimentaldecorators: true
+declare var dec: any;
+
+class A {}
+
+// https://github.com/Microsoft/TypeScript/issues/16417
+@dec
+class B extends A {
+    static x = 1;
+    static y = B.x;
+    m() {
+        return B.x;
+    }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass9/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/decoratorOnClass9/output.js
@@ -1,0 +1,15 @@
+var B_1;
+class A {
+}
+// https://github.com/Microsoft/TypeScript/issues/16417
+let B = class B extends A {
+    static { B_1 = this; }
+    static x = 1;
+    static y = B_1.x;
+    m() {
+        return B_1.x;
+    }
+};
+B = B_1 = babelHelpers.decorate([
+    dec
+], B);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod1/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod1/input.ts
@@ -1,0 +1,7 @@
+// @target: ES5
+// @experimentaldecorators: true
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+class C {
+    @dec method() {}
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod1/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod1/output.js
@@ -1,0 +1,6 @@
+class C {
+    method() { }
+}
+babelHelpers.decorate([
+    dec
+], C.prototype, "method", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod10/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod10/input.ts
@@ -1,0 +1,7 @@
+// @target: ES5
+// @experimentaldecorators: true
+declare function dec(target: Function, paramIndex: number): void;
+
+class C {
+    @dec method() {}
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod10/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod10/output.js
@@ -1,0 +1,6 @@
+class C {
+    method() { }
+}
+babelHelpers.decorate([
+    dec
+], C.prototype, "method", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod11/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod11/input.ts
@@ -1,0 +1,10 @@
+// @target: ES5
+// @experimentaldecorators: true
+module M {
+    class C {
+        decorator(target: Object, key: string): void { }
+
+        @(this.decorator)
+        method() { }
+    }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod11/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod11/output.js
@@ -1,0 +1,12 @@
+// @target: ES5
+// @experimentaldecorators: true
+var M;
+(function (M) {
+    class C {
+        decorator(target, key) { }
+        method() { }
+    }
+    babelHelpers.decorate([
+        (this.decorator)
+    ], C.prototype, "method", null);
+})(M || (M = {}));

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod12/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod12/input.ts
@@ -1,0 +1,11 @@
+// @target: ES5
+// @experimentaldecorators: true
+module M {
+    class S {
+        decorator(target: Object, key: string): void { }
+    }
+    class C extends S {
+        @(super.decorator)
+        method() { }
+    }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod12/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod12/output.js
@@ -1,0 +1,14 @@
+// @target: ES5
+// @experimentaldecorators: true
+var M;
+(function (M) {
+    class S {
+        decorator(target, key) { }
+    }
+    class C extends S {
+        method() { }
+    }
+    babelHelpers.decorate([
+        (super.decorator)
+    ], C.prototype, "method", null);
+})(M || (M = {}));

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod13/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod13/input.ts
@@ -1,0 +1,8 @@
+// @target: ES6
+// @experimentaldecorators: true
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+class C {
+    @dec ["1"]() { }
+    @dec ["b"]() { }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod13/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod13/output.js
@@ -1,0 +1,10 @@
+class C {
+    ["1"]() { }
+    ["b"]() { }
+}
+babelHelpers.decorate([
+    dec
+], C.prototype, "1", null);
+babelHelpers.decorate([
+    dec
+], C.prototype, "b", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod14/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod14/input.ts
@@ -1,0 +1,14 @@
+// @target: esnext
+// @experimentaldecorators: true
+// @emitdecoratormetadata: true
+declare var decorator: any;
+
+class Foo {
+    private prop = () => {
+        return 0;
+    }
+    @decorator
+    foo() {
+        return 0;
+    }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod14/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod14/output.js
@@ -1,0 +1,14 @@
+class Foo {
+    prop = () => {
+        return 0;
+    };
+    foo() {
+        return 0;
+    }
+}
+babelHelpers.decorate([
+    decorator,
+    __metadata("design:type", Function),
+    __metadata("design:paramtypes", []),
+    __metadata("design:returntype", void 0)
+], Foo.prototype, "foo", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod15/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod15/input.ts
@@ -1,0 +1,12 @@
+// @target: esnext
+// @experimentaldecorators: true
+// @emitdecoratormetadata: true
+declare var decorator: any;
+
+class Foo {
+    private prop = 1
+    @decorator
+    foo() {
+        return 0;
+    }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod15/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod15/output.js
@@ -1,0 +1,12 @@
+class Foo {
+    prop = 1;
+    foo() {
+        return 0;
+    }
+}
+babelHelpers.decorate([
+    decorator,
+    __metadata("design:type", Function),
+    __metadata("design:paramtypes", []),
+    __metadata("design:returntype", void 0)
+], Foo.prototype, "foo", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod16/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod16/input.ts
@@ -1,0 +1,12 @@
+// @target: esnext
+// @experimentaldecorators: true
+// @emitdecoratormetadata: true
+declare var decorator: any;
+
+class Foo {
+    private prop
+    @decorator
+    foo() {
+        return 0;
+    }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod16/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod16/output.js
@@ -1,0 +1,12 @@
+class Foo {
+    prop;
+    foo() {
+        return 0;
+    }
+}
+babelHelpers.decorate([
+    decorator,
+    __metadata("design:type", Function),
+    __metadata("design:paramtypes", []),
+    __metadata("design:returntype", void 0)
+], Foo.prototype, "foo", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod17/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod17/input.ts
@@ -1,0 +1,11 @@
+// @target: esnext
+// @experimentaldecorators: true
+// @emitdecoratormetadata: true
+declare var decorator: any;
+
+class Foo {
+    private prop @decorator
+    foo() {
+        return 0;
+    }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod17/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod17/output.js
@@ -1,0 +1,12 @@
+class Foo {
+    prop;
+    foo() {
+        return 0;
+    }
+}
+babelHelpers.decorate([
+    decorator,
+    __metadata("design:type", Function),
+    __metadata("design:paramtypes", []),
+    __metadata("design:returntype", void 0)
+], Foo.prototype, "foo", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod18/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod18/input.ts
@@ -1,0 +1,11 @@
+// @target: esnext
+// @experimentaldecorators: true
+// @emitdecoratormetadata: true
+declare var decorator: any;
+
+class Foo {
+    p1
+
+    @decorator()
+    p2;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod18/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod18/output.js
@@ -1,0 +1,8 @@
+class Foo {
+    p1;
+    p2;
+}
+babelHelpers.decorate([
+    decorator(),
+    __metadata("design:type", Object)
+], Foo.prototype, "p2", void 0);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod19/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod19/input.ts
@@ -1,0 +1,19 @@
+// @target: esnext, es2022, es2015
+// @experimentaldecorators: true
+// @emitdecoratormetadata: true
+
+// https://github.com/microsoft/TypeScript/issues/48515
+declare var decorator: any;
+
+class C1 {
+    #x
+
+    @decorator((x: C1) => x.#x)
+    y() {}
+}
+
+class C2 {
+    #x
+
+    y(@decorator((x: C2) => x.#x) p) {}
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod19/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod19/output.js
@@ -1,0 +1,27 @@
+// @target: esnext, es2022, es2015
+// @experimentaldecorators: true
+// @emitdecoratormetadata: true
+class C1 {
+    #x;
+    y() { }
+    static {
+        babelHelpers.decorate([
+            decorator((x) => x.#x),
+            __metadata("design:type", Function),
+            __metadata("design:paramtypes", []),
+            __metadata("design:returntype", void 0)
+        ], C1.prototype, "y", null);
+    }
+}
+class C2 {
+    #x;
+    y(p) { }
+    static {
+        babelHelpers.decorate([
+            babelHelpers.decorateParam(0, decorator((x) => x.#x)),
+            __metadata("design:type", Function),
+            __metadata("design:paramtypes", [Object]),
+            __metadata("design:returntype", void 0)
+        ], C2.prototype, "y", null);
+    }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod2/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod2/input.ts
@@ -1,0 +1,7 @@
+// @target: ES5
+// @experimentaldecorators: true
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+class C {
+    @dec public method() {}
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod2/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod2/output.js
@@ -1,0 +1,6 @@
+class C {
+    method() { }
+}
+babelHelpers.decorate([
+    dec
+], C.prototype, "method", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod3/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod3/input.ts
@@ -1,0 +1,7 @@
+// @target: ES5
+// @experimentaldecorators: true
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+class C {
+    public @dec method() {}
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod3/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod3/output.js
@@ -1,0 +1,7 @@
+class C {
+    public;
+    method() { }
+}
+babelHelpers.decorate([
+    dec
+], C.prototype, "method", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod4/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod4/input.ts
@@ -1,0 +1,7 @@
+// @target: ES6
+// @experimentaldecorators: true
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+class C {
+    @dec ["method"]() {}
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod4/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod4/output.js
@@ -1,0 +1,6 @@
+class C {
+    ["method"]() { }
+}
+babelHelpers.decorate([
+    dec
+], C.prototype, "method", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod5/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod5/input.ts
@@ -1,0 +1,7 @@
+// @target: ES6
+// @experimentaldecorators: true
+declare function dec(): <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>;
+
+class C {
+    @dec() ["method"]() {}
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod5/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod5/output.js
@@ -1,0 +1,6 @@
+class C {
+    ["method"]() { }
+}
+babelHelpers.decorate([
+    dec()
+], C.prototype, "method", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod6/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod6/input.ts
@@ -1,0 +1,7 @@
+// @target: ES6
+// @experimentaldecorators: true
+declare function dec(): <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>;
+
+class C {
+    @dec ["method"]() {}
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod6/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod6/output.js
@@ -1,0 +1,6 @@
+class C {
+    ["method"]() { }
+}
+babelHelpers.decorate([
+    dec
+], C.prototype, "method", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod7/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod7/input.ts
@@ -1,0 +1,7 @@
+// @target: ES6
+// @experimentaldecorators: true
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+class C {
+    @dec public ["method"]() {}
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod7/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod7/output.js
@@ -1,0 +1,6 @@
+class C {
+    ["method"]() { }
+}
+babelHelpers.decorate([
+    dec
+], C.prototype, "method", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod8/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod8/input.ts
@@ -1,0 +1,7 @@
+// @target: ES5
+// @experimentaldecorators: true
+declare function dec<T>(target: T): T;
+
+class C {
+    @dec method() {}
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod8/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethod8/output.js
@@ -1,0 +1,6 @@
+class C {
+    method() { }
+}
+babelHelpers.decorate([
+    dec
+], C.prototype, "method", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethodOverload1/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethodOverload1/input.ts
@@ -1,0 +1,9 @@
+// @target: ES5
+// @experimentaldecorators: true
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+class C {
+    @dec
+    method()
+    method() { }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethodOverload1/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethodOverload1/output.js
@@ -1,0 +1,3 @@
+class C {
+    method() { }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethodOverload2/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethodOverload2/input.ts
@@ -1,0 +1,9 @@
+// @target: ES5
+// @experimentaldecorators: true
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+class C {
+    method()
+    @dec
+    method() { }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethodOverload2/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/decoratorOnClassMethodOverload2/output.js
@@ -1,0 +1,6 @@
+class C {
+    method() { }
+}
+babelHelpers.decorate([
+    dec
+], C.prototype, "method", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/options.json
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/options.json
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "transform-legacy-decorator"
+  ]
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/parameter/decoratorOnClassMethodParameter1/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/parameter/decoratorOnClassMethodParameter1/input.ts
@@ -1,0 +1,7 @@
+// @target:es5
+// @experimentaldecorators: true
+declare function dec(target: Object, propertyKey: string | symbol, parameterIndex: number): void;
+
+class C {
+    method(@dec p: number) {}
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/parameter/decoratorOnClassMethodParameter1/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/parameter/decoratorOnClassMethodParameter1/output.js
@@ -1,0 +1,6 @@
+class C {
+    method(p) { }
+}
+babelHelpers.decorate([
+    babelHelpers.decorateParam(0, dec)
+], C.prototype, "method", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/parameter/decoratorOnClassMethodParameter2/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/parameter/decoratorOnClassMethodParameter2/input.ts
@@ -1,0 +1,7 @@
+// @target:es5
+// @experimentaldecorators: true
+declare function dec(target: Object, propertyKey: string | symbol, parameterIndex: number): void;
+
+class C {
+    method(this: C, @dec p: number) {}
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/parameter/decoratorOnClassMethodParameter2/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/parameter/decoratorOnClassMethodParameter2/output.js
@@ -1,0 +1,6 @@
+class C {
+    method(p) { }
+}
+babelHelpers.decorate([
+    babelHelpers.decorateParam(0, dec)
+], C.prototype, "method", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/parameter/decoratorOnClassMethodParameter3/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/parameter/decoratorOnClassMethodParameter3/input.ts
@@ -1,0 +1,11 @@
+// @target: es2015
+// @experimentaldecorators: true
+
+// https://github.com/microsoft/TypeScript/issues/48509
+declare function dec(a: any): any;
+function fn(value: Promise<number>): any {
+  class Class {
+    async method(@dec(await value) arg: number) {}
+  }
+  return Class
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/parameter/decoratorOnClassMethodParameter3/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/parameter/decoratorOnClassMethodParameter3/output.js
@@ -1,0 +1,11 @@
+// @target: es2015
+// @experimentaldecorators: true
+function fn(value) {
+    class Class {
+        async method(arg) { }
+    }
+    babelHelpers.decorate([
+        babelHelpers.decorateParam(0, dec(await value))
+    ], Class.prototype, "method", null);
+    return Class;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/parameter/decoratorOnClassMethodThisParameter/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/parameter/decoratorOnClassMethodThisParameter/input.ts
@@ -1,0 +1,11 @@
+// @target:es5
+// @experimentaldecorators: true
+declare function dec(target: Object, propertyKey: string | symbol, parameterIndex: number): void;
+
+class C {
+    method(@dec this: C) {}
+}
+
+class C2 {
+    method(@dec allowed: C2, @dec this: C2) {}
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/parameter/decoratorOnClassMethodThisParameter/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/parameter/decoratorOnClassMethodThisParameter/output.js
@@ -1,0 +1,9 @@
+class C {
+    method() { }
+}
+class C2 {
+    method(allowed) { }
+}
+babelHelpers.decorate([
+    babelHelpers.decorateParam(0, dec)
+], C2.prototype, "method", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/parameter/options.json
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/method/parameter/options.json
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "transform-legacy-decorator"
+  ]
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty1/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty1/input.ts
@@ -1,0 +1,7 @@
+// @target: ES5
+// @experimentaldecorators: true
+declare function dec(target: any, propertyKey: string): void;
+
+class C {
+    @dec prop;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty1/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty1/output.js
@@ -1,0 +1,6 @@
+class C {
+    prop;
+}
+babelHelpers.decorate([
+    dec
+], C.prototype, "prop", void 0);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty10/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty10/input.ts
@@ -1,0 +1,7 @@
+// @target: ES5
+// @experimentaldecorators: true
+declare function dec(): <T>(target: any, propertyKey: string) => void;
+
+class C {
+    @dec() prop;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty10/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty10/output.js
@@ -1,0 +1,6 @@
+class C {
+    prop;
+}
+babelHelpers.decorate([
+    dec()
+], C.prototype, "prop", void 0);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty11/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty11/input.ts
@@ -1,0 +1,7 @@
+// @target: ES5
+// @experimentaldecorators: true
+declare function dec(): <T>(target: any, propertyKey: string) => void;
+
+class C {
+    @dec prop;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty11/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty11/output.js
@@ -1,0 +1,6 @@
+class C {
+    prop;
+}
+babelHelpers.decorate([
+    dec
+], C.prototype, "prop", void 0);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty12/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty12/input.ts
@@ -1,0 +1,9 @@
+// @target: es5
+// @experimentaldecorators: true
+// @emitdecoratormetadata: true
+declare function dec(): <T>(target: any, propertyKey: string) => void;
+
+class A {
+    @dec()
+    foo: `${string}`
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty12/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty12/output.js
@@ -1,0 +1,7 @@
+class A {
+    foo;
+}
+babelHelpers.decorate([
+    dec(),
+    __metadata("design:type", String)
+], A.prototype, "foo", void 0);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty13/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty13/input.ts
@@ -1,0 +1,7 @@
+// @target: ES2015
+// @experimentaldecorators: true
+declare function dec(target: any, propertyKey: string, desc: PropertyDescriptor): void;
+
+class C {
+    @dec accessor prop;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty13/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty13/output.js
@@ -1,0 +1,6 @@
+class C {
+    accessor prop;
+}
+babelHelpers.decorate([
+    dec
+], C.prototype, "prop", null);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty2/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty2/input.ts
@@ -1,0 +1,7 @@
+// @target: ES5
+// @experimentaldecorators: true
+declare function dec(target: any, propertyKey: string): void;
+
+class C {
+    @dec public prop;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty2/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty2/output.js
@@ -1,0 +1,6 @@
+class C {
+    prop;
+}
+babelHelpers.decorate([
+    dec
+], C.prototype, "prop", void 0);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty3/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty3/input.ts
@@ -1,0 +1,7 @@
+// @target: ES5
+// @experimentaldecorators: true
+declare function dec(target: any, propertyKey: string): void;
+
+class C {
+    public @dec prop;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty3/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty3/output.js
@@ -1,0 +1,7 @@
+class C {
+    public;
+    prop;
+}
+babelHelpers.decorate([
+    dec
+], C.prototype, "prop", void 0);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty6/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty6/input.ts
@@ -1,0 +1,7 @@
+// @target: ES5
+// @experimentaldecorators: true
+declare function dec(target: Function): void;
+
+class C {
+    @dec prop;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty6/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty6/output.js
@@ -1,0 +1,6 @@
+class C {
+    prop;
+}
+babelHelpers.decorate([
+    dec
+], C.prototype, "prop", void 0);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty7/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty7/input.ts
@@ -1,0 +1,7 @@
+// @target: ES5
+// @experimentaldecorators: true
+declare function dec(target: Function, propertyKey: string | symbol, paramIndex: number): void;
+
+class C {
+    @dec prop;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty7/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/decoratorOnClassProperty7/output.js
@@ -1,0 +1,6 @@
+class C {
+    prop;
+}
+babelHelpers.decorate([
+    dec
+], C.prototype, "prop", void 0);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/options.json
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/typescript/property/options.json
@@ -1,0 +1,5 @@
+{
+  "plugins": [
+    "transform-legacy-decorator"
+  ]
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/update-fixtures.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/update-fixtures.js
@@ -1,0 +1,106 @@
+/**
+ * This file is used to copy over all legacy decorators tests from submodule TypeScript repo to OXC,
+ * and re-generate output file which makes it consistent with our testing infrastructure.
+ *
+ * Q: Why would we need to re-generate output rather than copying over output from TypeScript as well?
+ * A: Mainly our implementation is based on Babel, so the output is largely different, and we should only
+ *    pay attention to the transform result that is handled by legacy decorator.
+ */
+
+import { readFileSync, rmSync, writeFileSync } from "fs";
+import { transpileModule } from "typescript";
+import { readdirSync, mkdirSync, statSync, copyFileSync } from "fs";
+import { dirname, extname, join } from "path";
+
+const __dirname = new URL(".", import.meta.url).pathname;
+
+// https://github.com/microsoft/TypeScript/blob/8da951cbb629b648753454872df4e1754982aef1/tests/cases/conformance/decorators/class
+const typescriptTestFolderPath = join(
+  __dirname,
+  "../../../../../coverage/typescript/tests/cases/conformance/decorators/class",
+);
+const oxcTestFolderPath = join(__dirname, "typescript");
+
+function copyTestsFromTypeScript() {
+  const items = readdirSync(typescriptTestFolderPath, { recursive: true });
+  for (const item of items) {
+    const originalFile = join(typescriptTestFolderPath, item);
+    const stat = statSync(originalFile);
+    if (stat.isFile()) {
+      // Skip multi-files tests
+      const hasMultiFiles =
+        Array.from(
+          readFileSync(originalFile)
+            .toString()
+            .matchAll(/\@filename\:/gi),
+        ).length > 1;
+
+      if (hasMultiFiles) {
+        continue;
+      }
+
+      const targetFile = join(
+        oxcTestFolderPath,
+        item.replace(extname(item), "/input.ts"),
+      );
+
+      mkdirSync(dirname(targetFile), { recursive: true });
+      // `abc.ts` -> `abc/input.ts`
+      copyFileSync(originalFile, targetFile);
+    } else if (stat.isDirectory()) {
+      // Generate options.json to indicate these tests should transform by legacy decorator plugin
+      const targetPath = join(oxcTestFolderPath, item);
+      mkdirSync(targetPath, { recursive: true });
+      writeBabelOptions(targetPath);
+    }
+  }
+}
+
+function writeBabelOptions(folder) {
+  const optionsFile = join(folder, "options.json");
+  const content = JSON.stringify({
+    plugins: ["transform-legacy-decorator"],
+  }, null, 2);
+  writeFileSync(optionsFile, content);
+}
+
+async function generateOutputFiles() {
+  const files = readdirSync(oxcTestFolderPath, { recursive: true });
+  for (const file of files) {
+    if (!file.endsWith("input.ts")) {
+      continue;
+    }
+    const inputFile = join(oxcTestFolderPath, file);
+    const source = readFileSync(inputFile, "utf8").toString();
+
+    const emitDecoratorMetadata = /\@emitDecoratorMetadata/gi.test(source);
+
+    /// Generate the output file path by using `typescript` library, and we need to set target to esnext
+    const output = transpileModule(source, {
+      compilerOptions: {
+        target: "esnext",
+        experimentalDecorators: true,
+        emitDecoratorMetadata,
+        noEmitHelpers: true,
+      },
+    });
+
+    // Rename helper functions to our own
+    const outputText = output.outputText
+      .replaceAll("__decorate(", "babelHelpers.decorate(")
+      .replaceAll("__param(", "babelHelpers.decorateParam(");
+
+    const outputFile = join(dirname(inputFile), "output.js");
+    writeFileSync(outputFile, outputText);
+  }
+}
+
+function run() {
+  try {
+    rmSync(oxcTestFolderPath, { recursive: true });
+  } catch { }
+  copyTestsFromTypeScript();
+  generateOutputFiles();
+}
+
+run();


### PR DESCRIPTION
Part of #8614 

All tests copy over from https://github.com/microsoft/TypeScript/blob/8da951cbb629b648753454872df4e1754982aef1/tests/cases/conformance/decorators/class, in addition, several multi-file tests were also adjusted.

The output is generated by
```ts
transpileModule(
  source,
  {
    compilerOptions: {
      target: 'esnext',
      experimentalDecorators: true,
      noEmitHelpers: true
    },
  }
)
```
and replace all `__decorate` with `babelHelpers.decorate` and `__param` with `babelHelpers.decorateParam`  