### PR TITLE
refactor(ast_tools): shorten code for reading file

### DIFF
--- a/tasks/ast_tools/src/output/mod.rs
+++ b/tasks/ast_tools/src/output/mod.rs
@@ -1,8 +1,4 @@
-use std::{
-    fs,
-    io::{self, Write},
-    path::Path,
-};
+use std::{fs, io, path::Path};
 
 use cow_utils::CowUtils;
 use proc_macro2::TokenStream;
@@ -91,6 +87,5 @@ fn write_to_file_impl(data: &[u8], path: &str) -> io::Result<()> {
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    let mut file = fs::File::create(path)?;
-    file.write_all(data)
+    fs::write(path, data)
 }

--- a/tasks/ast_tools/src/parse/load.rs
+++ b/tasks/ast_tools/src/parse/load.rs
@@ -1,4 +1,4 @@
-use std::{fs, io::Read};
+use std::fs;
 
 use indexmap::map::Entry;
 use syn::{
@@ -28,9 +28,7 @@ use super::{
 ///
 /// This is the bare minimum to be able to "link up" types to each other in next pass.
 pub fn load_file(file_id: FileId, file_path: &str, skeletons: &mut FxIndexMap<String, Skeleton>) {
-    let mut file = fs::File::open(file_path).unwrap();
-    let mut content = String::new();
-    file.read_to_string(&mut content).unwrap();
+    let content = fs::read_to_string(file_path).unwrap();
 
     let file = parse_file(content.as_str()).unwrap();
 


### PR DESCRIPTION
Pure refactor. Use shorter code for reading/writing files in `oxc_ast_tools`.