### PR TITLE
docs(ast): add allow(missing_docs) to all remaining fields for JS/TS nodes

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1,4 +1,7 @@
-#![allow(missing_docs)] // FIXME
+// FIXME: Many items in this file have `#![allow(missing_docs)]` and it would be a huge help
+// to remove all of these and add documentation. If you have time, please write some, it would
+// be a huge help :)
+#![warn(missing_docs)]
 
 // NB: `#[span]`, `#[scope(...)]`,`#[visit(...)]` and `#[generate_derive(...)]` do NOT do anything to the code.
 // They are purely markers for codegen used in `tasks/ast_tools` and `crates/oxc_traverse/scripts`. See docs in those crates.
@@ -30,18 +33,25 @@ use super::{macros::inherit_variants, *};
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct Program<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub source_type: SourceType,
     #[estree(skip)]
+    #[allow(missing_docs)]
     pub source_text: &'a str,
     /// Sorted comments
     #[estree(skip)]
     pub comments: Vec<'a, Comment>,
+    #[allow(missing_docs)]
     pub hashbang: Option<Hashbang<'a>>,
+    #[allow(missing_docs)]
     pub directives: Vec<'a, Directive<'a>>,
+    #[allow(missing_docs)]
     pub body: Vec<'a, Statement<'a>>,
     #[estree(skip)]
     #[clone_in(default)]
+    #[allow(missing_docs)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -204,7 +214,9 @@ pub use match_expression;
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(rename = "Identifier")]
 pub struct IdentifierName<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub name: Atom<'a>,
 }
 
@@ -218,6 +230,7 @@ pub struct IdentifierName<'a> {
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(rename = "Identifier")]
 pub struct IdentifierReference<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// The name of the identifier being referenced.
     pub name: Atom<'a>,
@@ -241,6 +254,7 @@ pub struct IdentifierReference<'a> {
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(rename = "Identifier")]
 pub struct BindingIdentifier<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// The identifier name being bound.
     pub name: Atom<'a>,
@@ -265,7 +279,9 @@ pub struct BindingIdentifier<'a> {
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(rename = "Identifier")]
 pub struct LabelIdentifier<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub name: Atom<'a>,
 }
 
@@ -276,6 +292,7 @@ pub struct LabelIdentifier<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ThisExpression {
+    #[allow(missing_docs)]
     pub span: Span,
 }
 
@@ -286,8 +303,10 @@ pub struct ThisExpression {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ArrayExpression<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     #[estree(ts_type = "Array<SpreadElement | Expression | null>")]
+    #[allow(missing_docs)]
     pub elements: Vec<'a, ArrayExpressionElement<'a>>,
     /// Array trailing comma
     /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#arrays>
@@ -326,6 +345,7 @@ pub enum ArrayExpressionElement<'a> {
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq)]
 pub struct Elision {
+    #[allow(missing_docs)]
     pub span: Span,
 }
 
@@ -336,10 +356,12 @@ pub struct Elision {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ObjectExpression<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// Properties declared in the object
     pub properties: Vec<'a, ObjectPropertyKind<'a>>,
     #[estree(skip)]
+    #[allow(missing_docs)]
     pub trailing_comma: Option<Span>,
 }
 
@@ -361,12 +383,19 @@ pub enum ObjectPropertyKind<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ObjectProperty<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub kind: PropertyKind,
+    #[allow(missing_docs)]
     pub key: PropertyKey<'a>,
+    #[allow(missing_docs)]
     pub value: Expression<'a>,
+    #[allow(missing_docs)]
     pub method: bool,
+    #[allow(missing_docs)]
     pub shorthand: bool,
+    #[allow(missing_docs)]
     pub computed: bool,
 }
 
@@ -409,8 +438,11 @@ pub enum PropertyKind {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TemplateLiteral<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub quasis: Vec<'a, TemplateElement<'a>>,
+    #[allow(missing_docs)]
     pub expressions: Vec<'a, Expression<'a>>,
 }
 
@@ -421,10 +453,14 @@ pub struct TemplateLiteral<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TaggedTemplateExpression<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub tag: Expression<'a>,
+    #[allow(missing_docs)]
     pub quasi: TemplateLiteral<'a>,
     #[ts]
+    #[allow(missing_docs)]
     pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
 }
 
@@ -435,8 +471,11 @@ pub struct TaggedTemplateExpression<'a> {
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TemplateElement<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub tail: bool,
+    #[allow(missing_docs)]
     pub value: TemplateElementValue<'a>,
 }
 
@@ -490,9 +529,13 @@ pub use match_member_expression;
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ComputedMemberExpression<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub object: Expression<'a>,
+    #[allow(missing_docs)]
     pub expression: Expression<'a>,
+    #[allow(missing_docs)]
     pub optional: bool, // for optional chaining
 }
 
@@ -503,9 +546,13 @@ pub struct ComputedMemberExpression<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct StaticMemberExpression<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub object: Expression<'a>,
+    #[allow(missing_docs)]
     pub property: IdentifierName<'a>,
+    #[allow(missing_docs)]
     pub optional: bool, // for optional chaining
 }
 
@@ -516,9 +563,13 @@ pub struct StaticMemberExpression<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct PrivateFieldExpression<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub object: Expression<'a>,
+    #[allow(missing_docs)]
     pub field: PrivateIdentifier<'a>,
+    #[allow(missing_docs)]
     pub optional: bool, // for optional chaining
 }
 
@@ -542,11 +593,16 @@ pub struct PrivateFieldExpression<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct CallExpression<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub callee: Expression<'a>,
     #[ts]
+    #[allow(missing_docs)]
     pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
+    #[allow(missing_docs)]
     pub arguments: Vec<'a, Argument<'a>>,
+    #[allow(missing_docs)]
     pub optional: bool, // for optional chaining
 }
 
@@ -566,10 +622,14 @@ pub struct CallExpression<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct NewExpression<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub callee: Expression<'a>,
+    #[allow(missing_docs)]
     pub arguments: Vec<'a, Argument<'a>>,
     #[ts]
+    #[allow(missing_docs)]
     pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
 }
 
@@ -580,8 +640,11 @@ pub struct NewExpression<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct MetaProperty<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub meta: IdentifierName<'a>,
+    #[allow(missing_docs)]
     pub property: IdentifierName<'a>,
 }
 
@@ -592,6 +655,7 @@ pub struct MetaProperty<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct SpreadElement<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// The expression being spread.
     pub argument: Expression<'a>,
@@ -621,9 +685,13 @@ pub enum Argument<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct UpdateExpression<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub operator: UpdateOperator,
+    #[allow(missing_docs)]
     pub prefix: bool,
+    #[allow(missing_docs)]
     pub argument: SimpleAssignmentTarget<'a>,
 }
 
@@ -634,8 +702,11 @@ pub struct UpdateExpression<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct UnaryExpression<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub operator: UnaryOperator,
+    #[allow(missing_docs)]
     pub argument: Expression<'a>,
 }
 
@@ -646,9 +717,13 @@ pub struct UnaryExpression<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct BinaryExpression<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub left: Expression<'a>,
+    #[allow(missing_docs)]
     pub operator: BinaryOperator,
+    #[allow(missing_docs)]
     pub right: Expression<'a>,
 }
 
@@ -659,9 +734,13 @@ pub struct BinaryExpression<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct PrivateInExpression<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub left: PrivateIdentifier<'a>,
+    #[allow(missing_docs)]
     pub operator: BinaryOperator, // BinaryOperator::In
+    #[allow(missing_docs)]
     pub right: Expression<'a>,
 }
 
@@ -672,9 +751,13 @@ pub struct PrivateInExpression<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct LogicalExpression<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub left: Expression<'a>,
+    #[allow(missing_docs)]
     pub operator: LogicalOperator,
+    #[allow(missing_docs)]
     pub right: Expression<'a>,
 }
 
@@ -685,9 +768,13 @@ pub struct LogicalExpression<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ConditionalExpression<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub test: Expression<'a>,
+    #[allow(missing_docs)]
     pub consequent: Expression<'a>,
+    #[allow(missing_docs)]
     pub alternate: Expression<'a>,
 }
 
@@ -698,9 +785,13 @@ pub struct ConditionalExpression<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct AssignmentExpression<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub operator: AssignmentOperator,
+    #[allow(missing_docs)]
     pub left: AssignmentTarget<'a>,
+    #[allow(missing_docs)]
     pub right: Expression<'a>,
 }
 
