### PR TITLE
refactor(ast): simplify generated code for `GetSpan`

### DIFF
--- a/crates/oxc_ast/src/generated/derive_get_span.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span.rs
@@ -62,48 +62,48 @@ impl GetSpan for Program<'_> {
 impl GetSpan for Expression<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::BooleanLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::NullLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::NumericLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::BigIntLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::RegExpLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::StringLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::TemplateLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::Identifier(it) => GetSpan::span(it.as_ref()),
-            Self::MetaProperty(it) => GetSpan::span(it.as_ref()),
-            Self::Super(it) => GetSpan::span(it.as_ref()),
-            Self::ArrayExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ArrowFunctionExpression(it) => GetSpan::span(it.as_ref()),
-            Self::AssignmentExpression(it) => GetSpan::span(it.as_ref()),
-            Self::AwaitExpression(it) => GetSpan::span(it.as_ref()),
-            Self::BinaryExpression(it) => GetSpan::span(it.as_ref()),
-            Self::CallExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ChainExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ClassExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ConditionalExpression(it) => GetSpan::span(it.as_ref()),
-            Self::FunctionExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ImportExpression(it) => GetSpan::span(it.as_ref()),
-            Self::LogicalExpression(it) => GetSpan::span(it.as_ref()),
-            Self::NewExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ObjectExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ParenthesizedExpression(it) => GetSpan::span(it.as_ref()),
-            Self::SequenceExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TaggedTemplateExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ThisExpression(it) => GetSpan::span(it.as_ref()),
-            Self::UnaryExpression(it) => GetSpan::span(it.as_ref()),
-            Self::UpdateExpression(it) => GetSpan::span(it.as_ref()),
-            Self::YieldExpression(it) => GetSpan::span(it.as_ref()),
-            Self::PrivateInExpression(it) => GetSpan::span(it.as_ref()),
-            Self::JSXElement(it) => GetSpan::span(it.as_ref()),
-            Self::JSXFragment(it) => GetSpan::span(it.as_ref()),
-            Self::TSAsExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSSatisfiesExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSTypeAssertion(it) => GetSpan::span(it.as_ref()),
-            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSInstantiationExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
+            Self::BooleanLiteral(it) => it.span(),
+            Self::NullLiteral(it) => it.span(),
+            Self::NumericLiteral(it) => it.span(),
+            Self::BigIntLiteral(it) => it.span(),
+            Self::RegExpLiteral(it) => it.span(),
+            Self::StringLiteral(it) => it.span(),
+            Self::TemplateLiteral(it) => it.span(),
+            Self::Identifier(it) => it.span(),
+            Self::MetaProperty(it) => it.span(),
+            Self::Super(it) => it.span(),
+            Self::ArrayExpression(it) => it.span(),
+            Self::ArrowFunctionExpression(it) => it.span(),
+            Self::AssignmentExpression(it) => it.span(),
+            Self::AwaitExpression(it) => it.span(),
+            Self::BinaryExpression(it) => it.span(),
+            Self::CallExpression(it) => it.span(),
+            Self::ChainExpression(it) => it.span(),
+            Self::ClassExpression(it) => it.span(),
+            Self::ConditionalExpression(it) => it.span(),
+            Self::FunctionExpression(it) => it.span(),
+            Self::ImportExpression(it) => it.span(),
+            Self::LogicalExpression(it) => it.span(),
+            Self::NewExpression(it) => it.span(),
+            Self::ObjectExpression(it) => it.span(),
+            Self::ParenthesizedExpression(it) => it.span(),
+            Self::SequenceExpression(it) => it.span(),
+            Self::TaggedTemplateExpression(it) => it.span(),
+            Self::ThisExpression(it) => it.span(),
+            Self::UnaryExpression(it) => it.span(),
+            Self::UpdateExpression(it) => it.span(),
+            Self::YieldExpression(it) => it.span(),
+            Self::PrivateInExpression(it) => it.span(),
+            Self::JSXElement(it) => it.span(),
+            Self::JSXFragment(it) => it.span(),
+            Self::TSAsExpression(it) => it.span(),
+            Self::TSSatisfiesExpression(it) => it.span(),
+            Self::TSTypeAssertion(it) => it.span(),
+            Self::TSNonNullExpression(it) => it.span(),
+            Self::TSInstantiationExpression(it) => it.span(),
+            Self::ComputedMemberExpression(it) => it.span(),
+            Self::StaticMemberExpression(it) => it.span(),
+            Self::PrivateFieldExpression(it) => it.span(),
         }
     }
 }
@@ -153,50 +153,50 @@ impl GetSpan for ArrayExpression<'_> {
 impl GetSpan for ArrayExpressionElement<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::SpreadElement(it) => GetSpan::span(it.as_ref()),
-            Self::Elision(it) => GetSpan::span(it),
-            Self::BooleanLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::NullLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::NumericLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::BigIntLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::RegExpLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::StringLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::TemplateLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::Identifier(it) => GetSpan::span(it.as_ref()),
-            Self::MetaProperty(it) => GetSpan::span(it.as_ref()),
-            Self::Super(it) => GetSpan::span(it.as_ref()),
-            Self::ArrayExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ArrowFunctionExpression(it) => GetSpan::span(it.as_ref()),
-            Self::AssignmentExpression(it) => GetSpan::span(it.as_ref()),
-            Self::AwaitExpression(it) => GetSpan::span(it.as_ref()),
-            Self::BinaryExpression(it) => GetSpan::span(it.as_ref()),
-            Self::CallExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ChainExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ClassExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ConditionalExpression(it) => GetSpan::span(it.as_ref()),
-            Self::FunctionExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ImportExpression(it) => GetSpan::span(it.as_ref()),
-            Self::LogicalExpression(it) => GetSpan::span(it.as_ref()),
-            Self::NewExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ObjectExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ParenthesizedExpression(it) => GetSpan::span(it.as_ref()),
-            Self::SequenceExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TaggedTemplateExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ThisExpression(it) => GetSpan::span(it.as_ref()),
-            Self::UnaryExpression(it) => GetSpan::span(it.as_ref()),
-            Self::UpdateExpression(it) => GetSpan::span(it.as_ref()),
-            Self::YieldExpression(it) => GetSpan::span(it.as_ref()),
-            Self::PrivateInExpression(it) => GetSpan::span(it.as_ref()),
-            Self::JSXElement(it) => GetSpan::span(it.as_ref()),
-            Self::JSXFragment(it) => GetSpan::span(it.as_ref()),
-            Self::TSAsExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSSatisfiesExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSTypeAssertion(it) => GetSpan::span(it.as_ref()),
-            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSInstantiationExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
+            Self::SpreadElement(it) => it.span(),
+            Self::Elision(it) => it.span(),
+            Self::BooleanLiteral(it) => it.span(),
+            Self::NullLiteral(it) => it.span(),
+            Self::NumericLiteral(it) => it.span(),
+            Self::BigIntLiteral(it) => it.span(),
+            Self::RegExpLiteral(it) => it.span(),
+            Self::StringLiteral(it) => it.span(),
+            Self::TemplateLiteral(it) => it.span(),
+            Self::Identifier(it) => it.span(),
+            Self::MetaProperty(it) => it.span(),
+            Self::Super(it) => it.span(),
+            Self::ArrayExpression(it) => it.span(),
+            Self::ArrowFunctionExpression(it) => it.span(),
+            Self::AssignmentExpression(it) => it.span(),
+            Self::AwaitExpression(it) => it.span(),
+            Self::BinaryExpression(it) => it.span(),
+            Self::CallExpression(it) => it.span(),
+            Self::ChainExpression(it) => it.span(),
+            Self::ClassExpression(it) => it.span(),
+            Self::ConditionalExpression(it) => it.span(),
+            Self::FunctionExpression(it) => it.span(),
+            Self::ImportExpression(it) => it.span(),
+            Self::LogicalExpression(it) => it.span(),
+            Self::NewExpression(it) => it.span(),
+            Self::ObjectExpression(it) => it.span(),
+            Self::ParenthesizedExpression(it) => it.span(),
+            Self::SequenceExpression(it) => it.span(),
+            Self::TaggedTemplateExpression(it) => it.span(),
+            Self::ThisExpression(it) => it.span(),
+            Self::UnaryExpression(it) => it.span(),
+            Self::UpdateExpression(it) => it.span(),
+            Self::YieldExpression(it) => it.span(),
+            Self::PrivateInExpression(it) => it.span(),
+            Self::JSXElement(it) => it.span(),
+            Self::JSXFragment(it) => it.span(),
+            Self::TSAsExpression(it) => it.span(),
+            Self::TSSatisfiesExpression(it) => it.span(),
+            Self::TSTypeAssertion(it) => it.span(),
+            Self::TSNonNullExpression(it) => it.span(),
+            Self::TSInstantiationExpression(it) => it.span(),
+            Self::ComputedMemberExpression(it) => it.span(),
+            Self::StaticMemberExpression(it) => it.span(),
+            Self::PrivateFieldExpression(it) => it.span(),
         }
     }
 }
@@ -218,8 +218,8 @@ impl GetSpan for ObjectExpression<'_> {
 impl GetSpan for ObjectPropertyKind<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::ObjectProperty(it) => GetSpan::span(it.as_ref()),
-            Self::SpreadProperty(it) => GetSpan::span(it.as_ref()),
+            Self::ObjectProperty(it) => it.span(),
+            Self::SpreadProperty(it) => it.span(),
         }
     }
 }
@@ -234,50 +234,50 @@ impl GetSpan for ObjectProperty<'_> {
 impl GetSpan for PropertyKey<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::StaticIdentifier(it) => GetSpan::span(it.as_ref()),
-            Self::PrivateIdentifier(it) => GetSpan::span(it.as_ref()),
-            Self::BooleanLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::NullLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::NumericLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::BigIntLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::RegExpLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::StringLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::TemplateLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::Identifier(it) => GetSpan::span(it.as_ref()),
-            Self::MetaProperty(it) => GetSpan::span(it.as_ref()),
-            Self::Super(it) => GetSpan::span(it.as_ref()),
-            Self::ArrayExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ArrowFunctionExpression(it) => GetSpan::span(it.as_ref()),
-            Self::AssignmentExpression(it) => GetSpan::span(it.as_ref()),
-            Self::AwaitExpression(it) => GetSpan::span(it.as_ref()),
-            Self::BinaryExpression(it) => GetSpan::span(it.as_ref()),
-            Self::CallExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ChainExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ClassExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ConditionalExpression(it) => GetSpan::span(it.as_ref()),
-            Self::FunctionExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ImportExpression(it) => GetSpan::span(it.as_ref()),
-            Self::LogicalExpression(it) => GetSpan::span(it.as_ref()),
-            Self::NewExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ObjectExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ParenthesizedExpression(it) => GetSpan::span(it.as_ref()),
-            Self::SequenceExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TaggedTemplateExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ThisExpression(it) => GetSpan::span(it.as_ref()),
-            Self::UnaryExpression(it) => GetSpan::span(it.as_ref()),
-            Self::UpdateExpression(it) => GetSpan::span(it.as_ref()),
-            Self::YieldExpression(it) => GetSpan::span(it.as_ref()),
-            Self::PrivateInExpression(it) => GetSpan::span(it.as_ref()),
-            Self::JSXElement(it) => GetSpan::span(it.as_ref()),
-            Self::JSXFragment(it) => GetSpan::span(it.as_ref()),
-            Self::TSAsExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSSatisfiesExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSTypeAssertion(it) => GetSpan::span(it.as_ref()),
-            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSInstantiationExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
+            Self::StaticIdentifier(it) => it.span(),
+            Self::PrivateIdentifier(it) => it.span(),
+            Self::BooleanLiteral(it) => it.span(),
+            Self::NullLiteral(it) => it.span(),
+            Self::NumericLiteral(it) => it.span(),
+            Self::BigIntLiteral(it) => it.span(),
+            Self::RegExpLiteral(it) => it.span(),
+            Self::StringLiteral(it) => it.span(),
+            Self::TemplateLiteral(it) => it.span(),
+            Self::Identifier(it) => it.span(),
+            Self::MetaProperty(it) => it.span(),
+            Self::Super(it) => it.span(),
+            Self::ArrayExpression(it) => it.span(),
+            Self::ArrowFunctionExpression(it) => it.span(),
+            Self::AssignmentExpression(it) => it.span(),
+            Self::AwaitExpression(it) => it.span(),
+            Self::BinaryExpression(it) => it.span(),
+            Self::CallExpression(it) => it.span(),
+            Self::ChainExpression(it) => it.span(),
+            Self::ClassExpression(it) => it.span(),
+            Self::ConditionalExpression(it) => it.span(),
+            Self::FunctionExpression(it) => it.span(),
+            Self::ImportExpression(it) => it.span(),
+            Self::LogicalExpression(it) => it.span(),
+            Self::NewExpression(it) => it.span(),
+            Self::ObjectExpression(it) => it.span(),
+            Self::ParenthesizedExpression(it) => it.span(),
+            Self::SequenceExpression(it) => it.span(),
+            Self::TaggedTemplateExpression(it) => it.span(),
+            Self::ThisExpression(it) => it.span(),
+            Self::UnaryExpression(it) => it.span(),
+            Self::UpdateExpression(it) => it.span(),
+            Self::YieldExpression(it) => it.span(),
+            Self::PrivateInExpression(it) => it.span(),
+            Self::JSXElement(it) => it.span(),
+            Self::JSXFragment(it) => it.span(),
+            Self::TSAsExpression(it) => it.span(),
+            Self::TSSatisfiesExpression(it) => it.span(),
+            Self::TSTypeAssertion(it) => it.span(),
+            Self::TSNonNullExpression(it) => it.span(),
+            Self::TSInstantiationExpression(it) => it.span(),
+            Self::ComputedMemberExpression(it) => it.span(),
+            Self::StaticMemberExpression(it) => it.span(),
+            Self::PrivateFieldExpression(it) => it.span(),
         }
     }
 }
@@ -306,9 +306,9 @@ impl GetSpan for TemplateElement<'_> {
 impl GetSpan for MemberExpression<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ComputedMemberExpression(it) => it.span(),
+            Self::StaticMemberExpression(it) => it.span(),
+            Self::PrivateFieldExpression(it) => it.span(),
         }
     }
 }
@@ -365,49 +365,49 @@ impl GetSpan for SpreadElement<'_> {
 impl GetSpan for Argument<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::SpreadElement(it) => GetSpan::span(it.as_ref()),
