### PR TITLE
fix(oxc_language_server): use `file_path` instead of `uri_path`

### DIFF
--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -531,11 +531,7 @@ impl Backend {
                 if !uri_path.starts_with(gitignore.path()) {
                     continue;
                 }
-
-                let path = PathBuf::from(uri.path());
-                let ignored =
-                    gitignore.matched_path_or_any_parents(&path, path.is_dir()).is_ignore();
-                if ignored {
+                if gitignore.matched_path_or_any_parents(&uri_path, uri_path.is_dir()).is_ignore() {
                     debug!("ignored: {uri}");
                     return true;
                 }


### PR DESCRIPTION
closes #8594 

This is because previously, oxlintrc.path was determined by `path.canonicalize().unwrap_or_else(|_| path.to_path_buf())`, but after #8214, it was changed to `path.to_path_buf()`. As a result, `\\?\D:\shulaoda` became `D:\shulaoda`. This caused the condition `uri_path.starts_with(gitignore.path())` to evaluate as `true`, preventing the bypass of the `is_ignore` check and exposing the original code issue.

https://github.com/oxc-project/oxc/blob/b1499e6711e3e79053b86192cb6a635000abc23b/crates/oxc_language_server/src/main.rs#L531-L533