### PR TITLE
chore: fix linter bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/linter_bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/linter_bug_report.yaml
@@ -21,7 +21,7 @@ body:
     attributes:
       label: What command did you run?
       description: Please include the full command with all arguments. If you're not certain (e.g. you're using the VSCode extension), please provide as much detail as possible.
-      placeholder: `oxlint -c .oxlintrc.json`
+      placeholder: "`oxlint -c .oxlintrc.json`"
 
   - type: textarea
     id: config


### PR DESCRIPTION
![grafik](https://github.com/user-attachments/assets/62ac4e2c-b2a1-4ec1-9d19-18e0e7dc2eea)

Installed YAML extension to avoid more errors. Introduced in https://github.com/oxc-project/oxc/pull/8818