### PR TITLE
refactor(ast): rename `#[estree(type)]` attr on types to `#[estree(rename)]`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -202,7 +202,7 @@ pub use match_expression;
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(type = "Identifier")]
+#[estree(rename = "Identifier")]
 pub struct IdentifierName<'a> {
     pub span: Span,
     pub name: Atom<'a>,
@@ -216,7 +216,7 @@ pub struct IdentifierName<'a> {
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(type = "Identifier")]
+#[estree(rename = "Identifier")]
 pub struct IdentifierReference<'a> {
     pub span: Span,
     /// The name of the identifier being referenced.
@@ -239,7 +239,7 @@ pub struct IdentifierReference<'a> {
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(type = "Identifier")]
+#[estree(rename = "Identifier")]
 pub struct BindingIdentifier<'a> {
     pub span: Span,
     /// The identifier name being bound.
@@ -263,7 +263,7 @@ pub struct BindingIdentifier<'a> {
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(type = "Identifier")]
+#[estree(rename = "Identifier")]
 pub struct LabelIdentifier<'a> {
     pub span: Span,
     pub name: Atom<'a>,
@@ -832,7 +832,7 @@ pub struct ObjectAssignmentTarget<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(type = "RestElement")]
+#[estree(rename = "RestElement")]
 pub struct AssignmentTargetRest<'a> {
     pub span: Span,
     #[estree(rename = "argument")]
@@ -1520,7 +1520,7 @@ pub struct ArrayPattern<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(type = "RestElement")]
+#[estree(rename = "RestElement")]
 pub struct BindingRestElement<'a> {
     pub span: Span,
     pub argument: BindingPattern<'a>,

--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -20,7 +20,7 @@ use oxc_syntax::number::{BigintBase, NumberBase};
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(type = "Literal", via = crate::serialize::ESTreeLiteral, add_ts = "raw: string | null")]
+#[estree(rename = "Literal", via = crate::serialize::ESTreeLiteral, add_ts = "raw: string | null")]
 pub struct BooleanLiteral {
     /// Node location in source code
     pub span: Span,
@@ -34,7 +34,7 @@ pub struct BooleanLiteral {
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(type = "Literal", via = crate::serialize::ESTreeLiteral, add_ts = "value: null, raw: \"null\" | null")]
+#[estree(rename = "Literal", via = crate::serialize::ESTreeLiteral, add_ts = "value: null, raw: \"null\" | null")]
 pub struct NullLiteral {
     /// Node location in source code
     pub span: Span,
@@ -46,7 +46,7 @@ pub struct NullLiteral {
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ESTree)]
-#[estree(type = "Literal", via = crate::serialize::ESTreeLiteral)]
+#[estree(rename = "Literal", via = crate::serialize::ESTreeLiteral)]
 pub struct NumericLiteral<'a> {
     /// Node location in source code
     pub span: Span,
@@ -67,7 +67,7 @@ pub struct NumericLiteral<'a> {
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ESTree)]
-#[estree(type = "Literal", via = crate::serialize::ESTreeLiteral)]
+#[estree(rename = "Literal", via = crate::serialize::ESTreeLiteral)]
 pub struct StringLiteral<'a> {
     /// Node location in source code
     pub span: Span,
@@ -86,7 +86,7 @@ pub struct StringLiteral<'a> {
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ESTree)]
-#[estree(type = "Literal", via = crate::serialize::ESTreeLiteral, add_ts = "value: null, bigint: string")]
+#[estree(rename = "Literal", via = crate::serialize::ESTreeLiteral, add_ts = "value: null, bigint: string")]
 pub struct BigIntLiteral<'a> {
     /// Node location in source code
     pub span: Span,
@@ -105,7 +105,7 @@ pub struct BigIntLiteral<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ESTree)]
 #[estree(
-	type = "Literal",
+	rename = "Literal",
 	via = crate::serialize::ESTreeLiteral,
 	add_ts = "value: {} | null, regex: { pattern: string, flags: string }"
 )]

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1042,7 +1042,7 @@ pub struct TSConstructSignatureDeclaration<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(type = "Identifier")]
+#[estree(rename = "Identifier")]
 pub struct TSIndexSignatureName<'a> {
     pub span: Span,
     pub name: Atom<'a>,

--- a/tasks/ast_tools/src/markers.rs
+++ b/tasks/ast_tools/src/markers.rs
@@ -119,13 +119,7 @@ impl Parse for ESTreeStructAttribute {
         let mut add_ts = None;
 
         loop {
-            let is_type = input.peek(Token![type]);
-            let ident = if is_type {
-                input.parse::<Token![type]>()?;
-                "type".to_string()
-            } else {
-                input.call(Ident::parse_any).unwrap().to_string()
-            };
+            let ident = input.call(Ident::parse_any).unwrap().to_string();
             match ident.as_str() {
                 "always_flatten" => {
                     if always_flatten {
@@ -146,7 +140,7 @@ impl Parse for ESTreeStructAttribute {
                         "Duplicate tag mode in #[estree(...)]"
                     );
                 }
-                "type" => {
+                "rename" => {
                     input.parse::<Token![=]>()?;
                     let value = input.parse::<LitStr>()?.value();
                     assert!(


### PR DESCRIPTION
To rename a type in ESTree AST, use `#[estree(rename = "Identifier")]` instead of `#[estree(type = "Identifier")]`.

This aligns with `serde`'s attribute, and avoids using the keyword `type`, which makes the attributes simpler to parse.