### PR TITLE
refactor(ast): remove unneeded lint attrs from generated code

### DIFF
--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -1,7 +1,7 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/derives/content_eq.rs`
 
-#![allow(clippy::match_like_matches_macro)]
+#![allow(clippy::match_same_arms)]
 
 use oxc_span::cmp::ContentEq;
 
@@ -43,7 +43,6 @@ impl ContentEq for Program<'_> {
 
 impl ContentEq for Expression<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::BooleanLiteral(a), Self::BooleanLiteral(b)) => a.content_eq(b),
             (Self::NullLiteral(a), Self::NullLiteral(b)) => a.content_eq(b),
@@ -136,7 +135,6 @@ impl ContentEq for ArrayExpression<'_> {
 
 impl ContentEq for ArrayExpressionElement<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::SpreadElement(a), Self::SpreadElement(b)) => a.content_eq(b),
             (Self::Elision(a), Self::Elision(b)) => a.content_eq(b),
@@ -207,7 +205,6 @@ impl ContentEq for ObjectExpression<'_> {
 
 impl ContentEq for ObjectPropertyKind<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::ObjectProperty(a), Self::ObjectProperty(b)) => a.content_eq(b),
             (Self::SpreadProperty(a), Self::SpreadProperty(b)) => a.content_eq(b),
@@ -229,7 +226,6 @@ impl ContentEq for ObjectProperty<'_> {
 
 impl ContentEq for PropertyKey<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::StaticIdentifier(a), Self::StaticIdentifier(b)) => a.content_eq(b),
             (Self::PrivateIdentifier(a), Self::PrivateIdentifier(b)) => a.content_eq(b),
@@ -323,7 +319,6 @@ impl ContentEq for TemplateElementValue<'_> {
 
 impl ContentEq for MemberExpression<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::ComputedMemberExpression(a), Self::ComputedMemberExpression(b)) => {
                 a.content_eq(b)
@@ -391,7 +386,6 @@ impl ContentEq for SpreadElement<'_> {
 
 impl ContentEq for Argument<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::SpreadElement(a), Self::SpreadElement(b)) => a.content_eq(b),
             (Self::BooleanLiteral(a), Self::BooleanLiteral(b)) => a.content_eq(b),
@@ -504,7 +498,6 @@ impl ContentEq for AssignmentExpression<'_> {
 
 impl ContentEq for AssignmentTarget<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::AssignmentTargetIdentifier(a), Self::AssignmentTargetIdentifier(b)) => {
                 a.content_eq(b)
@@ -530,7 +523,6 @@ impl ContentEq for AssignmentTarget<'_> {
 
 impl ContentEq for SimpleAssignmentTarget<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::AssignmentTargetIdentifier(a), Self::AssignmentTargetIdentifier(b)) => {
                 a.content_eq(b)
@@ -554,7 +546,6 @@ impl ContentEq for SimpleAssignmentTarget<'_> {
 
 impl ContentEq for AssignmentTargetPattern<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::ArrayAssignmentTarget(a), Self::ArrayAssignmentTarget(b)) => a.content_eq(b),
             (Self::ObjectAssignmentTarget(a), Self::ObjectAssignmentTarget(b)) => a.content_eq(b),
@@ -585,7 +576,6 @@ impl ContentEq for AssignmentTargetRest<'_> {
 
 impl ContentEq for AssignmentTargetMaybeDefault<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::AssignmentTargetWithDefault(a), Self::AssignmentTargetWithDefault(b)) => {
                 a.content_eq(b)
@@ -621,7 +611,6 @@ impl ContentEq for AssignmentTargetWithDefault<'_> {
 
 impl ContentEq for AssignmentTargetProperty<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (
                 Self::AssignmentTargetPropertyIdentifier(a),
@@ -677,7 +666,6 @@ impl ContentEq for ChainExpression<'_> {
 
 impl ContentEq for ChainElement<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::CallExpression(a), Self::CallExpression(b)) => a.content_eq(b),
             (Self::TSNonNullExpression(a), Self::TSNonNullExpression(b)) => a.content_eq(b),
@@ -699,7 +687,6 @@ impl ContentEq for ParenthesizedExpression<'_> {
 
 impl ContentEq for Statement<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::BlockStatement(a), Self::BlockStatement(b)) => a.content_eq(b),
             (Self::BreakStatement(a), Self::BreakStatement(b)) => a.content_eq(b),
@@ -765,7 +752,6 @@ impl ContentEq for BlockStatement<'_> {
 
 impl ContentEq for Declaration<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::VariableDeclaration(a), Self::VariableDeclaration(b)) => a.content_eq(b),
             (Self::FunctionDeclaration(a), Self::FunctionDeclaration(b)) => a.content_eq(b),
@@ -850,7 +836,6 @@ impl ContentEq for ForStatement<'_> {
 
 impl ContentEq for ForStatementInit<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::VariableDeclaration(a), Self::VariableDeclaration(b)) => a.content_eq(b),
             (Self::BooleanLiteral(a), Self::BooleanLiteral(b)) => a.content_eq(b),
@@ -916,7 +901,6 @@ impl ContentEq for ForInStatement<'_> {
 
 impl ContentEq for ForStatementLeft<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::VariableDeclaration(a), Self::VariableDeclaration(b)) => a.content_eq(b),
             (Self::AssignmentTargetIdentifier(a), Self::AssignmentTargetIdentifier(b)) => {
@@ -1039,7 +1023,6 @@ impl ContentEq for BindingPattern<'_> {
 
 impl ContentEq for BindingPatternKind<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::BindingIdentifier(a), Self::BindingIdentifier(b)) => a.content_eq(b),
             (Self::ObjectPattern(a), Self::ObjectPattern(b)) => a.content_eq(b),
@@ -1185,7 +1168,6 @@ impl ContentEq for ClassBody<'_> {
 
 impl ContentEq for ClassElement<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::StaticBlock(a), Self::StaticBlock(b)) => a.content_eq(b),
             (Self::MethodDefinition(a), Self::MethodDefinition(b)) => a.content_eq(b),
@@ -1262,7 +1244,6 @@ impl ContentEq for StaticBlock<'_> {
 
 impl ContentEq for ModuleDeclaration<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::ImportDeclaration(a), Self::ImportDeclaration(b)) => a.content_eq(b),
             (Self::ExportAllDeclaration(a), Self::ExportAllDeclaration(b)) => a.content_eq(b),
@@ -1325,7 +1306,6 @@ impl ContentEq for ImportPhase {
 
 impl ContentEq for ImportDeclarationSpecifier<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::ImportSpecifier(a), Self::ImportSpecifier(b)) => a.content_eq(b),
             (Self::ImportDefaultSpecifier(a), Self::ImportDefaultSpecifier(b)) => a.content_eq(b),
@@ -1373,7 +1353,6 @@ impl ContentEq for ImportAttribute<'_> {
 
 impl ContentEq for ImportAttributeKey<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::Identifier(a), Self::Identifier(b)) => a.content_eq(b),
             (Self::StringLiteral(a), Self::StringLiteral(b)) => a.content_eq(b),
@@ -1418,7 +1397,6 @@ impl ContentEq for ExportSpecifier<'_> {
 
 impl ContentEq for ExportDefaultDeclarationKind<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::FunctionDeclaration(a), Self::FunctionDeclaration(b)) => a.content_eq(b),
             (Self::ClassDeclaration(a), Self::ClassDeclaration(b)) => a.content_eq(b),
@@ -1478,7 +1456,6 @@ impl ContentEq for ExportDefaultDeclarationKind<'_> {
 
 impl ContentEq for ModuleExportName<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::IdentifierName(a), Self::IdentifierName(b)) => a.content_eq(b),
             (Self::IdentifierReference(a), Self::IdentifierReference(b)) => a.content_eq(b),
@@ -1512,7 +1489,6 @@ impl ContentEq for TSEnumMember<'_> {
 
 impl ContentEq for TSEnumMemberName<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::Identifier(a), Self::Identifier(b)) => a.content_eq(b),
             (Self::String(a), Self::String(b)) => a.content_eq(b),
@@ -1535,7 +1511,6 @@ impl ContentEq for TSLiteralType<'_> {
 
 impl ContentEq for TSLiteral<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::BooleanLiteral(a), Self::BooleanLiteral(b)) => a.content_eq(b),
             (Self::NullLiteral(a), Self::NullLiteral(b)) => a.content_eq(b),
@@ -1552,7 +1527,6 @@ impl ContentEq for TSLiteral<'_> {
 
 impl ContentEq for TSType<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::TSAnyKeyword(a), Self::TSAnyKeyword(b)) => a.content_eq(b),
             (Self::TSBigIntKeyword(a), Self::TSBigIntKeyword(b)) => a.content_eq(b),
@@ -1678,7 +1652,6 @@ impl ContentEq for TSRestType<'_> {
 
 impl ContentEq for TSTupleElement<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::TSOptionalType(a), Self::TSOptionalType(b)) => a.content_eq(b),
             (Self::TSRestType(a), Self::TSRestType(b)) => a.content_eq(b),
@@ -1818,7 +1791,6 @@ impl ContentEq for TSTypeReference<'_> {
 
 impl ContentEq for TSTypeName<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::IdentifierReference(a), Self::IdentifierReference(b)) => a.content_eq(b),
             (Self::QualifiedName(a), Self::QualifiedName(b)) => a.content_eq(b),
@@ -1907,7 +1879,6 @@ impl ContentEq for TSPropertySignature<'_> {
 
 impl ContentEq for TSSignature<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::TSIndexSignature(a), Self::TSIndexSignature(b)) => a.content_eq(b),
             (Self::TSPropertySignature(a), Self::TSPropertySignature(b)) => a.content_eq(b),
@@ -1993,7 +1964,6 @@ impl ContentEq for TSTypePredicate<'_> {
 
 impl ContentEq for TSTypePredicateName<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::Identifier(a), Self::Identifier(b)) => a.content_eq(b),
             (Self::This(a), Self::This(b)) => a.content_eq(b),
@@ -2019,7 +1989,6 @@ impl ContentEq for TSModuleDeclarationKind {
 
 impl ContentEq for TSModuleDeclarationName<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::Identifier(a), Self::Identifier(b)) => a.content_eq(b),
             (Self::StringLiteral(a), Self::StringLiteral(b)) => a.content_eq(b),
@@ -2030,7 +1999,6 @@ impl ContentEq for TSModuleDeclarationName<'_> {
 
 impl ContentEq for TSModuleDeclarationBody<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::TSModuleDeclaration(a), Self::TSModuleDeclaration(b)) => a.content_eq(b),
             (Self::TSModuleBlock(a), Self::TSModuleBlock(b)) => a.content_eq(b),
@@ -2067,7 +2035,6 @@ impl ContentEq for TSTypeQuery<'_> {
 
 impl ContentEq for TSTypeQueryExprName<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::TSImportType(a), Self::TSImportType(b)) => a.content_eq(b),
             (Self::IdentifierReference(a), Self::IdentifierReference(b)) => a.content_eq(b),
@@ -2103,7 +2070,6 @@ impl ContentEq for TSImportAttribute<'_> {
 
 impl ContentEq for TSImportAttributeName<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::Identifier(a), Self::Identifier(b)) => a.content_eq(b),
             (Self::StringLiteral(a), Self::StringLiteral(b)) => a.content_eq(b),
@@ -2184,7 +2150,6 @@ impl ContentEq for TSImportEqualsDeclaration<'_> {
 
 impl ContentEq for TSModuleReference<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::ExternalModuleReference(a), Self::ExternalModuleReference(b)) => a.content_eq(b),
             (Self::IdentifierReference(a), Self::IdentifierReference(b)) => a.content_eq(b),
@@ -2302,7 +2267,6 @@ impl ContentEq for JSXClosingFragment {
 
 impl ContentEq for JSXElementName<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::Identifier(a), Self::Identifier(b)) => a.content_eq(b),
             (Self::IdentifierReference(a), Self::IdentifierReference(b)) => a.content_eq(b),
@@ -2330,7 +2294,6 @@ impl ContentEq for JSXMemberExpression<'_> {
 
 impl ContentEq for JSXMemberExpressionObject<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::IdentifierReference(a), Self::IdentifierReference(b)) => a.content_eq(b),
             (Self::MemberExpression(a), Self::MemberExpression(b)) => a.content_eq(b),
@@ -2348,7 +2311,6 @@ impl ContentEq for JSXExpressionContainer<'_> {
 
 impl ContentEq for JSXExpression<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::EmptyExpression(a), Self::EmptyExpression(b)) => a.content_eq(b),
             (Self::BooleanLiteral(a), Self::BooleanLiteral(b)) => a.content_eq(b),
@@ -2412,7 +2374,6 @@ impl ContentEq for JSXEmptyExpression {
 
 impl ContentEq for JSXAttributeItem<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::Attribute(a), Self::Attribute(b)) => a.content_eq(b),
             (Self::SpreadAttribute(a), Self::SpreadAttribute(b)) => a.content_eq(b),
@@ -2436,7 +2397,6 @@ impl ContentEq for JSXSpreadAttribute<'_> {
 
 impl ContentEq for JSXAttributeName<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::Identifier(a), Self::Identifier(b)) => a.content_eq(b),
             (Self::NamespacedName(a), Self::NamespacedName(b)) => a.content_eq(b),
@@ -2447,7 +2407,6 @@ impl ContentEq for JSXAttributeName<'_> {
 
 impl ContentEq for JSXAttributeValue<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::StringLiteral(a), Self::StringLiteral(b)) => a.content_eq(b),
             (Self::ExpressionContainer(a), Self::ExpressionContainer(b)) => a.content_eq(b),
@@ -2466,7 +2425,6 @@ impl ContentEq for JSXIdentifier<'_> {
 
 impl ContentEq for JSXChild<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::Text(a), Self::Text(b)) => a.content_eq(b),
             (Self::Element(a), Self::Element(b)) => a.content_eq(b),

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1,7 +1,7 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/derives/estree.rs`
 
