### PR TITLE
test(linter): add diagnostic format test snapshots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2227,6 +2227,7 @@ dependencies = [
  "oxc_linter",
  "oxc_span",
  "rayon",
+ "regex",
  "rustc-hash",
  "serde",
  "serde_json",

--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -37,7 +37,6 @@ oxc_span = { workspace = true }
 
 bpaf = { workspace = true, features = ["autocomplete", "bright-color", "derive"] }
 ignore = { workspace = true, features = ["simd-accel"] }
-insta = { workspace = true }
 miette = { workspace = true }
 rayon = { workspace = true }
 rustc-hash = { workspace = true }
@@ -45,6 +44,10 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tracing-subscriber = { workspace = true, features = [] } # Omit the `regex` feature
+
+[dev-dependencies]
+insta = { workspace = true }
+regex = { workspace = true }
 
 [features]
 default = []

--- a/apps/oxlint/fixtures/output_formatter_diagnostic/.oxlintrc.json
+++ b/apps/oxlint/fixtures/output_formatter_diagnostic/.oxlintrc.json
@@ -1,0 +1,6 @@
+{
+    "rules": {
+        "no-debugger": "error",
+        "no-unused-vars": "warn"
+    }
+}

--- a/apps/oxlint/fixtures/output_formatter_diagnostic/test.js
+++ b/apps/oxlint/fixtures/output_formatter_diagnostic/test.js
@@ -1,0 +1,5 @@
+function foo(a, b) {
+    return a;
+}
+
+debugger;

--- a/apps/oxlint/src/output_formatter/mod.rs
+++ b/apps/oxlint/src/output_formatter/mod.rs
@@ -111,3 +111,53 @@ impl OutputFormatter {
         self.internal.get_diagnostic_reporter()
     }
 }
+
+#[cfg(test)]
+mod test {
+    use crate::tester::Tester;
+
+    const TEST_CWD: &str = "fixtures/output_formatter_diagnostic";
+
+    #[test]
+    fn test_output_formatter_diagnostic_default() {
+        let args = &["--format=default", "test.js"];
+
+        Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(args);
+    }
+
+    /// disabled for windows
+    /// json will output the offset which will be different for windows
+    /// when there are multiple lines (`\r\n` vs `\n`)
+    #[cfg(all(test, not(target_os = "windows")))]
+    #[test]
+    fn test_output_formatter_diagnostic_json() {
+        let args = &["--format=json", "test.js"];
+
+        Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(args);
+    }
+
+    #[test]
+    fn test_output_formatter_diagnostic_checkstyle() {
+        let args = &["--format=checkstyle", "test.js"];
+
+        Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(args);
+    }
+
+    #[test]
+    fn test_output_formatter_diagnostic_github() {
+        let args = &["--format=github", "test.js"];
+
+        Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(args);
+    }
+
+    /// disabled for windows
+    /// stylish will output the offset which will be different for windows
+    /// when there are multiple lines (`\r\n` vs `\n`)
+    #[cfg(all(test, not(target_os = "windows")))]
+    #[test]
+    fn test_output_formatter_diagnostic_stylish() {
+        let args = &["--format=stylish", "test.js"];
+
+        Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(args);
+    }
+}

--- a/apps/oxlint/src/snapshots/--format=checkstyle test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/--format=checkstyle test.js@oxlint.snap
@@ -1,0 +1,7 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+--format=checkstyle test.js
+----------
+<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"><file name="test.js"><error line="5" column="1" severity="error" message="`debugger` statement is not allowed" source="" /><error line="1" column="10" severity="warning" message="Function &apos;foo&apos; is declared but never used." source="" /><error line="1" column="17" severity="warning" message="Parameter &apos;b&apos; is declared but never used. Unused parameters should start with a &apos;_&apos;." source="" /></file></checkstyle>