-            Self::BooleanLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::NullLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::NumericLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::BigIntLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::RegExpLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::StringLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::TemplateLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::Identifier(it) => GetSpan::span(it.as_ref()),
-            Self::MetaProperty(it) => GetSpan::span(it.as_ref()),
-            Self::Super(it) => GetSpan::span(it.as_ref()),
-            Self::ArrayExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ArrowFunctionExpression(it) => GetSpan::span(it.as_ref()),
-            Self::AssignmentExpression(it) => GetSpan::span(it.as_ref()),
-            Self::AwaitExpression(it) => GetSpan::span(it.as_ref()),
-            Self::BinaryExpression(it) => GetSpan::span(it.as_ref()),
-            Self::CallExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ChainExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ClassExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ConditionalExpression(it) => GetSpan::span(it.as_ref()),
-            Self::FunctionExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ImportExpression(it) => GetSpan::span(it.as_ref()),
-            Self::LogicalExpression(it) => GetSpan::span(it.as_ref()),
-            Self::NewExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ObjectExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ParenthesizedExpression(it) => GetSpan::span(it.as_ref()),
-            Self::SequenceExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TaggedTemplateExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ThisExpression(it) => GetSpan::span(it.as_ref()),
-            Self::UnaryExpression(it) => GetSpan::span(it.as_ref()),
-            Self::UpdateExpression(it) => GetSpan::span(it.as_ref()),
-            Self::YieldExpression(it) => GetSpan::span(it.as_ref()),
-            Self::PrivateInExpression(it) => GetSpan::span(it.as_ref()),
-            Self::JSXElement(it) => GetSpan::span(it.as_ref()),
-            Self::JSXFragment(it) => GetSpan::span(it.as_ref()),
-            Self::TSAsExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSSatisfiesExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSTypeAssertion(it) => GetSpan::span(it.as_ref()),
-            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSInstantiationExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
+            Self::SpreadElement(it) => it.span(),
+            Self::BooleanLiteral(it) => it.span(),
+            Self::NullLiteral(it) => it.span(),
+            Self::NumericLiteral(it) => it.span(),
+            Self::BigIntLiteral(it) => it.span(),
+            Self::RegExpLiteral(it) => it.span(),
+            Self::StringLiteral(it) => it.span(),
+            Self::TemplateLiteral(it) => it.span(),
+            Self::Identifier(it) => it.span(),
+            Self::MetaProperty(it) => it.span(),
+            Self::Super(it) => it.span(),
+            Self::ArrayExpression(it) => it.span(),
+            Self::ArrowFunctionExpression(it) => it.span(),
+            Self::AssignmentExpression(it) => it.span(),
+            Self::AwaitExpression(it) => it.span(),
+            Self::BinaryExpression(it) => it.span(),
+            Self::CallExpression(it) => it.span(),
+            Self::ChainExpression(it) => it.span(),
+            Self::ClassExpression(it) => it.span(),
+            Self::ConditionalExpression(it) => it.span(),
+            Self::FunctionExpression(it) => it.span(),
+            Self::ImportExpression(it) => it.span(),
+            Self::LogicalExpression(it) => it.span(),
+            Self::NewExpression(it) => it.span(),
+            Self::ObjectExpression(it) => it.span(),
+            Self::ParenthesizedExpression(it) => it.span(),
+            Self::SequenceExpression(it) => it.span(),
+            Self::TaggedTemplateExpression(it) => it.span(),
+            Self::ThisExpression(it) => it.span(),
+            Self::UnaryExpression(it) => it.span(),
+            Self::UpdateExpression(it) => it.span(),
+            Self::YieldExpression(it) => it.span(),
+            Self::PrivateInExpression(it) => it.span(),
+            Self::JSXElement(it) => it.span(),
+            Self::JSXFragment(it) => it.span(),
+            Self::TSAsExpression(it) => it.span(),
+            Self::TSSatisfiesExpression(it) => it.span(),
+            Self::TSTypeAssertion(it) => it.span(),
+            Self::TSNonNullExpression(it) => it.span(),
+            Self::TSInstantiationExpression(it) => it.span(),
+            Self::ComputedMemberExpression(it) => it.span(),
+            Self::StaticMemberExpression(it) => it.span(),
+            Self::PrivateFieldExpression(it) => it.span(),
         }
     }
 }
@@ -464,17 +464,17 @@ impl GetSpan for AssignmentExpression<'_> {
 impl GetSpan for AssignmentTarget<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::AssignmentTargetIdentifier(it) => GetSpan::span(it.as_ref()),
-            Self::TSAsExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSSatisfiesExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSTypeAssertion(it) => GetSpan::span(it.as_ref()),
-            Self::TSInstantiationExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ArrayAssignmentTarget(it) => GetSpan::span(it.as_ref()),
-            Self::ObjectAssignmentTarget(it) => GetSpan::span(it.as_ref()),
+            Self::AssignmentTargetIdentifier(it) => it.span(),
+            Self::TSAsExpression(it) => it.span(),
+            Self::TSSatisfiesExpression(it) => it.span(),
+            Self::TSNonNullExpression(it) => it.span(),
+            Self::TSTypeAssertion(it) => it.span(),
+            Self::TSInstantiationExpression(it) => it.span(),
+            Self::ComputedMemberExpression(it) => it.span(),
+            Self::StaticMemberExpression(it) => it.span(),
+            Self::PrivateFieldExpression(it) => it.span(),
+            Self::ArrayAssignmentTarget(it) => it.span(),
+            Self::ObjectAssignmentTarget(it) => it.span(),
         }
     }
 }
@@ -482,15 +482,15 @@ impl GetSpan for AssignmentTarget<'_> {
 impl GetSpan for SimpleAssignmentTarget<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::AssignmentTargetIdentifier(it) => GetSpan::span(it.as_ref()),
-            Self::TSAsExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSSatisfiesExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSTypeAssertion(it) => GetSpan::span(it.as_ref()),
-            Self::TSInstantiationExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
+            Self::AssignmentTargetIdentifier(it) => it.span(),
+            Self::TSAsExpression(it) => it.span(),
+            Self::TSSatisfiesExpression(it) => it.span(),
+            Self::TSNonNullExpression(it) => it.span(),
+            Self::TSTypeAssertion(it) => it.span(),
+            Self::TSInstantiationExpression(it) => it.span(),
+            Self::ComputedMemberExpression(it) => it.span(),
+            Self::StaticMemberExpression(it) => it.span(),
+            Self::PrivateFieldExpression(it) => it.span(),
         }
     }
 }
@@ -498,8 +498,8 @@ impl GetSpan for SimpleAssignmentTarget<'_> {
 impl GetSpan for AssignmentTargetPattern<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::ArrayAssignmentTarget(it) => GetSpan::span(it.as_ref()),
-            Self::ObjectAssignmentTarget(it) => GetSpan::span(it.as_ref()),
+            Self::ArrayAssignmentTarget(it) => it.span(),
+            Self::ObjectAssignmentTarget(it) => it.span(),
         }
     }
 }
@@ -528,18 +528,18 @@ impl GetSpan for AssignmentTargetRest<'_> {
 impl GetSpan for AssignmentTargetMaybeDefault<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::AssignmentTargetWithDefault(it) => GetSpan::span(it.as_ref()),
-            Self::AssignmentTargetIdentifier(it) => GetSpan::span(it.as_ref()),
-            Self::TSAsExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSSatisfiesExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSTypeAssertion(it) => GetSpan::span(it.as_ref()),
-            Self::TSInstantiationExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ArrayAssignmentTarget(it) => GetSpan::span(it.as_ref()),
-            Self::ObjectAssignmentTarget(it) => GetSpan::span(it.as_ref()),
+            Self::AssignmentTargetWithDefault(it) => it.span(),
+            Self::AssignmentTargetIdentifier(it) => it.span(),
+            Self::TSAsExpression(it) => it.span(),
+            Self::TSSatisfiesExpression(it) => it.span(),
+            Self::TSNonNullExpression(it) => it.span(),
+            Self::TSTypeAssertion(it) => it.span(),
+            Self::TSInstantiationExpression(it) => it.span(),
+            Self::ComputedMemberExpression(it) => it.span(),
+            Self::StaticMemberExpression(it) => it.span(),
+            Self::PrivateFieldExpression(it) => it.span(),
+            Self::ArrayAssignmentTarget(it) => it.span(),
+            Self::ObjectAssignmentTarget(it) => it.span(),
         }
     }
 }
@@ -554,8 +554,8 @@ impl GetSpan for AssignmentTargetWithDefault<'_> {
 impl GetSpan for AssignmentTargetProperty<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::AssignmentTargetPropertyIdentifier(it) => GetSpan::span(it.as_ref()),
-            Self::AssignmentTargetPropertyProperty(it) => GetSpan::span(it.as_ref()),
+            Self::AssignmentTargetPropertyIdentifier(it) => it.span(),
+            Self::AssignmentTargetPropertyProperty(it) => it.span(),
         }
     }
 }
@@ -605,11 +605,11 @@ impl GetSpan for ChainExpression<'_> {
 impl GetSpan for ChainElement<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::CallExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
+            Self::CallExpression(it) => it.span(),
+            Self::TSNonNullExpression(it) => it.span(),
+            Self::ComputedMemberExpression(it) => it.span(),
+            Self::StaticMemberExpression(it) => it.span(),
+            Self::PrivateFieldExpression(it) => it.span(),
         }
     }
 }
@@ -624,38 +624,38 @@ impl GetSpan for ParenthesizedExpression<'_> {
 impl GetSpan for Statement<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::BlockStatement(it) => GetSpan::span(it.as_ref()),
-            Self::BreakStatement(it) => GetSpan::span(it.as_ref()),
-            Self::ContinueStatement(it) => GetSpan::span(it.as_ref()),
-            Self::DebuggerStatement(it) => GetSpan::span(it.as_ref()),
-            Self::DoWhileStatement(it) => GetSpan::span(it.as_ref()),
-            Self::EmptyStatement(it) => GetSpan::span(it.as_ref()),
-            Self::ExpressionStatement(it) => GetSpan::span(it.as_ref()),
-            Self::ForInStatement(it) => GetSpan::span(it.as_ref()),
-            Self::ForOfStatement(it) => GetSpan::span(it.as_ref()),
-            Self::ForStatement(it) => GetSpan::span(it.as_ref()),
-            Self::IfStatement(it) => GetSpan::span(it.as_ref()),
-            Self::LabeledStatement(it) => GetSpan::span(it.as_ref()),
-            Self::ReturnStatement(it) => GetSpan::span(it.as_ref()),
-            Self::SwitchStatement(it) => GetSpan::span(it.as_ref()),
-            Self::ThrowStatement(it) => GetSpan::span(it.as_ref()),
-            Self::TryStatement(it) => GetSpan::span(it.as_ref()),
-            Self::WhileStatement(it) => GetSpan::span(it.as_ref()),
-            Self::WithStatement(it) => GetSpan::span(it.as_ref()),
-            Self::VariableDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::FunctionDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::ClassDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::TSTypeAliasDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::TSInterfaceDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::TSEnumDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::TSModuleDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::TSImportEqualsDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::ImportDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::ExportAllDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::ExportDefaultDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::ExportNamedDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::TSExportAssignment(it) => GetSpan::span(it.as_ref()),
-            Self::TSNamespaceExportDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::BlockStatement(it) => it.span(),
+            Self::BreakStatement(it) => it.span(),
+            Self::ContinueStatement(it) => it.span(),
+            Self::DebuggerStatement(it) => it.span(),
+            Self::DoWhileStatement(it) => it.span(),
+            Self::EmptyStatement(it) => it.span(),
+            Self::ExpressionStatement(it) => it.span(),
+            Self::ForInStatement(it) => it.span(),
+            Self::ForOfStatement(it) => it.span(),
+            Self::ForStatement(it) => it.span(),
+            Self::IfStatement(it) => it.span(),
+            Self::LabeledStatement(it) => it.span(),
+            Self::ReturnStatement(it) => it.span(),
+            Self::SwitchStatement(it) => it.span(),
+            Self::ThrowStatement(it) => it.span(),
+            Self::TryStatement(it) => it.span(),
+            Self::WhileStatement(it) => it.span(),
+            Self::WithStatement(it) => it.span(),
+            Self::VariableDeclaration(it) => it.span(),
+            Self::FunctionDeclaration(it) => it.span(),
+            Self::ClassDeclaration(it) => it.span(),
+            Self::TSTypeAliasDeclaration(it) => it.span(),
+            Self::TSInterfaceDeclaration(it) => it.span(),
+            Self::TSEnumDeclaration(it) => it.span(),
+            Self::TSModuleDeclaration(it) => it.span(),
+            Self::TSImportEqualsDeclaration(it) => it.span(),
+            Self::ImportDeclaration(it) => it.span(),
+            Self::ExportAllDeclaration(it) => it.span(),
+            Self::ExportDefaultDeclaration(it) => it.span(),
+            Self::ExportNamedDeclaration(it) => it.span(),
+            Self::TSExportAssignment(it) => it.span(),
+            Self::TSNamespaceExportDeclaration(it) => it.span(),
         }
     }
 }
@@ -684,14 +684,14 @@ impl GetSpan for BlockStatement<'_> {
 impl GetSpan for Declaration<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::VariableDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::FunctionDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::ClassDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::TSTypeAliasDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::TSInterfaceDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::TSEnumDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::TSModuleDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::TSImportEqualsDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::VariableDeclaration(it) => it.span(),
+            Self::FunctionDeclaration(it) => it.span(),
+            Self::ClassDeclaration(it) => it.span(),
+            Self::TSTypeAliasDeclaration(it) => it.span(),
+            Self::TSInterfaceDeclaration(it) => it.span(),
+            Self::TSEnumDeclaration(it) => it.span(),
+            Self::TSModuleDeclaration(it) => it.span(),
+            Self::TSImportEqualsDeclaration(it) => it.span(),
         }
     }
 }
@@ -755,49 +755,49 @@ impl GetSpan for ForStatement<'_> {
 impl GetSpan for ForStatementInit<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::VariableDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::BooleanLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::NullLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::NumericLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::BigIntLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::RegExpLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::StringLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::TemplateLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::Identifier(it) => GetSpan::span(it.as_ref()),
