### PR TITLE
fix(linter): output `LintCommandInfo` for `CliRunResult::LintNoFilesFound`

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -147,6 +147,16 @@ impl Runner for LintRunner {
             // If explicit paths were provided, but all have been
             // filtered, return early.
             if provided_path_count > 0 {
+                if let Some(end) = output_formatter.lint_command_info(&LintCommandInfo {
+                    number_of_files: 0,
+                    number_of_rules: 0,
+                    threads_count: rayon::current_num_threads(),
+                    start_time: now.elapsed(),
+                }) {
+                    stdout.write_all(end.as_bytes()).or_else(Self::check_for_writer_error).unwrap();
+                    stdout.flush().unwrap();
+                };
+
                 return CliRunResult::LintNoFilesFound;
             }
 

--- a/apps/oxlint/src/snapshots/_--ignore-path fixtures__issue_7566__.oxlintignore fixtures__issue_7566__tests__main.js fixtures__issue_7566__tests__function__main.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-path fixtures__issue_7566__.oxlintignore fixtures__issue_7566__tests__main.js fixtures__issue_7566__tests__function__main.js@oxlint.snap
@@ -5,6 +5,7 @@ source: apps/oxlint/src/tester.rs
 arguments: --ignore-path fixtures/issue_7566/.oxlintignore fixtures/issue_7566/tests/main.js fixtures/issue_7566/tests/function/main.js
 working directory: 
 ----------
+Finished in <variable>ms on 0 files with 0 rules using 1 threads.
 ----------
 CLI result: LintNoFilesFound
 ----------

--- a/apps/oxlint/src/snapshots/_--ignore-path fixtures__linter__.customignore fixtures__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-path fixtures__linter__.customignore fixtures__linter__nan.js@oxlint.snap
@@ -5,6 +5,7 @@ source: apps/oxlint/src/tester.rs
 arguments: --ignore-path fixtures/linter/.customignore fixtures/linter/nan.js
 working directory: 
 ----------
+Finished in <variable>ms on 0 files with 0 rules using 1 threads.
 ----------
 CLI result: LintNoFilesFound
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension__main.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension__main.js@oxlint.snap
@@ -5,6 +5,7 @@ source: apps/oxlint/src/tester.rs
 arguments: -c fixtures/config_ignore_patterns/ignore_extension/eslintrc.json fixtures/config_ignore_patterns/ignore_extension/main.js
 working directory: 
 ----------
+Finished in <variable>ms on 0 files with 0 rules using 1 threads.
 ----------
 CLI result: LintNoFilesFound
 ----------


### PR DESCRIPTION
In the older version we outputted the found warnings and errors (which also be zero).
This is only reimplementing a part of the old behavior ands skips the old output here: 
https://github.com/oxc-project/oxc/blob/4a2f2a9cd996cacf85b9e14467397d34497f6e96/apps/oxlint/src/output_formatter/default.rs#L84-L110

Bug found here:
https://github.com/oxc-project/oxc/blob/659c225c5683363c8bd5ac78444ce7ce349b43e3/apps/oxlint/src/snapshots/_--ignore-path%20fixtures__linter__.customignore%20fixtures__linter__nan.js%40oxlint.snap