### PR TITLE
refactor(linter): improve `eslint/no-constant-condition`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_constant_condition.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_condition.rs
@@ -1,9 +1,10 @@
-use oxc_ast::AstKind;
+use oxc_ast::{ast::Expression, AstKind};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
+use rustc_hash::FxHashSet;
 
-use crate::{ast_util::IsConstant, context::LintContext, rule::Rule, AstNode};
+use crate::{ast_util::IsConstant, context::LintContext, rule::Rule};
 
 fn no_constant_condition_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected constant condition")
@@ -12,8 +13,16 @@ fn no_constant_condition_diagnostic(span: Span) -> OxcDiagnostic {
 }
 
 #[derive(Debug, Default, Clone)]
+pub enum CheckLoops {
+    All,
+    None,
+    #[default]
+    AllExceptWhileTrue,
+}
+
+#[derive(Debug, Default, Clone)]
 pub struct NoConstantCondition {
-    _check_loops: bool,
+    check_loops: CheckLoops,
 }
 
 declare_oxc_lint!(
@@ -69,29 +78,137 @@ declare_oxc_lint!(
 
 impl Rule for NoConstantCondition {
     fn from_configuration(value: serde_json::Value) -> Self {
-        let obj = value.get(0);
+        let raw_check_loops = value.get(0).and_then(|v| v.get("checkLoops"));
 
-        Self {
-            _check_loops: obj
-                .and_then(|v| v.get("checkLoops"))
-                .and_then(serde_json::Value::as_bool)
-                .unwrap_or_default(),
-        }
+        let check_loops = raw_check_loops
+            .and_then(|val| {
+                serde_json::Value::as_bool(val)
+                    .map(|val| if val { CheckLoops::All } else { CheckLoops::None })
+                    .or_else(|| {
+                        serde_json::Value::as_str(val).map(|val| match val {
+                            "all" => CheckLoops::All,
+                            "none" => CheckLoops::None,
+                            _ => CheckLoops::AllExceptWhileTrue,
+                        })
+                    })
+            })
+            .unwrap_or_default();
+
+        Self { check_loops }
     }
 
-    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        match node.kind() {
-            AstKind::IfStatement(if_stmt) => {
-                if if_stmt.test.is_constant(true, ctx) {
-                    ctx.diagnostic(no_constant_condition_diagnostic(if_stmt.test.span()));
+    fn run_once(&self, ctx: &LintContext) {
+        let mut current_scope = Span::default();
+        let mut scopes = Vec::<(Span, FxHashSet<Span>)>::new();
+        for node in ctx.semantic().nodes() {
+            let is_in_scope = node.span().start < current_scope.end;
+
+            // Exit previous generator function scope and emit diagnostics
+            if !is_in_scope {
+                if let Some((prev_scope, spans)) = scopes.pop() {
+                    current_scope = prev_scope;
+                    for span in spans {
+                        ctx.diagnostic(no_constant_condition_diagnostic(span));
+                    }
                 }
             }
-            AstKind::ConditionalExpression(condition_expr) => {
-                if condition_expr.test.is_constant(true, ctx) {
-                    ctx.diagnostic(no_constant_condition_diagnostic(condition_expr.test.span()));
+
+            match node.kind() {
+                AstKind::IfStatement(if_stmt) => {
+                    if if_stmt.test.is_constant(true, ctx) {
+                        ctx.diagnostic(no_constant_condition_diagnostic(if_stmt.test.span()));
+                    }
+                }
+                AstKind::ConditionalExpression(condition_expr) => {
+                    if condition_expr.test.is_constant(true, ctx) {
+                        ctx.diagnostic(no_constant_condition_diagnostic(
+                            condition_expr.test.span(),
+                        ));
+                    }
+                }
+                AstKind::WhileStatement(while_stmt) => {
+                    if let CheckLoops::AllExceptWhileTrue = self.check_loops {
+                        if let Expression::BooleanLiteral(val) = &while_stmt.test {
+                            if val.value {
+                                return;
+                            }
+                        }
+                    }
+                    self.check_loop(ctx, &while_stmt.test, &mut scopes, is_in_scope);
+                }
+                AstKind::DoWhileStatement(do_while_stmt) => {
+                    self.check_loop(ctx, &do_while_stmt.test, &mut scopes, is_in_scope);
+                }
+                AstKind::ForStatement(for_stmt) => {
+                    if let Some(expr) = &for_stmt.test {
+                        self.check_loop(ctx, expr, &mut scopes, is_in_scope);
+                    }
+                }
+                AstKind::Function(func) => {
+                    if func.generator {
+                        scopes.push((current_scope, FxHashSet::default()));
+                        current_scope = func.span;
+                    }
+                }
+                AstKind::YieldExpression(yield_expr) => {
+                    if let Some((_, spans)) = scopes.last_mut() {
+                        for node in ctx.nodes().ancestors(node.id()).skip(1) {
+                            match node.kind() {
+                                AstKind::Function(func) => {
+                                    if func.generator {
+                                        break;
+                                    }
+                                }
+                                AstKind::WhileStatement(while_stmt) => {
+                                    spans.remove(&while_stmt.test.span());
+                                }
+                                AstKind::DoWhileStatement(do_while_stmt) => {
+                                    spans.remove(&do_while_stmt.test.span());
+                                }
+                                AstKind::ForStatement(for_stmt) => {
+                                    if let Some(expr) = &for_stmt.test {
+                                        let span = expr.span();
+                                        if yield_expr.span().start > span.start {
+                                            spans.remove(&span);
+                                        }
+                                    }
+                                }
+                                _ => {}
+                            }
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        // Emit remaining diagnostics
+        for (_, spans) in scopes {
+            for span in spans {
+                ctx.diagnostic(no_constant_condition_diagnostic(span));
+            }
+        }
+    }
+}
+
+impl NoConstantCondition {
+    fn check_loop<'a>(
+        &self,
+        ctx: &LintContext<'a>,
+        expr: &Expression<'a>,
+        scopes: &mut [(Span, FxHashSet<Span>)],
+        is_in_scope: bool,
+    ) {
+        if matches!(self.check_loops, CheckLoops::All | CheckLoops::AllExceptWhileTrue)
+            && expr.is_constant(true, ctx)
+        {
+            if is_in_scope {
+                if let Some((_, spans)) = scopes.last_mut() {
+                    spans.insert(expr.span());
+                    return;
                 }
             }
-            _ => {}
+            ctx.diagnostic(no_constant_condition_diagnostic(expr.span()));
         }
     }
 }
@@ -162,6 +279,22 @@ fn test() {
         ("if (-(a || true));", None),
         ("if (~(a || 1));", None),
         ("if (+(a && 0) === +(b && 0));", None),
+        ("while(~!a);", None),
+        ("while(a = b);", None),
+        ("while(`${a}`);", None),
+        ("for(;x < 10;);", None),
+        ("for(;;);", None),
+        ("for(;`${a}`;);", None),
+        ("do{ }while(x)", None),
+        ("q > 0 ? 1 : 2;", None),
+        ("`${a}` === a ? 1 : 2", None),
+        ("`foo${a}` === a ? 1 : 2", None),
+        ("tag`a` === a ? 1 : 2", None),
+        ("tag`${a}` === a ? 1 : 2", None),
+        ("while(x += 3) {}", None),
+        ("while(tag`a`) {}", None),
+        ("while(tag`${a}`) {}", None),
+        ("while(`\\\n${a}`) {}", None),
         ("if(typeof x === 'undefined'){}", None),
         ("if(`${typeof x}` === 'undefined'){}", None),
         ("if(a === 'str' && typeof b){}", None),
@@ -204,6 +337,26 @@ fn test() {
         ("if ('' + [y, 'm'] === '' + ['ty']) {}", None),
         ("if ([,] in\n\n($2))\n ;\nelse\n ;", None),
         ("if ([...x]+'' === 'y'){}", None),
+        ("while(true);", Some(serde_json::json!([{ "checkLoops": false }]))),
+        ("for(;true;);", Some(serde_json::json!([{ "checkLoops": false }]))),
+        ("do{}while(true)", Some(serde_json::json!([{ "checkLoops": false }]))),
+        ("while(true);", Some(serde_json::json!([{ "checkLoops": "none" }]))),
+        ("for(;true;);", Some(serde_json::json!([{ "checkLoops": "none" }]))),
+        ("do{}while(true)", Some(serde_json::json!([{ "checkLoops": "none" }]))),
+        ("while(true);", Some(serde_json::json!([{ "checkLoops": "allExceptWhileTrue" }]))),
+        ("while(true);", None),
+        ("while(a == b);", Some(serde_json::json!([{ "checkLoops": "all" }]))),
+        ("do{ }while(x);", Some(serde_json::json!([{ "checkLoops": "all" }]))),
+        ("for (let x = 0; x <= 10; x++) {};", Some(serde_json::json!([{ "checkLoops": "all" }]))),
+        ("function* foo(){while(true){yield 'foo';}}", None),
+        ("function* foo(){for(;true;){yield 'foo';}}", None),
+        ("function* foo(){do{yield 'foo';}while(true)}", None),
+        ("function* foo(){while (true) { while(true) {yield;}}}", None),
+        ("function* foo() {for (; yield; ) {}}", None),
+        ("function* foo() {for (; ; yield) {}}", None),
+        ("function* foo() {while (true) {function* foo() {yield;}yield;}}", None),
+        ("function* foo() { for (let x = yield; x < 10; x++) {yield;}yield;}", None),
+        ("function* foo() { for (let x = yield; ; x++) { yield; }}", None),
         ("if (new Number(x) + 1 === 2) {}", None),
         ("if([a]==[b]) {}", None),
         ("if (+[...a]) {}", None),
@@ -216,45 +369,30 @@ fn test() {
         ("if (Boolean(a)) {}", None),
         ("if (Boolean(...args)) {}", None),
         ("if (foo.Boolean(1)) {}", None),
-        // TODO
-        // ("const undefined = 'lol'; if (undefined) {}", None),
-        // ("function foo(Boolean) { if (Boolean(1)) {} }", None),
-        // ("const Boolean = () => {}; if (Boolean(1)) {}", None),
-        // "if (Boolean()) {}",
-        // "if (undefined) {}",
-        ("q > 0 ? 1 : 2;", None),
-        ("`${a}` === a ? 1 : 2", None),
-        ("`foo${a}` === a ? 1 : 2", None),
-        ("tag`a` === a ? 1 : 2", None),
-        ("tag`${a}` === a ? 1 : 2", None),
-        //TODO
-        // ("while(~!a);", None),
-        // ("while(a = b);", None),
-        // ("while(`${a}`);", None),
-        // ("for(;x < 10;);", None),
-        // ("for(;;);", None),
-        // ("for(;`${a}`;);", None),
-        // ("do{ }while(x)", None),
-        // ("while(x += 3) {}", None),
-        // ("while(tag`a`) {}", None),
-        // ("while(tag`${a}`) {}", None),
-        // ("while(`\\\n${a}`) {}", None),
-        // ("while(true);", Some(json!([{"checkLoops":false}]))),
-        // ("for(;true;);", Some(json!([{"checkLoops":false}]))),
-        // ("do{}while(true)", Some(json!([{"checkLoops":false}]))),
-        // ("function* foo(){while(true){yield 'foo';}}", None),
-        // ("function* foo(){for(;true;){yield 'foo';}}", None),
-        // ("function* foo(){do{yield 'foo';}while(true)}", None),
-        // ("function* foo(){while (true) { while(true) {yield;}}}", None),
-        // ("function* foo() {for (; yield; ) {}}", None),
-        // ("function* foo() {for (; ; yield) {}}", None),
-        // ("function* foo() {while (true) {function* foo() {yield;}yield;}}", None),
-        // ("function* foo() { for (let x = yield; x < 10; x++) {yield;}yield;}", None),
-        // ("function* foo() { for (let x = yield; ; x++) { yield; }}", None),
+        ("function foo(Boolean) { if (Boolean(1)) {} }", None),
+        ("const Boolean = () => {}; if (Boolean(1)) {}", None),
+        ("const undefined = 'lol'; if (undefined) {}", None),
     ];
 
     let fail = vec![
-        ("if(-2);", None),
+        ("for(;true;);", None),
+        ("for(;``;);", None),
+        ("for(;`foo`;);", None),
+        ("for(;`foo${bar}`;);", None),
+        ("do{}while(true)", None),
+        ("do{}while('1')", None),
+        ("do{}while(0)", None),
+        ("do{}while(t = -2)", None),
+        ("do{}while(``)", None),
+        ("do{}while(`foo`)", None),
+        ("do{}while(`foo${bar}`)", None),
+        ("true ? 1 : 2;", None),
+        ("1 ? 1 : 2;", None),
+        ("q = 0 ? 1 : 2;", None),
+        ("(q = 0) ? 1 : 2;", None),
+        ("`` ? 1 : 2;", None),
+        ("`foo` ? 1 : 2;", None),
+        ("`foo${bar}` ? 1 : 2;", None),
         ("if(-2);", None),
         ("if(true);", None),
         ("if(1);", None),
@@ -306,11 +444,23 @@ fn test() {
         ("if((a &&= null) && b);", None),
         ("if(false || (a &&= false));", None),
         ("if((a &&= false) || false);", None),
+        ("while([]);", None),
+        ("while(~!0);", None),
+        ("while(x = 1);", None),
+        ("while(function(){});", None),
+        ("while(true);", Some(serde_json::json!([{ "checkLoops": "all" }]))),
+        ("while(1);", None),
+        ("while(() => {});", None),
+        ("while(`foo`);", None),
+        ("while(``);", None),
+        ("while(`${'foo'}`);", None),
+        ("while(`${'foo' + 'bar'}`);", None),
         ("if(typeof x){}", None),
         ("if(typeof 'abc' === 'string'){}", None),
         ("if(a = typeof b){}", None),
         ("if(a, typeof b){}", None),
         ("if(typeof 'a' == 'string' || typeof 'b' == 'string'){}", None),
+        ("while(typeof x){}", None),
         ("if(1 || void x);", None),
         ("if(void x);", None),
         ("if(y = void x);", None),
@@ -331,6 +481,61 @@ fn test() {
         ("if('str1' && 'str2'){}", None),
         ("if(abc==='str' || 'str'){}", None),
         ("if(a || 'str'){}", None),
+        ("while(x = 1);", Some(serde_json::json!([{ "checkLoops": "all" }]))),
+        ("do{ }while(x = 1)", Some(serde_json::json!([{ "checkLoops": "all" }]))),
+        ("for (;true;) {};", Some(serde_json::json!([{ "checkLoops": "all" }]))),
+        (
+            "function* foo(){while(true){} yield 'foo';}",
+            Some(serde_json::json!([{ "checkLoops": "all" }])),
+        ),
+        (
+            "function* foo(){while(true){} yield 'foo';}",
+            Some(serde_json::json!([{ "checkLoops": true }])),
+        ),
+        (
+            "function* foo(){while(true){if (true) {yield 'foo';}}}",
+            Some(serde_json::json!([{ "checkLoops": "all" }])),
+        ),
+        (
+            "function* foo(){while(true){if (true) {yield 'foo';}}}",
+            Some(serde_json::json!([{ "checkLoops": true }])),
+        ),
+        (
+            "function* foo(){while(true){yield 'foo';} while(true) {}}",
+            Some(serde_json::json!([{ "checkLoops": "all" }])),
+        ),
+        (
+            "function* foo(){while(true){yield 'foo';} while(true) {}}",
+            Some(serde_json::json!([{ "checkLoops": true }])),
+        ),
+        (
+            "var a = function* foo(){while(true){} yield 'foo';}",
+            Some(serde_json::json!([{ "checkLoops": "all" }])),
+        ),
+        (
+            "var a = function* foo(){while(true){} yield 'foo';}",
+            Some(serde_json::json!([{ "checkLoops": true }])),
+        ),
+        (
+            "while (true) { function* foo() {yield;}}",
+            Some(serde_json::json!([{ "checkLoops": "all" }])),
+        ),
+        (
+            "while (true) { function* foo() {yield;}}",
+            Some(serde_json::json!([{ "checkLoops": true }])),
+        ),
+        ("function* foo(){if (true) {yield 'foo';}}", None),
+        ("function* foo() {for (let foo = yield; true;) {}}", None),
+        ("function* foo() {for (foo = yield; true;) {}}", None),
+        (
+            "function foo() {while (true) {function* bar() {while (true) {yield;}}}}",
+            Some(serde_json::json!([{ "checkLoops": "all" }])),
+        ),
+        (
+            "function foo() {while (true) {const bar = function*() {while (true) {yield;}}}}",
+            Some(serde_json::json!([{ "checkLoops": "all" }])),
+        ),
+        ("function* foo() { for (let foo = 1 + 2 + 3 + (yield); true; baz) {}}", None),
         ("if([a]) {}", None),
         ("if([]) {}", None),
         ("if(''+['a']) {}", None),
@@ -346,66 +551,27 @@ fn test() {
         ("if(0o1n);", None),
         ("if(0x1n);", None),
         ("if(0x1n || foo);", None),
-        // Classes and instances are always truthy
         ("if(class {}) {}", None),
         ("if(new Foo()) {}", None),
-        // Boxed primitives are always truthy
         ("if(new Boolean(foo)) {}", None),
         ("if(new String(foo)) {}", None),
         ("if(new Number(foo)) {}", None),
-        // Spreading a constant array
         ("if(`${[...['a']]}`) {}", None),
-        // undefined is always falsy (except in old browsers that let you
-        // re-assign, but that's an obscure enough edge case to not worry about)
         ("if (undefined) {}", None),
-        // Coercion to boolean via Boolean function
         ("if (Boolean(1)) {}", None),
         ("if (Boolean()) {}", None),
         ("if (Boolean([a])) {}", None),
         ("if (Boolean(1)) { function Boolean() {}}", None),
-        ("true ? 1 : 2;", None),
-        ("1 ? 1 : 2;", None),
-        ("q = 0 ? 1 : 2;", None),
-        ("(q = 0) ? 1 : 2;", None),
-        ("`` ? 1 : 2;", None),
-        ("`foo` ? 1 : 2;", None),
-        ("`foo${bar}` ? 1 : 2;", None),
-        // TODO
-        // ("for(;true;);", None),
-        // ("for(;``;);", None),
-        // ("for(;`foo`;);", None),
-        // ("for(;`foo${bar}`;);", None),
-        // ("do{}while(true)", None),
-        // ("do{}while('1')", None),
-        // ("do{}while(0)", None),
-        // ("do{}while(t = -2)", None),
-        // ("do{}while(``)", None),
-        // ("do{}while(`foo`)", None),
-        // ("do{}while(`foo${bar}`)", None),
-        // ("while([]);", None),
-        // ("while(~!0);", None),
-        // ("while(x = 1);", None),
-        // ("while(function(){});", None),
-        // ("while(true);", None),
-        // ("while(1);", None),
-        // ("while(() => {});", None),
-        // ("while(`foo`);", None),
-        // ("while(``);", None),
-        // ("while(`${'foo'}`);", None),
-        // ("while(`${'foo' + 'bar'}`);", None),
-        // ("function* foo(){while(true){} yield 'foo';}", None),
-        // ("function* foo(){while(true){if (true) {yield 'foo';}}}", None),
-        // ("function* foo(){while(true){yield 'foo';} while(true) {}}", None),
-        // ("var a = function* foo(){while(true){} yield 'foo';}", None),
-        // ("while (true) { function* foo() {yield;}}", None),
-        // ("function* foo(){if (true) {yield 'foo';}}", None),
-        // ("function* foo() {for (let foo = yield; true;) {}}", None),
-        // ("function* foo() {for (foo = yield; true;) {}}", None),
-        // ("function foo() {while (true) {function* bar() {while (true) {yield;}}}}", None),
-        // ("function foo() {while (true) {const bar = function*() {while (true) {yield;}}}}", None),
-        // ("function* foo() { for (let foo = 1 + 2 + 3 + (yield); true; baz) {}}", None),
     ];
 
     Tester::new(NoConstantCondition::NAME, NoConstantCondition::PLUGIN, pass, fail)
         .test_and_snapshot();
+
+    let pass = vec![
+        ("if (Boolean()) {}", None, Some(serde_json::json!({ "globals": { "Boolean": "off" } }))),
+        ("if (undefined) {}", None, Some(serde_json::json!({ "globals": { "undefined": "off" } }))),
+    ];
+    let fail = vec![];
+
+    Tester::new(NoConstantCondition::NAME, NoConstantCondition::PLUGIN, pass, fail).test();
 }

--- a/crates/oxc_linter/src/snapshots/eslint_no_constant_condition.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_constant_condition.snap
@@ -2,9 +2,128 @@
 source: crates/oxc_linter/src/tester.rs
 ---
   ⚠ eslint(no-constant-condition): Unexpected constant condition
-   ╭─[no_constant_condition.tsx:1:4]
- 1 │ if(-2);
-   ·    ──
+   ╭─[no_constant_condition.tsx:1:6]
+ 1 │ for(;true;);
+   ·      ────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:6]
+ 1 │ for(;``;);
+   ·      ──
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:6]
+ 1 │ for(;`foo`;);
+   ·      ─────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:6]
+ 1 │ for(;`foo${bar}`;);
+   ·      ───────────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:11]
+ 1 │ do{}while(true)
+   ·           ────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:11]
+ 1 │ do{}while('1')
+   ·           ───
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:11]
+ 1 │ do{}while(0)
+   ·           ─
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:11]
+ 1 │ do{}while(t = -2)
+   ·           ──────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:11]
+ 1 │ do{}while(``)
+   ·           ──
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:11]
+ 1 │ do{}while(`foo`)
+   ·           ─────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:11]
+ 1 │ do{}while(`foo${bar}`)
+   ·           ───────────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:1]
+ 1 │ true ? 1 : 2;
+   · ────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:1]
+ 1 │ 1 ? 1 : 2;
+   · ─
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:5]
+ 1 │ q = 0 ? 1 : 2;
+   ·     ─
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:1]
+ 1 │ (q = 0) ? 1 : 2;
+   · ───────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:1]
+ 1 │ `` ? 1 : 2;
+   · ──
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:1]
+ 1 │ `foo` ? 1 : 2;
+   · ─────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:1]
+ 1 │ `foo${bar}` ? 1 : 2;
+   · ───────────
    ╰────
   help: Constant expression as a test condition is not allowed
 
