### PR TITLE
chore: improve linter bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/linter_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/linter_bug_report.yaml
@@ -21,12 +21,17 @@ body:
     attributes:
       label: What command did you run?
       description: Please include the full command with all arguments. If you're not certain (e.g. you're using the VSCode extension), please provide as much detail as possible.
+      placeholder: `oxlint -c .oxlintrc.json`
 
   - type: textarea
     id: config
     attributes:
-      label: What does your `.oxlint.json` config file look like?
+      label: What does your `.oxlintrc.json` config file look like?
       description: If you're not using a config file, please say so. Otherwise paste please paste its contents here.
+      value: |
+        ```jsonc
+        // your config here
+        ```
 
   - type: textarea
     id: what-happened


### PR DESCRIPTION
- changed the `.oxlint.json` to `.oxlintrc.json` because this is our default name
- added placeholder and prepared values for formatting (not tested)