-            Self::MetaProperty(it) => GetSpan::span(it.as_ref()),
-            Self::Super(it) => GetSpan::span(it.as_ref()),
-            Self::ArrayExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ArrowFunctionExpression(it) => GetSpan::span(it.as_ref()),
-            Self::AssignmentExpression(it) => GetSpan::span(it.as_ref()),
-            Self::AwaitExpression(it) => GetSpan::span(it.as_ref()),
-            Self::BinaryExpression(it) => GetSpan::span(it.as_ref()),
-            Self::CallExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ChainExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ClassExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ConditionalExpression(it) => GetSpan::span(it.as_ref()),
-            Self::FunctionExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ImportExpression(it) => GetSpan::span(it.as_ref()),
-            Self::LogicalExpression(it) => GetSpan::span(it.as_ref()),
-            Self::NewExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ObjectExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ParenthesizedExpression(it) => GetSpan::span(it.as_ref()),
-            Self::SequenceExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TaggedTemplateExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ThisExpression(it) => GetSpan::span(it.as_ref()),
-            Self::UnaryExpression(it) => GetSpan::span(it.as_ref()),
-            Self::UpdateExpression(it) => GetSpan::span(it.as_ref()),
-            Self::YieldExpression(it) => GetSpan::span(it.as_ref()),
-            Self::PrivateInExpression(it) => GetSpan::span(it.as_ref()),
-            Self::JSXElement(it) => GetSpan::span(it.as_ref()),
-            Self::JSXFragment(it) => GetSpan::span(it.as_ref()),
-            Self::TSAsExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSSatisfiesExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSTypeAssertion(it) => GetSpan::span(it.as_ref()),
-            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSInstantiationExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
+            Self::VariableDeclaration(it) => it.span(),
+            Self::BooleanLiteral(it) => it.span(),
+            Self::NullLiteral(it) => it.span(),
+            Self::NumericLiteral(it) => it.span(),
+            Self::BigIntLiteral(it) => it.span(),
+            Self::RegExpLiteral(it) => it.span(),
+            Self::StringLiteral(it) => it.span(),
+            Self::TemplateLiteral(it) => it.span(),
+            Self::Identifier(it) => it.span(),
+            Self::MetaProperty(it) => it.span(),
+            Self::Super(it) => it.span(),
+            Self::ArrayExpression(it) => it.span(),
+            Self::ArrowFunctionExpression(it) => it.span(),
+            Self::AssignmentExpression(it) => it.span(),
+            Self::AwaitExpression(it) => it.span(),
+            Self::BinaryExpression(it) => it.span(),
+            Self::CallExpression(it) => it.span(),
+            Self::ChainExpression(it) => it.span(),
+            Self::ClassExpression(it) => it.span(),
+            Self::ConditionalExpression(it) => it.span(),
+            Self::FunctionExpression(it) => it.span(),
+            Self::ImportExpression(it) => it.span(),
+            Self::LogicalExpression(it) => it.span(),
+            Self::NewExpression(it) => it.span(),
+            Self::ObjectExpression(it) => it.span(),
+            Self::ParenthesizedExpression(it) => it.span(),
+            Self::SequenceExpression(it) => it.span(),
+            Self::TaggedTemplateExpression(it) => it.span(),
+            Self::ThisExpression(it) => it.span(),
+            Self::UnaryExpression(it) => it.span(),
+            Self::UpdateExpression(it) => it.span(),
+            Self::YieldExpression(it) => it.span(),
+            Self::PrivateInExpression(it) => it.span(),
+            Self::JSXElement(it) => it.span(),
+            Self::JSXFragment(it) => it.span(),
+            Self::TSAsExpression(it) => it.span(),
+            Self::TSSatisfiesExpression(it) => it.span(),
+            Self::TSTypeAssertion(it) => it.span(),
+            Self::TSNonNullExpression(it) => it.span(),
+            Self::TSInstantiationExpression(it) => it.span(),
+            Self::ComputedMemberExpression(it) => it.span(),
+            Self::StaticMemberExpression(it) => it.span(),
+            Self::PrivateFieldExpression(it) => it.span(),
         }
     }
 }
@@ -812,18 +812,18 @@ impl GetSpan for ForInStatement<'_> {
 impl GetSpan for ForStatementLeft<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::VariableDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::AssignmentTargetIdentifier(it) => GetSpan::span(it.as_ref()),
-            Self::TSAsExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSSatisfiesExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSTypeAssertion(it) => GetSpan::span(it.as_ref()),
-            Self::TSInstantiationExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ArrayAssignmentTarget(it) => GetSpan::span(it.as_ref()),
-            Self::ObjectAssignmentTarget(it) => GetSpan::span(it.as_ref()),
+            Self::VariableDeclaration(it) => it.span(),
+            Self::AssignmentTargetIdentifier(it) => it.span(),
+            Self::TSAsExpression(it) => it.span(),
+            Self::TSSatisfiesExpression(it) => it.span(),
+            Self::TSNonNullExpression(it) => it.span(),
+            Self::TSTypeAssertion(it) => it.span(),
+            Self::TSInstantiationExpression(it) => it.span(),
+            Self::ComputedMemberExpression(it) => it.span(),
+            Self::StaticMemberExpression(it) => it.span(),
+            Self::PrivateFieldExpression(it) => it.span(),
+            Self::ArrayAssignmentTarget(it) => it.span(),
+            Self::ObjectAssignmentTarget(it) => it.span(),
         }
     }
 }
@@ -922,17 +922,17 @@ impl GetSpan for DebuggerStatement {
 impl GetSpan for BindingPattern<'_> {
     #[inline]
     fn span(&self) -> Span {
-        GetSpan::span(&self.kind)
+        self.kind.span()
     }
 }
 
 impl GetSpan for BindingPatternKind<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::BindingIdentifier(it) => GetSpan::span(it.as_ref()),
-            Self::ObjectPattern(it) => GetSpan::span(it.as_ref()),
-            Self::ArrayPattern(it) => GetSpan::span(it.as_ref()),
-            Self::AssignmentPattern(it) => GetSpan::span(it.as_ref()),
+            Self::BindingIdentifier(it) => it.span(),
+            Self::ObjectPattern(it) => it.span(),
+            Self::ArrayPattern(it) => it.span(),
+            Self::AssignmentPattern(it) => it.span(),
         }
     }
 }
@@ -1031,11 +1031,11 @@ impl GetSpan for ClassBody<'_> {
 impl GetSpan for ClassElement<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::StaticBlock(it) => GetSpan::span(it.as_ref()),
-            Self::MethodDefinition(it) => GetSpan::span(it.as_ref()),
-            Self::PropertyDefinition(it) => GetSpan::span(it.as_ref()),
-            Self::AccessorProperty(it) => GetSpan::span(it.as_ref()),
-            Self::TSIndexSignature(it) => GetSpan::span(it.as_ref()),
+            Self::StaticBlock(it) => it.span(),
+            Self::MethodDefinition(it) => it.span(),
+            Self::PropertyDefinition(it) => it.span(),
+            Self::AccessorProperty(it) => it.span(),
+            Self::TSIndexSignature(it) => it.span(),
         }
     }
 }
@@ -1071,12 +1071,12 @@ impl GetSpan for StaticBlock<'_> {
 impl GetSpan for ModuleDeclaration<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::ImportDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::ExportAllDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::ExportDefaultDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::ExportNamedDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::TSExportAssignment(it) => GetSpan::span(it.as_ref()),
-            Self::TSNamespaceExportDeclaration(it) => GetSpan::span(it.as_ref()),
+            Self::ImportDeclaration(it) => it.span(),
+            Self::ExportAllDeclaration(it) => it.span(),
+            Self::ExportDefaultDeclaration(it) => it.span(),
+            Self::ExportNamedDeclaration(it) => it.span(),
+            Self::TSExportAssignment(it) => it.span(),
+            Self::TSNamespaceExportDeclaration(it) => it.span(),
         }
     }
 }
@@ -1105,9 +1105,9 @@ impl GetSpan for ImportDeclaration<'_> {
 impl GetSpan for ImportDeclarationSpecifier<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::ImportSpecifier(it) => GetSpan::span(it.as_ref()),
-            Self::ImportDefaultSpecifier(it) => GetSpan::span(it.as_ref()),
-            Self::ImportNamespaceSpecifier(it) => GetSpan::span(it.as_ref()),
+            Self::ImportSpecifier(it) => it.span(),
+            Self::ImportDefaultSpecifier(it) => it.span(),
+            Self::ImportNamespaceSpecifier(it) => it.span(),
         }
     }
 }
@@ -1150,8 +1150,8 @@ impl GetSpan for ImportAttribute<'_> {
 impl GetSpan for ImportAttributeKey<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::Identifier(it) => GetSpan::span(it),
-            Self::StringLiteral(it) => GetSpan::span(it),
+            Self::Identifier(it) => it.span(),
+            Self::StringLiteral(it) => it.span(),
         }
     }
 }
@@ -1187,51 +1187,51 @@ impl GetSpan for ExportSpecifier<'_> {
 impl GetSpan for ExportDefaultDeclarationKind<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::FunctionDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::ClassDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::TSInterfaceDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::BooleanLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::NullLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::NumericLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::BigIntLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::RegExpLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::StringLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::TemplateLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::Identifier(it) => GetSpan::span(it.as_ref()),
-            Self::MetaProperty(it) => GetSpan::span(it.as_ref()),
-            Self::Super(it) => GetSpan::span(it.as_ref()),
-            Self::ArrayExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ArrowFunctionExpression(it) => GetSpan::span(it.as_ref()),
-            Self::AssignmentExpression(it) => GetSpan::span(it.as_ref()),
-            Self::AwaitExpression(it) => GetSpan::span(it.as_ref()),
-            Self::BinaryExpression(it) => GetSpan::span(it.as_ref()),
-            Self::CallExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ChainExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ClassExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ConditionalExpression(it) => GetSpan::span(it.as_ref()),
-            Self::FunctionExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ImportExpression(it) => GetSpan::span(it.as_ref()),
-            Self::LogicalExpression(it) => GetSpan::span(it.as_ref()),
-            Self::NewExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ObjectExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ParenthesizedExpression(it) => GetSpan::span(it.as_ref()),
-            Self::SequenceExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TaggedTemplateExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ThisExpression(it) => GetSpan::span(it.as_ref()),
-            Self::UnaryExpression(it) => GetSpan::span(it.as_ref()),
-            Self::UpdateExpression(it) => GetSpan::span(it.as_ref()),
-            Self::YieldExpression(it) => GetSpan::span(it.as_ref()),
-            Self::PrivateInExpression(it) => GetSpan::span(it.as_ref()),
-            Self::JSXElement(it) => GetSpan::span(it.as_ref()),
-            Self::JSXFragment(it) => GetSpan::span(it.as_ref()),
-            Self::TSAsExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSSatisfiesExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSTypeAssertion(it) => GetSpan::span(it.as_ref()),
-            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSInstantiationExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
+            Self::FunctionDeclaration(it) => it.span(),
+            Self::ClassDeclaration(it) => it.span(),
+            Self::TSInterfaceDeclaration(it) => it.span(),
+            Self::BooleanLiteral(it) => it.span(),
+            Self::NullLiteral(it) => it.span(),
+            Self::NumericLiteral(it) => it.span(),
+            Self::BigIntLiteral(it) => it.span(),
+            Self::RegExpLiteral(it) => it.span(),
+            Self::StringLiteral(it) => it.span(),
+            Self::TemplateLiteral(it) => it.span(),
+            Self::Identifier(it) => it.span(),
+            Self::MetaProperty(it) => it.span(),
+            Self::Super(it) => it.span(),
+            Self::ArrayExpression(it) => it.span(),
+            Self::ArrowFunctionExpression(it) => it.span(),
+            Self::AssignmentExpression(it) => it.span(),
+            Self::AwaitExpression(it) => it.span(),
+            Self::BinaryExpression(it) => it.span(),
+            Self::CallExpression(it) => it.span(),
+            Self::ChainExpression(it) => it.span(),
+            Self::ClassExpression(it) => it.span(),
+            Self::ConditionalExpression(it) => it.span(),
+            Self::FunctionExpression(it) => it.span(),
+            Self::ImportExpression(it) => it.span(),
+            Self::LogicalExpression(it) => it.span(),
+            Self::NewExpression(it) => it.span(),
+            Self::ObjectExpression(it) => it.span(),
+            Self::ParenthesizedExpression(it) => it.span(),
+            Self::SequenceExpression(it) => it.span(),
+            Self::TaggedTemplateExpression(it) => it.span(),
+            Self::ThisExpression(it) => it.span(),
+            Self::UnaryExpression(it) => it.span(),
+            Self::UpdateExpression(it) => it.span(),
+            Self::YieldExpression(it) => it.span(),
+            Self::PrivateInExpression(it) => it.span(),
+            Self::JSXElement(it) => it.span(),
+            Self::JSXFragment(it) => it.span(),
+            Self::TSAsExpression(it) => it.span(),
+            Self::TSSatisfiesExpression(it) => it.span(),
+            Self::TSTypeAssertion(it) => it.span(),
+            Self::TSNonNullExpression(it) => it.span(),
+            Self::TSInstantiationExpression(it) => it.span(),
+            Self::ComputedMemberExpression(it) => it.span(),
+            Self::StaticMemberExpression(it) => it.span(),
+            Self::PrivateFieldExpression(it) => it.span(),
         }
     }
 }
@@ -1239,9 +1239,9 @@ impl GetSpan for ExportDefaultDeclarationKind<'_> {
 impl GetSpan for ModuleExportName<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::IdentifierName(it) => GetSpan::span(it),
-            Self::IdentifierReference(it) => GetSpan::span(it),
-            Self::StringLiteral(it) => GetSpan::span(it),
+            Self::IdentifierName(it) => it.span(),
+            Self::IdentifierReference(it) => it.span(),
+            Self::StringLiteral(it) => it.span(),
         }
     }
 }
@@ -1270,8 +1270,8 @@ impl GetSpan for TSEnumMember<'_> {
 impl GetSpan for TSEnumMemberName<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::Identifier(it) => GetSpan::span(it.as_ref()),
-            Self::String(it) => GetSpan::span(it.as_ref()),
+            Self::Identifier(it) => it.span(),
+            Self::String(it) => it.span(),
         }
     }
 }
@@ -1293,14 +1293,14 @@ impl GetSpan for TSLiteralType<'_> {
 impl GetSpan for TSLiteral<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::BooleanLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::NullLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::NumericLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::BigIntLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::RegExpLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::StringLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::TemplateLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::UnaryExpression(it) => GetSpan::span(it.as_ref()),
+            Self::BooleanLiteral(it) => it.span(),
+            Self::NullLiteral(it) => it.span(),
+            Self::NumericLiteral(it) => it.span(),
+            Self::BigIntLiteral(it) => it.span(),
+            Self::RegExpLiteral(it) => it.span(),
+            Self::StringLiteral(it) => it.span(),
+            Self::TemplateLiteral(it) => it.span(),
+            Self::UnaryExpression(it) => it.span(),
         }
     }
 }
@@ -1308,44 +1308,44 @@ impl GetSpan for TSLiteral<'_> {
 impl GetSpan for TSType<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::TSAnyKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSBigIntKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSBooleanKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSIntrinsicKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSNeverKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSNullKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSNumberKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSObjectKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSStringKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSSymbolKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSUndefinedKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSUnknownKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSVoidKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSArrayType(it) => GetSpan::span(it.as_ref()),