@@ -732,11 +823,17 @@ inherit_variants! {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
 pub enum SimpleAssignmentTarget<'a> {
+    #[allow(missing_docs)]
     AssignmentTargetIdentifier(Box<'a, IdentifierReference<'a>>) = 0,
+    #[allow(missing_docs)]
     TSAsExpression(Box<'a, TSAsExpression<'a>>) = 1,
+    #[allow(missing_docs)]
     TSSatisfiesExpression(Box<'a, TSSatisfiesExpression<'a>>) = 2,
+    #[allow(missing_docs)]
     TSNonNullExpression(Box<'a, TSNonNullExpression<'a>>) = 3,
+    #[allow(missing_docs)]
     TSTypeAssertion(Box<'a, TSTypeAssertion<'a>>) = 4,
+    #[allow(missing_docs)]
     TSInstantiationExpression(Box<'a, TSInstantiationExpression<'a>>) = 5,
     // `MemberExpression` variants added here by `inherit_variants!` macro
     @inherit MemberExpression
@@ -781,11 +878,14 @@ macro_rules! match_simple_assignment_target {
 }
 pub use match_simple_assignment_target;
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
 pub enum AssignmentTargetPattern<'a> {
+    #[allow(missing_docs)]
     ArrayAssignmentTarget(Box<'a, ArrayAssignmentTarget<'a>>) = 8,
+    #[allow(missing_docs)]
     ObjectAssignmentTarget(Box<'a, ObjectAssignmentTarget<'a>>) = 9,
 }
 
@@ -805,10 +905,14 @@ pub use match_assignment_target_pattern;
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ArrayAssignmentTarget<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub elements: Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>,
+    #[allow(missing_docs)]
     #[estree(append_to = "elements")]
     pub rest: Option<AssignmentTargetRest<'a>>,
+    #[allow(missing_docs)]
     #[estree(skip)]
     pub trailing_comma: Option<Span>,
 }
@@ -820,8 +924,11 @@ pub struct ArrayAssignmentTarget<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ObjectAssignmentTarget<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub properties: Vec<'a, AssignmentTargetProperty<'a>>,
+    #[allow(missing_docs)]
     #[estree(append_to = "properties")]
     pub rest: Option<AssignmentTargetRest<'a>>,
 }
@@ -834,7 +941,9 @@ pub struct ObjectAssignmentTarget<'a> {
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(rename = "RestElement")]
 pub struct AssignmentTargetRest<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     #[estree(rename = "argument")]
     pub target: AssignmentTarget<'a>,
 }
@@ -849,26 +958,34 @@ inherit_variants! {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
 pub enum AssignmentTargetMaybeDefault<'a> {
+    #[allow(missing_docs)]
     AssignmentTargetWithDefault(Box<'a, AssignmentTargetWithDefault<'a>>) = 16,
     // `AssignmentTarget` variants added here by `inherit_variants!` macro
     @inherit AssignmentTarget
 }
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct AssignmentTargetWithDefault<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub binding: AssignmentTarget<'a>,
+    #[allow(missing_docs)]
     pub init: Expression<'a>,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
 pub enum AssignmentTargetProperty<'a> {
+    #[allow(missing_docs)]
     AssignmentTargetPropertyIdentifier(Box<'a, AssignmentTargetPropertyIdentifier<'a>>) = 0,
+    #[allow(missing_docs)]
     AssignmentTargetPropertyProperty(Box<'a, AssignmentTargetPropertyProperty<'a>>) = 1,
 }
 
@@ -879,8 +996,11 @@ pub enum AssignmentTargetProperty<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct AssignmentTargetPropertyIdentifier<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub binding: IdentifierReference<'a>,
+    #[allow(missing_docs)]
     pub init: Option<Expression<'a>>,
 }
 
@@ -891,8 +1011,11 @@ pub struct AssignmentTargetPropertyIdentifier<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct AssignmentTargetPropertyProperty<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub name: PropertyKey<'a>,
+    #[allow(missing_docs)]
     pub binding: AssignmentTargetMaybeDefault<'a>,
     /// Property was declared with a computed key
     pub computed: bool,
@@ -905,7 +1028,9 @@ pub struct AssignmentTargetPropertyProperty<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct SequenceExpression<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub expressions: Vec<'a, Expression<'a>>,
 }
 
@@ -916,6 +1041,7 @@ pub struct SequenceExpression<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct Super {
+    #[allow(missing_docs)]
     pub span: Span,
 }
 
@@ -926,7 +1052,9 @@ pub struct Super {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct AwaitExpression<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub argument: Expression<'a>,
 }
 
@@ -937,7 +1065,9 @@ pub struct AwaitExpression<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ChainExpression<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub expression: ChainElement<'a>,
 }
 
@@ -951,6 +1081,7 @@ inherit_variants! {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
 pub enum ChainElement<'a> {
+    #[allow(missing_docs)]
     CallExpression(Box<'a, CallExpression<'a>>) = 0,
     /// `foo?.baz!` or `foo?.[bar]!`
     TSNonNullExpression(Box<'a, TSNonNullExpression<'a>>) = 1,
@@ -966,7 +1097,9 @@ pub enum ChainElement<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ParenthesizedExpression<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub expression: Expression<'a>,
 }
 
@@ -982,23 +1115,41 @@ inherit_variants! {
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
 pub enum Statement<'a> {
     // Statements
+    #[allow(missing_docs)]
     BlockStatement(Box<'a, BlockStatement<'a>>) = 0,
+    #[allow(missing_docs)]
     BreakStatement(Box<'a, BreakStatement<'a>>) = 1,
+    #[allow(missing_docs)]
     ContinueStatement(Box<'a, ContinueStatement<'a>>) = 2,
+    #[allow(missing_docs)]
     DebuggerStatement(Box<'a, DebuggerStatement>) = 3,
+    #[allow(missing_docs)]
     DoWhileStatement(Box<'a, DoWhileStatement<'a>>) = 4,
+    #[allow(missing_docs)]
     EmptyStatement(Box<'a, EmptyStatement>) = 5,
+    #[allow(missing_docs)]
     ExpressionStatement(Box<'a, ExpressionStatement<'a>>) = 6,
+    #[allow(missing_docs)]
     ForInStatement(Box<'a, ForInStatement<'a>>) = 7,
+    #[allow(missing_docs)]
     ForOfStatement(Box<'a, ForOfStatement<'a>>) = 8,
+    #[allow(missing_docs)]
     ForStatement(Box<'a, ForStatement<'a>>) = 9,
+    #[allow(missing_docs)]
     IfStatement(Box<'a, IfStatement<'a>>) = 10,
+    #[allow(missing_docs)]
     LabeledStatement(Box<'a, LabeledStatement<'a>>) = 11,
+    #[allow(missing_docs)]
     ReturnStatement(Box<'a, ReturnStatement<'a>>) = 12,
+    #[allow(missing_docs)]
     SwitchStatement(Box<'a, SwitchStatement<'a>>) = 13,
+    #[allow(missing_docs)]
     ThrowStatement(Box<'a, ThrowStatement<'a>>) = 14,
+    #[allow(missing_docs)]
     TryStatement(Box<'a, TryStatement<'a>>) = 15,
+    #[allow(missing_docs)]
     WhileStatement(Box<'a, WhileStatement<'a>>) = 16,
+    #[allow(missing_docs)]
     WithStatement(Box<'a, WithStatement<'a>>) = 17,
     // `Declaration` variants added here by `inherit_variants!` macro
     @inherit Declaration
@@ -1014,6 +1165,7 @@ pub enum Statement<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct Directive<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// Directive with any escapes unescaped
     pub expression: StringLiteral<'a>,
@@ -1028,7 +1180,9 @@ pub struct Directive<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct Hashbang<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub value: Atom<'a>,
 }
 
@@ -1040,8 +1194,11 @@ pub struct Hashbang<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct BlockStatement<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub body: Vec<'a, Statement<'a>>,
+    #[allow(missing_docs)]
     #[estree(skip)]
     #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
@@ -1052,15 +1209,22 @@ pub struct BlockStatement<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
 pub enum Declaration<'a> {
+    #[allow(missing_docs)]
     VariableDeclaration(Box<'a, VariableDeclaration<'a>>) = 32,
+    #[allow(missing_docs)]
     #[visit(args(flags = ScopeFlags::Function))]
     FunctionDeclaration(Box<'a, Function<'a>>) = 33,
+    #[allow(missing_docs)]
     ClassDeclaration(Box<'a, Class<'a>>) = 34,
-
+    #[allow(missing_docs)]
     TSTypeAliasDeclaration(Box<'a, TSTypeAliasDeclaration<'a>>) = 35,
+    #[allow(missing_docs)]
     TSInterfaceDeclaration(Box<'a, TSInterfaceDeclaration<'a>>) = 36,
+    #[allow(missing_docs)]
     TSEnumDeclaration(Box<'a, TSEnumDeclaration<'a>>) = 37,
+    #[allow(missing_docs)]
     TSModuleDeclaration(Box<'a, TSModuleDeclaration<'a>>) = 38,
+    #[allow(missing_docs)]
     TSImportEqualsDeclaration(Box<'a, TSImportEqualsDeclaration<'a>>) = 39,
 }
 
@@ -1087,21 +1251,31 @@ pub use match_declaration;
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct VariableDeclaration<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub kind: VariableDeclarationKind,
+    #[allow(missing_docs)]
     pub declarations: Vec<'a, VariableDeclarator<'a>>,
+    #[allow(missing_docs)]
     #[ts]
     pub declare: bool,
 }
 
