### PR TITLE
refactor(ast): make generated code for `Visit` more understandable

### DIFF
--- a/crates/oxc_ast/src/generated/visit.rs
+++ b/crates/oxc_ast/src/generated/visit.rs
@@ -2106,8 +2106,8 @@ pub mod walk {
         let kind = AstKind::ArrayPattern(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
-        for elements in it.elements.iter().flatten() {
-            visitor.visit_binding_pattern(elements);
+        for el in it.elements.iter().flatten() {
+            visitor.visit_binding_pattern(el);
         }
         if let Some(rest) = &it.rest {
             visitor.visit_binding_rest_element(rest);
@@ -2866,8 +2866,8 @@ pub mod walk {
         let kind = AstKind::ArrayAssignmentTarget(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
-        for elements in it.elements.iter().flatten() {
-            visitor.visit_assignment_target_maybe_default(elements);
+        for el in it.elements.iter().flatten() {
+            visitor.visit_assignment_target_maybe_default(el);
         }
         if let Some(rest) = &it.rest {
             visitor.visit_assignment_target_rest(rest);

--- a/crates/oxc_ast/src/generated/visit_mut.rs
+++ b/crates/oxc_ast/src/generated/visit_mut.rs
@@ -2161,8 +2161,8 @@ pub mod walk_mut {
         let kind = AstType::ArrayPattern;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
-        for elements in it.elements.iter_mut().flatten() {
-            visitor.visit_binding_pattern(elements);
+        for el in it.elements.iter_mut().flatten() {
+            visitor.visit_binding_pattern(el);
         }
         if let Some(rest) = &mut it.rest {
             visitor.visit_binding_rest_element(rest);
@@ -2981,8 +2981,8 @@ pub mod walk_mut {
         let kind = AstType::ArrayAssignmentTarget;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
-        for elements in it.elements.iter_mut().flatten() {
-            visitor.visit_assignment_target_maybe_default(elements);
+        for el in it.elements.iter_mut().flatten() {
+            visitor.visit_assignment_target_maybe_default(el);
         }
         if let Some(rest) = &mut it.rest {
             visitor.visit_assignment_target_rest(rest);

--- a/tasks/ast_tools/src/generators/visit.rs
+++ b/tasks/ast_tools/src/generators/visit.rs
@@ -465,8 +465,8 @@ impl<'a> VisitBuilder<'a> {
                     TypeWrapper::VecOpt => {
                         let iter = if self.is_mut { quote!(iter_mut) } else { quote!(iter) };
                         quote! {
-                            for #name in it.#name.#iter().flatten() {
-                                visitor.#visit(#name #(#args)*);
+                            for el in it.#name.#iter().flatten() {
+                                visitor.#visit(el #(#args)*);
                             }
                         }
                     }


### PR DESCRIPTION
Pure refactor. `for elements in it.elements.iter().flatten()` doesn't make much sense - each item is a single element, not multiple elements. Change to `for el in it.elements.iter().flatten()`.