-            Self::TSConditionalType(it) => GetSpan::span(it.as_ref()),
-            Self::TSConstructorType(it) => GetSpan::span(it.as_ref()),
-            Self::TSFunctionType(it) => GetSpan::span(it.as_ref()),
-            Self::TSImportType(it) => GetSpan::span(it.as_ref()),
-            Self::TSIndexedAccessType(it) => GetSpan::span(it.as_ref()),
-            Self::TSInferType(it) => GetSpan::span(it.as_ref()),
-            Self::TSIntersectionType(it) => GetSpan::span(it.as_ref()),
-            Self::TSLiteralType(it) => GetSpan::span(it.as_ref()),
-            Self::TSMappedType(it) => GetSpan::span(it.as_ref()),
-            Self::TSNamedTupleMember(it) => GetSpan::span(it.as_ref()),
-            Self::TSQualifiedName(it) => GetSpan::span(it.as_ref()),
-            Self::TSTemplateLiteralType(it) => GetSpan::span(it.as_ref()),
-            Self::TSThisType(it) => GetSpan::span(it.as_ref()),
-            Self::TSTupleType(it) => GetSpan::span(it.as_ref()),
-            Self::TSTypeLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::TSTypeOperatorType(it) => GetSpan::span(it.as_ref()),
-            Self::TSTypePredicate(it) => GetSpan::span(it.as_ref()),
-            Self::TSTypeQuery(it) => GetSpan::span(it.as_ref()),
-            Self::TSTypeReference(it) => GetSpan::span(it.as_ref()),
-            Self::TSUnionType(it) => GetSpan::span(it.as_ref()),
-            Self::TSParenthesizedType(it) => GetSpan::span(it.as_ref()),
-            Self::JSDocNullableType(it) => GetSpan::span(it.as_ref()),
-            Self::JSDocNonNullableType(it) => GetSpan::span(it.as_ref()),
-            Self::JSDocUnknownType(it) => GetSpan::span(it.as_ref()),
+            Self::TSAnyKeyword(it) => it.span(),
+            Self::TSBigIntKeyword(it) => it.span(),
+            Self::TSBooleanKeyword(it) => it.span(),
+            Self::TSIntrinsicKeyword(it) => it.span(),
+            Self::TSNeverKeyword(it) => it.span(),
+            Self::TSNullKeyword(it) => it.span(),
+            Self::TSNumberKeyword(it) => it.span(),
+            Self::TSObjectKeyword(it) => it.span(),
+            Self::TSStringKeyword(it) => it.span(),
+            Self::TSSymbolKeyword(it) => it.span(),
+            Self::TSUndefinedKeyword(it) => it.span(),
+            Self::TSUnknownKeyword(it) => it.span(),
+            Self::TSVoidKeyword(it) => it.span(),
+            Self::TSArrayType(it) => it.span(),
+            Self::TSConditionalType(it) => it.span(),
+            Self::TSConstructorType(it) => it.span(),
+            Self::TSFunctionType(it) => it.span(),
+            Self::TSImportType(it) => it.span(),
+            Self::TSIndexedAccessType(it) => it.span(),
+            Self::TSInferType(it) => it.span(),
+            Self::TSIntersectionType(it) => it.span(),
+            Self::TSLiteralType(it) => it.span(),
+            Self::TSMappedType(it) => it.span(),
+            Self::TSNamedTupleMember(it) => it.span(),
+            Self::TSQualifiedName(it) => it.span(),
+            Self::TSTemplateLiteralType(it) => it.span(),
+            Self::TSThisType(it) => it.span(),
+            Self::TSTupleType(it) => it.span(),
+            Self::TSTypeLiteral(it) => it.span(),
+            Self::TSTypeOperatorType(it) => it.span(),
+            Self::TSTypePredicate(it) => it.span(),
+            Self::TSTypeQuery(it) => it.span(),
+            Self::TSTypeReference(it) => it.span(),
+            Self::TSUnionType(it) => it.span(),
+            Self::TSParenthesizedType(it) => it.span(),
+            Self::JSDocNullableType(it) => it.span(),
+            Self::JSDocNonNullableType(it) => it.span(),
+            Self::JSDocUnknownType(it) => it.span(),
         }
     }
 }
@@ -1430,46 +1430,46 @@ impl GetSpan for TSRestType<'_> {
 impl GetSpan for TSTupleElement<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::TSOptionalType(it) => GetSpan::span(it.as_ref()),
-            Self::TSRestType(it) => GetSpan::span(it.as_ref()),
-            Self::TSAnyKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSBigIntKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSBooleanKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSIntrinsicKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSNeverKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSNullKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSNumberKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSObjectKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSStringKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSSymbolKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSUndefinedKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSUnknownKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSVoidKeyword(it) => GetSpan::span(it.as_ref()),
-            Self::TSArrayType(it) => GetSpan::span(it.as_ref()),
-            Self::TSConditionalType(it) => GetSpan::span(it.as_ref()),
-            Self::TSConstructorType(it) => GetSpan::span(it.as_ref()),
-            Self::TSFunctionType(it) => GetSpan::span(it.as_ref()),
-            Self::TSImportType(it) => GetSpan::span(it.as_ref()),
-            Self::TSIndexedAccessType(it) => GetSpan::span(it.as_ref()),
-            Self::TSInferType(it) => GetSpan::span(it.as_ref()),
-            Self::TSIntersectionType(it) => GetSpan::span(it.as_ref()),
-            Self::TSLiteralType(it) => GetSpan::span(it.as_ref()),
-            Self::TSMappedType(it) => GetSpan::span(it.as_ref()),
-            Self::TSNamedTupleMember(it) => GetSpan::span(it.as_ref()),
-            Self::TSQualifiedName(it) => GetSpan::span(it.as_ref()),
-            Self::TSTemplateLiteralType(it) => GetSpan::span(it.as_ref()),
-            Self::TSThisType(it) => GetSpan::span(it.as_ref()),
-            Self::TSTupleType(it) => GetSpan::span(it.as_ref()),
-            Self::TSTypeLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::TSTypeOperatorType(it) => GetSpan::span(it.as_ref()),
-            Self::TSTypePredicate(it) => GetSpan::span(it.as_ref()),
-            Self::TSTypeQuery(it) => GetSpan::span(it.as_ref()),
-            Self::TSTypeReference(it) => GetSpan::span(it.as_ref()),
-            Self::TSUnionType(it) => GetSpan::span(it.as_ref()),
-            Self::TSParenthesizedType(it) => GetSpan::span(it.as_ref()),
-            Self::JSDocNullableType(it) => GetSpan::span(it.as_ref()),
-            Self::JSDocNonNullableType(it) => GetSpan::span(it.as_ref()),
-            Self::JSDocUnknownType(it) => GetSpan::span(it.as_ref()),
+            Self::TSOptionalType(it) => it.span(),
+            Self::TSRestType(it) => it.span(),
+            Self::TSAnyKeyword(it) => it.span(),
+            Self::TSBigIntKeyword(it) => it.span(),
+            Self::TSBooleanKeyword(it) => it.span(),
+            Self::TSIntrinsicKeyword(it) => it.span(),
+            Self::TSNeverKeyword(it) => it.span(),
+            Self::TSNullKeyword(it) => it.span(),
+            Self::TSNumberKeyword(it) => it.span(),
+            Self::TSObjectKeyword(it) => it.span(),
+            Self::TSStringKeyword(it) => it.span(),
+            Self::TSSymbolKeyword(it) => it.span(),
+            Self::TSUndefinedKeyword(it) => it.span(),
+            Self::TSUnknownKeyword(it) => it.span(),
+            Self::TSVoidKeyword(it) => it.span(),
+            Self::TSArrayType(it) => it.span(),
+            Self::TSConditionalType(it) => it.span(),
+            Self::TSConstructorType(it) => it.span(),
+            Self::TSFunctionType(it) => it.span(),
+            Self::TSImportType(it) => it.span(),
+            Self::TSIndexedAccessType(it) => it.span(),
+            Self::TSInferType(it) => it.span(),
+            Self::TSIntersectionType(it) => it.span(),
+            Self::TSLiteralType(it) => it.span(),
+            Self::TSMappedType(it) => it.span(),
+            Self::TSNamedTupleMember(it) => it.span(),
+            Self::TSQualifiedName(it) => it.span(),
+            Self::TSTemplateLiteralType(it) => it.span(),
+            Self::TSThisType(it) => it.span(),
+            Self::TSTupleType(it) => it.span(),
+            Self::TSTypeLiteral(it) => it.span(),
+            Self::TSTypeOperatorType(it) => it.span(),
+            Self::TSTypePredicate(it) => it.span(),
+            Self::TSTypeQuery(it) => it.span(),
+            Self::TSTypeReference(it) => it.span(),
+            Self::TSUnionType(it) => it.span(),
+            Self::TSParenthesizedType(it) => it.span(),
+            Self::JSDocNullableType(it) => it.span(),
+            Self::JSDocNonNullableType(it) => it.span(),
+            Self::JSDocUnknownType(it) => it.span(),
         }
     }
 }
@@ -1582,8 +1582,8 @@ impl GetSpan for TSTypeReference<'_> {
 impl GetSpan for TSTypeName<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::IdentifierReference(it) => GetSpan::span(it.as_ref()),
-            Self::QualifiedName(it) => GetSpan::span(it.as_ref()),
+            Self::IdentifierReference(it) => it.span(),
+            Self::QualifiedName(it) => it.span(),
         }
     }
 }
@@ -1654,11 +1654,11 @@ impl GetSpan for TSPropertySignature<'_> {
 impl GetSpan for TSSignature<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::TSIndexSignature(it) => GetSpan::span(it.as_ref()),
-            Self::TSPropertySignature(it) => GetSpan::span(it.as_ref()),
-            Self::TSCallSignatureDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::TSConstructSignatureDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::TSMethodSignature(it) => GetSpan::span(it.as_ref()),
+            Self::TSIndexSignature(it) => it.span(),
+            Self::TSPropertySignature(it) => it.span(),
+            Self::TSCallSignatureDeclaration(it) => it.span(),
+            Self::TSConstructSignatureDeclaration(it) => it.span(),
+            Self::TSMethodSignature(it) => it.span(),
         }
     }
 }
@@ -1715,8 +1715,8 @@ impl GetSpan for TSTypePredicate<'_> {
 impl GetSpan for TSTypePredicateName<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::Identifier(it) => GetSpan::span(it.as_ref()),
-            Self::This(it) => GetSpan::span(it),
+            Self::Identifier(it) => it.span(),
+            Self::This(it) => it.span(),
         }
     }
 }
@@ -1731,8 +1731,8 @@ impl GetSpan for TSModuleDeclaration<'_> {
 impl GetSpan for TSModuleDeclarationName<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::Identifier(it) => GetSpan::span(it),
-            Self::StringLiteral(it) => GetSpan::span(it),
+            Self::Identifier(it) => it.span(),
+            Self::StringLiteral(it) => it.span(),
         }
     }
 }
@@ -1740,8 +1740,8 @@ impl GetSpan for TSModuleDeclarationName<'_> {
 impl GetSpan for TSModuleDeclarationBody<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::TSModuleDeclaration(it) => GetSpan::span(it.as_ref()),
-            Self::TSModuleBlock(it) => GetSpan::span(it.as_ref()),
+            Self::TSModuleDeclaration(it) => it.span(),
+            Self::TSModuleBlock(it) => it.span(),
         }
     }
 }
@@ -1777,9 +1777,9 @@ impl GetSpan for TSTypeQuery<'_> {
 impl GetSpan for TSTypeQueryExprName<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::TSImportType(it) => GetSpan::span(it.as_ref()),
-            Self::IdentifierReference(it) => GetSpan::span(it.as_ref()),
-            Self::QualifiedName(it) => GetSpan::span(it.as_ref()),
+            Self::TSImportType(it) => it.span(),
+            Self::IdentifierReference(it) => it.span(),
+            Self::QualifiedName(it) => it.span(),
         }
     }
 }
@@ -1808,8 +1808,8 @@ impl GetSpan for TSImportAttribute<'_> {
 impl GetSpan for TSImportAttributeName<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::Identifier(it) => GetSpan::span(it),
-            Self::StringLiteral(it) => GetSpan::span(it),
+            Self::Identifier(it) => it.span(),
+            Self::StringLiteral(it) => it.span(),
         }
     }
 }
@@ -1873,9 +1873,9 @@ impl GetSpan for TSImportEqualsDeclaration<'_> {
 impl GetSpan for TSModuleReference<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::ExternalModuleReference(it) => GetSpan::span(it.as_ref()),
-            Self::IdentifierReference(it) => GetSpan::span(it.as_ref()),
-            Self::QualifiedName(it) => GetSpan::span(it.as_ref()),
+            Self::ExternalModuleReference(it) => it.span(),
+            Self::IdentifierReference(it) => it.span(),
+            Self::QualifiedName(it) => it.span(),
         }
     }
 }
@@ -1988,11 +1988,11 @@ impl GetSpan for JSXClosingFragment {
 impl GetSpan for JSXElementName<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::Identifier(it) => GetSpan::span(it.as_ref()),
-            Self::IdentifierReference(it) => GetSpan::span(it.as_ref()),
-            Self::NamespacedName(it) => GetSpan::span(it.as_ref()),
-            Self::MemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ThisExpression(it) => GetSpan::span(it.as_ref()),
+            Self::Identifier(it) => it.span(),
+            Self::IdentifierReference(it) => it.span(),
+            Self::NamespacedName(it) => it.span(),
+            Self::MemberExpression(it) => it.span(),
+            Self::ThisExpression(it) => it.span(),
         }
     }
 }
@@ -2014,9 +2014,9 @@ impl GetSpan for JSXMemberExpression<'_> {
 impl GetSpan for JSXMemberExpressionObject<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::IdentifierReference(it) => GetSpan::span(it.as_ref()),
-            Self::MemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ThisExpression(it) => GetSpan::span(it.as_ref()),
+            Self::IdentifierReference(it) => it.span(),
+            Self::MemberExpression(it) => it.span(),
+            Self::ThisExpression(it) => it.span(),
         }
     }
 }
@@ -2031,49 +2031,49 @@ impl GetSpan for JSXExpressionContainer<'_> {
 impl GetSpan for JSXExpression<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::EmptyExpression(it) => GetSpan::span(it),
