### PR TITLE
perf(mangler): optimize handling of collecting lived scope ids

### DIFF
--- a/crates/oxc_minifier/tests/mangler/mod.rs
+++ b/crates/oxc_minifier/tests/mangler/mod.rs
@@ -44,6 +44,8 @@ fn mangler() {
         "function _() { var x; let y; }", // x and y should have different names
         "function _() { { var x; var y; } }", // x and y should have different names
         "function _() { { var x; let y; } }", // x and y should have different names
+        "function _() { let a; { let b; { let c; { let d; var x; } } } }",
+        "function _() { let a; { let b; { let c; { console.log(a); let d; var x; } } } }",
     ];
     let top_level_cases = [
         "function foo(a) {a}",

--- a/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
+++ b/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
@@ -181,6 +181,37 @@ function _() {
 	}
 }
 
+function _() { let a; { let b; { let c; { let d; var x; } } } }
+function _() {
+	let a;
+	{
+		let a;
+		{
+			let a;
+			{
+				let a;
+				var b;
+			}
+		}
+	}
+}
+
+function _() { let a; { let b; { let c; { console.log(a); let d; var x; } } } }
+function _() {
+	let a;
+	{
+		let c;
+		{
+			let c;
+			{
+				console.log(a);
+				let c;
+				var b;
+			}
+		}
+	}
+}
+
 function foo(a) {a}
 function a(a) {
 	a;


### PR DESCRIPTION
Just some low-hanging fruit optimization.

I initially want to dedupe for reference scopes, so that we can avoid calling `scope_tree.ancestors(used_scope_id).take_while(|s_id| *s_id != scope_id)` for duplicate `used_scope_id` but the overhead of calling `unique` or `dedup` is over the improvement.