### PR TITLE
test(oxlint): test two real rules with same name but from different plugins

### DIFF
--- a/apps/oxlint/fixtures/disable_eslint_and_unicorn_alias_rules/.oxlintrc-eslint.json
+++ b/apps/oxlint/fixtures/disable_eslint_and_unicorn_alias_rules/.oxlintrc-eslint.json
@@ -1,6 +1,6 @@
 {
   "plugins": [],
   "rules": {
-    "eslint/no-nested-ternary": "off"
+    "eslint/no-negated-condition": "off"
   }
 }

--- a/apps/oxlint/fixtures/disable_eslint_and_unicorn_alias_rules/.oxlintrc-unicorn.json
+++ b/apps/oxlint/fixtures/disable_eslint_and_unicorn_alias_rules/.oxlintrc-unicorn.json
@@ -3,6 +3,6 @@
     "unicorn"
   ],
   "rules": {
-    "unicorn/no-nested-ternary": "off"
+    "unicorn/no-negated-condition": "off"
   }
 }

--- a/apps/oxlint/fixtures/disable_eslint_and_unicorn_alias_rules/test.js
+++ b/apps/oxlint/fixtures/disable_eslint_and_unicorn_alias_rules/test.js
@@ -1,1 +1,5 @@
-console.log(bar ? baz : qux === quxx ? bing : bam);
+if (!condition) {
+  console.log(123)
+} else {
+  console.log(666)
+}

--- a/apps/oxlint/fixtures/two_rules_with_same_rule_name/.oxlintrc.json
+++ b/apps/oxlint/fixtures/two_rules_with_same_rule_name/.oxlintrc.json
@@ -1,0 +1,9 @@
+{
+  "plugins": [
+    "unicorn"
+  ],
+  "rules": {
+    "eslint/no-nested-ternary": "off",
+    "unicorn/no-nested-ternary": "off"
+  }
+}

--- a/apps/oxlint/fixtures/two_rules_with_same_rule_name/test.js
+++ b/apps/oxlint/fixtures/two_rules_with_same_rule_name/test.js
@@ -1,0 +1,1 @@
+console.log(bar ? baz : qux === quxx ? bing : bam);

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -826,12 +826,20 @@ mod test {
 
     #[test]
     fn test_disable_eslint_and_unicorn_alias_rules() {
-        // Issue: <https://github.com/oxc-project/oxc/issues/8485>
         let args_1 = &["-c", ".oxlintrc-eslint.json", "test.js"];
         let args_2 = &["-c", ".oxlintrc-unicorn.json", "test.js"];
         Tester::new()
             .with_cwd("fixtures/disable_eslint_and_unicorn_alias_rules".into())
             .test_and_snapshot_multiple(&[args_1, args_2]);
+    }
+
+    #[test]
+    fn test_two_rules_with_same_rule_name_from_different_plugins() {
+        // Issue: <https://github.com/oxc-project/oxc/issues/8485>
+        let args = &["-c", ".oxlintrc.json", "test.js"];
+        Tester::new()
+            .with_cwd("fixtures/two_rules_with_same_rule_name".into())
+            .test_and_snapshot(args);
     }
 
     #[test]

--- a/apps/oxlint/src/snapshots/fixtures__two_rules_with_same_rule_name_-c .oxlintrc.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__two_rules_with_same_rule_name_-c .oxlintrc.json test.js@oxlint.snap
@@ -1,0 +1,12 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: -c .oxlintrc.json test.js
+working directory: fixtures/two_rules_with_same_rule_name
+----------
+Found 0 warnings and 0 errors.
+Finished in <variable>ms on 1 file with 61 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------


### PR DESCRIPTION
Related to #8814 

This test case is designed to verify that two different rules, having the same name but coming from different plugins, are treated as distinct rules rather than simple aliases.

In `unicorn`, there is only one rule, `no-negated-condition`, which is aliased to `eslint`.

https://github.com/oxc-project/oxc/blob/655b2126889a3307929a1a20047b317c1eefb140/crates/oxc_linter/src/config/rules.rs#L166-L178
