### PR TITLE
docs(ast): add documentation for all remaining JS AST methods

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -1,4 +1,3 @@
-// FIXME: lots of methods are missing docs. If you have time, it would be a huge help to add some :)
 #![warn(missing_docs)]
 use std::{borrow::Cow, fmt};
 
@@ -265,7 +264,8 @@ impl<'a> Expression<'a> {
         expr
     }
 
-    #[allow(missing_docs)]
+    /// Turns any chainable expression such as `a.b` or `b()` into the chained equivalent
+    /// such as `a?.b` or `b?.()`.
     pub fn into_chain_element(self) -> Option<ChainElement<'a>> {
         match self {
             Expression::StaticMemberExpression(e) => Some(ChainElement::StaticMemberExpression(e)),
@@ -751,25 +751,52 @@ impl Argument<'_> {
 }
 
 impl<'a> AssignmentTarget<'a> {
-    #[allow(missing_docs)]
-    pub fn get_identifier(&self) -> Option<&'a str> {
-        self.as_simple_assignment_target().and_then(SimpleAssignmentTarget::get_identifier)
+    /// Returns the identifier name of this assignment target when it is simple like `a = b`.
+    ///
+    /// ## Example
+    ///
+    /// - returns `a` when called on the left-hand side of `a = b`
+    /// - returns `b` when called on the left-hand side of `a.b = b`
+    /// - returns `None` when called on the left-hand side of `a[b] = b`
+    pub fn get_identifier_name(&self) -> Option<&'a str> {
+        self.as_simple_assignment_target().and_then(SimpleAssignmentTarget::get_identifier_name)
     }
 
-    #[allow(missing_docs)]
+    /// Returns the expression inside of this assignment target, if applicable, and returns a reference to it.
+    ///
+    /// For getting a mutable reference of the expression inside, use [`AssignmentTarget::get_expression_mut`].
+    ///
+    /// ## Example
+    ///
+    /// - returns `a` when called on `a!` in `a! = b`
+    /// - returns `None` when called on `a` in `a = b` because there is no inner expression to get
     pub fn get_expression(&self) -> Option<&Expression<'a>> {
         self.as_simple_assignment_target().and_then(SimpleAssignmentTarget::get_expression)
     }
 
