### PR TITLE
fix(minifier): remove incorrect not + conditional expression compression

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_conditions.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditions.rs
@@ -151,16 +151,6 @@ impl<'a> PeepholeOptimizations {
                 e.operator = e.operator.equality_inverse_operator().unwrap();
                 Some(ctx.ast.move_expression(&mut expr.argument))
             }
-            // `!(a == b ? foo: bar)` => `a != b ? foo : bar`
-            Expression::ConditionalExpression(conditional_expr) => {
-                if let Expression::BinaryExpression(e) = &mut conditional_expr.test {
-                    if e.operator.is_equality() {
-                        e.operator = e.operator.equality_inverse_operator().unwrap();
-                        return Some(ctx.ast.move_expression(&mut expr.argument));
-                    }
-                }
-                None
-            }
             // "!(a, b)" => "a, !b"
             Expression::SequenceExpression(sequence_expr) => {
                 if let Some(e) = sequence_expr.expressions.pop() {
@@ -2307,6 +2297,7 @@ mod test {
         test("!!!delete x.y", "!delete x.y");
         test("!!!!delete x.y", "delete x.y");
         test("var k = !!(foo instanceof bar)", "var k = foo instanceof bar");
+        test_same("!(a === 1 ? void 0 : a.b)"); // FIXME: can be compressed to `a === 1 || !a.b`
         test("!(a, b)", "a, !b");
     }
 

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -17,11 +17,11 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 
 1.25 MB    | 650.59 kB  | 646.76 kB  | 161.49 kB  | 163.73 kB  | three.js  
 
-2.14 MB    | 718.82 kB  | 724.14 kB  | 162.40 kB  | 181.07 kB  | victory.js
+2.14 MB    | 718.83 kB  | 724.14 kB  | 162.40 kB  | 181.07 kB  | victory.js
 
 3.20 MB    | 1.01 MB    | 1.01 MB    | 325.18 kB  | 331.56 kB  | echarts.js
 
-6.69 MB    | 2.30 MB    | 2.31 MB    | 469.97 kB  | 488.28 kB  | antd.js   
+6.69 MB    | 2.30 MB    | 2.31 MB    | 469.99 kB  | 488.28 kB  | antd.js   
 
-10.95 MB   | 3.37 MB    | 3.49 MB    | 866.63 kB  | 915.50 kB  | typescript.js
+10.95 MB   | 3.37 MB    | 3.49 MB    | 866.64 kB  | 915.50 kB  | typescript.js
 


### PR DESCRIPTION
```js
var foo = (a) => {
  if (!(a == null ? void 0 : a.b))
    return
  a.b(to);
};
foo(null)
```
was minified into
```js
var foo = (a) => {
	if (a == null && a.b) return;
	a.b(to);
};
foo(null);
```
which is incorrect (no error happens before and error happens after).
I found this while trying rolldown-vite with ecosystem-ci.

refs #8651