@@ -366,6 +485,83 @@ source: crates/oxc_linter/src/tester.rs
   help: Constant expression as a test condition is not allowed
 
   ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:7]
+ 1 │ while([]);
+   ·       ──
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:7]
+ 1 │ while(~!0);
+   ·       ───
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:7]
+ 1 │ while(x = 1);
+   ·       ─────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:7]
+ 1 │ while(function(){});
+   ·       ────────────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:7]
+ 1 │ while(true);
+   ·       ────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:7]
+ 1 │ while(1);
+   ·       ─
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:7]
+ 1 │ while(() => {});
+   ·       ────────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:7]
+ 1 │ while(`foo`);
+   ·       ─────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:7]
+ 1 │ while(``);
+   ·       ──
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:7]
+ 1 │ while(`${'foo'}`);
+   ·       ──────────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:7]
+ 1 │ while(`${'foo' + 'bar'}`);
+   ·       ──────────────────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
    ╭─[no_constant_condition.tsx:1:4]
  1 │ if(typeof x){}
    ·    ────────
@@ -397,6 +593,13 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_constant_condition.tsx:1:4]
  1 │ if(typeof 'a' == 'string' || typeof 'b' == 'string'){}
    ·    ────────────────────────────────────────────────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:7]
+ 1 │ while(typeof x){}
+   ·       ────────
    ╰────
   help: Constant expression as a test condition is not allowed
 