-            Self::BooleanLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::NullLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::NumericLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::BigIntLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::RegExpLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::StringLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::TemplateLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::Identifier(it) => GetSpan::span(it.as_ref()),
-            Self::MetaProperty(it) => GetSpan::span(it.as_ref()),
-            Self::Super(it) => GetSpan::span(it.as_ref()),
-            Self::ArrayExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ArrowFunctionExpression(it) => GetSpan::span(it.as_ref()),
-            Self::AssignmentExpression(it) => GetSpan::span(it.as_ref()),
-            Self::AwaitExpression(it) => GetSpan::span(it.as_ref()),
-            Self::BinaryExpression(it) => GetSpan::span(it.as_ref()),
-            Self::CallExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ChainExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ClassExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ConditionalExpression(it) => GetSpan::span(it.as_ref()),
-            Self::FunctionExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ImportExpression(it) => GetSpan::span(it.as_ref()),
-            Self::LogicalExpression(it) => GetSpan::span(it.as_ref()),
-            Self::NewExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ObjectExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ParenthesizedExpression(it) => GetSpan::span(it.as_ref()),
-            Self::SequenceExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TaggedTemplateExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ThisExpression(it) => GetSpan::span(it.as_ref()),
-            Self::UnaryExpression(it) => GetSpan::span(it.as_ref()),
-            Self::UpdateExpression(it) => GetSpan::span(it.as_ref()),
-            Self::YieldExpression(it) => GetSpan::span(it.as_ref()),
-            Self::PrivateInExpression(it) => GetSpan::span(it.as_ref()),
-            Self::JSXElement(it) => GetSpan::span(it.as_ref()),
-            Self::JSXFragment(it) => GetSpan::span(it.as_ref()),
-            Self::TSAsExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSSatisfiesExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSTypeAssertion(it) => GetSpan::span(it.as_ref()),
-            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSInstantiationExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
+            Self::EmptyExpression(it) => it.span(),
+            Self::BooleanLiteral(it) => it.span(),
+            Self::NullLiteral(it) => it.span(),
+            Self::NumericLiteral(it) => it.span(),
+            Self::BigIntLiteral(it) => it.span(),
+            Self::RegExpLiteral(it) => it.span(),
+            Self::StringLiteral(it) => it.span(),
+            Self::TemplateLiteral(it) => it.span(),
+            Self::Identifier(it) => it.span(),
+            Self::MetaProperty(it) => it.span(),
+            Self::Super(it) => it.span(),
+            Self::ArrayExpression(it) => it.span(),
+            Self::ArrowFunctionExpression(it) => it.span(),
+            Self::AssignmentExpression(it) => it.span(),
+            Self::AwaitExpression(it) => it.span(),
+            Self::BinaryExpression(it) => it.span(),
+            Self::CallExpression(it) => it.span(),
+            Self::ChainExpression(it) => it.span(),
+            Self::ClassExpression(it) => it.span(),
+            Self::ConditionalExpression(it) => it.span(),
+            Self::FunctionExpression(it) => it.span(),
+            Self::ImportExpression(it) => it.span(),
+            Self::LogicalExpression(it) => it.span(),
+            Self::NewExpression(it) => it.span(),
+            Self::ObjectExpression(it) => it.span(),
+            Self::ParenthesizedExpression(it) => it.span(),
+            Self::SequenceExpression(it) => it.span(),
+            Self::TaggedTemplateExpression(it) => it.span(),
+            Self::ThisExpression(it) => it.span(),
+            Self::UnaryExpression(it) => it.span(),
+            Self::UpdateExpression(it) => it.span(),
+            Self::YieldExpression(it) => it.span(),
+            Self::PrivateInExpression(it) => it.span(),
+            Self::JSXElement(it) => it.span(),
+            Self::JSXFragment(it) => it.span(),
+            Self::TSAsExpression(it) => it.span(),
+            Self::TSSatisfiesExpression(it) => it.span(),
+            Self::TSTypeAssertion(it) => it.span(),
+            Self::TSNonNullExpression(it) => it.span(),
+            Self::TSInstantiationExpression(it) => it.span(),
+            Self::ComputedMemberExpression(it) => it.span(),
+            Self::StaticMemberExpression(it) => it.span(),
+            Self::PrivateFieldExpression(it) => it.span(),
         }
     }
 }
@@ -2088,8 +2088,8 @@ impl GetSpan for JSXEmptyExpression {
 impl GetSpan for JSXAttributeItem<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::Attribute(it) => GetSpan::span(it.as_ref()),
-            Self::SpreadAttribute(it) => GetSpan::span(it.as_ref()),
+            Self::Attribute(it) => it.span(),
+            Self::SpreadAttribute(it) => it.span(),
         }
     }
 }
@@ -2111,8 +2111,8 @@ impl GetSpan for JSXSpreadAttribute<'_> {
 impl GetSpan for JSXAttributeName<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::Identifier(it) => GetSpan::span(it.as_ref()),
-            Self::NamespacedName(it) => GetSpan::span(it.as_ref()),
+            Self::Identifier(it) => it.span(),
+            Self::NamespacedName(it) => it.span(),
         }
     }
 }
@@ -2120,10 +2120,10 @@ impl GetSpan for JSXAttributeName<'_> {
 impl GetSpan for JSXAttributeValue<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::StringLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::ExpressionContainer(it) => GetSpan::span(it.as_ref()),
-            Self::Element(it) => GetSpan::span(it.as_ref()),
-            Self::Fragment(it) => GetSpan::span(it.as_ref()),
+            Self::StringLiteral(it) => it.span(),
+            Self::ExpressionContainer(it) => it.span(),
+            Self::Element(it) => it.span(),
+            Self::Fragment(it) => it.span(),
         }
     }
 }
@@ -2138,11 +2138,11 @@ impl GetSpan for JSXIdentifier<'_> {
 impl GetSpan for JSXChild<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::Text(it) => GetSpan::span(it.as_ref()),
-            Self::Element(it) => GetSpan::span(it.as_ref()),
-            Self::Fragment(it) => GetSpan::span(it.as_ref()),
-            Self::ExpressionContainer(it) => GetSpan::span(it.as_ref()),
-            Self::Spread(it) => GetSpan::span(it.as_ref()),
+            Self::Text(it) => it.span(),
+            Self::Element(it) => it.span(),
+            Self::Fragment(it) => it.span(),
+            Self::ExpressionContainer(it) => it.span(),
+            Self::Spread(it) => it.span(),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_get_span_mut.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span_mut.rs
@@ -62,48 +62,48 @@ impl GetSpanMut for Program<'_> {
 impl GetSpanMut for Expression<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::BooleanLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NullLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NumericLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::BigIntLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::RegExpLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::StringLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TemplateLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::MetaProperty(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Super(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ArrayExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ArrowFunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::AssignmentExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::AwaitExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::BinaryExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::CallExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ChainExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ClassExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ConditionalExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::FunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ImportExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::LogicalExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NewExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ObjectExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ParenthesizedExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::SequenceExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TaggedTemplateExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::UnaryExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::UpdateExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::YieldExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::PrivateInExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::JSXElement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::JSXFragment(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSAsExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSSatisfiesExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTypeAssertion(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSInstantiationExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BooleanLiteral(it) => it.span_mut(),
+            Self::NullLiteral(it) => it.span_mut(),
+            Self::NumericLiteral(it) => it.span_mut(),
+            Self::BigIntLiteral(it) => it.span_mut(),
+            Self::RegExpLiteral(it) => it.span_mut(),
+            Self::StringLiteral(it) => it.span_mut(),
+            Self::TemplateLiteral(it) => it.span_mut(),
+            Self::Identifier(it) => it.span_mut(),
+            Self::MetaProperty(it) => it.span_mut(),
+            Self::Super(it) => it.span_mut(),
+            Self::ArrayExpression(it) => it.span_mut(),
+            Self::ArrowFunctionExpression(it) => it.span_mut(),
+            Self::AssignmentExpression(it) => it.span_mut(),
+            Self::AwaitExpression(it) => it.span_mut(),
+            Self::BinaryExpression(it) => it.span_mut(),
+            Self::CallExpression(it) => it.span_mut(),
+            Self::ChainExpression(it) => it.span_mut(),
+            Self::ClassExpression(it) => it.span_mut(),
+            Self::ConditionalExpression(it) => it.span_mut(),
+            Self::FunctionExpression(it) => it.span_mut(),
+            Self::ImportExpression(it) => it.span_mut(),
+            Self::LogicalExpression(it) => it.span_mut(),
+            Self::NewExpression(it) => it.span_mut(),
+            Self::ObjectExpression(it) => it.span_mut(),
+            Self::ParenthesizedExpression(it) => it.span_mut(),
+            Self::SequenceExpression(it) => it.span_mut(),
+            Self::TaggedTemplateExpression(it) => it.span_mut(),
+            Self::ThisExpression(it) => it.span_mut(),
+            Self::UnaryExpression(it) => it.span_mut(),
+            Self::UpdateExpression(it) => it.span_mut(),
+            Self::YieldExpression(it) => it.span_mut(),
+            Self::PrivateInExpression(it) => it.span_mut(),
+            Self::JSXElement(it) => it.span_mut(),
+            Self::JSXFragment(it) => it.span_mut(),
+            Self::TSAsExpression(it) => it.span_mut(),
+            Self::TSSatisfiesExpression(it) => it.span_mut(),
+            Self::TSTypeAssertion(it) => it.span_mut(),
+            Self::TSNonNullExpression(it) => it.span_mut(),
+            Self::TSInstantiationExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
         }
     }
 }
@@ -153,50 +153,50 @@ impl GetSpanMut for ArrayExpression<'_> {
 impl GetSpanMut for ArrayExpressionElement<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::SpreadElement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Elision(it) => GetSpanMut::span_mut(it),
-            Self::BooleanLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NullLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NumericLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::BigIntLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::RegExpLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::StringLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TemplateLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::MetaProperty(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Super(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ArrayExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ArrowFunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::AssignmentExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::AwaitExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::BinaryExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::CallExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ChainExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ClassExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ConditionalExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::FunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ImportExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::LogicalExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NewExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ObjectExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ParenthesizedExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::SequenceExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TaggedTemplateExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::UnaryExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::UpdateExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::YieldExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::PrivateInExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::JSXElement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::JSXFragment(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSAsExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSSatisfiesExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTypeAssertion(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSInstantiationExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::SpreadElement(it) => it.span_mut(),
+            Self::Elision(it) => it.span_mut(),
+            Self::BooleanLiteral(it) => it.span_mut(),
+            Self::NullLiteral(it) => it.span_mut(),
+            Self::NumericLiteral(it) => it.span_mut(),
+            Self::BigIntLiteral(it) => it.span_mut(),
+            Self::RegExpLiteral(it) => it.span_mut(),
+            Self::StringLiteral(it) => it.span_mut(),
+            Self::TemplateLiteral(it) => it.span_mut(),
+            Self::Identifier(it) => it.span_mut(),
+            Self::MetaProperty(it) => it.span_mut(),
+            Self::Super(it) => it.span_mut(),
+            Self::ArrayExpression(it) => it.span_mut(),
+            Self::ArrowFunctionExpression(it) => it.span_mut(),
+            Self::AssignmentExpression(it) => it.span_mut(),
+            Self::AwaitExpression(it) => it.span_mut(),
+            Self::BinaryExpression(it) => it.span_mut(),
+            Self::CallExpression(it) => it.span_mut(),
+            Self::ChainExpression(it) => it.span_mut(),
+            Self::ClassExpression(it) => it.span_mut(),
+            Self::ConditionalExpression(it) => it.span_mut(),
+            Self::FunctionExpression(it) => it.span_mut(),
+            Self::ImportExpression(it) => it.span_mut(),
+            Self::LogicalExpression(it) => it.span_mut(),
+            Self::NewExpression(it) => it.span_mut(),
+            Self::ObjectExpression(it) => it.span_mut(),
+            Self::ParenthesizedExpression(it) => it.span_mut(),
+            Self::SequenceExpression(it) => it.span_mut(),
+            Self::TaggedTemplateExpression(it) => it.span_mut(),
+            Self::ThisExpression(it) => it.span_mut(),
+            Self::UnaryExpression(it) => it.span_mut(),
+            Self::UpdateExpression(it) => it.span_mut(),
+            Self::YieldExpression(it) => it.span_mut(),
+            Self::PrivateInExpression(it) => it.span_mut(),
+            Self::JSXElement(it) => it.span_mut(),
+            Self::JSXFragment(it) => it.span_mut(),
+            Self::TSAsExpression(it) => it.span_mut(),
+            Self::TSSatisfiesExpression(it) => it.span_mut(),
+            Self::TSTypeAssertion(it) => it.span_mut(),
+            Self::TSNonNullExpression(it) => it.span_mut(),
+            Self::TSInstantiationExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
         }
     }
 }
@@ -218,8 +218,8 @@ impl GetSpanMut for ObjectExpression<'_> {
 impl GetSpanMut for ObjectPropertyKind<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::ObjectProperty(it) => GetSpanMut::span_mut(&mut **it),
-            Self::SpreadProperty(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ObjectProperty(it) => it.span_mut(),
+            Self::SpreadProperty(it) => it.span_mut(),
         }
     }
 }
@@ -234,50 +234,50 @@ impl GetSpanMut for ObjectProperty<'_> {
 impl GetSpanMut for PropertyKey<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::StaticIdentifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::PrivateIdentifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::BooleanLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NullLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NumericLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::BigIntLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::RegExpLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::StringLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TemplateLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::MetaProperty(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Super(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ArrayExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ArrowFunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::AssignmentExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::AwaitExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::BinaryExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::CallExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ChainExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ClassExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ConditionalExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::FunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ImportExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::LogicalExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NewExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ObjectExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ParenthesizedExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::SequenceExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TaggedTemplateExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::UnaryExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::UpdateExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::YieldExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::PrivateInExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::JSXElement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::JSXFragment(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSAsExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSSatisfiesExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTypeAssertion(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSInstantiationExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StaticIdentifier(it) => it.span_mut(),
+            Self::PrivateIdentifier(it) => it.span_mut(),
+            Self::BooleanLiteral(it) => it.span_mut(),
+            Self::NullLiteral(it) => it.span_mut(),
+            Self::NumericLiteral(it) => it.span_mut(),
+            Self::BigIntLiteral(it) => it.span_mut(),
+            Self::RegExpLiteral(it) => it.span_mut(),
+            Self::StringLiteral(it) => it.span_mut(),
+            Self::TemplateLiteral(it) => it.span_mut(),
+            Self::Identifier(it) => it.span_mut(),
+            Self::MetaProperty(it) => it.span_mut(),
+            Self::Super(it) => it.span_mut(),
+            Self::ArrayExpression(it) => it.span_mut(),
+            Self::ArrowFunctionExpression(it) => it.span_mut(),
+            Self::AssignmentExpression(it) => it.span_mut(),
+            Self::AwaitExpression(it) => it.span_mut(),
+            Self::BinaryExpression(it) => it.span_mut(),
+            Self::CallExpression(it) => it.span_mut(),
+            Self::ChainExpression(it) => it.span_mut(),
+            Self::ClassExpression(it) => it.span_mut(),
+            Self::ConditionalExpression(it) => it.span_mut(),
+            Self::FunctionExpression(it) => it.span_mut(),
+            Self::ImportExpression(it) => it.span_mut(),
+            Self::LogicalExpression(it) => it.span_mut(),
+            Self::NewExpression(it) => it.span_mut(),
+            Self::ObjectExpression(it) => it.span_mut(),
+            Self::ParenthesizedExpression(it) => it.span_mut(),
+            Self::SequenceExpression(it) => it.span_mut(),
+            Self::TaggedTemplateExpression(it) => it.span_mut(),
+            Self::ThisExpression(it) => it.span_mut(),
+            Self::UnaryExpression(it) => it.span_mut(),
+            Self::UpdateExpression(it) => it.span_mut(),
+            Self::YieldExpression(it) => it.span_mut(),
+            Self::PrivateInExpression(it) => it.span_mut(),
+            Self::JSXElement(it) => it.span_mut(),
+            Self::JSXFragment(it) => it.span_mut(),
+            Self::TSAsExpression(it) => it.span_mut(),
+            Self::TSSatisfiesExpression(it) => it.span_mut(),
+            Self::TSTypeAssertion(it) => it.span_mut(),
+            Self::TSNonNullExpression(it) => it.span_mut(),
+            Self::TSInstantiationExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
         }
     }
 }
@@ -306,9 +306,9 @@ impl GetSpanMut for TemplateElement<'_> {
 impl GetSpanMut for MemberExpression<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
         }
     }
 }
