### PR TITLE
fix(linter): unicorn/switch-case-braces mangles code when applying fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,7 +209,7 @@ ignored = ["napi", "oxc_transform_napi", "oxc_parser_napi", "prettyplease"]
 [profile.dev]
 # Disabling debug info speeds up local and CI builds,
 # and we don't rely on it for debugging that much.
-debug = false
+debug = true
 
 [profile.dev.package]
 # Compile macros with some optimizations to make consuming crates build faster

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,7 +209,7 @@ ignored = ["napi", "oxc_transform_napi", "oxc_parser_napi", "prettyplease"]
 [profile.dev]
 # Disabling debug info speeds up local and CI builds,
 # and we don't rely on it for debugging that much.
-debug = true
+debug = false
 
 [profile.dev.package]
 # Compile macros with some optimizations to make consuming crates build faster

--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -486,9 +486,33 @@ fn is_definitely_non_error_type(ty: &TSType) -> bool {
         _ => false,
     }
 }
-
+/// Get the preceding indentation string before the start of a Span in a given source_text. Useful for maintaining the format of source code when applying a linting fix.
+/// 
+/// Slice into a source text until the start of given span. 
+/// Then, get the preceding spaces from the last line of the source text.
+/// If there are any non-whitespace characters preceding the span in the last line of source text, return None.
+/// 
+/// Examples:
+/// 
+/// 1. Given the following source text (with 2 preceding spaces):
+/// 
+/// ```ts
+///   const foo = 'bar'
+/// ```
+/// 
+/// and the Span encapsulating the const foo = 'bar' expression statement,
+/// this function will return "  " (2 preceding spaces).
+/// 
+/// 2. Given the following source text:
+/// 
+/// ```ts
+/// const fizz = 'buzz'; const foo = 'bar'
+/// ```
+/// 
+/// and the Span encapsulating the "foo = 'bar'" expression statement,
+/// this function will return None because there is non-whitespace before the statement, meaning it does not need to be indented before being written into a source code string.
+/// 
 pub fn get_preceding_indent_str(source_text: &str, span: Span) -> Option<&str> {
-    // slice source text until start of given span, then get the preceding spaces from the last line of the source text.
     let span_start = span.start as usize;
     let preceding_source_text = &source_text[..span_start];
 

--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -487,6 +487,24 @@ fn is_definitely_non_error_type(ty: &TSType) -> bool {
     }
 }
 
