### PR TITLE
feat(ast_tools): generate list of helper attributes in `oxc_ast_macros` crate

### DIFF
--- a/.github/.generated_ast_watch_list.yml
+++ b/.github/.generated_ast_watch_list.yml
@@ -20,6 +20,7 @@ src:
   - 'crates/oxc_ast/src/generated/get_id.rs'
   - 'crates/oxc_ast/src/generated/visit.rs'
   - 'crates/oxc_ast/src/generated/visit_mut.rs'
+  - 'crates/oxc_ast_macros/src/lib.rs'
   - 'crates/oxc_regular_expression/src/ast.rs'
   - 'crates/oxc_regular_expression/src/generated/derive_clone_in.rs'
   - 'crates/oxc_regular_expression/src/generated/derive_content_eq.rs'

--- a/crates/oxc_ast_macros/src/lib.rs
+++ b/crates/oxc_ast_macros/src/lib.rs
@@ -84,7 +84,7 @@ pub fn ast(_args: TokenStream, input: TokenStream) -> TokenStream {
 /// Its only purpose is to allow the occurrence of helper attributes used in `tasks/ast_tools`.
 ///
 /// Read [`macro@ast`] for further details.
-#[proc_macro_derive(Ast, attributes(scope, visit, span, generate_derive, clone_in, estree, ts))]
+#[proc_macro_derive(Ast, attributes(clone_in, estree, generate_derive, scope, span, ts, visit))]
 pub fn ast_derive(_input: TokenStream) -> TokenStream {
     TokenStream::new()
 }

--- a/tasks/ast_tools/src/codegen.rs
+++ b/tasks/ast_tools/src/codegen.rs
@@ -73,6 +73,11 @@ impl Codegen {
     pub fn attr_processor(&self, attr_name: &str) -> Option<(AttrProcessor, AttrPositions)> {
         self.attr_processors.get(attr_name).copied()
     }
+
+    /// Get all attributes which derives and generators handle.
+    pub fn attrs(&self) -> Vec<&'static str> {
+        self.attr_processors.keys().copied().collect()
+    }
 }
 
 /// Runner trait.

--- a/tasks/ast_tools/src/output/mod.rs
+++ b/tasks/ast_tools/src/output/mod.rs
@@ -9,7 +9,7 @@ mod javascript;
 mod rust;
 mod yaml;
 use javascript::print_javascript;
-use rust::print_rust;
+use rust::{print_rust, rust_fmt};
 use yaml::print_yaml;
 
 /// Get path for an output.
@@ -32,6 +32,7 @@ fn add_header(code: &str, generator_path: &str, comment_start: &str) -> String {
 #[expect(dead_code)]
 pub enum Output {
     Rust { path: String, tokens: TokenStream },
+    RustString { path: String, code: String },
     Javascript { path: String, code: String },
     Yaml { path: String, code: String },
     Raw { path: String, code: String },
@@ -47,6 +48,10 @@ impl Output {
         let (path, code) = match self {
             Self::Rust { path, tokens } => {
                 let code = print_rust(tokens, &generator_path);
+                (path, code)
+            }
+            Self::RustString { path, code } => {
+                let code = rust_fmt(&code);
                 (path, code)
             }
             Self::Javascript { path, code } => {

--- a/tasks/ast_tools/src/output/rust.rs
+++ b/tasks/ast_tools/src/output/rust.rs
@@ -21,7 +21,7 @@ pub fn print_rust(tokens: TokenStream, generator_path: &str) -> String {
 /// Format Rust code with `rustfmt`.
 ///
 /// Does not format on disk - interfaces with `rustfmt` via stdin/stdout.
-fn rust_fmt(source_text: &str) -> String {
+pub fn rust_fmt(source_text: &str) -> String {
     let mut rustfmt = Command::new("rustfmt")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())


### PR DESCRIPTION
Custom attributes used by generators (e.g. `#[visit]`) need to be added to the dummy `Ast` derive macro in `oxc_ast_macros`. Do this automatically, rather than requiring the person writing the generator to remember to do it.