### PR TITLE
feat(tasks/prettier): Show total match ratio with updating snapshot format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2037,6 +2037,7 @@ dependencies = [
  "oxc_tasks_common",
  "pico-args",
  "rustc-hash",
+ "similar",
  "walkdir",
 ]
 
@@ -2184,6 +2185,7 @@ dependencies = [
  "oxc_tasks_common",
  "oxc_tasks_transform_checker",
  "pico-args",
+ "similar",
  "walkdir",
 ]
 

--- a/tasks/common/src/diff.rs
+++ b/tasks/common/src/diff.rs
@@ -1,9 +1,10 @@
 use console::Style;
-use similar::{ChangeTag, TextDiff};
+use similar::{ChangeTag, DiffableStr, TextDiff};
 
-pub fn print_diff_in_terminal(expected: &str, actual: &str) {
-    let diff = TextDiff::from_lines(expected, actual);
-
+pub fn print_diff_in_terminal<T>(diff: &TextDiff<T>)
+where
+    T: DiffableStr + ?Sized,
+{
     for op in diff.ops() {
         for change in diff.iter_changes(op) {
             let (sign, style) = match change.tag() {

--- a/tasks/prettier_conformance/Cargo.toml
+++ b/tasks/prettier_conformance/Cargo.toml
@@ -33,4 +33,5 @@ oxc_tasks_common = { workspace = true }
 cow-utils = { workspace = true }
 pico-args = { workspace = true }
 rustc-hash = { workspace = true }
+similar = { workspace = true }
 walkdir = { workspace = true }

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -2,596 +2,395 @@ js compatibility: 251/641 (39.16%)
 
 # Failed
 
-### js/arrays
-* js/arrays/numbers-negative-comment-after-minus.js | 💥
-* js/arrays/numbers-negative.js | 💥
-* js/arrays/numbers-trailing-comma.js | 💥
-* js/arrays/numbers-with-holes.js | 💥
-* js/arrays/numbers-with-trailing-comments.js | 💥
-* js/arrays/numbers-with-tricky-comments.js | 💥
-* js/arrays/numbers2.js | 💥
-* js/arrays/numbers3.js | 💥
-* js/arrays/preserve_empty_lines.js | 💥
-
-### js/arrow-call
-* js/arrow-call/arrow_call.js | 💥💥💥
-* js/arrow-call/class-property.js | 💥💥💥
-
-### js/arrows
-* js/arrows/arrow-chain-with-trailing-comments.js | 💥💥
-* js/arrows/arrow_function_expression.js | 💥💥
-* js/arrows/assignment-chain-with-arrow-chain.js | 💥💥
-* js/arrows/call.js | 💥💥
-* js/arrows/chain-as-arg.js | 💥💥
-* js/arrows/chain-in-logical-expression.js | 💥💥
-* js/arrows/comment.js | 💥💥
-* js/arrows/curried.js | 💥💥
-* js/arrows/currying-2.js | 💥💥
-* js/arrows/currying-3.js | 💥💥
-* js/arrows/currying-4.js | 💥💥
-* js/arrows/currying.js | 💥💥
-* js/arrows/issue-1389-curry.js | 💥💥
-* js/arrows/long-call-no-args.js | 💥💥
-* js/arrows/parens.js | 💥💥
-
-### js/assignment
-* js/assignment/binaryish.js | 💥
-* js/assignment/call-with-template.js | 💥
-* js/assignment/chain-two-segments.js | 💥
-* js/assignment/chain.js | 💥
-* js/assignment/discussion-15196.js | 💥
-* js/assignment/issue-10218.js | 💥
-* js/assignment/issue-2184.js | 💥
-* js/assignment/issue-2540.js | 💥
-* js/assignment/issue-5610.js | 💥
-* js/assignment/issue-6922.js | 💥
-* js/assignment/issue-7572.js | 💥
-* js/assignment/issue-7961.js | 💥
-* js/assignment/lone-arg.js | 💥
-
-### js/assignment-comments
-* js/assignment-comments/call.js | 💥
-* js/assignment-comments/call2.js | 💥
-* js/assignment-comments/function.js | 💥
-* js/assignment-comments/identifier.js | 💥
-* js/assignment-comments/number.js | 💥
-* js/assignment-comments/string.js | 💥
-
-### js/async
-* js/async/inline-await.js | 💥
-* js/async/nested.js | 💥
-
-### js/binary-expressions
-* js/binary-expressions/arrow.js | 💥
-* js/binary-expressions/call.js | 💥
-* js/binary-expressions/comment.js | 💥
-* js/binary-expressions/if.js | 💥
-* js/binary-expressions/in_instanceof.js | 💥
-* js/binary-expressions/inline-jsx.js | 💥
-* js/binary-expressions/inline-object-array.js | 💥
-* js/binary-expressions/jsx_parent.js | 💥
-* js/binary-expressions/short-right.js | 💥
-* js/binary-expressions/test.js | 💥
-* js/binary-expressions/unary.js | 💥
-
-### js/break-calls
-* js/break-calls/break.js | 💥
-* js/break-calls/parent.js | 💥
-* js/break-calls/react.js | 💥
-
-### js/call/first-argument-expansion
-* js/call/first-argument-expansion/expression-2nd-arg.js | 💥
-* js/call/first-argument-expansion/issue-13237.js | 💥
-* js/call/first-argument-expansion/issue-2456.js | 💥
-* js/call/first-argument-expansion/issue-5172.js | 💥
-* js/call/first-argument-expansion/jsx.js | 💥
-* js/call/first-argument-expansion/test.js | 💥
-
-### js/call/no-argument
-* js/call/no-argument/special-cases.js | 💥
-
-### js/chain-expression
-* js/chain-expression/call-expression.js | 💥
-* js/chain-expression/issue-15785-1.js | 💥
-* js/chain-expression/issue-15785-2.js | 💥
-* js/chain-expression/issue-15785-3.js | 💥
-* js/chain-expression/issue-15916.js | 💥
-* js/chain-expression/member-expression.js | 💥
-* js/chain-expression/test-3.js | 💥
-* js/chain-expression/test-4.js | 💥
-* js/chain-expression/test.js | 💥
-
-### js/class-comment
-* js/class-comment/class-property.js | 💥
-* js/class-comment/misc.js | 💥
-* js/class-comment/superclass.js | 💥
-
-### js/class-extends
-* js/class-extends/extends.js | 💥
-
-### js/classes
-* js/classes/asi.js | 💥
-* js/classes/assignment.js | 💥
-* js/classes/empty.js | 💥
-* js/classes/method.js | 💥
-* js/classes/property.js | 💥
-
-### js/classes-private-fields
-* js/classes-private-fields/optional-chaining.js | 💥💥
-* js/classes-private-fields/with_comments.js | 💥💥
-
-### js/comments
-* js/comments/15661.js | 💥💥
-* js/comments/16398.js | 💥💥
-* js/comments/arrow.js | 💥💥
-* js/comments/assignment-pattern.js | 💥💥
-* js/comments/before-comma.js | 💥💥
-* js/comments/binary-expressions-block-comments.js | 💥💥
-* js/comments/binary-expressions-parens.js | 💥💥
-* js/comments/binary-expressions-single-comments.js | 💥💥
-* js/comments/binary-expressions.js | 💥💥
-* js/comments/blank.js | 💥💥
-* js/comments/break-continue-statements.js | 💥💥
-* js/comments/call_comment.js | 💥💥
-* js/comments/class.js | 💥💥
-* js/comments/dangling.js | 💥💥
-* js/comments/dangling_array.js | 💥💥
-* js/comments/dangling_for.js | 💥💥
-* js/comments/dynamic_imports.js | 💥💥
-* js/comments/emoji.js | 💥💥
-* js/comments/empty-statements.js | 💥💥
-* js/comments/export-and-import.js | 💥💥
-* js/comments/export.js | 💥💥
-* js/comments/first-line.js | 💥💥
-* js/comments/function-declaration.js | 💥💥
-* js/comments/if.js | 💥💥
-* js/comments/issue-3532.js | 💥💥
-* js/comments/issues.js | 💥💥
-* js/comments/jsdoc-nestled-dangling.js | 💥💥
-* js/comments/jsdoc-nestled.js | 💥💥
-* js/comments/jsdoc.js | 💥💥
-* js/comments/jsx.js | 💥💥
-* js/comments/last-arg.js | 💥💥
-* js/comments/multi-comments-2.js | 💥💥
-* js/comments/multi-comments-on-same-line-2.js | 💥💥
-* js/comments/multi-comments-on-same-line.js | 💥💥
-* js/comments/multi-comments.js | 💥💥
-* js/comments/preserve-new-line-last.js | 💥💥
-* js/comments/return-statement.js | 💥💥
-* js/comments/single-star-jsdoc.js | 💥💥
-* js/comments/switch.js | 💥💥
-* js/comments/tagged-template-literal.js | 💥💥
-* js/comments/template-literal.js | 💥💥
-* js/comments/trailing-jsdocs.js | 💥💥
-* js/comments/trailing_space.js | 💥💥
-* js/comments/try.js | 💥💥
-* js/comments/variable_declarator.js | 💥💥
-* js/comments/while.js | 💥💥
-
-### js/comments/flow-types
-* js/comments/flow-types/inline.js | 💥
-
-### js/comments/function
-* js/comments/function/between-parentheses-and-function-body.js | 💥
-
-### js/comments/html-like
-* js/comments/html-like/comment.js | 💥
-
-### js/comments-closure-typecast
-* js/comments-closure-typecast/binary-expr.js | 💥
-* js/comments-closure-typecast/closure-compiler-type-cast.js | 💥
-* js/comments-closure-typecast/comment-in-the-middle.js | 💥
-* js/comments-closure-typecast/comment-placement.js | 💥
-* js/comments-closure-typecast/extra-spaces-and-asterisks.js | 💥
-* js/comments-closure-typecast/iife-issue-5850-isolated.js | 💥
-* js/comments-closure-typecast/iife.js | 💥
-* js/comments-closure-typecast/issue-4124.js | 💥
-* js/comments-closure-typecast/issue-8045.js | 💥
-* js/comments-closure-typecast/issue-9358.js | 💥
-* js/comments-closure-typecast/member.js | 💥
-* js/comments-closure-typecast/nested.js | 💥
-* js/comments-closure-typecast/non-casts.js | 💥
-* js/comments-closure-typecast/object-with-comment.js | 💥
-* js/comments-closure-typecast/satisfies.js | 💥
-* js/comments-closure-typecast/superclass.js | 💥
-* js/comments-closure-typecast/ways-to-specify-type.js | 💥
-
-### js/conditional
-* js/conditional/comments.js | 💥💥
-* js/conditional/new-ternary-examples.js | 💥💥
-* js/conditional/new-ternary-spec.js | 💥💥
-* js/conditional/no-confusing-arrow.js | 💥💥
-* js/conditional/postfix-ternary-regressions.js | 💥💥
-
-### js/destructuring
-* js/destructuring/destructuring.js | 💥
-
-### js/destructuring-ignore
-* js/destructuring-ignore/ignore.js | 💥💥💥
-
-### js/directives
-* js/directives/escaped.js | 💥
-* js/directives/issue-7346.js | 💥
-* js/directives/newline.js | 💥
-
-### js/empty-paren-comment
-* js/empty-paren-comment/class-property.js | 💥
-* js/empty-paren-comment/class.js | 💥
-* js/empty-paren-comment/empty_paren_comment.js | 💥
-
-### js/export
-* js/export/blank-line-between-specifiers.js | 💥💥
-* js/export/same-local-and-exported.js | 💥💥
-
-### js/expression_statement
-* js/expression_statement/no_regression.js | 💥
-* js/expression_statement/use_strict.js | 💥
-
-### js/for
-* js/for/comment.js | 💥
-* js/for/continue-and-break-comment-1.js | 💥
-* js/for/continue-and-break-comment-2.js | 💥
-* js/for/continue-and-break-comment-without-blocks.js | 💥
-* js/for/for-in-with-initializer.js | 💥
-* js/for/parentheses.js | 💥
-
-### js/function
-* js/function/issue-10277.js | 💥
-
-### js/function-comments
-* js/function-comments/params-trail-comments.js | 💥
-
-### js/function-first-param
-* js/function-first-param/function_expression.js | 💥
-
-### js/function-single-destructuring
-* js/function-single-destructuring/array.js | 💥
-* js/function-single-destructuring/object.js | 💥
-
-### js/functional-composition
-* js/functional-composition/functional_compose.js | 💥
-* js/functional-composition/lodash_flow.js | 💥
-* js/functional-composition/lodash_flow_right.js | 💥
-* js/functional-composition/pipe-function-calls-with-comments.js | 💥
-* js/functional-composition/pipe-function-calls.js | 💥
-* js/functional-composition/ramda_compose.js | 💥
-* js/functional-composition/ramda_pipe.js | 💥
-* js/functional-composition/redux_connect.js | 💥
-* js/functional-composition/reselect_createselector.js | 💥
-* js/functional-composition/rxjs_pipe.js | 💥
-
-### js/generator
-* js/generator/async.js | 💥
-* js/generator/function-name-starts-with-get.js | 💥
-
-### js/identifier/parentheses
-* js/identifier/parentheses/let.js | 💥✨
-
-### js/if
-* js/if/comment_before_else.js | 💥
-* js/if/else.js | 💥
-* js/if/expr_and_same_line_comments.js | 💥
-* js/if/if_comments.js | 💥
-* js/if/issue-15168.js | 💥
-* js/if/non-block.js | 💥
-* js/if/trailing_comment.js | 💥
-
-### js/import
-* js/import/comments.js | 💥💥
-* js/import/empty-import.js | 💥💥
-* js/import/same-local-and-imported.js | 💥💥
-
-### js/import-assertions
-* js/import-assertions/empty.js | 💥
-* js/import-assertions/keyword-detect.js | 💥
-
-### js/import-attributes
-* js/import-attributes/empty.js | 💥
-* js/import-attributes/keyword-detect.js | 💥
-* js/import-attributes/long-sources.js | 💥
-
-### js/label
-* js/label/comment.js | 💥
-
-### js/last-argument-expansion
-* js/last-argument-expansion/arrow.js | 💥
-* js/last-argument-expansion/assignment-pattern.js | 💥
-* js/last-argument-expansion/break-parent.js | 💥
-* js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥
-* js/last-argument-expansion/edge_case.js | 💥
-* js/last-argument-expansion/empty-lines.js | 💥
-* js/last-argument-expansion/empty-object.js | 💥
-* js/last-argument-expansion/function-expression-issue-2239.js | 💥
-* js/last-argument-expansion/function-expression.js | 💥
-* js/last-argument-expansion/issue-10708.js | 💥
-* js/last-argument-expansion/issue-7518.js | 💥
-* js/last-argument-expansion/jsx.js | 💥
-* js/last-argument-expansion/overflow.js | 💥
-
-### js/line-suffix-boundary
-* js/line-suffix-boundary/boundary.js | 💥
-
-### js/literal
-* js/literal/number.js | 💥
-
-### js/logical_expressions
-* js/logical_expressions/issue-7024.js | 💥
-* js/logical_expressions/logical_expression_operators.js | 💥
-
-### js/member
-* js/member/conditional.js | 💥
-* js/member/expand.js | 💥
-* js/member/logical.js | 💥
-
-### js/method-chain
-* js/method-chain/bracket_0-1.js | 💥
-* js/method-chain/break-last-call.js | 💥
-* js/method-chain/break-last-member.js | 💥
-* js/method-chain/comment.js | 💥
-* js/method-chain/computed-merge.js | 💥
-* js/method-chain/computed.js | 💥
-* js/method-chain/conditional.js | 💥
-* js/method-chain/d3.js | 💥
-* js/method-chain/first_long.js | 💥
-* js/method-chain/fluent-configuration.js | 💥
-* js/method-chain/inline_merge.js | 💥
-* js/method-chain/issue-11298.js | 💥
-* js/method-chain/issue-3594.js | 💥
-* js/method-chain/issue-4125.js | 💥
-* js/method-chain/logical.js | 💥
-* js/method-chain/multiple-members.js | 💥
-* js/method-chain/object-literal.js | 💥
-* js/method-chain/pr-7889.js | 💥
-* js/method-chain/short-names.js | 💥
-* js/method-chain/square_0.js | 💥
-* js/method-chain/test.js | 💥
-* js/method-chain/this.js | 💥
-
-### js/new-expression
-* js/new-expression/with-member-expression.js | 💥
-
-### js/newline
-* js/newline/backslash_2028.js | 💥
-* js/newline/backslash_2029.js | 💥
-
-### js/no-semi
-* js/no-semi/class.js | 💥💥
-* js/no-semi/comments.js | 💥💥
-* js/no-semi/issue2006.js | 💥✨
-* js/no-semi/no-semi.js | 💥💥
-
-### js/non-strict
-* js/non-strict/keywords.js | 💥
-
-### js/nullish-coalescing
-* js/nullish-coalescing/nullish_coalesing_operator.js | 💥
-
-### js/numeric-separators
-* js/numeric-separators/number.js | 💥
-
-### js/object-prop-break-in
-* js/object-prop-break-in/comment.js | 💥
-* js/object-prop-break-in/short-keys.js | 💥
-
-### js/object-property-comment
-* js/object-property-comment/after-key.js | 💥
-
-### js/object-property-ignore
-* js/object-property-ignore/ignore.js | 💥💥💥
-* js/object-property-ignore/issue-5678.js | 💥💥💥
-
-### js/objects
-* js/objects/escape-sequence-key.js | 💥
-* js/objects/expand.js | 💥
-* js/objects/right-break.js | 💥
-
-### js/optional-chaining
-* js/optional-chaining/chaining.js | 💥
-* js/optional-chaining/comments.js | 💥
-* js/optional-chaining/eval.js | 💥
-
-### js/optional-chaining-assignment
-* js/optional-chaining-assignment/valid-complex-case.js | 💥
-* js/optional-chaining-assignment/valid-lhs-eq.js | 💥
-* js/optional-chaining-assignment/valid-lhs-plus-eq.js | 💥
-
-### js/performance
-* js/performance/nested-real.js | 💥
-
-### js/preserve-line
-* js/preserve-line/argument-list.js | 💥
-* js/preserve-line/comments.js | 💥
-* js/preserve-line/member-chain.js | 💥
-* js/preserve-line/parameter-list.js | 💥
-
-### js/quote-props
-* js/quote-props/numeric-separator.js | 💥💥💥💥
-* js/quote-props/objects.js | 💥💥💥💥
-
-### js/quotes
-* js/quotes/objects.js | 💥💥
-* js/quotes/strings.js | 💥💥
-
-### js/require-amd
-* js/require-amd/named-amd-module.js | 💥
-* js/require-amd/require.js | 💥
-
-### js/return
-* js/return/binaryish.js | 💥
-* js/return/comment.js | 💥
-
-### js/sequence-break
-* js/sequence-break/break.js | 💥
-
-### js/sequence-expression
-* js/sequence-expression/ignore.js | 💥
-* js/sequence-expression/parenthesized.js | 💥
-
-### js/strings
-* js/strings/escaped.js | 💥💥
-* js/strings/multiline-literal.js | 💥💥
-* js/strings/non-octal-eight-and-nine.js | 💥💥
-* js/strings/template-literals.js | 💥💥
-
-### js/switch
-* js/switch/comments.js | 💥
-* js/switch/comments2.js | 💥
-
-### js/template
-* js/template/call.js | 💥
-* js/template/comment.js | 💥
-* js/template/faulty-locations.js | 💥
-* js/template/graphql.js | 💥
-* js/template/indent.js | 💥
-* js/template/inline.js | 💥
-* js/template/parenthesis.js | 💥
-
-### js/template-align
-* js/template-align/indent.js | 💥💥
-
-### js/template-literals
-* js/template-literals/binary-exporessions.js | 💥
-* js/template-literals/conditional-expressions.js | 💥
-* js/template-literals/expressions.js | 💥
-* js/template-literals/indention.js | 💥
-* js/template-literals/logical-expressions.js | 💥
-* js/template-literals/sequence-expressions.js | 💥
-
-### js/ternaries
-* js/ternaries/binary.js | 💥💥💥💥💥💥💥💥
-* js/ternaries/func-call.js | 💥💥💥💥💥💥💥💥
-* js/ternaries/indent-after-paren.js | 💥💥💥💥💥💥💥💥
-* js/ternaries/indent.js | 💥💥💥💥💥💥💥💥
-* js/ternaries/nested-in-condition.js | 💥💥💥💥💥💥💥💥
-* js/ternaries/nested.js | 💥💥💥💥💥💥💥💥
-* js/ternaries/parenthesis.js | 💥💥💥💥💥💥💥💥
-* js/ternaries/test.js | 💥💥💥💥💥💥💥💥
-
-### js/ternaries/parenthesis
-* js/ternaries/parenthesis/await-expression.js | 💥💥
-
-### js/test-declarations
-* js/test-declarations/angular_async.js | 💥💥
-* js/test-declarations/angular_fakeAsync.js | 💥💥
-* js/test-declarations/angular_waitForAsync.js | 💥💥
-* js/test-declarations/angularjs_inject.js | 💥💥
-* js/test-declarations/jest-each-template-string.js | 💥💥
-* js/test-declarations/jest-each.js | 💥💥
-* js/test-declarations/test_declarations.js | 💥💥
-
-### js/throw_statement
-* js/throw_statement/binaryish.js | 💥
-* js/throw_statement/comment.js | 💥
-
-### js/trailing-comma
-* js/trailing-comma/es5.js | 💥💥✨
-* js/trailing-comma/function-calls.js | 💥💥✨
-* js/trailing-comma/jsx.js | 💥💥💥
-* js/trailing-comma/trailing_whitespace.js | 💥💥💥
-
-### js/try
-* js/try/catch.js | 💥
-* js/try/try.js | 💥
-
-### js/unary
-* js/unary/object.js | 💥
-
-### js/unary-expression
-* js/unary-expression/comments.js | 💥
-
-### js/unicode
-* js/unicode/combining-characters.js | 💥
-* js/unicode/nbsp-jsx.js | 💥
-
-### js/yield
-* js/yield/jsx-without-parenthesis.js | 💥
-* js/yield/jsx.js | 💥
-
-### jsx/attr-element
-* jsx/attr-element/attr-element.js | 💥
-
-### jsx/binary-expressions
-* jsx/binary-expressions/relational-operators.js | 💥
-
-### jsx/comments
-* jsx/comments/eslint-disable.js | 💥
-* jsx/comments/in-attributes.js | 💥
-* jsx/comments/in-end-tag.js | 💥
-* jsx/comments/in-tags.js | 💥
-* jsx/comments/jsx-tag-comment-after-prop.js | 💥
-* jsx/comments/like-a-comment-in-jsx-text.js | 💥
-
-### jsx/deprecated-jsx-bracket-same-line-option
-* jsx/deprecated-jsx-bracket-same-line-option/jsx.js | 💥💥💥💥
-
-### jsx/embed
-* jsx/embed/css-embed.js | 💥
-
-### jsx/escape
-* jsx/escape/nbsp.js | 💥
-
-### jsx/expression-with-types
-* jsx/expression-with-types/expression.js | 💥💥💥💥
-
-### jsx/fbt
-* jsx/fbt/test.js | 💥
-
-### jsx/fragment
-* jsx/fragment/fragment.js | 💥
-
-### jsx/ignore
-* jsx/ignore/jsx_ignore.js | 💥
-
-### jsx/jsx
-* jsx/jsx/array-iter.js | 💥💥💥💥
-* jsx/jsx/arrow.js | 💥💥💥💥
-* jsx/jsx/attr-comments.js | 💥💥💥💥
-* jsx/jsx/await.js | 💥💥💥💥
-* jsx/jsx/conditional-expression.js | 💥💥💥💥
-* jsx/jsx/expression.js | 💥💥💥💥
-* jsx/jsx/flow_fix_me.js | 💥💥💥💥
-* jsx/jsx/html_escape.js | 💥💥✨✨
-* jsx/jsx/hug.js | 💥💥💥💥
-* jsx/jsx/logical-expression.js | 💥💥💥💥
-* jsx/jsx/object-property.js | 💥💥💥💥
-* jsx/jsx/open-break.js | 💥💥💥💥
-* jsx/jsx/parens.js | 💥💥💥💥
-* jsx/jsx/quotes.js | 💥💥💥💥
-* jsx/jsx/regex.js | 💥💥💥💥
-* jsx/jsx/return-statement.js | 💥💥💥💥
-* jsx/jsx/spacing.js | 💥💥💥💥
-* jsx/jsx/template-literal-in-attr.js | 💥💥💥💥
-
-### jsx/last-line
-* jsx/last-line/last_line.js | 💥💥
-* jsx/last-line/single_prop_multiline_string.js | 💥💥
-
-### jsx/multiline-assign
-* jsx/multiline-assign/test.js | 💥
-
-### jsx/newlines
-* jsx/newlines/test.js | 💥
-* jsx/newlines/windows.js | 💥
-
-### jsx/optional-chaining
-* jsx/optional-chaining/optional-chaining.jsx | 💥
-
-### jsx/significant-space
-* jsx/significant-space/comments.js | 💥
-* jsx/significant-space/test.js | 💥
-
-### jsx/single-attribute-per-line
-* jsx/single-attribute-per-line/single-attribute-per-line.js | 💥💥
-
-### jsx/split-attrs
-* jsx/split-attrs/test.js | 💥
-
-### jsx/spread
-* jsx/spread/attribute.js | 💥
-* jsx/spread/child.js | 💥
-
-### jsx/stateless-arrow-fn
-* jsx/stateless-arrow-fn/test.js | 💥
-
-### jsx/text-wrap
-* jsx/text-wrap/test.js | 💥
+| Spec path | Failed or Passed | Match ratio |
+| :-------- | :--------------: | :---------: |
+| js/arrays/numbers-negative-comment-after-minus.js | 💥 | 17.28% |
+| js/arrays/numbers-negative.js | 💥 | 27.59% |
+| js/arrays/numbers-trailing-comma.js | 💥 | 88.89% |
+| js/arrays/numbers-with-holes.js | 💥 | 92.31% |
+| js/arrays/numbers-with-trailing-comments.js | 💥 | 28.57% |
+| js/arrays/numbers-with-tricky-comments.js | 💥 | 40.00% |
+| js/arrays/numbers2.js | 💥 | 93.62% |
+| js/arrays/numbers3.js | 💥 | 66.67% |
+| js/arrays/preserve_empty_lines.js | 💥 | 62.81% |
+| js/arrow-call/arrow_call.js | 💥💥💥 | 40.40% |
+| js/arrow-call/class-property.js | 💥💥💥 | 0.00% |
+| js/arrows/arrow-chain-with-trailing-comments.js | 💥💥 | 6.67% |
+| js/arrows/arrow_function_expression.js | 💥💥 | 97.14% |
+| js/arrows/assignment-chain-with-arrow-chain.js | 💥💥 | 60.25% |
+| js/arrows/call.js | 💥💥 | 35.29% |
+| js/arrows/chain-as-arg.js | 💥💥 | 75.76% |
+| js/arrows/chain-in-logical-expression.js | 💥💥 | 28.57% |
+| js/arrows/comment.js | 💥💥 | 32.79% |
+| js/arrows/curried.js | 💥💥 | 31.42% |
+| js/arrows/currying-2.js | 💥💥 | 60.42% |
+| js/arrows/currying-3.js | 💥💥 | 42.62% |
+| js/arrows/currying-4.js | 💥💥 | 68.27% |
+| js/arrows/currying.js | 💥💥 | 87.50% |
+| js/arrows/issue-1389-curry.js | 💥💥 | 14.58% |
+| js/arrows/long-call-no-args.js | 💥💥 | 0.00% |
+| js/arrows/parens.js | 💥💥 | 83.64% |
+| js/assignment/binaryish.js | 💥 | 85.71% |
+| js/assignment/call-with-template.js | 💥 | 70.00% |
+| js/assignment/chain-two-segments.js | 💥 | 0.00% |
+| js/assignment/chain.js | 💥 | 80.65% |
+| js/assignment/discussion-15196.js | 💥 | 91.53% |
+| js/assignment/issue-10218.js | 💥 | 52.63% |
+| js/assignment/issue-2184.js | 💥 | 75.00% |
+| js/assignment/issue-2540.js | 💥 | 0.00% |
+| js/assignment/issue-5610.js | 💥 | 76.92% |
+| js/assignment/issue-6922.js | 💥 | 68.00% |
+| js/assignment/issue-7572.js | 💥 | 72.73% |
+| js/assignment/issue-7961.js | 💥 | 83.33% |
+| js/assignment/lone-arg.js | 💥 | 51.16% |
+| js/assignment-comments/call.js | 💥 | 66.67% |
+| js/assignment-comments/call2.js | 💥 | 0.00% |
+| js/assignment-comments/function.js | 💥 | 28.21% |
+| js/assignment-comments/identifier.js | 💥 | 46.15% |
+| js/assignment-comments/number.js | 💥 | 30.00% |
+| js/assignment-comments/string.js | 💥 | 52.11% |
+| js/async/inline-await.js | 💥 | 25.00% |
+| js/async/nested.js | 💥 | 0.00% |
+| js/binary-expressions/arrow.js | 💥 | 55.32% |
+| js/binary-expressions/call.js | 💥 | 76.79% |
+| js/binary-expressions/comment.js | 💥 | 34.48% |
+| js/binary-expressions/if.js | 💥 | 92.31% |
+| js/binary-expressions/in_instanceof.js | 💥 | 98.63% |
+| js/binary-expressions/inline-jsx.js | 💥 | 33.33% |
+| js/binary-expressions/inline-object-array.js | 💥 | 48.24% |
+| js/binary-expressions/jsx_parent.js | 💥 | 33.33% |
+| js/binary-expressions/short-right.js | 💥 | 68.75% |
+| js/binary-expressions/test.js | 💥 | 82.46% |
+| js/binary-expressions/unary.js | 💥 | 75.00% |
+| js/break-calls/break.js | 💥 | 71.74% |
+| js/break-calls/parent.js | 💥 | 0.00% |
+| js/break-calls/react.js | 💥 | 52.92% |
+| js/call/first-argument-expansion/expression-2nd-arg.js | 💥 | 87.18% |
+| js/call/first-argument-expansion/issue-13237.js | 💥 | 82.35% |
+| js/call/first-argument-expansion/issue-2456.js | 💥 | 63.64% |
+| js/call/first-argument-expansion/issue-5172.js | 💥 | 65.22% |
+| js/call/first-argument-expansion/jsx.js | 💥 | 0.00% |
+| js/call/first-argument-expansion/test.js | 💥 | 89.17% |
+| js/call/no-argument/special-cases.js | 💥 | 0.00% |
+| js/chain-expression/call-expression.js | 💥 | 30.77% |
+| js/chain-expression/issue-15785-1.js | 💥 | 50.00% |
+| js/chain-expression/issue-15785-2.js | 💥 | 16.67% |
+| js/chain-expression/issue-15785-3.js | 💥 | 50.00% |
+| js/chain-expression/issue-15916.js | 💥 | 53.33% |
+| js/chain-expression/member-expression.js | 💥 | 31.82% |
+| js/chain-expression/test-3.js | 💥 | 37.50% |
+| js/chain-expression/test-4.js | 💥 | 97.67% |
+| js/chain-expression/test.js | 💥 | 25.00% |
+| js/class-comment/class-property.js | 💥 | 76.92% |
+| js/class-comment/misc.js | 💥 | 50.00% |
+| js/class-comment/superclass.js | 💥 | 45.71% |
+| js/class-extends/extends.js | 💥 | 76.60% |
+| js/classes/asi.js | 💥 | 85.71% |
+| js/classes/assignment.js | 💥 | 81.25% |
+| js/classes/empty.js | 💥 | 63.64% |
+| js/classes/method.js | 💥 | 71.43% |
+| js/classes/property.js | 💥 | 81.25% |
+| js/classes-private-fields/optional-chaining.js | 💥💥 | 50.00% |
+| js/classes-private-fields/with_comments.js | 💥💥 | 40.00% |
+| js/comments/15661.js | 💥💥 | 22.00% |
+| js/comments/16398.js | 💥💥 | 60.00% |
+| js/comments/arrow.js | 💥💥 | 33.33% |
+| js/comments/assignment-pattern.js | 💥💥 | 33.33% |
+| js/comments/before-comma.js | 💥💥 | 60.00% |
+| js/comments/binary-expressions-block-comments.js | 💥💥 | 36.84% |
+| js/comments/binary-expressions-parens.js | 💥💥 | 66.67% |
+| js/comments/binary-expressions-single-comments.js | 💥💥 | 29.41% |
+| js/comments/binary-expressions.js | 💥💥 | 59.32% |
+| js/comments/blank.js | 💥💥 | 0.00% |
+| js/comments/break-continue-statements.js | 💥💥 | 45.45% |
+| js/comments/call_comment.js | 💥💥 | 48.00% |
+| js/comments/class.js | 💥💥 | 73.68% |
+| js/comments/dangling.js | 💥💥 | 0.00% |
+| js/comments/dangling_array.js | 💥💥 | 20.00% |
+| js/comments/dangling_for.js | 💥💥 | 75.00% |
+| js/comments/dynamic_imports.js | 💥💥 | 35.71% |
+| js/comments/emoji.js | 💥💥 | 33.33% |
+| js/comments/empty-statements.js | 💥💥 | 0.00% |
+| js/comments/export-and-import.js | 💥💥 | 33.33% |
+| js/comments/export.js | 💥💥 | 47.46% |
+| js/comments/first-line.js | 💥💥 | 50.00% |
+| js/comments/function-declaration.js | 💥💥 | 55.00% |
+| js/comments/if.js | 💥💥 | 45.05% |
+| js/comments/issue-3532.js | 💥💥 | 27.78% |
+| js/comments/issues.js | 💥💥 | 33.33% |
+| js/comments/jsdoc-nestled-dangling.js | 💥💥 | 77.78% |
+| js/comments/jsdoc-nestled.js | 💥💥 | 56.41% |
+| js/comments/jsdoc.js | 💥💥 | 19.51% |
+| js/comments/jsx.js | 💥💥 | 47.85% |
+| js/comments/last-arg.js | 💥💥 | 32.65% |
+| js/comments/multi-comments-2.js | 💥💥 | 90.91% |
+| js/comments/multi-comments-on-same-line-2.js | 💥💥 | 0.00% |
+| js/comments/multi-comments-on-same-line.js | 💥💥 | 54.55% |
+| js/comments/multi-comments.js | 💥💥 | 37.04% |
+| js/comments/preserve-new-line-last.js | 💥💥 | 76.47% |
+| js/comments/return-statement.js | 💥💥 | 51.32% |
+| js/comments/single-star-jsdoc.js | 💥💥 | 12.50% |
+| js/comments/switch.js | 💥💥 | 80.00% |
+| js/comments/tagged-template-literal.js | 💥💥 | 53.85% |
+| js/comments/template-literal.js | 💥💥 | 39.13% |
+| js/comments/trailing-jsdocs.js | 💥💥 | 0.00% |
+| js/comments/trailing_space.js | 💥💥 | 57.14% |
+| js/comments/try.js | 💥💥 | 44.44% |
+| js/comments/variable_declarator.js | 💥💥 | 51.69% |
+| js/comments/while.js | 💥💥 | 33.33% |
+| js/comments/flow-types/inline.js | 💥 | 16.67% |
+| js/comments/function/between-parentheses-and-function-body.js | 💥 | 72.00% |
+| js/comments/html-like/comment.js | 💥 | 0.00% |
+| js/comments-closure-typecast/binary-expr.js | 💥 | 0.00% |
+| js/comments-closure-typecast/closure-compiler-type-cast.js | 💥 | 35.29% |
+| js/comments-closure-typecast/comment-in-the-middle.js | 💥 | 15.38% |
+| js/comments-closure-typecast/comment-placement.js | 💥 | 36.36% |
+| js/comments-closure-typecast/extra-spaces-and-asterisks.js | 💥 | 0.00% |
+| js/comments-closure-typecast/iife-issue-5850-isolated.js | 💥 | 0.00% |
+| js/comments-closure-typecast/iife.js | 💥 | 20.00% |
+| js/comments-closure-typecast/issue-4124.js | 💥 | 37.50% |
+| js/comments-closure-typecast/issue-8045.js | 💥 | 46.81% |
+| js/comments-closure-typecast/issue-9358.js | 💥 | 0.00% |
+| js/comments-closure-typecast/member.js | 💥 | 0.00% |
+| js/comments-closure-typecast/nested.js | 💥 | 13.33% |
+| js/comments-closure-typecast/non-casts.js | 💥 | 84.85% |
+| js/comments-closure-typecast/object-with-comment.js | 💥 | 10.53% |
+| js/comments-closure-typecast/satisfies.js | 💥 | 33.33% |
+| js/comments-closure-typecast/superclass.js | 💥 | 0.00% |
+| js/comments-closure-typecast/ways-to-specify-type.js | 💥 | 8.00% |
+| js/conditional/comments.js | 💥💥 | 30.58% |
+| js/conditional/new-ternary-examples.js | 💥💥 | 27.93% |
+| js/conditional/new-ternary-spec.js | 💥💥 | 33.16% |
+| js/conditional/no-confusing-arrow.js | 💥💥 | 40.00% |
+| js/conditional/postfix-ternary-regressions.js | 💥💥 | 52.77% |
+| js/destructuring/destructuring.js | 💥 | 75.73% |
+| js/destructuring-ignore/ignore.js | 💥💥💥 | 33.33% |
+| js/directives/escaped.js | 💥 | 69.84% |
+| js/directives/issue-7346.js | 💥 | 25.00% |
+| js/directives/newline.js | 💥 | 83.33% |
+| js/empty-paren-comment/class-property.js | 💥 | 22.22% |
+| js/empty-paren-comment/class.js | 💥 | 66.67% |
+| js/empty-paren-comment/empty_paren_comment.js | 💥 | 27.78% |
+| js/export/blank-line-between-specifiers.js | 💥💥 | 35.71% |
+| js/export/same-local-and-exported.js | 💥💥 | 66.67% |
+| js/expression_statement/no_regression.js | 💥 | 66.67% |
+| js/expression_statement/use_strict.js | 💥 | 0.00% |
+| js/for/comment.js | 💥 | 59.09% |
+| js/for/continue-and-break-comment-1.js | 💥 | 74.74% |
+| js/for/continue-and-break-comment-2.js | 💥 | 88.79% |
+| js/for/continue-and-break-comment-without-blocks.js | 💥 | 37.24% |
+| js/for/for-in-with-initializer.js | 💥 | 7.14% |
+| js/for/parentheses.js | 💥 | 98.00% |
+| js/function/issue-10277.js | 💥 | 36.36% |
+| js/function-comments/params-trail-comments.js | 💥 | 24.24% |
+| js/function-first-param/function_expression.js | 💥 | 96.55% |
+| js/function-single-destructuring/array.js | 💥 | 84.29% |
+| js/function-single-destructuring/object.js | 💥 | 76.79% |
+| js/functional-composition/functional_compose.js | 💥 | 38.96% |
+| js/functional-composition/lodash_flow.js | 💥 | 60.00% |
+| js/functional-composition/lodash_flow_right.js | 💥 | 60.00% |
+| js/functional-composition/pipe-function-calls-with-comments.js | 💥 | 31.43% |
+| js/functional-composition/pipe-function-calls.js | 💥 | 45.00% |
+| js/functional-composition/ramda_compose.js | 💥 | 60.87% |
+| js/functional-composition/ramda_pipe.js | 💥 | 73.68% |
+| js/functional-composition/redux_connect.js | 💥 | 0.00% |
+| js/functional-composition/reselect_createselector.js | 💥 | 33.33% |
+| js/functional-composition/rxjs_pipe.js | 💥 | 45.45% |
+| js/generator/async.js | 💥 | 92.86% |
+| js/generator/function-name-starts-with-get.js | 💥 | 83.33% |
+| js/identifier/parentheses/let.js | 💥✨ | 40.00% |
+| js/if/comment_before_else.js | 💥 | 66.67% |
+| js/if/else.js | 💥 | 94.44% |
+| js/if/expr_and_same_line_comments.js | 💥 | 41.98% |
+| js/if/if_comments.js | 💥 | 46.00% |
+| js/if/issue-15168.js | 💥 | 62.86% |
+| js/if/non-block.js | 💥 | 70.59% |
+| js/if/trailing_comment.js | 💥 | 64.52% |
+| js/import/comments.js | 💥💥 | 20.00% |
+| js/import/empty-import.js | 💥💥 | 12.50% |
+| js/import/same-local-and-imported.js | 💥💥 | 66.67% |
+| js/import-assertions/empty.js | 💥 | 71.43% |
+| js/import-assertions/keyword-detect.js | 💥 | 33.33% |
+| js/import-attributes/empty.js | 💥 | 71.43% |
+| js/import-attributes/keyword-detect.js | 💥 | 33.33% |
+| js/import-attributes/long-sources.js | 💥 | 65.57% |
+| js/label/comment.js | 💥 | 85.71% |
+| js/last-argument-expansion/arrow.js | 💥 | 12.90% |
+| js/last-argument-expansion/assignment-pattern.js | 💥 | 0.00% |
+| js/last-argument-expansion/break-parent.js | 💥 | 53.33% |
+| js/last-argument-expansion/dangling-comment-in-arrow-function.js | 💥 | 0.00% |
+| js/last-argument-expansion/edge_case.js | 💥 | 34.23% |
+| js/last-argument-expansion/empty-lines.js | 💥 | 12.50% |
+| js/last-argument-expansion/empty-object.js | 💥 | 54.17% |
+| js/last-argument-expansion/function-expression-issue-2239.js | 💥 | 0.00% |
+| js/last-argument-expansion/function-expression.js | 💥 | 26.32% |
+| js/last-argument-expansion/issue-10708.js | 💥 | 0.00% |
+| js/last-argument-expansion/issue-7518.js | 💥 | 72.00% |
+| js/last-argument-expansion/jsx.js | 💥 | 20.00% |
+| js/last-argument-expansion/overflow.js | 💥 | 51.02% |
+| js/line-suffix-boundary/boundary.js | 💥 | 40.00% |
+| js/literal/number.js | 💥 | 98.29% |
+| js/logical_expressions/issue-7024.js | 💥 | 18.18% |
+| js/logical_expressions/logical_expression_operators.js | 💥 | 95.08% |
+| js/member/conditional.js | 💥 | 57.14% |
+| js/member/expand.js | 💥 | 57.14% |
+| js/member/logical.js | 💥 | 85.71% |
+| js/method-chain/bracket_0-1.js | 💥 | 0.00% |
+| js/method-chain/break-last-call.js | 💥 | 83.33% |
+| js/method-chain/break-last-member.js | 💥 | 80.56% |
+| js/method-chain/comment.js | 💥 | 30.61% |
+| js/method-chain/computed-merge.js | 💥 | 41.38% |
+| js/method-chain/computed.js | 💥 | 0.00% |
+| js/method-chain/conditional.js | 💥 | 61.22% |
+| js/method-chain/d3.js | 💥 | 40.00% |
+| js/method-chain/first_long.js | 💥 | 57.14% |
+| js/method-chain/fluent-configuration.js | 💥 | 37.50% |
+| js/method-chain/inline_merge.js | 💥 | 64.29% |
+| js/method-chain/issue-11298.js | 💥 | 20.00% |
+| js/method-chain/issue-3594.js | 💥 | 50.00% |
+| js/method-chain/issue-4125.js | 💥 | 54.61% |
+| js/method-chain/logical.js | 💥 | 56.00% |
+| js/method-chain/multiple-members.js | 💥 | 45.65% |
+| js/method-chain/object-literal.js | 💥 | 7.69% |
+| js/method-chain/pr-7889.js | 💥 | 27.27% |
+| js/method-chain/short-names.js | 💥 | 0.00% |
+| js/method-chain/square_0.js | 💥 | 12.50% |
+| js/method-chain/test.js | 💥 | 54.55% |
+| js/method-chain/this.js | 💥 | 0.00% |
+| js/new-expression/with-member-expression.js | 💥 | 44.44% |
+| js/newline/backslash_2028.js | 💥 | 0.00% |
+| js/newline/backslash_2029.js | 💥 | 0.00% |
+| js/no-semi/class.js | 💥💥 | 88.37% |
+| js/no-semi/comments.js | 💥💥 | 71.43% |
+| js/no-semi/issue2006.js | 💥✨ | 37.50% |
+| js/no-semi/no-semi.js | 💥💥 | 84.12% |
+| js/non-strict/keywords.js | 💥 | 76.92% |
+| js/nullish-coalescing/nullish_coalesing_operator.js | 💥 | 80.00% |
+| js/numeric-separators/number.js | 💥 | 66.67% |
+| js/object-prop-break-in/comment.js | 💥 | 90.91% |
+| js/object-prop-break-in/short-keys.js | 💥 | 60.00% |
+| js/object-property-comment/after-key.js | 💥 | 71.43% |
+| js/object-property-ignore/ignore.js | 💥💥💥 | 69.14% |
+| js/object-property-ignore/issue-5678.js | 💥💥💥 | 23.88% |
+| js/objects/escape-sequence-key.js | 💥 | 66.67% |
+| js/objects/expand.js | 💥 | 50.00% |
+| js/objects/right-break.js | 💥 | 89.47% |
+| js/optional-chaining/chaining.js | 💥 | 83.91% |
+| js/optional-chaining/comments.js | 💥 | 17.91% |
+| js/optional-chaining/eval.js | 💥 | 82.93% |
+| js/optional-chaining-assignment/valid-complex-case.js | 💥 | 0.00% |
+| js/optional-chaining-assignment/valid-lhs-eq.js | 💥 | 0.00% |
+| js/optional-chaining-assignment/valid-lhs-plus-eq.js | 💥 | 0.00% |
+| js/performance/nested-real.js | 💥 | 97.04% |
+| js/preserve-line/argument-list.js | 💥 | 76.87% |
+| js/preserve-line/comments.js | 💥 | 75.47% |
+| js/preserve-line/member-chain.js | 💥 | 21.78% |
+| js/preserve-line/parameter-list.js | 💥 | 77.06% |
+| js/quote-props/numeric-separator.js | 💥💥💥💥 | 40.00% |
+| js/quote-props/objects.js | 💥💥💥💥 | 75.26% |
+| js/quotes/objects.js | 💥💥 | 80.00% |
+| js/quotes/strings.js | 💥💥 | 20.81% |
+| js/require-amd/named-amd-module.js | 💥 | 0.00% |
+| js/require-amd/require.js | 💥 | 2.17% |
+| js/return/binaryish.js | 💥 | 44.44% |
+| js/return/comment.js | 💥 | 58.82% |
+| js/sequence-break/break.js | 💥 | 35.09% |
+| js/sequence-expression/ignore.js | 💥 | 0.00% |
+| js/sequence-expression/parenthesized.js | 💥 | 23.53% |
+| js/strings/escaped.js | 💥💥 | 45.00% |
+| js/strings/multiline-literal.js | 💥💥 | 90.00% |
+| js/strings/non-octal-eight-and-nine.js | 💥💥 | 83.33% |
+| js/strings/template-literals.js | 💥💥 | 36.47% |
+| js/switch/comments.js | 💥 | 87.10% |
+| js/switch/comments2.js | 💥 | 58.82% |
+| js/template/call.js | 💥 | 57.14% |
+| js/template/comment.js | 💥 | 27.27% |
+| js/template/faulty-locations.js | 💥 | 84.62% |
+| js/template/graphql.js | 💥 | 34.48% |
+| js/template/indent.js | 💥 | 85.71% |
+| js/template/inline.js | 💥 | 81.48% |
+| js/template/parenthesis.js | 💥 | 81.32% |
+| js/template-align/indent.js | 💥💥 | 46.05% |
+| js/template-literals/binary-exporessions.js | 💥 | 0.00% |
+| js/template-literals/conditional-expressions.js | 💥 | 0.00% |
+| js/template-literals/expressions.js | 💥 | 63.64% |
+| js/template-literals/indention.js | 💥 | 51.16% |
+| js/template-literals/logical-expressions.js | 💥 | 0.00% |
+| js/template-literals/sequence-expressions.js | 💥 | 0.00% |
+| js/ternaries/binary.js | 💥💥💥💥💥💥💥💥 | 13.93% |
+| js/ternaries/func-call.js | 💥💥💥💥💥💥💥💥 | 45.20% |
+| js/ternaries/indent-after-paren.js | 💥💥💥💥💥💥💥💥 | 37.35% |
+| js/ternaries/indent.js | 💥💥💥💥💥💥💥💥 | 10.85% |
+| js/ternaries/nested-in-condition.js | 💥💥💥💥💥💥💥💥 | 15.90% |
+| js/ternaries/nested.js | 💥💥💥💥💥💥💥💥 | 26.56% |
+| js/ternaries/parenthesis.js | 💥💥💥💥💥💥💥💥 | 10.64% |
+| js/ternaries/test.js | 💥💥💥💥💥💥💥💥 | 30.99% |
+| js/ternaries/parenthesis/await-expression.js | 💥💥 | 14.29% |
+| js/test-declarations/angular_async.js | 💥💥 | 40.00% |
+| js/test-declarations/angular_fakeAsync.js | 💥💥 | 27.12% |
+| js/test-declarations/angular_waitForAsync.js | 💥💥 | 27.12% |
+| js/test-declarations/angularjs_inject.js | 💥💥 | 27.12% |
+| js/test-declarations/jest-each-template-string.js | 💥💥 | 25.00% |
+| js/test-declarations/jest-each.js | 💥💥 | 59.15% |
+| js/test-declarations/test_declarations.js | 💥💥 | 39.68% |
+| js/throw_statement/binaryish.js | 💥 | 40.74% |
+| js/throw_statement/comment.js | 💥 | 47.06% |
+| js/trailing-comma/es5.js | 💥💥✨ | 59.26% |
+| js/trailing-comma/function-calls.js | 💥💥✨ | 60.61% |
+| js/trailing-comma/jsx.js | 💥💥💥 | 0.00% |
+| js/trailing-comma/trailing_whitespace.js | 💥💥💥 | 69.37% |
+| js/try/catch.js | 💥 | 50.00% |
+| js/try/try.js | 💥 | 85.71% |
+| js/unary/object.js | 💥 | 85.71% |
+| js/unary-expression/comments.js | 💥 | 18.23% |
+| js/unicode/combining-characters.js | 💥 | 0.00% |
+| js/unicode/nbsp-jsx.js | 💥 | 0.00% |
+| js/yield/jsx-without-parenthesis.js | 💥 | 50.00% |
+| js/yield/jsx.js | 💥 | 50.00% |
+| jsx/attr-element/attr-element.js | 💥 | 0.00% |
+| jsx/binary-expressions/relational-operators.js | 💥 | 78.95% |
+| jsx/comments/eslint-disable.js | 💥 | 0.00% |
+| jsx/comments/in-attributes.js | 💥 | 41.67% |
+| jsx/comments/in-end-tag.js | 💥 | 17.07% |
+| jsx/comments/in-tags.js | 💥 | 54.55% |
+| jsx/comments/jsx-tag-comment-after-prop.js | 💥 | 26.67% |
+| jsx/comments/like-a-comment-in-jsx-text.js | 💥 | 0.00% |
+| jsx/deprecated-jsx-bracket-same-line-option/jsx.js | 💥💥💥💥 | 45.33% |
+| jsx/embed/css-embed.js | 💥 | 0.00% |
+| jsx/escape/nbsp.js | 💥 | 70.00% |
+| jsx/expression-with-types/expression.js | 💥💥💥💥 | 0.00% |
+| jsx/fbt/test.js | 💥 | 48.11% |
+| jsx/fragment/fragment.js | 💥 | 79.14% |
+| jsx/ignore/jsx_ignore.js | 💥 | 60.22% |
+| jsx/jsx/array-iter.js | 💥💥💥💥 | 20.97% |
+| jsx/jsx/arrow.js | 💥💥💥💥 | 29.17% |
+| jsx/jsx/attr-comments.js | 💥💥💥💥 | 0.00% |
+| jsx/jsx/await.js | 💥💥💥💥 | 16.47% |
+| jsx/jsx/conditional-expression.js | 💥💥💥💥 | 27.27% |
+| jsx/jsx/expression.js | 💥💥💥💥 | 32.74% |
+| jsx/jsx/flow_fix_me.js | 💥💥💥💥 | 0.00% |
+| jsx/jsx/html_escape.js | 💥💥✨✨ | 16.67% |
+| jsx/jsx/hug.js | 💥💥💥💥 | 33.85% |
+| jsx/jsx/logical-expression.js | 💥💥💥💥 | 35.82% |
+| jsx/jsx/object-property.js | 💥💥💥💥 | 52.63% |
+| jsx/jsx/open-break.js | 💥💥💥💥 | 21.43% |
+| jsx/jsx/parens.js | 💥💥💥💥 | 50.00% |
+| jsx/jsx/quotes.js | 💥💥💥💥 | 42.55% |
+| jsx/jsx/regex.js | 💥💥💥💥 | 75.00% |
+| jsx/jsx/return-statement.js | 💥💥💥💥 | 72.92% |
+| jsx/jsx/spacing.js | 💥💥💥💥 | 22.22% |
+| jsx/jsx/template-literal-in-attr.js | 💥💥💥💥 | 26.67% |
+| jsx/last-line/last_line.js | 💥💥 | 44.51% |
+| jsx/last-line/single_prop_multiline_string.js | 💥💥 | 22.88% |
+| jsx/multiline-assign/test.js | 💥 | 34.62% |
+| jsx/newlines/test.js | 💥 | 41.96% |
+| jsx/newlines/windows.js | 💥 | 0.00% |
+| jsx/optional-chaining/optional-chaining.jsx | 💥 | 18.18% |
+| jsx/significant-space/comments.js | 💥 | 40.00% |
+| jsx/significant-space/test.js | 💥 | 32.09% |
+| jsx/single-attribute-per-line/single-attribute-per-line.js | 💥💥 | 55.77% |
+| jsx/split-attrs/test.js | 💥 | 13.57% |
+| jsx/spread/attribute.js | 💥 | 30.19% |
+| jsx/spread/child.js | 💥 | 26.67% |
+| jsx/stateless-arrow-fn/test.js | 💥 | 14.79% |
+| jsx/text-wrap/test.js | 💥 | 38.20% |

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -2,639 +2,374 @@ ts compatibility: 199/568 (35.04%)
 
 # Failed
 
-### jsx/attr-element
-* jsx/attr-element/attr-element.js | 💥
-
-### jsx/binary-expressions
-* jsx/binary-expressions/relational-operators.js | 💥
-
-### jsx/comments
-* jsx/comments/eslint-disable.js | 💥
-* jsx/comments/in-attributes.js | 💥
-* jsx/comments/in-end-tag.js | 💥
-* jsx/comments/in-tags.js | 💥
-* jsx/comments/jsx-tag-comment-after-prop.js | 💥
-* jsx/comments/like-a-comment-in-jsx-text.js | 💥
-
-### jsx/deprecated-jsx-bracket-same-line-option
-* jsx/deprecated-jsx-bracket-same-line-option/jsx.js | 💥💥💥💥
-
-### jsx/embed
-* jsx/embed/css-embed.js | 💥
-
-### jsx/escape
-* jsx/escape/nbsp.js | 💥
-
-### jsx/expression-with-types
-* jsx/expression-with-types/expression.js | 💥💥💥💥
-
-### jsx/fbt
-* jsx/fbt/test.js | 💥
-
-### jsx/fragment
-* jsx/fragment/fragment.js | 💥
-
-### jsx/ignore
-* jsx/ignore/jsx_ignore.js | 💥
-
-### jsx/jsx
-* jsx/jsx/array-iter.js | 💥💥💥💥
-* jsx/jsx/arrow.js | 💥💥💥💥
-* jsx/jsx/attr-comments.js | 💥💥💥💥
-* jsx/jsx/await.js | 💥💥💥💥
-* jsx/jsx/conditional-expression.js | 💥💥💥💥
-* jsx/jsx/expression.js | 💥💥💥💥
-* jsx/jsx/flow_fix_me.js | 💥💥💥💥
-* jsx/jsx/html_escape.js | 💥💥✨✨
-* jsx/jsx/hug.js | 💥💥💥💥
-* jsx/jsx/logical-expression.js | 💥💥💥💥
-* jsx/jsx/object-property.js | 💥💥💥💥
-* jsx/jsx/open-break.js | 💥💥💥💥
-* jsx/jsx/parens.js | 💥💥💥💥
-* jsx/jsx/quotes.js | 💥💥💥💥
-* jsx/jsx/regex.js | 💥💥💥💥
-* jsx/jsx/return-statement.js | 💥💥💥💥
-* jsx/jsx/spacing.js | 💥💥💥💥
-* jsx/jsx/template-literal-in-attr.js | 💥💥💥💥
-
-### jsx/last-line
-* jsx/last-line/last_line.js | 💥💥
-* jsx/last-line/single_prop_multiline_string.js | 💥💥
-
-### jsx/multiline-assign
-* jsx/multiline-assign/test.js | 💥
-
-### jsx/newlines
-* jsx/newlines/test.js | 💥
-* jsx/newlines/windows.js | 💥
-
-### jsx/optional-chaining
-* jsx/optional-chaining/optional-chaining.jsx | 💥
-
-### jsx/significant-space
-* jsx/significant-space/comments.js | 💥
-* jsx/significant-space/test.js | 💥
-
-### jsx/single-attribute-per-line
-* jsx/single-attribute-per-line/single-attribute-per-line.js | 💥💥
-
-### jsx/split-attrs
-* jsx/split-attrs/test.js | 💥
-
-### jsx/spread
-* jsx/spread/attribute.js | 💥
-* jsx/spread/child.js | 💥
-
-### jsx/stateless-arrow-fn
-* jsx/stateless-arrow-fn/test.js | 💥
-
-### jsx/text-wrap
-* jsx/text-wrap/test.js | 💥
-
-### typescript/ambient
-* typescript/ambient/ambient.ts | 💥
-
-### typescript/angular-component-examples
-* typescript/angular-component-examples/15934-computed.component.ts | 💥💥
-* typescript/angular-component-examples/15934.component.ts | 💥💥
-* typescript/angular-component-examples/15969-computed.component.ts | 💥💥
-* typescript/angular-component-examples/test.component.ts | 💥💥
-
-### typescript/argument-expansion
-* typescript/argument-expansion/argument_expansion.ts | 💥
-* typescript/argument-expansion/arrow-with-return-type.ts | 💥
-
-### typescript/array
-* typescript/array/comment.ts | 💥
-
-### typescript/arrow
-* typescript/arrow/16067.ts | 💥💥
-* typescript/arrow/arrow_regression.ts | 💥💥
-* typescript/arrow/comments.ts | 💥💥
-* typescript/arrow/issue-6107-curry.ts | 💥💥
-
-### typescript/arrows
-* typescript/arrows/arrow_function_expression.ts | 💥✨
-* typescript/arrows/type_params.ts | 💥✨
-
-### typescript/as
-* typescript/as/as.ts | 💥
-* typescript/as/assignment2.ts | 💥
-* typescript/as/export_default_as.ts | 💥
-* typescript/as/expression-statement.ts | 💥
-* typescript/as/long-identifiers.ts | 💥
-* typescript/as/nested-await-and-as.ts | 💥
-* typescript/as/ternary.ts | 💥
-
-### typescript/assert
-* typescript/assert/comment.ts | 💥
-
-### typescript/assignment
-* typescript/assignment/issue-10846.ts | 💥
-* typescript/assignment/issue-10848.tsx | 💥
-* typescript/assignment/issue-10850.ts | 💥
-* typescript/assignment/parenthesized.ts | 💥
-
-### typescript/call-signature
-* typescript/call-signature/call-signature.ts | 💥
-
-### typescript/cast
-* typescript/cast/as-const.ts | 💥
-* typescript/cast/assert-and-assign.ts | 💥
-* typescript/cast/generic-cast.ts | 💥
-* typescript/cast/hug-args.ts | 💥
-* typescript/cast/parenthesis.ts | 💥
-* typescript/cast/tuple-and-record.ts | 💥
-
-### typescript/chain-expression
-* typescript/chain-expression/call-expression.ts | 💥
-* typescript/chain-expression/member-expression.ts | 💥
-* typescript/chain-expression/test.ts | 💥
-
-### typescript/class
-* typescript/class/constructor.ts | 💥
-* typescript/class/empty-method-body.ts | 💥
-* typescript/class/extends_implements.ts | 💥
-* typescript/class/generics.ts | 💥
-* typescript/class/issue-16723.ts | 💥
-* typescript/class/parameter-properties.ts | 💥
-* typescript/class/quoted-property.ts | 💥
-
-### typescript/class-comment
-* typescript/class-comment/class-implements.ts | 💥
-* typescript/class-comment/declare.ts | 💥
-* typescript/class-comment/generic.ts | 💥
-* typescript/class-comment/misc.ts | 💥
-
-### typescript/classes
-* typescript/classes/break-heritage.ts | 💥
-* typescript/classes/break.ts | 💥
-
-### typescript/comments
-* typescript/comments/15707.ts | 💥
-* typescript/comments/16065-2.ts | 💥
-* typescript/comments/16065.ts | 💥
-* typescript/comments/abstract_class.ts | 💥
-* typescript/comments/abstract_methods.ts | 💥
-* typescript/comments/after_jsx_generic.tsx | 💥
-* typescript/comments/declare_function.ts | 💥
-* typescript/comments/interface.ts | 💥
-* typescript/comments/issues.ts | 💥
-* typescript/comments/jsx.tsx | 💥
-* typescript/comments/location.ts | 💥
-* typescript/comments/mapped_types.ts | 💥
-* typescript/comments/method_types.ts | 💥
-* typescript/comments/methods.ts | 💥
-* typescript/comments/ts-parameter-proerty.ts | 💥
-* typescript/comments/type-parameters.ts | 💥
-* typescript/comments/type_literals.ts | 💥
-* typescript/comments/types.ts | 💥
-* typescript/comments/union.ts | 💥
-
-### typescript/comments-2
-* typescript/comments-2/dangling.ts | 💥💥
-* typescript/comments-2/issues.ts | 💥💥
-* typescript/comments-2/last-arg.ts | 💥💥
-
-### typescript/compiler
-* typescript/compiler/anyIsAssignableToObject.ts | 💥
-* typescript/compiler/castOfAwait.ts | 💥
-* typescript/compiler/castParentheses.ts | 💥
-* typescript/compiler/checkInfiniteExpansionTermination.ts | 💥
-* typescript/compiler/commentInNamespaceDeclarationWithIdentifierPathName.ts | 💥
-* typescript/compiler/commentsInterface.ts | 💥
-* typescript/compiler/contextualSignatureInstantiation2.ts | 💥
-* typescript/compiler/declareDottedModuleName.ts | 💥
-* typescript/compiler/es5ExportDefaultClassDeclaration4.ts | 💥
-* typescript/compiler/functionOverloadsOnGenericArity1.ts | 💥
-* typescript/compiler/indexSignatureWithInitializer.ts | 💥
-* typescript/compiler/mappedTypeWithCombinedTypeMappers.ts | 💥
-* typescript/compiler/privacyGloImport.ts | 💥
-
-### typescript/conditional-types
-* typescript/conditional-types/comments.ts | 💥💥
-* typescript/conditional-types/conditonal-types.ts | 💥💥
-* typescript/conditional-types/infer-type.ts | 💥💥
-* typescript/conditional-types/nested-in-condition.ts | 💥💥
-* typescript/conditional-types/new-ternary-spec.ts | 💥💥
-* typescript/conditional-types/parentheses.ts | 💥💥
-
-### typescript/conformance/classes
-* typescript/conformance/classes/mixinAccessModifiers.ts | 💥
-* typescript/conformance/classes/mixinClassesAnnotated.ts | 💥
-* typescript/conformance/classes/mixinClassesAnonymous.ts | 💥
-* typescript/conformance/classes/mixinClassesMembers.ts | 💥
-* typescript/conformance/classes/nestedClassDeclaration.ts | 💥
-
-### typescript/conformance/classes/classDeclarations/classHeritageSpecification
-* typescript/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsItselfIndirectly.ts | 💥
-
-### typescript/conformance/classes/constructorDeclarations/constructorParameters
-* typescript/conformance/classes/constructorDeclarations/constructorParameters/constructorImplementationWithDefaultValues2.ts | 💥
-* typescript/conformance/classes/constructorDeclarations/constructorParameters/constructorParameterProperties.ts | 💥
-* typescript/conformance/classes/constructorDeclarations/constructorParameters/constructorParameterProperties2.ts | 💥
-* typescript/conformance/classes/constructorDeclarations/constructorParameters/declarationEmitReadonly.ts | 💥
-* typescript/conformance/classes/constructorDeclarations/constructorParameters/readonlyConstructorAssignment.ts | 💥
-
-### typescript/conformance/comments
-* typescript/conformance/comments/comments.ts | 💥
-
-### typescript/conformance/declarationEmit/typePredicates
-* typescript/conformance/declarationEmit/typePredicates/declarationEmitThisPredicatesWithPrivateName01.ts | 💥
-
-### typescript/conformance/es6/Symbols
-* typescript/conformance/es6/Symbols/symbolProperty15.ts | 💥
-
-### typescript/conformance/es6/templates
-* typescript/conformance/es6/templates/templateStringWithEmbeddedTypeAssertionOnAdditionES6.ts | 💥
-
-### typescript/conformance/expressions/asOperator
-* typescript/conformance/expressions/asOperator/asOperatorContextualType.ts | 💥
-
-### typescript/conformance/expressions/functionCalls
-* typescript/conformance/expressions/functionCalls/callWithSpreadES6.ts | 💥
-
-### typescript/conformance/internalModules/importDeclarations
-* typescript/conformance/internalModules/importDeclarations/circularImportAlias.ts | 💥
-* typescript/conformance/internalModules/importDeclarations/exportImportAlias.ts | 💥
-* typescript/conformance/internalModules/importDeclarations/importAliasIdentifiers.ts | 💥
-* typescript/conformance/internalModules/importDeclarations/invalidImportAliasIdentifiers.ts | 💥
-* typescript/conformance/internalModules/importDeclarations/shadowedInternalModule.ts | 💥
-
-### typescript/conformance/types/any
-* typescript/conformance/types/any/anyAsConstructor.ts | 💥
-* typescript/conformance/types/any/anyAsFunctionCall.ts | 💥
-* typescript/conformance/types/any/anyAsGenericFunctionCall.ts | 💥
-
-### typescript/conformance/types/functions
-* typescript/conformance/types/functions/functionImplementationErrors.ts | 💥
-* typescript/conformance/types/functions/functionImplementations.ts | 💥
-* typescript/conformance/types/functions/functionOverloadErrorsSyntax.ts | 💥
-* typescript/conformance/types/functions/parameterInitializersForwardReferencing.ts | 💥
-
-### typescript/conformance/types/mappedType
-* typescript/conformance/types/mappedType/mappedType.ts | 💥
-
-### typescript/conformance/types/moduleDeclaration
-* typescript/conformance/types/moduleDeclaration/kind-detection.ts | 💥
-
-### typescript/conformance/types/namespaceExportDeclaration
-* typescript/conformance/types/namespaceExportDeclaration/exportAsNamespace.d.ts | 💥
-
-### typescript/conformance/types/parameterProperty
-* typescript/conformance/types/parameterProperty/parameterProperty.ts | 💥
-
-### typescript/conformance/types/tuple
-* typescript/conformance/types/tuple/contextualTypeWithTuple.ts | 💥
-* typescript/conformance/types/tuple/indexerWithTuple.ts | 💥
-* typescript/conformance/types/tuple/typeInferenceWithTupleType.ts | 💥
-* typescript/conformance/types/tuple/wideningTuples1.ts | 💥
-* typescript/conformance/types/tuple/wideningTuples2.ts | 💥
-* typescript/conformance/types/tuple/wideningTuples3.ts | 💥
-* typescript/conformance/types/tuple/wideningTuples5.ts | 💥
-* typescript/conformance/types/tuple/wideningTuples7.ts | 💥
-
-### typescript/conformance/types/tuple/emptyTuples
-* typescript/conformance/types/tuple/emptyTuples/emptyTuplesTypeAssertion02.ts | 💥
-
-### typescript/conformance/types/typeOperator
-* typescript/conformance/types/typeOperator/typeOperator.ts | 💥
-
-### typescript/conformance/types/typeParameter
-* typescript/conformance/types/typeParameter/typeParameter.ts | 💥
-
-### typescript/conformance/types/typeParameters/typeParameterLists
-* typescript/conformance/types/typeParameters/typeParameterLists/innerTypeParameterShadowingOuterOne.ts | 💥
-* typescript/conformance/types/typeParameters/typeParameterLists/innerTypeParameterShadowingOuterOne2.ts | 💥
-* typescript/conformance/types/typeParameters/typeParameterLists/staticMembersUsingClassTypeParameter.ts | 💥
-
-### typescript/conformance/types/union
-* typescript/conformance/types/union/unionTypeCallSignatures.ts | 💥
-* typescript/conformance/types/union/unionTypeCallSignatures3.ts | 💥
-* typescript/conformance/types/union/unionTypeCallSignatures4.ts | 💥
-* typescript/conformance/types/union/unionTypeConstructSignatures.ts | 💥
-* typescript/conformance/types/union/unionTypeEquivalence.ts | 💥
-* typescript/conformance/types/union/unionTypeFromArrayLiteral.ts | 💥
-* typescript/conformance/types/union/unionTypeIndexSignature.ts | 💥
-
-### typescript/const
-* typescript/const/initializer-ambient-context.ts | 💥
-
-### typescript/custom/modifiers
-* typescript/custom/modifiers/minustoken.ts | 💥
-* typescript/custom/modifiers/question.ts | 💥
-* typescript/custom/modifiers/readonly.ts | 💥
-
-### typescript/custom/module
-* typescript/custom/module/global.ts | 💥
-* typescript/custom/module/nestedNamespace.ts | 💥
-
-### typescript/custom/new
-* typescript/custom/new/newKeyword.ts | 💥
-
-### typescript/custom/stability
-* typescript/custom/stability/moduleBlock.ts | 💥
-
-### typescript/custom/typeParameters
-* typescript/custom/typeParameters/callAndConstructSignatureLong.ts | 💥
-* typescript/custom/typeParameters/functionTypeLong.ts | 💥
-* typescript/custom/typeParameters/interfaceParamsLong.ts | 💥
-* typescript/custom/typeParameters/typeParametersLong.ts | 💥
-* typescript/custom/typeParameters/variables.ts | 💥
-
-### typescript/declare
-* typescript/declare/declare_var.ts | 💥
-* typescript/declare/object-type-in-declare-function.ts | 💥
-
-### typescript/decorator-auto-accessors
-* typescript/decorator-auto-accessors/decorator-auto-accessors-type-annotations.ts | 💥
-
-### typescript/decorators
-* typescript/decorators/abstract-method.ts | 💥
-* typescript/decorators/accessor.ts | 💥
-* typescript/decorators/argument-list-preserve-line.ts | 💥
-* typescript/decorators/comments.ts | 💥
-* typescript/decorators/decorator-type-assertion.ts | 💥
-* typescript/decorators/decorators-comments.ts | 💥
-* typescript/decorators/decorators.ts | 💥
-* typescript/decorators/inline-decorators.ts | 💥
-* typescript/decorators/legacy.ts | 💥
-* typescript/decorators/mobx.ts | 💥
-
-### typescript/decorators-ts
-* typescript/decorators-ts/accessor-decorator.ts | 💥
-* typescript/decorators-ts/angular.ts | 💥
-* typescript/decorators-ts/method-decorator.ts | 💥
-* typescript/decorators-ts/mobx.ts | 💥
-* typescript/decorators-ts/multiple.ts | 💥
-* typescript/decorators-ts/parameter-decorator.ts | 💥
-* typescript/decorators-ts/property-decorator.ts | 💥
-* typescript/decorators-ts/typeorm.ts | 💥
-
-### typescript/definite
-* typescript/definite/definite.ts | 💥
-* typescript/definite/without-annotation.ts | 💥
-
-### typescript/end-of-line
-* typescript/end-of-line/multiline.ts | 💥💥💥
-
-### typescript/enum
-* typescript/enum/computed-members.ts | 💥
-* typescript/enum/enum.ts | 💥
-
-### typescript/export
-* typescript/export/comment.ts | 💥
-* typescript/export/export-type-star-from-2.ts | 💥
-
-### typescript/export-default
-* typescript/export-default/function_as.ts | 💥
-
-### typescript/function-type
-* typescript/function-type/consistent.ts | 💥
-* typescript/function-type/type-annotation.ts | 💥
-
-### typescript/functional-composition
-* typescript/functional-composition/pipe-function-calls-with-comments.ts | 💥
-* typescript/functional-composition/pipe-function-calls.ts | 💥
-
-### typescript/generic
-* typescript/generic/arrow-return-type.ts | 💥
-* typescript/generic/issue-6899.ts | 💥
-* typescript/generic/ungrouped-parameters.ts | 💥
-
-### typescript/import-export
-* typescript/import-export/empty-import.ts | 💥
-* typescript/import-export/type-modifier.ts | 💥
-
-### typescript/import-type
-* typescript/import-type/import-type.ts | 💥💥
-
-### typescript/index-signature
-* typescript/index-signature/index-signature.ts | 💥
-* typescript/index-signature/static.ts | 💥
-
-### typescript/infer-extends
-* typescript/infer-extends/basic.ts | 💥
-
-### typescript/instantiation-expression
-* typescript/instantiation-expression/basic.ts | 💥
-* typescript/instantiation-expression/inferface-asi.ts | 💥
-* typescript/instantiation-expression/new.ts | 💥
-* typescript/instantiation-expression/property-access.ts | 💥
-
-### typescript/interface
-* typescript/interface/comments-generic.ts | 💥💥
-* typescript/interface/comments.ts | 💥💥
-* typescript/interface/generic.ts | 💥💥
-* typescript/interface/ignore.ts | 💥💥
-* typescript/interface/long-extends.ts | 💥💥
-
-### typescript/interface/long-type-parameters
-* typescript/interface/long-type-parameters/long-type-parameters.ts | 💥💥
-
-### typescript/interface2
-* typescript/interface2/comments-declare.ts | 💥
-* typescript/interface2/comments.ts | 💥
-
-### typescript/interface2/break
-* typescript/interface2/break/break.ts | 💥💥💥
-
-### typescript/intersection
-* typescript/intersection/type-arguments.ts | 💥💥
-
-### typescript/intersection/consistent-with-flow
-* typescript/intersection/consistent-with-flow/comment.ts | 💥
-* typescript/intersection/consistent-with-flow/intersection-parens.ts | 💥
-
-### typescript/key-remapping-in-mapped-types
-* typescript/key-remapping-in-mapped-types/key-remapping.ts | 💥
-
-### typescript/keyof
-* typescript/keyof/keyof.ts | 💥
-
-### typescript/keyword-types
-* typescript/keyword-types/conditional-types.ts | 💥
-* typescript/keyword-types/keyword-types-with-parens-comments.ts | 💥
-
-### typescript/keywords
-* typescript/keywords/keywords-2.ts | 💥
-* typescript/keywords/module.ts | 💥
-
-### typescript/last-argument-expansion
-* typescript/last-argument-expansion/break.ts | 💥
-* typescript/last-argument-expansion/decorated-function.tsx | 💥
-* typescript/last-argument-expansion/edge_case.ts | 💥
-* typescript/last-argument-expansion/forward-ref.tsx | 💥
-
-### typescript/mapped-type
-* typescript/mapped-type/intersection.ts | 💥
-* typescript/mapped-type/issue-11098.ts | 💥
-* typescript/mapped-type/mapped-type.ts | 💥
-
-### typescript/mapped-type/break-mode
-* typescript/mapped-type/break-mode/break-mode.ts | 💥
-
-### typescript/method
-* typescript/method/issue-10352-consistency.ts | 💥
-
-### typescript/method-chain
-* typescript/method-chain/comment.ts | 💥
-
-### typescript/module
-* typescript/module/empty.ts | 💥
-* typescript/module/global.ts | 💥
-* typescript/module/keyword.ts | 💥
-* typescript/module/module_nested.ts | 💥
-* typescript/module/namespace_nested.ts | 💥
-
-### typescript/multiparser-css
-* typescript/multiparser-css/issue-6259.ts | 💥
-
-### typescript/new
-* typescript/new/new-signature.ts | 💥
-
-### typescript/no-semi
-* typescript/no-semi/no-semi.ts | 💥💥
-* typescript/no-semi/non-null.ts | 💥💥
-
-### typescript/non-null
-* typescript/non-null/braces.ts | 💥
-* typescript/non-null/optional-chain.ts | 💥
-* typescript/non-null/parens.ts | 💥
-
-### typescript/nosemi
-* typescript/nosemi/type.ts | 💥
-
-### typescript/optional-method
-* typescript/optional-method/optional-method.ts | 💥
-
-### typescript/optional-type
-* typescript/optional-type/complex.ts | 💥
-
-### typescript/prettier-ignore
-* typescript/prettier-ignore/issue-14238.ts | 💥
-* typescript/prettier-ignore/mapped-types.ts | 💥
-* typescript/prettier-ignore/prettier-ignore-nested-unions.ts | 💥
-* typescript/prettier-ignore/prettier-ignore-parenthesized-type.ts | 💥
-
-### typescript/private-fields-in-in
-* typescript/private-fields-in-in/basic.ts | 💥
-
-### typescript/rest-type
-* typescript/rest-type/complex.ts | 💥
-* typescript/rest-type/infer-type.ts | 💥
-
-### typescript/satisfies-operators
-* typescript/satisfies-operators/argument-expansion.ts | 💥💥
-* typescript/satisfies-operators/assignment.ts | 💥💥
-* typescript/satisfies-operators/basic.ts | 💥💥
-* typescript/satisfies-operators/comments-unstable.ts | 💥💥
-* typescript/satisfies-operators/comments.ts | 💥💥
-* typescript/satisfies-operators/export-default-as.ts | 💥💥
-* typescript/satisfies-operators/expression-statement.ts | 💥💥
-* typescript/satisfies-operators/gt-lt.ts | 💥💥
-* typescript/satisfies-operators/hug-args.ts | 💥💥
-* typescript/satisfies-operators/lhs.ts | 💥💥
-* typescript/satisfies-operators/nested-await-and-satisfies.ts | 💥💥
-* typescript/satisfies-operators/non-null.ts | 💥💥
-* typescript/satisfies-operators/satisfies.ts | 💥💥
-* typescript/satisfies-operators/template-literal.ts | 💥💥
-* typescript/satisfies-operators/ternary.ts | 💥💥
-* typescript/satisfies-operators/types-comments.ts | 💥💥
-
-### typescript/static-blocks
-* typescript/static-blocks/nested.ts | 💥
-
-### typescript/template-literals
-* typescript/template-literals/as-expression.ts | 💥
-
-### typescript/ternaries
-* typescript/ternaries/indent.ts | 💥
-
-### typescript/test-declarations
-* typescript/test-declarations/test_declarations.ts | 💥💥
-
-### typescript/trailing-comma
-* typescript/trailing-comma/arrow-functions.tsx | 💥💥💥
-* typescript/trailing-comma/trailing.ts | 💥💥💥
-* typescript/trailing-comma/type-arguments.ts | 💥💥💥
-* typescript/trailing-comma/type-parameters-vs-arguments.ts | 💥💥💥
-
-### typescript/tsx
-* typescript/tsx/member-expression.tsx | 💥
-* typescript/tsx/not-react.ts | 💥
-* typescript/tsx/react.tsx | 💥
-* typescript/tsx/type-parameters.tsx | 💥
-* typescript/tsx/url.tsx | 💥
-
-### typescript/tuple
-* typescript/tuple/dangling-comments.ts | 💥💥💥
-* typescript/tuple/trailing-comma-for-empty-tuples.ts | 💥💥💥
-* typescript/tuple/trailing-comma-trailing-rest.ts | 💥💥💥
-* typescript/tuple/trailing-comma.ts | 💥💥💥
-* typescript/tuple/tuple-labeled.ts | 💥💥💥
-* typescript/tuple/tuple-rest-not-last.ts | 💥💥💥
-* typescript/tuple/tuple.ts | 💥💥💥
-
-### typescript/type-alias
-* typescript/type-alias/conditional.ts | 💥
-* typescript/type-alias/issue-100857.ts | 💥
-* typescript/type-alias/issue-9874.ts | 💥
-
-### typescript/type-arguments-bit-shift-left-like
-* typescript/type-arguments-bit-shift-left-like/1.ts | 💥
-* typescript/type-arguments-bit-shift-left-like/3.ts | 💥
-* typescript/type-arguments-bit-shift-left-like/4.ts | 💥
-* typescript/type-arguments-bit-shift-left-like/5.tsx | 💥
-
-### typescript/type-member-get-set
-* typescript/type-member-get-set/type-member-get-set.ts | 💥
-
-### typescript/type-only-module-specifiers
-* typescript/type-only-module-specifiers/basic.ts | 💥
-
-### typescript/typeof
-* typescript/typeof/typeof.ts | 💥
-
-### typescript/typeof-this
-* typescript/typeof-this/decorators.ts | 💥
-* typescript/typeof-this/typeof-this.ts | 💥
-
-### typescript/typeparams
-* typescript/typeparams/class-method.ts | 💥
-* typescript/typeparams/const.ts | 💥
-* typescript/typeparams/line-breaking-after-extends-2.ts | 💥
-* typescript/typeparams/line-breaking-after-extends.ts | 💥
-* typescript/typeparams/long-function-arg.ts | 💥
-* typescript/typeparams/tagged-template-expression.ts | 💥
-
-### typescript/typeparams/empty-parameters-with-arrow-function
-* typescript/typeparams/empty-parameters-with-arrow-function/issue-13817.ts | 💥
-
-### typescript/typeparams/print-width-120
-* typescript/typeparams/print-width-120/issue-7542.tsx | 💥
-
-### typescript/typeparams/trailing-comma
-* typescript/typeparams/trailing-comma/type-paramters.ts | 💥💥💥
-
-### typescript/union
-* typescript/union/comments.ts | 💥
-* typescript/union/inlining.ts | 💥
-* typescript/union/union-parens.ts | 💥
-* typescript/union/with-type-params.ts | 💥
-
-### typescript/union/consistent-with-flow
-* typescript/union/consistent-with-flow/comment.ts | 💥
-* typescript/union/consistent-with-flow/comments.ts | 💥
-* typescript/union/consistent-with-flow/prettier-ignore.ts | 💥
-* typescript/union/consistent-with-flow/single-type.ts | 💥
-* typescript/union/consistent-with-flow/within-tuple.ts | 💥
-
-### typescript/union/single-type
-* typescript/union/single-type/single-type.ts | 💥
-
-### typescript/update-expression
-* typescript/update-expression/update-expressions.ts | 💥
-
-### typescript/webhost
-* typescript/webhost/webtsc.ts | 💥
+| Spec path | Failed or Passed | Match ratio |
+| :-------- | :--------------: | :---------: |
+| jsx/attr-element/attr-element.js | 💥 | 0.00% |
+| jsx/binary-expressions/relational-operators.js | 💥 | 78.95% |
+| jsx/comments/eslint-disable.js | 💥 | 0.00% |
+| jsx/comments/in-attributes.js | 💥 | 41.67% |
+| jsx/comments/in-end-tag.js | 💥 | 17.07% |
+| jsx/comments/in-tags.js | 💥 | 54.55% |
+| jsx/comments/jsx-tag-comment-after-prop.js | 💥 | 26.67% |
+| jsx/comments/like-a-comment-in-jsx-text.js | 💥 | 0.00% |
+| jsx/deprecated-jsx-bracket-same-line-option/jsx.js | 💥💥💥💥 | 45.33% |
+| jsx/embed/css-embed.js | 💥 | 0.00% |
+| jsx/escape/nbsp.js | 💥 | 70.00% |
+| jsx/expression-with-types/expression.js | 💥💥💥💥 | 0.00% |
+| jsx/fbt/test.js | 💥 | 48.11% |
+| jsx/fragment/fragment.js | 💥 | 79.14% |
+| jsx/ignore/jsx_ignore.js | 💥 | 60.22% |
+| jsx/jsx/array-iter.js | 💥💥💥💥 | 20.97% |
+| jsx/jsx/arrow.js | 💥💥💥💥 | 29.17% |
+| jsx/jsx/attr-comments.js | 💥💥💥💥 | 0.00% |
+| jsx/jsx/await.js | 💥💥💥💥 | 16.47% |
+| jsx/jsx/conditional-expression.js | 💥💥💥💥 | 27.27% |
+| jsx/jsx/expression.js | 💥💥💥💥 | 32.74% |
+| jsx/jsx/flow_fix_me.js | 💥💥💥💥 | 0.00% |
+| jsx/jsx/html_escape.js | 💥💥✨✨ | 16.67% |
+| jsx/jsx/hug.js | 💥💥💥💥 | 33.85% |
+| jsx/jsx/logical-expression.js | 💥💥💥💥 | 35.82% |
+| jsx/jsx/object-property.js | 💥💥💥💥 | 52.63% |
+| jsx/jsx/open-break.js | 💥💥💥💥 | 21.43% |
+| jsx/jsx/parens.js | 💥💥💥💥 | 50.00% |
+| jsx/jsx/quotes.js | 💥💥💥💥 | 42.55% |
+| jsx/jsx/regex.js | 💥💥💥💥 | 75.00% |
+| jsx/jsx/return-statement.js | 💥💥💥💥 | 72.92% |
+| jsx/jsx/spacing.js | 💥💥💥💥 | 22.22% |
+| jsx/jsx/template-literal-in-attr.js | 💥💥💥💥 | 26.67% |
+| jsx/last-line/last_line.js | 💥💥 | 44.51% |
+| jsx/last-line/single_prop_multiline_string.js | 💥💥 | 22.88% |
+| jsx/multiline-assign/test.js | 💥 | 34.62% |
+| jsx/newlines/test.js | 💥 | 41.96% |
+| jsx/newlines/windows.js | 💥 | 0.00% |
+| jsx/optional-chaining/optional-chaining.jsx | 💥 | 18.18% |
+| jsx/significant-space/comments.js | 💥 | 40.00% |
+| jsx/significant-space/test.js | 💥 | 32.09% |
+| jsx/single-attribute-per-line/single-attribute-per-line.js | 💥💥 | 55.77% |
+| jsx/split-attrs/test.js | 💥 | 13.57% |
+| jsx/spread/attribute.js | 💥 | 30.19% |
+| jsx/spread/child.js | 💥 | 26.67% |
+| jsx/stateless-arrow-fn/test.js | 💥 | 14.79% |
+| jsx/text-wrap/test.js | 💥 | 38.20% |
+| typescript/ambient/ambient.ts | 💥 | 88.24% |
+| typescript/angular-component-examples/15934-computed.component.ts | 💥💥 | 61.54% |
+| typescript/angular-component-examples/15934.component.ts | 💥💥 | 38.46% |
+| typescript/angular-component-examples/15969-computed.component.ts | 💥💥 | 75.00% |
+| typescript/angular-component-examples/test.component.ts | 💥💥 | 41.18% |
+| typescript/argument-expansion/argument_expansion.ts | 💥 | 92.56% |
+| typescript/argument-expansion/arrow-with-return-type.ts | 💥 | 21.21% |
+| typescript/array/comment.ts | 💥 | 76.92% |
+| typescript/arrow/16067.ts | 💥💥 | 21.88% |
+| typescript/arrow/arrow_regression.ts | 💥💥 | 60.87% |
+| typescript/arrow/comments.ts | 💥💥 | 62.50% |
+| typescript/arrow/issue-6107-curry.ts | 💥💥 | 12.90% |
+| typescript/arrows/arrow_function_expression.ts | 💥✨ | 0.00% |
+| typescript/arrows/type_params.ts | 💥✨ | 0.00% |
+| typescript/as/as.ts | 💥 | 55.38% |
+| typescript/as/assignment2.ts | 💥 | 67.61% |
+| typescript/as/export_default_as.ts | 💥 | 0.00% |
+| typescript/as/expression-statement.ts | 💥 | 57.14% |
+| typescript/as/long-identifiers.ts | 💥 | 88.89% |
+| typescript/as/nested-await-and-as.ts | 💥 | 0.00% |
+| typescript/as/ternary.ts | 💥 | 37.78% |
+| typescript/assert/comment.ts | 💥 | 0.00% |
+| typescript/assignment/issue-10846.ts | 💥 | 63.16% |
+| typescript/assignment/issue-10848.tsx | 💥 | 39.44% |
+| typescript/assignment/issue-10850.ts | 💥 | 50.00% |
+| typescript/assignment/parenthesized.ts | 💥 | 18.18% |
+| typescript/call-signature/call-signature.ts | 💥 | 86.44% |
+| typescript/cast/as-const.ts | 💥 | 44.44% |
+| typescript/cast/assert-and-assign.ts | 💥 | 0.00% |
+| typescript/cast/generic-cast.ts | 💥 | 38.38% |
+| typescript/cast/hug-args.ts | 💥 | 21.05% |
+| typescript/cast/parenthesis.ts | 💥 | 66.67% |
+| typescript/cast/tuple-and-record.ts | 💥 | 0.00% |
+| typescript/chain-expression/call-expression.ts | 💥 | 24.59% |
+| typescript/chain-expression/member-expression.ts | 💥 | 21.88% |
+| typescript/chain-expression/test.ts | 💥 | 0.00% |
+| typescript/class/constructor.ts | 💥 | 96.15% |
+| typescript/class/empty-method-body.ts | 💥 | 58.82% |
+| typescript/class/extends_implements.ts | 💥 | 71.11% |
+| typescript/class/generics.ts | 💥 | 80.00% |
+| typescript/class/issue-16723.ts | 💥 | 77.78% |
+| typescript/class/parameter-properties.ts | 💥 | 65.12% |
+| typescript/class/quoted-property.ts | 💥 | 66.67% |
+| typescript/class-comment/class-implements.ts | 💥 | 64.47% |
+| typescript/class-comment/declare.ts | 💥 | 42.11% |
+| typescript/class-comment/generic.ts | 💥 | 78.26% |
+| typescript/class-comment/misc.ts | 💥 | 66.67% |
+| typescript/classes/break-heritage.ts | 💥 | 98.36% |
+| typescript/classes/break.ts | 💥 | 95.56% |
+| typescript/comments/15707.ts | 💥 | 38.96% |
+| typescript/comments/16065-2.ts | 💥 | 46.51% |
+| typescript/comments/16065.ts | 💥 | 77.78% |
+| typescript/comments/abstract_class.ts | 💥 | 54.55% |
+| typescript/comments/abstract_methods.ts | 💥 | 25.00% |
+| typescript/comments/after_jsx_generic.tsx | 💥 | 10.81% |
+| typescript/comments/declare_function.ts | 💥 | 22.22% |
+| typescript/comments/interface.ts | 💥 | 21.62% |
+| typescript/comments/issues.ts | 💥 | 13.11% |
+| typescript/comments/jsx.tsx | 💥 | 20.00% |
+| typescript/comments/location.ts | 💥 | 76.47% |
+| typescript/comments/mapped_types.ts | 💥 | 36.92% |
+| typescript/comments/method_types.ts | 💥 | 64.10% |
+| typescript/comments/methods.ts | 💥 | 42.42% |
+| typescript/comments/ts-parameter-proerty.ts | 💥 | 44.44% |
+| typescript/comments/type-parameters.ts | 💥 | 20.83% |
+| typescript/comments/type_literals.ts | 💥 | 61.54% |
+| typescript/comments/types.ts | 💥 | 0.00% |
+| typescript/comments/union.ts | 💥 | 7.69% |
+| typescript/comments-2/dangling.ts | 💥💥 | 0.00% |
+| typescript/comments-2/issues.ts | 💥💥 | 88.89% |
+| typescript/comments-2/last-arg.ts | 💥💥 | 57.50% |
+| typescript/compiler/anyIsAssignableToObject.ts | 💥 | 93.33% |
+| typescript/compiler/castOfAwait.ts | 💥 | 80.00% |
+| typescript/compiler/castParentheses.ts | 💥 | 54.55% |
+| typescript/compiler/checkInfiniteExpansionTermination.ts | 💥 | 83.33% |
+| typescript/compiler/commentInNamespaceDeclarationWithIdentifierPathName.ts | 💥 | 20.00% |
+| typescript/compiler/commentsInterface.ts | 💥 | 66.67% |
+| typescript/compiler/contextualSignatureInstantiation2.ts | 💥 | 40.00% |
+| typescript/compiler/declareDottedModuleName.ts | 💥 | 51.85% |
+| typescript/compiler/es5ExportDefaultClassDeclaration4.ts | 💥 | 69.57% |
+| typescript/compiler/functionOverloadsOnGenericArity1.ts | 💥 | 84.21% |
+| typescript/compiler/indexSignatureWithInitializer.ts | 💥 | 66.67% |
+| typescript/compiler/mappedTypeWithCombinedTypeMappers.ts | 💥 | 56.25% |
+| typescript/compiler/privacyGloImport.ts | 💥 | 73.19% |
+| typescript/conditional-types/comments.ts | 💥💥 | 17.81% |
+| typescript/conditional-types/conditonal-types.ts | 💥💥 | 39.21% |
+| typescript/conditional-types/infer-type.ts | 💥💥 | 21.67% |
+| typescript/conditional-types/nested-in-condition.ts | 💥💥 | 11.96% |
+| typescript/conditional-types/new-ternary-spec.ts | 💥💥 | 12.63% |
+| typescript/conditional-types/parentheses.ts | 💥💥 | 14.54% |
+| typescript/conformance/classes/mixinAccessModifiers.ts | 💥 | 88.68% |
+| typescript/conformance/classes/mixinClassesAnnotated.ts | 💥 | 78.79% |
+| typescript/conformance/classes/mixinClassesAnonymous.ts | 💥 | 79.41% |
+| typescript/conformance/classes/mixinClassesMembers.ts | 💥 | 99.00% |
+| typescript/conformance/classes/nestedClassDeclaration.ts | 💥 | 87.50% |
+| typescript/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsItselfIndirectly.ts | 💥 | 91.30% |
+| typescript/conformance/classes/constructorDeclarations/constructorParameters/constructorImplementationWithDefaultValues2.ts | 💥 | 88.37% |
+| typescript/conformance/classes/constructorDeclarations/constructorParameters/constructorParameterProperties.ts | 💥 | 55.32% |
+| typescript/conformance/classes/constructorDeclarations/constructorParameters/constructorParameterProperties2.ts | 💥 | 90.32% |
+| typescript/conformance/classes/constructorDeclarations/constructorParameters/declarationEmitReadonly.ts | 💥 | 75.00% |
+| typescript/conformance/classes/constructorDeclarations/constructorParameters/readonlyConstructorAssignment.ts | 💥 | 91.43% |
+| typescript/conformance/comments/comments.ts | 💥 | 0.00% |
+| typescript/conformance/declarationEmit/typePredicates/declarationEmitThisPredicatesWithPrivateName01.ts | 💥 | 82.35% |
+| typescript/conformance/es6/Symbols/symbolProperty15.ts | 💥 | 96.55% |
+| typescript/conformance/es6/templates/templateStringWithEmbeddedTypeAssertionOnAdditionES6.ts | 💥 | 0.00% |
+| typescript/conformance/expressions/asOperator/asOperatorContextualType.ts | 💥 | 0.00% |
+| typescript/conformance/expressions/functionCalls/callWithSpreadES6.ts | 💥 | 95.83% |
+| typescript/conformance/internalModules/importDeclarations/circularImportAlias.ts | 💥 | 94.12% |
+| typescript/conformance/internalModules/importDeclarations/exportImportAlias.ts | 💥 | 88.72% |
+| typescript/conformance/internalModules/importDeclarations/importAliasIdentifiers.ts | 💥 | 94.85% |
+| typescript/conformance/internalModules/importDeclarations/invalidImportAliasIdentifiers.ts | 💥 | 95.65% |
+| typescript/conformance/internalModules/importDeclarations/shadowedInternalModule.ts | 💥 | 93.55% |
+| typescript/conformance/types/any/anyAsConstructor.ts | 💥 | 62.50% |
+| typescript/conformance/types/any/anyAsFunctionCall.ts | 💥 | 72.73% |
+| typescript/conformance/types/any/anyAsGenericFunctionCall.ts | 💥 | 86.96% |
+| typescript/conformance/types/functions/functionImplementationErrors.ts | 💥 | 94.12% |
+| typescript/conformance/types/functions/functionImplementations.ts | 💥 | 87.15% |
+| typescript/conformance/types/functions/functionOverloadErrorsSyntax.ts | 💥 | 77.78% |
+| typescript/conformance/types/functions/parameterInitializersForwardReferencing.ts | 💥 | 97.14% |
+| typescript/conformance/types/mappedType/mappedType.ts | 💥 | 50.00% |
+| typescript/conformance/types/moduleDeclaration/kind-detection.ts | 💥 | 0.00% |
+| typescript/conformance/types/namespaceExportDeclaration/exportAsNamespace.d.ts | 💥 | 66.67% |
+| typescript/conformance/types/parameterProperty/parameterProperty.ts | 💥 | 50.00% |
+| typescript/conformance/types/tuple/contextualTypeWithTuple.ts | 💥 | 95.83% |
+| typescript/conformance/types/tuple/indexerWithTuple.ts | 💥 | 22.22% |
+| typescript/conformance/types/tuple/typeInferenceWithTupleType.ts | 💥 | 78.26% |
+| typescript/conformance/types/tuple/wideningTuples1.ts | 💥 | 88.89% |
+| typescript/conformance/types/tuple/wideningTuples2.ts | 💥 | 90.91% |
+| typescript/conformance/types/tuple/wideningTuples3.ts | 💥 | 85.71% |
+| typescript/conformance/types/tuple/wideningTuples5.ts | 💥 | 66.67% |
+| typescript/conformance/types/tuple/wideningTuples7.ts | 💥 | 88.89% |
+| typescript/conformance/types/tuple/emptyTuples/emptyTuplesTypeAssertion02.ts | 💥 | 66.67% |
+| typescript/conformance/types/typeOperator/typeOperator.ts | 💥 | 0.00% |
+| typescript/conformance/types/typeParameter/typeParameter.ts | 💥 | 66.67% |
+| typescript/conformance/types/typeParameters/typeParameterLists/innerTypeParameterShadowingOuterOne.ts | 💥 | 75.56% |
+| typescript/conformance/types/typeParameters/typeParameterLists/innerTypeParameterShadowingOuterOne2.ts | 💥 | 76.67% |
+| typescript/conformance/types/typeParameters/typeParameterLists/staticMembersUsingClassTypeParameter.ts | 💥 | 96.55% |
+| typescript/conformance/types/union/unionTypeCallSignatures.ts | 💥 | 27.08% |
+| typescript/conformance/types/union/unionTypeCallSignatures3.ts | 💥 | 55.17% |
+| typescript/conformance/types/union/unionTypeCallSignatures4.ts | 💥 | 80.00% |
+| typescript/conformance/types/union/unionTypeConstructSignatures.ts | 💥 | 22.83% |
+| typescript/conformance/types/union/unionTypeEquivalence.ts | 💥 | 81.08% |
+| typescript/conformance/types/union/unionTypeFromArrayLiteral.ts | 💥 | 59.65% |
+| typescript/conformance/types/union/unionTypeIndexSignature.ts | 💥 | 22.64% |
+| typescript/const/initializer-ambient-context.ts | 💥 | 96.55% |
+| typescript/custom/modifiers/minustoken.ts | 💥 | 20.00% |
+| typescript/custom/modifiers/question.ts | 💥 | 0.00% |
+| typescript/custom/modifiers/readonly.ts | 💥 | 0.00% |
+| typescript/custom/module/global.ts | 💥 | 80.00% |
+| typescript/custom/module/nestedNamespace.ts | 💥 | 66.67% |
+| typescript/custom/new/newKeyword.ts | 💥 | 85.71% |
+| typescript/custom/stability/moduleBlock.ts | 💥 | 97.56% |
+| typescript/custom/typeParameters/callAndConstructSignatureLong.ts | 💥 | 19.05% |
+| typescript/custom/typeParameters/functionTypeLong.ts | 💥 | 57.14% |
+| typescript/custom/typeParameters/interfaceParamsLong.ts | 💥 | 0.00% |
+| typescript/custom/typeParameters/typeParametersLong.ts | 💥 | 0.00% |
+| typescript/custom/typeParameters/variables.ts | 💥 | 85.25% |
+| typescript/declare/declare_var.ts | 💥 | 75.00% |
+| typescript/declare/object-type-in-declare-function.ts | 💥 | 77.78% |
+| typescript/decorator-auto-accessors/decorator-auto-accessors-type-annotations.ts | 💥 | 25.00% |
+| typescript/decorators/abstract-method.ts | 💥 | 85.71% |
+| typescript/decorators/accessor.ts | 💥 | 85.71% |
+| typescript/decorators/argument-list-preserve-line.ts | 💥 | 85.71% |
+| typescript/decorators/comments.ts | 💥 | 88.89% |
+| typescript/decorators/decorator-type-assertion.ts | 💥 | 60.00% |
+| typescript/decorators/decorators-comments.ts | 💥 | 83.33% |
+| typescript/decorators/decorators.ts | 💥 | 61.11% |
+| typescript/decorators/inline-decorators.ts | 💥 | 68.75% |
+| typescript/decorators/legacy.ts | 💥 | 85.71% |
+| typescript/decorators/mobx.ts | 💥 | 66.67% |
+| typescript/decorators-ts/accessor-decorator.ts | 💥 | 94.12% |
+| typescript/decorators-ts/angular.ts | 💥 | 33.33% |
+| typescript/decorators-ts/method-decorator.ts | 💥 | 95.24% |
+| typescript/decorators-ts/mobx.ts | 💥 | 75.00% |
+| typescript/decorators-ts/multiple.ts | 💥 | 75.00% |
+| typescript/decorators-ts/parameter-decorator.ts | 💥 | 81.25% |
+| typescript/decorators-ts/property-decorator.ts | 💥 | 86.96% |
+| typescript/decorators-ts/typeorm.ts | 💥 | 90.00% |
+| typescript/definite/definite.ts | 💥 | 71.43% |
+| typescript/definite/without-annotation.ts | 💥 | 58.33% |
+| typescript/end-of-line/multiline.ts | 💥💥💥 | 29.27% |
+| typescript/enum/computed-members.ts | 💥 | 0.00% |
+| typescript/enum/enum.ts | 💥 | 95.45% |
+| typescript/export/comment.ts | 💥 | 50.00% |
+| typescript/export/export-type-star-from-2.ts | 💥 | 50.00% |
+| typescript/export-default/function_as.ts | 💥 | 0.00% |
+| typescript/function-type/consistent.ts | 💥 | 19.51% |
+| typescript/function-type/type-annotation.ts | 💥 | 0.00% |
+| typescript/functional-composition/pipe-function-calls-with-comments.ts | 💥 | 31.43% |
+| typescript/functional-composition/pipe-function-calls.ts | 💥 | 30.77% |
+| typescript/generic/arrow-return-type.ts | 💥 | 80.77% |
+| typescript/generic/issue-6899.ts | 💥 | 20.00% |
+| typescript/generic/ungrouped-parameters.ts | 💥 | 58.33% |
+| typescript/import-export/empty-import.ts | 💥 | 12.50% |
+| typescript/import-export/type-modifier.ts | 💥 | 96.55% |
+| typescript/import-type/import-type.ts | 💥💥 | 92.86% |
+| typescript/index-signature/index-signature.ts | 💥 | 50.00% |
+| typescript/index-signature/static.ts | 💥 | 66.67% |
+| typescript/infer-extends/basic.ts | 💥 | 8.70% |
+| typescript/instantiation-expression/basic.ts | 💥 | 66.67% |
+| typescript/instantiation-expression/inferface-asi.ts | 💥 | 88.89% |
+| typescript/instantiation-expression/new.ts | 💥 | 66.67% |
+| typescript/instantiation-expression/property-access.ts | 💥 | 7.14% |
+| typescript/interface/comments-generic.ts | 💥💥 | 15.79% |
+| typescript/interface/comments.ts | 💥💥 | 85.71% |
+| typescript/interface/generic.ts | 💥💥 | 18.18% |
+| typescript/interface/ignore.ts | 💥💥 | 74.21% |
+| typescript/interface/long-extends.ts | 💥💥 | 65.22% |
+| typescript/interface/long-type-parameters/long-type-parameters.ts | 💥💥 | 0.00% |
+| typescript/interface2/comments-declare.ts | 💥 | 50.00% |
+| typescript/interface2/comments.ts | 💥 | 59.02% |
+| typescript/interface2/break/break.ts | 💥💥💥 | 50.67% |
+| typescript/intersection/type-arguments.ts | 💥💥 | 16.00% |
+| typescript/intersection/consistent-with-flow/comment.ts | 💥 | 0.00% |
+| typescript/intersection/consistent-with-flow/intersection-parens.ts | 💥 | 32.56% |
+| typescript/key-remapping-in-mapped-types/key-remapping.ts | 💥 | 25.00% |
+| typescript/keyof/keyof.ts | 💥 | 20.00% |
+| typescript/keyword-types/conditional-types.ts | 💥 | 0.00% |
+| typescript/keyword-types/keyword-types-with-parens-comments.ts | 💥 | 0.00% |
+| typescript/keywords/keywords-2.ts | 💥 | 96.97% |
+| typescript/keywords/module.ts | 💥 | 91.67% |
+| typescript/last-argument-expansion/break.ts | 💥 | 36.36% |
+| typescript/last-argument-expansion/decorated-function.tsx | 💥 | 71.67% |
+| typescript/last-argument-expansion/edge_case.ts | 💥 | 0.00% |
+| typescript/last-argument-expansion/forward-ref.tsx | 💥 | 35.09% |
+| typescript/mapped-type/intersection.ts | 💥 | 0.00% |
+| typescript/mapped-type/issue-11098.ts | 💥 | 26.09% |
+| typescript/mapped-type/mapped-type.ts | 💥 | 33.33% |
+| typescript/mapped-type/break-mode/break-mode.ts | 💥 | 0.00% |
+| typescript/method/issue-10352-consistency.ts | 💥 | 55.81% |
+| typescript/method-chain/comment.ts | 💥 | 0.00% |
+| typescript/module/empty.ts | 💥 | 0.00% |
+| typescript/module/global.ts | 💥 | 50.00% |
+| typescript/module/keyword.ts | 💥 | 91.43% |
+| typescript/module/module_nested.ts | 💥 | 25.93% |
+| typescript/module/namespace_nested.ts | 💥 | 25.93% |
+| typescript/multiparser-css/issue-6259.ts | 💥 | 13.33% |
+| typescript/new/new-signature.ts | 💥 | 92.80% |
+| typescript/no-semi/no-semi.ts | 💥💥 | 78.95% |
+| typescript/no-semi/non-null.ts | 💥💥 | 40.00% |
+| typescript/non-null/braces.ts | 💥 | 54.55% |
+| typescript/non-null/optional-chain.ts | 💥 | 72.22% |
+| typescript/non-null/parens.ts | 💥 | 61.22% |
+| typescript/nosemi/type.ts | 💥 | 88.89% |
+| typescript/optional-method/optional-method.ts | 💥 | 84.21% |
+| typescript/optional-type/complex.ts | 💥 | 0.00% |
+| typescript/prettier-ignore/issue-14238.ts | 💥 | 0.00% |
+| typescript/prettier-ignore/mapped-types.ts | 💥 | 26.83% |
+| typescript/prettier-ignore/prettier-ignore-nested-unions.ts | 💥 | 7.69% |
+| typescript/prettier-ignore/prettier-ignore-parenthesized-type.ts | 💥 | 0.00% |
+| typescript/private-fields-in-in/basic.ts | 💥 | 68.75% |
+| typescript/rest-type/complex.ts | 💥 | 0.00% |
+| typescript/rest-type/infer-type.ts | 💥 | 58.33% |
+| typescript/satisfies-operators/argument-expansion.ts | 💥💥 | 80.00% |
+| typescript/satisfies-operators/assignment.ts | 💥💥 | 63.83% |
+| typescript/satisfies-operators/basic.ts | 💥💥 | 84.48% |
+| typescript/satisfies-operators/comments-unstable.ts | 💥💥 | 72.73% |
+| typescript/satisfies-operators/comments.ts | 💥💥 | 0.00% |
+| typescript/satisfies-operators/export-default-as.ts | 💥💥 | 0.00% |
+| typescript/satisfies-operators/expression-statement.ts | 💥💥 | 70.83% |
+| typescript/satisfies-operators/gt-lt.ts | 💥💥 | 0.00% |
+| typescript/satisfies-operators/hug-args.ts | 💥💥 | 0.00% |
+| typescript/satisfies-operators/lhs.ts | 💥💥 | 40.00% |
+| typescript/satisfies-operators/nested-await-and-satisfies.ts | 💥💥 | 0.00% |
+| typescript/satisfies-operators/non-null.ts | 💥💥 | 40.00% |
+| typescript/satisfies-operators/satisfies.ts | 💥💥 | 50.00% |
+| typescript/satisfies-operators/template-literal.ts | 💥💥 | 0.00% |
+| typescript/satisfies-operators/ternary.ts | 💥💥 | 37.78% |
+| typescript/satisfies-operators/types-comments.ts | 💥💥 | 0.00% |
+| typescript/static-blocks/nested.ts | 💥 | 83.33% |
+| typescript/template-literals/as-expression.ts | 💥 | 0.00% |
+| typescript/ternaries/indent.ts | 💥 | 23.30% |
+| typescript/test-declarations/test_declarations.ts | 💥💥 | 0.00% |
+| typescript/trailing-comma/arrow-functions.tsx | 💥💥💥 | 0.00% |
+| typescript/trailing-comma/trailing.ts | 💥💥💥 | 83.33% |
+| typescript/trailing-comma/type-arguments.ts | 💥💥💥 | 10.53% |
+| typescript/trailing-comma/type-parameters-vs-arguments.ts | 💥💥💥 | 66.67% |
+| typescript/tsx/member-expression.tsx | 💥 | 20.00% |
+| typescript/tsx/not-react.ts | 💥 | 85.71% |
+| typescript/tsx/react.tsx | 💥 | 40.00% |
+| typescript/tsx/type-parameters.tsx | 💥 | 95.24% |
+| typescript/tsx/url.tsx | 💥 | 58.06% |
+| typescript/tuple/dangling-comments.ts | 💥💥💥 | 27.03% |
+| typescript/tuple/trailing-comma-for-empty-tuples.ts | 💥💥💥 | 20.00% |
+| typescript/tuple/trailing-comma-trailing-rest.ts | 💥💥💥 | 87.50% |
+| typescript/tuple/trailing-comma.ts | 💥💥💥 | 90.48% |
+| typescript/tuple/tuple-labeled.ts | 💥💥💥 | 92.86% |
+| typescript/tuple/tuple-rest-not-last.ts | 💥💥💥 | 50.00% |
+| typescript/tuple/tuple.ts | 💥💥💥 | 12.50% |
+| typescript/type-alias/conditional.ts | 💥 | 22.73% |
+| typescript/type-alias/issue-100857.ts | 💥 | 75.36% |
+| typescript/type-alias/issue-9874.ts | 💥 | 0.00% |
+| typescript/type-arguments-bit-shift-left-like/1.ts | 💥 | 0.00% |
+| typescript/type-arguments-bit-shift-left-like/3.ts | 💥 | 0.00% |
+| typescript/type-arguments-bit-shift-left-like/4.ts | 💥 | 0.00% |
+| typescript/type-arguments-bit-shift-left-like/5.tsx | 💥 | 0.00% |
+| typescript/type-member-get-set/type-member-get-set.ts | 💥 | 61.54% |
+| typescript/type-only-module-specifiers/basic.ts | 💥 | 55.56% |
+| typescript/typeof/typeof.ts | 💥 | 25.00% |
+| typescript/typeof-this/decorators.ts | 💥 | 90.91% |
+| typescript/typeof-this/typeof-this.ts | 💥 | 80.00% |
+| typescript/typeparams/class-method.ts | 💥 | 77.53% |
+| typescript/typeparams/const.ts | 💥 | 15.62% |
+| typescript/typeparams/line-breaking-after-extends-2.ts | 💥 | 19.23% |
+| typescript/typeparams/line-breaking-after-extends.ts | 💥 | 17.14% |
+| typescript/typeparams/long-function-arg.ts | 💥 | 45.71% |
+| typescript/typeparams/tagged-template-expression.ts | 💥 | 60.00% |
+| typescript/typeparams/empty-parameters-with-arrow-function/issue-13817.ts | 💥 | 30.00% |
+| typescript/typeparams/print-width-120/issue-7542.tsx | 💥 | 76.47% |
+| typescript/typeparams/trailing-comma/type-paramters.ts | 💥💥💥 | 28.57% |
+| typescript/union/comments.ts | 💥 | 15.38% |
+| typescript/union/inlining.ts | 💥 | 43.86% |
+| typescript/union/union-parens.ts | 💥 | 38.00% |
+| typescript/union/with-type-params.ts | 💥 | 0.00% |
+| typescript/union/consistent-with-flow/comment.ts | 💥 | 0.00% |
+| typescript/union/consistent-with-flow/comments.ts | 💥 | 10.00% |
+| typescript/union/consistent-with-flow/prettier-ignore.ts | 💥 | 13.33% |
+| typescript/union/consistent-with-flow/single-type.ts | 💥 | 3.92% |
+| typescript/union/consistent-with-flow/within-tuple.ts | 💥 | 37.59% |
+| typescript/union/single-type/single-type.ts | 💥 | 66.67% |
+| typescript/update-expression/update-expressions.ts | 💥 | 77.42% |
+| typescript/webhost/webtsc.ts | 💥 | 5.61% |

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -264,7 +264,6 @@ fn test_snapshots(
                     print_with_border(&format!("OxcOutput: {}LoC", actual.lines().count()));
                     println!("{actual}");
                     print_with_border("Diff");
-
                     oxc_tasks_common::print_diff_in_terminal(&diff);
                 }
                 println!();

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -8,6 +8,7 @@ use std::path::{Path, PathBuf};
 
 use cow_utils::CowUtils;
 use rustc_hash::FxHashSet;
+use similar::TextDiff;
 use walkdir::WalkDir;
 
 use oxc_allocator::Allocator;
@@ -74,7 +75,9 @@ impl TestRunner {
         let mut total_failed_file_count = 0;
         let mut failed_reports = String::new();
         failed_reports.push_str("# Failed\n");
-
+        failed_reports.push('\n');
+        failed_reports.push_str("| Spec path | Failed or Passed | Match ratio |\n");
+        failed_reports.push_str("| :-------- | :--------------: | :---------: |\n");
         for dir in &test_dirs {
             let inputs = collect_test_files(dir, None);
             let failed_test_files = test_snapshots(dir, &inputs, false);
@@ -82,21 +85,14 @@ impl TestRunner {
             total_tested_file_count += inputs.len();
             total_failed_file_count += failed_test_files.len();
 
-            if !failed_test_files.is_empty() {
-                // Use dir as header
+            for (path, (failed, passed, ratio)) in failed_test_files {
                 failed_reports.push_str(&format!(
-                    "\n### {}\n",
-                    &dir.strip_prefix(fixtures_root()).unwrap().to_string_lossy()
+                    "| {} | {}{} | {:.2}% |\n",
+                    path.strip_prefix(fixtures_root()).unwrap().to_string_lossy(),
+                    "💥".repeat(failed),
+                    "✨".repeat(passed),
+                    ratio * 100.0
                 ));
-                // Each failed test file
-                for (path, (failed, passed)) in failed_test_files {
-                    failed_reports.push_str(&format!(
-                        "* {} | {}{}\n",
-                        path.strip_prefix(fixtures_root()).unwrap().to_string_lossy(),
-                        "💥".repeat(failed),
-                        "✨".repeat(passed),
-                    ));
-                }
             }
         }
 
@@ -191,7 +187,7 @@ fn test_snapshots(
     dir: &Path,
     test_files: &Vec<PathBuf>,
     has_debug_filter: bool,
-) -> Vec<(PathBuf, (usize, usize))> {
+) -> Vec<(PathBuf, (usize, usize, f32))> {
     // Parse all `runFormatTest()` calls and collect format options
     let spec_path = &dir.join(FORMAT_TEST_SPEC_NAME);
     let spec_calls = parse_spec(spec_path);
@@ -210,6 +206,7 @@ fn test_snapshots(
         let source_text = std::fs::read_to_string(path).unwrap();
 
         let mut failed_count = 0;
+        let mut total_diff_ratio = 0.0;
         // Check every combination of options!
         for (prettier_options, snapshot_options) in &spec_calls {
             // Single snapshot file contains multiple test cases, so need to find the right one
@@ -231,9 +228,11 @@ fn test_snapshots(
             );
 
             let result = expected == actual;
+            let diff = TextDiff::from_lines(&expected, &actual);
 
             if !result {
                 failed_count += 1;
+                total_diff_ratio += diff.ratio();
             }
 
             if has_debug_filter {
@@ -265,15 +264,22 @@ fn test_snapshots(
                     print_with_border(&format!("OxcOutput: {}LoC", actual.lines().count()));
                     println!("{actual}");
                     print_with_border("Diff");
-                    oxc_tasks_common::print_diff_in_terminal(&expected, &actual);
+
+                    oxc_tasks_common::print_diff_in_terminal(&diff);
                 }
                 println!();
             }
         }
 
         if failed_count != 0 {
-            let passed_count = spec_calls.len() - failed_count;
-            failed_test_files.push((path.clone(), (failed_count, passed_count)));
+            let total_count = spec_calls.len();
+            let passed_count = total_count - failed_count;
+            #[expect(clippy::cast_precision_loss)]
+            let max_diff_ratio = total_count as f32;
+            failed_test_files.push((
+                path.clone(),
+                (failed_count, passed_count, total_diff_ratio / max_diff_ratio),
+            ));
         }
     }
 

--- a/tasks/transform_conformance/Cargo.toml
+++ b/tasks/transform_conformance/Cargo.toml
@@ -29,4 +29,5 @@ oxc_tasks_transform_checker = { workspace = true }
 cow-utils = { workspace = true }
 indexmap = { workspace = true }
 pico-args = { workspace = true }
+similar = { workspace = true }
 walkdir = { workspace = true }

--- a/tasks/transform_conformance/src/test_case.rs
+++ b/tasks/transform_conformance/src/test_case.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use cow_utils::CowUtils;
+use similar::TextDiff;
 
 use oxc::{
     allocator::Allocator,
@@ -349,8 +350,9 @@ impl TestCase {
                 if let Some(actual_errors) = &actual_errors {
                     println!("{actual_errors}\n");
                     if !passed {
+                        let diff = TextDiff::from_lines(&output, actual_errors);
                         println!("Diff:\n");
-                        print_diff_in_terminal(&output, actual_errors);
+                        print_diff_in_terminal(&diff);
                     }
                 }
             } else {
@@ -365,8 +367,9 @@ impl TestCase {
                     println!("{actual_errors}\n");
                 }
                 if !passed {
+                    let diff = TextDiff::from_lines(&output, &transformed_code);
                     println!("Diff:\n");
-                    print_diff_in_terminal(&output, &transformed_code);
+                    print_diff_in_terminal(&diff);
                 }
             }
 


### PR DESCRIPTION
Previously, #8634 visualized each spec result, but this was not enough.

If the implementation has been updated but the spec still fails, there is no way to know if there is an improvement or not.

This time, finally, all progress is visualized! 🤩 

![image](https://github.com/user-attachments/assets/df5b4658-450a-4b0c-8348-ffc9b977c50c)

e.g. here `arrow_function_expression` is mostly passing, except for comment handling.