### PR TITLE
perf(minifier): normalize `undefined` to `void 0` before everything else

### DIFF
--- a/crates/oxc_minifier/examples/minifier.rs
+++ b/crates/oxc_minifier/examples/minifier.rs
@@ -27,7 +27,7 @@ fn main() -> std::io::Result<()> {
 
     let mut allocator = Allocator::default();
     let printed = minify(&allocator, &source_text, source_type, mangle, nospace);
-    println!("{printed}");
+    // println!("{printed}");
 
     if twice {
         allocator.reset();

--- a/crates/oxc_minifier/src/ctx.rs
+++ b/crates/oxc_minifier/src/ctx.rs
@@ -62,6 +62,7 @@ impl<'a> Ctx<'a, '_> {
         }
     }
 
+    #[inline]
     pub fn is_identifier_undefined(self, ident: &IdentifierReference) -> bool {
         if ident.name == "undefined" && ident.is_global_reference(self.symbols()) {
             return true;
@@ -69,6 +70,7 @@ impl<'a> Ctx<'a, '_> {
         false
     }
 
+    #[inline]
     pub fn is_identifier_infinity(self, ident: &IdentifierReference) -> bool {
         if ident.name == "Infinity" && ident.is_global_reference(self.symbols()) {
             return true;
@@ -76,6 +78,7 @@ impl<'a> Ctx<'a, '_> {
         false
     }
 
+    #[inline]
     pub fn is_identifier_nan(self, ident: &IdentifierReference) -> bool {
         if ident.name == "NaN" && ident.is_global_reference(self.symbols()) {
             return true;

--- a/crates/oxc_minifier/src/peephole/minimize_conditions.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditions.rs
@@ -4,10 +4,9 @@ use oxc_ecmascript::{
     constant_evaluation::{ConstantEvaluation, ValueType},
     ToInt32,
 };
-use oxc_semantic::ReferenceFlags;
 use oxc_span::{cmp::ContentEq, GetSpan};
 use oxc_syntax::es_target::ESTarget;
-use oxc_traverse::{Ancestor, MaybeBoundIdentifier, TraverseCtx};
+use oxc_traverse::{Ancestor, TraverseCtx};
 
 use crate::ctx::Ctx;
 
@@ -366,13 +365,9 @@ impl<'a> PeepholeOptimizations {
             unreachable!()
         };
         let return_stmt = return_stmt.unbox();
-        if let Some(e) = return_stmt.argument {
-            e
-        } else {
-            let name = "undefined";
-            let symbol_id = ctx.scopes().find_binding(ctx.current_scope_id(), name);
-            let ident = MaybeBoundIdentifier::new(Atom::from(name), symbol_id);
-            ident.create_expression(ReferenceFlags::read(), ctx)
+        match return_stmt.argument {
+            Some(e) => e,
+            None => ctx.ast.void_0(return_stmt.span),
         }
     }
 

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -871,7 +871,6 @@ impl<'a> LatePeepholeOptimizations {
         }
 
         if let Some(folded_expr) = match expr {
-            Expression::Identifier(ident) => Self::try_compress_undefined(ident, ctx),
             Expression::BooleanLiteral(_) => Self::try_compress_boolean(expr, ctx),
             _ => None,
         } {
@@ -891,23 +890,6 @@ impl<'a> LatePeepholeOptimizations {
         {
             e.arguments.clear();
         }
-    }
-
-    /// Transforms `undefined` => `void 0`
-    fn try_compress_undefined(
-        ident: &IdentifierReference<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) -> Option<Expression<'a>> {
-        if !Ctx(ctx).is_identifier_undefined(ident) {
-            return None;
-        }
-        // `delete undefined` returns `false`
-        // `delete void 0` returns `true`
-        if matches!(ctx.parent(), Ancestor::UnaryExpressionArgument(e) if e.operator().is_delete())
-        {
-            return None;
-        }
-        Some(ctx.ast.void_0(ident.span))
     }
 
     /// Transforms boolean expression `true` => `!0` `false` => `!1`.

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -9,7 +9,7 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 
 342.15 kB  | 118.19 kB  | 118.14 kB  | 44.45 kB   | 44.37 kB   | vue.js    
 
-544.10 kB  | 71.73 kB   | 72.48 kB   | 26.14 kB   | 26.20 kB   | lodash.js 
+544.10 kB  | 71.75 kB   | 72.48 kB   | 26.15 kB   | 26.20 kB   | lodash.js 
 
 555.77 kB  | 272.89 kB  | 270.13 kB  | 90.90 kB   | 90.80 kB   | d3.js     
 


### PR DESCRIPTION
so subsequent code don't need to lookup `undefined`.