-    #[allow(missing_docs)]
+    /// Returns the expression inside of this assignment target, if applicable, and returns a mutable reference to it.
+    ///
+    /// For getting an immutable reference of the expression inside, use [`AssignmentTarget::get_expression`].
+    ///
+    /// ## Example
+    ///
+    /// - returns `a` when called on `a!` in `a! = b`
+    /// - returns `None` when called on `a` in `a = b` because there is no inner expression to get
     pub fn get_expression_mut(&mut self) -> Option<&mut Expression<'a>> {
         self.as_simple_assignment_target_mut().and_then(SimpleAssignmentTarget::get_expression_mut)
     }
 }
 
 impl<'a> SimpleAssignmentTarget<'a> {
-    #[allow(missing_docs)]
-    pub fn get_identifier(&self) -> Option<&'a str> {
+    /// Returns the identifier name of this assignment target if the target is an identifier or
+    /// a member expression, or `None` otherwise.
+    ///
+    /// ## Example
+    ///
+    /// - returns identifier `a` when called on the left-hand side of `a = b`
+    /// - returns identifier `b` when called on the left-hand side of `a.b = b`
+    /// - returns `None` when called on the left-hand side of `a[b] = b` because it is not an identifier
+    pub fn get_identifier_name(&self) -> Option<&'a str> {
         match self {
             Self::AssignmentTargetIdentifier(ident) => Some(ident.name.as_str()),
             match_member_expression!(Self) => self.to_member_expression().static_property_name(),
@@ -777,7 +804,12 @@ impl<'a> SimpleAssignmentTarget<'a> {
         }
     }
 
-    #[allow(missing_docs)]
+    /// Returns the expression inside of this assignment target, if applicable, and returns a reference to it.
+    ///
+    /// ## Example
+    ///
+    /// - returns `a` when called on `a!` in `a! = b`
+    /// - returns `None` when called on `a` in `a = b` because there is no inner expression to get
     pub fn get_expression(&self) -> Option<&Expression<'a>> {
         match self {
             Self::TSAsExpression(expr) => Some(&expr.expression),
@@ -788,7 +820,14 @@ impl<'a> SimpleAssignmentTarget<'a> {
         }
     }
 
-    #[allow(missing_docs)]
+    /// Returns the expression inside of this assignment target, if applicable, and returns a mutable reference to it.
+    ///
+    /// For getting an immutable reference of the expression inside, use [`SimpleAssignmentTarget::get_expression`].
+    ///
+    /// ## Example
+    ///
+    /// - returns `a` when called on `a!` in `a! = b`
+    /// - returns `None` when called on `a` in `a = b` because there is no inner expression to get
     pub fn get_expression_mut(&mut self) -> Option<&mut Expression<'a>> {
         match self {
             Self::TSAsExpression(expr) => Some(&mut expr.expression),
@@ -802,7 +841,8 @@ impl<'a> SimpleAssignmentTarget<'a> {
 }
 
 impl<'a> ArrayAssignmentTarget<'a> {
-    #[allow(missing_docs)]
+    /// Creates a new array assignment target (like `[a, b]` in the code `[a, b] = [1, 2]`)
+    /// using the given elements.
     pub fn new_with_elements(
         span: Span,
         elements: Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>,
@@ -812,7 +852,8 @@ impl<'a> ArrayAssignmentTarget<'a> {
 }
 
 impl<'a> ObjectAssignmentTarget<'a> {
-    #[allow(missing_docs)]
+    /// Creates a new object assignment target (like `{a, b}` in the code `({a, b} = obj)`) using
+    /// the given properties.
     pub fn new_with_properties(
         span: Span,
         properties: Vec<'a, AssignmentTargetProperty<'a>>,
@@ -820,19 +861,38 @@ impl<'a> ObjectAssignmentTarget<'a> {
         Self { span, properties, rest: None }
     }
 
-    #[allow(missing_docs)]
+    /// Returns `true` if this object assignment target is empty.
+    ///
+    /// ## Example
+    ///
+    /// - `{}` => `true`
+    /// - `{a}` => `false`
+    /// - `{...a}` => `false`
     pub fn is_empty(&self) -> bool {
         self.properties.is_empty() && self.rest.is_none()
     }
 
-    #[allow(missing_docs)]
+    /// Returns the number of identifiers in this object assignment target.
+    ///
+    /// ## Example
+    ///
+    /// - `{}` => `0`
+    /// - `{a}` => `1`
+    /// - `{...a}` => `1`
+    /// - `{a, b}` => `2`
+    /// - `{a, b, ...c}` => `3`
     pub fn len(&self) -> usize {
         self.properties.len() + usize::from(self.rest.is_some())
     }
 }
 
 impl AssignmentTargetMaybeDefault<'_> {
-    #[allow(missing_docs)]
+    /// Returns the identifier bound by this assignment target.
+    ///
+    /// ## Example
+    ///
+    /// - returns `b` when called on `a: b = 1` in `({a: b = 1} = obj)
+    /// - returns `b` when called on `a: b` in `({a: b} = obj)
     pub fn identifier(&self) -> Option<&IdentifierReference<'_>> {
         match self {
             AssignmentTargetMaybeDefault::AssignmentTargetIdentifier(id) => Some(id),
@@ -883,7 +943,15 @@ impl Statement<'_> {
         )
     }
 
-    #[allow(missing_docs)]
+    /// Returns `true` if this statement affects control flow, such as `return`, `throw`, `break`, or `continue`.
+    ///
+    /// ## Example
+    ///
+    /// - `return true` => `true`
+    /// - `throw new Error()` => `true`
+    /// - `break` => `true`
+    /// - `continue` => `true`
+    /// - `if (true) { }` => `false`
     pub fn is_jump_statement(&self) -> bool {
         matches!(
             self,
@@ -1049,33 +1117,67 @@ impl SwitchCase<'_> {
 }
 
 impl<'a> BindingPattern<'a> {
-    #[allow(missing_docs)]
-    pub fn get_identifier(&self) -> Option<Atom<'a>> {
-        self.kind.get_identifier()
+    /// Returns the name of the bound identifier in this binding pattern, if it has one, or `None` otherwise.
+    ///
+    /// ## Example
+    ///
+    /// - calling on `a = 1` in `let a = 1` would return `Some("a")`
+    /// - calling on `a = 1` in `let {a = 1} = c` would return `Some("a")`
+    /// - calling on `a: b` in `let {a: b} = c` would return `None`
+    pub fn get_identifier_name(&self) -> Option<Atom<'a>> {
+        self.kind.get_identifier_name()
     }
 
-    #[allow(missing_docs)]
+    /// Returns the bound identifier in this binding pattern, if it has one, or `None` otherwise.
+    ///
+    /// To just get the name of the bound identifier, use [`BindingPattern::get_identifier_name`].
+    ///
+    /// ## Example
+    ///
+    /// - calling on `a = 1` in `let a = 1` would return `Some(BindingIdentifier { name: "a", .. })`
+    /// - calling on `a = 1` in `let {a = 1} = c` would return `Some(BindingIdentifier { name: "a", .. })`
+    /// - calling on `a: b` in `let {a: b} = c` would return `None`
     pub fn get_binding_identifier(&self) -> Option<&BindingIdentifier<'a>> {
         self.kind.get_binding_identifier()
     }
 
-    #[allow(missing_docs)]
+    /// Returns the bound identifiers in this binding pattern.
+    ///
+    /// ## Example
+    ///
+    /// - `let {} = obj` would return `[]`
+    /// - `let {a, b} = obj` would return `[a, b]`
+    /// - `let {a = 1, b: c} = obj` would return `[a, c]`
     pub fn get_binding_identifiers(&self) -> std::vec::Vec<&BindingIdentifier<'a>> {
         self.kind.get_binding_identifiers()
     }
 }
 
 impl<'a> BindingPatternKind<'a> {
-    #[allow(missing_docs)]
-    pub fn get_identifier(&self) -> Option<Atom<'a>> {
+    /// Returns the name of the bound identifier in this binding pattern, if it has one, or `None` otherwise.
+    ///
+    /// ## Example
+    ///
+    /// - calling on `a = 1` in `let a = 1` would return `Some("a")`
+    /// - calling on `a = 1` in `let {a = 1} = c` would return `Some("a")`
+    /// - calling on `a: b` in `let {a: b} = c` would return `None`
+    pub fn get_identifier_name(&self) -> Option<Atom<'a>> {
         match self {
             Self::BindingIdentifier(ident) => Some(ident.name),
-            Self::AssignmentPattern(assign) => assign.left.get_identifier(),
+            Self::AssignmentPattern(assign) => assign.left.get_identifier_name(),
             _ => None,
         }
     }
 
-    #[allow(missing_docs)]
+    /// Returns the bound identifier in this binding pattern, if it has one, or `None` otherwise.
+    ///
+    /// To just get the name of the bound identifier, use [`BindingPatternKind::get_identifier_name`].
+    ///
+    /// ## Example
+    ///
+    /// - calling on `a = 1` in `let a = 1` would return `Some(BindingIdentifier { name: "a", .. })`
+    /// - calling on `a = 1` in `let {a = 1} = c` would return `Some(BindingIdentifier { name: "a", .. })`
+    /// - calling on `a: b` in `let {a: b} = c` would return `None`
     pub fn get_binding_identifier(&self) -> Option<&BindingIdentifier<'a>> {
         match self {
             Self::BindingIdentifier(ident) => Some(ident),
@@ -1102,14 +1204,27 @@ impl<'a> BindingPatternKind<'a> {
         }
     }
 
-    #[allow(missing_docs)]
+    /// Returns the bound identifiers in this binding pattern.
+    ///
+    /// ## Example
+    ///
+    /// - `let {} = obj` would return `[]`
+    /// - `let {a, b} = obj` would return `[a, b]`
+    /// - `let {a = 1, b: c} = obj` would return `[a, c]`
     pub fn get_binding_identifiers(&self) -> std::vec::Vec<&BindingIdentifier<'a>> {
         let mut idents = vec![];
         self.append_binding_identifiers(&mut idents);
         idents
     }
 
-    #[allow(missing_docs)]
+    /// Returns `true` if this binding pattern is destructuring.
+    ///
+    /// ## Example
+    ///
+    /// - `{a, b}` in `let {a, b} = obj` would return `true`
+    /// - `[a, b]` in `let [a, b] = arr` would return `true`
+    /// - `a = 1` in `let {a = 1} = obj` would return `true`
+    /// - `a` in `let {a = 1} = obj` would return `false`
     pub fn is_destructuring_pattern(&self) -> bool {
         match self {
             Self::ObjectPattern(_) | Self::ArrayPattern(_) => true,
@@ -1118,22 +1233,22 @@ impl<'a> BindingPatternKind<'a> {
         }
     }
 
-    #[allow(missing_docs)]
+    /// Returns `true` if this binding pattern is a binding identifier like `a` in `let a = 1`.
     pub fn is_binding_identifier(&self) -> bool {
         matches!(self, Self::BindingIdentifier(_))
     }
 
-    #[allow(missing_docs)]
+    /// Returns `true` if this binding pattern is an object pattern like `{a}` in `let {a} = obj`.
     pub fn is_object_pattern(&self) -> bool {
         matches!(self, Self::ObjectPattern(_))
     }
 
-    #[allow(missing_docs)]
+    /// Returns `true` if this binding pattern is an array pattern like `[a]` in `let [a] = arr`.
     pub fn is_array_pattern(&self) -> bool {
         matches!(self, Self::ArrayPattern(_))
     }
 
-    #[allow(missing_docs)]
+    /// Returns `true` if this binding pattern is an assignment pattern like `a = 1` in `let {a = 1} = obj`.
     pub fn is_assignment_pattern(&self) -> bool {
         matches!(self, Self::AssignmentPattern(_))
     }
@@ -1379,7 +1494,16 @@ impl<'a> ClassElement<'a> {
         }
     }
 
-    #[allow(missing_docs)]
+    /// Returns `true` if this [`ClassElement`] is computed.
+    ///
+    /// The following all return `true`:
+    /// ```ts
+    /// class C {
+    ///   [a] = 1;
+    ///   [b]() {}
+    ///   accessor [c] = 2;
+    /// }
+    /// ```
     pub fn computed(&self) -> bool {
         match self {
             Self::TSIndexSignature(_) | Self::StaticBlock(_) => false,
@@ -1389,7 +1513,7 @@ impl<'a> ClassElement<'a> {
         }
     }
 
-    #[allow(missing_docs)]
+    /// Returns the [accessibility][`TSAccessibility`] of this [`ClassElement`], if any is indicated.
     pub fn accessibility(&self) -> Option<TSAccessibility> {
         match self {
             Self::StaticBlock(_) | Self::TSIndexSignature(_) | Self::AccessorProperty(_) => None,
@@ -1398,7 +1522,8 @@ impl<'a> ClassElement<'a> {
         }
     }
 
-    #[allow(missing_docs)]
+    /// Returns whether this [`ClassElement`] method is a constructor, method, getter, or setter,
+    /// or `None` otherwise if it is not a method definition.
     pub fn method_definition_kind(&self) -> Option<MethodDefinitionKind> {
         match self {
             Self::TSIndexSignature(_)
@@ -1409,7 +1534,9 @@ impl<'a> ClassElement<'a> {
         }
     }
 
-    #[allow(missing_docs)]
+    /// Returns the [`PropertyKey`] of this [`ClassElement`], if any.
+    ///
+    /// This is either the name of the method, property name, or accessor name.
     pub fn property_key(&self) -> Option<&PropertyKey<'a>> {
         match self {
             Self::TSIndexSignature(_) | Self::StaticBlock(_) => None,

--- a/crates/oxc_ast/src/ast_kind_impl.rs
+++ b/crates/oxc_ast/src/ast_kind_impl.rs
@@ -222,7 +222,7 @@ impl AstKind<'_> {
             Self::VariableDeclaration(_) => "VariableDeclaration".into(),
             Self::VariableDeclarator(v) => format!(
                 "VariableDeclarator({})",
-                v.id.get_identifier().unwrap_or(Atom::from(DESTRUCTURE.as_ref()))
+                v.id.get_identifier_name().unwrap_or(Atom::from(DESTRUCTURE.as_ref()))
             )
             .into(),
 
@@ -290,7 +290,8 @@ impl AstKind<'_> {
             Self::ArrayExpressionElement(_) => "ArrayExpressionElement".into(),
             Self::AssignmentTarget(_) => "AssignmentTarget".into(),
             Self::SimpleAssignmentTarget(a) => {
-                format!("SimpleAssignmentTarget({})", a.get_identifier().unwrap_or(&UNKNOWN)).into()
+                format!("SimpleAssignmentTarget({})", a.get_identifier_name().unwrap_or(&UNKNOWN))
+                    .into()
             }
             Self::AssignmentTargetPattern(_) => "AssignmentTargetPattern".into(),
             Self::ArrayAssignmentTarget(_) => "ArrayAssignmentTarget".into(),
@@ -305,7 +306,7 @@ impl AstKind<'_> {
             Self::FormalParameters(_) => "FormalParameters".into(),
             Self::FormalParameter(p) => format!(
                 "FormalParameter({})",
-                p.pattern.get_identifier().unwrap_or(Atom::from(DESTRUCTURE.as_ref()))
+                p.pattern.get_identifier_name().unwrap_or(Atom::from(DESTRUCTURE.as_ref()))
             )
             .into(),
             Self::CatchParameter(_) => "CatchParameter".into(),

--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -199,7 +199,7 @@ impl<'a> IsolatedDeclarations<'a> {
         param: &FormalParameter<'a>,
         type_annotation: Option<Box<'a, TSTypeAnnotation<'a>>>,
     ) -> Option<ClassElement<'a>> {
-        let Some(ident_name) = param.pattern.get_identifier() else {
+        let Some(ident_name) = param.pattern.get_identifier_name() else {
             // A parameter property may not be declared using a binding pattern.(1187)
             return None;
         };

--- a/crates/oxc_isolated_declarations/src/declaration.rs
+++ b/crates/oxc_isolated_declarations/src/declaration.rs
@@ -55,7 +55,7 @@ impl<'a> IsolatedDeclarations<'a> {
         }
 
         if check_binding {
-            if let Some(name) = decl.id.get_identifier() {
+            if let Some(name) = decl.id.get_identifier_name() {
                 if !self.scope.has_reference(&name) {
                     return None;
                 }

--- a/crates/oxc_isolated_declarations/src/lib.rs
+++ b/crates/oxc_isolated_declarations/src/lib.rs
@@ -523,7 +523,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 match &decl.declaration {
                     Some(Declaration::VariableDeclaration(var)) => {
                         for declarator in &var.declarations {
-                            if let Some(name) = declarator.id.get_identifier() {
+                            if let Some(name) = declarator.id.get_identifier_name() {
                                 assignable_properties_for_namespace
                                     .entry(&ident.name)
                                     .or_default()
@@ -580,7 +580,7 @@ impl<'a> IsolatedDeclarations<'a> {
                             if declarator.id.type_annotation.is_none()
                                 && declarator.init.as_ref().is_some_and(Expression::is_function)
                             {
-                                if let Some(name) = declarator.id.get_identifier() {
+                                if let Some(name) = declarator.id.get_identifier_name() {
                                     can_expando_function_names.insert(name);
                                 }
                             }
@@ -613,7 +613,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         if declarator.id.type_annotation.is_none()
                             && declarator.init.as_ref().is_some_and(Expression::is_function)
                         {
-                            if let Some(name) = declarator.id.get_identifier() {
+                            if let Some(name) = declarator.id.get_identifier_name() {
                                 if self.scope.has_reference(&name) {
                                     can_expando_function_names.insert(name);
                                 }

--- a/crates/oxc_linter/src/rules/eslint/func_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/func_names.rs
@@ -485,10 +485,10 @@ fn guess_function_name<'a>(ctx: &LintContext<'a>, parent_id: NodeId) -> Option<C
             | AstKind::TSNonNullExpression(_)
             | AstKind::TSSatisfiesExpression(_) => continue,
             AstKind::AssignmentExpression(assign) => {
-                return assign.left.get_identifier().map(Cow::Borrowed);
+                return assign.left.get_identifier_name().map(Cow::Borrowed);
             }
             AstKind::VariableDeclarator(decl) => {
-                return decl.id.get_identifier().as_ref().map(Atom::as_str).map(Cow::Borrowed);
+                return decl.id.get_identifier_name().as_ref().map(Atom::as_str).map(Cow::Borrowed);
             }
             AstKind::ObjectProperty(prop) => {
                 return prop.key.static_name().and_then(|name| {

--- a/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty_function.rs
@@ -112,7 +112,7 @@ fn get_function_name_and_kind<'a>(
                 return (kind, method.key.name());
             }
             AstKind::VariableDeclarator(decl) => {
-                return ("function", decl.id.get_identifier().map(Into::into));
+                return ("function", decl.id.get_identifier_name().map(Into::into));
             }
             _ => return ("function", None),
         }

--- a/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_plusplus.rs
@@ -106,7 +106,7 @@ impl Rule for NoPlusplus {
             return;
         }
 
-        let ident = expr.argument.get_identifier();
+        let ident = expr.argument.get_identifier_name();
 
         if let Some(ident) = ident {
             let operator = match expr.operator {

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/binding_pattern.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/binding_pattern.rs
@@ -64,7 +64,8 @@ impl<'a> HasAnyUsedBinding<'a> for ArrayPattern<'a> {
     fn has_any_used_binding(&self, ctx: BindingContext<'_, 'a>) -> bool {
         self.elements.iter().flatten().any(|el| {
             // if the destructured element is ignored, it is considered used
-            el.get_identifier().is_some_and(|name| ctx.options.is_ignored_array_destructured(&name))
+            el.get_identifier_name()
+                .is_some_and(|name| ctx.options.is_ignored_array_destructured(&name))
                 || el.has_any_used_binding(ctx)
         }) || self.rest.as_ref().is_some_and(|rest| rest.argument.has_any_used_binding(ctx))
     }

--- a/crates/oxc_linter/src/rules/nextjs/no_page_custom_font.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_page_custom_font.rs
@@ -101,7 +101,7 @@ fn is_inside_export_default(node: &AstNode<'_>, ctx: &LintContext<'_>) -> bool {
                 let AstKind::VariableDeclarator(declarator) = parent_parent_kind else {
                     return None;
                 };
-                declarator.id.get_identifier().map(|id| id.to_string())
+                declarator.id.get_identifier_name().map(|id| id.to_string())
             },
             |id| Some(id.name.to_string()),
         );

--- a/crates/oxc_linter/src/rules/oxc/no_async_endpoint_handlers.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_async_endpoint_handlers.rs
@@ -234,7 +234,7 @@ impl NoAsyncEndpointHandlers {
                             if let Expression::Identifier(id) = &init {
                                 if decl
                                     .id
-                                    .get_identifier()
+                                    .get_identifier_name()
                                     .is_some_and(|declared| declared == id.name)
                                 {
                                     return;

--- a/crates/oxc_linter/src/rules/promise/prefer_await_to_callbacks.rs
+++ b/crates/oxc_linter/src/rules/promise/prefer_await_to_callbacks.rs
@@ -100,8 +100,10 @@ impl Rule for PreferAwaitToCallbacks {
                         return;
                     };
 
-                    if matches!(param.pattern.get_identifier().as_deref(), Some("err" | "error"))
-                        && !Self::is_inside_yield_or_await(node.id(), ctx)
+                    if matches!(
+                        param.pattern.get_identifier_name().as_deref(),
+                        Some("err" | "error")
+                    ) && !Self::is_inside_yield_or_await(node.id(), ctx)
                     {
                         ctx.diagnostic(prefer_await_to_callbacks(last_arg.span()));
                     }
@@ -124,7 +126,7 @@ impl PreferAwaitToCallbacks {
             return;
         };
 
-        let id = param.pattern.get_identifier();
+        let id = param.pattern.get_identifier_name();
         if matches!(id.as_deref(), Some("callback" | "cb")) {
             ctx.diagnostic(prefer_await_to_callbacks(param.span));
         }

--- a/crates/oxc_linter/src/rules/react/no_array_index_key.rs
+++ b/crates/oxc_linter/src/rules/react/no_array_index_key.rs
@@ -147,11 +147,11 @@ fn find_index_param_name_by_position<'a>(
 ) -> Option<&'a str> {
     call_expr.arguments.first().and_then(|argument| match argument {
         Argument::ArrowFunctionExpression(arrow_fn_expr) => {
-            Some(arrow_fn_expr.params.items.get(position)?.pattern.get_identifier()?.as_str())
+            Some(arrow_fn_expr.params.items.get(position)?.pattern.get_identifier_name()?.as_str())
         }
-        Argument::FunctionExpression(regular_fn_expr) => {
-            Some(regular_fn_expr.params.items.get(position)?.pattern.get_identifier()?.as_str())
-        }
+        Argument::FunctionExpression(regular_fn_expr) => Some(
+            regular_fn_expr.params.items.get(position)?.pattern.get_identifier_name()?.as_str(),
+        ),
         _ => None,
     })
 }

--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -396,18 +396,18 @@ fn get_declaration_identifier<'a>(
 
             match parent.kind() {
                 AstKind::VariableDeclarator(decl) => {
-                    decl.id.get_identifier().map(|id| Cow::Borrowed(id.as_str()))
+                    decl.id.get_identifier_name().map(|id| Cow::Borrowed(id.as_str()))
                 }
                 // useHook = () => {};
                 AstKind::AssignmentExpression(expr)
                     if matches!(expr.operator, AssignmentOperator::Assign) =>
                 {
-                    expr.left.get_identifier().map(std::convert::Into::into)
+                    expr.left.get_identifier_name().map(std::convert::Into::into)
                 }
                 // const {useHook = () => {}} = {};
                 // ({useHook = () => {}} = {});
                 AstKind::AssignmentPattern(patt) => {
-                    patt.left.get_identifier().map(|id| Cow::Borrowed(id.as_str()))
+                    patt.left.get_identifier_name().map(|id| Cow::Borrowed(id.as_str()))
                 }
                 // { useHook: () => {} }
                 // { useHook() {} }

--- a/crates/oxc_linter/src/utils/express.rs
+++ b/crates/oxc_linter/src/utils/express.rs
@@ -93,7 +93,7 @@ const COMMON_REQUEST_NAMES: Set<&'static str> = phf_set! {
     "request",
 };
 fn is_req_param(param: &FormalParameter) -> bool {
-    param.pattern.get_identifier().is_some_and(|id| COMMON_REQUEST_NAMES.contains(id.as_str()))
+    param.pattern.get_identifier_name().is_some_and(|id| COMMON_REQUEST_NAMES.contains(id.as_str()))
 }
 
 const COMMON_RESPONSE_NAMES: Set<&'static str> = phf_set! {
@@ -102,7 +102,10 @@ const COMMON_RESPONSE_NAMES: Set<&'static str> = phf_set! {
     "response",
 };
 fn is_res_param(param: &FormalParameter) -> bool {
-    param.pattern.get_identifier().is_some_and(|id| COMMON_RESPONSE_NAMES.contains(id.as_str()))
+    param
+        .pattern
+        .get_identifier_name()
+        .is_some_and(|id| COMMON_RESPONSE_NAMES.contains(id.as_str()))
 }
 
 const COMMON_NEXT_NAMES: Set<&'static str> = phf_set! {
@@ -110,7 +113,7 @@ const COMMON_NEXT_NAMES: Set<&'static str> = phf_set! {
     "next",
 };
 fn is_next_param(param: &FormalParameter) -> bool {
-    param.pattern.get_identifier().is_some_and(|id| COMMON_NEXT_NAMES.contains(id.as_str()))
+    param.pattern.get_identifier_name().is_some_and(|id| COMMON_NEXT_NAMES.contains(id.as_str()))
 }
 
 const COMMON_ERROR_NAMES: Set<&'static str> = phf_set! {
@@ -120,5 +123,5 @@ const COMMON_ERROR_NAMES: Set<&'static str> = phf_set! {
     "exception",
 };
 fn is_error_param(param: &FormalParameter) -> bool {
-    param.pattern.get_identifier().is_some_and(|id| COMMON_ERROR_NAMES.contains(id.as_str()))
+    param.pattern.get_identifier_name().is_some_and(|id| COMMON_ERROR_NAMES.contains(id.as_str()))
 }

--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -415,7 +415,7 @@ impl<'a> TypeScriptNamespace<'a, '_> {
         // is smaller than `const a = 1; N.a = a`;
         if is_all_binding_identifier {
             var_decl.declarations.iter_mut().for_each(|declarator| {
-                let Some(property_name) = declarator.id.get_identifier() else {
+                let Some(property_name) = declarator.id.get_identifier_name() else {
                     return;
                 };
                 if let Some(init) = &mut declarator.init {

--- a/tasks/prettier_conformance/src/spec.rs
+++ b/tasks/prettier_conformance/src/spec.rs
@@ -52,7 +52,7 @@ impl VisitMut<'_> for SpecParser {
     // runFormatTest(import.meta, parser, { semi: false });
     // ````
     fn visit_variable_declarator(&mut self, decl: &mut VariableDeclarator<'_>) {
-        let Some(name) = decl.id.get_identifier() else { return };
+        let Some(name) = decl.id.get_identifier_name() else { return };
         if !matches!(name.as_str(), "parser" | "parsers") {
             return;
         }


### PR DESCRIPTION
Finishes the remaining items that require documenting for the JS AST implementations. Once again, I tried my best to ensure these are accurate, but it might not be 100% correct.

I also renamed the `get_identifier` method to `get_identifier_name` to make it clear that it returns an `Atom`/`str` and not an `Identifier`.