### PR TITLE
chore(oxc_release.toml): add `crates/oxc_language_server/Cargo.toml`

### DIFF
--- a/oxc_release.toml
+++ b/oxc_release.toml
@@ -20,4 +20,5 @@ versioned_files = [
   "crates/oxc_linter/Cargo.toml",
   "editors/vscode/package.json",
   "npm/oxlint/package.json",
+  "crates/oxc_language_server/Cargo.toml",
 ]


### PR DESCRIPTION
close #8603 

Add `crates/oxc_language_server/Cargo.toml` to release LS with linter's release