+#[allow(missing_docs)]
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[generate_derive(CloneIn, ContentEq, ESTree)]
 pub enum VariableDeclarationKind {
+    #[allow(missing_docs)]
     Var = 0,
+    #[allow(missing_docs)]
     Const = 1,
+    #[allow(missing_docs)]
     Let = 2,
+    #[allow(missing_docs)]
     Using = 3,
+    #[allow(missing_docs)]
     #[estree(rename = "await using")]
     AwaitUsing = 4,
 }
@@ -1118,11 +1292,16 @@ pub enum VariableDeclarationKind {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct VariableDeclarator<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     #[estree(skip)]
     pub kind: VariableDeclarationKind,
+    #[allow(missing_docs)]
     pub id: BindingPattern<'a>,
+    #[allow(missing_docs)]
     pub init: Option<Expression<'a>>,
+    #[allow(missing_docs)]
     #[ts]
     pub definite: bool,
 }
@@ -1132,6 +1311,7 @@ pub struct VariableDeclarator<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct EmptyStatement {
+    #[allow(missing_docs)]
     pub span: Span,
 }
 
@@ -1140,7 +1320,9 @@ pub struct EmptyStatement {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ExpressionStatement<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub expression: Expression<'a>,
 }
 
@@ -1149,9 +1331,13 @@ pub struct ExpressionStatement<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct IfStatement<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub test: Expression<'a>,
+    #[allow(missing_docs)]
     pub consequent: Statement<'a>,
+    #[allow(missing_docs)]
     pub alternate: Option<Statement<'a>>,
 }
 
@@ -1160,8 +1346,11 @@ pub struct IfStatement<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct DoWhileStatement<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub body: Statement<'a>,
+    #[allow(missing_docs)]
     pub test: Expression<'a>,
 }
 
@@ -1170,8 +1359,11 @@ pub struct DoWhileStatement<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct WhileStatement<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub test: Expression<'a>,
+    #[allow(missing_docs)]
     pub body: Statement<'a>,
 }
 
@@ -1181,11 +1373,17 @@ pub struct WhileStatement<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ForStatement<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub init: Option<ForStatementInit<'a>>,
+    #[allow(missing_docs)]
     pub test: Option<Expression<'a>>,
+    #[allow(missing_docs)]
     pub update: Option<Expression<'a>>,
+    #[allow(missing_docs)]
     pub body: Statement<'a>,
+    #[allow(missing_docs)]
     #[estree(skip)]
     #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
@@ -1201,6 +1399,7 @@ inherit_variants! {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
 pub enum ForStatementInit<'a> {
+    #[allow(missing_docs)]
     VariableDeclaration(Box<'a, VariableDeclaration<'a>>) = 64,
     // `Expression` variants added here by `inherit_variants!` macro
     @inherit Expression
@@ -1213,10 +1412,15 @@ pub enum ForStatementInit<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ForInStatement<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub left: ForStatementLeft<'a>,
+    #[allow(missing_docs)]
     pub right: Expression<'a>,
+    #[allow(missing_docs)]
     pub body: Statement<'a>,
+    #[allow(missing_docs)]
     #[estree(skip)]
     #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
@@ -1232,6 +1436,7 @@ inherit_variants! {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
 pub enum ForStatementLeft<'a> {
+    #[allow(missing_docs)]
     VariableDeclaration(Box<'a, VariableDeclaration<'a>>) = 16,
     // `AssignmentTarget` variants added here by `inherit_variants!` macro
     @inherit AssignmentTarget
@@ -1243,11 +1448,17 @@ pub enum ForStatementLeft<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ForOfStatement<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub r#await: bool,
+    #[allow(missing_docs)]
     pub left: ForStatementLeft<'a>,
+    #[allow(missing_docs)]
     pub right: Expression<'a>,
+    #[allow(missing_docs)]
     pub body: Statement<'a>,
+    #[allow(missing_docs)]
     #[estree(skip)]
     #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
@@ -1258,7 +1469,9 @@ pub struct ForOfStatement<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ContinueStatement<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub label: Option<LabelIdentifier<'a>>,
 }
 
@@ -1267,7 +1480,9 @@ pub struct ContinueStatement<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct BreakStatement<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub label: Option<LabelIdentifier<'a>>,
 }
 
@@ -1276,7 +1491,9 @@ pub struct BreakStatement<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ReturnStatement<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub argument: Option<Expression<'a>>,
 }
 
@@ -1285,8 +1502,11 @@ pub struct ReturnStatement<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct WithStatement<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub object: Expression<'a>,
+    #[allow(missing_docs)]
     pub body: Statement<'a>,
 }
 
@@ -1296,21 +1516,29 @@ pub struct WithStatement<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct SwitchStatement<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub discriminant: Expression<'a>,
+    #[allow(missing_docs)]
     #[scope(enter_before)]
     pub cases: Vec<'a, SwitchCase<'a>>,
+    #[allow(missing_docs)]
     #[estree(skip)]
     #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct SwitchCase<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub test: Option<Expression<'a>>,
+    #[allow(missing_docs)]
     pub consequent: Vec<'a, Statement<'a>>,
 }
 
@@ -1319,8 +1547,11 @@ pub struct SwitchCase<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct LabeledStatement<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub label: LabelIdentifier<'a>,
+    #[allow(missing_docs)]
     pub body: Statement<'a>,
 }
 
@@ -1335,6 +1566,7 @@ pub struct LabeledStatement<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ThrowStatement<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// The expression being thrown, e.g. `err` in `throw err;`
     pub argument: Expression<'a>,
@@ -1359,6 +1591,7 @@ pub struct ThrowStatement<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TryStatement<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// Statements in the `try` block
     pub block: Box<'a, BlockStatement<'a>>,
@@ -1385,11 +1618,13 @@ pub struct TryStatement<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct CatchClause<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// The caught error parameter, e.g. `e` in `catch (e) {}`
     pub param: Option<CatchParameter<'a>>,
     /// The statements run when an error is caught
     pub body: Box<'a, BlockStatement<'a>>,
+    #[allow(missing_docs)]
     #[estree(skip)]
     #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
@@ -1412,6 +1647,7 @@ pub struct CatchClause<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct CatchParameter<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// The bound error
     pub pattern: BindingPattern<'a>,
@@ -1428,6 +1664,7 @@ pub struct CatchParameter<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct DebuggerStatement {
+    #[allow(missing_docs)]
     pub span: Span,
 }
 
@@ -1444,13 +1681,17 @@ pub struct BindingPattern<'a> {
         ts_type = "(BindingIdentifier | ObjectPattern | ArrayPattern | AssignmentPattern)"
     )]
     #[span]
+    #[allow(missing_docs)]
     pub kind: BindingPatternKind<'a>,
+    #[allow(missing_docs)]
     #[ts]
     pub type_annotation: Option<Box<'a, TSTypeAnnotation<'a>>>,
+    #[allow(missing_docs)]
     #[ts]
     pub optional: bool,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
@@ -1468,42 +1709,60 @@ pub enum BindingPatternKind<'a> {
     AssignmentPattern(Box<'a, AssignmentPattern<'a>>) = 3,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct AssignmentPattern<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub left: BindingPattern<'a>,
+    #[allow(missing_docs)]
     pub right: Expression<'a>,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ObjectPattern<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub properties: Vec<'a, BindingProperty<'a>>,
+    #[allow(missing_docs)]
     #[estree(append_to = "properties")]
     pub rest: Option<Box<'a, BindingRestElement<'a>>>,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct BindingProperty<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub key: PropertyKey<'a>,
+    #[allow(missing_docs)]
     pub value: BindingPattern<'a>,
+    #[allow(missing_docs)]
     pub shorthand: bool,
+    #[allow(missing_docs)]
     pub computed: bool,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ArrayPattern<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub elements: Vec<'a, Option<BindingPattern<'a>>>,
+    #[allow(missing_docs)]
     #[estree(append_to = "elements")]
     pub rest: Option<Box<'a, BindingRestElement<'a>>>,
 }
@@ -1522,7 +1781,9 @@ pub struct ArrayPattern<'a> {
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(rename = "RestElement")]
 pub struct BindingRestElement<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub argument: BindingPattern<'a>,
 }
 
@@ -1570,7 +1831,9 @@ pub struct BindingRestElement<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct Function<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub r#type: FunctionType,
     /// The function identifier. [`None`] for anonymous function expressions.
     pub id: Option<BindingIdentifier<'a>>,
