### PR TITLE
refactor(linter): remove usage of `url` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1848,7 +1848,6 @@ dependencies = [
  "serde",
  "serde_json",
  "simdutf8",
- "url",
 ]
 
 [[package]]
@@ -2142,7 +2141,6 @@ dependencies = [
  "project-root",
  "similar",
  "ureq",
- "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -198,7 +198,6 @@ tower-lsp = "0.20.0"
 tracing-subscriber = "0.3.19"
 tsify = "0.4.5"
 ureq = { version = "3.0.0", default-features = false }
-url = "2.5.4"
 walkdir = "2.5.0"
 wasm-bindgen = "0.2.99"
 

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -58,7 +58,6 @@ schemars = { workspace = true, features = ["indexmap2"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 simdutf8 = { workspace = true }
-url = { workspace = true }
 
 [dev-dependencies]
 insta = { workspace = true }

--- a/crates/oxc_linter/src/rules/nextjs/google_font_display.rs
+++ b/crates/oxc_linter/src/rules/nextjs/google_font_display.rs
@@ -6,7 +6,7 @@ use oxc_span::{GetSpan, Span};
 use crate::{
     context::LintContext,
     rule::Rule,
-    utils::{get_string_literal_prop_value, has_jsx_prop_ignore_case},
+    utils::{find_url_query_value, get_string_literal_prop_value, has_jsx_prop_ignore_case},
     AstNode,
 };
 
@@ -102,21 +102,13 @@ impl Rule for GoogleFontDisplay {
         };
 
         if href_prop_value.starts_with("https://fonts.googleapis.com/css") {
-            let Ok(url) = url::Url::parse(href_prop_value) else {
-                return;
-            };
-
-            let Some((_, display_value)) = url.query_pairs().find(|(key, _)| key == "display")
-            else {
+            let Some(display_value) = find_url_query_value(href_prop_value, "display") else {
                 ctx.diagnostic(font_display_parameter_missing(jsx_opening_element_name.span));
                 return;
             };
 
-            if matches!(&*display_value, "auto" | "block" | "fallback") {
-                ctx.diagnostic(not_recommended_font_display_value(
-                    href_prop.span(),
-                    &display_value,
-                ));
+            if matches!(display_value, "auto" | "block" | "fallback") {
+                ctx.diagnostic(not_recommended_font_display_value(href_prop.span(), display_value));
             }
         }
     }

--- a/crates/oxc_linter/src/utils/mod.rs
+++ b/crates/oxc_linter/src/utils/mod.rs
@@ -7,13 +7,14 @@ mod promise;
 mod react;
 mod react_perf;
 mod unicorn;
+mod url;
 mod vitest;
 
 use std::{io, path::Path};
 
 pub use self::{
     config::*, express::*, jest::*, jsdoc::*, nextjs::*, promise::*, react::*, react_perf::*,
-    unicorn::*, vitest::*,
+    unicorn::*, url::*, vitest::*,
 };
 
 /// List of Jest rules that have Vitest equivalents.

--- a/crates/oxc_linter/src/utils/url.rs
+++ b/crates/oxc_linter/src/utils/url.rs
@@ -1,0 +1,49 @@
+/// Finds the first value of a query parameter in a URL. Is not guaranteed to be accurate
+/// with the URL standard and is just meant to be a simple helper that doesn't require
+/// fully parsing the URL.
+///
+/// # Example
+///
+/// ```rust
+/// find_url_query_value("https://example.com/?foo=bar&baz=qux", "baz") // => Some("qux")
+/// ```
+pub fn find_url_query_value<'url>(url: &'url str, key: &str) -> Option<&'url str> {
+    // Return None right away if this doesn't look like a URL at all.
+    if !url.starts_with("http://") && !url.starts_with("https://") {
+        return None;
+    }
+    // Skip everything up to the first `?` as we're not parsing the host/path/etc.
+    let url = url.split('?').nth(1)?;
+    // Now parse the query string in pairs of `key=value`, we don't need
+    // to be too strict about this as we're not trying to be spec-compliant.
+    for pair in url.split('&') {
+        if let Some((k, v)) = pair.split_once('=') {
+            if k == key {
+                return Some(v);
+            }
+        }
+    }
+    None
+}
+
+mod test {
+    #[test]
+    fn test_find_url_query_value() {
+        use super::find_url_query_value;
+        assert_eq!(find_url_query_value("something", "q"), None);
+        assert_eq!(find_url_query_value("https://example.com/?foo=bar", "foo"), Some("bar"));
+        assert_eq!(find_url_query_value("https://example.com/?foo=bar", "baz"), None);
+        assert_eq!(
+            find_url_query_value("https://example.com/?foo=bar&baz=qux", "baz"),
+            Some("qux")
+        );
+        assert_eq!(
+            find_url_query_value("https://example.com/?foo=bar&foo=qux", "foo"),
+            Some("bar")
+        );
+        assert_eq!(
+            find_url_query_value("https://polyfill.io/v3/polyfill.min.js?features=WeakSet%2CPromise%2CPromise.prototype.finally%2Ces2015%2Ces5%2Ces6", "features"),
+            Some("WeakSet%2CPromise%2CPromise.prototype.finally%2Ces2015%2Ces5%2Ces6")
+        );
+    }
+}

--- a/tasks/common/Cargo.toml
+++ b/tasks/common/Cargo.toml
@@ -19,4 +19,3 @@ project-root = { workspace = true }
 similar = { workspace = true }
 
 ureq = { workspace = true, features = ["json", "rustls"] }
-url = { workspace = true }

--- a/tasks/common/src/test_file.rs
+++ b/tasks/common/src/test_file.rs
@@ -1,4 +1,4 @@
-use std::{fmt, str::FromStr};
+use std::fmt;
 
 use crate::{project_root, request::agent};
 
@@ -94,11 +94,11 @@ impl TestFile {
     /// # Errors
     /// # Panics
     pub fn get_source_text(lib: &str) -> Result<(String, String), String> {
-        let url = url::Url::from_str(lib).map_err(err_to_string)?;
-
-        let segments = url.path_segments().ok_or_else(|| "lib url has no segments".to_string())?;
-
-        let filename = segments.last().ok_or_else(|| "lib url has no segments".to_string())?;
+        if !lib.starts_with("https://") {
+            return Err(format!("Not an https url: {lib:?}"));
+        }
+        let filename =
+            lib.split('/').last().ok_or_else(|| "lib url has no segments".to_string())?;
 
         let file = project_root().join("target").join(filename);
 


### PR DESCRIPTION
In the linter, this was only used for getting a query parameter value out of a URL. These lint rules already check that the URL value is a known-good URL so we don't need to validate and parse it. I've replaced these usages with a simple helper function to get the value from the query string.

There was also a usage in the tasks directory for getting test files and I've also skipped validating here since it's not strictly necessary as we control all inputs.