@@ -537,6 +740,139 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_constant_condition.tsx:1:4]
  1 │ if(a || 'str'){}
    ·    ──────────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:7]
+ 1 │ while(x = 1);
+   ·       ─────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:12]
+ 1 │ do{ }while(x = 1)
+   ·            ─────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:7]
+ 1 │ for (;true;) {};
+   ·       ────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:23]
+ 1 │ function* foo(){while(true){} yield 'foo';}
+   ·                       ────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:23]
+ 1 │ function* foo(){while(true){} yield 'foo';}
+   ·                       ────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:33]
+ 1 │ function* foo(){while(true){if (true) {yield 'foo';}}}
+   ·                                 ────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:33]
+ 1 │ function* foo(){while(true){if (true) {yield 'foo';}}}
+   ·                                 ────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:49]
+ 1 │ function* foo(){while(true){yield 'foo';} while(true) {}}
+   ·                                                 ────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:49]
+ 1 │ function* foo(){while(true){yield 'foo';} while(true) {}}
+   ·                                                 ────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:31]
+ 1 │ var a = function* foo(){while(true){} yield 'foo';}
+   ·                               ────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:31]
+ 1 │ var a = function* foo(){while(true){} yield 'foo';}
+   ·                               ────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:8]
+ 1 │ while (true) { function* foo() {yield;}}
+   ·        ────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:8]
+ 1 │ while (true) { function* foo() {yield;}}
+   ·        ────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:21]
+ 1 │ function* foo(){if (true) {yield 'foo';}}
+   ·                     ────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:40]
+ 1 │ function* foo() {for (let foo = yield; true;) {}}
+   ·                                        ────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:36]
+ 1 │ function* foo() {for (foo = yield; true;) {}}
+   ·                                    ────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:24]
+ 1 │ function foo() {while (true) {function* bar() {while (true) {yield;}}}}
+   ·                        ────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:24]
+ 1 │ function foo() {while (true) {const bar = function*() {while (true) {yield;}}}}
+   ·                        ────
+   ╰────
+  help: Constant expression as a test condition is not allowed
+
+  ⚠ eslint(no-constant-condition): Unexpected constant condition
+   ╭─[no_constant_condition.tsx:1:55]
+ 1 │ function* foo() { for (let foo = 1 + 2 + 3 + (yield); true; baz) {}}
+   ·                                                       ────
    ╰────
   help: Constant expression as a test condition is not allowed
 
