### PR TITLE
feat(minifier): replace `const` with `let` for non-exported read-only variables

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -947,6 +947,11 @@ impl<'a> BindingPattern<'a> {
     pub fn get_binding_identifier(&self) -> Option<&BindingIdentifier<'a>> {
         self.kind.get_binding_identifier()
     }
+
+    #[allow(missing_docs)]
+    pub fn get_binding_identifiers(&self) -> std::vec::Vec<&BindingIdentifier<'a>> {
+        self.kind.get_binding_identifiers()
+    }
 }
 
 impl<'a> BindingPatternKind<'a> {
@@ -966,6 +971,31 @@ impl<'a> BindingPatternKind<'a> {
             Self::AssignmentPattern(assign) => assign.left.get_binding_identifier(),
             _ => None,
         }
+    }
+
+    fn append_binding_identifiers<'b>(
+        &'b self,
+        idents: &mut std::vec::Vec<&'b BindingIdentifier<'a>>,
+    ) {
+        match self {
+            Self::BindingIdentifier(ident) => idents.push(ident),
+            Self::AssignmentPattern(assign) => assign.left.kind.append_binding_identifiers(idents),
+            Self::ArrayPattern(pattern) => pattern
+                .elements
+                .iter()
+                .filter_map(|item| item.as_ref())
+                .for_each(|item| item.kind.append_binding_identifiers(idents)),
+            Self::ObjectPattern(pattern) => pattern.properties.iter().for_each(|item| {
+                item.value.kind.append_binding_identifiers(idents);
+            }),
+        }
+    }
+
+    #[allow(missing_docs)]
+    pub fn get_binding_identifiers(&self) -> std::vec::Vec<&BindingIdentifier<'a>> {
+        let mut idents = vec![];
+        self.append_binding_identifiers(&mut idents);
+        idents
     }
 
     #[allow(missing_docs)]