@@ -1581,9 +1844,12 @@ pub struct Function<'a> {
     /// function bar() { }  // <- generator: false
     /// ```
     pub generator: bool,
+    #[allow(missing_docs)]
     pub r#async: bool,
+    #[allow(missing_docs)]
     #[ts]
     pub declare: bool,
+    #[allow(missing_docs)]
     #[ts]
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
     /// Declaring `this` in a Function <https://www.typescriptlang.org/docs/handbook/2/functions.html#declaring-this-in-a-function>
@@ -1624,18 +1890,23 @@ pub struct Function<'a> {
     /// }
     /// ```
     pub body: Option<Box<'a, FunctionBody<'a>>>,
+    #[allow(missing_docs)]
     #[estree(skip)]
     #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
+#[allow(missing_docs)]
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[generate_derive(CloneIn, ContentEq, ESTree)]
 #[estree(no_rename_variants)]
 pub enum FunctionType {
+    #[allow(missing_docs)]
     FunctionDeclaration = 0,
+    #[allow(missing_docs)]
     FunctionExpression = 1,
+    #[allow(missing_docs)]
     TSDeclareFunction = 2,
     /// <https://github.com/typescript-eslint/typescript-eslint/pull/1289>
     TSEmptyBodyFunctionExpression = 3,
@@ -1647,30 +1918,42 @@ pub enum FunctionType {
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(custom_serialize)]
 pub struct FormalParameters<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub kind: FormalParameterKind,
+    #[allow(missing_docs)]
     #[estree(ts_type = "Array<FormalParameter | FormalParameterRest>")]
     pub items: Vec<'a, FormalParameter<'a>>,
+    #[allow(missing_docs)]
     #[estree(skip)]
     pub rest: Option<Box<'a, BindingRestElement<'a>>>,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct FormalParameter<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     #[ts]
     pub decorators: Vec<'a, Decorator<'a>>,
+    #[allow(missing_docs)]
     pub pattern: BindingPattern<'a>,
+    #[allow(missing_docs)]
     #[ts]
     pub accessibility: Option<TSAccessibility>,
+    #[allow(missing_docs)]
     #[ts]
     pub readonly: bool,
+    #[allow(missing_docs)]
     #[ts]
     pub r#override: bool,
 }
 
+#[allow(missing_docs)]
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[generate_derive(CloneIn, ContentEq, ESTree)]
@@ -1691,8 +1974,11 @@ pub enum FormalParameterKind {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct FunctionBody<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub directives: Vec<'a, Directive<'a>>,
+    #[allow(missing_docs)]
     pub statements: Vec<'a, Statement<'a>>,
 }
 
@@ -1705,17 +1991,23 @@ pub struct FunctionBody<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ArrowFunctionExpression<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// Is the function body an arrow expression? i.e. `() => expr` instead of `() => {}`
     pub expression: bool,
+    #[allow(missing_docs)]
     pub r#async: bool,
+    #[allow(missing_docs)]
     #[ts]
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
+    #[allow(missing_docs)]
     pub params: Box<'a, FormalParameters<'a>>,
+    #[allow(missing_docs)]
     #[ts]
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
     /// See `expression` for whether this arrow expression returns an expression.
     pub body: Box<'a, FunctionBody<'a>>,
+    #[allow(missing_docs)]
     #[estree(skip)]
     #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
@@ -1726,8 +2018,11 @@ pub struct ArrowFunctionExpression<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct YieldExpression<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub delegate: bool,
+    #[allow(missing_docs)]
     pub argument: Option<Expression<'a>>,
 }
 
@@ -1737,7 +2032,9 @@ pub struct YieldExpression<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct Class<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub r#type: ClassType,
     /// Decorators applied to the class.
     ///
@@ -1753,6 +2050,7 @@ pub struct Class<'a> {
     pub decorators: Vec<'a, Decorator<'a>>,
     /// Class identifier, AKA the name
     pub id: Option<BindingIdentifier<'a>>,
+    #[allow(missing_docs)]
     #[scope(enter_before)]
     #[ts]
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
@@ -1783,6 +2081,7 @@ pub struct Class<'a> {
     /// ```
     #[ts]
     pub implements: Option<Vec<'a, TSClassImplements<'a>>>,
+    #[allow(missing_docs)]
     pub body: Box<'a, ClassBody<'a>>,
     /// Whether the class is abstract
     ///
@@ -1808,6 +2107,7 @@ pub struct Class<'a> {
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
+#[allow(missing_docs)]
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[generate_derive(CloneIn, ContentEq, ESTree)]
@@ -1826,11 +2126,14 @@ pub enum ClassType {
     ClassExpression = 1,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ClassBody<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub body: Vec<'a, ClassElement<'a>>,
 }
 
@@ -1856,12 +2159,15 @@ pub struct ClassBody<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
 pub enum ClassElement<'a> {
+    #[allow(missing_docs)]
     StaticBlock(Box<'a, StaticBlock<'a>>) = 0,
     /// Class Methods
     ///
     /// Includes static and non-static methods, constructors, getters, and setters.
     MethodDefinition(Box<'a, MethodDefinition<'a>>) = 1,
+    #[allow(missing_docs)]
     PropertyDefinition(Box<'a, PropertyDefinition<'a>>) = 2,
+    #[allow(missing_docs)]
     AccessorProperty(Box<'a, AccessorProperty<'a>>) = 3,
     /// Index Signature
     ///
@@ -1874,18 +2180,23 @@ pub enum ClassElement<'a> {
     TSIndexSignature(Box<'a, TSIndexSignature<'a>>) = 4,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct MethodDefinition<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// Method definition type
     ///
     /// This will always be true when an `abstract` modifier is used on the method.
     pub r#type: MethodDefinitionType,
+    #[allow(missing_docs)]
     #[ts]
     pub decorators: Vec<'a, Decorator<'a>>,
+    #[allow(missing_docs)]
     pub key: PropertyKey<'a>,
+    #[allow(missing_docs)]
     #[visit(args(flags = match self.kind {
         MethodDefinitionKind::Get => ScopeFlags::Function | ScopeFlags::GetAccessor,
         MethodDefinitionKind::Set => ScopeFlags::Function | ScopeFlags::SetAccessor,
@@ -1893,31 +2204,43 @@ pub struct MethodDefinition<'a> {
         MethodDefinitionKind::Method => ScopeFlags::Function,
     }))]
     pub value: Box<'a, Function<'a>>, // FunctionExpression
+    #[allow(missing_docs)]
     pub kind: MethodDefinitionKind,
+    #[allow(missing_docs)]
     pub computed: bool,
+    #[allow(missing_docs)]
     pub r#static: bool,
+    #[allow(missing_docs)]
     #[ts]
     pub r#override: bool,
+    #[allow(missing_docs)]
     #[ts]
     pub optional: bool,
+    #[allow(missing_docs)]
     #[ts]
     pub accessibility: Option<TSAccessibility>,
 }
 
+#[allow(missing_docs)]
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[generate_derive(CloneIn, ContentEq, ESTree)]
 #[estree(no_rename_variants)]
 pub enum MethodDefinitionType {
+    #[allow(missing_docs)]
     MethodDefinition = 0,
+    #[allow(missing_docs)]
     TSAbstractMethodDefinition = 1,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct PropertyDefinition<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub r#type: PropertyDefinitionType,
     /// Decorators applied to the property.
     ///
@@ -1968,11 +2291,13 @@ pub struct PropertyDefinition<'a> {
     /// ```
     #[ts]
     pub declare: bool,
+    #[allow(missing_docs)]
     #[ts]
     pub r#override: bool,
     /// `true` when created with an optional modifier (`?`)
     #[ts]
     pub optional: bool,
+    #[allow(missing_docs)]
     #[ts]
     pub definite: bool,
     /// `true` when declared with a `readonly` modifier
@@ -2001,15 +2326,19 @@ pub struct PropertyDefinition<'a> {
     pub accessibility: Option<TSAccessibility>,
 }
 
+#[allow(missing_docs)]
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[generate_derive(CloneIn, ContentEq, ESTree)]
 #[estree(no_rename_variants)]
 pub enum PropertyDefinitionType {
+    #[allow(missing_docs)]
     PropertyDefinition = 0,
+    #[allow(missing_docs)]
     TSAbstractPropertyDefinition = 1,
 }
 
+#[allow(missing_docs)]
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[generate_derive(CloneIn, ContentEq, ESTree)]
@@ -2031,7 +2360,9 @@ pub enum MethodDefinitionKind {
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct PrivateIdentifier<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub name: Atom<'a>,
 }
 
@@ -2053,8 +2384,11 @@ pub struct PrivateIdentifier<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct StaticBlock<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub body: Vec<'a, Statement<'a>>,
+    #[allow(missing_docs)]
     #[estree(skip)]
     #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
@@ -2118,12 +2452,15 @@ macro_rules! match_module_declaration {
 }
 pub use match_module_declaration;
 