@@ -365,49 +365,49 @@ impl GetSpanMut for SpreadElement<'_> {
 impl GetSpanMut for Argument<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::SpreadElement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::BooleanLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NullLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NumericLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::BigIntLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::RegExpLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::StringLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TemplateLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::MetaProperty(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Super(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ArrayExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ArrowFunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::AssignmentExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::AwaitExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::BinaryExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::CallExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ChainExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ClassExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ConditionalExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::FunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ImportExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::LogicalExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NewExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ObjectExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ParenthesizedExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::SequenceExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TaggedTemplateExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::UnaryExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::UpdateExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::YieldExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::PrivateInExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::JSXElement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::JSXFragment(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSAsExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSSatisfiesExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTypeAssertion(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSInstantiationExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::SpreadElement(it) => it.span_mut(),
+            Self::BooleanLiteral(it) => it.span_mut(),
+            Self::NullLiteral(it) => it.span_mut(),
+            Self::NumericLiteral(it) => it.span_mut(),
+            Self::BigIntLiteral(it) => it.span_mut(),
+            Self::RegExpLiteral(it) => it.span_mut(),
+            Self::StringLiteral(it) => it.span_mut(),
+            Self::TemplateLiteral(it) => it.span_mut(),
+            Self::Identifier(it) => it.span_mut(),
+            Self::MetaProperty(it) => it.span_mut(),
+            Self::Super(it) => it.span_mut(),
+            Self::ArrayExpression(it) => it.span_mut(),
+            Self::ArrowFunctionExpression(it) => it.span_mut(),
+            Self::AssignmentExpression(it) => it.span_mut(),
+            Self::AwaitExpression(it) => it.span_mut(),
+            Self::BinaryExpression(it) => it.span_mut(),
+            Self::CallExpression(it) => it.span_mut(),
+            Self::ChainExpression(it) => it.span_mut(),
+            Self::ClassExpression(it) => it.span_mut(),
+            Self::ConditionalExpression(it) => it.span_mut(),
+            Self::FunctionExpression(it) => it.span_mut(),
+            Self::ImportExpression(it) => it.span_mut(),
+            Self::LogicalExpression(it) => it.span_mut(),
+            Self::NewExpression(it) => it.span_mut(),
+            Self::ObjectExpression(it) => it.span_mut(),
+            Self::ParenthesizedExpression(it) => it.span_mut(),
+            Self::SequenceExpression(it) => it.span_mut(),
+            Self::TaggedTemplateExpression(it) => it.span_mut(),
+            Self::ThisExpression(it) => it.span_mut(),
+            Self::UnaryExpression(it) => it.span_mut(),
+            Self::UpdateExpression(it) => it.span_mut(),
+            Self::YieldExpression(it) => it.span_mut(),
+            Self::PrivateInExpression(it) => it.span_mut(),
+            Self::JSXElement(it) => it.span_mut(),
+            Self::JSXFragment(it) => it.span_mut(),
+            Self::TSAsExpression(it) => it.span_mut(),
+            Self::TSSatisfiesExpression(it) => it.span_mut(),
+            Self::TSTypeAssertion(it) => it.span_mut(),
+            Self::TSNonNullExpression(it) => it.span_mut(),
+            Self::TSInstantiationExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
         }
     }
 }
@@ -464,17 +464,17 @@ impl GetSpanMut for AssignmentExpression<'_> {
 impl GetSpanMut for AssignmentTarget<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::AssignmentTargetIdentifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSAsExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSSatisfiesExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTypeAssertion(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSInstantiationExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ArrayAssignmentTarget(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ObjectAssignmentTarget(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AssignmentTargetIdentifier(it) => it.span_mut(),
+            Self::TSAsExpression(it) => it.span_mut(),
+            Self::TSSatisfiesExpression(it) => it.span_mut(),
+            Self::TSNonNullExpression(it) => it.span_mut(),
+            Self::TSTypeAssertion(it) => it.span_mut(),
+            Self::TSInstantiationExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
+            Self::ArrayAssignmentTarget(it) => it.span_mut(),
+            Self::ObjectAssignmentTarget(it) => it.span_mut(),
         }
     }
 }
@@ -482,15 +482,15 @@ impl GetSpanMut for AssignmentTarget<'_> {
 impl GetSpanMut for SimpleAssignmentTarget<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::AssignmentTargetIdentifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSAsExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSSatisfiesExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTypeAssertion(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSInstantiationExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AssignmentTargetIdentifier(it) => it.span_mut(),
+            Self::TSAsExpression(it) => it.span_mut(),
+            Self::TSSatisfiesExpression(it) => it.span_mut(),
+            Self::TSNonNullExpression(it) => it.span_mut(),
+            Self::TSTypeAssertion(it) => it.span_mut(),
+            Self::TSInstantiationExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
         }
     }
 }
@@ -498,8 +498,8 @@ impl GetSpanMut for SimpleAssignmentTarget<'_> {
 impl GetSpanMut for AssignmentTargetPattern<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::ArrayAssignmentTarget(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ObjectAssignmentTarget(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ArrayAssignmentTarget(it) => it.span_mut(),
+            Self::ObjectAssignmentTarget(it) => it.span_mut(),
         }
     }
 }
@@ -528,18 +528,18 @@ impl GetSpanMut for AssignmentTargetRest<'_> {
 impl GetSpanMut for AssignmentTargetMaybeDefault<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::AssignmentTargetWithDefault(it) => GetSpanMut::span_mut(&mut **it),
-            Self::AssignmentTargetIdentifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSAsExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSSatisfiesExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTypeAssertion(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSInstantiationExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ArrayAssignmentTarget(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ObjectAssignmentTarget(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AssignmentTargetWithDefault(it) => it.span_mut(),
+            Self::AssignmentTargetIdentifier(it) => it.span_mut(),
+            Self::TSAsExpression(it) => it.span_mut(),
+            Self::TSSatisfiesExpression(it) => it.span_mut(),
+            Self::TSNonNullExpression(it) => it.span_mut(),
+            Self::TSTypeAssertion(it) => it.span_mut(),
+            Self::TSInstantiationExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
+            Self::ArrayAssignmentTarget(it) => it.span_mut(),
+            Self::ObjectAssignmentTarget(it) => it.span_mut(),
         }
     }
 }
@@ -554,8 +554,8 @@ impl GetSpanMut for AssignmentTargetWithDefault<'_> {
 impl GetSpanMut for AssignmentTargetProperty<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::AssignmentTargetPropertyIdentifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::AssignmentTargetPropertyProperty(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AssignmentTargetPropertyIdentifier(it) => it.span_mut(),
+            Self::AssignmentTargetPropertyProperty(it) => it.span_mut(),
         }
     }
 }
@@ -605,11 +605,11 @@ impl GetSpanMut for ChainExpression<'_> {
 impl GetSpanMut for ChainElement<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::CallExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::CallExpression(it) => it.span_mut(),
+            Self::TSNonNullExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
         }
     }
 }
@@ -624,38 +624,38 @@ impl GetSpanMut for ParenthesizedExpression<'_> {
 impl GetSpanMut for Statement<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::BlockStatement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::BreakStatement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ContinueStatement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::DebuggerStatement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::DoWhileStatement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::EmptyStatement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ExpressionStatement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ForInStatement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ForOfStatement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ForStatement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::IfStatement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::LabeledStatement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ReturnStatement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::SwitchStatement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ThrowStatement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TryStatement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::WhileStatement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::WithStatement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::VariableDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::FunctionDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ClassDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTypeAliasDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSInterfaceDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSEnumDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSModuleDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSImportEqualsDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ImportDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ExportAllDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ExportDefaultDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ExportNamedDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSExportAssignment(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSNamespaceExportDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BlockStatement(it) => it.span_mut(),
+            Self::BreakStatement(it) => it.span_mut(),
+            Self::ContinueStatement(it) => it.span_mut(),
+            Self::DebuggerStatement(it) => it.span_mut(),
+            Self::DoWhileStatement(it) => it.span_mut(),
+            Self::EmptyStatement(it) => it.span_mut(),
+            Self::ExpressionStatement(it) => it.span_mut(),
+            Self::ForInStatement(it) => it.span_mut(),
+            Self::ForOfStatement(it) => it.span_mut(),
+            Self::ForStatement(it) => it.span_mut(),
+            Self::IfStatement(it) => it.span_mut(),
+            Self::LabeledStatement(it) => it.span_mut(),
+            Self::ReturnStatement(it) => it.span_mut(),
+            Self::SwitchStatement(it) => it.span_mut(),
+            Self::ThrowStatement(it) => it.span_mut(),
+            Self::TryStatement(it) => it.span_mut(),
+            Self::WhileStatement(it) => it.span_mut(),
+            Self::WithStatement(it) => it.span_mut(),
+            Self::VariableDeclaration(it) => it.span_mut(),
+            Self::FunctionDeclaration(it) => it.span_mut(),
+            Self::ClassDeclaration(it) => it.span_mut(),
+            Self::TSTypeAliasDeclaration(it) => it.span_mut(),
+            Self::TSInterfaceDeclaration(it) => it.span_mut(),
+            Self::TSEnumDeclaration(it) => it.span_mut(),
+            Self::TSModuleDeclaration(it) => it.span_mut(),
+            Self::TSImportEqualsDeclaration(it) => it.span_mut(),
+            Self::ImportDeclaration(it) => it.span_mut(),
+            Self::ExportAllDeclaration(it) => it.span_mut(),
+            Self::ExportDefaultDeclaration(it) => it.span_mut(),
+            Self::ExportNamedDeclaration(it) => it.span_mut(),
+            Self::TSExportAssignment(it) => it.span_mut(),
+            Self::TSNamespaceExportDeclaration(it) => it.span_mut(),
         }
     }
 }
@@ -684,14 +684,14 @@ impl GetSpanMut for BlockStatement<'_> {
 impl GetSpanMut for Declaration<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::VariableDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::FunctionDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ClassDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTypeAliasDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSInterfaceDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSEnumDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSModuleDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSImportEqualsDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::VariableDeclaration(it) => it.span_mut(),
+            Self::FunctionDeclaration(it) => it.span_mut(),
+            Self::ClassDeclaration(it) => it.span_mut(),
+            Self::TSTypeAliasDeclaration(it) => it.span_mut(),
+            Self::TSInterfaceDeclaration(it) => it.span_mut(),
+            Self::TSEnumDeclaration(it) => it.span_mut(),
+            Self::TSModuleDeclaration(it) => it.span_mut(),
+            Self::TSImportEqualsDeclaration(it) => it.span_mut(),
         }
     }
 }
@@ -755,49 +755,49 @@ impl GetSpanMut for ForStatement<'_> {
 impl GetSpanMut for ForStatementInit<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::VariableDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::BooleanLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NullLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NumericLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::BigIntLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::RegExpLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::StringLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TemplateLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::MetaProperty(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Super(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ArrayExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ArrowFunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::AssignmentExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::AwaitExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::BinaryExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::CallExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ChainExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ClassExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ConditionalExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::FunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ImportExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::LogicalExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NewExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ObjectExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ParenthesizedExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::SequenceExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TaggedTemplateExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::UnaryExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::UpdateExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::YieldExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::PrivateInExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::JSXElement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::JSXFragment(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSAsExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSSatisfiesExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTypeAssertion(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSInstantiationExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::VariableDeclaration(it) => it.span_mut(),
+            Self::BooleanLiteral(it) => it.span_mut(),
+            Self::NullLiteral(it) => it.span_mut(),
+            Self::NumericLiteral(it) => it.span_mut(),
+            Self::BigIntLiteral(it) => it.span_mut(),
+            Self::RegExpLiteral(it) => it.span_mut(),
+            Self::StringLiteral(it) => it.span_mut(),
+            Self::TemplateLiteral(it) => it.span_mut(),
+            Self::Identifier(it) => it.span_mut(),
+            Self::MetaProperty(it) => it.span_mut(),
+            Self::Super(it) => it.span_mut(),
+            Self::ArrayExpression(it) => it.span_mut(),
+            Self::ArrowFunctionExpression(it) => it.span_mut(),
+            Self::AssignmentExpression(it) => it.span_mut(),
+            Self::AwaitExpression(it) => it.span_mut(),
+            Self::BinaryExpression(it) => it.span_mut(),
+            Self::CallExpression(it) => it.span_mut(),
+            Self::ChainExpression(it) => it.span_mut(),
+            Self::ClassExpression(it) => it.span_mut(),
+            Self::ConditionalExpression(it) => it.span_mut(),
+            Self::FunctionExpression(it) => it.span_mut(),
+            Self::ImportExpression(it) => it.span_mut(),
+            Self::LogicalExpression(it) => it.span_mut(),
+            Self::NewExpression(it) => it.span_mut(),
+            Self::ObjectExpression(it) => it.span_mut(),
+            Self::ParenthesizedExpression(it) => it.span_mut(),
+            Self::SequenceExpression(it) => it.span_mut(),
+            Self::TaggedTemplateExpression(it) => it.span_mut(),
+            Self::ThisExpression(it) => it.span_mut(),
+            Self::UnaryExpression(it) => it.span_mut(),
+            Self::UpdateExpression(it) => it.span_mut(),
+            Self::YieldExpression(it) => it.span_mut(),
+            Self::PrivateInExpression(it) => it.span_mut(),
+            Self::JSXElement(it) => it.span_mut(),
+            Self::JSXFragment(it) => it.span_mut(),
+            Self::TSAsExpression(it) => it.span_mut(),
+            Self::TSSatisfiesExpression(it) => it.span_mut(),
+            Self::TSTypeAssertion(it) => it.span_mut(),
+            Self::TSNonNullExpression(it) => it.span_mut(),
+            Self::TSInstantiationExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
         }
     }
 }
@@ -812,18 +812,18 @@ impl GetSpanMut for ForInStatement<'_> {
 impl GetSpanMut for ForStatementLeft<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::VariableDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::AssignmentTargetIdentifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSAsExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSSatisfiesExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTypeAssertion(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSInstantiationExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ArrayAssignmentTarget(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ObjectAssignmentTarget(it) => GetSpanMut::span_mut(&mut **it),
+            Self::VariableDeclaration(it) => it.span_mut(),
+            Self::AssignmentTargetIdentifier(it) => it.span_mut(),
+            Self::TSAsExpression(it) => it.span_mut(),
+            Self::TSSatisfiesExpression(it) => it.span_mut(),
+            Self::TSNonNullExpression(it) => it.span_mut(),
+            Self::TSTypeAssertion(it) => it.span_mut(),
+            Self::TSInstantiationExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
+            Self::ArrayAssignmentTarget(it) => it.span_mut(),
+            Self::ObjectAssignmentTarget(it) => it.span_mut(),
         }
     }
 }
