### PR TITLE
feat(minifier): replace `Math.pow` with `**`

### DIFF
--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -3,7 +3,7 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 -------------------------------------------------------------------------------------
 72.14 kB   | 23.61 kB   | 23.70 kB   | 8.55 kB    | 8.54 kB    | react.development.js
 
-173.90 kB  | 59.71 kB   | 59.82 kB   | 19.26 kB   | 19.33 kB   | moment.js 
+173.90 kB  | 59.70 kB   | 59.82 kB   | 19.26 kB   | 19.33 kB   | moment.js 
 
 287.63 kB  | 89.58 kB   | 90.07 kB   | 31.08 kB   | 31.95 kB   | jquery.js 
 
@@ -11,17 +11,17 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 
 544.10 kB  | 71.50 kB   | 72.48 kB   | 25.92 kB   | 26.20 kB   | lodash.js 
 
-555.77 kB  | 272.35 kB  | 270.13 kB  | 88.60 kB   | 90.80 kB   | d3.js     
+555.77 kB  | 272.12 kB  | 270.13 kB  | 88.59 kB   | 90.80 kB   | d3.js     
 
 1.01 MB    | 458.28 kB  | 458.89 kB  | 123.94 kB  | 126.71 kB  | bundle.min.js
 
-1.25 MB    | 650.82 kB  | 646.76 kB  | 161.51 kB  | 163.73 kB  | three.js  
+1.25 MB    | 650.70 kB  | 646.76 kB  | 161.49 kB  | 163.73 kB  | three.js  
 
-2.14 MB    | 719.54 kB  | 724.14 kB  | 162.47 kB  | 181.07 kB  | victory.js
+2.14 MB    | 719.06 kB  | 724.14 kB  | 162.43 kB  | 181.07 kB  | victory.js
 
-3.20 MB    | 1.01 MB    | 1.01 MB    | 325.41 kB  | 331.56 kB  | echarts.js
+3.20 MB    | 1.01 MB    | 1.01 MB    | 325.38 kB  | 331.56 kB  | echarts.js
 
 6.69 MB    | 2.30 MB    | 2.31 MB    | 470.00 kB  | 488.28 kB  | antd.js   
 
-10.95 MB   | 3.37 MB    | 3.49 MB    | 866.65 kB  | 915.50 kB  | typescript.js
+10.95 MB   | 3.37 MB    | 3.49 MB    | 866.66 kB  | 915.50 kB  | typescript.js
 


### PR DESCRIPTION
Replaces `Math.pow(a, b)` with `(+a) ** (+b)`. `+` does `ToNumber` and `**` does `Number::exponentiate` when both operands are number.
`+` is not added when `a` or `b` is already a number.

**Reference**
- [Spec of `Math.pow`](https://tc39.es/ecma262/multipage/numbers-and-dates.html#sec-math.pow)
- [Spec of `**`](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-exp-operator-runtime-semantics-evaluation)
- [Spec of unary `+`](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-unary-plus-operator-runtime-semantics-evaluation)