### PR TITLE
refactor(oxlint): move output from `CliRunResult::InvalidOption` to outside and use more Enums for different invalid options

### DIFF
--- a/apps/oxlint/src/result.rs
+++ b/apps/oxlint/src/result.rs
@@ -3,7 +3,11 @@ use std::process::{ExitCode, Termination};
 #[derive(Debug)]
 pub enum CliRunResult {
     None,
-    InvalidOptions { message: String },
+    InvalidOptionConfig,
+    InvalidOptionTsConfig,
+    InvalidOptionSeverityWithoutFilter,
+    InvalidOptionSeverityWithoutPluginName,
+    InvalidOptionSeverityWithoutRuleName,
     LintSucceeded,
     LintFoundErrors,
     LintMaxWarningsExceeded,
@@ -27,11 +31,12 @@ impl Termination for CliRunResult {
             Self::ConfigFileInitFailed
             | Self::LintFoundErrors
             | Self::LintNoWarningsAllowed
-            | Self::LintMaxWarningsExceeded => ExitCode::FAILURE,
-            Self::InvalidOptions { message } => {
-                println!("Invalid Options: {message}");
-                ExitCode::FAILURE
-            }
+            | Self::LintMaxWarningsExceeded
+            | Self::InvalidOptionConfig
+            | Self::InvalidOptionTsConfig
+            | Self::InvalidOptionSeverityWithoutFilter
+            | Self::InvalidOptionSeverityWithoutPluginName
+            | Self::InvalidOptionSeverityWithoutRuleName => ExitCode::FAILURE,
         }
     }
 }

--- a/apps/oxlint/src/snapshots/_--tsconfig oxc__tsconfig.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--tsconfig oxc__tsconfig.json@oxlint.snap
@@ -1,0 +1,8 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --tsconfig oxc/tsconfig.json
+working directory: 
+----------
+The tsconfig file "<cwd>/oxc/tsconfig.json" does not exist, Please provide a valid tsconfig file.


### PR DESCRIPTION
Now we can choose which exit code to use for a specific (unexpected) result