+pub fn get_preceding_indent_str<'a>(source_text: &'a str, span: Span) -> Option<&'a str> {
+    // slice source text until start of given span, then get the preceding spaces from the last line of the source text.
+    let span_start = span.start as usize;
+    let preceding_source_text = &source_text[..span_start];
+    
+    match preceding_source_text.lines().last() {
+        Some(line) => {
+            // only return if the line is whitespace.
+            if line.trim().is_empty() {
+                Some(line)
+            } else {
+                None
+            }
+        }
+        None => None,
+    }
+}
+
 pub fn could_be_error(ctx: &LintContext, expr: &Expression) -> bool {
     match expr.get_inner_expression() {
         Expression::NewExpression(_)

--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -497,24 +497,23 @@ fn is_definitely_non_error_type(ty: &TSType) -> bool {
 /// 1. Given the following source_text (with 2 preceding spaces):
 ///
 /// ```ts
-///   const foo = 'bar'
+///   break
 /// ```
 ///
-/// and the Span encapsulating the const foo = 'bar' expression statement,
+/// and the Span encapsulating the break statement,
 /// 
 /// this function will return "  " (2 preceding spaces).
 ///
 /// 2. Given the following source_text:
 ///
 /// ```ts
-/// const fizz = 'buzz'; const foo = 'bar'
+/// const foo = 'bar'; break;
 /// ```
 ///
-/// and the Span encapsulating the "foo = 'bar'" expression statement,
+/// and the Span encapsulating the break statement,
 /// 
 /// this function will return None because there is non-whitespace before the statement, 
-/// meaning the line of source_text containing the span does not need to be indented before writing the span contents into a source code string.
-///
+/// meaning the line of source_text containing the Span is not indented on a new line.
 pub fn get_preceding_indent_str(source_text: &str, span: Span) -> Option<&str> {
     let span_start = span.start as usize;
     let preceding_source_text = &source_text[..span_start];

--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -487,22 +487,13 @@ fn is_definitely_non_error_type(ty: &TSType) -> bool {
     }
 }
 
-pub fn get_preceding_indent_str<'a>(source_text: &'a str, span: Span) -> Option<&'a str> {
+pub fn get_preceding_indent_str(source_text: &str, span: Span) -> Option<&str> {
     // slice source text until start of given span, then get the preceding spaces from the last line of the source text.
     let span_start = span.start as usize;
     let preceding_source_text = &source_text[..span_start];
-    
-    match preceding_source_text.lines().last() {
-        Some(line) => {
-            // only return if the line is whitespace.
-            if line.trim().is_empty() {
-                Some(line)
-            } else {
-                None
-            }
-        }
-        None => None,
-    }
+
+    // only return last line if is whitespace
+    preceding_source_text.lines().last().filter(|&line| line.trim().is_empty())
 }
 
 pub fn could_be_error(ctx: &LintContext, expr: &Expression) -> bool {

--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -486,31 +486,34 @@ fn is_definitely_non_error_type(ty: &TSType) -> bool {
         _ => false,
     }
 }
-/// Get the preceding indentation string before the start of a Span in a given source_text. Useful for maintaining the format of source code when applying a linting fix.
+/// Get the preceding indentation string before the start of a Span in a given source_text string slice. Useful for maintaining the format of source code when applying a linting fix.
 ///
-/// Slice into a source text until the start of given span.
-/// Then, get the preceding spaces from the last line of the source text.
-/// If there are any non-whitespace characters preceding the span in the last line of source text, return None.
+/// Slice into source_text until the start of given Span.
+/// Then, get the preceding spaces from the last line of the source_text.
+/// If there are any non-whitespace characters preceding the Span in the last line of source_text, return None.
 ///
 /// Examples:
 ///
-/// 1. Given the following source text (with 2 preceding spaces):
+/// 1. Given the following source_text (with 2 preceding spaces):
 ///
 /// ```ts
 ///   const foo = 'bar'
 /// ```
 ///
 /// and the Span encapsulating the const foo = 'bar' expression statement,
+/// 
 /// this function will return "  " (2 preceding spaces).
 ///
-/// 2. Given the following source text:
+/// 2. Given the following source_text:
 ///
 /// ```ts
 /// const fizz = 'buzz'; const foo = 'bar'
 /// ```
 ///
 /// and the Span encapsulating the "foo = 'bar'" expression statement,
-/// this function will return None because there is non-whitespace before the statement, meaning it does not need to be indented before being written into a source code string.
+/// 
+/// this function will return None because there is non-whitespace before the statement, 
+/// meaning the line of source_text containing the span does not need to be indented before writing the span contents into a source code string.
 ///
 pub fn get_preceding_indent_str(source_text: &str, span: Span) -> Option<&str> {
     let span_start = span.start as usize;

--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -487,31 +487,31 @@ fn is_definitely_non_error_type(ty: &TSType) -> bool {
     }
 }
 /// Get the preceding indentation string before the start of a Span in a given source_text. Useful for maintaining the format of source code when applying a linting fix.
-/// 
-/// Slice into a source text until the start of given span. 
+///
+/// Slice into a source text until the start of given span.
 /// Then, get the preceding spaces from the last line of the source text.
 /// If there are any non-whitespace characters preceding the span in the last line of source text, return None.
-/// 
+///
 /// Examples:
-/// 
+///
 /// 1. Given the following source text (with 2 preceding spaces):
-/// 
+///
 /// ```ts
 ///   const foo = 'bar'
 /// ```
-/// 
+///
 /// and the Span encapsulating the const foo = 'bar' expression statement,
 /// this function will return "  " (2 preceding spaces).
-/// 
+///
 /// 2. Given the following source text:
-/// 
+///
 /// ```ts
 /// const fizz = 'buzz'; const foo = 'bar'
 /// ```
-/// 
+///
 /// and the Span encapsulating the "foo = 'bar'" expression statement,
 /// this function will return None because there is non-whitespace before the statement, meaning it does not need to be indented before being written into a source code string.
-/// 
+///
 pub fn get_preceding_indent_str(source_text: &str, span: Span) -> Option<&str> {
     let span_start = span.start as usize;
     let preceding_source_text = &source_text[..span_start];

--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -501,7 +501,7 @@ fn is_definitely_non_error_type(ty: &TSType) -> bool {
 /// ```
 ///
 /// and the Span encapsulating the break statement,
-/// 
+///
 /// this function will return "  " (2 preceding spaces).
 ///
 /// 2. Given the following source_text:
@@ -511,8 +511,8 @@ fn is_definitely_non_error_type(ty: &TSType) -> bool {
 /// ```
 ///
 /// and the Span encapsulating the break statement,
-/// 
-/// this function will return None because there is non-whitespace before the statement, 
+///
+/// this function will return None because there is non-whitespace before the statement,
 /// meaning the line of source_text containing the Span is not indented on a new line.
 pub fn get_preceding_indent_str(source_text: &str, span: Span) -> Option<&str> {
     let span_start = span.start as usize;

--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -207,7 +207,7 @@ impl Rule for SwitchCaseBraces {
 fn test() {
     use crate::tester::Tester;
 
-    let pass: Vec<&str> = vec![
+    let pass = vec![
         "switch(something) { case 1: case 2: {console.log('something'); break;}}",
         "switch(foo){ case 1: { break; } }",
         "switch(foo){ case 1: { ; /* <-- not empty */} }",
@@ -216,7 +216,7 @@ fn test() {
         "switch(foo){ default: { doSomething(); } }",
     ];
 
-    let fail: Vec<&str> = vec![
+    let fail = vec![
         "switch(s){case'':/]/}",
         "switch(something) { case 1: {} case 2: {console.log('something'); break;}}",
         "switch(something) { case 1: case 2: console.log('something'); break;}",

--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -161,8 +161,9 @@ impl Rule for SwitchCaseBraces {
 
                                     for x in &case.consequent {
                                         if matches!(x, Statement::ExpressionStatement(_) | Statement::BreakStatement(_)) {
+                                            // indent the statement in the case consequent, if needed
                                             let indent_str = get_preceding_indent_str(source_text, x.span());
-
+                                           
                                             if indent_str.is_some() {
                                                 formatter.print_ascii_byte(b'\n');
                                                 formatter.print_str(indent_str.unwrap());
@@ -172,26 +173,17 @@ impl Rule for SwitchCaseBraces {
                                         formatter.print_str(x.span().source_text(source_text));
                                     }
 
+                                    // indent the closing case bracket, if needed
                                     let case_indent_str = get_preceding_indent_str(source_text, case.span());
-
                                     if case_indent_str.is_some() {
                                         formatter.print_ascii_byte(b'\n');
                                         formatter.print_str(case_indent_str.unwrap());
-
-                                        // indent
-                                        // let switch_indent_str = get_preceding_indent_str(source_text, switch.span());
-                                        // formatter.print_str(switch_indent_str.unwrap_or(""));
                                     }
 
                                     formatter.print_ascii_byte(b'}');
 
-                                    // TODO: add space diff between discriminant and first case
-
                                     formatter.into_source_text()
                                 };
-
-                                println!("case.span: {:?}", case.span);
-                                println!("modified_code: {modified_code}");
 
                                 fixer.replace(case.span, modified_code)
                             },
@@ -255,7 +247,7 @@ fn test() {
             "switch(foo) { default: doSomething(); }",
             Some(serde_json::json!(["avoid"])),
         ),
-        // Issue:  https://github.com/oxc-project/oxc/issues/8491
+        // Issue: https://github.com/oxc-project/oxc/issues/8491
         (
             "
                 const alpha = 7
@@ -283,7 +275,7 @@ fn test() {
                 }
             ",
             None,
-        )
+        ),
     ];
 
     Tester::new(SwitchCaseBraces::NAME, SwitchCaseBraces::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -160,12 +160,35 @@ impl Rule for SwitchCaseBraces {
                                     let source_text = ctx.source_text();
                                     println!("source_text: {source_text}");
 
-                                    for x in &case.consequent {
-                                        if let Statement::ExpressionStatement(stmt) = x {
-                                            formatter.print_str("\n");
+                                    let mut consequent_num = 0;
+                                    let case_test = case.test.as_ref().unwrap().span();
+                                    let mut prev_span_end = case_test.end;
 
-                                            println!("stmt: {stmt:?}");
-                                        };
+                                    println!("case_test: {:?}", case_test);
+
+                                    for x in &case.consequent {
+                                        if matches!(x, Statement::ExpressionStatement(_) | Statement::BreakStatement(_)) {
+                                            formatter.print_str("\n");
+                                            let mut space_diff: usize = (x.span().start - prev_span_end).try_into().unwrap();
+
+                                            if consequent_num == 0 {space_diff -= 3;} else {
+                                                space_diff -= 1;
+                                            }
+
+                                            let space = &" ".repeat(space_diff);
+                                            println!("space_diff: {space_diff}");
+                                            formatter.print_str(space);
+
+
+
+                                            prev_span_end = x.span().end;
+
+                                            consequent_num += 1;
+
+                                            // TODO: figure out how to add correct spaces using spans.
+                                            // println!("stmt: {x:?}");
+                                            // println!("stmt.span: {:?}", x.span());
+                                        }
 
                                         formatter.print_str(x.span().source_text(source_text));
                                     }

--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -227,6 +227,34 @@ fn test() {
             "switch(foo) { default: doSomething(); }",
             Some(serde_json::json!(["avoid"])),
         ),
+        (
+            "
+                const alpha = 7
+                let beta = ''
+                let gamma = 0
+
+                switch (alpha) {
+                    case 1: 
+                        beta = 'one'
+                        gamma = 1
+                        break
+                }
+            ",
+            "
+                const alpha = 7
+                let beta = ''
+                let gamma = 0
+
+                switch (alpha) {
+                    case 1: {
+                        beta = 'one'
+                        gamma = 1
+                        break
+                    }
+                }
+            ",
+            None,
+        )
     ];
 
     Tester::new(SwitchCaseBraces::NAME, SwitchCaseBraces::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -166,7 +166,9 @@ impl Rule for SwitchCaseBraces {
                                                 | Statement::BreakStatement(_)
                                         ) {
                                             // indent the statement in the case consequent, if needed
-                                            if let Some(indent_str) = get_preceding_indent_str(source_text, x.span()) {
+                                            if let Some(indent_str) =
+                                                get_preceding_indent_str(source_text, x.span())
+                                            {
                                                 formatter.print_ascii_byte(b'\n');
                                                 formatter.print_str(indent_str);
                                             }
@@ -176,7 +178,9 @@ impl Rule for SwitchCaseBraces {
                                     }
 
                                     // indent the closing case bracket, if needed
-                                    if let Some(case_indent_str) = get_preceding_indent_str(source_text, case.span()) {
+                                    if let Some(case_indent_str) =
+                                        get_preceding_indent_str(source_text, case.span())
+                                    {
                                         formatter.print_ascii_byte(b'\n');
                                         formatter.print_str(case_indent_str);
                                     }

--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -159,6 +159,8 @@ impl Rule for SwitchCaseBraces {
 
                                     let source_text = ctx.source_text();
                                     println!("source_text: {source_text}");
+                                    // better way to do this is to index into source text
+                                    // maybe create get_indent_str fn
 
                                     let mut consequent_num = 0;
                                     let case_test = case.test.as_ref().unwrap().span();

--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -168,12 +168,14 @@ impl Rule for SwitchCaseBraces {
 
                                     for x in &case.consequent {
                                         if matches!(x, Statement::ExpressionStatement(_) | Statement::BreakStatement(_)) {
-                                            formatter.print_str("\n");
                                             let mut space_diff: usize = (x.span().start - prev_span_end).try_into().unwrap();
 
                                             if consequent_num == 0 {space_diff -= 3;} else {
                                                 space_diff -= 1;
                                             }
+
+                                            formatter.print_str("\n");
+
 
                                             let space = &" ".repeat(space_diff);
                                             println!("space_diff: {space_diff}");
@@ -194,6 +196,8 @@ impl Rule for SwitchCaseBraces {
                                     }
 
                                     formatter.print_ascii_byte(b'}');
+
+                                    // TODO: add space diff between discriminant and first case
 
                                     formatter.into_source_text()
                                 };

--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -158,7 +158,15 @@ impl Rule for SwitchCaseBraces {
                                     formatter.print_ascii_byte(b'{');
 
                                     let source_text = ctx.source_text();
+                                    println!("source_text: {source_text}");
+
                                     for x in &case.consequent {
+                                        if let Statement::ExpressionStatement(stmt) = x {
+                                            formatter.print_str("\n");
+
+                                            println!("stmt: {stmt:?}");
+                                        };
+
                                         formatter.print_str(x.span().source_text(source_text));
                                     }
 
@@ -166,6 +174,8 @@ impl Rule for SwitchCaseBraces {
 
                                     formatter.into_source_text()
                                 };
+
+                                println!("modified_code: {modified_code}");
 
                                 fixer.replace(case.span, modified_code)
                             },
@@ -184,49 +194,50 @@ impl Rule for SwitchCaseBraces {
 fn test() {
     use crate::tester::Tester;
 
-    let pass = vec![
-        "switch(something) { case 1: case 2: {console.log('something'); break;}}",
-        "switch(foo){ case 1: { break; } }",
-        "switch(foo){ case 1: { ; /* <-- not empty */} }",
-        "switch(foo){ case 1: { {} /* <-- not empty */} }",
-        "switch(foo){ case 1: { break; } }",
-        "switch(foo){ default: { doSomething(); } }",
+    let pass: Vec<&str> = vec![
+        // "switch(something) { case 1: case 2: {console.log('something'); break;}}",
+        // "switch(foo){ case 1: { break; } }",
+        // "switch(foo){ case 1: { ; /* <-- not empty */} }",
+        // "switch(foo){ case 1: { {} /* <-- not empty */} }",
+        // "switch(foo){ case 1: { break; } }",
+        // "switch(foo){ default: { doSomething(); } }",
     ];
 
-    let fail = vec![
-        "switch(s){case'':/]/}",
-        "switch(something) { case 1: {} case 2: {console.log('something'); break;}}",
-        "switch(something) { case 1: case 2: console.log('something'); break;}",
-        "switch(foo) { case 1: {} case 2: {} default: { doSomething(); } }",
-        "switch(foo) { case 1: { /* fallthrough */ } default: {}/* fallthrough */ case 3: { doSomething(); break; } }",
-        "switch(foo) { default: doSomething(); }",
-        "switch(foo) { case 1: { doSomething(); } break; /* <-- This should be between braces */ }",
-        "switch(foo) { default: label: {} }",
-        "switch(something) { case 1: case 2: { console.log('something'); break; } case 3: console.log('something else'); }",
+    let fail: Vec<&str> = vec![
+        // "switch(s){case'':/]/}",
+        // "switch(something) { case 1: {} case 2: {console.log('something'); break;}}",
+        // "switch(something) { case 1: case 2: console.log('something'); break;}",
+        // "switch(foo) { case 1: {} case 2: {} default: { doSomething(); } }",
+        // "switch(foo) { case 1: { /* fallthrough */ } default: {}/* fallthrough */ case 3: { doSomething(); break; } }",
+        // "switch(foo) { default: doSomething(); }",
+        // "switch(foo) { case 1: { doSomething(); } break; /* <-- This should be between braces */ }",
+        // "switch(foo) { default: label: {} }",
+        // "switch(something) { case 1: case 2: { console.log('something'); break; } case 3: console.log('something else'); }",
     ];
 
     let fix = vec![
-        (
-            "switch(something) { case 1: {} case 2: {console.log('something'); break;}}",
-            "switch(something) { case 1:  case 2: {console.log('something'); break;}}",
-            None,
-        ),
-        (
-            "switch(something) { case 1: {} case 2: console.log('something'); break;}",
-            "switch(something) { case 1:  case 2: {console.log('something');break;}}",
-            None,
-        ),
-        (
-            "switch(foo) { default: doSomething(); }",
-            "switch(foo) { default: {doSomething();} }",
-            None,
-        ),
-        ("switch(s){case'':/]/}", "switch(s){case '': {/]/}}", None),
-        (
-            "switch(foo) { default: {doSomething();} }",
-            "switch(foo) { default: doSomething(); }",
-            Some(serde_json::json!(["avoid"])),
-        ),
+        // (
+        //     "switch(something) { case 1: {} case 2: {console.log('something'); break;}}",
+        //     "switch(something) { case 1:  case 2: {console.log('something'); break;}}",
+        //     None,
+        // ),
+        // (
+        //     "switch(something) { case 1: {} case 2: console.log('something'); break;}",
+        //     "switch(something) { case 1:  case 2: {console.log('something');break;}}",
+        //     None,
+        // ),
+        // (
+        //     "switch(foo) { default: doSomething(); }",
+        //     "switch(foo) { default: {doSomething();} }",
+        //     None,
+        // ),
+        // ("switch(s){case'':/]/}", "switch(s){case '': {/]/}}", None),
+        // (
+        //     "switch(foo) { default: {doSomething();} }",
+        //     "switch(foo) { default: doSomething(); }",
+        //     Some(serde_json::json!(["avoid"])),
+        // ),
+        // Issue:  https://github.com/oxc-project/oxc/issues/8491
         (
             "
                 const alpha = 7

--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -160,13 +160,15 @@ impl Rule for SwitchCaseBraces {
                                     let source_text = ctx.source_text();
 
                                     for x in &case.consequent {
-                                        if matches!(x, Statement::ExpressionStatement(_) | Statement::BreakStatement(_)) {
+                                        if matches!(
+                                            x,
+                                            Statement::ExpressionStatement(_)
+                                                | Statement::BreakStatement(_)
+                                        ) {
                                             // indent the statement in the case consequent, if needed
-                                            let indent_str = get_preceding_indent_str(source_text, x.span());
-                                           
-                                            if indent_str.is_some() {
+                                            if let Some(indent_str) = get_preceding_indent_str(source_text, x.span()) {
                                                 formatter.print_ascii_byte(b'\n');
-                                                formatter.print_str(indent_str.unwrap());
+                                                formatter.print_str(indent_str);
                                             }
                                         }
 
@@ -174,10 +176,9 @@ impl Rule for SwitchCaseBraces {
                                     }
 
                                     // indent the closing case bracket, if needed
-                                    let case_indent_str = get_preceding_indent_str(source_text, case.span());
-                                    if case_indent_str.is_some() {
+                                    if let Some(case_indent_str) = get_preceding_indent_str(source_text, case.span()) {
                                         formatter.print_ascii_byte(b'\n');
-                                        formatter.print_str(case_indent_str.unwrap());
+                                        formatter.print_str(case_indent_str);
                                     }
 
                                     formatter.print_ascii_byte(b'}');
@@ -197,8 +198,6 @@ impl Rule for SwitchCaseBraces {
         }
     }
 }
-
-
 
 #[test]
 fn test() {


### PR DESCRIPTION
Fixes #8491.

Essentially, the fix was ensuring that we track the indentation of a `StatementExpression` or `BreakStatement` when we apply a fix for this lint rule, and to make sure we add these statements on a new line with the proper indentation. I also made sure we're indenting the closing case brackets correctly.

To do this, I added a `get_preceding_indent_str` fn to the `ast_utils` that handles getting the preceding indentation of a `Span` in a `source_text` &str. It returns an Option in case no indentation is found, or if the statement is not the only one on a given line. 

This new fn was useful when addressing this particular bug, but I figure it might be useful for other fixer use cases, too. I added some documentation for this fn for clarity.