### PR TITLE
refactor(ast): remove excess line breaks from generated code

### DIFF
--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -6,13 +6,9 @@
 use oxc_allocator::{Allocator, CloneIn};
 
 use crate::ast::comment::*;
-
 use crate::ast::js::*;
-
 use crate::ast::jsx::*;
-
 use crate::ast::literal::*;
-
 use crate::ast::ts::*;
 
 impl<'alloc> CloneIn<'alloc> for BooleanLiteral {

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -6,13 +6,9 @@
 use oxc_span::cmp::ContentEq;
 
 use crate::ast::comment::*;
-
 use crate::ast::js::*;
-
 use crate::ast::jsx::*;
-
 use crate::ast::literal::*;
-
 use crate::ast::ts::*;
 
 impl ContentEq for BooleanLiteral {

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -6,11 +6,8 @@
 use serde::{ser::SerializeMap, Serialize, Serializer};
 
 use crate::ast::js::*;
-
 use crate::ast::jsx::*;
-
 use crate::ast::literal::*;
-
 use crate::ast::ts::*;
 
 impl Serialize for BooleanLiteral {

--- a/crates/oxc_ast/src/generated/derive_get_address.rs
+++ b/crates/oxc_ast/src/generated/derive_get_address.rs
@@ -6,9 +6,7 @@
 use oxc_allocator::{Address, GetAddress};
 
 use crate::ast::js::*;
-
 use crate::ast::jsx::*;
-
 use crate::ast::ts::*;
 
 impl GetAddress for Expression<'_> {

--- a/crates/oxc_ast/src/generated/derive_get_span.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span.rs
@@ -6,11 +6,8 @@
 use oxc_span::{GetSpan, Span};
 
 use crate::ast::js::*;
-
 use crate::ast::jsx::*;
-
 use crate::ast::literal::*;
-
 use crate::ast::ts::*;
 
 impl GetSpan for BooleanLiteral {

--- a/crates/oxc_ast/src/generated/derive_get_span_mut.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span_mut.rs
@@ -6,11 +6,8 @@
 use oxc_span::{GetSpanMut, Span};
 
 use crate::ast::js::*;
-
 use crate::ast::jsx::*;
-
 use crate::ast::literal::*;
-
 use crate::ast::ts::*;
 
 impl GetSpanMut for BooleanLiteral {

--- a/crates/oxc_span/src/generated/derive_estree.rs
+++ b/crates/oxc_span/src/generated/derive_estree.rs
@@ -6,7 +6,6 @@
 use serde::{ser::SerializeMap, Serialize, Serializer};
 
 use crate::source_type::*;
-
 use crate::span::types::*;
 
 impl Serialize for Span {

--- a/crates/oxc_syntax/src/generated/derive_clone_in.rs
+++ b/crates/oxc_syntax/src/generated/derive_clone_in.rs
@@ -6,7 +6,6 @@
 use oxc_allocator::{Allocator, CloneIn};
 
 use crate::number::*;
-
 use crate::operator::*;
 
 impl<'alloc> CloneIn<'alloc> for NumberBase {

--- a/crates/oxc_syntax/src/generated/derive_content_eq.rs
+++ b/crates/oxc_syntax/src/generated/derive_content_eq.rs
@@ -6,7 +6,6 @@
 use oxc_span::cmp::ContentEq;
 
 use crate::number::*;
-
 use crate::operator::*;
 
 impl ContentEq for NumberBase {

--- a/tasks/ast_tools/src/derives/mod.rs
+++ b/tasks/ast_tools/src/derives/mod.rs
@@ -52,15 +52,13 @@ pub trait Derive {
                 .chain(["*"])
                 .join("::");
             let use_module: ItemUse = parse_str(format!("use {local_path};").as_str()).unwrap();
-            quote! {
-                ///@@line_break
-                #use_module
-            }
+            quote!( #use_module )
         });
 
         quote! {
             #prelude
 
+            ///@@line_break
             #(#use_modules)*
 
             ///@@line_break


### PR DESCRIPTION
Pure refactor. Just remove excess line breaks.