### PR TITLE
perf(linter): reduce unnecessary rule method executions to improve performance

### DIFF
--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -25,6 +25,7 @@ pub mod table;
 use std::{path::Path, rc::Rc, sync::Arc};
 
 use oxc_semantic::{AstNode, Semantic};
+use rule::ShouldRunMeta;
 
 pub use crate::{
     config::{
@@ -105,11 +106,11 @@ impl Linter {
             Rc::new(ContextHost::new(path, semantic, module_record, self.options, config));
 
         let rules = rules.iter().filter_map(|rule| {
-            let state = rule.should_run(&ctx_host);
-            if state.enable {
-                Some(Rc::new((rule, Rc::clone(&ctx_host).spawn(rule), state)))
-            } else {
+            let meta = rule.should_run(&ctx_host);
+            if meta.is_empty() {
                 None
+            } else {
+                Some((Rc::new((rule, Rc::clone(&ctx_host).spawn(rule))), meta))
             }
         });
 
@@ -141,16 +142,17 @@ impl Linter {
             let (run, run_once, run_on_symbol, run_on_jest_node) = rules.fold(
                 (Vec::new(), Vec::new(), Vec::new(), Vec::new()),
                 |(mut run, mut run_once, mut run_on_symbol, mut run_on_jest_node), rule| {
-                    if rule.2.run_once {
+                    let (rule, meta) = rule;
+                    if meta.contains(ShouldRunMeta::IS_RUN_ONCE) {
                         run_once.push(Rc::clone(&rule));
                     }
-                    if rule.2.run_on_symbol {
+                    if meta.contains(ShouldRunMeta::IS_RUN_ON_SYMBOL) {
                         run_on_symbol.push(Rc::clone(&rule));
                     }
-                    if rule.2.run_on_jest_node {
+                    if meta.contains(ShouldRunMeta::IS_RUN_ON_JEST_NODE) {
                         run_on_jest_node.push(Rc::clone(&rule));
                     }
-                    if rule.2.run {
+                    if meta.contains(ShouldRunMeta::IS_RUN) {
                         run.push(rule);
                     }
                     (run, run_once, run_on_symbol, run_on_jest_node)
@@ -158,53 +160,50 @@ impl Linter {
             );
 
             for rule in &run_once {
-                let (rule, ref ctx, _) = rule.as_ref();
+                let (rule, ref ctx) = rule.as_ref();
                 rule.run_once(ctx);
             }
-
             if !run_on_symbol.is_empty() {
                 for symbol in semantic.symbols().symbol_ids() {
                     for rule in &run_on_symbol {
-                        let (rule, ref ctx, _) = rule.as_ref();
+                        let (rule, ref ctx) = rule.as_ref();
                         rule.run_on_symbol(symbol, ctx);
                     }
                 }
             }
-
             if !run.is_empty() {
                 for node in semantic.nodes() {
                     for rule in &run {
-                        let (rule, ref ctx, _) = rule.as_ref();
+                        let (rule, ctx) = rule.as_ref();
                         rule.run(node, ctx);
                     }
                 }
             }
-
             if should_run_on_jest_node && !run_on_jest_node.is_empty() {
                 for jest_node in iter_possible_jest_call_node(semantic) {
                     for rule in &run_on_jest_node {
-                        let (rule, ref ctx, _) = rule.as_ref();
+                        let (rule, ctx) = rule.as_ref();
                         rule.run_on_jest_node(&jest_node, ctx);
                     }
                 }
             }
         } else {
-            for rule in rules {
-                let (rule, ref ctx, state) = rule.as_ref();
-                if state.run_once {
+            for (rule, meta) in rules {
+                let (rule, ref ctx) = rule.as_ref();
+                if meta.contains(ShouldRunMeta::IS_RUN_ONCE) {
                     rule.run_once(ctx);
                 }
-                if state.run_on_symbol {
+                if meta.contains(ShouldRunMeta::IS_RUN_ON_SYMBOL) {
                     for symbol in semantic.symbols().symbol_ids() {
                         rule.run_on_symbol(symbol, ctx);
                     }
                 }
-                if state.run {
+                if meta.contains(ShouldRunMeta::IS_RUN) {
                     for node in semantic.nodes() {
                         rule.run(node, ctx);
                     }
                 }
-                if state.run_on_jest_node && should_run_on_jest_node {
+                if should_run_on_jest_node && meta.contains(ShouldRunMeta::IS_RUN_ON_JEST_NODE) {
                     for jest_node in iter_possible_jest_call_node(semantic) {
                         rule.run_on_jest_node(&jest_node, ctx);
                     }

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -15,44 +15,55 @@ use crate::{
     AllowWarnDeny, AstNode, FixKind, RuleEnum,
 };
 
-#[derive(Debug, Clone, Copy)]
-pub struct ShouldRunState {
-    pub enable: bool,
-    pub run: bool,
-    pub run_once: bool,
-    pub run_on_symbol: bool,
-    pub run_on_jest_node: bool,
-}
-
-impl From<bool> for ShouldRunState {
-    fn from(value: bool) -> Self {
-        Self::new(value)
+bitflags::bitflags! {
+    #[derive(Debug)]
+    pub struct ShouldRunMeta: u8 {
+        const IS_RUN = 1;
+        const IS_RUN_ONCE = 1 << 1;
+        const IS_RUN_ON_SYMBOL = 1 << 2;
+        const IS_RUN_ON_JEST_NODE = 1 << 3;
     }
 }
 
-impl ShouldRunState {
-    pub fn new(enable: bool) -> Self {
-        Self { enable, run: false, run_once: false, run_on_symbol: false, run_on_jest_node: false }
+impl ShouldRunMeta {
+    pub fn new() -> Self {
+        ShouldRunMeta::empty()
     }
 
-    pub fn with_run(mut self, yes: bool) -> Self {
-        self.run = yes;
-        self
+    pub fn with_run(self, yes: bool) -> Self {
+        let other = ShouldRunMeta::IS_RUN;
+        if yes {
+            self.union(other)
+        } else {
+            self.difference(other)
+        }
     }
 
-    pub fn with_run_once(mut self, yes: bool) -> Self {
-        self.run_once = yes;
-        self
+    pub fn with_run_once(self, yes: bool) -> Self {
+        let other = ShouldRunMeta::IS_RUN_ONCE;
+        if yes {
+            self.union(other)
+        } else {
+            self.difference(other)
+        }
     }
 
-    pub fn with_run_on_symbol(mut self, yes: bool) -> Self {
-        self.run_on_symbol = yes;
-        self
+    pub fn with_run_on_symbol(self, yes: bool) -> Self {
+        let other = ShouldRunMeta::IS_RUN_ON_SYMBOL;
+        if yes {
+            self.union(other)
+        } else {
+            self.difference(other)
+        }
     }
 
-    pub fn with_run_on_jest_node(mut self, yes: bool) -> Self {
-        self.run_on_jest_node = yes;
-        self
+    pub fn with_run_on_jest_node(self, yes: bool) -> Self {
+        let other = ShouldRunMeta::IS_RUN_ON_JEST_NODE;
+        if yes {
+            self.union(other)
+        } else {
+            self.difference(other)
+        }
     }
 }
 
@@ -98,8 +109,8 @@ pub trait Rule: Sized + Default + fmt::Debug {
     /// [`linter`]: crate::Linter
     #[expect(unused_variables)]
     #[inline]
-    fn should_run(&self, ctx: &ContextHost) -> ShouldRunState {
-        ShouldRunState::new(true).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> ShouldRunMeta {
+        ShouldRunMeta::new().with_run(true)
     }
 }
 

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -15,6 +15,47 @@ use crate::{
     AllowWarnDeny, AstNode, FixKind, RuleEnum,
 };
 
+#[derive(Debug, Clone, Copy)]
+pub struct ShouldRunState {
+    pub enable: bool,
+    pub run: bool,
+    pub run_once: bool,
+    pub run_on_symbol: bool,
+    pub run_on_jest_node: bool,
+}
+
+impl From<bool> for ShouldRunState {
+    fn from(value: bool) -> Self {
+        Self::new(value)
+    }
+}
+
+impl ShouldRunState {
+    pub fn new(enable: bool) -> Self {
+        Self { enable, run: false, run_once: false, run_on_symbol: false, run_on_jest_node: false }
+    }
+
+    pub fn with_run(mut self, yes: bool) -> Self {
+        self.run = yes;
+        self
+    }
+
+    pub fn with_run_once(mut self, yes: bool) -> Self {
+        self.run_once = yes;
+        self
+    }
+
+    pub fn with_run_on_symbol(mut self, yes: bool) -> Self {
+        self.run_on_symbol = yes;
+        self
+    }
+
+    pub fn with_run_on_jest_node(mut self, yes: bool) -> Self {
+        self.run_on_jest_node = yes;
+        self
+    }
+}
+
 pub trait Rule: Sized + Default + fmt::Debug {
     /// Initialize from eslint json configuration
     fn from_configuration(_value: serde_json::Value) -> Self {
@@ -57,8 +98,8 @@ pub trait Rule: Sized + Default + fmt::Debug {
     /// [`linter`]: crate::Linter
     #[expect(unused_variables)]
     #[inline]
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        true
+    fn should_run(&self, ctx: &ContextHost) -> ShouldRunState {
+        ShouldRunState::new(true).with_run(true)
     }
 }
 

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -26,44 +26,29 @@ bitflags::bitflags! {
 }
 
 impl ShouldRunMeta {
+    #[inline]
     pub fn new() -> Self {
         ShouldRunMeta::empty()
     }
 
-    pub fn with_run(self, yes: bool) -> Self {
-        let other = ShouldRunMeta::IS_RUN;
-        if yes {
-            self.union(other)
-        } else {
-            self.difference(other)
-        }
+    pub fn with_run(mut self, yes: bool) -> Self {
+        self.set(ShouldRunMeta::IS_RUN, yes);
+        self
     }
 
-    pub fn with_run_once(self, yes: bool) -> Self {
-        let other = ShouldRunMeta::IS_RUN_ONCE;
-        if yes {
-            self.union(other)
-        } else {
-            self.difference(other)
-        }
+    pub fn with_run_once(mut self, yes: bool) -> Self {
+        self.set(ShouldRunMeta::IS_RUN_ONCE, yes);
+        self
     }
 
-    pub fn with_run_on_symbol(self, yes: bool) -> Self {
-        let other = ShouldRunMeta::IS_RUN_ON_SYMBOL;
-        if yes {
-            self.union(other)
-        } else {
-            self.difference(other)
-        }
+    pub fn with_run_on_symbol(mut self, yes: bool) -> Self {
+        self.set(ShouldRunMeta::IS_RUN_ON_SYMBOL, yes);
+        self
     }
 
-    pub fn with_run_on_jest_node(self, yes: bool) -> Self {
-        let other = ShouldRunMeta::IS_RUN_ON_JEST_NODE;
-        if yes {
-            self.union(other)
-        } else {
-            self.difference(other)
-        }
+    pub fn with_run_on_jest_node(mut self, yes: bool) -> Self {
+        self.set(ShouldRunMeta::IS_RUN_ON_JEST_NODE, yes);
+        self
     }
 }
 
@@ -110,7 +95,7 @@ pub trait Rule: Sized + Default + fmt::Debug {
     #[expect(unused_variables)]
     #[inline]
     fn should_run(&self, ctx: &ContextHost) -> ShouldRunMeta {
-        ShouldRunMeta::new().with_run(true)
+        ShouldRunMeta::IS_RUN
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/func_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/func_names.rs
@@ -371,7 +371,7 @@ impl Rule for FuncNames {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/eslint/func_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/func_names.rs
@@ -370,8 +370,8 @@ impl Rule for FuncNames {
         Self { default_config, generators_config }
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/eslint/func_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/func_names.rs
@@ -370,6 +370,10 @@ impl Rule for FuncNames {
         Self { default_config, generators_config }
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext<'_>) {
         let mut invalid_funcs: Vec<(&Function, &AstNode)> = vec![];
 

--- a/crates/oxc_linter/src/rules/eslint/getter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/getter_return.rs
@@ -104,9 +104,9 @@ impl Rule for GetterReturn {
         Self { allow_implicit }
     }
 
-    fn should_run(&self, ctx: &ContextHost) -> bool {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
         // https://eslint.org/docs/latest/rules/getter-return#handled_by_typescript
-        !ctx.source_type().is_typescript()
+        crate::rule::ShouldRunState::new(!ctx.source_type().is_typescript()).with_run(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/getter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/getter_return.rs
@@ -104,9 +104,9 @@ impl Rule for GetterReturn {
         Self { allow_implicit }
     }
 
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
         // https://eslint.org/docs/latest/rules/getter-return#handled_by_typescript
-        crate::rule::ShouldRunState::new(!ctx.source_type().is_typescript()).with_run(true)
+        crate::rule::ShouldRunMeta::new().with_run(!ctx.source_type().is_typescript())
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
@@ -82,8 +82,8 @@ impl Rule for MaxClassesPerFile {
         }
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
@@ -83,7 +83,7 @@ impl Rule for MaxClassesPerFile {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_classes_per_file.rs
@@ -82,6 +82,10 @@ impl Rule for MaxClassesPerFile {
         }
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext<'_>) {
         let mut class_count = ctx.semantic().classes().declarations.len();
 

--- a/crates/oxc_linter/src/rules/eslint/max_lines.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_lines.rs
@@ -79,8 +79,8 @@ impl Rule for MaxLines {
         }
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     #[allow(clippy::cast_possible_truncation)]

--- a/crates/oxc_linter/src/rules/eslint/max_lines.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_lines.rs
@@ -80,7 +80,7 @@ impl Rule for MaxLines {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     #[allow(clippy::cast_possible_truncation)]

--- a/crates/oxc_linter/src/rules/eslint/max_lines.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_lines.rs
@@ -79,6 +79,10 @@ impl Rule for MaxLines {
         }
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     #[allow(clippy::cast_possible_truncation)]
     fn run_once(&self, ctx: &LintContext) {
         let comment_lines = if self.skip_comments {

--- a/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
@@ -36,7 +36,7 @@ declare_oxc_lint!(
 
 impl Rule for NoClassAssign {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_symbol(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_SYMBOL
     }
 
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
@@ -35,6 +35,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoClassAssign {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_symbol(true)
+    }
+
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
         let symbol_table = ctx.semantic().symbols();
         if symbol_table.get_flags(symbol_id).is_class() {

--- a/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
@@ -35,8 +35,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoClassAssign {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_symbol(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_symbol(true)
     }
 
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
@@ -51,6 +51,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoConstAssign {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_symbol(true)
+    }
+
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
         let symbol_table = ctx.semantic().symbols();
         if symbol_table.get_flags(symbol_id).is_const_variable() {

--- a/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
@@ -51,8 +51,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoConstAssign {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_symbol(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_symbol(true)
     }
 
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
@@ -52,7 +52,7 @@ declare_oxc_lint!(
 
 impl Rule for NoConstAssign {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_symbol(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_SYMBOL
     }
 
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
@@ -45,7 +45,7 @@ declare_oxc_lint!(
 
 impl Rule for NoDupeClassMembers {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
@@ -44,6 +44,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDupeClassMembers {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         ctx.semantic().classes().iter_enumerated().for_each(|(class_id, _)| {
             let mut defined_elements = FxHashMap::default();

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_class_members.rs
@@ -44,8 +44,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDupeClassMembers {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
@@ -85,6 +85,10 @@ impl Rule for NoDuplicateImports {
         }
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let module_record = ctx.module_record();
         let mut import_map: FxHashMap<&CompactStr, Vec<(ImportType, Span, ModuleType)>> =

--- a/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
@@ -86,7 +86,7 @@ impl Rule for NoDuplicateImports {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
@@ -85,8 +85,8 @@ impl Rule for NoDuplicateImports {
         }
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
@@ -37,6 +37,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoExAssign {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_symbol(true)
+    }
+
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
         let symbol_table = ctx.semantic().symbols();
         if symbol_table.get_flags(symbol_id).is_catch_variable() {

--- a/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
@@ -38,7 +38,7 @@ declare_oxc_lint!(
 
 impl Rule for NoExAssign {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_symbol(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_SYMBOL
     }
 
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
@@ -37,8 +37,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoExAssign {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_symbol(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_symbol(true)
     }
 
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
@@ -87,7 +87,7 @@ impl Rule for NoExtendNative {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
@@ -86,8 +86,8 @@ impl Rule for NoExtendNative {
         }))
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
@@ -86,6 +86,10 @@ impl Rule for NoExtendNative {
         }))
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let symbols = ctx.symbols();
         for reference_id_list in ctx.scopes().root_unresolved_references_ids() {

--- a/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
@@ -33,6 +33,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoFuncAssign {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_symbol(true)
+    }
+
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
         let symbol_table = ctx.semantic().symbols();
         let decl = symbol_table.get_declaration(symbol_id);

--- a/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
@@ -34,7 +34,7 @@ declare_oxc_lint!(
 
 impl Rule for NoFuncAssign {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_symbol(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_SYMBOL
     }
 
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
@@ -33,8 +33,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoFuncAssign {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_symbol(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_symbol(true)
     }
 
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
@@ -59,7 +59,7 @@ impl Rule for NoGlobalAssign {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
@@ -58,6 +58,10 @@ impl Rule for NoGlobalAssign {
         }))
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let symbol_table = ctx.symbols();
         for (name, reference_id_list) in ctx.scopes().root_unresolved_references() {

--- a/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_global_assign.rs
@@ -58,8 +58,8 @@ impl Rule for NoGlobalAssign {
         }))
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
@@ -52,7 +52,7 @@ const REFLECT_MUTATION_METHODS: phf::Set<&'static str> =
 
 impl Rule for NoImportAssign {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_symbol(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_SYMBOL
     }
 
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
@@ -51,6 +51,10 @@ const REFLECT_MUTATION_METHODS: phf::Set<&'static str> =
     phf_set!("defineProperty", "deleteProperty", "set", "setPrototypeOf");
 
 impl Rule for NoImportAssign {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_symbol(true)
+    }
+
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
         let symbol_table = ctx.semantic().symbols();
         if symbol_table.get_flags(symbol_id).is_import() {

--- a/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
@@ -51,8 +51,8 @@ const REFLECT_MUTATION_METHODS: phf::Set<&'static str> =
     phf_set!("defineProperty", "deleteProperty", "set", "setPrototypeOf");
 
 impl Rule for NoImportAssign {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_symbol(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_symbol(true)
     }
 
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
@@ -40,8 +40,8 @@ impl Rule for NoIrregularWhitespace {
         }
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
@@ -39,6 +39,10 @@ impl Rule for NoIrregularWhitespace {
             ctx.diagnostic(no_irregular_whitespace_diagnostic(*irregular_whitespace));
         }
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
 }
 
 #[allow(clippy::unicode_not_nfc, clippy::invisible_characters)]

--- a/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
@@ -41,7 +41,7 @@ impl Rule for NoIrregularWhitespace {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
@@ -61,7 +61,7 @@ impl Rule for NoRedeclare {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_symbol(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_SYMBOL
     }
 
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
@@ -60,8 +60,8 @@ impl Rule for NoRedeclare {
         Self { built_in_globals }
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_symbol(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_symbol(true)
     }
 
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
@@ -60,6 +60,10 @@ impl Rule for NoRedeclare {
         Self { built_in_globals }
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_symbol(true)
+    }
+
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext) {
         let symbol_table = ctx.semantic().symbols();
         let decl_node_id = symbol_table.get_declaration(symbol_id);

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
@@ -410,6 +410,10 @@ impl Rule for NoRestrictedImports {
         Self(Box::new(NoRestrictedImportsConfig { paths, patterns }))
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext<'_>) {
         let module_record = ctx.module_record();
 

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
@@ -410,8 +410,8 @@ impl Rule for NoRestrictedImports {
         Self(Box::new(NoRestrictedImportsConfig { paths, patterns }))
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
@@ -411,7 +411,7 @@ impl Rule for NoRestrictedImports {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
@@ -40,7 +40,7 @@ declare_oxc_lint!(
 
 impl Rule for NoShadowRestrictedNames {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_symbol(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_SYMBOL
     }
 
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
@@ -39,6 +39,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoShadowRestrictedNames {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_symbol(true)
+    }
+
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
         let name = ctx.symbols().get_name(symbol_id);
 

--- a/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
@@ -39,8 +39,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoShadowRestrictedNames {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_symbol(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_symbol(true)
     }
 
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
@@ -55,6 +55,10 @@ enum DefinitelyCallsThisBeforeSuper {
 }
 
 impl Rule for NoThisBeforeSuper {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let cfg = ctx.cfg();
         let semantic = ctx.semantic();

--- a/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
@@ -55,8 +55,8 @@ enum DefinitelyCallsThisBeforeSuper {
 }
 
 impl Rule for NoThisBeforeSuper {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_this_before_super.rs
@@ -56,7 +56,7 @@ enum DefinitelyCallsThisBeforeSuper {
 
 impl Rule for NoThisBeforeSuper {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -45,6 +45,10 @@ impl Rule for NoUndef {
         Self { type_of }
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let symbol_table = ctx.symbols();
 

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -45,8 +45,8 @@ impl Rule for NoUndef {
         Self { type_of }
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -46,7 +46,7 @@ impl Rule for NoUndef {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
@@ -52,6 +52,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnreachable {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let nodes = ctx.nodes();
         let Some(root) = nodes.root_node() else { return };

--- a/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
@@ -52,8 +52,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnreachable {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unreachable.rs
@@ -53,7 +53,7 @@ declare_oxc_lint!(
 
 impl Rule for NoUnreachable {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
@@ -39,6 +39,13 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnusedLabels {
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(
+            ctx.file_path().extension().is_some_and(|ext| ext != "svelte"),
+        )
+        .with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         for id in ctx.semantic().unused_labels() {
             let node = ctx.semantic().nodes().get_node(*id);
@@ -50,10 +57,6 @@ impl Rule for NoUnusedLabels {
                 |fixer| fixer.replace_with(stmt, &stmt.body),
             );
         }
-    }
-
-    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
-        ctx.file_path().extension().is_some_and(|ext| ext != "svelte")
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_labels.rs
@@ -39,11 +39,9 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnusedLabels {
-    fn should_run(&self, ctx: &crate::context::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(
-            ctx.file_path().extension().is_some_and(|ext| ext != "svelte"),
-        )
-        .with_run_once(true)
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> crate::rule::ShouldRunMeta {
+        let enable = ctx.file_path().extension().is_some_and(|ext| ext != "svelte");
+        crate::rule::ShouldRunMeta::new().with_run_once(enable)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
@@ -91,7 +91,7 @@ declare_oxc_lint!(
 
 impl Rule for NoUnusedPrivateClassMembers {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
@@ -90,8 +90,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnusedPrivateClassMembers {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_private_class_members.rs
@@ -90,6 +90,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnusedPrivateClassMembers {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         ctx.semantic().classes().iter_enumerated().for_each(|(class_id, _)| {
             for (element_id, element) in

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -214,16 +214,14 @@ impl Rule for NoUnusedVars {
         self.run_on_symbol_internal(&symbol, ctx);
     }
 
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
         // ignore .d.ts and vue/svelte files.
         // 1. declarations have side effects (they get merged together)
         // 2. vue/svelte scripts declare variables that get used in the template, which
         //    we can't detect
-        crate::rule::ShouldRunState::new(
-            !ctx.source_type().is_typescript_definition()
-                && !ctx.file_path().extension().is_some_and(|ext| ext == "vue" || ext == "svelte"),
-        )
-        .with_run_on_symbol(true)
+        let enable = !ctx.source_type().is_typescript_definition()
+            && !ctx.file_path().extension().is_some_and(|ext| ext == "vue" || ext == "svelte");
+        crate::rule::ShouldRunMeta::new().with_run_on_symbol(enable)
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -214,13 +214,16 @@ impl Rule for NoUnusedVars {
         self.run_on_symbol_internal(&symbol, ctx);
     }
 
-    fn should_run(&self, ctx: &ContextHost) -> bool {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
         // ignore .d.ts and vue/svelte files.
         // 1. declarations have side effects (they get merged together)
         // 2. vue/svelte scripts declare variables that get used in the template, which
         //    we can't detect
-        !ctx.source_type().is_typescript_definition()
-            && !ctx.file_path().extension().is_some_and(|ext| ext == "vue" || ext == "svelte")
+        crate::rule::ShouldRunState::new(
+            !ctx.source_type().is_typescript_definition()
+                && !ctx.file_path().extension().is_some_and(|ext| ext == "vue" || ext == "svelte"),
+        )
+        .with_run_on_symbol(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/sort_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_imports.rs
@@ -134,6 +134,10 @@ impl Rule for SortImports {
         }))
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let Some(root) = ctx.nodes().root_node() else {
             return;

--- a/crates/oxc_linter/src/rules/eslint/sort_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_imports.rs
@@ -135,7 +135,7 @@ impl Rule for SortImports {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/sort_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_imports.rs
@@ -134,8 +134,8 @@ impl Rule for SortImports {
         }))
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
+++ b/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
@@ -57,7 +57,7 @@ impl Rule for UnicodeBom {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
+++ b/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
@@ -56,6 +56,10 @@ impl Rule for UnicodeBom {
         }
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let source = ctx.source_text();
         let has_bomb = source.starts_with('﻿');

--- a/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
+++ b/crates/oxc_linter/src/rules/eslint/unicode_bom.rs
@@ -56,8 +56,8 @@ impl Rule for UnicodeBom {
         }
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/import/default.rs
+++ b/crates/oxc_linter/src/rules/import/default.rs
@@ -52,6 +52,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for Default {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext<'_>) {
         let module_record = ctx.module_record();
         let loaded_modules = module_record.loaded_modules.read().unwrap();

--- a/crates/oxc_linter/src/rules/import/default.rs
+++ b/crates/oxc_linter/src/rules/import/default.rs
@@ -53,7 +53,7 @@ declare_oxc_lint!(
 
 impl Rule for Default {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/default.rs
+++ b/crates/oxc_linter/src/rules/import/default.rs
@@ -52,8 +52,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for Default {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/export.rs
+++ b/crates/oxc_linter/src/rules/import/export.rs
@@ -50,8 +50,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for Export {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/export.rs
+++ b/crates/oxc_linter/src/rules/import/export.rs
@@ -51,7 +51,7 @@ declare_oxc_lint!(
 
 impl Rule for Export {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/export.rs
+++ b/crates/oxc_linter/src/rules/import/export.rs
@@ -50,6 +50,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for Export {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext<'_>) {
         let module_record = ctx.module_record();
         let named_export = &module_record.exported_bindings;

--- a/crates/oxc_linter/src/rules/import/first.rs
+++ b/crates/oxc_linter/src/rules/import/first.rs
@@ -111,7 +111,7 @@ impl Rule for First {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/first.rs
+++ b/crates/oxc_linter/src/rules/import/first.rs
@@ -110,8 +110,8 @@ impl Rule for First {
         }
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/first.rs
+++ b/crates/oxc_linter/src/rules/import/first.rs
@@ -110,6 +110,10 @@ impl Rule for First {
         }
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext<'_>) {
         let mut non_import_count = 0;
         let mut any_relative = false;
@@ -184,7 +188,7 @@ fn test() {
         ),
         // covers TSImportEqualsDeclaration (original rule support it, but with no test cases)
         (
-            r"import { x } from './foo'; 
+            r"import { x } from './foo';
             import F3 = require('mod');
             export { x, y }",
             None,

--- a/crates/oxc_linter/src/rules/import/max_dependencies.rs
+++ b/crates/oxc_linter/src/rules/import/max_dependencies.rs
@@ -97,7 +97,7 @@ impl Rule for MaxDependencies {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/max_dependencies.rs
+++ b/crates/oxc_linter/src/rules/import/max_dependencies.rs
@@ -96,6 +96,10 @@ impl Rule for MaxDependencies {
         }
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext<'_>) {
         let module_record = ctx.module_record();
         let mut module_count = module_record.import_entries.len();

--- a/crates/oxc_linter/src/rules/import/max_dependencies.rs
+++ b/crates/oxc_linter/src/rules/import/max_dependencies.rs
@@ -96,8 +96,8 @@ impl Rule for MaxDependencies {
         }
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/named.rs
+++ b/crates/oxc_linter/src/rules/import/named.rs
@@ -83,8 +83,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for Named {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/named.rs
+++ b/crates/oxc_linter/src/rules/import/named.rs
@@ -84,7 +84,7 @@ declare_oxc_lint!(
 
 impl Rule for Named {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/named.rs
+++ b/crates/oxc_linter/src/rules/import/named.rs
@@ -83,6 +83,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for Named {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext<'_>) {
         let semantic = ctx.semantic();
 

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -117,6 +117,10 @@ impl Rule for Namespace {
         }
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext<'_>) {
         let module_record = ctx.module_record();
 

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -118,7 +118,7 @@ impl Rule for Namespace {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -117,8 +117,8 @@ impl Rule for Namespace {
         }
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/no_cycle.rs
+++ b/crates/oxc_linter/src/rules/import/no_cycle.rs
@@ -117,6 +117,10 @@ impl Rule for NoCycle {
         }
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext<'_>) {
         let module_record = ctx.module_record();
 

--- a/crates/oxc_linter/src/rules/import/no_cycle.rs
+++ b/crates/oxc_linter/src/rules/import/no_cycle.rs
@@ -118,7 +118,7 @@ impl Rule for NoCycle {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/no_cycle.rs
+++ b/crates/oxc_linter/src/rules/import/no_cycle.rs
@@ -117,8 +117,8 @@ impl Rule for NoCycle {
         }
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/no_default_export.rs
+++ b/crates/oxc_linter/src/rules/import/no_default_export.rs
@@ -46,7 +46,7 @@ declare_oxc_lint!(
 
 impl Rule for NoDefaultExport {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/no_default_export.rs
+++ b/crates/oxc_linter/src/rules/import/no_default_export.rs
@@ -45,6 +45,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDefaultExport {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext<'_>) {
         let module_record = ctx.module_record();
         if let Some(span) = module_record.export_default {

--- a/crates/oxc_linter/src/rules/import/no_default_export.rs
+++ b/crates/oxc_linter/src/rules/import/no_default_export.rs
@@ -45,8 +45,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDefaultExport {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/no_duplicates.rs
+++ b/crates/oxc_linter/src/rules/import/no_duplicates.rs
@@ -89,6 +89,10 @@ impl Rule for NoDuplicates {
         }
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext<'_>) {
         let module_record = ctx.module_record();
 

--- a/crates/oxc_linter/src/rules/import/no_duplicates.rs
+++ b/crates/oxc_linter/src/rules/import/no_duplicates.rs
@@ -90,7 +90,7 @@ impl Rule for NoDuplicates {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/no_duplicates.rs
+++ b/crates/oxc_linter/src/rules/import/no_duplicates.rs
@@ -89,8 +89,8 @@ impl Rule for NoDuplicates {
         }
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/no_named_as_default.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default.rs
@@ -60,7 +60,7 @@ declare_oxc_lint!(
 
 impl Rule for NoNamedAsDefault {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/no_named_as_default.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default.rs
@@ -59,6 +59,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNamedAsDefault {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext<'_>) {
         let module_record = ctx.module_record();
         for import_entry in &module_record.import_entries {

--- a/crates/oxc_linter/src/rules/import/no_named_as_default.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default.rs
@@ -59,8 +59,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNamedAsDefault {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
@@ -75,6 +75,10 @@ fn get_symbol_id_from_ident(
 }
 
 impl Rule for NoNamedAsDefaultMember {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext<'_>) {
         let module_record = ctx.module_record();
 

--- a/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
@@ -76,7 +76,7 @@ fn get_symbol_id_from_ident(
 
 impl Rule for NoNamedAsDefaultMember {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_as_default_member.rs
@@ -75,8 +75,8 @@ fn get_symbol_id_from_ident(
 }
 
 impl Rule for NoNamedAsDefaultMember {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/no_named_default.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_default.rs
@@ -40,8 +40,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNamedDefault {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/import/no_named_default.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_default.rs
@@ -40,6 +40,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNamedDefault {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         ctx.module_record().import_entries.iter().for_each(|entry| {
             let ImportImportName::Name(import_name) = &entry.import_name else {

--- a/crates/oxc_linter/src/rules/import/no_named_default.rs
+++ b/crates/oxc_linter/src/rules/import/no_named_default.rs
@@ -41,7 +41,7 @@ declare_oxc_lint!(
 
 impl Rule for NoNamedDefault {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/import/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/import/no_namespace.rs
@@ -98,7 +98,7 @@ impl Rule for NoNamespace {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/import/no_namespace.rs
@@ -97,8 +97,8 @@ impl Rule for NoNamespace {
         }))
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/import/no_namespace.rs
@@ -97,6 +97,10 @@ impl Rule for NoNamespace {
         }))
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext<'_>) {
         let module_record = ctx.module_record();
 

--- a/crates/oxc_linter/src/rules/import/no_self_import.rs
+++ b/crates/oxc_linter/src/rules/import/no_self_import.rs
@@ -42,6 +42,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoSelfImport {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext<'_>) {
         let module_record = ctx.module_record();
         let resolved_absolute_path = &module_record.resolved_absolute_path;

--- a/crates/oxc_linter/src/rules/import/no_self_import.rs
+++ b/crates/oxc_linter/src/rules/import/no_self_import.rs
@@ -42,8 +42,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoSelfImport {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/no_self_import.rs
+++ b/crates/oxc_linter/src/rules/import/no_self_import.rs
@@ -43,7 +43,7 @@ declare_oxc_lint!(
 
 impl Rule for NoSelfImport {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/unambiguous.rs
+++ b/crates/oxc_linter/src/rules/import/unambiguous.rs
@@ -48,8 +48,8 @@ declare_oxc_lint!(
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/unambiguous.md>
 impl Rule for Unambiguous {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/unambiguous.rs
+++ b/crates/oxc_linter/src/rules/import/unambiguous.rs
@@ -49,7 +49,7 @@ declare_oxc_lint!(
 /// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/unambiguous.md>
 impl Rule for Unambiguous {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/import/unambiguous.rs
+++ b/crates/oxc_linter/src/rules/import/unambiguous.rs
@@ -48,6 +48,10 @@ declare_oxc_lint!(
 
 /// <https://github.com/import-js/eslint-plugin-import/blob/v2.29.1/docs/rules/unambiguous.md>
 impl Rule for Unambiguous {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext<'_>) {
         if !ctx.module_record().has_module_syntax {
             ctx.diagnostic(unambiguous_diagnostic(Span::default()));

--- a/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
+++ b/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
@@ -202,6 +202,10 @@ impl Rule for ConsistentTestIt {
         Self(Box::new(ConsistentTestItConfig { within_describe, within_fn }))
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let mut describe_nesting_hash: FxHashMap<ScopeId, i32> = FxHashMap::default();
         let mut possible_jest_nodes = collect_possible_jest_call_node(ctx);

--- a/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
+++ b/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
@@ -202,8 +202,8 @@ impl Rule for ConsistentTestIt {
         Self(Box::new(ConsistentTestItConfig { within_describe, within_fn }))
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
+++ b/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
@@ -203,7 +203,7 @@ impl Rule for ConsistentTestIt {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/expect_expect.rs
@@ -132,6 +132,10 @@ impl Rule for ExpectExpect {
     ) {
         run(self, jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 fn run<'a>(

--- a/crates/oxc_linter/src/rules/jest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/expect_expect.rs
@@ -133,8 +133,8 @@ impl Rule for ExpectExpect {
         run(self, jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/expect_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/expect_expect.rs
@@ -134,7 +134,7 @@ impl Rule for ExpectExpect {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/max_expects.rs
+++ b/crates/oxc_linter/src/rules/jest/max_expects.rs
@@ -77,8 +77,8 @@ impl Rule for MaxExpects {
         Self { max }
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/max_expects.rs
+++ b/crates/oxc_linter/src/rules/jest/max_expects.rs
@@ -77,6 +77,10 @@ impl Rule for MaxExpects {
         Self { max }
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let mut count_map: FxHashMap<usize, usize> = FxHashMap::default();
 
@@ -498,7 +502,7 @@ fn test() {
         (
             " test('should pass', async () => {
 			     expect.hasAssertions();
-			   
+
 			     expect(true).toBeDefined();
 			     expect(true).toBeDefined();
 			     expect(true).toBeDefined();

--- a/crates/oxc_linter/src/rules/jest/max_expects.rs
+++ b/crates/oxc_linter/src/rules/jest/max_expects.rs
@@ -78,7 +78,7 @@ impl Rule for MaxExpects {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
@@ -134,7 +134,7 @@ impl Rule for MaxNestedDescribe {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
@@ -133,8 +133,8 @@ impl Rule for MaxNestedDescribe {
         Self { max }
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/max_nested_describe.rs
@@ -133,6 +133,10 @@ impl Rule for MaxNestedDescribe {
         Self { max }
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let mut describes_hooks_depth: Vec<ScopeId> = vec![];
         let mut possibles_jest_nodes = collect_possible_jest_call_node(ctx);
@@ -422,7 +426,7 @@ fn test() {
                     describe('another suite', () => {
                         describe('another suite', () => {
                             describe('another suite', () => {
-                            
+
                             })
                         })
                     })
@@ -441,7 +445,7 @@ fn test() {
                             describe('another suite', () => {
                                 describe('another suite', () => {
                                     describe('another suite', () => {
-                                
+
                                     })
                                 })
                             })

--- a/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
@@ -69,7 +69,7 @@ impl Rule for NoAliasMethods {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
@@ -68,8 +68,8 @@ impl Rule for NoAliasMethods {
         run(jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_alias_methods.rs
@@ -67,6 +67,10 @@ impl Rule for NoAliasMethods {
     ) {
         run(jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/jest/no_commented_out_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_commented_out_tests.rs
@@ -54,6 +54,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoCommentedOutTests {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         lazy_static! {
         //  /^\s*[xf]?(test|it|describe)(\.\w+|\[['"]\w+['"]\])?\s*\(/mu

--- a/crates/oxc_linter/src/rules/jest/no_commented_out_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_commented_out_tests.rs
@@ -55,7 +55,7 @@ declare_oxc_lint!(
 
 impl Rule for NoCommentedOutTests {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/no_commented_out_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_commented_out_tests.rs
@@ -54,8 +54,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoCommentedOutTests {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
@@ -79,8 +79,8 @@ impl Rule for NoConditionalExpect {
         run(jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
@@ -80,7 +80,7 @@ impl Rule for NoConditionalExpect {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/no_conditional_expect.rs
@@ -78,6 +78,10 @@ impl Rule for NoConditionalExpect {
     ) {
         run(jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
+++ b/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
@@ -76,6 +76,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoConfusingSetTimeout {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let scopes = ctx.scopes();
         let symbol_table = ctx.symbols();

--- a/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
+++ b/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
@@ -77,7 +77,7 @@ declare_oxc_lint!(
 
 impl Rule for NoConfusingSetTimeout {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
+++ b/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
@@ -76,8 +76,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoConfusingSetTimeout {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
@@ -98,6 +98,10 @@ impl Rule for NoDisabledTests {
     ) {
         run(jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
@@ -268,7 +272,7 @@ fn test() {
         r#"it("contains a call to pending", function () { pending() })"#,
         "pending();",
         r#"
-            import { describe } from 'vitest'; 
+            import { describe } from 'vitest';
             describe.skip("foo", function () {})
         "#,
     ];

--- a/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
@@ -100,7 +100,7 @@ impl Rule for NoDisabledTests {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
@@ -99,8 +99,8 @@ impl Rule for NoDisabledTests {
         run(jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_done_callback.rs
+++ b/crates/oxc_linter/src/rules/jest/no_done_callback.rs
@@ -85,8 +85,8 @@ impl Rule for NoDoneCallback {
         run(jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_done_callback.rs
+++ b/crates/oxc_linter/src/rules/jest/no_done_callback.rs
@@ -86,7 +86,7 @@ impl Rule for NoDoneCallback {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_done_callback.rs
+++ b/crates/oxc_linter/src/rules/jest/no_done_callback.rs
@@ -84,6 +84,10 @@ impl Rule for NoDoneCallback {
     ) {
         run(jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/jest/no_duplicate_hooks.rs
+++ b/crates/oxc_linter/src/rules/jest/no_duplicate_hooks.rs
@@ -104,7 +104,7 @@ declare_oxc_lint!(
 
 impl Rule for NoDuplicateHooks {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/no_duplicate_hooks.rs
+++ b/crates/oxc_linter/src/rules/jest/no_duplicate_hooks.rs
@@ -103,8 +103,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDuplicateHooks {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/no_duplicate_hooks.rs
+++ b/crates/oxc_linter/src/rules/jest/no_duplicate_hooks.rs
@@ -103,6 +103,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDuplicateHooks {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let Some(root_node) = ctx.nodes().root_node() else {
             return;
@@ -583,7 +587,7 @@ fn test() {
                     beforeEach(() => {})
                     afterEach(() => {})
                     afterAll(() => {})
-                
+
                     test("bar", () => {
                         someFn();
                     })
@@ -708,7 +712,7 @@ fn test() {
                 describe.each(['hello'])('%s', () => {
                     beforeEach(() => {});
                     beforeEach(() => {});
-                    
+
                     it('is not fine', () => {});
                 });
             ",
@@ -719,14 +723,14 @@ fn test() {
                 describe('something', () => {
                     describe.each(['hello'])('%s', () => {
                         beforeEach(() => {});
-                    
+
                         it('is fine', () => {});
                     });
-			    
+
                     describe.each(['world'])('%s', () => {
                         beforeEach(() => {});
                         beforeEach(() => {});
-                    
+
                         it('is not fine', () => {});
                     });
                 });

--- a/crates/oxc_linter/src/rules/jest/no_export.rs
+++ b/crates/oxc_linter/src/rules/jest/no_export.rs
@@ -37,6 +37,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoExport {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         // only used in jest files
         if !is_jest_file(ctx) {

--- a/crates/oxc_linter/src/rules/jest/no_export.rs
+++ b/crates/oxc_linter/src/rules/jest/no_export.rs
@@ -38,7 +38,7 @@ declare_oxc_lint!(
 
 impl Rule for NoExport {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/no_export.rs
+++ b/crates/oxc_linter/src/rules/jest/no_export.rs
@@ -37,8 +37,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoExport {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
@@ -76,7 +76,7 @@ impl Rule for NoFocusedTests {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
@@ -74,6 +74,10 @@ impl Rule for NoFocusedTests {
     ) {
         run(jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {
@@ -172,7 +176,7 @@ fn test() {
     let fail_vitest = vec![
         (
             r#"
-            import { it } from 'vitest'; 
+            import { it } from 'vitest';
             it.only("test", () => {});
             "#,
             None,

--- a/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_focused_tests.rs
@@ -75,8 +75,8 @@ impl Rule for NoFocusedTests {
         run(jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_hooks.rs
+++ b/crates/oxc_linter/src/rules/jest/no_hooks.rs
@@ -103,7 +103,7 @@ impl Rule for NoHooks {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_hooks.rs
+++ b/crates/oxc_linter/src/rules/jest/no_hooks.rs
@@ -102,8 +102,8 @@ impl Rule for NoHooks {
         self.run(jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_hooks.rs
+++ b/crates/oxc_linter/src/rules/jest/no_hooks.rs
@@ -101,6 +101,10 @@ impl Rule for NoHooks {
     ) {
         self.run(jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 impl NoHooks {

--- a/crates/oxc_linter/src/rules/jest/no_identical_title.rs
+++ b/crates/oxc_linter/src/rules/jest/no_identical_title.rs
@@ -72,8 +72,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoIdenticalTitle {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/no_identical_title.rs
+++ b/crates/oxc_linter/src/rules/jest/no_identical_title.rs
@@ -72,6 +72,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoIdenticalTitle {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let possible_jest_nodes = collect_possible_jest_call_node(ctx);
         let mut title_to_span_mapping = FxHashMap::default();

--- a/crates/oxc_linter/src/rules/jest/no_identical_title.rs
+++ b/crates/oxc_linter/src/rules/jest/no_identical_title.rs
@@ -73,7 +73,7 @@ declare_oxc_lint!(
 
 impl Rule for NoIdenticalTitle {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/no_interpolation_in_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_interpolation_in_snapshots.rs
@@ -65,7 +65,7 @@ impl Rule for NoInterpolationInSnapshots {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_interpolation_in_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_interpolation_in_snapshots.rs
@@ -63,6 +63,10 @@ impl Rule for NoInterpolationInSnapshots {
     ) {
         run(jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/jest/no_interpolation_in_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_interpolation_in_snapshots.rs
@@ -64,8 +64,8 @@ impl Rule for NoInterpolationInSnapshots {
         run(jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
+++ b/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
@@ -44,6 +44,10 @@ const COMMON_ERROR_TEXT: &str = "Illegal usage of jasmine global";
 const COMMON_HELP_TEXT: &str = "prefer use Jest own API";
 
 impl Rule for NoJasmineGlobals {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let symbol_table = ctx.symbols();
         let jasmine_references = ctx

--- a/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
+++ b/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
@@ -45,7 +45,7 @@ const COMMON_HELP_TEXT: &str = "prefer use Jest own API";
 
 impl Rule for NoJasmineGlobals {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run(true).with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN.with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
+++ b/crates/oxc_linter/src/rules/jest/no_jasmine_globals.rs
@@ -44,8 +44,8 @@ const COMMON_ERROR_TEXT: &str = "Illegal usage of jasmine global";
 const COMMON_HELP_TEXT: &str = "prefer use Jest own API";
 
 impl Rule for NoJasmineGlobals {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(true).with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
@@ -161,8 +161,8 @@ impl Rule for NoLargeSnapshots {
         Self(Box::new(NoLargeSnapshotsConfig { max_size, inline_max_size, allowed_snapshots }))
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
@@ -161,6 +161,10 @@ impl Rule for NoLargeSnapshots {
         Self(Box::new(NoLargeSnapshotsConfig { max_size, inline_max_size, allowed_snapshots }))
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let is_snap = ctx.file_path().to_str().is_some_and(|p| {
             Path::new(p).extension().is_some_and(|ext| ext.eq_ignore_ascii_case("snap"))

--- a/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
@@ -162,7 +162,7 @@ impl Rule for NoLargeSnapshots {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
+++ b/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
@@ -45,8 +45,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoMocksImport {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
+++ b/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
@@ -46,7 +46,7 @@ declare_oxc_lint!(
 
 impl Rule for NoMocksImport {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
+++ b/crates/oxc_linter/src/rules/jest/no_mocks_import.rs
@@ -45,6 +45,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoMocksImport {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let module_records = ctx.module_record();
 

--- a/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
@@ -81,6 +81,10 @@ impl Rule for NoRestrictedJestMethods {
     ) {
         self.run(jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 impl NoRestrictedJestMethods {

--- a/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
@@ -82,8 +82,8 @@ impl Rule for NoRestrictedJestMethods {
         self.run(jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
@@ -83,7 +83,7 @@ impl Rule for NoRestrictedJestMethods {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_restricted_matchers.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_matchers.rs
@@ -98,6 +98,10 @@ impl Rule for NoRestrictedMatchers {
     ) {
         self.run(jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 impl NoRestrictedMatchers {

--- a/crates/oxc_linter/src/rules/jest/no_restricted_matchers.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_matchers.rs
@@ -99,8 +99,8 @@ impl Rule for NoRestrictedMatchers {
         self.run(jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_restricted_matchers.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_matchers.rs
@@ -100,7 +100,7 @@ impl Rule for NoRestrictedMatchers {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_standalone_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/no_standalone_expect.rs
@@ -72,8 +72,8 @@ impl Rule for NoStandaloneExpect {
         Self(Box::new(NoStandaloneExpectConfig { additional_test_block_functions }))
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/jest/no_standalone_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/no_standalone_expect.rs
@@ -73,7 +73,7 @@ impl Rule for NoStandaloneExpect {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/jest/no_standalone_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/no_standalone_expect.rs
@@ -72,6 +72,10 @@ impl Rule for NoStandaloneExpect {
         Self(Box::new(NoStandaloneExpectConfig { additional_test_block_functions }))
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext<'_>) {
         let possible_jest_nodes = collect_possible_jest_call_node(ctx);
         let id_nodes_mapping =

--- a/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
+++ b/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
@@ -68,7 +68,7 @@ impl Rule for NoTestPrefixes {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
+++ b/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
@@ -67,8 +67,8 @@ impl Rule for NoTestPrefixes {
         run(jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
+++ b/crates/oxc_linter/src/rules/jest/no_test_prefixes.rs
@@ -66,6 +66,10 @@ impl Rule for NoTestPrefixes {
     ) {
         run(jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
+++ b/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
@@ -89,16 +89,17 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUntypedMockFactory {
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript())
+            .with_run_on_jest_node(true)
+    }
+
     fn run_on_jest_node<'a, 'c>(
         &self,
         jest_node: &PossibleJestNode<'a, 'c>,
         ctx: &'c LintContext<'a>,
     ) {
         Self::run(jest_node, ctx);
-    }
-
-    fn should_run(&self, ctx: &crate::context::ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
+++ b/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
@@ -89,9 +89,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUntypedMockFactory {
-    fn should_run(&self, ctx: &crate::context::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript())
-            .with_run_on_jest_node(true)
+    fn should_run(&self, ctx: &crate::context::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(ctx.source_type().is_typescript())
     }
 
     fn run_on_jest_node<'a, 'c>(

--- a/crates/oxc_linter/src/rules/jest/prefer_called_with.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_called_with.rs
@@ -58,7 +58,7 @@ impl Rule for PreferCalledWith {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/prefer_called_with.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_called_with.rs
@@ -56,6 +56,10 @@ impl Rule for PreferCalledWith {
     ) {
         Self::run(jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 impl PreferCalledWith {

--- a/crates/oxc_linter/src/rules/jest/prefer_called_with.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_called_with.rs
@@ -57,8 +57,8 @@ impl Rule for PreferCalledWith {
         Self::run(jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/prefer_comparison_matcher.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_comparison_matcher.rs
@@ -69,8 +69,8 @@ impl Rule for PreferComparisonMatcher {
         Self::run(jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/prefer_comparison_matcher.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_comparison_matcher.rs
@@ -68,6 +68,10 @@ impl Rule for PreferComparisonMatcher {
     ) {
         Self::run(jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 impl PreferComparisonMatcher {

--- a/crates/oxc_linter/src/rules/jest/prefer_comparison_matcher.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_comparison_matcher.rs
@@ -70,7 +70,7 @@ impl Rule for PreferComparisonMatcher {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/prefer_each.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_each.rs
@@ -69,8 +69,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferEach {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/jest/prefer_each.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_each.rs
@@ -69,6 +69,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferEach {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext<'_>) {
         let mut skip = FxHashSet::<NodeId>::default();
         ctx.nodes().iter().for_each(|node| {

--- a/crates/oxc_linter/src/rules/jest/prefer_each.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_each.rs
@@ -70,7 +70,7 @@ declare_oxc_lint!(
 
 impl Rule for PreferEach {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/jest/prefer_equality_matcher.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_equality_matcher.rs
@@ -54,8 +54,8 @@ impl Rule for PreferEqualityMatcher {
         Self::run(jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/prefer_equality_matcher.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_equality_matcher.rs
@@ -53,6 +53,10 @@ impl Rule for PreferEqualityMatcher {
     ) {
         Self::run(jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 impl PreferEqualityMatcher {

--- a/crates/oxc_linter/src/rules/jest/prefer_equality_matcher.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_equality_matcher.rs
@@ -55,7 +55,7 @@ impl Rule for PreferEqualityMatcher {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/prefer_expect_resolves.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_expect_resolves.rs
@@ -82,8 +82,8 @@ impl Rule for PreferExpectResolves {
         Self::run(jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/prefer_expect_resolves.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_expect_resolves.rs
@@ -81,6 +81,10 @@ impl Rule for PreferExpectResolves {
     ) {
         Self::run(jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 impl PreferExpectResolves {

--- a/crates/oxc_linter/src/rules/jest/prefer_expect_resolves.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_expect_resolves.rs
@@ -83,7 +83,7 @@ impl Rule for PreferExpectResolves {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/prefer_hooks_in_order.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_hooks_in_order.rs
@@ -143,6 +143,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferHooksInOrder {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let mut previous_hook_orders: FxHashMap<ScopeId, (u8, Span)> = FxHashMap::default();
 
@@ -1167,13 +1171,13 @@ fn test() {
                     it('foo nested', () => {
                         // this is a test
                     });
-                    
-                    describe('deeply nested', () => { 
+
+                    describe('deeply nested', () => {
                         afterAll(() => {});
                         afterAll(() => {});
                         // This comment does nothing
                         afterEach(() => {});
-                
+
                         it('foo nested', () => {
                             // this is a test
                         });
@@ -1198,7 +1202,7 @@ fn test() {
                 it('foo', () => {
                     // this is a test
                 });
-            
+
                 describe('my nested test', () => {
                     afterAll(() => {});
                     afterEach(() => {});
@@ -1222,26 +1226,26 @@ fn test() {
                 it('accepts this input', () => {
                     // ...
                 });
-                
+
                 it('returns that value', () => {
                     // ...
                 });
 
                 describe('when the database has specific values', () => {
                     const specificValue = '...';
-                
+
                     beforeEach(() => {
                         seedMyDatabase(specificValue);
                     });
-                
+
                     it('accepts that input', () => {
                         // ...
                     });
-                
+
                     it('throws an error', () => {
                         // ...
                     });
-                
+
                     afterEach(() => {
                         clearLogger();
                     });
@@ -1249,12 +1253,12 @@ fn test() {
                     beforeEach(() => {
                         mockLogger();
                     });
-                
+
                     it('logs a message', () => {
                         // ...
                     });
                 });
-                
+
                 afterAll(() => {
                     removeMyDatabase();
                 });

--- a/crates/oxc_linter/src/rules/jest/prefer_hooks_in_order.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_hooks_in_order.rs
@@ -144,7 +144,7 @@ declare_oxc_lint!(
 
 impl Rule for PreferHooksInOrder {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/prefer_hooks_in_order.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_hooks_in_order.rs
@@ -143,8 +143,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferHooksInOrder {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/prefer_hooks_on_top.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_hooks_on_top.rs
@@ -140,6 +140,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferHooksOnTop {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let mut hooks_contexts: FxHashMap<ScopeId, bool> = FxHashMap::default();
         let mut possibles_jest_nodes = collect_possible_jest_call_node(ctx);

--- a/crates/oxc_linter/src/rules/jest/prefer_hooks_on_top.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_hooks_on_top.rs
@@ -141,7 +141,7 @@ declare_oxc_lint!(
 
 impl Rule for PreferHooksOnTop {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/prefer_hooks_on_top.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_hooks_on_top.rs
@@ -140,8 +140,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferHooksOnTop {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/prefer_lowercase_title/mod.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_lowercase_title/mod.rs
@@ -243,8 +243,8 @@ impl Rule for PreferLowercaseTitle {
         }
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/prefer_lowercase_title/mod.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_lowercase_title/mod.rs
@@ -244,7 +244,7 @@ impl Rule for PreferLowercaseTitle {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/prefer_lowercase_title/mod.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_lowercase_title/mod.rs
@@ -242,6 +242,10 @@ impl Rule for PreferLowercaseTitle {
             self.lint_string(ctx, template_string.as_str(), template_expr.span);
         }
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 impl PreferLowercaseTitle {

--- a/crates/oxc_linter/src/rules/jest/prefer_strict_equal.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_strict_equal.rs
@@ -47,8 +47,8 @@ impl Rule for PreferStrictEqual {
         Self::run(jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/prefer_strict_equal.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_strict_equal.rs
@@ -46,6 +46,10 @@ impl Rule for PreferStrictEqual {
     ) {
         Self::run(jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 impl PreferStrictEqual {

--- a/crates/oxc_linter/src/rules/jest/prefer_strict_equal.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_strict_equal.rs
@@ -48,7 +48,7 @@ impl Rule for PreferStrictEqual {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
@@ -89,7 +89,7 @@ impl Rule for PreferToBe {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
@@ -88,8 +88,8 @@ impl Rule for PreferToBe {
         Self::run(jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_be.rs
@@ -87,6 +87,10 @@ impl Rule for PreferToBe {
     ) {
         Self::run(jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 impl PreferToBe {

--- a/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
@@ -63,7 +63,7 @@ impl Rule for PreferToContain {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
@@ -61,6 +61,10 @@ impl Rule for PreferToContain {
     ) {
         Self::run(jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 impl PreferToContain {

--- a/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_contain.rs
@@ -62,8 +62,8 @@ impl Rule for PreferToContain {
         Self::run(jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
@@ -60,6 +60,10 @@ impl Rule for PreferToHaveLength {
     ) {
         Self::run(jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 impl PreferToHaveLength {

--- a/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
@@ -62,7 +62,7 @@ impl Rule for PreferToHaveLength {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_to_have_length.rs
@@ -61,8 +61,8 @@ impl Rule for PreferToHaveLength {
         Self::run(jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/prefer_todo.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_todo.rs
@@ -58,7 +58,7 @@ impl Rule for PreferTodo {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/prefer_todo.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_todo.rs
@@ -56,6 +56,10 @@ impl Rule for PreferTodo {
     ) {
         run(jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/jest/prefer_todo.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_todo.rs
@@ -57,8 +57,8 @@ impl Rule for PreferTodo {
         run(jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/require_to_throw_message.rs
+++ b/crates/oxc_linter/src/rules/jest/require_to_throw_message.rs
@@ -55,8 +55,8 @@ impl Rule for RequireToThrowMessage {
         Self::run(jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/require_to_throw_message.rs
+++ b/crates/oxc_linter/src/rules/jest/require_to_throw_message.rs
@@ -56,7 +56,7 @@ impl Rule for RequireToThrowMessage {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/require_to_throw_message.rs
+++ b/crates/oxc_linter/src/rules/jest/require_to_throw_message.rs
@@ -54,6 +54,10 @@ impl Rule for RequireToThrowMessage {
     ) {
         Self::run(jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 impl RequireToThrowMessage {

--- a/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
@@ -122,6 +122,10 @@ impl Rule for RequireTopLevelDescribe {
         Self { max_number_of_top_level_describes }
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let mut describe_contexts: FxHashMap<ScopeId, usize> = FxHashMap::default();
         let mut possibles_jest_nodes = collect_possible_jest_call_node(ctx);

--- a/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
@@ -122,8 +122,8 @@ impl Rule for RequireTopLevelDescribe {
         Self { max_number_of_top_level_describes }
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
@@ -123,7 +123,7 @@ impl Rule for RequireTopLevelDescribe {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jest/valid_describe_callback.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_describe_callback.rs
@@ -83,7 +83,7 @@ impl Rule for ValidDescribeCallback {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/valid_describe_callback.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_describe_callback.rs
@@ -81,6 +81,10 @@ impl Rule for ValidDescribeCallback {
     ) {
         run(jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/jest/valid_describe_callback.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_describe_callback.rs
@@ -82,8 +82,8 @@ impl Rule for ValidDescribeCallback {
         run(jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/valid_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_expect.rs
@@ -132,6 +132,10 @@ impl Rule for ValidExpect {
     ) {
         self.run(jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 impl ValidExpect {

--- a/crates/oxc_linter/src/rules/jest/valid_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_expect.rs
@@ -134,7 +134,7 @@ impl Rule for ValidExpect {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/valid_expect.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_expect.rs
@@ -133,8 +133,8 @@ impl Rule for ValidExpect {
         self.run(jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/valid_title.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_title.rs
@@ -136,6 +136,10 @@ impl Rule for ValidTitle {
     ) {
         self.run(jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 impl ValidTitle {

--- a/crates/oxc_linter/src/rules/jest/valid_title.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_title.rs
@@ -137,8 +137,8 @@ impl Rule for ValidTitle {
         self.run(jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/jest/valid_title.rs
+++ b/crates/oxc_linter/src/rules/jest/valid_title.rs
@@ -138,7 +138,7 @@ impl Rule for ValidTitle {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/jsdoc/check_access.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_access.rs
@@ -65,8 +65,8 @@ const ACCESS_LEVELS: phf::Set<&'static str> = phf_set! {
 };
 
 impl Rule for CheckAccess {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jsdoc/check_access.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_access.rs
@@ -66,7 +66,7 @@ const ACCESS_LEVELS: phf::Set<&'static str> = phf_set! {
 
 impl Rule for CheckAccess {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jsdoc/check_access.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_access.rs
@@ -65,6 +65,10 @@ const ACCESS_LEVELS: phf::Set<&'static str> = phf_set! {
 };
 
 impl Rule for CheckAccess {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let settings = &ctx.settings().jsdoc;
         let resolved_access_tag_name = settings.resolve_tag_name("access");

--- a/crates/oxc_linter/src/rules/jsdoc/check_property_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_property_names.rs
@@ -62,6 +62,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for CheckPropertyNames {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let settings = &ctx.settings().jsdoc;
         let resolved_property_tag_name = settings.resolve_tag_name("property");

--- a/crates/oxc_linter/src/rules/jsdoc/check_property_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_property_names.rs
@@ -63,7 +63,7 @@ declare_oxc_lint!(
 
 impl Rule for CheckPropertyNames {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jsdoc/check_property_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_property_names.rs
@@ -62,8 +62,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for CheckPropertyNames {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
@@ -204,7 +204,7 @@ impl Rule for CheckTagNames {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
@@ -203,8 +203,8 @@ impl Rule for CheckTagNames {
             .map_or_else(Self::default, |value| Self(Box::new(value)))
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_tag_names.rs
@@ -203,6 +203,10 @@ impl Rule for CheckTagNames {
             .map_or_else(Self::default, |value| Self(Box::new(value)))
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let settings = &ctx.settings().jsdoc;
         let config = &self.0;

--- a/crates/oxc_linter/src/rules/jsdoc/empty_tags.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/empty_tags.rs
@@ -98,8 +98,8 @@ impl Rule for EmptyTags {
             .map_or_else(Self::default, |value| Self(Box::new(value)))
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jsdoc/empty_tags.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/empty_tags.rs
@@ -99,7 +99,7 @@ impl Rule for EmptyTags {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jsdoc/empty_tags.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/empty_tags.rs
@@ -98,6 +98,10 @@ impl Rule for EmptyTags {
             .map_or_else(Self::default, |value| Self(Box::new(value)))
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let settings = &ctx.settings().jsdoc;
 

--- a/crates/oxc_linter/src/rules/jsdoc/require_property.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property.rs
@@ -60,6 +60,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequireProperty {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let settings = &ctx.settings().jsdoc;
         let resolved_property_tag_name = settings.resolve_tag_name("property");

--- a/crates/oxc_linter/src/rules/jsdoc/require_property.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property.rs
@@ -60,8 +60,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequireProperty {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jsdoc/require_property.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property.rs
@@ -61,7 +61,7 @@ declare_oxc_lint!(
 
 impl Rule for RequireProperty {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jsdoc/require_property_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property_description.rs
@@ -50,7 +50,7 @@ declare_oxc_lint!(
 
 impl Rule for RequirePropertyDescription {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jsdoc/require_property_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property_description.rs
@@ -49,8 +49,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequirePropertyDescription {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jsdoc/require_property_description.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property_description.rs
@@ -49,6 +49,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequirePropertyDescription {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let settings = &ctx.settings().jsdoc;
         let resolved_property_tag_name = settings.resolve_tag_name("property");

--- a/crates/oxc_linter/src/rules/jsdoc/require_property_name.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property_name.rs
@@ -49,6 +49,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequirePropertyName {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let settings = &ctx.settings().jsdoc;
         let resolved_property_tag_name = settings.resolve_tag_name("property");

--- a/crates/oxc_linter/src/rules/jsdoc/require_property_name.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property_name.rs
@@ -50,7 +50,7 @@ declare_oxc_lint!(
 
 impl Rule for RequirePropertyName {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jsdoc/require_property_name.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property_name.rs
@@ -49,8 +49,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequirePropertyName {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jsdoc/require_property_type.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property_type.rs
@@ -49,8 +49,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequirePropertyType {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jsdoc/require_property_type.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property_type.rs
@@ -50,7 +50,7 @@ declare_oxc_lint!(
 
 impl Rule for RequirePropertyType {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jsdoc/require_property_type.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_property_type.rs
@@ -49,6 +49,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequirePropertyType {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let settings = &ctx.settings().jsdoc;
         let resolved_property_tag_name = settings.resolve_tag_name("property");

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
@@ -104,6 +104,10 @@ impl Rule for RequireReturns {
             .map_or_else(Self::default, |value| Self(Box::new(value)))
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         // Step 1. Collect functions to check
         // In this rule, existence of `return` statement differs the behavior.

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
@@ -104,8 +104,8 @@ impl Rule for RequireReturns {
             .map_or_else(Self::default, |value| Self(Box::new(value)))
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
@@ -105,7 +105,7 @@ impl Rule for RequireReturns {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/nextjs/no_async_client_component.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_async_client_component.rs
@@ -34,7 +34,7 @@ declare_oxc_lint!(
 
 impl Rule for NoAsyncClientComponent {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/nextjs/no_async_client_component.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_async_client_component.rs
@@ -33,8 +33,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoAsyncClientComponent {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/nextjs/no_async_client_component.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_async_client_component.rs
@@ -33,6 +33,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoAsyncClientComponent {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let Some(root) = ctx.nodes().root_node() else {
             return;
@@ -120,7 +124,7 @@ fn test() {
 			    ",
         r#"
 			    "use client"
-			
+
 			    export default async function myFunction() {
 			      return ''
 			    }
@@ -129,25 +133,25 @@ fn test() {
 			    async function MyComponent() {
 			      return <></>
 			    }
-			
+
 			    export default MyComponent
 			    ",
         r#"
 			    "use client"
-			
+
 			    async function myFunction() {
 			      return ''
 			    }
-			
+
 			    export default myFunction
 			    "#,
         r#"
 			    "use client"
-			
+
 			    const myFunction = () => {
 			      return ''
 			    }
-			
+
 			    export default myFunction
 			    "#,
     ];
@@ -155,43 +159,43 @@ fn test() {
     let fail = vec![
         r#"
 			      "use client"
-			
+
 			      export default async function MyComponent() {
 			        return <></>
 			      }
 			      "#,
         r#"
 			      "use client"
-			
+
 			      export default async function MyFunction() {
 			        return ''
 			      }
 			      "#,
         r#"
 			      "use client"
-			
+
 			      async function MyComponent() {
 			        return <></>
 			      }
-			
+
 			      export default MyComponent
 			      "#,
         r#"
 			      "use client"
-			
+
 			      async function MyFunction() {
 			        return ''
 			      }
-			
+
 			      export default MyFunction
 			      "#,
         r#"
 			      "use client"
-			
+
 			      const MyFunction = async () => {
 			        return '123'
 			      }
-			
+
 			      export default MyFunction
 			      "#,
     ];

--- a/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
@@ -46,8 +46,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDuplicateHead {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_symbol(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_symbol(true)
     }
 
     fn run_on_symbol(&self, symbol_id: oxc_semantic::SymbolId, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
@@ -47,7 +47,7 @@ declare_oxc_lint!(
 
 impl Rule for NoDuplicateHead {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_symbol(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_SYMBOL
     }
 
     fn run_on_symbol(&self, symbol_id: oxc_semantic::SymbolId, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
@@ -46,6 +46,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDuplicateHead {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_symbol(true)
+    }
+
     fn run_on_symbol(&self, symbol_id: oxc_semantic::SymbolId, ctx: &LintContext<'_>) {
         let symbols = ctx.symbols();
         let name = symbols.get_name(symbol_id);

--- a/crates/oxc_linter/src/rules/nextjs/no_typos.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_typos.rs
@@ -52,17 +52,15 @@ const NEXTJS_DATA_FETCHING_FUNCTIONS: phf::Set<&'static str> = phf_set! {
 const THRESHOLD: i32 = 1;
 
 impl Rule for NoTypos {
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        let Some(path) = ctx.file_path().to_str() else {
-            return false;
-        };
-        let Some(path_after_pages) = path.split("pages").nth(1) else {
-            return false;
-        };
-        if path_after_pages.starts_with("/api") {
-            return false;
-        }
-        true
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        let enable = ctx
+            .file_path()
+            .to_str()
+            .and_then(|path| path.split("pages").nth(1))
+            .filter(|path_after_pages| !path_after_pages.starts_with("/api"))
+            .is_some();
+
+        crate::rule::ShouldRunState::new(enable).with_run(true)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/nextjs/no_typos.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_typos.rs
@@ -52,7 +52,7 @@ const NEXTJS_DATA_FETCHING_FUNCTIONS: phf::Set<&'static str> = phf_set! {
 const THRESHOLD: i32 = 1;
 
 impl Rule for NoTypos {
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
         let enable = ctx
             .file_path()
             .to_str()
@@ -60,7 +60,7 @@ impl Rule for NoTypos {
             .filter(|path_after_pages| !path_after_pages.starts_with("/api"))
             .is_some();
 
-        crate::rule::ShouldRunState::new(enable).with_run(true)
+        crate::rule::ShouldRunMeta::new().with_run(enable)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
@@ -70,6 +70,10 @@ impl Rule for NoBarrelFile {
         }
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext<'_>) {
         let module_record = ctx.module_record();
 

--- a/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
@@ -70,8 +70,8 @@ impl Rule for NoBarrelFile {
         }
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
@@ -71,7 +71,7 @@ impl Rule for NoBarrelFile {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/react/button_has_type.rs
+++ b/crates/oxc_linter/src/rules/react/button_has_type.rs
@@ -87,8 +87,8 @@ impl Rule for ButtonHasType {
         }
     }
 
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/button_has_type.rs
+++ b/crates/oxc_linter/src/rules/react/button_has_type.rs
@@ -71,6 +71,26 @@ declare_oxc_lint!(
 );
 
 impl Rule for ButtonHasType {
+    fn from_configuration(value: serde_json::Value) -> Self {
+        let value = value.as_array().and_then(|arr| arr.first()).and_then(|val| val.as_object());
+
+        Self {
+            button: value
+                .and_then(|val| val.get("button").and_then(serde_json::Value::as_bool))
+                .unwrap_or(true),
+            submit: value
+                .and_then(|val| val.get("submit").and_then(serde_json::Value::as_bool))
+                .unwrap_or(true),
+            reset: value
+                .and_then(|val| val.get("reset").and_then(serde_json::Value::as_bool))
+                .unwrap_or(true),
+        }
+    }
+
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::JSXOpeningElement(jsx_el) => {
@@ -135,26 +155,6 @@ impl Rule for ButtonHasType {
             }
             _ => {}
         }
-    }
-
-    fn from_configuration(value: serde_json::Value) -> Self {
-        let value = value.as_array().and_then(|arr| arr.first()).and_then(|val| val.as_object());
-
-        Self {
-            button: value
-                .and_then(|val| val.get("button").and_then(serde_json::Value::as_bool))
-                .unwrap_or(true),
-            submit: value
-                .and_then(|val| val.get("submit").and_then(serde_json::Value::as_bool))
-                .unwrap_or(true),
-            reset: value
-                .and_then(|val| val.get("reset").and_then(serde_json::Value::as_bool))
-                .unwrap_or(true),
-        }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/jsx_boolean_value.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_boolean_value.rs
@@ -116,6 +116,10 @@ impl Rule for JsxBooleanValue {
         }))
     }
 
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_opening_elem) = node.kind() else { return };
 
@@ -161,10 +165,6 @@ impl Rule for JsxBooleanValue {
                 _ => {}
             }
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/jsx_boolean_value.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_boolean_value.rs
@@ -116,8 +116,8 @@ impl Rule for JsxBooleanValue {
         }))
     }
 
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
@@ -335,6 +335,10 @@ impl Rule for JsxCurlyBracePresence {
         }
     }
 
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::JSXElement(el) => {
@@ -353,10 +357,6 @@ impl Rule for JsxCurlyBracePresence {
             }
             _ => {}
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
     }
 }
 
@@ -790,7 +790,7 @@ fn test() {
         (
             r#"
 			        import React from "react";
-			
+
 			        const Component = () => {
 			          return <span>{"/*"}</span>;
 			        };

--- a/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
@@ -335,8 +335,8 @@ impl Rule for JsxCurlyBracePresence {
         }
     }
 
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -63,6 +63,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for JsxKey {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::JSXElement(jsx_elem) => {
@@ -75,10 +79,6 @@ impl Rule for JsxKey {
 
             _ => {}
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/jsx_key.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_key.rs
@@ -63,8 +63,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for JsxKey {
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
@@ -54,8 +54,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for JsxNoCommentTextnodes {
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_comment_textnodes.rs
@@ -54,6 +54,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for JsxNoCommentTextnodes {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXText(jsx_text) = node.kind() else {
             return;
@@ -62,10 +66,6 @@ impl Rule for JsxNoCommentTextnodes {
         if has_comment_pattern(&jsx_text.value) {
             ctx.diagnostic(jsx_no_comment_textnodes_diagnostic(jsx_text.span));
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
@@ -51,8 +51,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for JsxNoDuplicateProps {
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_duplicate_props.rs
@@ -51,6 +51,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for JsxNoDuplicateProps {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(jsx_opening_elem) = node.kind() else {
             return;
@@ -75,10 +79,6 @@ impl Rule for JsxNoDuplicateProps {
                 ));
             }
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/jsx_no_script_url.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_script_url.rs
@@ -123,8 +123,8 @@ impl Rule for JsxNoScriptUrl {
         }
     }
 
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_target_blank.rs
@@ -157,8 +157,8 @@ impl Rule for JsxNoTargetBlank {
         }
     }
 
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
@@ -61,8 +61,8 @@ fn get_member_ident<'a>(
 }
 
 impl Rule for JsxNoUndef {
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_undef.rs
@@ -61,6 +61,10 @@ fn get_member_ident<'a>(
 }
 
 impl Rule for JsxNoUndef {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         if let AstKind::JSXOpeningElement(elem) = &node.kind() {
             if let Some(ident) = get_resolvable_ident(&elem.name) {
@@ -75,10 +79,6 @@ impl Rule for JsxNoUndef {
                 ctx.diagnostic(jsx_no_undef_diagnostic(name, ident.span));
             }
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
@@ -68,6 +68,10 @@ impl Rule for JsxNoUselessFragment {
         }
     }
 
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::JSXElement(jsx_elem) => {
@@ -81,10 +85,6 @@ impl Rule for JsxNoUselessFragment {
             }
             _ => {}
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_no_useless_fragment.rs
@@ -68,8 +68,8 @@ impl Rule for JsxNoUselessFragment {
         }
     }
 
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/jsx_props_no_spread_multi.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_props_no_spread_multi.rs
@@ -61,8 +61,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for JsxPropsNoSpreadMulti {
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/jsx_props_no_spread_multi.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_props_no_spread_multi.rs
@@ -61,6 +61,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for JsxPropsNoSpreadMulti {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         if let AstKind::JSXOpeningElement(jsx_opening_el) = node.kind() {
             let spread_attrs =
@@ -126,10 +130,6 @@ impl Rule for JsxPropsNoSpreadMulti {
                 },
             );
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/no_children_prop.rs
+++ b/crates/oxc_linter/src/rules/react/no_children_prop.rs
@@ -63,6 +63,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoChildrenProp {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::JSXAttributeItem(JSXAttributeItem::Attribute(attr)) => {
@@ -92,10 +96,6 @@ impl Rule for NoChildrenProp {
             }
             _ => {}
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/no_children_prop.rs
+++ b/crates/oxc_linter/src/rules/react/no_children_prop.rs
@@ -63,8 +63,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoChildrenProp {
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/no_danger.rs
+++ b/crates/oxc_linter/src/rules/react/no_danger.rs
@@ -56,8 +56,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDanger {
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/no_danger.rs
+++ b/crates/oxc_linter/src/rules/react/no_danger.rs
@@ -56,6 +56,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDanger {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::JSXElement(jsx_elem) => {
@@ -90,10 +94,6 @@ impl Rule for NoDanger {
             }
             _ => {}
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
@@ -83,8 +83,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDirectMutationState {
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_direct_mutation_state.rs
@@ -83,6 +83,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDirectMutationState {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::AssignmentExpression(assignment_expr) => {
@@ -117,10 +121,6 @@ impl Rule for NoDirectMutationState {
 
             _ => {}
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
+++ b/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
@@ -44,6 +44,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoFindDomNode {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
@@ -70,10 +74,6 @@ impl Rule for NoFindDomNode {
             return;
         };
         ctx.diagnostic(no_find_dom_node_diagnostic(span));
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
+++ b/crates/oxc_linter/src/rules/react/no_find_dom_node.rs
@@ -44,8 +44,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoFindDomNode {
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/no_is_mounted.rs
+++ b/crates/oxc_linter/src/rules/react/no_is_mounted.rs
@@ -47,8 +47,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoIsMounted {
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/no_is_mounted.rs
+++ b/crates/oxc_linter/src/rules/react/no_is_mounted.rs
@@ -47,6 +47,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoIsMounted {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
@@ -70,10 +74,6 @@ impl Rule for NoIsMounted {
                 break;
             }
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/no_render_return_value.rs
+++ b/crates/oxc_linter/src/rules/react/no_render_return_value.rs
@@ -47,6 +47,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoRenderReturnValue {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
@@ -89,10 +93,6 @@ impl Rule for NoRenderReturnValue {
                 }
             }
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/no_render_return_value.rs
+++ b/crates/oxc_linter/src/rules/react/no_render_return_value.rs
@@ -47,8 +47,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoRenderReturnValue {
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/no_set_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_set_state.rs
@@ -53,8 +53,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoSetState {
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/no_set_state.rs
+++ b/crates/oxc_linter/src/rules/react/no_set_state.rs
@@ -53,6 +53,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoSetState {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;
@@ -70,10 +74,6 @@ impl Rule for NoSetState {
         }
 
         ctx.diagnostic(no_set_state_diagnostic(call_expr.callee.span()));
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/no_string_refs.rs
+++ b/crates/oxc_linter/src/rules/react/no_string_refs.rs
@@ -116,6 +116,10 @@ impl Rule for NoStringRefs {
         Self { no_template_literals }
     }
 
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::JSXAttributeItem(JSXAttributeItem::Attribute(attr)) => {
@@ -133,10 +137,6 @@ impl Rule for NoStringRefs {
             }
             _ => {}
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/no_string_refs.rs
+++ b/crates/oxc_linter/src/rules/react/no_string_refs.rs
@@ -116,8 +116,8 @@ impl Rule for NoStringRefs {
         Self { no_template_literals }
     }
 
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
+++ b/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
@@ -48,8 +48,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnescapedEntities {
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
+++ b/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
@@ -48,6 +48,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnescapedEntities {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         if let AstKind::JSXText(jsx_text) = node.kind() {
             let source = jsx_text.span.source_text(ctx.source_text());
@@ -68,10 +72,6 @@ impl Rule for NoUnescapedEntities {
                 }
             }
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/no_unknown_property.rs
+++ b/crates/oxc_linter/src/rules/react/no_unknown_property.rs
@@ -479,6 +479,10 @@ impl Rule for NoUnknownProperty {
             .map_or_else(Self::default, |value| Self(Box::new(value)))
     }
 
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXOpeningElement(el) = &node.kind() else {
             return;
@@ -556,10 +560,6 @@ impl Rule for NoUnknownProperty {
                         },
                     );
             });
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/no_unknown_property.rs
+++ b/crates/oxc_linter/src/rules/react/no_unknown_property.rs
@@ -479,8 +479,8 @@ impl Rule for NoUnknownProperty {
             .map_or_else(Self::default, |value| Self(Box::new(value)))
     }
 
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
@@ -58,6 +58,10 @@ impl Rule for PreferEs6Class {
         }
     }
 
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         if matches!(self.prefer_es6_class_option, PreferES6ClassOptionType::Always) {
             if is_es5_component(node) {
@@ -74,10 +78,6 @@ impl Rule for PreferEs6Class {
                 class_expr.id.as_ref().map_or(class_expr.span, |id| id.span),
             ));
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
+++ b/crates/oxc_linter/src/rules/react/prefer_es6_class.rs
@@ -58,8 +58,8 @@ impl Rule for PreferEs6Class {
         }
     }
 
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
+++ b/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
@@ -47,6 +47,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for ReactInJsxScope {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let node_span = match node.kind() {
             AstKind::JSXOpeningElement(v) => v.name.span(),
@@ -62,10 +66,6 @@ impl Rule for ReactInJsxScope {
         if scope.find_binding(node.scope_id(), react_name).is_none() {
             ctx.diagnostic(react_in_jsx_scope_diagnostic(node_span));
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
+++ b/crates/oxc_linter/src/rules/react/react_in_jsx_scope.rs
@@ -47,8 +47,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for ReactInJsxScope {
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/require_render_return.rs
+++ b/crates/oxc_linter/src/rules/react/require_render_return.rs
@@ -50,8 +50,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequireRenderReturn {
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/require_render_return.rs
+++ b/crates/oxc_linter/src/rules/react/require_render_return.rs
@@ -50,6 +50,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequireRenderReturn {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         if !matches!(node.kind(), AstKind::ArrowFunctionExpression(_) | AstKind::Function(_)) {
             return;
@@ -78,10 +82,6 @@ impl Rule for RequireRenderReturn {
                 _ => {}
             };
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -109,11 +109,14 @@ declare_oxc_lint!(
 );
 
 impl Rule for RulesOfHooks {
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
         // disable this rule in vue/nuxt and svelte(kit) files
         // react hook can be build in only `.ts` files,
         // but `useX` functions are popular and can be false positive in other frameworks
-        !ctx.file_path().extension().is_some_and(|ext| ext == "vue" || ext == "svelte")
+        crate::rule::ShouldRunState::new(
+            !ctx.file_path().extension().is_some_and(|ext| ext == "vue" || ext == "svelte"),
+        )
+        .with_run(true)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -109,14 +109,13 @@ declare_oxc_lint!(
 );
 
 impl Rule for RulesOfHooks {
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
         // disable this rule in vue/nuxt and svelte(kit) files
         // react hook can be build in only `.ts` files,
         // but `useX` functions are popular and can be false positive in other frameworks
-        crate::rule::ShouldRunState::new(
+        crate::rule::ShouldRunMeta::new().with_run(
             !ctx.file_path().extension().is_some_and(|ext| ext == "vue" || ext == "svelte"),
         )
-        .with_run(true)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/self_closing_comp.rs
+++ b/crates/oxc_linter/src/rules/react/self_closing_comp.rs
@@ -79,6 +79,10 @@ impl Rule for SelfClosingComp {
         }
     }
 
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::JSXElement(jsx_el) = node.kind() else {
             return;
@@ -123,10 +127,6 @@ impl Rule for SelfClosingComp {
         if self.html && is_dom_comp || self.component && !is_dom_comp {
             ctx.diagnostic(self_closing_comp_diagnostic(jsx_closing_elem.span));
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/self_closing_comp.rs
+++ b/crates/oxc_linter/src/rules/react/self_closing_comp.rs
@@ -79,8 +79,8 @@ impl Rule for SelfClosingComp {
         }
     }
 
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/style_prop_object.rs
+++ b/crates/oxc_linter/src/rules/react/style_prop_object.rs
@@ -156,8 +156,8 @@ impl Rule for StylePropObject {
         Self(Box::new(StylePropObjectConfig { allow }))
     }
 
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/style_prop_object.rs
+++ b/crates/oxc_linter/src/rules/react/style_prop_object.rs
@@ -156,6 +156,10 @@ impl Rule for StylePropObject {
         Self(Box::new(StylePropObjectConfig { allow }))
     }
 
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::JSXElement(jsx_elem) => {
@@ -226,10 +230,6 @@ impl Rule for StylePropObject {
             }
             _ => {}
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/void_dom_elements_no_children.rs
+++ b/crates/oxc_linter/src/rules/react/void_dom_elements_no_children.rs
@@ -71,8 +71,8 @@ pub fn is_void_dom_element(element_name: &str) -> bool {
 }
 
 impl Rule for VoidDomElementsNoChildren {
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/react/void_dom_elements_no_children.rs
+++ b/crates/oxc_linter/src/rules/react/void_dom_elements_no_children.rs
@@ -71,6 +71,10 @@ pub fn is_void_dom_element(element_name: &str) -> bool {
 }
 
 impl Rule for VoidDomElementsNoChildren {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::JSXElement(jsx_el) => {
@@ -147,10 +151,6 @@ impl Rule for VoidDomElementsNoChildren {
             }
             _ => {}
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/adjacent_overload_signatures.rs
+++ b/crates/oxc_linter/src/rules/typescript/adjacent_overload_signatures.rs
@@ -9,11 +9,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{CompactStr, GetSpan, Span};
 
-use crate::{
-    context::{ContextHost, LintContext},
-    rule::Rule,
-    AstNode,
-};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn adjacent_overload_signatures_diagnostic(
     fn_name: &str,
@@ -285,6 +281,10 @@ fn check_and_report(methods: &Vec<Option<Method>>, ctx: &LintContext<'_>) {
 }
 
 impl Rule for AdjacentOverloadSignatures {
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::Class(class) => {
@@ -323,10 +323,6 @@ impl Rule for AdjacentOverloadSignatures {
             }
             _ => {}
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/adjacent_overload_signatures.rs
+++ b/crates/oxc_linter/src/rules/typescript/adjacent_overload_signatures.rs
@@ -281,8 +281,8 @@ fn check_and_report(methods: &Vec<Option<Method>>, ctx: &LintContext<'_>) {
 }
 
 impl Rule for AdjacentOverloadSignatures {
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/array_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/array_type.rs
@@ -116,8 +116,8 @@ impl Rule for ArrayType {
         }))
     }
 
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/array_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/array_type.rs
@@ -7,10 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::AstNode;
 use oxc_span::Span;
 
-use crate::{
-    context::{ContextHost, LintContext},
-    rule::Rule,
-};
+use crate::{context::LintContext, rule::Rule};
 
 #[derive(Debug, Default, Clone)]
 pub struct ArrayType(Box<ArrayTypeConfig>);
@@ -119,6 +116,10 @@ impl Rule for ArrayType {
         }))
     }
 
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let default_config = &self.default;
         let readonly_config: &ArrayOption =
@@ -138,10 +139,6 @@ impl Rule for ArrayType {
             }
             _ => {}
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
@@ -152,8 +152,8 @@ impl Rule for BanTsComment {
         }))
     }
 
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run_once(true)
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(ctx.source_type().is_typescript())
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_ts_comment.rs
@@ -5,10 +5,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use regex::Regex;
 
-use crate::{
-    context::{ContextHost, LintContext},
-    rule::Rule,
-};
+use crate::{context::LintContext, rule::Rule};
 
 fn comment(ts_comment_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
@@ -155,6 +152,10 @@ impl Rule for BanTsComment {
         }))
     }
 
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let comments = ctx.semantic().comments();
         for comm in comments {
@@ -215,10 +216,6 @@ impl Rule for BanTsComment {
                 }
             }
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/ban_tslint_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_tslint_comment.rs
@@ -33,8 +33,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for BanTslintComment {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/typescript/ban_tslint_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_tslint_comment.rs
@@ -33,6 +33,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for BanTslintComment {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let comments = ctx.semantic().comments();
         for comment in comments {

--- a/crates/oxc_linter/src/rules/typescript/ban_tslint_comment.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_tslint_comment.rs
@@ -34,7 +34,7 @@ declare_oxc_lint!(
 
 impl Rule for BanTslintComment {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/typescript/ban_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_types.rs
@@ -4,11 +4,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{
-    context::{ContextHost, LintContext},
-    rule::Rule,
-    AstNode,
-};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn type_diagnostic(banned_type: &str, suggested_type: &str, span2: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!(
@@ -59,6 +55,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for BanTypes {
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::TSTypeReference(typ) => {
@@ -91,10 +91,6 @@ impl Rule for BanTypes {
             }
             _ => {}
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/ban_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_types.rs
@@ -55,8 +55,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for BanTypes {
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
@@ -91,8 +91,8 @@ impl Rule for ConsistentGenericConstructors {
         }))
     }
 
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
@@ -81,6 +81,20 @@ declare_oxc_lint!(
 );
 
 impl Rule for ConsistentGenericConstructors {
+    fn from_configuration(value: serde_json::Value) -> Self {
+        Self(Box::new(ConsistentGenericConstructorsConfig {
+            option: value
+                .get(0)
+                .and_then(|v| v.as_str())
+                .and_then(|s| PreferGenericType::try_from(s).ok())
+                .unwrap_or_default(),
+        }))
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::VariableDeclarator(variable_declarator) => {
@@ -108,20 +122,6 @@ impl Rule for ConsistentGenericConstructors {
             }
             _ => {}
         }
-    }
-
-    fn from_configuration(value: serde_json::Value) -> Self {
-        Self(Box::new(ConsistentGenericConstructorsConfig {
-            option: value
-                .get(0)
-                .and_then(|v| v.as_str())
-                .and_then(|s| PreferGenericType::try_from(s).ok())
-                .unwrap_or_default(),
-        }))
-    }
-
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
@@ -69,8 +69,8 @@ impl Rule for ConsistentIndexedObjectStyle {
         Self { is_record_mode: config == ConsistentIndexedObjectStyleConfig::Record }
     }
 
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
@@ -6,11 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{
-    context::{ContextHost, LintContext},
-    rule::Rule,
-    AstNode,
-};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn consistent_indexed_object_style_diagnostic(a: &str, b: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(format!("A {a} is preferred over an {b}."))
@@ -71,6 +67,10 @@ impl Rule for ConsistentIndexedObjectStyle {
             },
         );
         Self { is_record_mode: config == ConsistentIndexedObjectStyleConfig::Record }
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -248,10 +248,6 @@ impl Rule for ConsistentIndexedObjectStyle {
                 }
             }
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
@@ -6,11 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{
-    context::{ContextHost, LintContext},
-    rule::Rule,
-    AstNode,
-};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn consistent_type_definitions_diagnostic(
     preferred_type_kind: &str,
@@ -71,6 +67,10 @@ impl Rule for ConsistentTypeDefinitions {
             },
         );
         Self { config }
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -237,10 +237,6 @@ impl Rule for ConsistentTypeDefinitions {
             }
             _ => {}
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_definitions.rs
@@ -69,8 +69,8 @@ impl Rule for ConsistentTypeDefinitions {
         Self { config }
     }
 
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -138,8 +138,8 @@ impl Rule for ConsistentTypeImports {
         Self(Box::new(config))
     }
 
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -14,7 +14,7 @@ use oxc_semantic::{Reference, SymbolId};
 use oxc_span::{GetSpan, Span};
 
 use crate::{
-    context::{ContextHost, LintContext},
+    context::LintContext,
     fixer::{RuleFix, RuleFixer},
     rule::Rule,
     AstNode,
@@ -136,6 +136,10 @@ impl Rule for ConsistentTypeImports {
             },
         );
         Self(Box::new(config))
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -265,10 +269,6 @@ impl Rule for ConsistentTypeImports {
                 fixer_fn,
             );
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -158,8 +158,8 @@ impl Rule for ExplicitFunctionReturnType {
         }))
     }
 
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -13,7 +13,7 @@ use rustc_hash::FxHashSet;
 
 use crate::{
     ast_util::outermost_paren_parent,
-    context::{ContextHost, LintContext},
+    context::LintContext,
     rule::Rule,
     rules::eslint::array_callback_return::return_checker::{
         check_statement, StatementReturnStatus,
@@ -158,6 +158,10 @@ impl Rule for ExplicitFunctionReturnType {
         }))
     }
 
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::Function(func) => {
@@ -295,10 +299,6 @@ impl Rule for ExplicitFunctionReturnType {
             }
             _ => {}
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
@@ -76,8 +76,8 @@ fn is_confusable_operator(operator: BinaryOperator) -> bool {
 }
 
 impl Rule for NoConfusingNonNullAssertion {
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_confusing_non_null_assertion.rs
@@ -7,11 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_syntax::operator::{AssignmentOperator, BinaryOperator};
 
-use crate::{
-    context::{ContextHost, LintContext},
-    rule::Rule,
-    AstNode,
-};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 #[derive(Debug, Default, Clone)]
 pub struct NoConfusingNonNullAssertion;
@@ -80,6 +76,10 @@ fn is_confusable_operator(operator: BinaryOperator) -> bool {
 }
 
 impl Rule for NoConfusingNonNullAssertion {
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::BinaryExpression(binary_expr)
@@ -114,10 +114,6 @@ impl Rule for NoConfusingNonNullAssertion {
             }
             _ => {}
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
@@ -83,8 +83,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDuplicateEnumValues {
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     #[allow(clippy::float_cmp)]

--- a/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
@@ -7,11 +7,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 use rustc_hash::FxHashMap;
 
-use crate::{
-    context::{ContextHost, LintContext},
-    rule::Rule,
-    AstNode,
-};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_duplicate_enum_values_diagnostic(
     first_init_span: Span,
@@ -87,6 +83,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDuplicateEnumValues {
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     #[allow(clippy::float_cmp)]
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::TSEnumDeclaration(enum_body) = node.kind() else {
@@ -127,10 +127,6 @@ impl Rule for NoDuplicateEnumValues {
                 _ => {}
             }
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
@@ -51,8 +51,8 @@ impl Rule for NoEmptyInterface {
         Self { allow_single_extends }
     }
 
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_interface.rs
@@ -4,11 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use serde_json::Value;
 
-use crate::{
-    context::{ContextHost, LintContext},
-    rule::Rule,
-    AstNode,
-};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_empty_interface_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("an empty interface is equivalent to `{}`").with_label(span)
@@ -55,6 +51,10 @@ impl Rule for NoEmptyInterface {
         Self { allow_single_extends }
     }
 
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         if let AstKind::TSInterfaceDeclaration(interface) = node.kind() {
             if interface.body.body.is_empty() {
@@ -72,10 +72,6 @@ impl Rule for NoEmptyInterface {
                 }
             }
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
@@ -119,8 +119,8 @@ impl Rule for NoEmptyObjectType {
         }))
     }
 
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
@@ -119,6 +119,10 @@ impl Rule for NoEmptyObjectType {
         }))
     }
 
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::TSInterfaceDeclaration(interface) if interface.body.body.len() == 0 => {
@@ -140,10 +144,6 @@ impl Rule for NoEmptyObjectType {
             }
             _ => {}
         }
-    }
-
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 
@@ -265,11 +265,11 @@ fn test() {
 			interface Base {
 			  name: string;
 			}
-			
+
 			interface Derived {
 			  age: number;
 			}
-			
+
 			// valid because extending multiple interfaces can be used instead of a union type
 			interface Both extends Base, Derived {}
 			    ",
@@ -288,7 +288,7 @@ fn test() {
 			interface Base {
 			  name: string;
 			}
-			
+
 			interface Derived extends Base {}
 			      ",
             Some(serde_json::json!([{ "allowInterfaces": "with-single-extends" }])),
@@ -300,9 +300,9 @@ fn test() {
 			interface Base {
 			  props: string;
 			}
-			
+
 			interface Derived extends Base {}
-			
+
 			class Derived {}
 			      ",
             Some(serde_json::json!([{ "allowInterfaces": "with-single-extends" }])),
@@ -348,9 +348,9 @@ fn test() {
 			interface Base {
 			  props: string;
 			}
-			
+
 			interface Derived extends Base {}
-			
+
 			class Other {}
 			      ",
             None,
@@ -362,9 +362,9 @@ fn test() {
 			interface Base {
 			  props: string;
 			}
-			
+
 			interface Derived extends Base {}
-			
+
 			class Derived {}
 			      ",
             None,
@@ -376,9 +376,9 @@ fn test() {
 			interface Base {
 			  props: string;
 			}
-			
+
 			interface Derived extends Base {}
-			
+
 			const derived = class Derived {};
 			      ",
             None,
@@ -390,7 +390,7 @@ fn test() {
 			interface Base {
 			  name: string;
 			}
-			
+
 			interface Derived extends Base {}
 			      ",
             None,

--- a/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
@@ -98,8 +98,8 @@ impl Rule for NoExplicitAny {
         Self { fix_to_unknown, ignore_rest_args }
     }
 
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_explicit_any.rs
@@ -4,11 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use serde_json::Value;
 
-use crate::{
-    context::{ContextHost, LintContext},
-    rule::Rule,
-    AstNode,
-};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_explicit_any_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected any. Specify a different type.")
@@ -92,6 +88,20 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoExplicitAny {
+    fn from_configuration(value: Value) -> Self {
+        let Some(cfg) = value.get(0) else {
+            return Self::default();
+        };
+        let fix_to_unknown = cfg.get("fixToUnknown").and_then(Value::as_bool).unwrap_or(false);
+        let ignore_rest_args = cfg.get("ignoreRestArgs").and_then(Value::as_bool).unwrap_or(false);
+
+        Self { fix_to_unknown, ignore_rest_args }
+    }
+
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::TSAnyKeyword(any) = node.kind() else {
             return;
@@ -107,20 +117,6 @@ impl Rule for NoExplicitAny {
         } else {
             ctx.diagnostic(no_explicit_any_diagnostic(any.span));
         }
-    }
-
-    fn from_configuration(value: Value) -> Self {
-        let Some(cfg) = value.get(0) else {
-            return Self::default();
-        };
-        let fix_to_unknown = cfg.get("fixToUnknown").and_then(Value::as_bool).unwrap_or(false);
-        let ignore_rest_args = cfg.get("ignoreRestArgs").and_then(Value::as_bool).unwrap_or(false);
-
-        Self { fix_to_unknown, ignore_rest_args }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
@@ -3,11 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{
-    context::{ContextHost, LintContext},
-    rule::Rule,
-    AstNode,
-};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_extra_non_null_assertion_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("extra non-null assertion").with_label(span)
@@ -35,6 +31,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoExtraNonNullAssertion {
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let expr = match node.kind() {
             AstKind::TSNonNullExpression(expr) => {
@@ -66,10 +66,6 @@ impl Rule for NoExtraNonNullAssertion {
             let end = expr.span.end - 1;
             ctx.diagnostic(no_extra_non_null_assertion_diagnostic(Span::new(end, end)));
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
@@ -31,8 +31,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoExtraNonNullAssertion {
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_import_type_side_effects.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_import_type_side_effects.rs
@@ -6,12 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{
-    context::{ContextHost, LintContext},
-    fixer::Fix,
-    rule::Rule,
-    AstNode,
-};
+use crate::{context::LintContext, fixer::Fix, rule::Rule, AstNode};
 
 fn no_import_type_side_effects_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("TypeScript will only remove the inline type specifiers which will leave behind a side effect import at runtime.")
@@ -68,6 +63,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoImportTypeSideEffects {
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::ImportDeclaration(import_decl) = node.kind() else {
             return;
@@ -121,10 +120,6 @@ impl Rule for NoImportTypeSideEffects {
                 fixes
             },
         );
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_import_type_side_effects.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_import_type_side_effects.rs
@@ -63,8 +63,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoImportTypeSideEffects {
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_misused_new.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_misused_new.rs
@@ -55,8 +55,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoMisusedNew {
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_misused_new.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_misused_new.rs
@@ -55,6 +55,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoMisusedNew {
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::TSInterfaceDeclaration(interface_decl) => {
@@ -113,10 +117,6 @@ impl Rule for NoMisusedNew {
             }
             _ => {}
         }
-    }
-
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_namespace.rs
@@ -57,11 +57,12 @@ impl Rule for NoNamespace {
         }
     }
 
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        let meta = crate::rule::ShouldRunMeta::new();
         if self.allow_definition_files && ctx.source_type().is_typescript_definition() {
-            return false.into();
+            return meta;
         }
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+        meta.with_run(ctx.source_type().is_typescript())
     }
 
     #[allow(clippy::cast_possible_truncation)]

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
@@ -35,8 +35,8 @@ fn no_non_null_asserted_nullish_coalescing_diagnostic(span: Span) -> OxcDiagnost
 }
 
 impl Rule for NoNonNullAssertedNullishCoalescing {
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
@@ -4,11 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
 use oxc_span::Span;
 
-use crate::{
-    context::{ContextHost, LintContext},
-    rule::Rule,
-    AstNode,
-};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 #[derive(Debug, Default, Clone)]
 pub struct NoNonNullAssertedNullishCoalescing;
@@ -39,6 +35,10 @@ fn no_non_null_asserted_nullish_coalescing_diagnostic(span: Span) -> OxcDiagnost
 }
 
 impl Rule for NoNonNullAssertedNullishCoalescing {
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::LogicalExpression(expr) = node.kind() else { return };
         let Expression::TSNonNullExpression(ts_non_null_expr) = &expr.left else { return };
@@ -51,10 +51,6 @@ impl Rule for NoNonNullAssertedNullishCoalescing {
         }
 
         ctx.diagnostic(no_non_null_asserted_nullish_coalescing_diagnostic(ts_non_null_expr.span));
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 fn has_assignment_before_node(

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
@@ -39,8 +39,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNonNullAssertedOptionalChain {
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
@@ -6,11 +6,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{
-    context::{ContextHost, LintContext},
-    rule::Rule,
-    AstNode,
-};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_non_null_asserted_optional_chain_diagnostic(span: Span, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("non-null assertions after an optional chain expression")
@@ -43,6 +39,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoNonNullAssertedOptionalChain {
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::TSNonNullExpression(non_null_expr) = node.kind() else {
             return;
@@ -94,10 +94,6 @@ impl Rule for NoNonNullAssertedOptionalChain {
                 Span::new(non_null_end, non_null_end),
             ));
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
@@ -38,8 +38,8 @@ impl Rule for NoNonNullAssertion {
         ctx.diagnostic(no_non_null_assertion_diagnostic(expr.span));
     }
 
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_assertion.rs
@@ -3,11 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{
-    context::{ContextHost, LintContext},
-    rule::Rule,
-    AstNode,
-};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 #[derive(Debug, Default, Clone)]
 pub struct NoNonNullAssertion;
@@ -42,8 +38,8 @@ impl Rule for NoNonNullAssertion {
         ctx.diagnostic(no_non_null_assertion_diagnostic(expr.span));
     }
 
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
@@ -8,11 +8,7 @@ use oxc_span::{CompactStr, GetSpan, Span};
 use rustc_hash::FxHashSet;
 use serde_json::Value;
 
-use crate::{
-    context::{ContextHost, LintContext},
-    rule::Rule,
-    AstNode,
-};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_this_alias_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unexpected aliasing of 'this' to local variable.")
@@ -99,6 +95,10 @@ impl Rule for NoThisAlias {
         }))
     }
 
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::VariableDeclarator(decl) => {
@@ -156,10 +156,6 @@ impl Rule for NoThisAlias {
             }
             _ => {}
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_this_alias.rs
@@ -95,8 +95,8 @@ impl Rule for NoThisAlias {
         }))
     }
 
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_constraint.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_constraint.rs
@@ -49,8 +49,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnnecessaryTypeConstraint {
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_constraint.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_type_constraint.rs
@@ -3,11 +3,7 @@ use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 
-use crate::{
-    context::{ContextHost, LintContext},
-    rule::Rule,
-    AstNode,
-};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_unnecessary_type_constraint_diagnostic(
     generic_type: &str,
@@ -53,6 +49,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnnecessaryTypeConstraint {
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         if let AstKind::TSTypeParameterDeclaration(decl) = node.kind() {
             for param in &decl.params {
@@ -71,10 +71,6 @@ impl Rule for NoUnnecessaryTypeConstraint {
                 }
             }
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
@@ -4,11 +4,7 @@ use oxc_macros::declare_oxc_lint;
 use oxc_semantic::SymbolId;
 use oxc_span::Span;
 
-use crate::{
-    context::{ContextHost, LintContext},
-    rule::Rule,
-    AstNode,
-};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
 fn no_unsafe_declaration_merging_diagnostic(span: Span, span1: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Unsafe declaration merging between classes and interfaces.")
@@ -40,6 +36,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnsafeDeclarationMerging {
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::Class(decl) => {
@@ -65,10 +65,6 @@ impl Rule for NoUnsafeDeclarationMerging {
             }
             _ => {}
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
@@ -36,8 +36,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnsafeDeclarationMerging {
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_function_type.rs
@@ -57,8 +57,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnsafeFunctionType {
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_function_type.rs
@@ -57,6 +57,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoUnsafeFunctionType {
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::TSTypeReference(reference) => {
@@ -76,10 +80,6 @@ impl Rule for NoUnsafeFunctionType {
             }
             _ => {}
         }
-    }
-
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
@@ -39,6 +39,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoVarRequires {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::CallExpression(expr) = node.kind() else {
             return;
@@ -70,10 +74,6 @@ impl Rule for NoVarRequires {
                 ctx.diagnostic(no_var_requires_diagnostic(node.kind().span()));
             }
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_var_requires.rs
@@ -39,8 +39,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoVarRequires {
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/no_wrapper_object_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_wrapper_object_types.rs
@@ -55,6 +55,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoWrapperObjectTypes {
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let (ident_name, ident_span, reference_id) = match node.kind() {
             AstKind::TSTypeReference(type_ref) => {
@@ -99,10 +103,6 @@ impl Rule for NoWrapperObjectTypes {
                 ctx.diagnostic(no_wrapper_object_types(ident_span));
             }
         }
-    }
-
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/no_wrapper_object_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_wrapper_object_types.rs
@@ -55,8 +55,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoWrapperObjectTypes {
-    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &crate::rules::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/prefer_as_const.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_as_const.rs
@@ -45,8 +45,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferAsConst {
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/prefer_as_const.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_as_const.rs
@@ -45,6 +45,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferAsConst {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::VariableDeclarator(variable_declarator) => {
@@ -85,10 +89,6 @@ impl Rule for PreferAsConst {
             }
             _ => {}
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
@@ -46,8 +46,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferEnumInitializers {
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_enum_initializers.rs
@@ -46,6 +46,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferEnumInitializers {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::TSEnumDeclaration(decl) = node.kind() else {
             return;
@@ -62,10 +66,6 @@ impl Rule for PreferEnumInitializers {
                 }
             }
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
@@ -316,6 +316,10 @@ fn check_member(member: &TSSignature, node: &AstNode<'_>, ctx: &LintContext<'_>)
 }
 
 impl Rule for PreferFunctionType {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::TSInterfaceDeclaration(decl) => {
@@ -398,10 +402,6 @@ impl Rule for PreferFunctionType {
 
             _ => {}
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_function_type.rs
@@ -316,8 +316,8 @@ fn check_member(member: &TSSignature, node: &AstNode<'_>, ctx: &LintContext<'_>)
 }
 
 impl Rule for PreferFunctionType {
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
@@ -59,6 +59,10 @@ impl Rule for PreferLiteralEnumMember {
         }
     }
 
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::TSEnumMember(decl) = node.kind() else {
             return;
@@ -112,10 +116,6 @@ impl Rule for PreferLiteralEnumMember {
         }
 
         ctx.diagnostic(prefer_literal_enum_member_diagnostic(decl.span));
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_literal_enum_member.rs
@@ -59,8 +59,8 @@ impl Rule for PreferLiteralEnumMember {
         }
     }
 
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
@@ -45,8 +45,8 @@ fn is_valid_module(module: &TSModuleDeclaration) -> bool {
 }
 
 impl Rule for PreferNamespaceKeyword {
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_typescript())
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {

--- a/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_namespace_keyword.rs
@@ -45,6 +45,10 @@ fn is_valid_module(module: &TSModuleDeclaration) -> bool {
 }
 
 impl Rule for PreferNamespaceKeyword {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run(true)
+    }
+
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::TSModuleDeclaration(module) = node.kind() else { return };
 
@@ -61,10 +65,6 @@ impl Rule for PreferNamespaceKeyword {
             let span_start = module.span.start + u32::try_from(offset).unwrap();
             fixer.replace(Span::sized(span_start, 6), "namespace")
         });
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
@@ -48,8 +48,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferTsExpectError {
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run_once(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(ctx.source_type().is_typescript())
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_ts_expect_error.rs
@@ -48,6 +48,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for PreferTsExpectError {
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let comments = ctx.semantic().comments();
 
@@ -76,10 +80,6 @@ impl Rule for PreferTsExpectError {
                 });
             }
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
+++ b/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
@@ -104,6 +104,10 @@ impl Rule for TripleSlashReference {
         }))
     }
 
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         let Some(root) = ctx.nodes().root_node() else {
             return;
@@ -159,10 +163,6 @@ impl Rule for TripleSlashReference {
                 }
             }
         }
-    }
-
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_typescript()
     }
 }
 

--- a/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
+++ b/crates/oxc_linter/src/rules/typescript/triple_slash_reference.rs
@@ -104,8 +104,8 @@ impl Rule for TripleSlashReference {
         }))
     }
 
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_typescript()).with_run_once(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(ctx.source_type().is_typescript())
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/unicorn/filename_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/filename_case.rs
@@ -139,8 +139,8 @@ impl Rule for FilenameCase {
         Self::default()
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once<'a>(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/unicorn/filename_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/filename_case.rs
@@ -140,7 +140,7 @@ impl Rule for FilenameCase {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once<'a>(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/unicorn/filename_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/filename_case.rs
@@ -139,6 +139,10 @@ impl Rule for FilenameCase {
         Self::default()
     }
 
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once<'a>(&self, ctx: &LintContext<'_>) {
         let file_path = ctx.file_path();
         let Some(filename) = file_path.file_stem().and_then(|s| s.to_str()) else {

--- a/crates/oxc_linter/src/rules/unicorn/no_abusive_eslint_disable.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_abusive_eslint_disable.rs
@@ -53,8 +53,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoAbusiveEslintDisable {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/unicorn/no_abusive_eslint_disable.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_abusive_eslint_disable.rs
@@ -53,6 +53,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoAbusiveEslintDisable {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         for span in ctx.disable_directives().disable_all_comments() {
             ctx.diagnostic(no_abusive_eslint_disable_diagnostic(*span));

--- a/crates/oxc_linter/src/rules/unicorn/no_abusive_eslint_disable.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_abusive_eslint_disable.rs
@@ -54,7 +54,7 @@ declare_oxc_lint!(
 
 impl Rule for NoAbusiveEslintDisable {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/unicorn/no_empty_file.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_empty_file.rs
@@ -38,6 +38,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoEmptyFile {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext) {
         if ctx
             .file_path()

--- a/crates/oxc_linter/src/rules/unicorn/no_empty_file.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_empty_file.rs
@@ -38,8 +38,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoEmptyFile {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/unicorn/no_empty_file.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_empty_file.rs
@@ -39,7 +39,7 @@ declare_oxc_lint!(
 
 impl Rule for NoEmptyFile {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext) {

--- a/crates/oxc_linter/src/rules/vitest/no_conditional_tests.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_conditional_tests.rs
@@ -66,7 +66,7 @@ impl Rule for NoConditionalTests {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/vitest/no_conditional_tests.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_conditional_tests.rs
@@ -65,8 +65,8 @@ impl Rule for NoConditionalTests {
         run(jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/vitest/no_conditional_tests.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_conditional_tests.rs
@@ -64,6 +64,10 @@ impl Rule for NoConditionalTests {
     ) {
         run(jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>) -> Option<()> {

--- a/crates/oxc_linter/src/rules/vitest/no_import_node_test.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_import_node_test.rs
@@ -52,6 +52,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoImportNodeTest {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    }
+
     fn run_once(&self, ctx: &LintContext<'_>) {
         let module_record = ctx.module_record();
 

--- a/crates/oxc_linter/src/rules/vitest/no_import_node_test.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_import_node_test.rs
@@ -53,7 +53,7 @@ declare_oxc_lint!(
 
 impl Rule for NoImportNodeTest {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_once(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ONCE
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/vitest/no_import_node_test.rs
+++ b/crates/oxc_linter/src/rules/vitest/no_import_node_test.rs
@@ -52,8 +52,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoImportNodeTest {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_once(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_once(true)
     }
 
     fn run_once(&self, ctx: &LintContext<'_>) {

--- a/crates/oxc_linter/src/rules/vitest/prefer_to_be_falsy.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_to_be_falsy.rs
@@ -48,7 +48,7 @@ impl Rule for PreferToBeFalsy {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/vitest/prefer_to_be_falsy.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_to_be_falsy.rs
@@ -47,8 +47,8 @@ impl Rule for PreferToBeFalsy {
         prefer_to_be_simply_bool(jest_node, ctx, false);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/vitest/prefer_to_be_falsy.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_to_be_falsy.rs
@@ -46,6 +46,10 @@ impl Rule for PreferToBeFalsy {
     ) {
         prefer_to_be_simply_bool(jest_node, ctx, false);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/vitest/prefer_to_be_object.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_to_be_object.rs
@@ -74,6 +74,10 @@ impl Rule for PreferToBeObject {
     ) {
         Self::run(jest_node, ctx);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 impl PreferToBeObject {

--- a/crates/oxc_linter/src/rules/vitest/prefer_to_be_object.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_to_be_object.rs
@@ -76,7 +76,7 @@ impl Rule for PreferToBeObject {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/vitest/prefer_to_be_object.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_to_be_object.rs
@@ -75,8 +75,8 @@ impl Rule for PreferToBeObject {
         Self::run(jest_node, ctx);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/vitest/prefer_to_be_truthy.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_to_be_truthy.rs
@@ -109,8 +109,8 @@ impl Rule for PreferToBeTruthy {
         prefer_to_be_simply_bool(jest_node, ctx, true);
     }
 
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 }
 

--- a/crates/oxc_linter/src/rules/vitest/prefer_to_be_truthy.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_to_be_truthy.rs
@@ -110,7 +110,7 @@ impl Rule for PreferToBeTruthy {
     }
 
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 }
 

--- a/crates/oxc_linter/src/rules/vitest/prefer_to_be_truthy.rs
+++ b/crates/oxc_linter/src/rules/vitest/prefer_to_be_truthy.rs
@@ -108,6 +108,10 @@ impl Rule for PreferToBeTruthy {
     ) {
         prefer_to_be_simply_bool(jest_node, ctx, true);
     }
+
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/vitest/require_local_test_context_for_concurrent_snapshots.rs
+++ b/crates/oxc_linter/src/rules/vitest/require_local_test_context_for_concurrent_snapshots.rs
@@ -91,8 +91,8 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequireLocalTestContextForConcurrentSnapshots {
-    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
     }
 
     fn run_on_jest_node<'a, 'c>(

--- a/crates/oxc_linter/src/rules/vitest/require_local_test_context_for_concurrent_snapshots.rs
+++ b/crates/oxc_linter/src/rules/vitest/require_local_test_context_for_concurrent_snapshots.rs
@@ -92,7 +92,7 @@ declare_oxc_lint!(
 
 impl Rule for RequireLocalTestContextForConcurrentSnapshots {
     fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunMeta {
-        crate::rule::ShouldRunMeta::new().with_run_on_jest_node(true)
+        crate::rule::ShouldRunMeta::IS_RUN_ON_JEST_NODE
     }
 
     fn run_on_jest_node<'a, 'c>(

--- a/crates/oxc_linter/src/rules/vitest/require_local_test_context_for_concurrent_snapshots.rs
+++ b/crates/oxc_linter/src/rules/vitest/require_local_test_context_for_concurrent_snapshots.rs
@@ -91,6 +91,10 @@ declare_oxc_lint!(
 );
 
 impl Rule for RequireLocalTestContextForConcurrentSnapshots {
+    fn should_run(&self, _: &crate::ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(true).with_run_on_jest_node(true)
+    }
+
     fn run_on_jest_node<'a, 'c>(
         &self,
         jest_node: &PossibleJestNode<'a, 'c>,
@@ -164,12 +168,12 @@ fn test() {
         r#"it.concurrent("something", (context) => { expect(true).toMatchSnapshot() })"#,
         r#"it.concurrent("something", () => {
 			                 expect(true).toMatchSnapshot();
-			
+
 			                 expect(true).toMatchSnapshot();
 			            })"#,
         r#"it.concurrent("something", () => {
 			                 expect(true).toBe(true);
-			
+
 			                 expect(true).toMatchSnapshot();
 			            })"#,
         r#"it.concurrent("should fail", () => { expect(true).toMatchFileSnapshot("./test/basic.output.html") })"#,

--- a/crates/oxc_linter/src/snapshots/jest_max_nested_describe.snap
+++ b/crates/oxc_linter/src/snapshots/jest_max_nested_describe.snap
@@ -121,7 +121,7 @@ source: crates/oxc_linter/src/tester.rs
     ╭─[max_nested_describe.tsx:7:37]
   6 │                                     describe('another suite', () => {
   7 │ ╭─▶                                     describe('another suite', () => {
-  8 │ │                                   
+  8 │ │   
   9 │ ╰─▶                                     })
  10 │                                     })
     ╰────

--- a/crates/oxc_linter/src/snapshots/jest_no_disabled_tests.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_disabled_tests.snap
@@ -248,7 +248,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test suite
    ╭─[no_disabled_tests.tsx:3:13]
- 2 │             import { describe } from 'vitest'; 
+ 2 │             import { describe } from 'vitest';
  3 │             describe.skip("foo", function () {})
    ·             ─────────────
  4 │         

--- a/crates/oxc_linter/src/snapshots/jest_no_duplicate_hooks.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_duplicate_hooks.snap
@@ -204,7 +204,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │                     beforeEach(() => {});
  4 │                     beforeEach(() => {});
    ·                     ────────────────────
- 5 │                     
+ 5 │ 
    ╰────
   help: Describe blocks can only have one of each hook. Consider consolidating the duplicate hooks into a single call.
 
@@ -213,6 +213,6 @@ source: crates/oxc_linter/src/tester.rs
  10 │                         beforeEach(() => {});
  11 │                         beforeEach(() => {});
     ·                         ────────────────────
- 12 │                     
+ 12 │ 
     ╰────
   help: Describe blocks can only have one of each hook. Consider consolidating the duplicate hooks into a single call.

--- a/crates/oxc_linter/src/snapshots/jest_no_focused_tests.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_focused_tests.snap
@@ -129,7 +129,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint-plugin-jest(no-focused-tests): Unexpected focused test.
    ╭─[no_focused_tests.tsx:3:16]
- 2 │             import { it } from 'vitest'; 
+ 2 │             import { it } from 'vitest';
  3 │             it.only("test", () => {});
    ·                ────
  4 │             

--- a/crates/oxc_linter/src/snapshots/jest_prefer_hooks_in_order.snap
+++ b/crates/oxc_linter/src/snapshots/jest_prefer_hooks_in_order.snap
@@ -540,7 +540,7 @@ source: crates/oxc_linter/src/tester.rs
  23 │                         afterEach(() => {});
     ·                         ─────────┬─────────
     ·                                  ╰── this should be moved to before the "afterAll" hook
- 24 │                 
+ 24 │ 
     ╰────
   help: "afterEach" hooks should be before any "afterAll" hooks
 
@@ -591,7 +591,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint-plugin-jest(prefer-hooks-in-order): Test hooks are not in a consistent order.
     ╭─[prefer_hooks_in_order.tsx:34:21]
- 33 │                     
+ 33 │     
  34 │ ╭─▶                     afterEach(() => {
  35 │ │                           clearLogger();
  36 │ ├─▶                     });
@@ -601,6 +601,6 @@ source: crates/oxc_linter/src/tester.rs
  39 │ │                           mockLogger();
  40 │ ├─▶                     });
     · ╰──── this should be moved to before the "afterEach" hook
- 41 │                     
+ 41 │     
     ╰────
   help: "beforeEach" hooks should be before any "afterEach" hooks

--- a/crates/oxc_linter/src/snapshots/nextjs_no_async_client_component.snap
+++ b/crates/oxc_linter/src/snapshots/nextjs_no_async_client_component.snap
@@ -3,7 +3,7 @@ source: crates/oxc_linter/src/tester.rs
 ---
   ⚠ eslint-plugin-next(no-async-client-component): Prevent client components from being async functions.
    ╭─[no_async_client_component.tsx:4:40]
- 3 │             
+ 3 │ 
  4 │                   export default async function MyComponent() {
    ·                                                 ───────────
  5 │                     return <></>
@@ -12,7 +12,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint-plugin-next(no-async-client-component): Prevent client components from being async functions.
    ╭─[no_async_client_component.tsx:4:40]
- 3 │             
+ 3 │ 
  4 │                   export default async function MyFunction() {
    ·                                                 ──────────
  5 │                     return ''
@@ -21,7 +21,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint-plugin-next(no-async-client-component): Prevent client components from being async functions.
    ╭─[no_async_client_component.tsx:4:25]
- 3 │             
+ 3 │ 
  4 │                   async function MyComponent() {
    ·                                  ───────────
  5 │                     return <></>
@@ -30,7 +30,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint-plugin-next(no-async-client-component): Prevent client components from being async functions.
    ╭─[no_async_client_component.tsx:4:25]
- 3 │             
+ 3 │ 
  4 │                   async function MyFunction() {
    ·                                  ──────────
  5 │                     return ''
@@ -39,7 +39,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint-plugin-next(no-async-client-component): Prevent client components from being async functions.
    ╭─[no_async_client_component.tsx:4:16]
- 3 │             
+ 3 │ 
  4 │                   const MyFunction = async () => {
    ·                         ──────────
  5 │                     return '123'

--- a/crates/oxc_linter/src/snapshots/typescript_no_empty_object_type.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_empty_object_type.snap
@@ -17,34 +17,34 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ typescript-eslint(no-empty-object-type): Do not use an empty interface declaration.
    ╭─[no_empty_object_type.tsx:6:35]
- 5 │             
+ 5 │ 
  6 │             interface Derived extends Base {}
    ·                                            ──
- 7 │             
+ 7 │ 
    ╰────
   help: To avoid confusion around the {} type allowing any non-nullish value, this rule bans usage of the {} type.
 
   ⚠ typescript-eslint(no-empty-object-type): Do not use an empty interface declaration.
    ╭─[no_empty_object_type.tsx:6:35]
- 5 │             
+ 5 │ 
  6 │             interface Derived extends Base {}
    ·                                            ──
- 7 │             
+ 7 │ 
    ╰────
   help: To avoid confusion around the {} type allowing any non-nullish value, this rule bans usage of the {} type.
 
   ⚠ typescript-eslint(no-empty-object-type): Do not use an empty interface declaration.
    ╭─[no_empty_object_type.tsx:6:35]
- 5 │             
+ 5 │ 
  6 │             interface Derived extends Base {}
    ·                                            ──
- 7 │             
+ 7 │ 
    ╰────
   help: To avoid confusion around the {} type allowing any non-nullish value, this rule bans usage of the {} type.
 
   ⚠ typescript-eslint(no-empty-object-type): Do not use an empty interface declaration.
    ╭─[no_empty_object_type.tsx:6:35]
- 5 │             
+ 5 │ 
  6 │             interface Derived extends Base {}
    ·                                            ──
  7 │                   

--- a/crates/oxc_linter/src/snapshots/vitest_require_local_test_context_for_concurrent_snapshots.snap
+++ b/crates/oxc_linter/src/snapshots/vitest_require_local_test_context_for_concurrent_snapshots.snap
@@ -41,13 +41,13 @@ source: crates/oxc_linter/src/tester.rs
  1 │ it.concurrent("something", () => {
  2 │                              expect(true).toMatchSnapshot();
    ·                              ──────────────────────────────
- 3 │             
+ 3 │ 
    ╰────
   help: Use local Test Context instead
 
   ⚠ eslint-plugin-vitest(require-local-test-context-for-concurrent-snapshots): Require local Test Context for concurrent snapshot tests
    ╭─[require_local_test_context_for_concurrent_snapshots.tsx:4:21]
- 3 │             
+ 3 │ 
  4 │                              expect(true).toMatchSnapshot();
    ·                              ──────────────────────────────
  5 │                         })
@@ -56,7 +56,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint-plugin-vitest(require-local-test-context-for-concurrent-snapshots): Require local Test Context for concurrent snapshot tests
    ╭─[require_local_test_context_for_concurrent_snapshots.tsx:4:21]
- 3 │             
+ 3 │ 
  4 │                              expect(true).toMatchSnapshot();
    ·                              ──────────────────────────────
  5 │                         })

--- a/crates/oxc_linter/src/utils/react_perf.rs
+++ b/crates/oxc_linter/src/utils/react_perf.rs
@@ -117,8 +117,8 @@ where
         }
     }
 
-    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
-        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunMeta {
+        crate::rule::ShouldRunMeta::new().with_run(ctx.source_type().is_jsx())
     }
 }
 

--- a/crates/oxc_linter/src/utils/react_perf.rs
+++ b/crates/oxc_linter/src/utils/react_perf.rs
@@ -117,8 +117,8 @@ where
         }
     }
 
-    fn should_run(&self, ctx: &ContextHost) -> bool {
-        ctx.source_type().is_jsx()
+    fn should_run(&self, ctx: &ContextHost) -> crate::rule::ShouldRunState {
+        crate::rule::ShouldRunState::new(ctx.source_type().is_jsx()).with_run(true)
     }
 }
 

--- a/crates/oxc_macros/src/declare_all_lint_rules.rs
+++ b/crates/oxc_macros/src/declare_all_lint_rules.rs
@@ -78,7 +78,7 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
 
         use crate::{
             context::{ContextHost, LintContext},
-            rule::{Rule, RuleCategory, RuleFixMeta, RuleMeta},
+            rule::{Rule, RuleCategory, RuleFixMeta, RuleMeta, ShouldRunState},
             utils::PossibleJestNode,
             AstNode
         };
@@ -164,7 +164,7 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
                 }
             }
 
-            pub(super) fn should_run(&self, ctx: &ContextHost) -> bool {
+            pub(super) fn should_run(&self, ctx: &ContextHost) -> ShouldRunState {
                 match self {
                     #(Self::#struct_names(rule) => rule.should_run(ctx)),*
                 }

--- a/crates/oxc_macros/src/declare_all_lint_rules.rs
+++ b/crates/oxc_macros/src/declare_all_lint_rules.rs
@@ -78,7 +78,7 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
 
         use crate::{
             context::{ContextHost, LintContext},
-            rule::{Rule, RuleCategory, RuleFixMeta, RuleMeta, ShouldRunState},
+            rule::{Rule, RuleCategory, RuleFixMeta, RuleMeta, ShouldRunMeta},
             utils::PossibleJestNode,
             AstNode
         };
@@ -164,7 +164,7 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
                 }
             }
 
-            pub(super) fn should_run(&self, ctx: &ContextHost) -> ShouldRunState {
+            pub(super) fn should_run(&self, ctx: &ContextHost) -> ShouldRunMeta {
                 match self {
                     #(Self::#struct_names(rule) => rule.should_run(ctx)),*
                 }


### PR DESCRIPTION
We can make full use of `should_run` to avoid unnecessary iterations over nodes and rules.