### PR TITLE
refactor(linter): move stdout outside LintRunner

### DIFF
--- a/apps/oxlint/src/output_formatter/checkstyle.rs
+++ b/apps/oxlint/src/output_formatter/checkstyle.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, io::Write};
+use std::borrow::Cow;
 
 use rustc_hash::FxHashMap;
 
@@ -13,8 +13,8 @@ use crate::output_formatter::InternalFormatter;
 pub struct CheckStyleOutputFormatter;
 
 impl InternalFormatter for CheckStyleOutputFormatter {
-    fn all_rules(&mut self, writer: &mut dyn Write) {
-        writeln!(writer, "flag --rules with flag --format=checkstyle is not allowed").unwrap();
+    fn all_rules(&self) -> Option<String> {
+        None
     }
 
     fn get_diagnostic_reporter(&self) -> Box<dyn DiagnosticReporter> {

--- a/apps/oxlint/src/output_formatter/default.rs
+++ b/apps/oxlint/src/output_formatter/default.rs
@@ -1,4 +1,4 @@
-use std::{io::Write, time::Duration};
+use std::time::Duration;
 
 use oxc_diagnostics::{
     reporter::{DiagnosticReporter, DiagnosticResult},
@@ -12,13 +12,16 @@ use crate::output_formatter::InternalFormatter;
 pub struct DefaultOutputFormatter;
 
 impl InternalFormatter for DefaultOutputFormatter {
-    fn all_rules(&mut self, writer: &mut dyn Write) {
+    fn all_rules(&self) -> Option<String> {
+        let mut output = String::new();
         let table = RuleTable::new();
         for section in table.sections {
-            writeln!(writer, "{}", section.render_markdown_table(None)).unwrap();
+            output.push_str(section.render_markdown_table(None).as_str());
+            output.push('\n');
         }
-        writeln!(writer, "Default: {}", table.turned_on_by_default_count).unwrap();
-        writeln!(writer, "Total: {}", table.total).unwrap();
+        output.push_str(format!("Default: {}\n", table.turned_on_by_default_count).as_str());
+        output.push_str(format!("Total: {}\n", table.total).as_str());
+        Some(output)
     }
 
     fn lint_command_info(&self, lint_command_info: &super::LintCommandInfo) -> Option<String> {
@@ -125,11 +128,10 @@ mod test {
 
     #[test]
     fn all_rules() {
-        let mut writer = Vec::new();
-        let mut formatter = DefaultOutputFormatter;
+        let formatter = DefaultOutputFormatter;
+        let result = formatter.all_rules();
 
-        formatter.all_rules(&mut writer);
-        assert!(!writer.is_empty());
+        assert!(result.is_some());
     }
 
     #[test]

--- a/apps/oxlint/src/output_formatter/github.rs
+++ b/apps/oxlint/src/output_formatter/github.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, io::Write};
+use std::borrow::Cow;
 
 use oxc_diagnostics::{
     reporter::{DiagnosticReporter, DiagnosticResult, Info},
@@ -11,8 +11,8 @@ use crate::output_formatter::InternalFormatter;
 pub struct GithubOutputFormatter;
 
 impl InternalFormatter for GithubOutputFormatter {
-    fn all_rules(&mut self, writer: &mut dyn Write) {
-        writeln!(writer, "flag --rules with flag --format=github is not allowed").unwrap();
+    fn all_rules(&self) -> Option<String> {
+        None
     }
 
     fn get_diagnostic_reporter(&self) -> Box<dyn DiagnosticReporter> {

--- a/apps/oxlint/src/output_formatter/json.rs
+++ b/apps/oxlint/src/output_formatter/json.rs
@@ -1,9 +1,8 @@
-use std::io::Write;
-
-use oxc_diagnostics::reporter::DiagnosticResult;
-use oxc_diagnostics::{reporter::DiagnosticReporter, Error};
-use oxc_linter::rules::RULES;
-use oxc_linter::RuleCategory;
+use oxc_diagnostics::{
+    reporter::{DiagnosticReporter, DiagnosticResult},
+    Error,
+};
+use oxc_linter::{rules::RULES, RuleCategory};
 
 use miette::JSONReportHandler;
 
@@ -13,7 +12,7 @@ use crate::output_formatter::InternalFormatter;
 pub struct JsonOutputFormatter;
 
 impl InternalFormatter for JsonOutputFormatter {
-    fn all_rules(&mut self, writer: &mut dyn Write) {
+    fn all_rules(&self) -> Option<String> {
         #[derive(Debug, serde::Serialize)]
         struct RuleInfoJson<'a> {
             scope: &'a str,
@@ -27,13 +26,10 @@ impl InternalFormatter for JsonOutputFormatter {
             category: rule.category(),
         });
 
-        writer
-            .write_all(
-                serde_json::to_string_pretty(&rules_info.collect::<Vec<_>>())
-                    .expect("Failed to serialize")
-                    .as_bytes(),
-            )
-            .unwrap();
+        Some(
+            serde_json::to_string_pretty(&rules_info.collect::<Vec<_>>())
+                .expect("Failed to serialize"),
+        )
     }
 
     fn get_diagnostic_reporter(&self) -> Box<dyn DiagnosticReporter> {

--- a/apps/oxlint/src/output_formatter/mod.rs
+++ b/apps/oxlint/src/output_formatter/mod.rs
@@ -5,7 +5,6 @@ mod json;
 mod stylish;
 mod unix;
 
-use std::io::{BufWriter, Stdout, Write};
 use std::str::FromStr;
 use std::time::Duration;
 
@@ -63,10 +62,7 @@ pub struct LintCommandInfo {
 /// The Formatter is then managed by [`OutputFormatter`].
 trait InternalFormatter {
     /// Print all available rules by oxlint
-    /// Some Formatter do not know how to output the rules in the style,
-    /// instead you should print out that this combination of flags is not supported.
-    /// Example: "flag --rules with flag --format=checkstyle is not allowed"
-    fn all_rules(&mut self, writer: &mut dyn Write);
+    fn all_rules(&self) -> Option<String>;
 
     /// At the end of the Lint command the Formatter can output extra information.
     fn lint_command_info(&self, _lint_command_info: &LintCommandInfo) -> Option<String> {
@@ -100,8 +96,8 @@ impl OutputFormatter {
 
     /// Print all available rules by oxlint
     /// See [`InternalFormatter::all_rules`] for more details.
-    pub fn all_rules(&mut self, writer: &mut BufWriter<Stdout>) {
-        self.internal.all_rules(writer);
+    pub fn all_rules(&self) -> Option<String> {
+        self.internal.all_rules()
     }
 
     /// At the end of the Lint command we may output extra information.

--- a/apps/oxlint/src/output_formatter/stylish.rs
+++ b/apps/oxlint/src/output_formatter/stylish.rs
@@ -1,5 +1,3 @@
-use std::io::Write;
-
 use oxc_diagnostics::{
     reporter::{DiagnosticReporter, DiagnosticResult, Info},
     Error, Severity,
@@ -12,8 +10,8 @@ use crate::output_formatter::InternalFormatter;
 pub struct StylishOutputFormatter;
 
 impl InternalFormatter for StylishOutputFormatter {
-    fn all_rules(&mut self, writer: &mut dyn Write) {
-        writeln!(writer, "flag --rules with flag --format=stylish is not allowed").unwrap();
+    fn all_rules(&self) -> Option<String> {
+        None
     }
 
     fn get_diagnostic_reporter(&self) -> Box<dyn DiagnosticReporter> {

--- a/apps/oxlint/src/output_formatter/unix.rs
+++ b/apps/oxlint/src/output_formatter/unix.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, io::Write};
+use std::borrow::Cow;
 
 use oxc_diagnostics::{
     reporter::{DiagnosticReporter, DiagnosticResult, Info},
@@ -11,8 +11,8 @@ use crate::output_formatter::InternalFormatter;
 pub struct UnixOutputFormatter;
 
 impl InternalFormatter for UnixOutputFormatter {
-    fn all_rules(&mut self, writer: &mut dyn Write) {
-        writeln!(writer, "flag --rules with flag --format=unix is not allowed").unwrap();
+    fn all_rules(&self) -> Option<String> {
+        None
     }
 
     fn get_diagnostic_reporter(&self) -> Box<dyn DiagnosticReporter> {

--- a/apps/oxlint/src/runner.rs
+++ b/apps/oxlint/src/runner.rs
@@ -1,3 +1,5 @@
+use std::io::Write;
+
 use crate::cli::CliRunResult;
 
 /// A trait for exposing functionality to the CLI.
@@ -7,5 +9,5 @@ pub trait Runner {
     fn new(matches: Self::Options) -> Self;
 
     /// Executes the runner, providing some result to the CLI.
-    fn run(self) -> CliRunResult;
+    fn run(self, stdout: &mut dyn Write) -> CliRunResult;
 }


### PR DESCRIPTION
This is needed so we can use a custom `Write` implementation (or just `[u8]`) to make snapshots.
In this step I also updated `OutputFormatter::all_rules` so the Formatter does not need to handle the write-error.