@@ -922,17 +922,17 @@ impl GetSpanMut for DebuggerStatement {
 impl GetSpanMut for BindingPattern<'_> {
     #[inline]
     fn span_mut(&mut self) -> &mut Span {
-        GetSpanMut::span_mut(&mut self.kind)
+        self.kind.span_mut()
     }
 }
 
 impl GetSpanMut for BindingPatternKind<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::BindingIdentifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ObjectPattern(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ArrayPattern(it) => GetSpanMut::span_mut(&mut **it),
-            Self::AssignmentPattern(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BindingIdentifier(it) => it.span_mut(),
+            Self::ObjectPattern(it) => it.span_mut(),
+            Self::ArrayPattern(it) => it.span_mut(),
+            Self::AssignmentPattern(it) => it.span_mut(),
         }
     }
 }
@@ -1031,11 +1031,11 @@ impl GetSpanMut for ClassBody<'_> {
 impl GetSpanMut for ClassElement<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::StaticBlock(it) => GetSpanMut::span_mut(&mut **it),
-            Self::MethodDefinition(it) => GetSpanMut::span_mut(&mut **it),
-            Self::PropertyDefinition(it) => GetSpanMut::span_mut(&mut **it),
-            Self::AccessorProperty(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSIndexSignature(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StaticBlock(it) => it.span_mut(),
+            Self::MethodDefinition(it) => it.span_mut(),
+            Self::PropertyDefinition(it) => it.span_mut(),
+            Self::AccessorProperty(it) => it.span_mut(),
+            Self::TSIndexSignature(it) => it.span_mut(),
         }
     }
 }
@@ -1071,12 +1071,12 @@ impl GetSpanMut for StaticBlock<'_> {
 impl GetSpanMut for ModuleDeclaration<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::ImportDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ExportAllDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ExportDefaultDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ExportNamedDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSExportAssignment(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSNamespaceExportDeclaration(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ImportDeclaration(it) => it.span_mut(),
+            Self::ExportAllDeclaration(it) => it.span_mut(),
+            Self::ExportDefaultDeclaration(it) => it.span_mut(),
+            Self::ExportNamedDeclaration(it) => it.span_mut(),
+            Self::TSExportAssignment(it) => it.span_mut(),
+            Self::TSNamespaceExportDeclaration(it) => it.span_mut(),
         }
     }
 }
@@ -1105,9 +1105,9 @@ impl GetSpanMut for ImportDeclaration<'_> {
 impl GetSpanMut for ImportDeclarationSpecifier<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::ImportSpecifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ImportDefaultSpecifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ImportNamespaceSpecifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ImportSpecifier(it) => it.span_mut(),
+            Self::ImportDefaultSpecifier(it) => it.span_mut(),
+            Self::ImportNamespaceSpecifier(it) => it.span_mut(),
         }
     }
 }
@@ -1150,8 +1150,8 @@ impl GetSpanMut for ImportAttribute<'_> {
 impl GetSpanMut for ImportAttributeKey<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::Identifier(it) => GetSpanMut::span_mut(it),
-            Self::StringLiteral(it) => GetSpanMut::span_mut(it),
+            Self::Identifier(it) => it.span_mut(),
+            Self::StringLiteral(it) => it.span_mut(),
         }
     }
 }
@@ -1187,51 +1187,51 @@ impl GetSpanMut for ExportSpecifier<'_> {
 impl GetSpanMut for ExportDefaultDeclarationKind<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::FunctionDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ClassDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSInterfaceDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::BooleanLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NullLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NumericLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::BigIntLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::RegExpLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::StringLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TemplateLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::MetaProperty(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Super(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ArrayExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ArrowFunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::AssignmentExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::AwaitExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::BinaryExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::CallExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ChainExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ClassExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ConditionalExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::FunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ImportExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::LogicalExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NewExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ObjectExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ParenthesizedExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::SequenceExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TaggedTemplateExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::UnaryExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::UpdateExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::YieldExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::PrivateInExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::JSXElement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::JSXFragment(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSAsExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSSatisfiesExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTypeAssertion(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSInstantiationExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::FunctionDeclaration(it) => it.span_mut(),
+            Self::ClassDeclaration(it) => it.span_mut(),
+            Self::TSInterfaceDeclaration(it) => it.span_mut(),
+            Self::BooleanLiteral(it) => it.span_mut(),
+            Self::NullLiteral(it) => it.span_mut(),
+            Self::NumericLiteral(it) => it.span_mut(),
+            Self::BigIntLiteral(it) => it.span_mut(),
+            Self::RegExpLiteral(it) => it.span_mut(),
+            Self::StringLiteral(it) => it.span_mut(),
+            Self::TemplateLiteral(it) => it.span_mut(),
+            Self::Identifier(it) => it.span_mut(),
+            Self::MetaProperty(it) => it.span_mut(),
+            Self::Super(it) => it.span_mut(),
+            Self::ArrayExpression(it) => it.span_mut(),
+            Self::ArrowFunctionExpression(it) => it.span_mut(),
+            Self::AssignmentExpression(it) => it.span_mut(),
+            Self::AwaitExpression(it) => it.span_mut(),
+            Self::BinaryExpression(it) => it.span_mut(),
+            Self::CallExpression(it) => it.span_mut(),
+            Self::ChainExpression(it) => it.span_mut(),
+            Self::ClassExpression(it) => it.span_mut(),
+            Self::ConditionalExpression(it) => it.span_mut(),
+            Self::FunctionExpression(it) => it.span_mut(),
+            Self::ImportExpression(it) => it.span_mut(),
+            Self::LogicalExpression(it) => it.span_mut(),
+            Self::NewExpression(it) => it.span_mut(),
+            Self::ObjectExpression(it) => it.span_mut(),
+            Self::ParenthesizedExpression(it) => it.span_mut(),
+            Self::SequenceExpression(it) => it.span_mut(),
+            Self::TaggedTemplateExpression(it) => it.span_mut(),
+            Self::ThisExpression(it) => it.span_mut(),
+            Self::UnaryExpression(it) => it.span_mut(),
+            Self::UpdateExpression(it) => it.span_mut(),
+            Self::YieldExpression(it) => it.span_mut(),
+            Self::PrivateInExpression(it) => it.span_mut(),
+            Self::JSXElement(it) => it.span_mut(),
+            Self::JSXFragment(it) => it.span_mut(),
+            Self::TSAsExpression(it) => it.span_mut(),
+            Self::TSSatisfiesExpression(it) => it.span_mut(),
+            Self::TSTypeAssertion(it) => it.span_mut(),
+            Self::TSNonNullExpression(it) => it.span_mut(),
+            Self::TSInstantiationExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
         }
     }
 }
@@ -1239,9 +1239,9 @@ impl GetSpanMut for ExportDefaultDeclarationKind<'_> {
 impl GetSpanMut for ModuleExportName<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::IdentifierName(it) => GetSpanMut::span_mut(it),
-            Self::IdentifierReference(it) => GetSpanMut::span_mut(it),
-            Self::StringLiteral(it) => GetSpanMut::span_mut(it),
+            Self::IdentifierName(it) => it.span_mut(),
+            Self::IdentifierReference(it) => it.span_mut(),
+            Self::StringLiteral(it) => it.span_mut(),
         }
     }
 }
@@ -1270,8 +1270,8 @@ impl GetSpanMut for TSEnumMember<'_> {
 impl GetSpanMut for TSEnumMemberName<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::String(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Identifier(it) => it.span_mut(),
+            Self::String(it) => it.span_mut(),
         }
     }
 }
@@ -1293,14 +1293,14 @@ impl GetSpanMut for TSLiteralType<'_> {
 impl GetSpanMut for TSLiteral<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::BooleanLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NullLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NumericLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::BigIntLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::RegExpLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::StringLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TemplateLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::UnaryExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BooleanLiteral(it) => it.span_mut(),
+            Self::NullLiteral(it) => it.span_mut(),
+            Self::NumericLiteral(it) => it.span_mut(),
+            Self::BigIntLiteral(it) => it.span_mut(),
+            Self::RegExpLiteral(it) => it.span_mut(),
+            Self::StringLiteral(it) => it.span_mut(),
+            Self::TemplateLiteral(it) => it.span_mut(),
+            Self::UnaryExpression(it) => it.span_mut(),
         }
     }
 }
@@ -1308,44 +1308,44 @@ impl GetSpanMut for TSLiteral<'_> {
 impl GetSpanMut for TSType<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::TSAnyKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSBigIntKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSBooleanKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSIntrinsicKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSNeverKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSNullKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSNumberKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSObjectKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSStringKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSSymbolKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSUndefinedKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSUnknownKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSVoidKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSArrayType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSConditionalType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSConstructorType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSFunctionType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSImportType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSIndexedAccessType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSInferType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSIntersectionType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSLiteralType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSMappedType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSNamedTupleMember(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSQualifiedName(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTemplateLiteralType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSThisType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTupleType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTypeLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTypeOperatorType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTypePredicate(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTypeQuery(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTypeReference(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSUnionType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSParenthesizedType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::JSDocNullableType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::JSDocNonNullableType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::JSDocUnknownType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSAnyKeyword(it) => it.span_mut(),
+            Self::TSBigIntKeyword(it) => it.span_mut(),
+            Self::TSBooleanKeyword(it) => it.span_mut(),
+            Self::TSIntrinsicKeyword(it) => it.span_mut(),
+            Self::TSNeverKeyword(it) => it.span_mut(),
+            Self::TSNullKeyword(it) => it.span_mut(),
+            Self::TSNumberKeyword(it) => it.span_mut(),
+            Self::TSObjectKeyword(it) => it.span_mut(),
+            Self::TSStringKeyword(it) => it.span_mut(),
+            Self::TSSymbolKeyword(it) => it.span_mut(),
+            Self::TSUndefinedKeyword(it) => it.span_mut(),
+            Self::TSUnknownKeyword(it) => it.span_mut(),
+            Self::TSVoidKeyword(it) => it.span_mut(),
+            Self::TSArrayType(it) => it.span_mut(),
+            Self::TSConditionalType(it) => it.span_mut(),
+            Self::TSConstructorType(it) => it.span_mut(),
+            Self::TSFunctionType(it) => it.span_mut(),
+            Self::TSImportType(it) => it.span_mut(),
+            Self::TSIndexedAccessType(it) => it.span_mut(),
+            Self::TSInferType(it) => it.span_mut(),
+            Self::TSIntersectionType(it) => it.span_mut(),
+            Self::TSLiteralType(it) => it.span_mut(),
+            Self::TSMappedType(it) => it.span_mut(),
+            Self::TSNamedTupleMember(it) => it.span_mut(),
+            Self::TSQualifiedName(it) => it.span_mut(),
+            Self::TSTemplateLiteralType(it) => it.span_mut(),
+            Self::TSThisType(it) => it.span_mut(),
+            Self::TSTupleType(it) => it.span_mut(),
+            Self::TSTypeLiteral(it) => it.span_mut(),
+            Self::TSTypeOperatorType(it) => it.span_mut(),
+            Self::TSTypePredicate(it) => it.span_mut(),
+            Self::TSTypeQuery(it) => it.span_mut(),
+            Self::TSTypeReference(it) => it.span_mut(),
+            Self::TSUnionType(it) => it.span_mut(),
+            Self::TSParenthesizedType(it) => it.span_mut(),
+            Self::JSDocNullableType(it) => it.span_mut(),
+            Self::JSDocNonNullableType(it) => it.span_mut(),
+            Self::JSDocUnknownType(it) => it.span_mut(),
         }
     }
 }
@@ -1430,46 +1430,46 @@ impl GetSpanMut for TSRestType<'_> {
 impl GetSpanMut for TSTupleElement<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::TSOptionalType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSRestType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSAnyKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSBigIntKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSBooleanKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSIntrinsicKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSNeverKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSNullKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSNumberKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSObjectKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSStringKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSSymbolKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSUndefinedKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSUnknownKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSVoidKeyword(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSArrayType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSConditionalType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSConstructorType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSFunctionType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSImportType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSIndexedAccessType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSInferType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSIntersectionType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSLiteralType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSMappedType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSNamedTupleMember(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSQualifiedName(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTemplateLiteralType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSThisType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTupleType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTypeLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTypeOperatorType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTypePredicate(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTypeQuery(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTypeReference(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSUnionType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSParenthesizedType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::JSDocNullableType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::JSDocNonNullableType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::JSDocUnknownType(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSOptionalType(it) => it.span_mut(),
+            Self::TSRestType(it) => it.span_mut(),
+            Self::TSAnyKeyword(it) => it.span_mut(),
+            Self::TSBigIntKeyword(it) => it.span_mut(),
+            Self::TSBooleanKeyword(it) => it.span_mut(),
+            Self::TSIntrinsicKeyword(it) => it.span_mut(),
+            Self::TSNeverKeyword(it) => it.span_mut(),
+            Self::TSNullKeyword(it) => it.span_mut(),
+            Self::TSNumberKeyword(it) => it.span_mut(),
+            Self::TSObjectKeyword(it) => it.span_mut(),
+            Self::TSStringKeyword(it) => it.span_mut(),
+            Self::TSSymbolKeyword(it) => it.span_mut(),
+            Self::TSUndefinedKeyword(it) => it.span_mut(),
+            Self::TSUnknownKeyword(it) => it.span_mut(),
+            Self::TSVoidKeyword(it) => it.span_mut(),
+            Self::TSArrayType(it) => it.span_mut(),
+            Self::TSConditionalType(it) => it.span_mut(),
+            Self::TSConstructorType(it) => it.span_mut(),
+            Self::TSFunctionType(it) => it.span_mut(),
+            Self::TSImportType(it) => it.span_mut(),
+            Self::TSIndexedAccessType(it) => it.span_mut(),
+            Self::TSInferType(it) => it.span_mut(),
+            Self::TSIntersectionType(it) => it.span_mut(),
+            Self::TSLiteralType(it) => it.span_mut(),
+            Self::TSMappedType(it) => it.span_mut(),
+            Self::TSNamedTupleMember(it) => it.span_mut(),
+            Self::TSQualifiedName(it) => it.span_mut(),
+            Self::TSTemplateLiteralType(it) => it.span_mut(),
+            Self::TSThisType(it) => it.span_mut(),
+            Self::TSTupleType(it) => it.span_mut(),
+            Self::TSTypeLiteral(it) => it.span_mut(),
+            Self::TSTypeOperatorType(it) => it.span_mut(),
+            Self::TSTypePredicate(it) => it.span_mut(),
+            Self::TSTypeQuery(it) => it.span_mut(),
+            Self::TSTypeReference(it) => it.span_mut(),
+            Self::TSUnionType(it) => it.span_mut(),
+            Self::TSParenthesizedType(it) => it.span_mut(),
+            Self::JSDocNullableType(it) => it.span_mut(),
+            Self::JSDocNonNullableType(it) => it.span_mut(),
+            Self::JSDocUnknownType(it) => it.span_mut(),
         }
     }
 }
@@ -1582,8 +1582,8 @@ impl GetSpanMut for TSTypeReference<'_> {
 impl GetSpanMut for TSTypeName<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::IdentifierReference(it) => GetSpanMut::span_mut(&mut **it),
-            Self::QualifiedName(it) => GetSpanMut::span_mut(&mut **it),
+            Self::IdentifierReference(it) => it.span_mut(),
+            Self::QualifiedName(it) => it.span_mut(),
         }
     }
 }
@@ -1654,11 +1654,11 @@ impl GetSpanMut for TSPropertySignature<'_> {
 impl GetSpanMut for TSSignature<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::TSIndexSignature(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSPropertySignature(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSCallSignatureDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSConstructSignatureDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSMethodSignature(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSIndexSignature(it) => it.span_mut(),
+            Self::TSPropertySignature(it) => it.span_mut(),
+            Self::TSCallSignatureDeclaration(it) => it.span_mut(),
+            Self::TSConstructSignatureDeclaration(it) => it.span_mut(),
+            Self::TSMethodSignature(it) => it.span_mut(),
         }
     }
 }
@@ -1715,8 +1715,8 @@ impl GetSpanMut for TSTypePredicate<'_> {
 impl GetSpanMut for TSTypePredicateName<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::This(it) => GetSpanMut::span_mut(it),
+            Self::Identifier(it) => it.span_mut(),
+            Self::This(it) => it.span_mut(),
         }
     }
 }
