### PR TITLE
refactor(semantic): simplify `ScopeTree::iter_bindings`

### DIFF
--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -287,13 +287,9 @@ mod tests {
         let source = "function Fn() {}";
         let allocator = Allocator::default();
         let semantic = get_semantic(&allocator, source, SourceType::default());
+        let scopes = semantic.scopes();
 
-        let top_level_a = semantic
-            .scopes()
-            .iter_bindings()
-            .find(|(_scope_id, _symbol_id, name)| *name == "Fn")
-            .unwrap();
-        assert_eq!(semantic.symbols.get_scope_id(top_level_a.1), top_level_a.0);
+        assert!(scopes.get_binding(scopes.root_scope_id(), "Fn").is_some());
     }
 
     #[test]

--- a/crates/oxc_semantic/src/scope.rs
+++ b/crates/oxc_semantic/src/scope.rs
@@ -310,10 +310,8 @@ impl ScopeTree {
     /// If you only want bindings in a specific scope, use [`iter_bindings_in`].
     ///
     /// [`iter_bindings_in`]: ScopeTree::iter_bindings_in
-    pub fn iter_bindings(&self) -> impl Iterator<Item = (ScopeId, SymbolId, &str)> + '_ {
-        self.cell.borrow_dependent().bindings.iter_enumerated().flat_map(|(scope_id, bindings)| {
-            bindings.iter().map(move |(&name, &symbol_id)| (scope_id, symbol_id, name))
-        })
+    pub fn iter_bindings(&self) -> impl Iterator<Item = (ScopeId, &Bindings)> + '_ {
+        self.cell.borrow_dependent().bindings.iter_enumerated()
     }
 
     /// Iterate over bindings declared inside a scope.


### PR DESCRIPTION
The previous implementation is a little weird, I think it should be a shortcut of `bindings.iter`, It is infrequent we need to iter all symbols and know its scope ID. Only two cases in tests, and no use case in `Rolldown`