### PR TITLE
fix(mangler): handle cases where a var is declared in a block scope

### DIFF
--- a/crates/oxc_minifier/tests/mangler/mod.rs
+++ b/crates/oxc_minifier/tests/mangler/mod.rs
@@ -40,6 +40,10 @@ fn mangler() {
         "function _() { var x; try { throw 0 } catch (e) { e } }", // e can shadow x
         "function _() { var x; try { throw 0 } catch (e) { var e } }", // e can shadow x (not implemented)
         "function _() { var x; try { throw 0 } catch { var e } }",     // e should not shadow x
+        "function _() { var x; var y; }", // x and y should have different names
+        "function _() { var x; let y; }", // x and y should have different names
+        "function _() { { var x; var y; } }", // x and y should have different names
+        "function _() { { var x; let y; } }", // x and y should have different names
     ];
     let top_level_cases = [
         "function foo(a) {a}",

--- a/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
+++ b/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
@@ -153,6 +153,34 @@ function _() {
 	}
 }
 
+function _() { var x; var y; }
+function _() {
+	var a;
+	var b;
+}
+
+function _() { var x; let y; }
+function _() {
+	var a;
+	let b;
+}
+
+function _() { { var x; var y; } }
+function _() {
+	{
+		var a;
+		var b;
+	}
+}
+
+function _() { { var x; let y; } }
+function _() {
+	{
+		var a;
+		let b;
+	}
+}
+
 function foo(a) {a}
 function a(a) {
 	a;


### PR DESCRIPTION
This PR fixes the mangler that it was outputting `function _() { { var a; let a; } }` for `function _() { { var x; let y; } }`.
This caused this error: https://github.com/oxc-project/monitor-oxc/actions/runs/12962575667/job/36159286596#step:8:31

refs #8705