-#![allow(unused_imports, unused_mut, clippy::match_same_arms)]
+#![allow(unused_imports, clippy::match_same_arms)]
 
 use serde::{ser::SerializeMap, Serialize, Serializer};
 

--- a/crates/oxc_ast/src/generated/visit.rs
+++ b/crates/oxc_ast/src/generated/visit.rs
@@ -7,14 +7,7 @@
 //! * [visitor pattern](https://rust-unofficial.github.io/patterns/patterns/behavioural/visitor.html)
 //! * [rustc visitor](https://github.com/rust-lang/rust/blob/1.82.0/compiler/rustc_ast/src/visit.rs)
 
-#![allow(
-    unused_variables,
-    clippy::extra_unused_type_parameters,
-    clippy::explicit_iter_loop,
-    clippy::self_named_module_files,
-    clippy::semicolon_if_nothing_returned,
-    clippy::match_wildcard_for_single_variants
-)]
+#![allow(unused_variables, clippy::semicolon_if_nothing_returned)]
 
 use std::cell::Cell;
 

--- a/crates/oxc_ast/src/generated/visit_mut.rs
+++ b/crates/oxc_ast/src/generated/visit_mut.rs
@@ -7,14 +7,7 @@
 //! * [visitor pattern](https://rust-unofficial.github.io/patterns/patterns/behavioural/visitor.html)
 //! * [rustc visitor](https://github.com/rust-lang/rust/blob/1.82.0/compiler/rustc_ast/src/visit.rs)
 
