### PR TITLE
refactor(linter): replace MIME guessing with extension check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,22 +1313,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mime"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1839,7 +1823,6 @@ dependencies = [
  "lazy_static",
  "markdown",
  "memchr",
- "mime_guess",
  "nonmax",
  "oxc_allocator",
  "oxc_ast",
@@ -3379,12 +3362,6 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
-
-[[package]]
-name = "unicase"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-id"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,6 @@ markdown = "1.0.0-alpha.21"
 memchr = "2.7.4"
 miette = { package = "oxc-miette", version = "1.0.2", features = ["fancy-no-syscall"] }
 mimalloc = "0.1.43"
-mime_guess = "2.0.5"
 nonmax = "0.5.5"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -48,7 +48,6 @@ json-strip-comments = { workspace = true }
 language-tags = { workspace = true }
 lazy_static = { workspace = true }
 memchr = { workspace = true }
-mime_guess = { workspace = true }
 nonmax = { workspace = true }
 phf = { workspace = true, features = ["macros"] }
 rayon = { workspace = true }

--- a/crates/oxc_linter/src/config/oxlintrc.rs
+++ b/crates/oxc_linter/src/config/oxlintrc.rs
@@ -1,4 +1,7 @@
-use std::path::{Path, PathBuf};
+use std::{
+    ffi::OsStr,
+    path::{Path, PathBuf},
+};
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -109,14 +112,14 @@ impl Oxlintrc {
         })?;
 
         let json = serde_json::from_str::<serde_json::Value>(&string).map_err(|err| {
-            let guess = mime_guess::from_path(path);
-            let err = match guess.first() {
+            let ext = path.extension().and_then(OsStr::to_str);
+            let err = match ext {
                 // syntax error
-                Some(mime) if mime.subtype() == "json" => err.to_string(),
-                Some(_) => "Only json configuration is supported".to_string(),
+                Some(ext) if is_json_ext(ext) => err.to_string(),
+                Some(_) => "Only JSON configuration files are supported".to_string(),
                 None => {
                     format!(
-                        "{err}, if the configuration is not a json file, please use json instead."
+                        "{err}, if the configuration is not a JSON file, please use JSON instead."
                     )
                 }
             };
@@ -131,6 +134,10 @@ impl Oxlintrc {
 
         Ok(config)
     }
+}
+
+fn is_json_ext(ext: &str) -> bool {
+    ext == "json" || ext == "jsonc"
 }
 
 #[cfg(test)]


### PR DESCRIPTION
I noticed that we were using this `mime_guess` crate, when it all it really does internally is check the extension of the file and map that to known MIME types: https://github.com/abonander/mime_guess/blob/805964fb54871f0154ee155bf21729b77ffd4a1c/src/lib.rs#L87-L90

Since we only expect JSON configuration files, I've replaced the MIME guessing with a simple extension check.