@@ -1731,8 +1731,8 @@ impl GetSpanMut for TSModuleDeclaration<'_> {
 impl GetSpanMut for TSModuleDeclarationName<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::Identifier(it) => GetSpanMut::span_mut(it),
-            Self::StringLiteral(it) => GetSpanMut::span_mut(it),
+            Self::Identifier(it) => it.span_mut(),
+            Self::StringLiteral(it) => it.span_mut(),
         }
     }
 }
@@ -1740,8 +1740,8 @@ impl GetSpanMut for TSModuleDeclarationName<'_> {
 impl GetSpanMut for TSModuleDeclarationBody<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::TSModuleDeclaration(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSModuleBlock(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSModuleDeclaration(it) => it.span_mut(),
+            Self::TSModuleBlock(it) => it.span_mut(),
         }
     }
 }
@@ -1777,9 +1777,9 @@ impl GetSpanMut for TSTypeQuery<'_> {
 impl GetSpanMut for TSTypeQueryExprName<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::TSImportType(it) => GetSpanMut::span_mut(&mut **it),
-            Self::IdentifierReference(it) => GetSpanMut::span_mut(&mut **it),
-            Self::QualifiedName(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSImportType(it) => it.span_mut(),
+            Self::IdentifierReference(it) => it.span_mut(),
+            Self::QualifiedName(it) => it.span_mut(),
         }
     }
 }
@@ -1808,8 +1808,8 @@ impl GetSpanMut for TSImportAttribute<'_> {
 impl GetSpanMut for TSImportAttributeName<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::Identifier(it) => GetSpanMut::span_mut(it),
-            Self::StringLiteral(it) => GetSpanMut::span_mut(it),
+            Self::Identifier(it) => it.span_mut(),
+            Self::StringLiteral(it) => it.span_mut(),
         }
     }
 }
@@ -1873,9 +1873,9 @@ impl GetSpanMut for TSImportEqualsDeclaration<'_> {
 impl GetSpanMut for TSModuleReference<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::ExternalModuleReference(it) => GetSpanMut::span_mut(&mut **it),
-            Self::IdentifierReference(it) => GetSpanMut::span_mut(&mut **it),
-            Self::QualifiedName(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ExternalModuleReference(it) => it.span_mut(),
+            Self::IdentifierReference(it) => it.span_mut(),
+            Self::QualifiedName(it) => it.span_mut(),
         }
     }
 }
@@ -1988,11 +1988,11 @@ impl GetSpanMut for JSXClosingFragment {
 impl GetSpanMut for JSXElementName<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::IdentifierReference(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NamespacedName(it) => GetSpanMut::span_mut(&mut **it),
-            Self::MemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Identifier(it) => it.span_mut(),
+            Self::IdentifierReference(it) => it.span_mut(),
+            Self::NamespacedName(it) => it.span_mut(),
+            Self::MemberExpression(it) => it.span_mut(),
+            Self::ThisExpression(it) => it.span_mut(),
         }
     }
 }
@@ -2014,9 +2014,9 @@ impl GetSpanMut for JSXMemberExpression<'_> {
 impl GetSpanMut for JSXMemberExpressionObject<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::IdentifierReference(it) => GetSpanMut::span_mut(&mut **it),
-            Self::MemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::IdentifierReference(it) => it.span_mut(),
+            Self::MemberExpression(it) => it.span_mut(),
+            Self::ThisExpression(it) => it.span_mut(),
         }
     }
 }
@@ -2031,49 +2031,49 @@ impl GetSpanMut for JSXExpressionContainer<'_> {
 impl GetSpanMut for JSXExpression<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::EmptyExpression(it) => GetSpanMut::span_mut(it),
-            Self::BooleanLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NullLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NumericLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::BigIntLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::RegExpLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::StringLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TemplateLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::MetaProperty(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Super(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ArrayExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ArrowFunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::AssignmentExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::AwaitExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::BinaryExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::CallExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ChainExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ClassExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ConditionalExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::FunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ImportExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::LogicalExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NewExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ObjectExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ParenthesizedExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::SequenceExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TaggedTemplateExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::UnaryExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::UpdateExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::YieldExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::PrivateInExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::JSXElement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::JSXFragment(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSAsExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSSatisfiesExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTypeAssertion(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSInstantiationExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::EmptyExpression(it) => it.span_mut(),
+            Self::BooleanLiteral(it) => it.span_mut(),
+            Self::NullLiteral(it) => it.span_mut(),
+            Self::NumericLiteral(it) => it.span_mut(),
+            Self::BigIntLiteral(it) => it.span_mut(),
+            Self::RegExpLiteral(it) => it.span_mut(),
+            Self::StringLiteral(it) => it.span_mut(),
+            Self::TemplateLiteral(it) => it.span_mut(),
+            Self::Identifier(it) => it.span_mut(),
+            Self::MetaProperty(it) => it.span_mut(),
+            Self::Super(it) => it.span_mut(),
+            Self::ArrayExpression(it) => it.span_mut(),
+            Self::ArrowFunctionExpression(it) => it.span_mut(),
+            Self::AssignmentExpression(it) => it.span_mut(),
+            Self::AwaitExpression(it) => it.span_mut(),
+            Self::BinaryExpression(it) => it.span_mut(),
+            Self::CallExpression(it) => it.span_mut(),
+            Self::ChainExpression(it) => it.span_mut(),
+            Self::ClassExpression(it) => it.span_mut(),
+            Self::ConditionalExpression(it) => it.span_mut(),
+            Self::FunctionExpression(it) => it.span_mut(),
+            Self::ImportExpression(it) => it.span_mut(),
+            Self::LogicalExpression(it) => it.span_mut(),
+            Self::NewExpression(it) => it.span_mut(),
+            Self::ObjectExpression(it) => it.span_mut(),
+            Self::ParenthesizedExpression(it) => it.span_mut(),
+            Self::SequenceExpression(it) => it.span_mut(),
+            Self::TaggedTemplateExpression(it) => it.span_mut(),
+            Self::ThisExpression(it) => it.span_mut(),
+            Self::UnaryExpression(it) => it.span_mut(),
+            Self::UpdateExpression(it) => it.span_mut(),
+            Self::YieldExpression(it) => it.span_mut(),
+            Self::PrivateInExpression(it) => it.span_mut(),
+            Self::JSXElement(it) => it.span_mut(),
+            Self::JSXFragment(it) => it.span_mut(),
+            Self::TSAsExpression(it) => it.span_mut(),
+            Self::TSSatisfiesExpression(it) => it.span_mut(),
+            Self::TSTypeAssertion(it) => it.span_mut(),
+            Self::TSNonNullExpression(it) => it.span_mut(),
+            Self::TSInstantiationExpression(it) => it.span_mut(),
+            Self::ComputedMemberExpression(it) => it.span_mut(),
+            Self::StaticMemberExpression(it) => it.span_mut(),
+            Self::PrivateFieldExpression(it) => it.span_mut(),
         }
     }
 }
@@ -2088,8 +2088,8 @@ impl GetSpanMut for JSXEmptyExpression {
 impl GetSpanMut for JSXAttributeItem<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::Attribute(it) => GetSpanMut::span_mut(&mut **it),
-            Self::SpreadAttribute(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Attribute(it) => it.span_mut(),
+            Self::SpreadAttribute(it) => it.span_mut(),
         }
     }
 }
@@ -2111,8 +2111,8 @@ impl GetSpanMut for JSXSpreadAttribute<'_> {
 impl GetSpanMut for JSXAttributeName<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NamespacedName(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Identifier(it) => it.span_mut(),
+            Self::NamespacedName(it) => it.span_mut(),
         }
     }
 }
@@ -2120,10 +2120,10 @@ impl GetSpanMut for JSXAttributeName<'_> {
 impl GetSpanMut for JSXAttributeValue<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::StringLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ExpressionContainer(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Element(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Fragment(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StringLiteral(it) => it.span_mut(),
+            Self::ExpressionContainer(it) => it.span_mut(),
+            Self::Element(it) => it.span_mut(),
+            Self::Fragment(it) => it.span_mut(),
         }
     }
 }
@@ -2138,11 +2138,11 @@ impl GetSpanMut for JSXIdentifier<'_> {
 impl GetSpanMut for JSXChild<'_> {
     fn span_mut(&mut self) -> &mut Span {
         match self {
-            Self::Text(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Element(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Fragment(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ExpressionContainer(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Spread(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Text(it) => it.span_mut(),
+            Self::Element(it) => it.span_mut(),
+            Self::Fragment(it) => it.span_mut(),
+            Self::ExpressionContainer(it) => it.span_mut(),
+            Self::Spread(it) => it.span_mut(),
         }
     }
 }

--- a/tasks/ast_tools/src/derives/get_span.rs
+++ b/tasks/ast_tools/src/derives/get_span.rs
@@ -50,23 +50,12 @@ impl Derive for DeriveGetSpan {
     }
 
     fn derive(&self, type_def: StructOrEnum, schema: &Schema) -> TokenStream {
+        let trait_name = "GetSpan";
+        let method_name = "span";
         let self_ty = quote!(&self);
         let result_ty = quote!(Span);
         let result_expr = quote!(self.span);
-        let reference = quote!( & );
-        let unboxed_ref = quote!(it.as_ref());
-
-        derive_type(
-            type_def,
-            "GetSpan",
-            "span",
-            &self_ty,
-            &result_ty,
-            &result_expr,
-            &reference,
-            &unboxed_ref,
-            schema,
-        )
+        derive_type(type_def, trait_name, method_name, &self_ty, &result_ty, &result_expr, schema)
     }
 }
 
@@ -89,28 +78,16 @@ impl Derive for DeriveGetSpanMut {
     }
 
     fn derive(&self, type_def: StructOrEnum, schema: &Schema) -> TokenStream {
+        let trait_name = "GetSpanMut";
+        let method_name = "span_mut";
         let self_ty = quote!(&mut self);
         let result_ty = quote!(&mut Span);
         let result_expr = quote!(&mut self.span);
-        let reference = quote!( &mut );
-        let unboxed_ref = quote!(&mut **it);
-
-        derive_type(
-            type_def,
-            "GetSpanMut",
-            "span_mut",
-            &self_ty,
-            &result_ty,
-            &result_expr,
-            &reference,
-            &unboxed_ref,
-            schema,
-        )
+        derive_type(type_def, trait_name, method_name, &self_ty, &result_ty, &result_expr, schema)
     }
 }
 
 /// Generate `GetSpan` / `GetSpanMut` trait implementation for a type.
-#[expect(clippy::too_many_arguments)]
 fn derive_type(
     type_def: StructOrEnum,
     trait_name: &str,
@@ -118,8 +95,6 @@ fn derive_type(
     self_ty: &TokenStream,
     result_ty: &TokenStream,
     result_expr: &TokenStream,
-    reference: &TokenStream,
-    unboxed_ref: &TokenStream,
     schema: &Schema,
 ) -> TokenStream {
     let trait_ident = format_ident!("{trait_name}");
@@ -132,23 +107,15 @@ fn derive_type(
             self_ty,
             result_ty,
             result_expr,
-            reference,
             schema,
         ),
-        StructOrEnum::Enum(enum_def) => derive_enum(
-            enum_def,
-            &trait_ident,
-            &method_ident,
-            self_ty,
-            result_ty,
-            unboxed_ref,
-            schema,
-        ),
+        StructOrEnum::Enum(enum_def) => {
+            derive_enum(enum_def, &trait_ident, &method_ident, self_ty, result_ty, schema)
+        }
     }
 }
 
 /// Generate `GetSpan` / `GetSpanMut` trait implementation for a struct.
-#[expect(clippy::too_many_arguments)]
 fn derive_struct(
     struct_def: &StructDef,
     trait_ident: &Ident,
@@ -156,14 +123,13 @@ fn derive_struct(
     self_ty: &TokenStream,
     result_ty: &TokenStream,
     result_expr: &TokenStream,
-    reference: &TokenStream,
     schema: &Schema,
 ) -> TokenStream {
     let ty = struct_def.ty_anon(schema);
 
     let result_expr = if let Some(field_index) = struct_def.span.span_field_index {
         let field_ident = struct_def.fields[field_index].ident();
-        &quote!( #trait_ident::#method_ident(#reference self.#field_ident) )
+        &quote!( self.#field_ident.#method_ident() )
     } else {
         result_expr
     };
@@ -185,21 +151,13 @@ fn derive_enum(
     method_ident: &Ident,
     self_ty: &TokenStream,
     result_ty: &TokenStream,
-    unboxed_ref: &TokenStream,
     schema: &Schema,
 ) -> TokenStream {
     let ty = enum_def.ty_anon(schema);
 
     let matches = enum_def.all_variants(schema).map(|variant| {
         let variant_ident = variant.ident();
-        let variant_type = variant.field_type(schema).unwrap();
-        // TODO: Just generate `it.span()` or `it.span_mut()`.
-        // Then output is the same whether variant is boxed or not, and `unboxed_ref` is not needed.
-        if variant_type.is_box() {
-            quote!( Self::#variant_ident(it) => #trait_ident::#method_ident(#unboxed_ref) )
-        } else {
-            quote!( Self::#variant_ident(it) => #trait_ident::#method_ident(it) )
-        }
+        quote!( Self::#variant_ident(it) => it.#method_ident() )
     });
 
     quote! {


### PR DESCRIPTION
Generated code for `GetSpan` was excessively verbose. Simplify it.