-#![allow(
-    unused_variables,
-    clippy::extra_unused_type_parameters,
-    clippy::explicit_iter_loop,
-    clippy::self_named_module_files,
-    clippy::semicolon_if_nothing_returned,
-    clippy::match_wildcard_for_single_variants
-)]
+#![allow(unused_variables, clippy::semicolon_if_nothing_returned)]
 
 use std::cell::Cell;
 

--- a/crates/oxc_regular_expression/src/generated/derive_content_eq.rs
+++ b/crates/oxc_regular_expression/src/generated/derive_content_eq.rs
@@ -1,7 +1,7 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/derives/content_eq.rs`
 
-#![allow(clippy::match_like_matches_macro)]
+#![allow(clippy::match_same_arms)]
 
 use oxc_span::cmp::ContentEq;
 
@@ -27,7 +27,6 @@ impl ContentEq for Alternative<'_> {
 
 impl ContentEq for Term<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::BoundaryAssertion(a), Self::BoundaryAssertion(b)) => a.content_eq(b),
             (Self::LookAroundAssertion(a), Self::LookAroundAssertion(b)) => a.content_eq(b),
@@ -137,7 +136,6 @@ impl ContentEq for CharacterClassContentsKind {
 
 impl ContentEq for CharacterClassContents<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        #[allow(clippy::match_same_arms)]
         match (self, other) {
             (Self::CharacterClassRange(a), Self::CharacterClassRange(b)) => a.content_eq(b),
             (Self::CharacterClassEscape(a), Self::CharacterClassEscape(b)) => a.content_eq(b),

--- a/crates/oxc_regular_expression/src/generated/derive_estree.rs
+++ b/crates/oxc_regular_expression/src/generated/derive_estree.rs
@@ -1,7 +1,7 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/derives/estree.rs`
 
