### PR TITLE
refactor(ast): rename `#[estree(type)]` attr on struct fields to `#[estree(ts_type)]`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -287,7 +287,7 @@ pub struct ThisExpression {
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ArrayExpression<'a> {
     pub span: Span,
-    #[estree(type = "Array<SpreadElement | Expression | null>")]
+    #[estree(ts_type = "Array<SpreadElement | Expression | null>")]
     pub elements: Vec<'a, ArrayExpressionElement<'a>>,
     /// Array trailing comma
     /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#arrays>
@@ -1441,7 +1441,7 @@ pub struct BindingPattern<'a> {
     // estree(flatten) the attributes because estree has no `BindingPattern`
     #[estree(
         flatten,
-        type = "(BindingIdentifier | ObjectPattern | ArrayPattern | AssignmentPattern)"
+        ts_type = "(BindingIdentifier | ObjectPattern | ArrayPattern | AssignmentPattern)"
     )]
     #[span]
     pub kind: BindingPatternKind<'a>,
@@ -1649,7 +1649,7 @@ pub enum FunctionType {
 pub struct FormalParameters<'a> {
     pub span: Span,
     pub kind: FormalParameterKind,
-    #[estree(type = "Array<FormalParameter | FormalParameterRest>")]
+    #[estree(ts_type = "Array<FormalParameter | FormalParameterRest>")]
     pub items: Vec<'a, FormalParameter<'a>>,
     #[estree(skip)]
     pub rest: Option<Box<'a, BindingRestElement<'a>>>,
@@ -2196,7 +2196,7 @@ pub struct ImportExpression<'a> {
 pub struct ImportDeclaration<'a> {
     pub span: Span,
     /// `None` for `import 'foo'`, `Some([])` for `import {} from 'foo'`
-    #[estree(via = crate::serialize::OptionVecDefault, type = "Array<ImportDeclarationSpecifier>")]
+    #[estree(via = crate::serialize::OptionVecDefault, ts_type = "Array<ImportDeclarationSpecifier>")]
     pub specifiers: Option<Vec<'a, ImportDeclarationSpecifier<'a>>>,
     pub source: StringLiteral<'a>,
     pub phase: Option<ImportPhase>,

--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -91,7 +91,7 @@ pub struct BigIntLiteral<'a> {
     /// Node location in source code
     pub span: Span,
     /// The bigint as it appears in source code
-    #[estree(type = "string | null")]
+    #[estree(ts_type = "string | null")]
     pub raw: Atom<'a>,
     /// The base representation used by the literal in source code
     #[estree(skip)]

--- a/tasks/ast_tools/src/markers.rs
+++ b/tasks/ast_tools/src/markers.rs
@@ -234,13 +234,7 @@ impl Parse for ESTreeFieldAttribute {
         let mut via = None;
 
         loop {
-            let is_type = input.peek(Token![type]);
-            let ident = if is_type {
-                input.parse::<Token![type]>()?;
-                "type".to_string()
-            } else {
-                input.call(Ident::parse_any).unwrap().to_string()
-            };
+            let ident = input.call(Ident::parse_any).unwrap().to_string();
             match ident.as_str() {
                 "rename" => {
                     input.parse::<Token![=]>()?;
@@ -263,11 +257,11 @@ impl Parse for ESTreeFieldAttribute {
                         skip = true;
                     }
                 }
-                "type" => {
+                "ts_type" => {
                     input.parse::<Token![=]>()?;
                     assert!(
                         typescript_type.replace(input.parse::<LitStr>()?.value()).is_none(),
-                        "Duplicate estree(type)"
+                        "Duplicate estree(ts_type)"
                     );
                 }
                 "append_to" => {


### PR DESCRIPTION
To override the TS type of a struct field in ESTree AST, use `#[estree(ts_type = "Identifier")]` instead of `#[estree(type = "Identifier")]`.

This is clearer, and avoids using the keyword `type`, which makes the attributes simpler to parse.
