### PR TITLE
feat(oxc_language_server): implement `oxc.fixAll` workspace command

### DIFF
--- a/crates/oxc_language_server/Cargo.toml
+++ b/crates/oxc_language_server/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 
 [[bin]]
 name = "oxc_language_server"
-test = false
+test = true
 doctest = false
 
 [dependencies]

--- a/crates/oxc_language_server/README.md
+++ b/crates/oxc_language_server/README.md
@@ -8,6 +8,8 @@ This crate provides an [LSP](https://microsoft.github.io/language-server-protoco
 - Workspace
   - [Workspace Folders](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspaceFoldersServerCapabilities): `true`
   - File Operations: `false`
+  - [Workspace commands](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_executeCommand)
+    - `oxc.fixAll`, requires `{ uri: URL }` as command argument. Does safe fixes in `uri` file.
 - [Code Actions Provider](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#codeActionKind):
   - `quickfix`
   - `source.fixAll.oxc`, behaves the same as `quickfix` only used when the `CodeActionContext#only` contains
@@ -31,6 +33,10 @@ The server will revalidate or reset the diagnostics for all open files and send 
 
 The server expects this request when the oxlint configuration is changed.
 The server will revalidate the diagnostics for all open files and send one or more [textDocument/publishDiagnostics](#textdocumentpublishdiagnostics) requests to the client.
+
+#### [workspace/executeCommand](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_executeCommand)
+
+Executes a [Command](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_executeCommand) if it exists. See [Server Capabilities](#server-capabilities)
 
 ### TextDocument
 

--- a/crates/oxc_language_server/src/capabilities.rs
+++ b/crates/oxc_language_server/src/capabilities.rs
@@ -79,7 +79,8 @@ impl From<Capabilities> for ServerCapabilities {
 mod test {
     use tower_lsp::lsp_types::{
         ClientCapabilities, CodeActionClientCapabilities, CodeActionKindLiteralSupport,
-        CodeActionLiteralSupport, TextDocumentClientCapabilities,
+        CodeActionLiteralSupport, TextDocumentClientCapabilities, WorkspaceClientCapabilities,
+        WorkspaceEditClientCapabilities,
     };
 
     use super::Capabilities;
@@ -111,12 +112,20 @@ mod test {
                 }),
                 ..TextDocumentClientCapabilities::default()
             }),
+            workspace: Some(WorkspaceClientCapabilities {
+                workspace_edit: Some(WorkspaceEditClientCapabilities {
+                    document_changes: Some(true),
+                    ..WorkspaceEditClientCapabilities::default()
+                }),
+                ..WorkspaceClientCapabilities::default()
+            }),
             ..ClientCapabilities::default()
         };
 
         let capabilities = Capabilities::from(client_capabilities);
 
         assert!(capabilities.code_action_provider);
+        assert!(capabilities.workspace_edit);
     }
 
     #[test]
@@ -141,11 +150,19 @@ mod test {
                 }),
                 ..TextDocumentClientCapabilities::default()
             }),
+            workspace: Some(WorkspaceClientCapabilities {
+                workspace_edit: Some(WorkspaceEditClientCapabilities {
+                    document_changes: Some(true),
+                    ..WorkspaceEditClientCapabilities::default()
+                }),
+                ..WorkspaceClientCapabilities::default()
+            }),
             ..ClientCapabilities::default()
         };
 
         let capabilities = Capabilities::from(client_capabilities);
 
         assert!(capabilities.code_action_provider);
+        assert!(capabilities.workspace_edit);
     }
 }

--- a/crates/oxc_language_server/src/commands.rs
+++ b/crates/oxc_language_server/src/commands.rs
@@ -104,10 +104,7 @@ impl WorkspaceCommand for FixAllCommand {
                     }),
                     edit: WorkspaceEdit {
                         #[expect(clippy::disallowed_types)]
-                        changes: Some(std::collections::HashMap::from([(
-                            url.clone(),
-                            edits.clone(),
-                        )])),
+                        changes: Some(std::collections::HashMap::from([(url, edits)])),
                         ..WorkspaceEdit::default()
                     },
                 })