-#![allow(unused_imports, unused_mut, clippy::match_same_arms)]
+#![allow(unused_imports, clippy::match_same_arms)]
 
 use serde::{ser::SerializeMap, Serialize, Serializer};
 

--- a/crates/oxc_span/src/generated/derive_estree.rs
+++ b/crates/oxc_span/src/generated/derive_estree.rs
@@ -1,7 +1,7 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/derives/estree.rs`
 
-#![allow(unused_imports, unused_mut, clippy::match_same_arms)]
+#![allow(unused_imports, clippy::match_same_arms)]
 
 use serde::{ser::SerializeMap, Serialize, Serializer};
 

--- a/crates/oxc_syntax/src/generated/derive_content_eq.rs
+++ b/crates/oxc_syntax/src/generated/derive_content_eq.rs
@@ -1,7 +1,7 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/derives/content_eq.rs`
 
-#![allow(clippy::match_like_matches_macro)]
+#![allow(clippy::match_same_arms)]
 
 use oxc_span::cmp::ContentEq;
 

--- a/crates/oxc_syntax/src/generated/derive_estree.rs
+++ b/crates/oxc_syntax/src/generated/derive_estree.rs
@@ -1,7 +1,7 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/derives/estree.rs`
 
-#![allow(unused_imports, unused_mut, clippy::match_same_arms)]
+#![allow(unused_imports, clippy::match_same_arms)]
 
 use serde::{ser::SerializeMap, Serialize, Serializer};
 

--- a/tasks/ast_tools/src/derives/content_eq.rs
+++ b/tasks/ast_tools/src/derives/content_eq.rs
@@ -21,8 +21,7 @@ impl Derive for DeriveContentEq {
 
     fn prelude(&self) -> TokenStream {
         quote! {
-            // NOTE: writing long match expressions formats better than using `matches` macro.
-            #![allow(clippy::match_like_matches_macro)]
+            #![allow(clippy::match_same_arms)]
 
             ///@@line_break
             use oxc_span::cmp::ContentEq;
@@ -74,7 +73,6 @@ fn derive_enum(enum_def: &EnumDef, schema: &Schema) -> TokenStream {
             }
         });
         quote! {
-            #[allow(clippy::match_same_arms)]
             match (self, other) {
                 #(#matches,)*
                 _ => false,

--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -42,7 +42,7 @@ impl Derive for DeriveESTree {
 
     fn prelude(&self) -> TokenStream {
         quote! {
-            #![allow(unused_imports, unused_mut, clippy::match_same_arms)]
+            #![allow(unused_imports, clippy::match_same_arms)]
 
             ///@@line_break
             use serde::{Serialize, Serializer, ser::SerializeMap};

--- a/tasks/ast_tools/src/generators/visit.rs
+++ b/tasks/ast_tools/src/generators/visit.rs
@@ -228,14 +228,7 @@ fn generate_output(
         //! * [rustc visitor](https://github.com/rust-lang/rust/blob/1.82.0/compiler/rustc_ast/src/visit.rs)
 
         //!@@line_break
-        #![allow(
-            unused_variables,
-            clippy::extra_unused_type_parameters,
-            clippy::explicit_iter_loop,
-            clippy::self_named_module_files,
-            clippy::semicolon_if_nothing_returned,
-            clippy::match_wildcard_for_single_variants
-        )]
+        #![allow(unused_variables, clippy::semicolon_if_nothing_returned)]
 
         ///@@line_break
         use std::cell::Cell;


### PR DESCRIPTION
Remove unnecessary `#[allow]` attributes from generated code.