+#[allow(missing_docs)]
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[generate_derive(CloneIn, ContentEq, ESTree)]
 #[estree(no_rename_variants)]
 pub enum AccessorPropertyType {
+    #[allow(missing_docs)]
     AccessorProperty = 0,
+    #[allow(missing_docs)]
     TSAbstractAccessorProperty = 1,
 }
 
@@ -2139,7 +2476,9 @@ pub enum AccessorPropertyType {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct AccessorProperty<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub r#type: AccessorPropertyType,
     /// Decorators applied to the accessor property.
     ///
@@ -2180,25 +2519,33 @@ pub struct AccessorProperty<'a> {
     pub accessibility: Option<TSAccessibility>,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ImportExpression<'a> {
     pub span: Span,
+    #[allow(missing_docs)]
     pub source: Expression<'a>,
+    #[allow(missing_docs)]
     pub arguments: Vec<'a, Expression<'a>>,
+    #[allow(missing_docs)]
     pub phase: Option<ImportPhase>,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ImportDeclaration<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// `None` for `import 'foo'`, `Some([])` for `import {} from 'foo'`
     #[estree(via = crate::serialize::OptionVecDefault, ts_type = "Array<ImportDeclarationSpecifier>")]
     pub specifiers: Option<Vec<'a, ImportDeclarationSpecifier<'a>>>,
+    #[allow(missing_docs)]
     pub source: StringLiteral<'a>,
+    #[allow(missing_docs)]
     pub phase: Option<ImportPhase>,
     /// Some(vec![]) for empty assertion
     #[ts]
@@ -2217,10 +2564,13 @@ pub struct ImportDeclaration<'a> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[generate_derive(CloneIn, ContentEq, ESTree)]
 pub enum ImportPhase {
+    #[allow(missing_docs)]
     Source = 0,
+    #[allow(missing_docs)]
     Defer = 1,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
@@ -2236,11 +2586,14 @@ pub enum ImportDeclarationSpecifier<'a> {
 
 // import {imported} from "source"
 // import {imported as local} from "source"
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ImportSpecifier<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub imported: ModuleExportName<'a>,
     /// The name of the imported symbol.
     ///
@@ -2254,6 +2607,7 @@ pub struct ImportSpecifier<'a> {
     /// //              ^^^
     /// ```
     pub local: BindingIdentifier<'a>,
+    #[allow(missing_docs)]
     #[ts]
     pub import_kind: ImportOrExportKind,
 }
@@ -2269,6 +2623,7 @@ pub struct ImportSpecifier<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ImportDefaultSpecifier<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// The name of the imported symbol.
     pub local: BindingIdentifier<'a>,
@@ -2284,33 +2639,46 @@ pub struct ImportDefaultSpecifier<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ImportNamespaceSpecifier<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub local: BindingIdentifier<'a>,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct WithClause<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub attributes_keyword: IdentifierName<'a>, // `with` or `assert`
+    #[allow(missing_docs)]
     pub with_entries: Vec<'a, ImportAttribute<'a>>,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ImportAttribute<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub key: ImportAttributeKey<'a>,
+    #[allow(missing_docs)]
     pub value: StringLiteral<'a>,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub enum ImportAttributeKey<'a> {
+    #[allow(missing_docs)]
     Identifier(IdentifierName<'a>) = 0,
+    #[allow(missing_docs)]
     StringLiteral(StringLiteral<'a>) = 1,
 }
 
@@ -2329,9 +2697,13 @@ pub enum ImportAttributeKey<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ExportNamedDeclaration<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub declaration: Option<Declaration<'a>>,
+    #[allow(missing_docs)]
     pub specifiers: Vec<'a, ExportSpecifier<'a>>,
+    #[allow(missing_docs)]
     pub source: Option<StringLiteral<'a>>,
     /// `export type { foo }`
     #[ts]
@@ -2354,8 +2726,11 @@ pub struct ExportNamedDeclaration<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ExportDefaultDeclaration<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub declaration: ExportDefaultDeclarationKind<'a>,
+    #[allow(missing_docs)]
     pub exported: ModuleExportName<'a>, // the `default` Keyword
 }
 
@@ -2372,13 +2747,16 @@ pub struct ExportDefaultDeclaration<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ExportAllDeclaration<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// If this declaration is re-named
     pub exported: Option<ModuleExportName<'a>>,
+    #[allow(missing_docs)]
     pub source: StringLiteral<'a>,
     /// Will be `Some(vec![])` for empty assertion
     #[ts]
     pub with_clause: Option<Box<'a, WithClause<'a>>>, // Some(vec![]) for empty assertion
+    #[allow(missing_docs)]
     #[ts]
     pub export_kind: ImportOrExportKind, // `export type *`
 }
@@ -2398,10 +2776,14 @@ pub struct ExportAllDeclaration<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ExportSpecifier<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub local: ModuleExportName<'a>,
+    #[allow(missing_docs)]
     pub exported: ModuleExportName<'a>,
     #[ts]
+    #[allow(missing_docs)]
     pub export_kind: ImportOrExportKind, // `export type *`
 }
 
@@ -2416,9 +2798,12 @@ inherit_variants! {
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
 pub enum ExportDefaultDeclarationKind<'a> {
     #[visit(args(flags = ScopeFlags::Function))]
+    #[allow(missing_docs)]
     FunctionDeclaration(Box<'a, Function<'a>>) = 64,
+    #[allow(missing_docs)]
     ClassDeclaration(Box<'a, Class<'a>>) = 65,
 
+    #[allow(missing_docs)]
     TSInterfaceDeclaration(Box<'a, TSInterfaceDeclaration<'a>>) = 66,
 
     // `Expression` variants added here by `inherit_variants!` macro
@@ -2437,8 +2822,10 @@ pub enum ExportDefaultDeclarationKind<'a> {
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub enum ModuleExportName<'a> {
+    #[allow(missing_docs)]
     IdentifierName(IdentifierName<'a>) = 0,
     /// For `local` in `ExportSpecifier`: `foo` in `export { foo }`
     IdentifierReference(IdentifierReference<'a>) = 1,
+    #[allow(missing_docs)]
     StringLiteral(StringLiteral<'a>) = 2,
 }

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1,8 +1,11 @@
+// FIXME: Many items in this file have `#![allow(missing_docs)]` and it would be a huge help
+// to remove all of these and add documentation. If you have time, please write some, it would
+// be a huge help :)
+#![warn(missing_docs)]
 //! TypeScript Definitions
 //!
 //! - [AST Spec](https://github.com/typescript-eslint/typescript-eslint/tree/v8.9.0/packages/ast-spec)
 //! - [Archived TypeScript spec](https://github.com/microsoft/TypeScript/blob/3c99d50da5a579d9fa92d02664b1b66d4ff55944/doc/spec-ARCHIVED.md)
-#![allow(missing_docs)] // FIXME
 
 // NB: `#[span]`, `#[scope(...)]`,`#[visit(...)]` and `#[generate_derive(...)]` do NOT do anything to the code.
 // They are purely markers for codegen used in `tasks/ast_tools` and `crates/oxc_traverse/scripts`. See docs in those crates.
@@ -32,7 +35,9 @@ use super::{inherit_variants, js::*, literal::*};
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSThisParameter<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     #[estree(skip)]
     pub this_span: Span,
     /// Type type the `this` keyword will have in the function
@@ -64,13 +69,18 @@ pub struct TSThisParameter<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSEnumDeclaration<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub id: BindingIdentifier<'a>,
+    #[allow(missing_docs)]
     #[scope(enter_before)]
     pub members: Vec<'a, TSEnumMember<'a>>,
     /// `true` for const enums
     pub r#const: bool,
+    #[allow(missing_docs)]
     pub declare: bool,
+    #[allow(missing_docs)]
     #[estree(skip)]
     #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
@@ -97,8 +107,11 @@ pub struct TSEnumDeclaration<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSEnumMember<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub id: TSEnumMemberName<'a>,
+    #[allow(missing_docs)]
     pub initializer: Option<Expression<'a>>,
 }
 
@@ -107,7 +120,9 @@ pub struct TSEnumMember<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
 pub enum TSEnumMemberName<'a> {
+    #[allow(missing_docs)]
     Identifier(Box<'a, IdentifierName<'a>>) = 0,
+    #[allow(missing_docs)]
     String(Box<'a, StringLiteral<'a>>) = 1,
 }
 
@@ -151,7 +166,9 @@ pub struct TSTypeAnnotation<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSLiteralType<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub literal: TSLiteral<'a>,
 }
 
@@ -160,13 +177,21 @@ pub struct TSLiteralType<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
 pub enum TSLiteral<'a> {
