### PR TITLE
feat(ast_tools): do not overwrite files if no changes

### DIFF
--- a/tasks/ast_tools/src/output/mod.rs
+++ b/tasks/ast_tools/src/output/mod.rs
@@ -83,6 +83,13 @@ impl RawOutput {
 }
 
 fn write_to_file_impl(data: &[u8], path: &str) -> io::Result<()> {
+    // If contents hasn't changed, don't touch the file
+    if let Ok(existing_data) = fs::read(path) {
+        if existing_data == data {
+            return Ok(());
+        }
+    }
+
     let path = Path::new(path);
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;


### PR DESCRIPTION
If files do not need to change from what's already on disk, don't overwrite them. This avoids clippy etc reloading the files.