--- a/apps/oxlint/src/snapshots/--format=default test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/--format=default test.js@oxlint.snap
@@ -1,0 +1,35 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+--format=default test.js
+----------
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[test.js:5:1]
+ 4 | 
+ 5 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Delete this code.
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html\eslint(no-unused-vars)]8;;\: Function 'foo' is declared but never used.
+   ,-[test.js:1:10]
+ 1 | function foo(a, b) {
+   :          ^|^
+   :           `-- 'foo' is declared here
+ 2 |     return a;
+   `----
+  help: Consider removing this declaration.
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html\eslint(no-unused-vars)]8;;\: Parameter 'b' is declared but never used. Unused parameters should start with a '_'.
+   ,-[test.js:1:17]
+ 1 | function foo(a, b) {
+   :                 |
+   :                 `-- 'b' is declared here
+ 2 |     return a;
+   `----
+  help: Consider removing this parameter.
+
+Found 2 warnings and 1 error.
+Finished in <variable> on 1 file with 97 rules using <variable>.

--- a/apps/oxlint/src/snapshots/--format=github test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/--format=github test.js@oxlint.snap
@@ -1,0 +1,9 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+--format=github test.js
+----------
+::error file=test.js,line=5,endLine=5,col=1,endColumn=10,title=oxlint::`debugger` statement is not allowed
+::warning file=test.js,line=1,endLine=1,col=10,endColumn=13,title=oxlint::Function 'foo' is declared but never used.
+::warning file=test.js,line=1,endLine=1,col=17,endColumn=18,title=oxlint::Parameter 'b' is declared but never used. Unused parameters should start with a '_'.

--- a/apps/oxlint/src/snapshots/--format=json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/--format=json test.js@oxlint.snap
@@ -1,0 +1,11 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+--format=json test.js
+----------
+[
+	{"message": "`debugger` statement is not allowed","code": "eslint(no-debugger)","severity": "error","causes": [],"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html","help": "Delete this code.","filename": "test.js","labels": [{"span": {"offset": 38,"length": 9}}],"related": []},
+	{"message": "Function 'foo' is declared but never used.","code": "eslint(no-unused-vars)","severity": "warning","causes": [],"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html","help": "Consider removing this declaration.","filename": "test.js","labels": [{"label": "'foo' is declared here","span": {"offset": 9,"length": 3}}],"related": []},
+	{"message": "Parameter 'b' is declared but never used. Unused parameters should start with a '_'.","code": "eslint(no-unused-vars)","severity": "warning","causes": [],"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html","help": "Consider removing this parameter.","filename": "test.js","labels": [{"label": "'b' is declared here","span": {"offset": 16,"length": 1}}],"related": []}
+]

--- a/apps/oxlint/src/snapshots/--format=stylish test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/--format=stylish test.js@oxlint.snap
@@ -1,0 +1,13 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+--format=stylish test.js
+----------
+
+[4mtest.js[0m
+  [2m9:3 [0m  [33mwarning[0m  Function 'foo' is declared but never used.  [2meslint(no-unused-vars)[0m
+  [2m16:1[0m  [33mwarning[0m  Parameter 'b' is declared but never used. Unused parameters should start with a '_'.  [2meslint(no-unused-vars)[0m
+  [2m38:9[0m  [31merror[0m  `debugger` statement is not allowed  [2meslint(no-debugger)[0m
+
+[31m✖ 3 problems (1 error, 2 warnings)[0m

--- a/apps/oxlint/src/tester.rs
+++ b/apps/oxlint/src/tester.rs
@@ -3,8 +3,9 @@ use crate::cli::{lint_command, CliRunResult, LintResult, LintRunner};
 #[cfg(test)]
 use crate::runner::Runner;
 #[cfg(test)]
+use regex::Regex;
+#[cfg(test)]
 use std::{env, path::PathBuf};
-
 #[cfg(test)]
 pub struct Tester {
     cwd: PathBuf,
@@ -64,8 +65,13 @@ impl Tester {
         settings.set_omit_expression(true);
         settings.set_snapshot_suffix("oxlint");
 
+        let regex = Regex::new(r"\d+ms|\d+ threads?").unwrap();
+
+        let output_string = &String::from_utf8(output).unwrap();
+        let output_string = regex.replace_all(output_string, "<variable>");
+
         settings.bind(|| {
-            insta::assert_snapshot!(format!("{}", args_string), String::from_utf8(output).unwrap());
+            insta::assert_snapshot!(format!("{}", args_string), output_string);
         });
     }
 }


### PR DESCRIPTION

windows will fail, looks like the offset missmatch is because of `\r\n` vs `\n`.

```
Snapshot file: apps\oxlint\src\snapshots\--format=json test.js@oxlint.snap
Snapshot: --format=json test.js@oxlint
Source: C:\dev\oxc:74
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────-old snapshot
+new results
────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────    0     0 │ ##########
    1     1 │ --format=json test.js
    2     2 │ ----------
    3     3 │ [
    4       │-  {"message": "`debugger` statement is not allowed","code": "eslint(no-debugger)","severity": "error","causes": [],"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html","help": "Delete this code.","filename": "test.js","labels": [{"span": {"offset": 38,"length": 9}}],"related": []},
          4 │+  {"message": "`debugger` statement is not allowed","code": "eslint(no-debugger)","severity": "error","causes": [],"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html","help": "Delete this code.","filename": "test.js","labels": [{"span": {"offset": 42,"length": 9}}],"related": []},
    5     5 │   {"message": "Function 'foo' is declared but never used.","code": "eslint(no-unused-vars)","severity": "warning","causes": [],"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html","help": "Consider removing this declaration.","filename": "test.js","labels": [{"label": "'foo' is declared here","span": {"offset": 9,"length": 3}}],"related": []},
    6     6 │   {"message": "Parameter 'b' is declared but never used. Unused parameters should start with a '_'.","code": "eslint(no-unused-vars)","severity": "warning","causes": [],"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html","help": "Consider removing this parameter.","filename": "test.js","labels": [{"label": "'b' is declared here","span": {"offset": 16,"length": 1}}],"related": []}
    7     7 │ ]
────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────To update snapshots run `cargo insta review`
Stopped on the first failure. Run `cargo insta test` to run all snapshots.
thread 'output_formatter::test::test_output_formatter_diagnostic_json' panicked at C:\Users\sysix\.cargo\registry\src\index.crates.io-6f17d22bba15001f\insta-1.42.0\src\runtime.rs:679:13:
snapshot assertion for '--format=json test.js@oxlint' failed in line 74
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

---- output_formatter::test::test_output_formatter_diagnostic_stylish stdout ----
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ Snapshot Summary ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━Snapshot file: apps\oxlint\src\snapshots\--format=stylish test.js@oxlint.snap
Snapshot: --format=stylish test.js@oxlint
Source: C:\dev\oxc:74
──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────-old snapshot
+new results
────────────┬─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────    3     3 │
    4     4 │ ␛[4mtest.js␛[0m␊
    5     5 │   ␛[2m9:3 ␛[0m  ␛[33mwarning␛[0m  Function 'foo' is declared but never used.  ␛[2meslint(no-unused-vars)␛[0m␊
    6     6 │   ␛[2m16:1␛[0m  ␛[33mwarning␛[0m  Parameter 'b' is declared but never used. Unused parameters should start with a '_'.  ␛[2meslint(no-unused-vars)␛[0m␊
    7       │-  ␛[2m38:9␛[0m  ␛[31merror␛[0m  `debugger` statement is not allowed  ␛[2meslint(no-debugger)␛[0m␊
          7 │+  ␛[2m42:9␛[0m  ␛[31merror␛[0m  `debugger` statement is not allowed  ␛[2meslint(no-debugger)␛[0m␊
    8     8 │ 
    9     9 │ ␛[31m✖ 3 problems (1 error, 2 warnings)␛[0m
────────────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────To update snapshots run `cargo insta review`
Stopped on the first failure. Run `cargo insta test` to run all snapshots.
thread 'output_formatter::test::test_output_formatter_diagnostic_stylish' panicked at C:\Users\sysix\.cargo\registry\src\index.crates.io-6f17d22bba15001f\insta-1.42.0\src\runtime.rs:679:13:
snapshot assertion for '--format=stylish test.js@oxlint' failed in line 74


failures:
    output_formatter::test::test_output_formatter_diagnostic_json
    output_formatter::test::test_output_formatter_diagnostic_stylish

test result: FAILED. 85 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.12s

```