+    #[allow(missing_docs)]
     BooleanLiteral(Box<'a, BooleanLiteral>) = 0,
+    #[allow(missing_docs)]
     NullLiteral(Box<'a, NullLiteral>) = 1,
+    #[allow(missing_docs)]
     NumericLiteral(Box<'a, NumericLiteral<'a>>) = 2,
+    #[allow(missing_docs)]
     BigIntLiteral(Box<'a, BigIntLiteral<'a>>) = 3,
+    #[allow(missing_docs)]
     RegExpLiteral(Box<'a, RegExpLiteral<'a>>) = 4,
+    #[allow(missing_docs)]
     StringLiteral(Box<'a, StringLiteral<'a>>) = 5,
+    #[allow(missing_docs)]
     TemplateLiteral(Box<'a, TemplateLiteral<'a>>) = 6,
+    #[allow(missing_docs)]
     UnaryExpression(Box<'a, UnaryExpression<'a>>) = 7,
 }
 
@@ -186,45 +211,83 @@ pub enum TSLiteral<'a> {
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
 pub enum TSType<'a> {
     // Keyword
+    #[allow(missing_docs)]
     TSAnyKeyword(Box<'a, TSAnyKeyword>) = 0,
+    #[allow(missing_docs)]
     TSBigIntKeyword(Box<'a, TSBigIntKeyword>) = 1,
+    #[allow(missing_docs)]
     TSBooleanKeyword(Box<'a, TSBooleanKeyword>) = 2,
+    #[allow(missing_docs)]
     TSIntrinsicKeyword(Box<'a, TSIntrinsicKeyword>) = 3,
+    #[allow(missing_docs)]
     TSNeverKeyword(Box<'a, TSNeverKeyword>) = 4,
+    #[allow(missing_docs)]
     TSNullKeyword(Box<'a, TSNullKeyword>) = 5,
+    #[allow(missing_docs)]
     TSNumberKeyword(Box<'a, TSNumberKeyword>) = 6,
+    #[allow(missing_docs)]
     TSObjectKeyword(Box<'a, TSObjectKeyword>) = 7,
+    #[allow(missing_docs)]
     TSStringKeyword(Box<'a, TSStringKeyword>) = 8,
+    #[allow(missing_docs)]
     TSSymbolKeyword(Box<'a, TSSymbolKeyword>) = 9,
+    #[allow(missing_docs)]
     TSUndefinedKeyword(Box<'a, TSUndefinedKeyword>) = 11,
+    #[allow(missing_docs)]
     TSUnknownKeyword(Box<'a, TSUnknownKeyword>) = 12,
+    #[allow(missing_docs)]
     TSVoidKeyword(Box<'a, TSVoidKeyword>) = 13,
     // Compound
+    #[allow(missing_docs)]
     TSArrayType(Box<'a, TSArrayType<'a>>) = 14,
+    #[allow(missing_docs)]
     TSConditionalType(Box<'a, TSConditionalType<'a>>) = 15,
+    #[allow(missing_docs)]
     TSConstructorType(Box<'a, TSConstructorType<'a>>) = 16,
+    #[allow(missing_docs)]
     TSFunctionType(Box<'a, TSFunctionType<'a>>) = 17,
+    #[allow(missing_docs)]
     TSImportType(Box<'a, TSImportType<'a>>) = 18,
+    #[allow(missing_docs)]
     TSIndexedAccessType(Box<'a, TSIndexedAccessType<'a>>) = 19,
+    #[allow(missing_docs)]
     TSInferType(Box<'a, TSInferType<'a>>) = 20,
+    #[allow(missing_docs)]
     TSIntersectionType(Box<'a, TSIntersectionType<'a>>) = 21,
+    #[allow(missing_docs)]
     TSLiteralType(Box<'a, TSLiteralType<'a>>) = 22,
+    #[allow(missing_docs)]
     TSMappedType(Box<'a, TSMappedType<'a>>) = 23,
+    #[allow(missing_docs)]
     TSNamedTupleMember(Box<'a, TSNamedTupleMember<'a>>) = 24,
+    #[allow(missing_docs)]
     TSQualifiedName(Box<'a, TSQualifiedName<'a>>) = 25,
+    #[allow(missing_docs)]
     TSTemplateLiteralType(Box<'a, TSTemplateLiteralType<'a>>) = 26,
+    #[allow(missing_docs)]
     TSThisType(Box<'a, TSThisType>) = 10,
+    #[allow(missing_docs)]
     TSTupleType(Box<'a, TSTupleType<'a>>) = 27,
+    #[allow(missing_docs)]
     TSTypeLiteral(Box<'a, TSTypeLiteral<'a>>) = 28,
+    #[allow(missing_docs)]
     TSTypeOperatorType(Box<'a, TSTypeOperator<'a>>) = 29,
+    #[allow(missing_docs)]
     TSTypePredicate(Box<'a, TSTypePredicate<'a>>) = 30,
+    #[allow(missing_docs)]
     TSTypeQuery(Box<'a, TSTypeQuery<'a>>) = 31,
+    #[allow(missing_docs)]
     TSTypeReference(Box<'a, TSTypeReference<'a>>) = 32,
+    #[allow(missing_docs)]
     TSUnionType(Box<'a, TSUnionType<'a>>) = 33,
+    #[allow(missing_docs)]
     TSParenthesizedType(Box<'a, TSParenthesizedType<'a>>) = 34,
     // JSDoc
+    #[allow(missing_docs)]
     JSDocNullableType(Box<'a, JSDocNullableType<'a>>) = 35,
+    #[allow(missing_docs)]
     JSDocNonNullableType(Box<'a, JSDocNonNullableType<'a>>) = 36,
+    #[allow(missing_docs)]
     JSDocUnknownType(Box<'a, JSDocUnknownType>) = 37,
 }
 
@@ -292,6 +355,7 @@ pub use match_ts_type;
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSConditionalType<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// The type before `extends` in the test expression.
     pub check_type: TSType<'a>,
@@ -303,6 +367,7 @@ pub struct TSConditionalType<'a> {
     /// The type evaluated to if the test is false.
     #[scope(exit_before)]
     pub false_type: TSType<'a>,
+    #[allow(missing_docs)]
     #[estree(skip)]
     #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
@@ -321,6 +386,7 @@ pub struct TSConditionalType<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSUnionType<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// The types in the union.
     pub types: Vec<'a, TSType<'a>>,
@@ -343,7 +409,9 @@ pub struct TSUnionType<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSIntersectionType<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub types: Vec<'a, TSType<'a>>,
 }
 
@@ -360,7 +428,9 @@ pub struct TSIntersectionType<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSParenthesizedType<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub type_annotation: TSType<'a>,
 }
 
@@ -377,7 +447,9 @@ pub struct TSParenthesizedType<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSTypeOperator<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub operator: TSTypeOperatorOperator,
     /// The type being operated on
     pub type_annotation: TSType<'a>,
@@ -388,8 +460,11 @@ pub struct TSTypeOperator<'a> {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[generate_derive(CloneIn, ContentEq, ESTree)]
 pub enum TSTypeOperatorOperator {
+    #[allow(missing_docs)]
     Keyof = 0,
+    #[allow(missing_docs)]
     Unique = 1,
+    #[allow(missing_docs)]
     Readonly = 2,
 }
 
@@ -408,7 +483,9 @@ pub enum TSTypeOperatorOperator {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSArrayType<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub element_type: TSType<'a>,
 }
 
@@ -427,8 +504,11 @@ pub struct TSArrayType<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSIndexedAccessType<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub object_type: TSType<'a>,
+    #[allow(missing_docs)]
     pub index_type: TSType<'a>,
 }
 
@@ -445,7 +525,9 @@ pub struct TSIndexedAccessType<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSTupleType<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub element_types: Vec<'a, TSTupleElement<'a>>,
 }
 
@@ -463,9 +545,13 @@ pub struct TSTupleType<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSNamedTupleMember<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub element_type: TSTupleElement<'a>,
+    #[allow(missing_docs)]
     pub label: IdentifierName<'a>,
+    #[allow(missing_docs)]
     pub optional: bool,
 }
 
@@ -482,7 +568,9 @@ pub struct TSNamedTupleMember<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSOptionalType<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub type_annotation: TSType<'a>,
 }
 
@@ -498,7 +586,9 @@ pub struct TSOptionalType<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSRestType<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub type_annotation: TSType<'a>,
 }
 
@@ -516,7 +606,9 @@ inherit_variants! {
 pub enum TSTupleElement<'a> {
     // Discriminants start at 64, so that `TSTupleElement::is_ts_type` is a single
     // bitwise AND operation on the discriminant (`discriminant & 63 != 0`).
+    #[allow(missing_docs)]
     TSOptionalType(Box<'a, TSOptionalType<'a>>) = 64,
+    #[allow(missing_docs)]
     TSRestType(Box<'a, TSRestType<'a>>) = 65,
     // `TSType` variants added here by `inherit_variants!` macro
     @inherit TSType
@@ -536,6 +628,7 @@ pub enum TSTupleElement<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSAnyKeyword {
+    #[allow(missing_docs)]
     pub span: Span,
 }
 
@@ -552,6 +645,7 @@ pub struct TSAnyKeyword {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSStringKeyword {
+    #[allow(missing_docs)]
     pub span: Span,
 }
 
@@ -568,6 +662,7 @@ pub struct TSStringKeyword {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSBooleanKeyword {
+    #[allow(missing_docs)]
     pub span: Span,
 }
 
@@ -584,6 +679,7 @@ pub struct TSBooleanKeyword {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSNumberKeyword {
+    #[allow(missing_docs)]
     pub span: Span,
 }
 
@@ -601,6 +697,7 @@ pub struct TSNumberKeyword {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSNeverKeyword {
+    #[allow(missing_docs)]
     pub span: Span,
 }
 
@@ -618,6 +715,7 @@ pub struct TSNeverKeyword {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSIntrinsicKeyword {
+    #[allow(missing_docs)]
     pub span: Span,
 }
 
@@ -636,6 +734,7 @@ pub struct TSIntrinsicKeyword {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSUnknownKeyword {
+    #[allow(missing_docs)]
     pub span: Span,
 }
 
@@ -653,6 +752,7 @@ pub struct TSUnknownKeyword {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSNullKeyword {
+    #[allow(missing_docs)]
     pub span: Span,
 }
 
@@ -672,41 +772,52 @@ pub struct TSNullKeyword {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSUndefinedKeyword {
+    #[allow(missing_docs)]
     pub span: Span,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSVoidKeyword {
+    #[allow(missing_docs)]
     pub span: Span,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSSymbolKeyword {
+    #[allow(missing_docs)]
     pub span: Span,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSThisType {
+    #[allow(missing_docs)]
     pub span: Span,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSObjectKeyword {
+    #[allow(missing_docs)]
     pub span: Span,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSBigIntKeyword {
+    #[allow(missing_docs)]
     pub span: Span,
 }
 
@@ -722,8 +833,11 @@ pub struct TSBigIntKeyword {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSTypeReference<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub type_name: TSTypeName<'a>,
+    #[allow(missing_docs)]
     pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
 }
 
@@ -734,7 +848,9 @@ pub struct TSTypeReference<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
 pub enum TSTypeName<'a> {
+    #[allow(missing_docs)]
     IdentifierReference(Box<'a, IdentifierReference<'a>>) = 0,
+    #[allow(missing_docs)]
     QualifiedName(Box<'a, TSQualifiedName<'a>>) = 1,
 }
 
@@ -759,16 +875,22 @@ pub use match_ts_type_name;
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSQualifiedName<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub left: TSTypeName<'a>,
+    #[allow(missing_docs)]
     pub right: IdentifierName<'a>,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSTypeParameterInstantiation<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub params: Vec<'a, TSType<'a>>,
 }
 
@@ -793,6 +915,7 @@ pub struct TSTypeParameterInstantiation<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSTypeParameter<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// The name of the parameter, e.g. `T` in `type Foo<T> = ...`.
     pub name: BindingIdentifier<'a>,
@@ -808,11 +931,14 @@ pub struct TSTypeParameter<'a> {
     pub r#const: bool,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSTypeParameterDeclaration<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub params: Vec<'a, TSTypeParameter<'a>>,
 }
 
@@ -829,24 +955,33 @@ pub struct TSTypeParameterDeclaration<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSTypeAliasDeclaration<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// Type alias's identifier, e.g. `Foo` in `type Foo = number`.
     pub id: BindingIdentifier<'a>,
+    #[allow(missing_docs)]
     #[scope(enter_before)]
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
+    #[allow(missing_docs)]
     pub type_annotation: TSType<'a>,
+    #[allow(missing_docs)]
     pub declare: bool,
+    #[allow(missing_docs)]
     #[estree(skip)]
     #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
+#[allow(missing_docs)]
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[generate_derive(CloneIn, ContentEq, ESTree)]
 pub enum TSAccessibility {
+    #[allow(missing_docs)]
     Private = 0,
+    #[allow(missing_docs)]
     Protected = 1,
+    #[allow(missing_docs)]
     Public = 2,
 }
 
@@ -864,8 +999,11 @@ pub enum TSAccessibility {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSClassImplements<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub expression: TSTypeName<'a>,
+    #[allow(missing_docs)]
     pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
 }
 
@@ -889,6 +1027,7 @@ pub struct TSClassImplements<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSInterfaceDeclaration<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// The identifier (name) of the interface.
     pub id: BindingIdentifier<'a>,
@@ -897,9 +1036,11 @@ pub struct TSInterfaceDeclaration<'a> {
     pub extends: Option<Vec<'a, TSInterfaceHeritage<'a>>>,
     /// Type parameters that get bound to the interface.
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
+    #[allow(missing_docs)]
     pub body: Box<'a, TSInterfaceBody<'a>>,
     /// `true` for `declare interface Foo {}`
     pub declare: bool,
+    #[allow(missing_docs)]
     #[estree(skip)]
     #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
@@ -910,7 +1051,9 @@ pub struct TSInterfaceDeclaration<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSInterfaceBody<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub body: Vec<'a, TSSignature<'a>>,
 }
 
@@ -933,22 +1076,34 @@ pub struct TSInterfaceBody<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSPropertySignature<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub computed: bool,
+    #[allow(missing_docs)]
     pub optional: bool,
+    #[allow(missing_docs)]
     pub readonly: bool,
+    #[allow(missing_docs)]
     pub key: PropertyKey<'a>,
+    #[allow(missing_docs)]
     pub type_annotation: Option<Box<'a, TSTypeAnnotation<'a>>>,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
 pub enum TSSignature<'a> {
+    #[allow(missing_docs)]
     TSIndexSignature(Box<'a, TSIndexSignature<'a>>) = 0,
+    #[allow(missing_docs)]
     TSPropertySignature(Box<'a, TSPropertySignature<'a>>) = 1,
+    #[allow(missing_docs)]
     TSCallSignatureDeclaration(Box<'a, TSCallSignatureDeclaration<'a>>) = 2,
+    #[allow(missing_docs)]
     TSConstructSignatureDeclaration(Box<'a, TSConstructSignatureDeclaration<'a>>) = 3,
+    #[allow(missing_docs)]
     TSMethodSignature(Box<'a, TSMethodSignature<'a>>) = 4,
 }
 
@@ -967,30 +1122,45 @@ pub enum TSSignature<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSIndexSignature<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub parameters: Vec<'a, TSIndexSignatureName<'a>>,
+    #[allow(missing_docs)]
     pub type_annotation: Box<'a, TSTypeAnnotation<'a>>,
+    #[allow(missing_docs)]
     pub readonly: bool,
+    #[allow(missing_docs)]
     pub r#static: bool,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSCallSignatureDeclaration<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
+    #[allow(missing_docs)]
     pub this_param: Option<TSThisParameter<'a>>,
+    #[allow(missing_docs)]
     pub params: Box<'a, FormalParameters<'a>>,
+    #[allow(missing_docs)]
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
 }
 
+#[allow(missing_docs)]
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[generate_derive(CloneIn, ContentEq, ESTree)]
 pub enum TSMethodSignatureKind {
+    #[allow(missing_docs)]
     Method = 0,
+    #[allow(missing_docs)]
     Get = 1,
+    #[allow(missing_docs)]
     Set = 2,
 }
 
@@ -1010,15 +1180,25 @@ pub enum TSMethodSignatureKind {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSMethodSignature<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub key: PropertyKey<'a>,
+    #[allow(missing_docs)]
     pub computed: bool,
+    #[allow(missing_docs)]
     pub optional: bool,
+    #[allow(missing_docs)]
     pub kind: TSMethodSignatureKind,
+    #[allow(missing_docs)]
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
+    #[allow(missing_docs)]
     pub this_param: Option<Box<'a, TSThisParameter<'a>>>,
+    #[allow(missing_docs)]
     pub params: Box<'a, FormalParameters<'a>>,
+    #[allow(missing_docs)]
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
+    #[allow(missing_docs)]
     #[estree(skip)]
     #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
@@ -1030,31 +1210,44 @@ pub struct TSMethodSignature<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSConstructSignatureDeclaration<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
+    #[allow(missing_docs)]
     pub params: Box<'a, FormalParameters<'a>>,
+    #[allow(missing_docs)]
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
+    #[allow(missing_docs)]
     #[estree(skip)]
     #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(rename = "Identifier")]
 pub struct TSIndexSignatureName<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub name: Atom<'a>,
+    #[allow(missing_docs)]
     pub type_annotation: Box<'a, TSTypeAnnotation<'a>>,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSInterfaceHeritage<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub expression: Expression<'a>,
+    #[allow(missing_docs)]
     pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
 }
 
@@ -1082,6 +1275,7 @@ pub struct TSInterfaceHeritage<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSTypePredicate<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// The identifier the predicate operates on
     pub parameter_name: TSTypePredicateName<'a>,
@@ -1092,14 +1286,18 @@ pub struct TSTypePredicate<'a> {
     /// declare function isString(x: any): asserts x is string; // true
     /// ```
     pub asserts: bool,
+    #[allow(missing_docs)]
     pub type_annotation: Option<Box<'a, TSTypeAnnotation<'a>>>,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub enum TSTypePredicateName<'a> {
+    #[allow(missing_docs)]
     Identifier(Box<'a, IdentifierName<'a>>) = 0,
+    #[allow(missing_docs)]
     This(TSThisType) = 1,
 }
 
@@ -1137,11 +1335,13 @@ pub enum TSTypePredicateName<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSModuleDeclaration<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// The name of the module/namespace being declared.
     ///
     /// Note that for `declare global {}`, no symbol will be created for the module name.
     pub id: TSModuleDeclarationName<'a>,
+    #[allow(missing_docs)]
     #[scope(enter_before)]
     pub body: Option<TSModuleDeclarationBody<'a>>,
     /// The keyword used to define this module declaration.
@@ -1158,12 +1358,15 @@ pub struct TSModuleDeclaration<'a> {
     ///         ^^^^^^
     /// ```
     pub kind: TSModuleDeclarationKind,
+    #[allow(missing_docs)]
     pub declare: bool,
+    #[allow(missing_docs)]
     #[estree(skip)]
     #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
+#[allow(missing_docs)]
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[generate_derive(CloneIn, ContentEq, ESTree)]
@@ -1200,35 +1403,47 @@ pub enum TSModuleDeclarationKind {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub enum TSModuleDeclarationName<'a> {
+    #[allow(missing_docs)]
     Identifier(BindingIdentifier<'a>) = 0,
+    #[allow(missing_docs)]
     StringLiteral(StringLiteral<'a>) = 1,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
 pub enum TSModuleDeclarationBody<'a> {
+    #[allow(missing_docs)]
     TSModuleDeclaration(Box<'a, TSModuleDeclaration<'a>>) = 0,
+    #[allow(missing_docs)]
     TSModuleBlock(Box<'a, TSModuleBlock<'a>>) = 1,
 }
 
 // See serializer in serialize.rs
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(custom_serialize)]
 pub struct TSModuleBlock<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     #[estree(skip)]
     pub directives: Vec<'a, Directive<'a>>,
+    #[allow(missing_docs)]
     pub body: Vec<'a, Statement<'a>>,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSTypeLiteral<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub members: Vec<'a, TSSignature<'a>>,
 }
 
@@ -1249,6 +1464,7 @@ pub struct TSTypeLiteral<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSInferType<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// The type bound when the
     pub type_parameter: Box<'a, TSTypeParameter<'a>>,
@@ -1267,8 +1483,11 @@ pub struct TSInferType<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSTypeQuery<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub expr_name: TSTypeQueryExprName<'a>,
+    #[allow(missing_docs)]
     pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
 }
 
@@ -1282,48 +1501,64 @@ inherit_variants! {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
 pub enum TSTypeQueryExprName<'a> {
+    #[allow(missing_docs)]
     TSImportType(Box<'a, TSImportType<'a>>) = 2,
     // `TSTypeName` variants added here by `inherit_variants!` macro
     @inherit TSTypeName
 }
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSImportType<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// `true` for `typeof import("foo")`
     pub is_type_of: bool,
     pub parameter: TSType<'a>,
+    #[allow(missing_docs)]
     pub qualifier: Option<TSTypeName<'a>>,
+    #[allow(missing_docs)]
     pub attributes: Option<Box<'a, TSImportAttributes<'a>>>,
+    #[allow(missing_docs)]
     pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSImportAttributes<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub attributes_keyword: IdentifierName<'a>, // `with` or `assert`
+    #[allow(missing_docs)]
     pub elements: Vec<'a, TSImportAttribute<'a>>,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSImportAttribute<'a> {
     pub span: Span,
+    #[allow(missing_docs)]
     pub name: TSImportAttributeName<'a>,
+    #[allow(missing_docs)]
     pub value: Expression<'a>,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub enum TSImportAttributeName<'a> {
+    #[allow(missing_docs)]
     Identifier(IdentifierName<'a>) = 0,
+    #[allow(missing_docs)]
     StringLiteral(StringLiteral<'a>) = 1,
 }
 
@@ -1339,6 +1574,7 @@ pub enum TSImportAttributeName<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSFunctionType<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// Generic type parameters
     ///
@@ -1364,14 +1600,20 @@ pub struct TSFunctionType<'a> {
     pub return_type: Box<'a, TSTypeAnnotation<'a>>,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSConstructorType<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub r#abstract: bool,
+    #[allow(missing_docs)]
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
+    #[allow(missing_docs)]
     pub params: Box<'a, FormalParameters<'a>>,
+    #[allow(missing_docs)]
     pub return_type: Box<'a, TSTypeAnnotation<'a>>,
 }
 
@@ -1401,10 +1643,13 @@ pub struct TSConstructorType<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSMappedType<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// Key type parameter, e.g. `P` in `[P in keyof T]`.
     pub type_parameter: Box<'a, TSTypeParameter<'a>>,
+    #[allow(missing_docs)]
     pub name_type: Option<TSType<'a>>,
+    #[allow(missing_docs)]
     pub type_annotation: Option<TSType<'a>>,
     /// Optional modifier on type annotation
     ///
@@ -1430,11 +1675,13 @@ pub struct TSMappedType<'a> {
     /// type Qux = { [P in keyof T]: T[P] }           // None
     /// ```
     pub readonly: TSMappedTypeModifierOperator,
+    #[allow(missing_docs)]
     #[estree(skip)]
     #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
+#[allow(missing_docs)]
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[generate_derive(CloneIn, ContentEq, ESTree)]
@@ -1466,6 +1713,7 @@ pub enum TSMappedTypeModifierOperator {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSTemplateLiteralType<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// The string parts of the template literal.
     pub quasis: Vec<'a, TemplateElement<'a>>,
@@ -1473,12 +1721,16 @@ pub struct TSTemplateLiteralType<'a> {
     pub types: Vec<'a, TSType<'a>>,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSAsExpression<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub expression: Expression<'a>,
+    #[allow(missing_docs)]
     pub type_annotation: TSType<'a>,
 }
 
@@ -1498,6 +1750,7 @@ pub struct TSAsExpression<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSSatisfiesExpression<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
     /// The value expression being constrained.
     pub expression: Expression<'a>,
@@ -1505,22 +1758,31 @@ pub struct TSSatisfiesExpression<'a> {
     pub type_annotation: TSType<'a>,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSTypeAssertion<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub expression: Expression<'a>,
+    #[allow(missing_docs)]
     pub type_annotation: TSType<'a>,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSImportEqualsDeclaration<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub id: BindingIdentifier<'a>,
+    #[allow(missing_docs)]
     pub module_reference: TSModuleReference<'a>,
+    #[allow(missing_docs)]
     pub import_kind: ImportOrExportKind,
 }
 
@@ -1534,25 +1796,32 @@ inherit_variants! {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
 pub enum TSModuleReference<'a> {
+    #[allow(missing_docs)]
     ExternalModuleReference(Box<'a, TSExternalModuleReference<'a>>) = 2,
     // `TSTypeName` variants added here by `inherit_variants!` macro
     @inherit TSTypeName
 }
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSExternalModuleReference<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub expression: StringLiteral<'a>,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSNonNullExpression<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub expression: Expression<'a>,
 }
 
@@ -1584,7 +1853,9 @@ pub struct TSNonNullExpression<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct Decorator<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub expression: Expression<'a>,
 }
 
@@ -1595,7 +1866,9 @@ pub struct Decorator<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSExportAssignment<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub expression: Expression<'a>,
 }
 
@@ -1606,16 +1879,22 @@ pub struct TSExportAssignment<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSNamespaceExportDeclaration<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub id: IdentifierName<'a>,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct TSInstantiationExpression<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub expression: Expression<'a>,
+    #[allow(missing_docs)]
     pub type_parameters: Box<'a, TSTypeParameterInstantiation<'a>>,
 }
 
@@ -1637,7 +1916,9 @@ pub enum ImportOrExportKind {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct JSDocNullableType<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub type_annotation: TSType<'a>,
     /// Was `?` after the type annotation?
     pub postfix: bool,
@@ -1648,14 +1929,19 @@ pub struct JSDocNullableType<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct JSDocNonNullableType<'a> {
+    #[allow(missing_docs)]
     pub span: Span,
+    #[allow(missing_docs)]
     pub type_annotation: TSType<'a>,
+    #[allow(missing_docs)]
     pub postfix: bool,
 }
 
+#[allow(missing_docs)]
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct JSDocUnknownType {
+    #[allow(missing_docs)]
     pub span: Span,
 }


### PR DESCRIPTION
Requires that all new fields/structs/enums in the JS and TS files must have documentation.