--- a/crates/oxc_language_server/src/commands.rs
+++ b/crates/oxc_language_server/src/commands.rs
@@ -1,0 +1,118 @@
+use log::error;
+use serde::Deserialize;
+use tower_lsp::{
+    jsonrpc::{self, Error},
+    lsp_types::{
+        request::ApplyWorkspaceEdit, ApplyWorkspaceEditParams, DidChangeTextDocumentParams,
+        TextDocumentContentChangeEvent, TextEdit, Url, VersionedTextDocumentIdentifier,
+        WorkspaceEdit,
+    },
+    LanguageServer,
+};
+
+use crate::{capabilities::Capabilities, Backend};
+
+pub const LSP_COMMANDS: [WorkspaceCommands; 1] = [WorkspaceCommands::FixAll(FixAllCommand)];
+
+pub trait WorkspaceCommand {
+    fn command_id(&self) -> String;
+    fn available(&self, cap: Capabilities) -> bool;
+    type CommandArgs<'a>: serde::Deserialize<'a>;
+    async fn execute<'a>(
+        &self,
+        backend: &Backend,
+        args: Self::CommandArgs<'a>,
+    ) -> jsonrpc::Result<Option<serde_json::Value>>;
+}
+
+pub enum WorkspaceCommands {
+    FixAll(FixAllCommand),
+}
+
+impl WorkspaceCommands {
+    pub fn command_id(&self) -> String {
+        match self {
+            WorkspaceCommands::FixAll(c) => c.command_id().into(),
+        }
+    }
+    pub fn available(&self, cap: Capabilities) -> bool {
+        match self {
+            WorkspaceCommands::FixAll(c) => c.available(cap),
+        }
+    }
+    pub async fn execute(
+        &self,
+        backend: &Backend,
+        args: Vec<serde_json::Value>,
+    ) -> jsonrpc::Result<Option<serde_json::Value>> {
+        match self {
+            WorkspaceCommands::FixAll(c) => {
+                let arg: Result<
+                    <FixAllCommand as WorkspaceCommand>::CommandArgs<'_>,
+                    serde_json::Error,
+                > = serde_json::from_value(serde_json::Value::Array(args));
+                if let Err(e) = arg {
+                    error!("Invalid args passed to {:?}: {e}", c.command_id());
+                    return Err(Error::invalid_request());
+                }
+                let arg = arg.unwrap();
+
+                c.execute(backend, arg).await
+            }
+        }
+    }
+}
+
+pub struct FixAllCommand;
+
+#[derive(Deserialize)]
+pub struct FixAllCommandArg {
+    uri: String,
+}
+
+impl WorkspaceCommand for FixAllCommand {
+    fn command_id(&self) -> String {
+        "oxc.fixAll".into()
+    }
+    fn available(&self, cap: Capabilities) -> bool {
+        cap.workspace_edit
+    }
+    type CommandArgs<'a> = (FixAllCommandArg,);
+
+    async fn execute<'a>(
+        &self,
+        backend: &Backend,
+        args: Self::CommandArgs<'a>,
+    ) -> jsonrpc::Result<Option<serde_json::Value>> {
+        let url = Url::parse(&args.0.uri);
+        if let Err(e) = url {
+            error!("Invalid uri passed to {:?}: {e}", self.command_id());
+            return Err(Error::invalid_request());
+        }
+        let url = url.unwrap();
+
+        let mut edits = vec![];
+        if let Some(value) = backend.diagnostics_report_map.get(&url.to_string()) {
+            for report in value.iter() {
+                if let Some(fixed) = &report.fixed_content {
+                    edits.push(TextEdit { range: fixed.range, new_text: fixed.code.clone() })
+                }
+            }
+            let _ = backend
+                .client
+                .send_request::<ApplyWorkspaceEdit>(ApplyWorkspaceEditParams {
+                    label: Some("Oxlint fix all".into()),
+                    edit: WorkspaceEdit {
+                        changes: Some(std::collections::HashMap::from([(
+                            url.clone(),
+                            edits.clone(),
+                        )])),
+                        ..WorkspaceEdit::default()
+                    },
+                })
+                .await;
+        }
+
+        Ok(None)
+    }
+}

