### PR TITLE
fix(linter): correctly replace rule severity with duplicate rule name configurations

### DIFF
--- a/apps/oxlint/fixtures/typescript_eslint/eslintrc.json
+++ b/apps/oxlint/fixtures/typescript_eslint/eslintrc.json
@@ -3,7 +3,7 @@
   "plugins": ["@typescript-eslint"],
   "rules": {
     "no-loss-of-precision": "off",
-    "@typescript-eslint/no-loss-of-precision": "error",
-    "@typescript-eslint/no-namespace": "warn"
+    "@typescript-eslint/no-namespace": "warn",
+    "@typescript-eslint/no-loss-of-precision": "error"
   }
 }

--- a/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json --disable-typescript-plugin fixtures__typescript_eslint__test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json --disable-typescript-plugin fixtures__typescript_eslint__test.ts@oxlint.snap
@@ -15,15 +15,15 @@ working directory:
    `----
   help: Consider removing this declaration.
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-loss-of-precision.html\eslint(no-loss-of-precision)]8;;\: This number literal will lose precision at runtime.
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-loss-of-precision.html\eslint(no-loss-of-precision)]8;;\: This number literal will lose precision at runtime.
    ,-[fixtures/typescript_eslint/test.ts:4:1]
  3 | 
  4 | 9007199254740993 // no-loss-of-precision
    : ^^^^^^^^^^^^^^^^
    `----
 
-Found 2 warnings and 0 errors.
+Found 1 warning and 1 error.
 Finished in <variable>ms on 1 file with 48 rules using 1 threads.
 ----------
-CLI result: LintSucceeded
+CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json fixtures__typescript_eslint__test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json fixtures__typescript_eslint__test.ts@oxlint.snap
@@ -23,15 +23,15 @@ working directory:
    `----
   help: Replace the namespace with an ES2015 module or use `declare module`
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-loss-of-precision.html\eslint(no-loss-of-precision)]8;;\: This number literal will lose precision at runtime.
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-loss-of-precision.html\eslint(no-loss-of-precision)]8;;\: This number literal will lose precision at runtime.
    ,-[fixtures/typescript_eslint/test.ts:4:1]
  3 | 
  4 | 9007199254740993 // no-loss-of-precision
    : ^^^^^^^^^^^^^^^^
    `----
 
-Found 3 warnings and 0 errors.
+Found 2 warnings and 1 error.
 Finished in <variable>ms on 1 file with 59 rules using 1 threads.
 ----------
-CLI result: LintSucceeded
+CLI result: LintFoundErrors
 ----------

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -132,7 +132,7 @@ impl OxlintRules {
                             if let Some(rule) = rules.get(&plugin_name) {
                                 rules_to_replace.push(RuleWithSeverity::new(
                                     rule.read_json(config),
-                                    rule.severity,
+                                    rule_config.severity,
                                 ));
                             }
                             // If the given rule is not found in the rule list (for example, if all rules are disabled),
@@ -474,8 +474,7 @@ mod test {
     #[test]
     fn test_override_plugin_prefix_duplicates() {
         let configs = [
-            // FIXME: this should be valid
-            // json!({ "@typescript-eslint/no-unused-vars": "error" }),
+            json!({ "@typescript-eslint/no-unused-vars": "error" }),
             json!({ "no-unused-vars": "off", "typescript/no-unused-vars": "error" }),
             json!({ "no-unused-vars": "off", "@typescript-eslint/no-unused-vars": "error" }),
         ];
@@ -501,7 +500,7 @@ mod test {
             assert_eq!(rules.len(), 1, "{config:?}");
             let rule = rules.iter().next().unwrap();
             assert_eq!(rule.name(), "no-unused-vars", "{config:?}");
-            assert_eq!(rule.severity, AllowWarnDeny::Warn, "{config:?}");
+            assert_eq!(rule.severity, AllowWarnDeny::Deny, "{config:?}");
         }
     }
 }


### PR DESCRIPTION
See the snapshot changes of `apps/oxlint/fixtures/typescript_eslint/eslintrc.json`.