--- a/crates/oxc_minifier/src/compressor.rs
+++ b/crates/oxc_minifier/src/compressor.rs
@@ -34,7 +34,8 @@ impl<'a> Compressor<'a> {
         program: &mut Program<'a>,
     ) {
         let mut ctx = ReusableTraverseCtx::new(scopes, symbols, self.allocator);
-        let normalize_options = NormalizeOptions { convert_while_to_fors: true };
+        let normalize_options =
+            NormalizeOptions { convert_while_to_fors: true, convert_const_to_let: true };
         Normalize::new(normalize_options, self.options).build(program, &mut ctx);
         PeepholeOptimizations::new(self.options.target).run_in_loop(program, &mut ctx);
         LatePeepholeOptimizations::new(self.options.target).build(program, &mut ctx);
@@ -53,7 +54,8 @@ impl<'a> Compressor<'a> {
         program: &mut Program<'a>,
     ) {
         let mut ctx = ReusableTraverseCtx::new(scopes, symbols, self.allocator);
-        let normalize_options = NormalizeOptions { convert_while_to_fors: false };
+        let normalize_options =
+            NormalizeOptions { convert_while_to_fors: false, convert_const_to_let: false };
         Normalize::new(normalize_options, self.options).build(program, &mut ctx);
         DeadCodeElimination::new().build(program, &mut ctx);
     }

--- a/crates/oxc_minifier/src/peephole/minimize_conditions.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditions.rs
@@ -1267,7 +1267,10 @@ mod test {
 
         // Dot not fold `let` and `const`.
         // Lexical declaration cannot appear in a single-statement context.
-        test_same("if (foo) { const bar = 1 } else { const baz = 1 }");
+        test(
+            "if (foo) { const bar = 1 } else { const baz = 1 }",
+            "if (foo) { let bar = 1 } else { let baz = 1 }",
+        );
         test_same("if (foo) { let bar = 1 } else { let baz = 1 }");
         // test(
         // "if (foo) { var bar = 1 } else { var baz = 1 }",
@@ -1401,8 +1404,8 @@ mod test {
     fn test_fold_returns_integration2() {
         // if-then-else duplicate statement removal handles this case:
         test(
-            "function test(a) {if (a) {const a = Math.random();if(a) {return a;}} return a; }",
-            "function test(a) { if (a) { const a = Math.random(); if (a) return a; } return a; }",
+            "function test(a) {if (a) {let a = Math.random();if(a) {return a;}} return a; }",
+            "function test(a) { if (a) { let a = Math.random(); if (a) return a; } return a; }",
         );
     }
 
@@ -1412,7 +1415,7 @@ mod test {
         // refers to a different variable.
         // We only try removing duplicate statements if the AST is normalized and names are unique.
         test_same(
-            "if (Math.random() < 0.5) { const x = 3; alert(x); } else { const x = 5; alert(x); }",
+            "if (Math.random() < 0.5) { let x = 3; alert(x); } else { let x = 5; alert(x); }",
         );
     }
 

--- a/crates/oxc_minifier/src/peephole/minimize_exit_points.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_exit_points.rs
@@ -130,7 +130,7 @@ mod test {
         test(
             "function f(a) {
               if (a) {
-                const a = Math.random();
+                let a = Math.random();
                 if (a < 0.5) {
                     return a;
                 }
@@ -139,7 +139,7 @@ mod test {
             }",
             "function f(a) {
               if (a) {
-                const a = Math.random();
+                let a = Math.random();
                 if (a < 0.5) return a;
               }
               return a;

--- a/crates/oxc_minifier/src/peephole/statement_fusion.rs
+++ b/crates/oxc_minifier/src/peephole/statement_fusion.rs
@@ -248,7 +248,7 @@ mod test {
     fn fuse_into_vanilla_for2() {
         test("a;b;c;for(var d;g;){}", "a,b,c;for(var d;g;);");
         test("a;b;c;for(let d;g;){}", "a,b,c;for(let d;g;);");
-        test("a;b;c;for(const d = 5;g;){}", "a,b,c;for(const d = 5;g;);");
+        test("a;b;c;for(const d = 5;g;){}", "a,b,c;for(let d = 5;g;);");
     }
 
     #[test]
@@ -292,10 +292,10 @@ mod test {
         test("a; {b;}", "a,b");
         test("a; {b; var a = 1;}", "{a, b; var a = 1;}");
         test_same("a; { b; let a = 1; }");
-        test_same("a; { b; const a = 1; }");
+        test("a; { b; const a = 1; }", "a; { b; let a = 1; }");
         test_same("a; { b; class a {} }");
         test_same("a; { b; function a() {} }");
-        test_same("a; { b; const otherVariable = 1; }");
+        test("a; { b; const otherVariable = 1; }", "a; { b; let otherVariable = 1; }");
 
         // test(
         // "function f(a) { if (COND) { a; { b; let a = 1; } } }",

--- a/crates/oxc_minifier/tests/peephole/esbuild.rs
+++ b/crates/oxc_minifier/tests/peephole/esbuild.rs
@@ -155,15 +155,15 @@ fn js_parser_test() {
     test("const a=0; while (1) ;", "const a = 0;for (;;) ;");
     test("var a; for (var b;;) ;", "for (var a, b;;) ;");
     test("let a; for (let b;;) ;", "let a;for (let b;;) ;");
-    test("const a=0; for (const b = 1;;) ;", "const a = 0;for (const b = 1;;) ;");
+    test("const a=0; for (const b = 1;;) ;", "const a = 0;for (let b = 1;;) ;");
     test("export var a; while (1) ;", "export var a;for (;;) ;");
     test("export let a; while (1) ;", "export let a;for (;;) ;");
     test("export const a=0; while (1) ;", "export const a = 0;for (;;) ;");
     test("export var a; for (var b;;) ;", "export var a;for (var b;;) ;");
     test("export let a; for (let b;;) ;", "export let a;for (let b;;) ;");
-    test("export const a=0; for (const b = 1;;) ;", "export const a = 0;for (const b = 1;;) ;");
+    test("export const a=0; for (const b = 1;;) ;", "export const a = 0;for (let b = 1;;) ;");
     test("var a; for (let b;;) ;", "var a;for (let b;;) ;");
-    test("let a; for (const b=0;;) ;", "let a;for (const b = 0;;) ;");
+    test("let a; for (const b=0;;) ;", "let a;for (let b = 0;;) ;");
     test("const a=0; for (var b;;) ;", "const a = 0;for (var b;;) ;");
     test("a(); while (1) ;", "for (a();;) ;");
     test("a(); for (b();;) ;", "for (a(), b();;) ;");
@@ -272,7 +272,7 @@ fn js_parser_test() {
     // test("x['-2147483648']", "x[-2147483648];");
     test("x['-2147483649']", "x['-2147483649'];");
     test("while(1) { while (1) {} }", "for (;;) for (;;)  ;");
-    test("while(1) { const x = y; }", "for (;;) { const x = y;}");
+    test("while(1) { const x = y; }", "for (;;) { let x = y;}");
     test("while(1) { let x; }", "for (;;) { let x;}");
     // test("while(1) { var x; }", "for (;;) var x;");
     test("while(1) { class X {} }", "for (;;) { class X { }}");

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -11,13 +11,13 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 
 544.10 kB  | 71.50 kB   | 72.48 kB   | 25.92 kB   | 26.20 kB   | lodash.js 
 
-555.77 kB  | 272.12 kB  | 270.13 kB  | 88.59 kB   | 90.80 kB   | d3.js     
+555.77 kB  | 271.68 kB  | 270.13 kB  | 88.48 kB   | 90.80 kB   | d3.js     
 
-1.01 MB    | 458.28 kB  | 458.89 kB  | 123.94 kB  | 126.71 kB  | bundle.min.js
+1.01 MB    | 457.66 kB  | 458.89 kB  | 123.79 kB  | 126.71 kB  | bundle.min.js
 
 1.25 MB    | 650.70 kB  | 646.76 kB  | 161.49 kB  | 163.73 kB  | three.js  
 
-2.14 MB    | 719.06 kB  | 724.14 kB  | 162.43 kB  | 181.07 kB  | victory.js
+2.14 MB    | 719.00 kB  | 724.14 kB  | 162.41 kB  | 181.07 kB  | victory.js
 
 3.20 MB    | 1.01 MB    | 1.01 MB    | 325.38 kB  | 331.56 kB  | echarts.js
 


### PR DESCRIPTION
Replace `const` with `let` when that value does not have any assignments and not exposed.