@@ -719,54 +1055,5 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_constant_condition.tsx:1:5]
  1 │ if (Boolean(1)) { function Boolean() {}}
    ·     ──────────
-   ╰────
-  help: Constant expression as a test condition is not allowed
-
-  ⚠ eslint(no-constant-condition): Unexpected constant condition
-   ╭─[no_constant_condition.tsx:1:1]
- 1 │ true ? 1 : 2;
-   · ────
-   ╰────
-  help: Constant expression as a test condition is not allowed
-
-  ⚠ eslint(no-constant-condition): Unexpected constant condition
-   ╭─[no_constant_condition.tsx:1:1]
- 1 │ 1 ? 1 : 2;
-   · ─
-   ╰────
-  help: Constant expression as a test condition is not allowed
-
-  ⚠ eslint(no-constant-condition): Unexpected constant condition
-   ╭─[no_constant_condition.tsx:1:5]
- 1 │ q = 0 ? 1 : 2;
-   ·     ─
-   ╰────
-  help: Constant expression as a test condition is not allowed
-
-  ⚠ eslint(no-constant-condition): Unexpected constant condition
-   ╭─[no_constant_condition.tsx:1:1]
- 1 │ (q = 0) ? 1 : 2;
-   · ───────
-   ╰────
-  help: Constant expression as a test condition is not allowed
-
-  ⚠ eslint(no-constant-condition): Unexpected constant condition
-   ╭─[no_constant_condition.tsx:1:1]
- 1 │ `` ? 1 : 2;
-   · ──
-   ╰────
-  help: Constant expression as a test condition is not allowed
-
-  ⚠ eslint(no-constant-condition): Unexpected constant condition
-   ╭─[no_constant_condition.tsx:1:1]
- 1 │ `foo` ? 1 : 2;
-   · ─────
-   ╰────
-  help: Constant expression as a test condition is not allowed
-
-  ⚠ eslint(no-constant-condition): Unexpected constant condition
-   ╭─[no_constant_condition.tsx:1:1]
- 1 │ `foo${bar}` ? 1 : 2;
-   · ───────────
    ╰────
   help: Constant expression as a test condition is not allowed


### PR DESCRIPTION
I've re-ported all the test cases for `eslint/no-constant-condition` and ensured they pass successfully. Additionally, I have aligned its options configuration with `eslint`.