--- a/crates/oxc_language_server/src/commands.rs
+++ b/crates/oxc_language_server/src/commands.rs
@@ -3,11 +3,8 @@ use serde::Deserialize;
 use tower_lsp::{
     jsonrpc::{self, Error},
     lsp_types::{
-        request::ApplyWorkspaceEdit, ApplyWorkspaceEditParams, DidChangeTextDocumentParams,
-        TextDocumentContentChangeEvent, TextEdit, Url, VersionedTextDocumentIdentifier,
-        WorkspaceEdit,
+        request::ApplyWorkspaceEdit, ApplyWorkspaceEditParams, TextEdit, Url, WorkspaceEdit,
     },
-    LanguageServer,
 };
 
 use crate::{capabilities::Capabilities, Backend};

--- a/crates/oxc_language_server/src/commands.rs
+++ b/crates/oxc_language_server/src/commands.rs
@@ -72,7 +72,7 @@ impl WorkspaceCommand for FixAllCommand {
         "oxc.fixAll".into()
     }
     fn available(&self, cap: Capabilities) -> bool {
-        cap.workspace_edit
+        cap.workspace_apply_edit
     }
     type CommandArgs<'a> = (FixAllCommandArg,);
 
@@ -98,7 +98,10 @@ impl WorkspaceCommand for FixAllCommand {
             let _ = backend
                 .client
                 .send_request::<ApplyWorkspaceEdit>(ApplyWorkspaceEditParams {
-                    label: Some("Oxlint fix all".into()),
+                    label: Some(match edits.len() {
+                        1 => "Oxlint: 1 fix applied".into(),
+                        n => format!("Oxlint: {} fixes applied", n),
+                    }),
                     edit: WorkspaceEdit {
                         changes: Some(std::collections::HashMap::from([(
                             url.clone(),

--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -1,5 +1,6 @@
 use std::{fmt::Debug, path::PathBuf, str::FromStr};
 
+use commands::LSP_COMMANDS;
 use dashmap::DashMap;
 use futures::future::join_all;
 use globset::Glob;
@@ -14,8 +15,9 @@ use tower_lsp::{
         CodeAction, CodeActionKind, CodeActionOrCommand, CodeActionParams, CodeActionResponse,
         ConfigurationItem, Diagnostic, DidChangeConfigurationParams, DidChangeTextDocumentParams,
         DidChangeWatchedFilesParams, DidCloseTextDocumentParams, DidOpenTextDocumentParams,
-        DidSaveTextDocumentParams, InitializeParams, InitializeResult, InitializedParams,
-        NumberOrString, Position, Range, ServerInfo, TextEdit, Url, WorkspaceEdit,
+        DidSaveTextDocumentParams, ExecuteCommandParams, InitializeParams, InitializeResult,
+        InitializedParams, NumberOrString, Position, Range, ServerInfo, TextEdit, Url,
+        WorkspaceEdit,
     },
     Client, LanguageServer, LspService, Server,
 };
@@ -27,6 +29,7 @@ use crate::linter::error_with_position::DiagnosticReport;
 use crate::linter::server_linter::ServerLinter;
 
 mod capabilities;
+mod commands;
 mod linter;
 
 type FxDashMap<K, V> = DashMap<K, V, FxBuildHasher>;
@@ -385,6 +388,18 @@ impl LanguageServer for Backend {
         }
 
         Ok(Some(code_actions_vec))
+    }
+
+    async fn execute_command(
+        &self,
+        params: ExecuteCommandParams,
+    ) -> Result<Option<serde_json::Value>> {
+        let command = LSP_COMMANDS.iter().find(|c| c.command_id() == params.command);
+
+        return match command {
+            Some(c) => c.execute(self, params.arguments).await,
+            None => Err(Error::invalid_request()),
+        };
     }
 }
 

--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -1,20 +1,8 @@
 import { promises as fsPromises } from 'node:fs';
 
-import {
-  commands,
-  ExtensionContext,
-  StatusBarAlignment,
-  StatusBarItem,
-  ThemeColor,
-  window,
-  workspace,
-} from 'vscode';
+import { commands, ExtensionContext, StatusBarAlignment, StatusBarItem, ThemeColor, window, workspace } from 'vscode';
 
-import {
-  ExecuteCommandRequest,
-  MessageType,
-  ShowMessageNotification,
-} from 'vscode-languageclient';
+import { ExecuteCommandRequest, MessageType, ShowMessageNotification } from 'vscode-languageclient';
 
 import { Executable, LanguageClient, LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node';
 
@@ -95,10 +83,10 @@ export async function activate(context: ExtensionContext) {
         command: LspCommands.FixAll,
         arguments: [{
           uri: textEditor.document.uri.toString(),
-        }]
-      }
+        }],
+      };
 
-      await client.sendRequest(ExecuteCommandRequest.type, params)
+      await client.sendRequest(ExecuteCommandRequest.type, params);
     },
   );
 

--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -1,8 +1,6 @@
 import { promises as fsPromises } from 'node:fs';
 
 import {
-  CodeAction,
-  Command,
   commands,
   ExtensionContext,
   StatusBarAlignment,
@@ -13,11 +11,8 @@ import {
 } from 'vscode';
 
 import {
-  CodeActionRequest,
-  CodeActionTriggerKind,
+  ExecuteCommandRequest,
   MessageType,
-  Position,
-  Range,
   ShowMessageNotification,
 } from 'vscode-languageclient';
 
@@ -35,6 +30,10 @@ const enum OxcCommands {
   ApplyAllFixesFile = `${commandPrefix}.applyAllFixesFile`,
   ShowOutputChannel = `${commandPrefix}.showOutputChannel`,
   ToggleEnable = `${commandPrefix}.toggleEnable`,
+}
+
+const enum LspCommands {
+  FixAll = 'oxc.fixAll',
 }
 
 let client: LanguageClient;
@@ -92,45 +91,14 @@ export async function activate(context: ExtensionContext) {
         return;
       }
 
-      const lastLine = textEditor.document.lineAt(textEditor.document.lineCount - 1);
-      const codeActionResult = await client.sendRequest(CodeActionRequest.type, {
-        textDocument: {
+      const params = {
+        command: LspCommands.FixAll,
+        arguments: [{
           uri: textEditor.document.uri.toString(),
-        },
-        range: Range.create(Position.create(0, 0), lastLine.range.end),
-        context: {
-          diagnostics: [],
-          only: [],
-          triggerKind: CodeActionTriggerKind.Invoked,
-        },
-      });
-      const commandsOrCodeActions = await client.protocol2CodeConverter.asCodeActionResult(codeActionResult || []);
-
-      await Promise.all(
-        commandsOrCodeActions
-          .map(async (codeActionOrCommand) => {
-            // Commands are always applied. Regardless of whether it's a Command or CodeAction#command.
-            if (isCommand(codeActionOrCommand)) {
-              await commands.executeCommand(codeActionOrCommand.command, codeActionOrCommand.arguments);
-            } else {
-              // Only preferred edits are applied
-              // LSP states edits must be run first, then commands
-              if (codeActionOrCommand.edit && codeActionOrCommand.isPreferred) {
-                await workspace.applyEdit(codeActionOrCommand.edit);
-              }
-              if (codeActionOrCommand.command) {
-                await commands.executeCommand(
-                  codeActionOrCommand.command.command,
-                  codeActionOrCommand.command.arguments,
-                );
-              }
-            }
-          }),
-      );
-
-      function isCommand(codeActionOrCommand: CodeAction | Command): codeActionOrCommand is Command {
-        return typeof codeActionOrCommand.command === 'string';
+        }]
       }
+
+      await client.sendRequest(ExecuteCommandRequest.type, params)
     },
   );
 


### PR DESCRIPTION
This pull request focuses on optimizing the implementation of the `oxlint.applyAllFixesFile` vscode command by adding the command interface to the LSP instead of requesting all code actions and executing the preferred ones. This PR contains an abstraction above the LSP workspace commands, the `oxc.fixAll` command itself and minor changes to the vscode extension.

Since the `workspace/executeCommand` handler is new, I've created an abstraction to register the commands and parse their arguments. While it isn't necessary, I feel like it makes future additions to the LS easier.

I tested the command in both vscode and neovim, doubt it will be hard to use this in the zed / intellij projects.