### PR TITLE
feat(minifier): support `a[0]` and `this.a` in `has_no_side_effect_for_evaluation_same_target`

### DIFF
--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -7,7 +7,7 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 
 287.63 kB  | 89.58 kB   | 90.07 kB   | 31.08 kB   | 31.95 kB   | jquery.js 
 
-342.15 kB  | 117.76 kB  | 118.14 kB  | 43.67 kB   | 44.37 kB   | vue.js    
+342.15 kB  | 117.72 kB  | 118.14 kB  | 43.66 kB   | 44.37 kB   | vue.js    
 
 544.10 kB  | 71.50 kB   | 72.48 kB   | 25.92 kB   | 26.20 kB   | lodash.js 
 
@@ -15,13 +15,13 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 
 1.01 MB    | 457.66 kB  | 458.89 kB  | 123.79 kB  | 126.71 kB  | bundle.min.js
 
-1.25 MB    | 650.70 kB  | 646.76 kB  | 161.49 kB  | 163.73 kB  | three.js  
+1.25 MB    | 650.64 kB  | 646.76 kB  | 161.49 kB  | 163.73 kB  | three.js  
 
-2.14 MB    | 719.00 kB  | 724.14 kB  | 162.41 kB  | 181.07 kB  | victory.js
+2.14 MB    | 718.99 kB  | 724.14 kB  | 162.41 kB  | 181.07 kB  | victory.js
 
-3.20 MB    | 1.01 MB    | 1.01 MB    | 325.38 kB  | 331.56 kB  | echarts.js
+3.20 MB    | 1.01 MB    | 1.01 MB    | 325.29 kB  | 331.56 kB  | echarts.js
 
-6.69 MB    | 2.30 MB    | 2.31 MB    | 470.00 kB  | 488.28 kB  | antd.js   
+6.69 MB    | 2.30 MB    | 2.31 MB    | 469.99 kB  | 488.28 kB  | antd.js   
 
-10.95 MB   | 3.37 MB    | 3.49 MB    | 866.64 kB  | 915.50 kB  | typescript.js
+10.95 MB   | 3.37 MB    | 3.49 MB    | 866.60 kB  | 915.50 kB  | typescript.js
 


### PR DESCRIPTION
Add support for `a[0]` and `this.a` in `has_no_side_effect_for_evaluation_same_target` function.