### PR TITLE
refactor(ast): re-order generated code

### DIFF
--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -9,48 +9,6 @@ use crate::ast::*;
 
 #[cfg(target_pointer_width = "64")]
 const _: () = {
-    assert!(size_of::<BooleanLiteral>() == 16usize);
-    assert!(align_of::<BooleanLiteral>() == 8usize);
-    assert!(offset_of!(BooleanLiteral, span) == 0usize);
-    assert!(offset_of!(BooleanLiteral, value) == 8usize);
-
-    assert!(size_of::<NullLiteral>() == 8usize);
-    assert!(align_of::<NullLiteral>() == 8usize);
-    assert!(offset_of!(NullLiteral, span) == 0usize);
-
-    assert!(size_of::<NumericLiteral>() == 40usize);
-    assert!(align_of::<NumericLiteral>() == 8usize);
-    assert!(offset_of!(NumericLiteral, span) == 0usize);
-    assert!(offset_of!(NumericLiteral, value) == 8usize);
-    assert!(offset_of!(NumericLiteral, raw) == 16usize);
-    assert!(offset_of!(NumericLiteral, base) == 32usize);
-
-    assert!(size_of::<StringLiteral>() == 40usize);
-    assert!(align_of::<StringLiteral>() == 8usize);
-    assert!(offset_of!(StringLiteral, span) == 0usize);
-    assert!(offset_of!(StringLiteral, value) == 8usize);
-    assert!(offset_of!(StringLiteral, raw) == 24usize);
-
-    assert!(size_of::<BigIntLiteral>() == 32usize);
-    assert!(align_of::<BigIntLiteral>() == 8usize);
-    assert!(offset_of!(BigIntLiteral, span) == 0usize);
-    assert!(offset_of!(BigIntLiteral, raw) == 8usize);
-    assert!(offset_of!(BigIntLiteral, base) == 24usize);
-
-    assert!(size_of::<RegExpLiteral>() == 56usize);
-    assert!(align_of::<RegExpLiteral>() == 8usize);
-    assert!(offset_of!(RegExpLiteral, span) == 0usize);
-    assert!(offset_of!(RegExpLiteral, regex) == 8usize);
-    assert!(offset_of!(RegExpLiteral, raw) == 40usize);
-
-    assert!(size_of::<RegExp>() == 32usize);
-    assert!(align_of::<RegExp>() == 8usize);
-    assert!(offset_of!(RegExp, pattern) == 0usize);
-    assert!(offset_of!(RegExp, flags) == 24usize);
-
-    assert!(size_of::<RegExpPattern>() == 24usize);
-    assert!(align_of::<RegExpPattern>() == 8usize);
-
     assert!(size_of::<Program>() == 160usize);
     assert!(align_of::<Program>() == 8usize);
     assert!(offset_of!(Program, span) == 0usize);
@@ -788,6 +746,151 @@ const _: () = {
     assert!(size_of::<ModuleExportName>() == 48usize);
     assert!(align_of::<ModuleExportName>() == 8usize);
 
+    assert!(size_of::<BooleanLiteral>() == 16usize);
+    assert!(align_of::<BooleanLiteral>() == 8usize);
+    assert!(offset_of!(BooleanLiteral, span) == 0usize);
+    assert!(offset_of!(BooleanLiteral, value) == 8usize);
+
+    assert!(size_of::<NullLiteral>() == 8usize);
+    assert!(align_of::<NullLiteral>() == 8usize);
+    assert!(offset_of!(NullLiteral, span) == 0usize);
+
+    assert!(size_of::<NumericLiteral>() == 40usize);
+    assert!(align_of::<NumericLiteral>() == 8usize);
+    assert!(offset_of!(NumericLiteral, span) == 0usize);
+    assert!(offset_of!(NumericLiteral, value) == 8usize);
+    assert!(offset_of!(NumericLiteral, raw) == 16usize);
+    assert!(offset_of!(NumericLiteral, base) == 32usize);
+
+    assert!(size_of::<StringLiteral>() == 40usize);
+    assert!(align_of::<StringLiteral>() == 8usize);
+    assert!(offset_of!(StringLiteral, span) == 0usize);
+    assert!(offset_of!(StringLiteral, value) == 8usize);
+    assert!(offset_of!(StringLiteral, raw) == 24usize);
+
+    assert!(size_of::<BigIntLiteral>() == 32usize);
+    assert!(align_of::<BigIntLiteral>() == 8usize);
+    assert!(offset_of!(BigIntLiteral, span) == 0usize);
+    assert!(offset_of!(BigIntLiteral, raw) == 8usize);
+    assert!(offset_of!(BigIntLiteral, base) == 24usize);
+
+    assert!(size_of::<RegExpLiteral>() == 56usize);
+    assert!(align_of::<RegExpLiteral>() == 8usize);
+    assert!(offset_of!(RegExpLiteral, span) == 0usize);
+    assert!(offset_of!(RegExpLiteral, regex) == 8usize);
+    assert!(offset_of!(RegExpLiteral, raw) == 40usize);
+
+    assert!(size_of::<RegExp>() == 32usize);
+    assert!(align_of::<RegExp>() == 8usize);
+    assert!(offset_of!(RegExp, pattern) == 0usize);
+    assert!(offset_of!(RegExp, flags) == 24usize);
+
+    assert!(size_of::<RegExpPattern>() == 24usize);
+    assert!(align_of::<RegExpPattern>() == 8usize);
+
+    assert!(size_of::<JSXElement>() == 56usize);
+    assert!(align_of::<JSXElement>() == 8usize);
+    assert!(offset_of!(JSXElement, span) == 0usize);
+    assert!(offset_of!(JSXElement, opening_element) == 8usize);
+    assert!(offset_of!(JSXElement, closing_element) == 16usize);
+    assert!(offset_of!(JSXElement, children) == 24usize);
+
+    assert!(size_of::<JSXOpeningElement>() == 72usize);
+    assert!(align_of::<JSXOpeningElement>() == 8usize);
+    assert!(offset_of!(JSXOpeningElement, span) == 0usize);
+    assert!(offset_of!(JSXOpeningElement, self_closing) == 8usize);
+    assert!(offset_of!(JSXOpeningElement, name) == 16usize);
+    assert!(offset_of!(JSXOpeningElement, attributes) == 32usize);
+    assert!(offset_of!(JSXOpeningElement, type_parameters) == 64usize);
+
+    assert!(size_of::<JSXClosingElement>() == 24usize);
+    assert!(align_of::<JSXClosingElement>() == 8usize);
+    assert!(offset_of!(JSXClosingElement, span) == 0usize);
+    assert!(offset_of!(JSXClosingElement, name) == 8usize);
+
+    assert!(size_of::<JSXFragment>() == 56usize);
+    assert!(align_of::<JSXFragment>() == 8usize);
+    assert!(offset_of!(JSXFragment, span) == 0usize);
+    assert!(offset_of!(JSXFragment, opening_fragment) == 8usize);
+    assert!(offset_of!(JSXFragment, closing_fragment) == 16usize);
+    assert!(offset_of!(JSXFragment, children) == 24usize);
+
+    assert!(size_of::<JSXOpeningFragment>() == 8usize);
+    assert!(align_of::<JSXOpeningFragment>() == 8usize);
+    assert!(offset_of!(JSXOpeningFragment, span) == 0usize);
+
+    assert!(size_of::<JSXClosingFragment>() == 8usize);
+    assert!(align_of::<JSXClosingFragment>() == 8usize);
+    assert!(offset_of!(JSXClosingFragment, span) == 0usize);
+
+    assert!(size_of::<JSXElementName>() == 16usize);
+    assert!(align_of::<JSXElementName>() == 8usize);
+
+    assert!(size_of::<JSXNamespacedName>() == 56usize);
+    assert!(align_of::<JSXNamespacedName>() == 8usize);
+    assert!(offset_of!(JSXNamespacedName, span) == 0usize);
+    assert!(offset_of!(JSXNamespacedName, namespace) == 8usize);
+    assert!(offset_of!(JSXNamespacedName, property) == 32usize);
+
+    assert!(size_of::<JSXMemberExpression>() == 48usize);
+    assert!(align_of::<JSXMemberExpression>() == 8usize);
+    assert!(offset_of!(JSXMemberExpression, span) == 0usize);
+    assert!(offset_of!(JSXMemberExpression, object) == 8usize);
+    assert!(offset_of!(JSXMemberExpression, property) == 24usize);
+
+    assert!(size_of::<JSXMemberExpressionObject>() == 16usize);
+    assert!(align_of::<JSXMemberExpressionObject>() == 8usize);
+
+    assert!(size_of::<JSXExpressionContainer>() == 24usize);
+    assert!(align_of::<JSXExpressionContainer>() == 8usize);
+    assert!(offset_of!(JSXExpressionContainer, span) == 0usize);
+    assert!(offset_of!(JSXExpressionContainer, expression) == 8usize);
+
+    assert!(size_of::<JSXExpression>() == 16usize);
+    assert!(align_of::<JSXExpression>() == 8usize);
+
+    assert!(size_of::<JSXEmptyExpression>() == 8usize);
+    assert!(align_of::<JSXEmptyExpression>() == 8usize);
+    assert!(offset_of!(JSXEmptyExpression, span) == 0usize);
+
+    assert!(size_of::<JSXAttributeItem>() == 16usize);
+    assert!(align_of::<JSXAttributeItem>() == 8usize);
+
+    assert!(size_of::<JSXAttribute>() == 40usize);
+    assert!(align_of::<JSXAttribute>() == 8usize);
+    assert!(offset_of!(JSXAttribute, span) == 0usize);
+    assert!(offset_of!(JSXAttribute, name) == 8usize);
+    assert!(offset_of!(JSXAttribute, value) == 24usize);
+
+    assert!(size_of::<JSXSpreadAttribute>() == 24usize);
+    assert!(align_of::<JSXSpreadAttribute>() == 8usize);
+    assert!(offset_of!(JSXSpreadAttribute, span) == 0usize);
+    assert!(offset_of!(JSXSpreadAttribute, argument) == 8usize);
+
+    assert!(size_of::<JSXAttributeName>() == 16usize);
+    assert!(align_of::<JSXAttributeName>() == 8usize);
+
+    assert!(size_of::<JSXAttributeValue>() == 16usize);
+    assert!(align_of::<JSXAttributeValue>() == 8usize);
+
+    assert!(size_of::<JSXIdentifier>() == 24usize);
+    assert!(align_of::<JSXIdentifier>() == 8usize);
+    assert!(offset_of!(JSXIdentifier, span) == 0usize);
+    assert!(offset_of!(JSXIdentifier, name) == 8usize);
+
+    assert!(size_of::<JSXChild>() == 16usize);
+    assert!(align_of::<JSXChild>() == 8usize);
+
+    assert!(size_of::<JSXSpreadChild>() == 24usize);
+    assert!(align_of::<JSXSpreadChild>() == 8usize);
+    assert!(offset_of!(JSXSpreadChild, span) == 0usize);
+    assert!(offset_of!(JSXSpreadChild, expression) == 8usize);
+
+    assert!(size_of::<JSXText>() == 24usize);
+    assert!(align_of::<JSXText>() == 8usize);
+    assert!(offset_of!(JSXText, span) == 0usize);
+    assert!(offset_of!(JSXText, value) == 8usize);
+
     assert!(size_of::<TSThisParameter>() == 24usize);
     assert!(align_of::<TSThisParameter>() == 8usize);
     assert!(offset_of!(TSThisParameter, span) == 0usize);
@@ -1275,109 +1378,6 @@ const _: () = {
     assert!(align_of::<JSDocUnknownType>() == 8usize);
     assert!(offset_of!(JSDocUnknownType, span) == 0usize);
 
-    assert!(size_of::<JSXElement>() == 56usize);
-    assert!(align_of::<JSXElement>() == 8usize);
-    assert!(offset_of!(JSXElement, span) == 0usize);
-    assert!(offset_of!(JSXElement, opening_element) == 8usize);
-    assert!(offset_of!(JSXElement, closing_element) == 16usize);
-    assert!(offset_of!(JSXElement, children) == 24usize);
-
-    assert!(size_of::<JSXOpeningElement>() == 72usize);
-    assert!(align_of::<JSXOpeningElement>() == 8usize);
-    assert!(offset_of!(JSXOpeningElement, span) == 0usize);
-    assert!(offset_of!(JSXOpeningElement, self_closing) == 8usize);
-    assert!(offset_of!(JSXOpeningElement, name) == 16usize);
-    assert!(offset_of!(JSXOpeningElement, attributes) == 32usize);
-    assert!(offset_of!(JSXOpeningElement, type_parameters) == 64usize);
-
-    assert!(size_of::<JSXClosingElement>() == 24usize);
-    assert!(align_of::<JSXClosingElement>() == 8usize);
-    assert!(offset_of!(JSXClosingElement, span) == 0usize);
-    assert!(offset_of!(JSXClosingElement, name) == 8usize);
-
-    assert!(size_of::<JSXFragment>() == 56usize);
-    assert!(align_of::<JSXFragment>() == 8usize);
-    assert!(offset_of!(JSXFragment, span) == 0usize);
-    assert!(offset_of!(JSXFragment, opening_fragment) == 8usize);
-    assert!(offset_of!(JSXFragment, closing_fragment) == 16usize);
-    assert!(offset_of!(JSXFragment, children) == 24usize);
-
-    assert!(size_of::<JSXOpeningFragment>() == 8usize);
-    assert!(align_of::<JSXOpeningFragment>() == 8usize);
-    assert!(offset_of!(JSXOpeningFragment, span) == 0usize);
-
-    assert!(size_of::<JSXClosingFragment>() == 8usize);
-    assert!(align_of::<JSXClosingFragment>() == 8usize);
-    assert!(offset_of!(JSXClosingFragment, span) == 0usize);
-
-    assert!(size_of::<JSXElementName>() == 16usize);
-    assert!(align_of::<JSXElementName>() == 8usize);
-
-    assert!(size_of::<JSXNamespacedName>() == 56usize);
-    assert!(align_of::<JSXNamespacedName>() == 8usize);
-    assert!(offset_of!(JSXNamespacedName, span) == 0usize);
-    assert!(offset_of!(JSXNamespacedName, namespace) == 8usize);
-    assert!(offset_of!(JSXNamespacedName, property) == 32usize);
-
-    assert!(size_of::<JSXMemberExpression>() == 48usize);
-    assert!(align_of::<JSXMemberExpression>() == 8usize);
-    assert!(offset_of!(JSXMemberExpression, span) == 0usize);
-    assert!(offset_of!(JSXMemberExpression, object) == 8usize);
-    assert!(offset_of!(JSXMemberExpression, property) == 24usize);
-
-    assert!(size_of::<JSXMemberExpressionObject>() == 16usize);
-    assert!(align_of::<JSXMemberExpressionObject>() == 8usize);
-
-    assert!(size_of::<JSXExpressionContainer>() == 24usize);
-    assert!(align_of::<JSXExpressionContainer>() == 8usize);
-    assert!(offset_of!(JSXExpressionContainer, span) == 0usize);
-    assert!(offset_of!(JSXExpressionContainer, expression) == 8usize);
-
-    assert!(size_of::<JSXExpression>() == 16usize);
-    assert!(align_of::<JSXExpression>() == 8usize);
-
-    assert!(size_of::<JSXEmptyExpression>() == 8usize);
-    assert!(align_of::<JSXEmptyExpression>() == 8usize);
-    assert!(offset_of!(JSXEmptyExpression, span) == 0usize);
-
-    assert!(size_of::<JSXAttributeItem>() == 16usize);
-    assert!(align_of::<JSXAttributeItem>() == 8usize);
-
-    assert!(size_of::<JSXAttribute>() == 40usize);
-    assert!(align_of::<JSXAttribute>() == 8usize);
-    assert!(offset_of!(JSXAttribute, span) == 0usize);
-    assert!(offset_of!(JSXAttribute, name) == 8usize);
-    assert!(offset_of!(JSXAttribute, value) == 24usize);
-
-    assert!(size_of::<JSXSpreadAttribute>() == 24usize);
-    assert!(align_of::<JSXSpreadAttribute>() == 8usize);
-    assert!(offset_of!(JSXSpreadAttribute, span) == 0usize);
-    assert!(offset_of!(JSXSpreadAttribute, argument) == 8usize);
-
-    assert!(size_of::<JSXAttributeName>() == 16usize);
-    assert!(align_of::<JSXAttributeName>() == 8usize);
-
-    assert!(size_of::<JSXAttributeValue>() == 16usize);
-    assert!(align_of::<JSXAttributeValue>() == 8usize);
-
-    assert!(size_of::<JSXIdentifier>() == 24usize);
-    assert!(align_of::<JSXIdentifier>() == 8usize);
-    assert!(offset_of!(JSXIdentifier, span) == 0usize);
-    assert!(offset_of!(JSXIdentifier, name) == 8usize);
-
-    assert!(size_of::<JSXChild>() == 16usize);
-    assert!(align_of::<JSXChild>() == 8usize);
-
-    assert!(size_of::<JSXSpreadChild>() == 24usize);
-    assert!(align_of::<JSXSpreadChild>() == 8usize);
-    assert!(offset_of!(JSXSpreadChild, span) == 0usize);
-    assert!(offset_of!(JSXSpreadChild, expression) == 8usize);
-
-    assert!(size_of::<JSXText>() == 24usize);
-    assert!(align_of::<JSXText>() == 8usize);
-    assert!(offset_of!(JSXText, span) == 0usize);
-    assert!(offset_of!(JSXText, value) == 8usize);
-
     assert!(size_of::<CommentKind>() == 1usize);
     assert!(align_of::<CommentKind>() == 1usize);
 
@@ -1575,48 +1575,6 @@ const _: () = {
 
 #[cfg(target_pointer_width = "32")]
 const _: () = {
-    assert!(size_of::<BooleanLiteral>() == 12usize);
-    assert!(align_of::<BooleanLiteral>() == 4usize);
-    assert!(offset_of!(BooleanLiteral, span) == 0usize);
-    assert!(offset_of!(BooleanLiteral, value) == 8usize);
-
-    assert!(size_of::<NullLiteral>() == 8usize);
-    assert!(align_of::<NullLiteral>() == 4usize);
-    assert!(offset_of!(NullLiteral, span) == 0usize);
-
-    assert!(size_of::<NumericLiteral>() == 32usize);
-    assert!(align_of::<NumericLiteral>() == 8usize);
-    assert!(offset_of!(NumericLiteral, span) == 0usize);
-    assert!(offset_of!(NumericLiteral, value) == 8usize);
-    assert!(offset_of!(NumericLiteral, raw) == 16usize);
-    assert!(offset_of!(NumericLiteral, base) == 24usize);
-
-    assert!(size_of::<StringLiteral>() == 24usize);
-    assert!(align_of::<StringLiteral>() == 4usize);
-    assert!(offset_of!(StringLiteral, span) == 0usize);
-    assert!(offset_of!(StringLiteral, value) == 8usize);
-    assert!(offset_of!(StringLiteral, raw) == 16usize);
-
-    assert!(size_of::<BigIntLiteral>() == 20usize);
-    assert!(align_of::<BigIntLiteral>() == 4usize);
-    assert!(offset_of!(BigIntLiteral, span) == 0usize);
-    assert!(offset_of!(BigIntLiteral, raw) == 8usize);
-    assert!(offset_of!(BigIntLiteral, base) == 16usize);
-
-    assert!(size_of::<RegExpLiteral>() == 32usize);
-    assert!(align_of::<RegExpLiteral>() == 4usize);
-    assert!(offset_of!(RegExpLiteral, span) == 0usize);
-    assert!(offset_of!(RegExpLiteral, regex) == 8usize);
-    assert!(offset_of!(RegExpLiteral, raw) == 24usize);
-
-    assert!(size_of::<RegExp>() == 16usize);
-    assert!(align_of::<RegExp>() == 4usize);
-    assert!(offset_of!(RegExp, pattern) == 0usize);
-    assert!(offset_of!(RegExp, flags) == 12usize);
-
-    assert!(size_of::<RegExpPattern>() == 12usize);
-    assert!(align_of::<RegExpPattern>() == 4usize);
-
     assert!(size_of::<Program>() == 88usize);
     assert!(align_of::<Program>() == 4usize);
     assert!(offset_of!(Program, span) == 0usize);
@@ -2354,6 +2312,151 @@ const _: () = {
     assert!(size_of::<ModuleExportName>() == 28usize);
     assert!(align_of::<ModuleExportName>() == 4usize);
 
+    assert!(size_of::<BooleanLiteral>() == 12usize);
+    assert!(align_of::<BooleanLiteral>() == 4usize);
+    assert!(offset_of!(BooleanLiteral, span) == 0usize);
+    assert!(offset_of!(BooleanLiteral, value) == 8usize);
+
+    assert!(size_of::<NullLiteral>() == 8usize);
+    assert!(align_of::<NullLiteral>() == 4usize);
+    assert!(offset_of!(NullLiteral, span) == 0usize);
+
+    assert!(size_of::<NumericLiteral>() == 32usize);
+    assert!(align_of::<NumericLiteral>() == 8usize);
+    assert!(offset_of!(NumericLiteral, span) == 0usize);
+    assert!(offset_of!(NumericLiteral, value) == 8usize);
+    assert!(offset_of!(NumericLiteral, raw) == 16usize);
+    assert!(offset_of!(NumericLiteral, base) == 24usize);
+
+    assert!(size_of::<StringLiteral>() == 24usize);
+    assert!(align_of::<StringLiteral>() == 4usize);
+    assert!(offset_of!(StringLiteral, span) == 0usize);
+    assert!(offset_of!(StringLiteral, value) == 8usize);
+    assert!(offset_of!(StringLiteral, raw) == 16usize);
+
+    assert!(size_of::<BigIntLiteral>() == 20usize);
+    assert!(align_of::<BigIntLiteral>() == 4usize);
+    assert!(offset_of!(BigIntLiteral, span) == 0usize);
+    assert!(offset_of!(BigIntLiteral, raw) == 8usize);
+    assert!(offset_of!(BigIntLiteral, base) == 16usize);
+
+    assert!(size_of::<RegExpLiteral>() == 32usize);
+    assert!(align_of::<RegExpLiteral>() == 4usize);
+    assert!(offset_of!(RegExpLiteral, span) == 0usize);
+    assert!(offset_of!(RegExpLiteral, regex) == 8usize);
+    assert!(offset_of!(RegExpLiteral, raw) == 24usize);
+
+    assert!(size_of::<RegExp>() == 16usize);
+    assert!(align_of::<RegExp>() == 4usize);
+    assert!(offset_of!(RegExp, pattern) == 0usize);
+    assert!(offset_of!(RegExp, flags) == 12usize);
+
+    assert!(size_of::<RegExpPattern>() == 12usize);
+    assert!(align_of::<RegExpPattern>() == 4usize);
+
+    assert!(size_of::<JSXElement>() == 32usize);
+    assert!(align_of::<JSXElement>() == 4usize);
+    assert!(offset_of!(JSXElement, span) == 0usize);
+    assert!(offset_of!(JSXElement, opening_element) == 8usize);
+    assert!(offset_of!(JSXElement, closing_element) == 12usize);
+    assert!(offset_of!(JSXElement, children) == 16usize);
+
+    assert!(size_of::<JSXOpeningElement>() == 40usize);
+    assert!(align_of::<JSXOpeningElement>() == 4usize);
+    assert!(offset_of!(JSXOpeningElement, span) == 0usize);
+    assert!(offset_of!(JSXOpeningElement, self_closing) == 8usize);
+    assert!(offset_of!(JSXOpeningElement, name) == 12usize);
+    assert!(offset_of!(JSXOpeningElement, attributes) == 20usize);
+    assert!(offset_of!(JSXOpeningElement, type_parameters) == 36usize);
+
+    assert!(size_of::<JSXClosingElement>() == 16usize);
+    assert!(align_of::<JSXClosingElement>() == 4usize);
+    assert!(offset_of!(JSXClosingElement, span) == 0usize);
+    assert!(offset_of!(JSXClosingElement, name) == 8usize);
+
+    assert!(size_of::<JSXFragment>() == 40usize);
+    assert!(align_of::<JSXFragment>() == 4usize);
+    assert!(offset_of!(JSXFragment, span) == 0usize);
+    assert!(offset_of!(JSXFragment, opening_fragment) == 8usize);
+    assert!(offset_of!(JSXFragment, closing_fragment) == 16usize);
+    assert!(offset_of!(JSXFragment, children) == 24usize);
+
+    assert!(size_of::<JSXOpeningFragment>() == 8usize);
+    assert!(align_of::<JSXOpeningFragment>() == 4usize);
+    assert!(offset_of!(JSXOpeningFragment, span) == 0usize);
+
+    assert!(size_of::<JSXClosingFragment>() == 8usize);
+    assert!(align_of::<JSXClosingFragment>() == 4usize);
+    assert!(offset_of!(JSXClosingFragment, span) == 0usize);
+
+    assert!(size_of::<JSXElementName>() == 8usize);
+    assert!(align_of::<JSXElementName>() == 4usize);
+
+    assert!(size_of::<JSXNamespacedName>() == 40usize);
+    assert!(align_of::<JSXNamespacedName>() == 4usize);
+    assert!(offset_of!(JSXNamespacedName, span) == 0usize);
+    assert!(offset_of!(JSXNamespacedName, namespace) == 8usize);
+    assert!(offset_of!(JSXNamespacedName, property) == 24usize);
+
+    assert!(size_of::<JSXMemberExpression>() == 32usize);
+    assert!(align_of::<JSXMemberExpression>() == 4usize);
+    assert!(offset_of!(JSXMemberExpression, span) == 0usize);
+    assert!(offset_of!(JSXMemberExpression, object) == 8usize);
+    assert!(offset_of!(JSXMemberExpression, property) == 16usize);
+
+    assert!(size_of::<JSXMemberExpressionObject>() == 8usize);
+    assert!(align_of::<JSXMemberExpressionObject>() == 4usize);
+
+    assert!(size_of::<JSXExpressionContainer>() == 20usize);
+    assert!(align_of::<JSXExpressionContainer>() == 4usize);
+    assert!(offset_of!(JSXExpressionContainer, span) == 0usize);
+    assert!(offset_of!(JSXExpressionContainer, expression) == 8usize);
+
+    assert!(size_of::<JSXExpression>() == 12usize);
+    assert!(align_of::<JSXExpression>() == 4usize);
+
+    assert!(size_of::<JSXEmptyExpression>() == 8usize);
+    assert!(align_of::<JSXEmptyExpression>() == 4usize);
+    assert!(offset_of!(JSXEmptyExpression, span) == 0usize);
+
+    assert!(size_of::<JSXAttributeItem>() == 8usize);
+    assert!(align_of::<JSXAttributeItem>() == 4usize);
+
+    assert!(size_of::<JSXAttribute>() == 24usize);
+    assert!(align_of::<JSXAttribute>() == 4usize);
+    assert!(offset_of!(JSXAttribute, span) == 0usize);
+    assert!(offset_of!(JSXAttribute, name) == 8usize);
+    assert!(offset_of!(JSXAttribute, value) == 16usize);
+
+    assert!(size_of::<JSXSpreadAttribute>() == 16usize);
+    assert!(align_of::<JSXSpreadAttribute>() == 4usize);
+    assert!(offset_of!(JSXSpreadAttribute, span) == 0usize);
+    assert!(offset_of!(JSXSpreadAttribute, argument) == 8usize);
+
+    assert!(size_of::<JSXAttributeName>() == 8usize);
+    assert!(align_of::<JSXAttributeName>() == 4usize);
+
+    assert!(size_of::<JSXAttributeValue>() == 8usize);
+    assert!(align_of::<JSXAttributeValue>() == 4usize);
+
+    assert!(size_of::<JSXIdentifier>() == 16usize);
+    assert!(align_of::<JSXIdentifier>() == 4usize);
+    assert!(offset_of!(JSXIdentifier, span) == 0usize);
+    assert!(offset_of!(JSXIdentifier, name) == 8usize);
+
+    assert!(size_of::<JSXChild>() == 8usize);
+    assert!(align_of::<JSXChild>() == 4usize);
+
+    assert!(size_of::<JSXSpreadChild>() == 16usize);
+    assert!(align_of::<JSXSpreadChild>() == 4usize);
+    assert!(offset_of!(JSXSpreadChild, span) == 0usize);
+    assert!(offset_of!(JSXSpreadChild, expression) == 8usize);
+
+    assert!(size_of::<JSXText>() == 16usize);
+    assert!(align_of::<JSXText>() == 4usize);
+    assert!(offset_of!(JSXText, span) == 0usize);
+    assert!(offset_of!(JSXText, value) == 8usize);
+
     assert!(size_of::<TSThisParameter>() == 20usize);
     assert!(align_of::<TSThisParameter>() == 4usize);
     assert!(offset_of!(TSThisParameter, span) == 0usize);
@@ -2840,109 +2943,6 @@ const _: () = {
     assert!(size_of::<JSDocUnknownType>() == 8usize);
     assert!(align_of::<JSDocUnknownType>() == 4usize);
     assert!(offset_of!(JSDocUnknownType, span) == 0usize);
-
-    assert!(size_of::<JSXElement>() == 32usize);
-    assert!(align_of::<JSXElement>() == 4usize);
-    assert!(offset_of!(JSXElement, span) == 0usize);
-    assert!(offset_of!(JSXElement, opening_element) == 8usize);
-    assert!(offset_of!(JSXElement, closing_element) == 12usize);
-    assert!(offset_of!(JSXElement, children) == 16usize);
-
-    assert!(size_of::<JSXOpeningElement>() == 40usize);
-    assert!(align_of::<JSXOpeningElement>() == 4usize);
-    assert!(offset_of!(JSXOpeningElement, span) == 0usize);
-    assert!(offset_of!(JSXOpeningElement, self_closing) == 8usize);
-    assert!(offset_of!(JSXOpeningElement, name) == 12usize);
-    assert!(offset_of!(JSXOpeningElement, attributes) == 20usize);
-    assert!(offset_of!(JSXOpeningElement, type_parameters) == 36usize);
-
-    assert!(size_of::<JSXClosingElement>() == 16usize);
-    assert!(align_of::<JSXClosingElement>() == 4usize);
-    assert!(offset_of!(JSXClosingElement, span) == 0usize);
-    assert!(offset_of!(JSXClosingElement, name) == 8usize);
-
-    assert!(size_of::<JSXFragment>() == 40usize);
-    assert!(align_of::<JSXFragment>() == 4usize);
-    assert!(offset_of!(JSXFragment, span) == 0usize);
-    assert!(offset_of!(JSXFragment, opening_fragment) == 8usize);
-    assert!(offset_of!(JSXFragment, closing_fragment) == 16usize);
-    assert!(offset_of!(JSXFragment, children) == 24usize);
-
-    assert!(size_of::<JSXOpeningFragment>() == 8usize);
-    assert!(align_of::<JSXOpeningFragment>() == 4usize);
-    assert!(offset_of!(JSXOpeningFragment, span) == 0usize);
-
-    assert!(size_of::<JSXClosingFragment>() == 8usize);
-    assert!(align_of::<JSXClosingFragment>() == 4usize);
-    assert!(offset_of!(JSXClosingFragment, span) == 0usize);
-
-    assert!(size_of::<JSXElementName>() == 8usize);
-    assert!(align_of::<JSXElementName>() == 4usize);
-
-    assert!(size_of::<JSXNamespacedName>() == 40usize);
-    assert!(align_of::<JSXNamespacedName>() == 4usize);
-    assert!(offset_of!(JSXNamespacedName, span) == 0usize);
-    assert!(offset_of!(JSXNamespacedName, namespace) == 8usize);
-    assert!(offset_of!(JSXNamespacedName, property) == 24usize);
-
-    assert!(size_of::<JSXMemberExpression>() == 32usize);
-    assert!(align_of::<JSXMemberExpression>() == 4usize);
-    assert!(offset_of!(JSXMemberExpression, span) == 0usize);
-    assert!(offset_of!(JSXMemberExpression, object) == 8usize);
-    assert!(offset_of!(JSXMemberExpression, property) == 16usize);
-
-    assert!(size_of::<JSXMemberExpressionObject>() == 8usize);
-    assert!(align_of::<JSXMemberExpressionObject>() == 4usize);
-
-    assert!(size_of::<JSXExpressionContainer>() == 20usize);
-    assert!(align_of::<JSXExpressionContainer>() == 4usize);
-    assert!(offset_of!(JSXExpressionContainer, span) == 0usize);
-    assert!(offset_of!(JSXExpressionContainer, expression) == 8usize);
-
-    assert!(size_of::<JSXExpression>() == 12usize);
-    assert!(align_of::<JSXExpression>() == 4usize);
-
-    assert!(size_of::<JSXEmptyExpression>() == 8usize);
-    assert!(align_of::<JSXEmptyExpression>() == 4usize);
-    assert!(offset_of!(JSXEmptyExpression, span) == 0usize);
-
-    assert!(size_of::<JSXAttributeItem>() == 8usize);
-    assert!(align_of::<JSXAttributeItem>() == 4usize);
-
-    assert!(size_of::<JSXAttribute>() == 24usize);
-    assert!(align_of::<JSXAttribute>() == 4usize);
-    assert!(offset_of!(JSXAttribute, span) == 0usize);
-    assert!(offset_of!(JSXAttribute, name) == 8usize);
-    assert!(offset_of!(JSXAttribute, value) == 16usize);
-
-    assert!(size_of::<JSXSpreadAttribute>() == 16usize);
-    assert!(align_of::<JSXSpreadAttribute>() == 4usize);
-    assert!(offset_of!(JSXSpreadAttribute, span) == 0usize);
-    assert!(offset_of!(JSXSpreadAttribute, argument) == 8usize);
-
-    assert!(size_of::<JSXAttributeName>() == 8usize);
-    assert!(align_of::<JSXAttributeName>() == 4usize);
-
-    assert!(size_of::<JSXAttributeValue>() == 8usize);
-    assert!(align_of::<JSXAttributeValue>() == 4usize);
-
-    assert!(size_of::<JSXIdentifier>() == 16usize);
-    assert!(align_of::<JSXIdentifier>() == 4usize);
-    assert!(offset_of!(JSXIdentifier, span) == 0usize);
-    assert!(offset_of!(JSXIdentifier, name) == 8usize);
-
-    assert!(size_of::<JSXChild>() == 8usize);
-    assert!(align_of::<JSXChild>() == 4usize);
-
-    assert!(size_of::<JSXSpreadChild>() == 16usize);
-    assert!(align_of::<JSXSpreadChild>() == 4usize);
-    assert!(offset_of!(JSXSpreadChild, span) == 0usize);
-    assert!(offset_of!(JSXSpreadChild, expression) == 8usize);
-
-    assert!(size_of::<JSXText>() == 16usize);
-    assert!(align_of::<JSXText>() == 4usize);
-    assert!(offset_of!(JSXText, span) == 0usize);
-    assert!(offset_of!(JSXText, value) == 8usize);
 
     assert!(size_of::<CommentKind>() == 1usize);
     assert!(align_of::<CommentKind>() == 1usize);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -24,202 +24,6 @@ pub struct AstBuilder<'a> {
 }
 
 impl<'a> AstBuilder<'a> {
-    /// Build a [`BooleanLiteral`].
-    ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_boolean_literal`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `value`: The boolean value itself
-    #[inline]
-    pub fn boolean_literal(self, span: Span, value: bool) -> BooleanLiteral {
-        BooleanLiteral { span, value }
-    }
-
-    /// Build a [`BooleanLiteral`], and store it in the memory arena.
-    ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::boolean_literal`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `value`: The boolean value itself
-    #[inline]
-    pub fn alloc_boolean_literal(self, span: Span, value: bool) -> Box<'a, BooleanLiteral> {
-        Box::new_in(self.boolean_literal(span, value), self.allocator)
-    }
-
-    /// Build a [`NullLiteral`].
-    ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_null_literal`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    #[inline]
-    pub fn null_literal(self, span: Span) -> NullLiteral {
-        NullLiteral { span }
-    }
-
-    /// Build a [`NullLiteral`], and store it in the memory arena.
-    ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::null_literal`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    #[inline]
-    pub fn alloc_null_literal(self, span: Span) -> Box<'a, NullLiteral> {
-        Box::new_in(self.null_literal(span), self.allocator)
-    }
-
-    /// Build a [`NumericLiteral`].
-    ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_numeric_literal`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `value`: The value of the number, converted into base 10
-    /// * `raw`: The number as it appears in source code
-    /// * `base`: The base representation used by the literal in source code
-    #[inline]
-    pub fn numeric_literal(
-        self,
-        span: Span,
-        value: f64,
-        raw: Option<Atom<'a>>,
-        base: NumberBase,
-    ) -> NumericLiteral<'a> {
-        NumericLiteral { span, value, raw, base }
-    }
-
-    /// Build a [`NumericLiteral`], and store it in the memory arena.
-    ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::numeric_literal`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `value`: The value of the number, converted into base 10
-    /// * `raw`: The number as it appears in source code
-    /// * `base`: The base representation used by the literal in source code
-    #[inline]
-    pub fn alloc_numeric_literal(
-        self,
-        span: Span,
-        value: f64,
-        raw: Option<Atom<'a>>,
-        base: NumberBase,
-    ) -> Box<'a, NumericLiteral<'a>> {
-        Box::new_in(self.numeric_literal(span, value, raw, base), self.allocator)
-    }
-
-    /// Build a [`StringLiteral`].
-    ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_string_literal`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `value`: The value of the string.
-    /// * `raw`: The raw string as it appears in source code.
-    #[inline]
-    pub fn string_literal<A>(self, span: Span, value: A, raw: Option<Atom<'a>>) -> StringLiteral<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        StringLiteral { span, value: value.into_in(self.allocator), raw }
-    }
-
-    /// Build a [`StringLiteral`], and store it in the memory arena.
-    ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::string_literal`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `value`: The value of the string.
-    /// * `raw`: The raw string as it appears in source code.
-    #[inline]
-    pub fn alloc_string_literal<A>(
-        self,
-        span: Span,
-        value: A,
-        raw: Option<Atom<'a>>,
-    ) -> Box<'a, StringLiteral<'a>>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        Box::new_in(self.string_literal(span, value, raw), self.allocator)
-    }
-
-    /// Build a [`BigIntLiteral`].
-    ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_big_int_literal`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `raw`: The bigint as it appears in source code
-    /// * `base`: The base representation used by the literal in source code
-    #[inline]
-    pub fn big_int_literal<A>(self, span: Span, raw: A, base: BigintBase) -> BigIntLiteral<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        BigIntLiteral { span, raw: raw.into_in(self.allocator), base }
-    }
-
-    /// Build a [`BigIntLiteral`], and store it in the memory arena.
-    ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::big_int_literal`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `raw`: The bigint as it appears in source code
-    /// * `base`: The base representation used by the literal in source code
-    #[inline]
-    pub fn alloc_big_int_literal<A>(
-        self,
-        span: Span,
-        raw: A,
-        base: BigintBase,
-    ) -> Box<'a, BigIntLiteral<'a>>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        Box::new_in(self.big_int_literal(span, raw, base), self.allocator)
-    }
-
-    /// Build a [`RegExpLiteral`].
-    ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_reg_exp_literal`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `regex`: The parsed regular expression. See [`oxc_regular_expression`] for more
-    /// * `raw`: The regular expression as it appears in source code
-    #[inline]
-    pub fn reg_exp_literal(
-        self,
-        span: Span,
-        regex: RegExp<'a>,
-        raw: Option<Atom<'a>>,
-    ) -> RegExpLiteral<'a> {
-        RegExpLiteral { span, regex, raw }
-    }
-
-    /// Build a [`RegExpLiteral`], and store it in the memory arena.
-    ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::reg_exp_literal`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `regex`: The parsed regular expression. See [`oxc_regular_expression`] for more
-    /// * `raw`: The regular expression as it appears in source code
-    #[inline]
-    pub fn alloc_reg_exp_literal(
-        self,
-        span: Span,
-        regex: RegExp<'a>,
-        raw: Option<Atom<'a>>,
-    ) -> Box<'a, RegExpLiteral<'a>> {
-        Box::new_in(self.reg_exp_literal(span, regex, raw), self.allocator)
-    }
-
     /// Build a [`Program`].
     ///
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_program`] instead.
@@ -7585,6 +7389,1069 @@ impl<'a> AstBuilder<'a> {
         ModuleExportName::StringLiteral(self.string_literal(span, value, raw))
     }
 
+    /// Build a [`BooleanLiteral`].
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_boolean_literal`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `value`: The boolean value itself
+    #[inline]
+    pub fn boolean_literal(self, span: Span, value: bool) -> BooleanLiteral {
+        BooleanLiteral { span, value }
+    }
+
+    /// Build a [`BooleanLiteral`], and store it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::boolean_literal`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `value`: The boolean value itself
+    #[inline]
+    pub fn alloc_boolean_literal(self, span: Span, value: bool) -> Box<'a, BooleanLiteral> {
+        Box::new_in(self.boolean_literal(span, value), self.allocator)
+    }
+
+    /// Build a [`NullLiteral`].
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_null_literal`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    #[inline]
+    pub fn null_literal(self, span: Span) -> NullLiteral {
+        NullLiteral { span }
+    }
+
+    /// Build a [`NullLiteral`], and store it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::null_literal`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    #[inline]
+    pub fn alloc_null_literal(self, span: Span) -> Box<'a, NullLiteral> {
+        Box::new_in(self.null_literal(span), self.allocator)
+    }
+
+    /// Build a [`NumericLiteral`].
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_numeric_literal`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `value`: The value of the number, converted into base 10
+    /// * `raw`: The number as it appears in source code
+    /// * `base`: The base representation used by the literal in source code
+    #[inline]
+    pub fn numeric_literal(
+        self,
+        span: Span,
+        value: f64,
+        raw: Option<Atom<'a>>,
+        base: NumberBase,
+    ) -> NumericLiteral<'a> {
+        NumericLiteral { span, value, raw, base }
+    }
+
+    /// Build a [`NumericLiteral`], and store it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::numeric_literal`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `value`: The value of the number, converted into base 10
+    /// * `raw`: The number as it appears in source code
+    /// * `base`: The base representation used by the literal in source code
+    #[inline]
+    pub fn alloc_numeric_literal(
+        self,
+        span: Span,
+        value: f64,
+        raw: Option<Atom<'a>>,
+        base: NumberBase,
+    ) -> Box<'a, NumericLiteral<'a>> {
+        Box::new_in(self.numeric_literal(span, value, raw, base), self.allocator)
+    }
+
+    /// Build a [`StringLiteral`].
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_string_literal`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `value`: The value of the string.
+    /// * `raw`: The raw string as it appears in source code.
+    #[inline]
+    pub fn string_literal<A>(self, span: Span, value: A, raw: Option<Atom<'a>>) -> StringLiteral<'a>
+    where
+        A: IntoIn<'a, Atom<'a>>,
+    {
+        StringLiteral { span, value: value.into_in(self.allocator), raw }
+    }
+
+    /// Build a [`StringLiteral`], and store it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::string_literal`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `value`: The value of the string.
+    /// * `raw`: The raw string as it appears in source code.
+    #[inline]
+    pub fn alloc_string_literal<A>(
+        self,
+        span: Span,
+        value: A,
+        raw: Option<Atom<'a>>,
+    ) -> Box<'a, StringLiteral<'a>>
+    where
+        A: IntoIn<'a, Atom<'a>>,
+    {
+        Box::new_in(self.string_literal(span, value, raw), self.allocator)
+    }
+
+    /// Build a [`BigIntLiteral`].
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_big_int_literal`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `raw`: The bigint as it appears in source code
+    /// * `base`: The base representation used by the literal in source code
+    #[inline]
+    pub fn big_int_literal<A>(self, span: Span, raw: A, base: BigintBase) -> BigIntLiteral<'a>
+    where
+        A: IntoIn<'a, Atom<'a>>,
+    {
+        BigIntLiteral { span, raw: raw.into_in(self.allocator), base }
+    }
+
+    /// Build a [`BigIntLiteral`], and store it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::big_int_literal`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `raw`: The bigint as it appears in source code
+    /// * `base`: The base representation used by the literal in source code
+    #[inline]
+    pub fn alloc_big_int_literal<A>(
+        self,
+        span: Span,
+        raw: A,
+        base: BigintBase,
+    ) -> Box<'a, BigIntLiteral<'a>>
+    where
+        A: IntoIn<'a, Atom<'a>>,
+    {
+        Box::new_in(self.big_int_literal(span, raw, base), self.allocator)
+    }
+
+    /// Build a [`RegExpLiteral`].
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_reg_exp_literal`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `regex`: The parsed regular expression. See [`oxc_regular_expression`] for more
+    /// * `raw`: The regular expression as it appears in source code
+    #[inline]
+    pub fn reg_exp_literal(
+        self,
+        span: Span,
+        regex: RegExp<'a>,
+        raw: Option<Atom<'a>>,
+    ) -> RegExpLiteral<'a> {
+        RegExpLiteral { span, regex, raw }
+    }
+
+    /// Build a [`RegExpLiteral`], and store it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::reg_exp_literal`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `regex`: The parsed regular expression. See [`oxc_regular_expression`] for more
+    /// * `raw`: The regular expression as it appears in source code
+    #[inline]
+    pub fn alloc_reg_exp_literal(
+        self,
+        span: Span,
+        regex: RegExp<'a>,
+        raw: Option<Atom<'a>>,
+    ) -> Box<'a, RegExpLiteral<'a>> {
+        Box::new_in(self.reg_exp_literal(span, regex, raw), self.allocator)
+    }
+
+    /// Build a [`JSXElement`].
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_element`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `opening_element`: Opening tag of the element.
+    /// * `closing_element`: Closing tag of the element. Will be [`None`] for self-closing tags.
+    /// * `children`: Children of the element. This can be text, other elements, or expressions.
+    #[inline]
+    pub fn jsx_element<T1, T2>(
+        self,
+        span: Span,
+        opening_element: T1,
+        closing_element: T2,
+        children: Vec<'a, JSXChild<'a>>,
+    ) -> JSXElement<'a>
+    where
+        T1: IntoIn<'a, Box<'a, JSXOpeningElement<'a>>>,
+        T2: IntoIn<'a, Option<Box<'a, JSXClosingElement<'a>>>>,
+    {
+        JSXElement {
+            span,
+            opening_element: opening_element.into_in(self.allocator),
+            closing_element: closing_element.into_in(self.allocator),
+            children,
+        }
+    }
+
+    /// Build a [`JSXElement`], and store it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_element`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `opening_element`: Opening tag of the element.
+    /// * `closing_element`: Closing tag of the element. Will be [`None`] for self-closing tags.
+    /// * `children`: Children of the element. This can be text, other elements, or expressions.
+    #[inline]
+    pub fn alloc_jsx_element<T1, T2>(
+        self,
+        span: Span,
+        opening_element: T1,
+        closing_element: T2,
+        children: Vec<'a, JSXChild<'a>>,
+    ) -> Box<'a, JSXElement<'a>>
+    where
+        T1: IntoIn<'a, Box<'a, JSXOpeningElement<'a>>>,
+        T2: IntoIn<'a, Option<Box<'a, JSXClosingElement<'a>>>>,
+    {
+        Box::new_in(
+            self.jsx_element(span, opening_element, closing_element, children),
+            self.allocator,
+        )
+    }
+
+    /// Build a [`JSXOpeningElement`].
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_opening_element`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `self_closing`: Is this tag self-closing?
+    /// * `name`: The possibly-namespaced tag name, e.g. `Foo` in `<Foo />`.
+    /// * `attributes`: List of JSX attributes. In React-like applications, these become props.
+    /// * `type_parameters`: Type parameters for generic JSX elements.
+    #[inline]
+    pub fn jsx_opening_element<T1>(
+        self,
+        span: Span,
+        self_closing: bool,
+        name: JSXElementName<'a>,
+        attributes: Vec<'a, JSXAttributeItem<'a>>,
+        type_parameters: T1,
+    ) -> JSXOpeningElement<'a>
+    where
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+    {
+        JSXOpeningElement {
+            span,
+            self_closing,
+            name,
+            attributes,
+            type_parameters: type_parameters.into_in(self.allocator),
+        }
+    }
+
+    /// Build a [`JSXOpeningElement`], and store it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_opening_element`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `self_closing`: Is this tag self-closing?
+    /// * `name`: The possibly-namespaced tag name, e.g. `Foo` in `<Foo />`.
+    /// * `attributes`: List of JSX attributes. In React-like applications, these become props.
+    /// * `type_parameters`: Type parameters for generic JSX elements.
+    #[inline]
+    pub fn alloc_jsx_opening_element<T1>(
+        self,
+        span: Span,
+        self_closing: bool,
+        name: JSXElementName<'a>,
+        attributes: Vec<'a, JSXAttributeItem<'a>>,
+        type_parameters: T1,
+    ) -> Box<'a, JSXOpeningElement<'a>>
+    where
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+    {
+        Box::new_in(
+            self.jsx_opening_element(span, self_closing, name, attributes, type_parameters),
+            self.allocator,
+        )
+    }
+
+    /// Build a [`JSXClosingElement`].
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_closing_element`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `name`: The tag name, e.g. `Foo` in `</Foo>`.
+    #[inline]
+    pub fn jsx_closing_element(
+        self,
+        span: Span,
+        name: JSXElementName<'a>,
+    ) -> JSXClosingElement<'a> {
+        JSXClosingElement { span, name }
+    }
+
+    /// Build a [`JSXClosingElement`], and store it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_closing_element`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `name`: The tag name, e.g. `Foo` in `</Foo>`.
+    #[inline]
+    pub fn alloc_jsx_closing_element(
+        self,
+        span: Span,
+        name: JSXElementName<'a>,
+    ) -> Box<'a, JSXClosingElement<'a>> {
+        Box::new_in(self.jsx_closing_element(span, name), self.allocator)
+    }
+
+    /// Build a [`JSXFragment`].
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_fragment`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `opening_fragment`: `<>`
+    /// * `closing_fragment`: `</>`
+    /// * `children`: Elements inside the fragment.
+    #[inline]
+    pub fn jsx_fragment(
+        self,
+        span: Span,
+        opening_fragment: JSXOpeningFragment,
+        closing_fragment: JSXClosingFragment,
+        children: Vec<'a, JSXChild<'a>>,
+    ) -> JSXFragment<'a> {
+        JSXFragment { span, opening_fragment, closing_fragment, children }
+    }
+
+    /// Build a [`JSXFragment`], and store it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_fragment`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `opening_fragment`: `<>`
+    /// * `closing_fragment`: `</>`
+    /// * `children`: Elements inside the fragment.
+    #[inline]
+    pub fn alloc_jsx_fragment(
+        self,
+        span: Span,
+        opening_fragment: JSXOpeningFragment,
+        closing_fragment: JSXClosingFragment,
+        children: Vec<'a, JSXChild<'a>>,
+    ) -> Box<'a, JSXFragment<'a>> {
+        Box::new_in(
+            self.jsx_fragment(span, opening_fragment, closing_fragment, children),
+            self.allocator,
+        )
+    }
+
+    /// Build a [`JSXElementName::Identifier`].
+    ///
+    /// This node contains a [`JSXIdentifier`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `name`: The name of the identifier.
+    #[inline]
+    pub fn jsx_element_name_jsx_identifier<A>(self, span: Span, name: A) -> JSXElementName<'a>
+    where
+        A: IntoIn<'a, Atom<'a>>,
+    {
+        JSXElementName::Identifier(self.alloc_jsx_identifier(span, name))
+    }
+
+    /// Build a [`JSXElementName::IdentifierReference`].
+    ///
+    /// This node contains an [`IdentifierReference`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// * `span`: The [`Span`] covering this node
+    /// * `name`: The name of the identifier being referenced.
+    #[inline]
+    pub fn jsx_element_name_identifier_reference<A>(self, span: Span, name: A) -> JSXElementName<'a>
+    where
+        A: IntoIn<'a, Atom<'a>>,
+    {
+        JSXElementName::IdentifierReference(self.alloc_identifier_reference(span, name))
+    }
+
+    /// Build a [`JSXElementName::NamespacedName`].
+    ///
+    /// This node contains a [`JSXNamespacedName`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `namespace`: Namespace portion of the name, e.g. `Apple` in `<Apple:Orange />`
+    /// * `property`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
+    #[inline]
+    pub fn jsx_element_name_jsx_namespaced_name(
+        self,
+        span: Span,
+        namespace: JSXIdentifier<'a>,
+        property: JSXIdentifier<'a>,
+    ) -> JSXElementName<'a> {
+        JSXElementName::NamespacedName(self.alloc_jsx_namespaced_name(span, namespace, property))
+    }
+
+    /// Build a [`JSXElementName::MemberExpression`].
+    ///
+    /// This node contains a [`JSXMemberExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `object`: The object being accessed. This is everything before the last `.`.
+    /// * `property`: The property being accessed. This is everything after the last `.`.
+    #[inline]
+    pub fn jsx_element_name_jsx_member_expression(
+        self,
+        span: Span,
+        object: JSXMemberExpressionObject<'a>,
+        property: JSXIdentifier<'a>,
+    ) -> JSXElementName<'a> {
+        JSXElementName::MemberExpression(self.alloc_jsx_member_expression(span, object, property))
+    }
+
+    /// Build a [`JSXElementName::ThisExpression`].
+    ///
+    /// This node contains a [`ThisExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// * `span`: The [`Span`] covering this node
+    #[inline]
+    pub fn jsx_element_name_this_expression(self, span: Span) -> JSXElementName<'a> {
+        JSXElementName::ThisExpression(self.alloc_this_expression(span))
+    }
+
+    /// Build a [`JSXNamespacedName`].
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_namespaced_name`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `namespace`: Namespace portion of the name, e.g. `Apple` in `<Apple:Orange />`
+    /// * `property`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
+    #[inline]
+    pub fn jsx_namespaced_name(
+        self,
+        span: Span,
+        namespace: JSXIdentifier<'a>,
+        property: JSXIdentifier<'a>,
+    ) -> JSXNamespacedName<'a> {
+        JSXNamespacedName { span, namespace, property }
+    }
+
+    /// Build a [`JSXNamespacedName`], and store it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_namespaced_name`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `namespace`: Namespace portion of the name, e.g. `Apple` in `<Apple:Orange />`
+    /// * `property`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
+    #[inline]
+    pub fn alloc_jsx_namespaced_name(
+        self,
+        span: Span,
+        namespace: JSXIdentifier<'a>,
+        property: JSXIdentifier<'a>,
+    ) -> Box<'a, JSXNamespacedName<'a>> {
+        Box::new_in(self.jsx_namespaced_name(span, namespace, property), self.allocator)
+    }
+
+    /// Build a [`JSXMemberExpression`].
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_member_expression`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `object`: The object being accessed. This is everything before the last `.`.
+    /// * `property`: The property being accessed. This is everything after the last `.`.
+    #[inline]
+    pub fn jsx_member_expression(
+        self,
+        span: Span,
+        object: JSXMemberExpressionObject<'a>,
+        property: JSXIdentifier<'a>,
+    ) -> JSXMemberExpression<'a> {
+        JSXMemberExpression { span, object, property }
+    }
+
+    /// Build a [`JSXMemberExpression`], and store it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_member_expression`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `object`: The object being accessed. This is everything before the last `.`.
+    /// * `property`: The property being accessed. This is everything after the last `.`.
+    #[inline]
+    pub fn alloc_jsx_member_expression(
+        self,
+        span: Span,
+        object: JSXMemberExpressionObject<'a>,
+        property: JSXIdentifier<'a>,
+    ) -> Box<'a, JSXMemberExpression<'a>> {
+        Box::new_in(self.jsx_member_expression(span, object, property), self.allocator)
+    }
+
+    /// Build a [`JSXMemberExpressionObject::IdentifierReference`].
+    ///
+    /// This node contains an [`IdentifierReference`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// * `span`: The [`Span`] covering this node
+    /// * `name`: The name of the identifier being referenced.
+    #[inline]
+    pub fn jsx_member_expression_object_identifier_reference<A>(
+        self,
+        span: Span,
+        name: A,
+    ) -> JSXMemberExpressionObject<'a>
+    where
+        A: IntoIn<'a, Atom<'a>>,
+    {
+        JSXMemberExpressionObject::IdentifierReference(self.alloc_identifier_reference(span, name))
+    }
+
+    /// Build a [`JSXMemberExpressionObject::MemberExpression`].
+    ///
+    /// This node contains a [`JSXMemberExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `object`: The object being accessed. This is everything before the last `.`.
+    /// * `property`: The property being accessed. This is everything after the last `.`.
+    #[inline]
+    pub fn jsx_member_expression_object_jsx_member_expression(
+        self,
+        span: Span,
+        object: JSXMemberExpressionObject<'a>,
+        property: JSXIdentifier<'a>,
+    ) -> JSXMemberExpressionObject<'a> {
+        JSXMemberExpressionObject::MemberExpression(
+            self.alloc_jsx_member_expression(span, object, property),
+        )
+    }
+
+    /// Build a [`JSXMemberExpressionObject::ThisExpression`].
+    ///
+    /// This node contains a [`ThisExpression`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// * `span`: The [`Span`] covering this node
+    #[inline]
+    pub fn jsx_member_expression_object_this_expression(
+        self,
+        span: Span,
+    ) -> JSXMemberExpressionObject<'a> {
+        JSXMemberExpressionObject::ThisExpression(self.alloc_this_expression(span))
+    }
+
+    /// Build a [`JSXExpressionContainer`].
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_expression_container`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `expression`: The expression inside the container.
+    #[inline]
+    pub fn jsx_expression_container(
+        self,
+        span: Span,
+        expression: JSXExpression<'a>,
+    ) -> JSXExpressionContainer<'a> {
+        JSXExpressionContainer { span, expression }
+    }
+
+    /// Build a [`JSXExpressionContainer`], and store it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_expression_container`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `expression`: The expression inside the container.
+    #[inline]
+    pub fn alloc_jsx_expression_container(
+        self,
+        span: Span,
+        expression: JSXExpression<'a>,
+    ) -> Box<'a, JSXExpressionContainer<'a>> {
+        Box::new_in(self.jsx_expression_container(span, expression), self.allocator)
+    }
+
+    /// Build a [`JSXExpression::EmptyExpression`].
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    #[inline]
+    pub fn jsx_expression_jsx_empty_expression(self, span: Span) -> JSXExpression<'a> {
+        JSXExpression::EmptyExpression(self.jsx_empty_expression(span))
+    }
+
+    /// Build a [`JSXEmptyExpression`].
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_empty_expression`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    #[inline]
+    pub fn jsx_empty_expression(self, span: Span) -> JSXEmptyExpression {
+        JSXEmptyExpression { span }
+    }
+
+    /// Build a [`JSXEmptyExpression`], and store it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_empty_expression`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    #[inline]
+    pub fn alloc_jsx_empty_expression(self, span: Span) -> Box<'a, JSXEmptyExpression> {
+        Box::new_in(self.jsx_empty_expression(span), self.allocator)
+    }
+
+    /// Build a [`JSXAttributeItem::Attribute`].
+    ///
+    /// This node contains a [`JSXAttribute`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `name`: The name of the attribute. This is a prop in React-like applications.
+    /// * `value`: The value of the attribute. This can be a string literal, an expression,
+    #[inline]
+    pub fn jsx_attribute_item_jsx_attribute(
+        self,
+        span: Span,
+        name: JSXAttributeName<'a>,
+        value: Option<JSXAttributeValue<'a>>,
+    ) -> JSXAttributeItem<'a> {
+        JSXAttributeItem::Attribute(self.alloc_jsx_attribute(span, name, value))
+    }
+
+    /// Build a [`JSXAttributeItem::SpreadAttribute`].
+    ///
+    /// This node contains a [`JSXSpreadAttribute`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `argument`: The expression being spread.
+    #[inline]
+    pub fn jsx_attribute_item_jsx_spread_attribute(
+        self,
+        span: Span,
+        argument: Expression<'a>,
+    ) -> JSXAttributeItem<'a> {
+        JSXAttributeItem::SpreadAttribute(self.alloc_jsx_spread_attribute(span, argument))
+    }
+
+    /// Build a [`JSXAttribute`].
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_attribute`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `name`: The name of the attribute. This is a prop in React-like applications.
+    /// * `value`: The value of the attribute. This can be a string literal, an expression,
+    #[inline]
+    pub fn jsx_attribute(
+        self,
+        span: Span,
+        name: JSXAttributeName<'a>,
+        value: Option<JSXAttributeValue<'a>>,
+    ) -> JSXAttribute<'a> {
+        JSXAttribute { span, name, value }
+    }
+
+    /// Build a [`JSXAttribute`], and store it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_attribute`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `name`: The name of the attribute. This is a prop in React-like applications.
+    /// * `value`: The value of the attribute. This can be a string literal, an expression,
+    #[inline]
+    pub fn alloc_jsx_attribute(
+        self,
+        span: Span,
+        name: JSXAttributeName<'a>,
+        value: Option<JSXAttributeValue<'a>>,
+    ) -> Box<'a, JSXAttribute<'a>> {
+        Box::new_in(self.jsx_attribute(span, name, value), self.allocator)
+    }
+
+    /// Build a [`JSXSpreadAttribute`].
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_spread_attribute`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `argument`: The expression being spread.
+    #[inline]
+    pub fn jsx_spread_attribute(
+        self,
+        span: Span,
+        argument: Expression<'a>,
+    ) -> JSXSpreadAttribute<'a> {
+        JSXSpreadAttribute { span, argument }
+    }
+
+    /// Build a [`JSXSpreadAttribute`], and store it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_spread_attribute`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `argument`: The expression being spread.
+    #[inline]
+    pub fn alloc_jsx_spread_attribute(
+        self,
+        span: Span,
+        argument: Expression<'a>,
+    ) -> Box<'a, JSXSpreadAttribute<'a>> {
+        Box::new_in(self.jsx_spread_attribute(span, argument), self.allocator)
+    }
+
+    /// Build a [`JSXAttributeName::Identifier`].
+    ///
+    /// This node contains a [`JSXIdentifier`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `name`: The name of the identifier.
+    #[inline]
+    pub fn jsx_attribute_name_jsx_identifier<A>(self, span: Span, name: A) -> JSXAttributeName<'a>
+    where
+        A: IntoIn<'a, Atom<'a>>,
+    {
+        JSXAttributeName::Identifier(self.alloc_jsx_identifier(span, name))
+    }
+
+    /// Build a [`JSXAttributeName::NamespacedName`].
+    ///
+    /// This node contains a [`JSXNamespacedName`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `namespace`: Namespace portion of the name, e.g. `Apple` in `<Apple:Orange />`
+    /// * `property`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
+    #[inline]
+    pub fn jsx_attribute_name_jsx_namespaced_name(
+        self,
+        span: Span,
+        namespace: JSXIdentifier<'a>,
+        property: JSXIdentifier<'a>,
+    ) -> JSXAttributeName<'a> {
+        JSXAttributeName::NamespacedName(self.alloc_jsx_namespaced_name(span, namespace, property))
+    }
+
+    /// Build a [`JSXAttributeValue::StringLiteral`].
+    ///
+    /// This node contains a [`StringLiteral`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `value`: The value of the string.
+    /// * `raw`: The raw string as it appears in source code.
+    #[inline]
+    pub fn jsx_attribute_value_string_literal<A>(
+        self,
+        span: Span,
+        value: A,
+        raw: Option<Atom<'a>>,
+    ) -> JSXAttributeValue<'a>
+    where
+        A: IntoIn<'a, Atom<'a>>,
+    {
+        JSXAttributeValue::StringLiteral(self.alloc_string_literal(span, value, raw))
+    }
+
+    /// Build a [`JSXAttributeValue::ExpressionContainer`].
+    ///
+    /// This node contains a [`JSXExpressionContainer`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `expression`: The expression inside the container.
+    #[inline]
+    pub fn jsx_attribute_value_jsx_expression_container(
+        self,
+        span: Span,
+        expression: JSXExpression<'a>,
+    ) -> JSXAttributeValue<'a> {
+        JSXAttributeValue::ExpressionContainer(
+            self.alloc_jsx_expression_container(span, expression),
+        )
+    }
+
+    /// Build a [`JSXAttributeValue::Element`].
+    ///
+    /// This node contains a [`JSXElement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `opening_element`: Opening tag of the element.
+    /// * `closing_element`: Closing tag of the element. Will be [`None`] for self-closing tags.
+    /// * `children`: Children of the element. This can be text, other elements, or expressions.
+    #[inline]
+    pub fn jsx_attribute_value_jsx_element<T1, T2>(
+        self,
+        span: Span,
+        opening_element: T1,
+        closing_element: T2,
+        children: Vec<'a, JSXChild<'a>>,
+    ) -> JSXAttributeValue<'a>
+    where
+        T1: IntoIn<'a, Box<'a, JSXOpeningElement<'a>>>,
+        T2: IntoIn<'a, Option<Box<'a, JSXClosingElement<'a>>>>,
+    {
+        JSXAttributeValue::Element(self.alloc_jsx_element(
+            span,
+            opening_element,
+            closing_element,
+            children,
+        ))
+    }
+
+    /// Build a [`JSXAttributeValue::Fragment`].
+    ///
+    /// This node contains a [`JSXFragment`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `opening_fragment`: `<>`
+    /// * `closing_fragment`: `</>`
+    /// * `children`: Elements inside the fragment.
+    #[inline]
+    pub fn jsx_attribute_value_jsx_fragment(
+        self,
+        span: Span,
+        opening_fragment: JSXOpeningFragment,
+        closing_fragment: JSXClosingFragment,
+        children: Vec<'a, JSXChild<'a>>,
+    ) -> JSXAttributeValue<'a> {
+        JSXAttributeValue::Fragment(self.alloc_jsx_fragment(
+            span,
+            opening_fragment,
+            closing_fragment,
+            children,
+        ))
+    }
+
+    /// Build a [`JSXIdentifier`].
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_identifier`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `name`: The name of the identifier.
+    #[inline]
+    pub fn jsx_identifier<A>(self, span: Span, name: A) -> JSXIdentifier<'a>
+    where
+        A: IntoIn<'a, Atom<'a>>,
+    {
+        JSXIdentifier { span, name: name.into_in(self.allocator) }
+    }
+
+    /// Build a [`JSXIdentifier`], and store it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_identifier`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `name`: The name of the identifier.
+    #[inline]
+    pub fn alloc_jsx_identifier<A>(self, span: Span, name: A) -> Box<'a, JSXIdentifier<'a>>
+    where
+        A: IntoIn<'a, Atom<'a>>,
+    {
+        Box::new_in(self.jsx_identifier(span, name), self.allocator)
+    }
+
+    /// Build a [`JSXChild::Text`].
+    ///
+    /// This node contains a [`JSXText`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `value`: The text content.
+    #[inline]
+    pub fn jsx_child_jsx_text<A>(self, span: Span, value: A) -> JSXChild<'a>
+    where
+        A: IntoIn<'a, Atom<'a>>,
+    {
+        JSXChild::Text(self.alloc_jsx_text(span, value))
+    }
+
+    /// Build a [`JSXChild::Element`].
+    ///
+    /// This node contains a [`JSXElement`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `opening_element`: Opening tag of the element.
+    /// * `closing_element`: Closing tag of the element. Will be [`None`] for self-closing tags.
+    /// * `children`: Children of the element. This can be text, other elements, or expressions.
+    #[inline]
+    pub fn jsx_child_jsx_element<T1, T2>(
+        self,
+        span: Span,
+        opening_element: T1,
+        closing_element: T2,
+        children: Vec<'a, JSXChild<'a>>,
+    ) -> JSXChild<'a>
+    where
+        T1: IntoIn<'a, Box<'a, JSXOpeningElement<'a>>>,
+        T2: IntoIn<'a, Option<Box<'a, JSXClosingElement<'a>>>>,
+    {
+        JSXChild::Element(self.alloc_jsx_element(span, opening_element, closing_element, children))
+    }
+
+    /// Build a [`JSXChild::Fragment`].
+    ///
+    /// This node contains a [`JSXFragment`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `opening_fragment`: `<>`
+    /// * `closing_fragment`: `</>`
+    /// * `children`: Elements inside the fragment.
+    #[inline]
+    pub fn jsx_child_jsx_fragment(
+        self,
+        span: Span,
+        opening_fragment: JSXOpeningFragment,
+        closing_fragment: JSXClosingFragment,
+        children: Vec<'a, JSXChild<'a>>,
+    ) -> JSXChild<'a> {
+        JSXChild::Fragment(self.alloc_jsx_fragment(
+            span,
+            opening_fragment,
+            closing_fragment,
+            children,
+        ))
+    }
+
+    /// Build a [`JSXChild::ExpressionContainer`].
+    ///
+    /// This node contains a [`JSXExpressionContainer`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `expression`: The expression inside the container.
+    #[inline]
+    pub fn jsx_child_jsx_expression_container(
+        self,
+        span: Span,
+        expression: JSXExpression<'a>,
+    ) -> JSXChild<'a> {
+        JSXChild::ExpressionContainer(self.alloc_jsx_expression_container(span, expression))
+    }
+
+    /// Build a [`JSXChild::Spread`].
+    ///
+    /// This node contains a [`JSXSpreadChild`] that will be stored in the memory arena.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `expression`: The expression being spread.
+    #[inline]
+    pub fn jsx_child_jsx_spread_child(
+        self,
+        span: Span,
+        expression: Expression<'a>,
+    ) -> JSXChild<'a> {
+        JSXChild::Spread(self.alloc_jsx_spread_child(span, expression))
+    }
+
+    /// Build a [`JSXSpreadChild`].
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_spread_child`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `expression`: The expression being spread.
+    #[inline]
+    pub fn jsx_spread_child(self, span: Span, expression: Expression<'a>) -> JSXSpreadChild<'a> {
+        JSXSpreadChild { span, expression }
+    }
+
+    /// Build a [`JSXSpreadChild`], and store it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_spread_child`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `expression`: The expression being spread.
+    #[inline]
+    pub fn alloc_jsx_spread_child(
+        self,
+        span: Span,
+        expression: Expression<'a>,
+    ) -> Box<'a, JSXSpreadChild<'a>> {
+        Box::new_in(self.jsx_spread_child(span, expression), self.allocator)
+    }
+
+    /// Build a [`JSXText`].
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_text`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `value`: The text content.
+    #[inline]
+    pub fn jsx_text<A>(self, span: Span, value: A) -> JSXText<'a>
+    where
+        A: IntoIn<'a, Atom<'a>>,
+    {
+        JSXText { span, value: value.into_in(self.allocator) }
+    }
+
+    /// Build a [`JSXText`], and store it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_text`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    /// * `value`: The text content.
+    #[inline]
+    pub fn alloc_jsx_text<A>(self, span: Span, value: A) -> Box<'a, JSXText<'a>>
+    where
+        A: IntoIn<'a, Atom<'a>>,
+    {
+        Box::new_in(self.jsx_text(span, value), self.allocator)
+    }
+
     /// Build a [`TSThisParameter`].
     ///
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_this_parameter`] instead.
@@ -12186,872 +13053,5 @@ impl<'a> AstBuilder<'a> {
     #[inline]
     pub fn alloc_js_doc_unknown_type(self, span: Span) -> Box<'a, JSDocUnknownType> {
         Box::new_in(self.js_doc_unknown_type(span), self.allocator)
-    }
-
-    /// Build a [`JSXElement`].
-    ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_element`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `opening_element`: Opening tag of the element.
-    /// * `closing_element`: Closing tag of the element. Will be [`None`] for self-closing tags.
-    /// * `children`: Children of the element. This can be text, other elements, or expressions.
-    #[inline]
-    pub fn jsx_element<T1, T2>(
-        self,
-        span: Span,
-        opening_element: T1,
-        closing_element: T2,
-        children: Vec<'a, JSXChild<'a>>,
-    ) -> JSXElement<'a>
-    where
-        T1: IntoIn<'a, Box<'a, JSXOpeningElement<'a>>>,
-        T2: IntoIn<'a, Option<Box<'a, JSXClosingElement<'a>>>>,
-    {
-        JSXElement {
-            span,
-            opening_element: opening_element.into_in(self.allocator),
-            closing_element: closing_element.into_in(self.allocator),
-            children,
-        }
-    }
-
-    /// Build a [`JSXElement`], and store it in the memory arena.
-    ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_element`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `opening_element`: Opening tag of the element.
-    /// * `closing_element`: Closing tag of the element. Will be [`None`] for self-closing tags.
-    /// * `children`: Children of the element. This can be text, other elements, or expressions.
-    #[inline]
-    pub fn alloc_jsx_element<T1, T2>(
-        self,
-        span: Span,
-        opening_element: T1,
-        closing_element: T2,
-        children: Vec<'a, JSXChild<'a>>,
-    ) -> Box<'a, JSXElement<'a>>
-    where
-        T1: IntoIn<'a, Box<'a, JSXOpeningElement<'a>>>,
-        T2: IntoIn<'a, Option<Box<'a, JSXClosingElement<'a>>>>,
-    {
-        Box::new_in(
-            self.jsx_element(span, opening_element, closing_element, children),
-            self.allocator,
-        )
-    }
-
-    /// Build a [`JSXOpeningElement`].
-    ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_opening_element`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `self_closing`: Is this tag self-closing?
-    /// * `name`: The possibly-namespaced tag name, e.g. `Foo` in `<Foo />`.
-    /// * `attributes`: List of JSX attributes. In React-like applications, these become props.
-    /// * `type_parameters`: Type parameters for generic JSX elements.
-    #[inline]
-    pub fn jsx_opening_element<T1>(
-        self,
-        span: Span,
-        self_closing: bool,
-        name: JSXElementName<'a>,
-        attributes: Vec<'a, JSXAttributeItem<'a>>,
-        type_parameters: T1,
-    ) -> JSXOpeningElement<'a>
-    where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
-        JSXOpeningElement {
-            span,
-            self_closing,
-            name,
-            attributes,
-            type_parameters: type_parameters.into_in(self.allocator),
-        }
-    }
-
-    /// Build a [`JSXOpeningElement`], and store it in the memory arena.
-    ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_opening_element`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `self_closing`: Is this tag self-closing?
-    /// * `name`: The possibly-namespaced tag name, e.g. `Foo` in `<Foo />`.
-    /// * `attributes`: List of JSX attributes. In React-like applications, these become props.
-    /// * `type_parameters`: Type parameters for generic JSX elements.
-    #[inline]
-    pub fn alloc_jsx_opening_element<T1>(
-        self,
-        span: Span,
-        self_closing: bool,
-        name: JSXElementName<'a>,
-        attributes: Vec<'a, JSXAttributeItem<'a>>,
-        type_parameters: T1,
-    ) -> Box<'a, JSXOpeningElement<'a>>
-    where
-        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
-    {
-        Box::new_in(
-            self.jsx_opening_element(span, self_closing, name, attributes, type_parameters),
-            self.allocator,
-        )
-    }
-
-    /// Build a [`JSXClosingElement`].
-    ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_closing_element`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `name`: The tag name, e.g. `Foo` in `</Foo>`.
-    #[inline]
-    pub fn jsx_closing_element(
-        self,
-        span: Span,
-        name: JSXElementName<'a>,
-    ) -> JSXClosingElement<'a> {
-        JSXClosingElement { span, name }
-    }
-
-    /// Build a [`JSXClosingElement`], and store it in the memory arena.
-    ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_closing_element`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `name`: The tag name, e.g. `Foo` in `</Foo>`.
-    #[inline]
-    pub fn alloc_jsx_closing_element(
-        self,
-        span: Span,
-        name: JSXElementName<'a>,
-    ) -> Box<'a, JSXClosingElement<'a>> {
-        Box::new_in(self.jsx_closing_element(span, name), self.allocator)
-    }
-
-    /// Build a [`JSXFragment`].
-    ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_fragment`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `opening_fragment`: `<>`
-    /// * `closing_fragment`: `</>`
-    /// * `children`: Elements inside the fragment.
-    #[inline]
-    pub fn jsx_fragment(
-        self,
-        span: Span,
-        opening_fragment: JSXOpeningFragment,
-        closing_fragment: JSXClosingFragment,
-        children: Vec<'a, JSXChild<'a>>,
-    ) -> JSXFragment<'a> {
-        JSXFragment { span, opening_fragment, closing_fragment, children }
-    }
-
-    /// Build a [`JSXFragment`], and store it in the memory arena.
-    ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_fragment`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `opening_fragment`: `<>`
-    /// * `closing_fragment`: `</>`
-    /// * `children`: Elements inside the fragment.
-    #[inline]
-    pub fn alloc_jsx_fragment(
-        self,
-        span: Span,
-        opening_fragment: JSXOpeningFragment,
-        closing_fragment: JSXClosingFragment,
-        children: Vec<'a, JSXChild<'a>>,
-    ) -> Box<'a, JSXFragment<'a>> {
-        Box::new_in(
-            self.jsx_fragment(span, opening_fragment, closing_fragment, children),
-            self.allocator,
-        )
-    }
-
-    /// Build a [`JSXElementName::Identifier`].
-    ///
-    /// This node contains a [`JSXIdentifier`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `name`: The name of the identifier.
-    #[inline]
-    pub fn jsx_element_name_jsx_identifier<A>(self, span: Span, name: A) -> JSXElementName<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        JSXElementName::Identifier(self.alloc_jsx_identifier(span, name))
-    }
-
-    /// Build a [`JSXElementName::IdentifierReference`].
-    ///
-    /// This node contains an [`IdentifierReference`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: The [`Span`] covering this node
-    /// * `name`: The name of the identifier being referenced.
-    #[inline]
-    pub fn jsx_element_name_identifier_reference<A>(self, span: Span, name: A) -> JSXElementName<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        JSXElementName::IdentifierReference(self.alloc_identifier_reference(span, name))
-    }
-
-    /// Build a [`JSXElementName::NamespacedName`].
-    ///
-    /// This node contains a [`JSXNamespacedName`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `namespace`: Namespace portion of the name, e.g. `Apple` in `<Apple:Orange />`
-    /// * `property`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
-    #[inline]
-    pub fn jsx_element_name_jsx_namespaced_name(
-        self,
-        span: Span,
-        namespace: JSXIdentifier<'a>,
-        property: JSXIdentifier<'a>,
-    ) -> JSXElementName<'a> {
-        JSXElementName::NamespacedName(self.alloc_jsx_namespaced_name(span, namespace, property))
-    }
-
-    /// Build a [`JSXElementName::MemberExpression`].
-    ///
-    /// This node contains a [`JSXMemberExpression`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `object`: The object being accessed. This is everything before the last `.`.
-    /// * `property`: The property being accessed. This is everything after the last `.`.
-    #[inline]
-    pub fn jsx_element_name_jsx_member_expression(
-        self,
-        span: Span,
-        object: JSXMemberExpressionObject<'a>,
-        property: JSXIdentifier<'a>,
-    ) -> JSXElementName<'a> {
-        JSXElementName::MemberExpression(self.alloc_jsx_member_expression(span, object, property))
-    }
-
-    /// Build a [`JSXElementName::ThisExpression`].
-    ///
-    /// This node contains a [`ThisExpression`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: The [`Span`] covering this node
-    #[inline]
-    pub fn jsx_element_name_this_expression(self, span: Span) -> JSXElementName<'a> {
-        JSXElementName::ThisExpression(self.alloc_this_expression(span))
-    }
-
-    /// Build a [`JSXNamespacedName`].
-    ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_namespaced_name`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `namespace`: Namespace portion of the name, e.g. `Apple` in `<Apple:Orange />`
-    /// * `property`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
-    #[inline]
-    pub fn jsx_namespaced_name(
-        self,
-        span: Span,
-        namespace: JSXIdentifier<'a>,
-        property: JSXIdentifier<'a>,
-    ) -> JSXNamespacedName<'a> {
-        JSXNamespacedName { span, namespace, property }
-    }
-
-    /// Build a [`JSXNamespacedName`], and store it in the memory arena.
-    ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_namespaced_name`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `namespace`: Namespace portion of the name, e.g. `Apple` in `<Apple:Orange />`
-    /// * `property`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
-    #[inline]
-    pub fn alloc_jsx_namespaced_name(
-        self,
-        span: Span,
-        namespace: JSXIdentifier<'a>,
-        property: JSXIdentifier<'a>,
-    ) -> Box<'a, JSXNamespacedName<'a>> {
-        Box::new_in(self.jsx_namespaced_name(span, namespace, property), self.allocator)
-    }
-
-    /// Build a [`JSXMemberExpression`].
-    ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_member_expression`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `object`: The object being accessed. This is everything before the last `.`.
-    /// * `property`: The property being accessed. This is everything after the last `.`.
-    #[inline]
-    pub fn jsx_member_expression(
-        self,
-        span: Span,
-        object: JSXMemberExpressionObject<'a>,
-        property: JSXIdentifier<'a>,
-    ) -> JSXMemberExpression<'a> {
-        JSXMemberExpression { span, object, property }
-    }
-
-    /// Build a [`JSXMemberExpression`], and store it in the memory arena.
-    ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_member_expression`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `object`: The object being accessed. This is everything before the last `.`.
-    /// * `property`: The property being accessed. This is everything after the last `.`.
-    #[inline]
-    pub fn alloc_jsx_member_expression(
-        self,
-        span: Span,
-        object: JSXMemberExpressionObject<'a>,
-        property: JSXIdentifier<'a>,
-    ) -> Box<'a, JSXMemberExpression<'a>> {
-        Box::new_in(self.jsx_member_expression(span, object, property), self.allocator)
-    }
-
-    /// Build a [`JSXMemberExpressionObject::IdentifierReference`].
-    ///
-    /// This node contains an [`IdentifierReference`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: The [`Span`] covering this node
-    /// * `name`: The name of the identifier being referenced.
-    #[inline]
-    pub fn jsx_member_expression_object_identifier_reference<A>(
-        self,
-        span: Span,
-        name: A,
-    ) -> JSXMemberExpressionObject<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        JSXMemberExpressionObject::IdentifierReference(self.alloc_identifier_reference(span, name))
-    }
-
-    /// Build a [`JSXMemberExpressionObject::MemberExpression`].
-    ///
-    /// This node contains a [`JSXMemberExpression`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `object`: The object being accessed. This is everything before the last `.`.
-    /// * `property`: The property being accessed. This is everything after the last `.`.
-    #[inline]
-    pub fn jsx_member_expression_object_jsx_member_expression(
-        self,
-        span: Span,
-        object: JSXMemberExpressionObject<'a>,
-        property: JSXIdentifier<'a>,
-    ) -> JSXMemberExpressionObject<'a> {
-        JSXMemberExpressionObject::MemberExpression(
-            self.alloc_jsx_member_expression(span, object, property),
-        )
-    }
-
-    /// Build a [`JSXMemberExpressionObject::ThisExpression`].
-    ///
-    /// This node contains a [`ThisExpression`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: The [`Span`] covering this node
-    #[inline]
-    pub fn jsx_member_expression_object_this_expression(
-        self,
-        span: Span,
-    ) -> JSXMemberExpressionObject<'a> {
-        JSXMemberExpressionObject::ThisExpression(self.alloc_this_expression(span))
-    }
-
-    /// Build a [`JSXExpressionContainer`].
-    ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_expression_container`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `expression`: The expression inside the container.
-    #[inline]
-    pub fn jsx_expression_container(
-        self,
-        span: Span,
-        expression: JSXExpression<'a>,
-    ) -> JSXExpressionContainer<'a> {
-        JSXExpressionContainer { span, expression }
-    }
-
-    /// Build a [`JSXExpressionContainer`], and store it in the memory arena.
-    ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_expression_container`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `expression`: The expression inside the container.
-    #[inline]
-    pub fn alloc_jsx_expression_container(
-        self,
-        span: Span,
-        expression: JSXExpression<'a>,
-    ) -> Box<'a, JSXExpressionContainer<'a>> {
-        Box::new_in(self.jsx_expression_container(span, expression), self.allocator)
-    }
-
-    /// Build a [`JSXExpression::EmptyExpression`].
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    #[inline]
-    pub fn jsx_expression_jsx_empty_expression(self, span: Span) -> JSXExpression<'a> {
-        JSXExpression::EmptyExpression(self.jsx_empty_expression(span))
-    }
-
-    /// Build a [`JSXEmptyExpression`].
-    ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_empty_expression`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    #[inline]
-    pub fn jsx_empty_expression(self, span: Span) -> JSXEmptyExpression {
-        JSXEmptyExpression { span }
-    }
-
-    /// Build a [`JSXEmptyExpression`], and store it in the memory arena.
-    ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_empty_expression`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    #[inline]
-    pub fn alloc_jsx_empty_expression(self, span: Span) -> Box<'a, JSXEmptyExpression> {
-        Box::new_in(self.jsx_empty_expression(span), self.allocator)
-    }
-
-    /// Build a [`JSXAttributeItem::Attribute`].
-    ///
-    /// This node contains a [`JSXAttribute`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `name`: The name of the attribute. This is a prop in React-like applications.
-    /// * `value`: The value of the attribute. This can be a string literal, an expression,
-    #[inline]
-    pub fn jsx_attribute_item_jsx_attribute(
-        self,
-        span: Span,
-        name: JSXAttributeName<'a>,
-        value: Option<JSXAttributeValue<'a>>,
-    ) -> JSXAttributeItem<'a> {
-        JSXAttributeItem::Attribute(self.alloc_jsx_attribute(span, name, value))
-    }
-
-    /// Build a [`JSXAttributeItem::SpreadAttribute`].
-    ///
-    /// This node contains a [`JSXSpreadAttribute`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `argument`: The expression being spread.
-    #[inline]
-    pub fn jsx_attribute_item_jsx_spread_attribute(
-        self,
-        span: Span,
-        argument: Expression<'a>,
-    ) -> JSXAttributeItem<'a> {
-        JSXAttributeItem::SpreadAttribute(self.alloc_jsx_spread_attribute(span, argument))
-    }
-
-    /// Build a [`JSXAttribute`].
-    ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_attribute`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `name`: The name of the attribute. This is a prop in React-like applications.
-    /// * `value`: The value of the attribute. This can be a string literal, an expression,
-    #[inline]
-    pub fn jsx_attribute(
-        self,
-        span: Span,
-        name: JSXAttributeName<'a>,
-        value: Option<JSXAttributeValue<'a>>,
-    ) -> JSXAttribute<'a> {
-        JSXAttribute { span, name, value }
-    }
-
-    /// Build a [`JSXAttribute`], and store it in the memory arena.
-    ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_attribute`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `name`: The name of the attribute. This is a prop in React-like applications.
-    /// * `value`: The value of the attribute. This can be a string literal, an expression,
-    #[inline]
-    pub fn alloc_jsx_attribute(
-        self,
-        span: Span,
-        name: JSXAttributeName<'a>,
-        value: Option<JSXAttributeValue<'a>>,
-    ) -> Box<'a, JSXAttribute<'a>> {
-        Box::new_in(self.jsx_attribute(span, name, value), self.allocator)
-    }
-
-    /// Build a [`JSXSpreadAttribute`].
-    ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_spread_attribute`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `argument`: The expression being spread.
-    #[inline]
-    pub fn jsx_spread_attribute(
-        self,
-        span: Span,
-        argument: Expression<'a>,
-    ) -> JSXSpreadAttribute<'a> {
-        JSXSpreadAttribute { span, argument }
-    }
-
-    /// Build a [`JSXSpreadAttribute`], and store it in the memory arena.
-    ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_spread_attribute`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `argument`: The expression being spread.
-    #[inline]
-    pub fn alloc_jsx_spread_attribute(
-        self,
-        span: Span,
-        argument: Expression<'a>,
-    ) -> Box<'a, JSXSpreadAttribute<'a>> {
-        Box::new_in(self.jsx_spread_attribute(span, argument), self.allocator)
-    }
-
-    /// Build a [`JSXAttributeName::Identifier`].
-    ///
-    /// This node contains a [`JSXIdentifier`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `name`: The name of the identifier.
-    #[inline]
-    pub fn jsx_attribute_name_jsx_identifier<A>(self, span: Span, name: A) -> JSXAttributeName<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        JSXAttributeName::Identifier(self.alloc_jsx_identifier(span, name))
-    }
-
-    /// Build a [`JSXAttributeName::NamespacedName`].
-    ///
-    /// This node contains a [`JSXNamespacedName`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `namespace`: Namespace portion of the name, e.g. `Apple` in `<Apple:Orange />`
-    /// * `property`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
-    #[inline]
-    pub fn jsx_attribute_name_jsx_namespaced_name(
-        self,
-        span: Span,
-        namespace: JSXIdentifier<'a>,
-        property: JSXIdentifier<'a>,
-    ) -> JSXAttributeName<'a> {
-        JSXAttributeName::NamespacedName(self.alloc_jsx_namespaced_name(span, namespace, property))
-    }
-
-    /// Build a [`JSXAttributeValue::StringLiteral`].
-    ///
-    /// This node contains a [`StringLiteral`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `value`: The value of the string.
-    /// * `raw`: The raw string as it appears in source code.
-    #[inline]
-    pub fn jsx_attribute_value_string_literal<A>(
-        self,
-        span: Span,
-        value: A,
-        raw: Option<Atom<'a>>,
-    ) -> JSXAttributeValue<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        JSXAttributeValue::StringLiteral(self.alloc_string_literal(span, value, raw))
-    }
-
-    /// Build a [`JSXAttributeValue::ExpressionContainer`].
-    ///
-    /// This node contains a [`JSXExpressionContainer`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `expression`: The expression inside the container.
-    #[inline]
-    pub fn jsx_attribute_value_jsx_expression_container(
-        self,
-        span: Span,
-        expression: JSXExpression<'a>,
-    ) -> JSXAttributeValue<'a> {
-        JSXAttributeValue::ExpressionContainer(
-            self.alloc_jsx_expression_container(span, expression),
-        )
-    }
-
-    /// Build a [`JSXAttributeValue::Element`].
-    ///
-    /// This node contains a [`JSXElement`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `opening_element`: Opening tag of the element.
-    /// * `closing_element`: Closing tag of the element. Will be [`None`] for self-closing tags.
-    /// * `children`: Children of the element. This can be text, other elements, or expressions.
-    #[inline]
-    pub fn jsx_attribute_value_jsx_element<T1, T2>(
-        self,
-        span: Span,
-        opening_element: T1,
-        closing_element: T2,
-        children: Vec<'a, JSXChild<'a>>,
-    ) -> JSXAttributeValue<'a>
-    where
-        T1: IntoIn<'a, Box<'a, JSXOpeningElement<'a>>>,
-        T2: IntoIn<'a, Option<Box<'a, JSXClosingElement<'a>>>>,
-    {
-        JSXAttributeValue::Element(self.alloc_jsx_element(
-            span,
-            opening_element,
-            closing_element,
-            children,
-        ))
-    }
-
-    /// Build a [`JSXAttributeValue::Fragment`].
-    ///
-    /// This node contains a [`JSXFragment`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `opening_fragment`: `<>`
-    /// * `closing_fragment`: `</>`
-    /// * `children`: Elements inside the fragment.
-    #[inline]
-    pub fn jsx_attribute_value_jsx_fragment(
-        self,
-        span: Span,
-        opening_fragment: JSXOpeningFragment,
-        closing_fragment: JSXClosingFragment,
-        children: Vec<'a, JSXChild<'a>>,
-    ) -> JSXAttributeValue<'a> {
-        JSXAttributeValue::Fragment(self.alloc_jsx_fragment(
-            span,
-            opening_fragment,
-            closing_fragment,
-            children,
-        ))
-    }
-
-    /// Build a [`JSXIdentifier`].
-    ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_identifier`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `name`: The name of the identifier.
-    #[inline]
-    pub fn jsx_identifier<A>(self, span: Span, name: A) -> JSXIdentifier<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        JSXIdentifier { span, name: name.into_in(self.allocator) }
-    }
-
-    /// Build a [`JSXIdentifier`], and store it in the memory arena.
-    ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_identifier`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `name`: The name of the identifier.
-    #[inline]
-    pub fn alloc_jsx_identifier<A>(self, span: Span, name: A) -> Box<'a, JSXIdentifier<'a>>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        Box::new_in(self.jsx_identifier(span, name), self.allocator)
-    }
-
-    /// Build a [`JSXChild::Text`].
-    ///
-    /// This node contains a [`JSXText`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `value`: The text content.
-    #[inline]
-    pub fn jsx_child_jsx_text<A>(self, span: Span, value: A) -> JSXChild<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        JSXChild::Text(self.alloc_jsx_text(span, value))
-    }
-
-    /// Build a [`JSXChild::Element`].
-    ///
-    /// This node contains a [`JSXElement`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `opening_element`: Opening tag of the element.
-    /// * `closing_element`: Closing tag of the element. Will be [`None`] for self-closing tags.
-    /// * `children`: Children of the element. This can be text, other elements, or expressions.
-    #[inline]
-    pub fn jsx_child_jsx_element<T1, T2>(
-        self,
-        span: Span,
-        opening_element: T1,
-        closing_element: T2,
-        children: Vec<'a, JSXChild<'a>>,
-    ) -> JSXChild<'a>
-    where
-        T1: IntoIn<'a, Box<'a, JSXOpeningElement<'a>>>,
-        T2: IntoIn<'a, Option<Box<'a, JSXClosingElement<'a>>>>,
-    {
-        JSXChild::Element(self.alloc_jsx_element(span, opening_element, closing_element, children))
-    }
-
-    /// Build a [`JSXChild::Fragment`].
-    ///
-    /// This node contains a [`JSXFragment`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `opening_fragment`: `<>`
-    /// * `closing_fragment`: `</>`
-    /// * `children`: Elements inside the fragment.
-    #[inline]
-    pub fn jsx_child_jsx_fragment(
-        self,
-        span: Span,
-        opening_fragment: JSXOpeningFragment,
-        closing_fragment: JSXClosingFragment,
-        children: Vec<'a, JSXChild<'a>>,
-    ) -> JSXChild<'a> {
-        JSXChild::Fragment(self.alloc_jsx_fragment(
-            span,
-            opening_fragment,
-            closing_fragment,
-            children,
-        ))
-    }
-
-    /// Build a [`JSXChild::ExpressionContainer`].
-    ///
-    /// This node contains a [`JSXExpressionContainer`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `expression`: The expression inside the container.
-    #[inline]
-    pub fn jsx_child_jsx_expression_container(
-        self,
-        span: Span,
-        expression: JSXExpression<'a>,
-    ) -> JSXChild<'a> {
-        JSXChild::ExpressionContainer(self.alloc_jsx_expression_container(span, expression))
-    }
-
-    /// Build a [`JSXChild::Spread`].
-    ///
-    /// This node contains a [`JSXSpreadChild`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `expression`: The expression being spread.
-    #[inline]
-    pub fn jsx_child_jsx_spread_child(
-        self,
-        span: Span,
-        expression: Expression<'a>,
-    ) -> JSXChild<'a> {
-        JSXChild::Spread(self.alloc_jsx_spread_child(span, expression))
-    }
-
-    /// Build a [`JSXSpreadChild`].
-    ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_spread_child`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `expression`: The expression being spread.
-    #[inline]
-    pub fn jsx_spread_child(self, span: Span, expression: Expression<'a>) -> JSXSpreadChild<'a> {
-        JSXSpreadChild { span, expression }
-    }
-
-    /// Build a [`JSXSpreadChild`], and store it in the memory arena.
-    ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_spread_child`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `expression`: The expression being spread.
-    #[inline]
-    pub fn alloc_jsx_spread_child(
-        self,
-        span: Span,
-        expression: Expression<'a>,
-    ) -> Box<'a, JSXSpreadChild<'a>> {
-        Box::new_in(self.jsx_spread_child(span, expression), self.allocator)
-    }
-
-    /// Build a [`JSXText`].
-    ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_text`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `value`: The text content.
-    #[inline]
-    pub fn jsx_text<A>(self, span: Span, value: A) -> JSXText<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        JSXText { span, value: value.into_in(self.allocator) }
-    }
-
-    /// Build a [`JSXText`], and store it in the memory arena.
-    ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_text`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `value`: The text content.
-    #[inline]
-    pub fn alloc_jsx_text<A>(self, span: Span, value: A) -> Box<'a, JSXText<'a>>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        Box::new_in(self.jsx_text(span, value), self.allocator)
     }
 }

--- a/crates/oxc_ast/src/generated/ast_kind.rs
+++ b/crates/oxc_ast/src/generated/ast_kind.rs
@@ -13,183 +13,177 @@ use crate::ast::*;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(u8)]
 pub enum AstType {
-    BooleanLiteral = 0,
-    NullLiteral = 1,
-    NumericLiteral = 2,
-    StringLiteral = 3,
-    BigIntLiteral = 4,
-    RegExpLiteral = 5,
-    Program = 6,
-    IdentifierName = 7,
-    IdentifierReference = 8,
-    BindingIdentifier = 9,
-    LabelIdentifier = 10,
-    ThisExpression = 11,
-    ArrayExpression = 12,
-    ArrayExpressionElement = 13,
-    Elision = 14,
-    ObjectExpression = 15,
-    ObjectProperty = 16,
-    PropertyKey = 17,
-    TemplateLiteral = 18,
-    TaggedTemplateExpression = 19,
-    MemberExpression = 20,
-    CallExpression = 21,
-    NewExpression = 22,
-    MetaProperty = 23,
-    SpreadElement = 24,
-    Argument = 25,
-    UpdateExpression = 26,
-    UnaryExpression = 27,
-    BinaryExpression = 28,
-    PrivateInExpression = 29,
-    LogicalExpression = 30,
-    ConditionalExpression = 31,
-    AssignmentExpression = 32,
-    AssignmentTarget = 33,
-    SimpleAssignmentTarget = 34,
-    AssignmentTargetPattern = 35,
-    ArrayAssignmentTarget = 36,
-    ObjectAssignmentTarget = 37,
-    AssignmentTargetWithDefault = 38,
-    SequenceExpression = 39,
-    Super = 40,
-    AwaitExpression = 41,
-    ChainExpression = 42,
-    ParenthesizedExpression = 43,
-    Directive = 44,
-    Hashbang = 45,
-    BlockStatement = 46,
-    VariableDeclaration = 47,
-    VariableDeclarator = 48,
-    EmptyStatement = 49,
-    ExpressionStatement = 50,
-    IfStatement = 51,
-    DoWhileStatement = 52,
-    WhileStatement = 53,
-    ForStatement = 54,
-    ForStatementInit = 55,
-    ForInStatement = 56,
-    ForOfStatement = 57,
-    ContinueStatement = 58,
-    BreakStatement = 59,
-    ReturnStatement = 60,
-    WithStatement = 61,
-    SwitchStatement = 62,
-    SwitchCase = 63,
-    LabeledStatement = 64,
-    ThrowStatement = 65,
-    TryStatement = 66,
-    CatchClause = 67,
-    CatchParameter = 68,
-    DebuggerStatement = 69,
-    AssignmentPattern = 70,
-    ObjectPattern = 71,
-    ArrayPattern = 72,
-    BindingRestElement = 73,
-    Function = 74,
-    FormalParameters = 75,
-    FormalParameter = 76,
-    FunctionBody = 77,
-    ArrowFunctionExpression = 78,
-    YieldExpression = 79,
-    Class = 80,
-    ClassBody = 81,
-    MethodDefinition = 82,
-    PropertyDefinition = 83,
-    PrivateIdentifier = 84,
-    StaticBlock = 85,
-    ModuleDeclaration = 86,
-    ImportExpression = 87,
-    ImportDeclaration = 88,
-    ImportSpecifier = 89,
-    ImportDefaultSpecifier = 90,
-    ImportNamespaceSpecifier = 91,
-    ExportNamedDeclaration = 92,
-    ExportDefaultDeclaration = 93,
-    ExportAllDeclaration = 94,
-    ExportSpecifier = 95,
-    TSThisParameter = 96,
-    TSEnumDeclaration = 97,
-    TSEnumMember = 98,
-    TSTypeAnnotation = 99,
-    TSLiteralType = 100,
-    TSConditionalType = 101,
-    TSUnionType = 102,
-    TSIntersectionType = 103,
-    TSParenthesizedType = 104,
-    TSIndexedAccessType = 105,
-    TSNamedTupleMember = 106,
-    TSAnyKeyword = 107,
-    TSStringKeyword = 108,
-    TSBooleanKeyword = 109,
-    TSNumberKeyword = 110,
-    TSNeverKeyword = 111,
-    TSIntrinsicKeyword = 112,
-    TSUnknownKeyword = 113,
-    TSNullKeyword = 114,
-    TSUndefinedKeyword = 115,
-    TSVoidKeyword = 116,
-    TSSymbolKeyword = 117,
-    TSThisType = 118,
-    TSObjectKeyword = 119,
-    TSBigIntKeyword = 120,
-    TSTypeReference = 121,
-    TSTypeName = 122,
-    TSQualifiedName = 123,
-    TSTypeParameterInstantiation = 124,
-    TSTypeParameter = 125,
-    TSTypeParameterDeclaration = 126,
-    TSTypeAliasDeclaration = 127,
-    TSClassImplements = 128,
-    TSInterfaceDeclaration = 129,
-    TSPropertySignature = 130,
-    TSMethodSignature = 131,
-    TSConstructSignatureDeclaration = 132,
-    TSInterfaceHeritage = 133,
-    TSModuleDeclaration = 134,
-    TSModuleBlock = 135,
-    TSTypeLiteral = 136,
-    TSInferType = 137,
-    TSTypeQuery = 138,
-    TSImportType = 139,
-    TSMappedType = 140,
-    TSTemplateLiteralType = 141,
-    TSAsExpression = 142,
-    TSSatisfiesExpression = 143,
-    TSTypeAssertion = 144,
-    TSImportEqualsDeclaration = 145,
-    TSModuleReference = 146,
-    TSExternalModuleReference = 147,
-    TSNonNullExpression = 148,
-    Decorator = 149,
-    TSExportAssignment = 150,
-    TSInstantiationExpression = 151,
-    JSXElement = 152,
-    JSXOpeningElement = 153,
-    JSXClosingElement = 154,
-    JSXFragment = 155,
-    JSXElementName = 156,
-    JSXNamespacedName = 157,
-    JSXMemberExpression = 158,
-    JSXMemberExpressionObject = 159,
-    JSXExpressionContainer = 160,
-    JSXAttributeItem = 161,
-    JSXSpreadAttribute = 162,
-    JSXIdentifier = 163,
-    JSXText = 164,
+    Program = 0,
+    IdentifierName = 1,
+    IdentifierReference = 2,
+    BindingIdentifier = 3,
+    LabelIdentifier = 4,
+    ThisExpression = 5,
+    ArrayExpression = 6,
+    ArrayExpressionElement = 7,
+    Elision = 8,
+    ObjectExpression = 9,
+    ObjectProperty = 10,
+    PropertyKey = 11,
+    TemplateLiteral = 12,
+    TaggedTemplateExpression = 13,
+    MemberExpression = 14,
+    CallExpression = 15,
+    NewExpression = 16,
+    MetaProperty = 17,
+    SpreadElement = 18,
+    Argument = 19,
+    UpdateExpression = 20,
+    UnaryExpression = 21,
+    BinaryExpression = 22,
+    PrivateInExpression = 23,
+    LogicalExpression = 24,
+    ConditionalExpression = 25,
+    AssignmentExpression = 26,
+    AssignmentTarget = 27,
+    SimpleAssignmentTarget = 28,
+    AssignmentTargetPattern = 29,
+    ArrayAssignmentTarget = 30,
+    ObjectAssignmentTarget = 31,
+    AssignmentTargetWithDefault = 32,
+    SequenceExpression = 33,
+    Super = 34,
+    AwaitExpression = 35,
+    ChainExpression = 36,
+    ParenthesizedExpression = 37,
+    Directive = 38,
+    Hashbang = 39,
+    BlockStatement = 40,
+    VariableDeclaration = 41,
+    VariableDeclarator = 42,
+    EmptyStatement = 43,
+    ExpressionStatement = 44,
+    IfStatement = 45,
+    DoWhileStatement = 46,
+    WhileStatement = 47,
+    ForStatement = 48,
+    ForStatementInit = 49,
+    ForInStatement = 50,
+    ForOfStatement = 51,
+    ContinueStatement = 52,
+    BreakStatement = 53,
+    ReturnStatement = 54,
+    WithStatement = 55,
+    SwitchStatement = 56,
+    SwitchCase = 57,
+    LabeledStatement = 58,
+    ThrowStatement = 59,
+    TryStatement = 60,
+    CatchClause = 61,
+    CatchParameter = 62,
+    DebuggerStatement = 63,
+    AssignmentPattern = 64,
+    ObjectPattern = 65,
+    ArrayPattern = 66,
+    BindingRestElement = 67,
+    Function = 68,
+    FormalParameters = 69,
+    FormalParameter = 70,
+    FunctionBody = 71,
+    ArrowFunctionExpression = 72,
+    YieldExpression = 73,
+    Class = 74,
+    ClassBody = 75,
+    MethodDefinition = 76,
+    PropertyDefinition = 77,
+    PrivateIdentifier = 78,
+    StaticBlock = 79,
+    ModuleDeclaration = 80,
+    ImportExpression = 81,
+    ImportDeclaration = 82,
+    ImportSpecifier = 83,
+    ImportDefaultSpecifier = 84,
+    ImportNamespaceSpecifier = 85,
+    ExportNamedDeclaration = 86,
+    ExportDefaultDeclaration = 87,
+    ExportAllDeclaration = 88,
+    ExportSpecifier = 89,
+    BooleanLiteral = 90,
+    NullLiteral = 91,
+    NumericLiteral = 92,
+    StringLiteral = 93,
+    BigIntLiteral = 94,
+    RegExpLiteral = 95,
+    JSXElement = 96,
+    JSXOpeningElement = 97,
+    JSXClosingElement = 98,
+    JSXFragment = 99,
+    JSXElementName = 100,
+    JSXNamespacedName = 101,
+    JSXMemberExpression = 102,
+    JSXMemberExpressionObject = 103,
+    JSXExpressionContainer = 104,
+    JSXAttributeItem = 105,
+    JSXSpreadAttribute = 106,
+    JSXIdentifier = 107,
+    JSXText = 108,
+    TSThisParameter = 109,
+    TSEnumDeclaration = 110,
+    TSEnumMember = 111,
+    TSTypeAnnotation = 112,
+    TSLiteralType = 113,
+    TSConditionalType = 114,
+    TSUnionType = 115,
+    TSIntersectionType = 116,
+    TSParenthesizedType = 117,
+    TSIndexedAccessType = 118,
+    TSNamedTupleMember = 119,
+    TSAnyKeyword = 120,
+    TSStringKeyword = 121,
+    TSBooleanKeyword = 122,
+    TSNumberKeyword = 123,
+    TSNeverKeyword = 124,
+    TSIntrinsicKeyword = 125,
+    TSUnknownKeyword = 126,
+    TSNullKeyword = 127,
+    TSUndefinedKeyword = 128,
+    TSVoidKeyword = 129,
+    TSSymbolKeyword = 130,
+    TSThisType = 131,
+    TSObjectKeyword = 132,
+    TSBigIntKeyword = 133,
+    TSTypeReference = 134,
+    TSTypeName = 135,
+    TSQualifiedName = 136,
+    TSTypeParameterInstantiation = 137,
+    TSTypeParameter = 138,
+    TSTypeParameterDeclaration = 139,
+    TSTypeAliasDeclaration = 140,
+    TSClassImplements = 141,
+    TSInterfaceDeclaration = 142,
+    TSPropertySignature = 143,
+    TSMethodSignature = 144,
+    TSConstructSignatureDeclaration = 145,
+    TSInterfaceHeritage = 146,
+    TSModuleDeclaration = 147,
+    TSModuleBlock = 148,
+    TSTypeLiteral = 149,
+    TSInferType = 150,
+    TSTypeQuery = 151,
+    TSImportType = 152,
+    TSMappedType = 153,
+    TSTemplateLiteralType = 154,
+    TSAsExpression = 155,
+    TSSatisfiesExpression = 156,
+    TSTypeAssertion = 157,
+    TSImportEqualsDeclaration = 158,
+    TSModuleReference = 159,
+    TSExternalModuleReference = 160,
+    TSNonNullExpression = 161,
+    Decorator = 162,
+    TSExportAssignment = 163,
+    TSInstantiationExpression = 164,
 }
 
 /// Untyped AST Node Kind
 #[derive(Debug, Clone, Copy)]
 #[repr(C, u8)]
 pub enum AstKind<'a> {
-    BooleanLiteral(&'a BooleanLiteral) = AstType::BooleanLiteral as u8,
-    NullLiteral(&'a NullLiteral) = AstType::NullLiteral as u8,
-    NumericLiteral(&'a NumericLiteral<'a>) = AstType::NumericLiteral as u8,
-    StringLiteral(&'a StringLiteral<'a>) = AstType::StringLiteral as u8,
-    BigIntLiteral(&'a BigIntLiteral<'a>) = AstType::BigIntLiteral as u8,
-    RegExpLiteral(&'a RegExpLiteral<'a>) = AstType::RegExpLiteral as u8,
     Program(&'a Program<'a>) = AstType::Program as u8,
     IdentifierName(&'a IdentifierName<'a>) = AstType::IdentifierName as u8,
     IdentifierReference(&'a IdentifierReference<'a>) = AstType::IdentifierReference as u8,
@@ -287,6 +281,26 @@ pub enum AstKind<'a> {
         AstType::ExportDefaultDeclaration as u8,
     ExportAllDeclaration(&'a ExportAllDeclaration<'a>) = AstType::ExportAllDeclaration as u8,
     ExportSpecifier(&'a ExportSpecifier<'a>) = AstType::ExportSpecifier as u8,
+    BooleanLiteral(&'a BooleanLiteral) = AstType::BooleanLiteral as u8,
+    NullLiteral(&'a NullLiteral) = AstType::NullLiteral as u8,
+    NumericLiteral(&'a NumericLiteral<'a>) = AstType::NumericLiteral as u8,
+    StringLiteral(&'a StringLiteral<'a>) = AstType::StringLiteral as u8,
+    BigIntLiteral(&'a BigIntLiteral<'a>) = AstType::BigIntLiteral as u8,
+    RegExpLiteral(&'a RegExpLiteral<'a>) = AstType::RegExpLiteral as u8,
+    JSXElement(&'a JSXElement<'a>) = AstType::JSXElement as u8,
+    JSXOpeningElement(&'a JSXOpeningElement<'a>) = AstType::JSXOpeningElement as u8,
+    JSXClosingElement(&'a JSXClosingElement<'a>) = AstType::JSXClosingElement as u8,
+    JSXFragment(&'a JSXFragment<'a>) = AstType::JSXFragment as u8,
+    JSXElementName(&'a JSXElementName<'a>) = AstType::JSXElementName as u8,
+    JSXNamespacedName(&'a JSXNamespacedName<'a>) = AstType::JSXNamespacedName as u8,
+    JSXMemberExpression(&'a JSXMemberExpression<'a>) = AstType::JSXMemberExpression as u8,
+    JSXMemberExpressionObject(&'a JSXMemberExpressionObject<'a>) =
+        AstType::JSXMemberExpressionObject as u8,
+    JSXExpressionContainer(&'a JSXExpressionContainer<'a>) = AstType::JSXExpressionContainer as u8,
+    JSXAttributeItem(&'a JSXAttributeItem<'a>) = AstType::JSXAttributeItem as u8,
+    JSXSpreadAttribute(&'a JSXSpreadAttribute<'a>) = AstType::JSXSpreadAttribute as u8,
+    JSXIdentifier(&'a JSXIdentifier<'a>) = AstType::JSXIdentifier as u8,
+    JSXText(&'a JSXText<'a>) = AstType::JSXText as u8,
     TSThisParameter(&'a TSThisParameter<'a>) = AstType::TSThisParameter as u8,
     TSEnumDeclaration(&'a TSEnumDeclaration<'a>) = AstType::TSEnumDeclaration as u8,
     TSEnumMember(&'a TSEnumMember<'a>) = AstType::TSEnumMember as u8,
@@ -349,20 +363,6 @@ pub enum AstKind<'a> {
     TSExportAssignment(&'a TSExportAssignment<'a>) = AstType::TSExportAssignment as u8,
     TSInstantiationExpression(&'a TSInstantiationExpression<'a>) =
         AstType::TSInstantiationExpression as u8,
-    JSXElement(&'a JSXElement<'a>) = AstType::JSXElement as u8,
-    JSXOpeningElement(&'a JSXOpeningElement<'a>) = AstType::JSXOpeningElement as u8,
-    JSXClosingElement(&'a JSXClosingElement<'a>) = AstType::JSXClosingElement as u8,
-    JSXFragment(&'a JSXFragment<'a>) = AstType::JSXFragment as u8,
-    JSXElementName(&'a JSXElementName<'a>) = AstType::JSXElementName as u8,
-    JSXNamespacedName(&'a JSXNamespacedName<'a>) = AstType::JSXNamespacedName as u8,
-    JSXMemberExpression(&'a JSXMemberExpression<'a>) = AstType::JSXMemberExpression as u8,
-    JSXMemberExpressionObject(&'a JSXMemberExpressionObject<'a>) =
-        AstType::JSXMemberExpressionObject as u8,
-    JSXExpressionContainer(&'a JSXExpressionContainer<'a>) = AstType::JSXExpressionContainer as u8,
-    JSXAttributeItem(&'a JSXAttributeItem<'a>) = AstType::JSXAttributeItem as u8,
-    JSXSpreadAttribute(&'a JSXSpreadAttribute<'a>) = AstType::JSXSpreadAttribute as u8,
-    JSXIdentifier(&'a JSXIdentifier<'a>) = AstType::JSXIdentifier as u8,
-    JSXText(&'a JSXText<'a>) = AstType::JSXText as u8,
 }
 
 impl AstKind<'_> {
@@ -380,12 +380,6 @@ impl AstKind<'_> {
 impl GetSpan for AstKind<'_> {
     fn span(&self) -> Span {
         match self {
-            Self::BooleanLiteral(it) => it.span(),
-            Self::NullLiteral(it) => it.span(),
-            Self::NumericLiteral(it) => it.span(),
-            Self::StringLiteral(it) => it.span(),
-            Self::BigIntLiteral(it) => it.span(),
-            Self::RegExpLiteral(it) => it.span(),
             Self::Program(it) => it.span(),
             Self::IdentifierName(it) => it.span(),
             Self::IdentifierReference(it) => it.span(),
@@ -476,6 +470,25 @@ impl GetSpan for AstKind<'_> {
             Self::ExportDefaultDeclaration(it) => it.span(),
             Self::ExportAllDeclaration(it) => it.span(),
             Self::ExportSpecifier(it) => it.span(),
+            Self::BooleanLiteral(it) => it.span(),
+            Self::NullLiteral(it) => it.span(),
+            Self::NumericLiteral(it) => it.span(),
+            Self::StringLiteral(it) => it.span(),
+            Self::BigIntLiteral(it) => it.span(),
+            Self::RegExpLiteral(it) => it.span(),
+            Self::JSXElement(it) => it.span(),
+            Self::JSXOpeningElement(it) => it.span(),
+            Self::JSXClosingElement(it) => it.span(),
+            Self::JSXFragment(it) => it.span(),
+            Self::JSXElementName(it) => it.span(),
+            Self::JSXNamespacedName(it) => it.span(),
+            Self::JSXMemberExpression(it) => it.span(),
+            Self::JSXMemberExpressionObject(it) => it.span(),
+            Self::JSXExpressionContainer(it) => it.span(),
+            Self::JSXAttributeItem(it) => it.span(),
+            Self::JSXSpreadAttribute(it) => it.span(),
+            Self::JSXIdentifier(it) => it.span(),
+            Self::JSXText(it) => it.span(),
             Self::TSThisParameter(it) => it.span(),
             Self::TSEnumDeclaration(it) => it.span(),
             Self::TSEnumMember(it) => it.span(),
@@ -532,78 +545,11 @@ impl GetSpan for AstKind<'_> {
             Self::Decorator(it) => it.span(),
             Self::TSExportAssignment(it) => it.span(),
             Self::TSInstantiationExpression(it) => it.span(),
-            Self::JSXElement(it) => it.span(),
-            Self::JSXOpeningElement(it) => it.span(),
-            Self::JSXClosingElement(it) => it.span(),
-            Self::JSXFragment(it) => it.span(),
-            Self::JSXElementName(it) => it.span(),
-            Self::JSXNamespacedName(it) => it.span(),
-            Self::JSXMemberExpression(it) => it.span(),
-            Self::JSXMemberExpressionObject(it) => it.span(),
-            Self::JSXExpressionContainer(it) => it.span(),
-            Self::JSXAttributeItem(it) => it.span(),
-            Self::JSXSpreadAttribute(it) => it.span(),
-            Self::JSXIdentifier(it) => it.span(),
-            Self::JSXText(it) => it.span(),
         }
     }
 }
 
 impl<'a> AstKind<'a> {
-    #[inline]
-    pub fn as_boolean_literal(self) -> Option<&'a BooleanLiteral> {
-        if let Self::BooleanLiteral(v) = self {
-            Some(v)
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    pub fn as_null_literal(self) -> Option<&'a NullLiteral> {
-        if let Self::NullLiteral(v) = self {
-            Some(v)
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    pub fn as_numeric_literal(self) -> Option<&'a NumericLiteral<'a>> {
-        if let Self::NumericLiteral(v) = self {
-            Some(v)
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    pub fn as_string_literal(self) -> Option<&'a StringLiteral<'a>> {
-        if let Self::StringLiteral(v) = self {
-            Some(v)
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    pub fn as_big_int_literal(self) -> Option<&'a BigIntLiteral<'a>> {
-        if let Self::BigIntLiteral(v) = self {
-            Some(v)
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    pub fn as_reg_exp_literal(self) -> Option<&'a RegExpLiteral<'a>> {
-        if let Self::RegExpLiteral(v) = self {
-            Some(v)
-        } else {
-            None
-        }
-    }
-
     #[inline]
     pub fn as_program(self) -> Option<&'a Program<'a>> {
         if let Self::Program(v) = self {
@@ -1415,6 +1361,177 @@ impl<'a> AstKind<'a> {
     }
 
     #[inline]
+    pub fn as_boolean_literal(self) -> Option<&'a BooleanLiteral> {
+        if let Self::BooleanLiteral(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn as_null_literal(self) -> Option<&'a NullLiteral> {
+        if let Self::NullLiteral(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn as_numeric_literal(self) -> Option<&'a NumericLiteral<'a>> {
+        if let Self::NumericLiteral(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn as_string_literal(self) -> Option<&'a StringLiteral<'a>> {
+        if let Self::StringLiteral(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn as_big_int_literal(self) -> Option<&'a BigIntLiteral<'a>> {
+        if let Self::BigIntLiteral(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn as_reg_exp_literal(self) -> Option<&'a RegExpLiteral<'a>> {
+        if let Self::RegExpLiteral(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn as_jsx_element(self) -> Option<&'a JSXElement<'a>> {
+        if let Self::JSXElement(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn as_jsx_opening_element(self) -> Option<&'a JSXOpeningElement<'a>> {
+        if let Self::JSXOpeningElement(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn as_jsx_closing_element(self) -> Option<&'a JSXClosingElement<'a>> {
+        if let Self::JSXClosingElement(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn as_jsx_fragment(self) -> Option<&'a JSXFragment<'a>> {
+        if let Self::JSXFragment(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn as_jsx_element_name(self) -> Option<&'a JSXElementName<'a>> {
+        if let Self::JSXElementName(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn as_jsx_namespaced_name(self) -> Option<&'a JSXNamespacedName<'a>> {
+        if let Self::JSXNamespacedName(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn as_jsx_member_expression(self) -> Option<&'a JSXMemberExpression<'a>> {
+        if let Self::JSXMemberExpression(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn as_jsx_member_expression_object(self) -> Option<&'a JSXMemberExpressionObject<'a>> {
+        if let Self::JSXMemberExpressionObject(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn as_jsx_expression_container(self) -> Option<&'a JSXExpressionContainer<'a>> {
+        if let Self::JSXExpressionContainer(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn as_jsx_attribute_item(self) -> Option<&'a JSXAttributeItem<'a>> {
+        if let Self::JSXAttributeItem(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn as_jsx_spread_attribute(self) -> Option<&'a JSXSpreadAttribute<'a>> {
+        if let Self::JSXSpreadAttribute(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn as_jsx_identifier(self) -> Option<&'a JSXIdentifier<'a>> {
+        if let Self::JSXIdentifier(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub fn as_jsx_text(self) -> Option<&'a JSXText<'a>> {
+        if let Self::JSXText(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
     pub fn as_ts_this_parameter(self) -> Option<&'a TSThisParameter<'a>> {
         if let Self::TSThisParameter(v) = self {
             Some(v)
@@ -1916,123 +2033,6 @@ impl<'a> AstKind<'a> {
     #[inline]
     pub fn as_ts_instantiation_expression(self) -> Option<&'a TSInstantiationExpression<'a>> {
         if let Self::TSInstantiationExpression(v) = self {
-            Some(v)
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    pub fn as_jsx_element(self) -> Option<&'a JSXElement<'a>> {
-        if let Self::JSXElement(v) = self {
-            Some(v)
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    pub fn as_jsx_opening_element(self) -> Option<&'a JSXOpeningElement<'a>> {
-        if let Self::JSXOpeningElement(v) = self {
-            Some(v)
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    pub fn as_jsx_closing_element(self) -> Option<&'a JSXClosingElement<'a>> {
-        if let Self::JSXClosingElement(v) = self {
-            Some(v)
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    pub fn as_jsx_fragment(self) -> Option<&'a JSXFragment<'a>> {
-        if let Self::JSXFragment(v) = self {
-            Some(v)
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    pub fn as_jsx_element_name(self) -> Option<&'a JSXElementName<'a>> {
-        if let Self::JSXElementName(v) = self {
-            Some(v)
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    pub fn as_jsx_namespaced_name(self) -> Option<&'a JSXNamespacedName<'a>> {
-        if let Self::JSXNamespacedName(v) = self {
-            Some(v)
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    pub fn as_jsx_member_expression(self) -> Option<&'a JSXMemberExpression<'a>> {
-        if let Self::JSXMemberExpression(v) = self {
-            Some(v)
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    pub fn as_jsx_member_expression_object(self) -> Option<&'a JSXMemberExpressionObject<'a>> {
-        if let Self::JSXMemberExpressionObject(v) = self {
-            Some(v)
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    pub fn as_jsx_expression_container(self) -> Option<&'a JSXExpressionContainer<'a>> {
-        if let Self::JSXExpressionContainer(v) = self {
-            Some(v)
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    pub fn as_jsx_attribute_item(self) -> Option<&'a JSXAttributeItem<'a>> {
-        if let Self::JSXAttributeItem(v) = self {
-            Some(v)
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    pub fn as_jsx_spread_attribute(self) -> Option<&'a JSXSpreadAttribute<'a>> {
-        if let Self::JSXSpreadAttribute(v) = self {
-            Some(v)
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    pub fn as_jsx_identifier(self) -> Option<&'a JSXIdentifier<'a>> {
-        if let Self::JSXIdentifier(v) = self {
-            Some(v)
-        } else {
-            None
-        }
-    }
-
-    #[inline]
-    pub fn as_jsx_text(self) -> Option<&'a JSXText<'a>> {
-        if let Self::JSXText(v) = self {
             Some(v)
         } else {
             None

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -11,89 +11,6 @@ use crate::ast::jsx::*;
 use crate::ast::literal::*;
 use crate::ast::ts::*;
 
-impl<'alloc> CloneIn<'alloc> for BooleanLiteral {
-    type Cloned = BooleanLiteral;
-    fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        BooleanLiteral {
-            span: CloneIn::clone_in(&self.span, allocator),
-            value: CloneIn::clone_in(&self.value, allocator),
-        }
-    }
-}
-
-impl<'alloc> CloneIn<'alloc> for NullLiteral {
-    type Cloned = NullLiteral;
-    fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        NullLiteral { span: CloneIn::clone_in(&self.span, allocator) }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for NumericLiteral<'_> {
-    type Cloned = NumericLiteral<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        NumericLiteral {
-            span: CloneIn::clone_in(&self.span, allocator),
-            value: CloneIn::clone_in(&self.value, allocator),
-            raw: CloneIn::clone_in(&self.raw, allocator),
-            base: CloneIn::clone_in(&self.base, allocator),
-        }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for StringLiteral<'_> {
-    type Cloned = StringLiteral<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        StringLiteral {
-            span: CloneIn::clone_in(&self.span, allocator),
-            value: CloneIn::clone_in(&self.value, allocator),
-            raw: CloneIn::clone_in(&self.raw, allocator),
-        }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for BigIntLiteral<'_> {
-    type Cloned = BigIntLiteral<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        BigIntLiteral {
-            span: CloneIn::clone_in(&self.span, allocator),
-            raw: CloneIn::clone_in(&self.raw, allocator),
-            base: CloneIn::clone_in(&self.base, allocator),
-        }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for RegExpLiteral<'_> {
-    type Cloned = RegExpLiteral<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        RegExpLiteral {
-            span: CloneIn::clone_in(&self.span, allocator),
-            regex: CloneIn::clone_in(&self.regex, allocator),
-            raw: CloneIn::clone_in(&self.raw, allocator),
-        }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for RegExp<'_> {
-    type Cloned = RegExp<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        RegExp {
-            pattern: CloneIn::clone_in(&self.pattern, allocator),
-            flags: CloneIn::clone_in(&self.flags, allocator),
-        }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for RegExpPattern<'_> {
-    type Cloned = RegExpPattern<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Raw(it) => RegExpPattern::Raw(CloneIn::clone_in(it, allocator)),
-            Self::Invalid(it) => RegExpPattern::Invalid(CloneIn::clone_in(it, allocator)),
-            Self::Pattern(it) => RegExpPattern::Pattern(CloneIn::clone_in(it, allocator)),
-        }
-    }
-}
-
 impl<'new_alloc> CloneIn<'new_alloc> for Program<'_> {
     type Cloned = Program<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
@@ -2564,6 +2481,458 @@ impl<'new_alloc> CloneIn<'new_alloc> for ModuleExportName<'_> {
     }
 }
 
+impl<'alloc> CloneIn<'alloc> for BooleanLiteral {
+    type Cloned = BooleanLiteral;
+    fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
+        BooleanLiteral {
+            span: CloneIn::clone_in(&self.span, allocator),
+            value: CloneIn::clone_in(&self.value, allocator),
+        }
+    }
+}
+
+impl<'alloc> CloneIn<'alloc> for NullLiteral {
+    type Cloned = NullLiteral;
+    fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
+        NullLiteral { span: CloneIn::clone_in(&self.span, allocator) }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for NumericLiteral<'_> {
+    type Cloned = NumericLiteral<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        NumericLiteral {
+            span: CloneIn::clone_in(&self.span, allocator),
+            value: CloneIn::clone_in(&self.value, allocator),
+            raw: CloneIn::clone_in(&self.raw, allocator),
+            base: CloneIn::clone_in(&self.base, allocator),
+        }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for StringLiteral<'_> {
+    type Cloned = StringLiteral<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        StringLiteral {
+            span: CloneIn::clone_in(&self.span, allocator),
+            value: CloneIn::clone_in(&self.value, allocator),
+            raw: CloneIn::clone_in(&self.raw, allocator),
+        }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for BigIntLiteral<'_> {
+    type Cloned = BigIntLiteral<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        BigIntLiteral {
+            span: CloneIn::clone_in(&self.span, allocator),
+            raw: CloneIn::clone_in(&self.raw, allocator),
+            base: CloneIn::clone_in(&self.base, allocator),
+        }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for RegExpLiteral<'_> {
+    type Cloned = RegExpLiteral<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        RegExpLiteral {
+            span: CloneIn::clone_in(&self.span, allocator),
+            regex: CloneIn::clone_in(&self.regex, allocator),
+            raw: CloneIn::clone_in(&self.raw, allocator),
+        }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for RegExp<'_> {
+    type Cloned = RegExp<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        RegExp {
+            pattern: CloneIn::clone_in(&self.pattern, allocator),
+            flags: CloneIn::clone_in(&self.flags, allocator),
+        }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for RegExpPattern<'_> {
+    type Cloned = RegExpPattern<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        match self {
+            Self::Raw(it) => RegExpPattern::Raw(CloneIn::clone_in(it, allocator)),
+            Self::Invalid(it) => RegExpPattern::Invalid(CloneIn::clone_in(it, allocator)),
+            Self::Pattern(it) => RegExpPattern::Pattern(CloneIn::clone_in(it, allocator)),
+        }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for JSXElement<'_> {
+    type Cloned = JSXElement<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        JSXElement {
+            span: CloneIn::clone_in(&self.span, allocator),
+            opening_element: CloneIn::clone_in(&self.opening_element, allocator),
+            closing_element: CloneIn::clone_in(&self.closing_element, allocator),
+            children: CloneIn::clone_in(&self.children, allocator),
+        }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for JSXOpeningElement<'_> {
+    type Cloned = JSXOpeningElement<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        JSXOpeningElement {
+            span: CloneIn::clone_in(&self.span, allocator),
+            self_closing: CloneIn::clone_in(&self.self_closing, allocator),
+            name: CloneIn::clone_in(&self.name, allocator),
+            attributes: CloneIn::clone_in(&self.attributes, allocator),
+            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
+        }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for JSXClosingElement<'_> {
+    type Cloned = JSXClosingElement<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        JSXClosingElement {
+            span: CloneIn::clone_in(&self.span, allocator),
+            name: CloneIn::clone_in(&self.name, allocator),
+        }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for JSXFragment<'_> {
+    type Cloned = JSXFragment<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        JSXFragment {
+            span: CloneIn::clone_in(&self.span, allocator),
+            opening_fragment: CloneIn::clone_in(&self.opening_fragment, allocator),
+            closing_fragment: CloneIn::clone_in(&self.closing_fragment, allocator),
+            children: CloneIn::clone_in(&self.children, allocator),
+        }
+    }
+}
+
+impl<'alloc> CloneIn<'alloc> for JSXOpeningFragment {
+    type Cloned = JSXOpeningFragment;
+    fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
+        JSXOpeningFragment { span: CloneIn::clone_in(&self.span, allocator) }
+    }
+}
+
+impl<'alloc> CloneIn<'alloc> for JSXClosingFragment {
+    type Cloned = JSXClosingFragment;
+    fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
+        JSXClosingFragment { span: CloneIn::clone_in(&self.span, allocator) }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for JSXElementName<'_> {
+    type Cloned = JSXElementName<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        match self {
+            Self::Identifier(it) => JSXElementName::Identifier(CloneIn::clone_in(it, allocator)),
+            Self::IdentifierReference(it) => {
+                JSXElementName::IdentifierReference(CloneIn::clone_in(it, allocator))
+            }
+            Self::NamespacedName(it) => {
+                JSXElementName::NamespacedName(CloneIn::clone_in(it, allocator))
+            }
+            Self::MemberExpression(it) => {
+                JSXElementName::MemberExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ThisExpression(it) => {
+                JSXElementName::ThisExpression(CloneIn::clone_in(it, allocator))
+            }
+        }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for JSXNamespacedName<'_> {
+    type Cloned = JSXNamespacedName<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        JSXNamespacedName {
+            span: CloneIn::clone_in(&self.span, allocator),
+            namespace: CloneIn::clone_in(&self.namespace, allocator),
+            property: CloneIn::clone_in(&self.property, allocator),
+        }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for JSXMemberExpression<'_> {
+    type Cloned = JSXMemberExpression<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        JSXMemberExpression {
+            span: CloneIn::clone_in(&self.span, allocator),
+            object: CloneIn::clone_in(&self.object, allocator),
+            property: CloneIn::clone_in(&self.property, allocator),
+        }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for JSXMemberExpressionObject<'_> {
+    type Cloned = JSXMemberExpressionObject<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        match self {
+            Self::IdentifierReference(it) => {
+                JSXMemberExpressionObject::IdentifierReference(CloneIn::clone_in(it, allocator))
+            }
+            Self::MemberExpression(it) => {
+                JSXMemberExpressionObject::MemberExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ThisExpression(it) => {
+                JSXMemberExpressionObject::ThisExpression(CloneIn::clone_in(it, allocator))
+            }
+        }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for JSXExpressionContainer<'_> {
+    type Cloned = JSXExpressionContainer<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        JSXExpressionContainer {
+            span: CloneIn::clone_in(&self.span, allocator),
+            expression: CloneIn::clone_in(&self.expression, allocator),
+        }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for JSXExpression<'_> {
+    type Cloned = JSXExpression<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        match self {
+            Self::EmptyExpression(it) => {
+                JSXExpression::EmptyExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::BooleanLiteral(it) => {
+                JSXExpression::BooleanLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::NullLiteral(it) => JSXExpression::NullLiteral(CloneIn::clone_in(it, allocator)),
+            Self::NumericLiteral(it) => {
+                JSXExpression::NumericLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::BigIntLiteral(it) => {
+                JSXExpression::BigIntLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::RegExpLiteral(it) => {
+                JSXExpression::RegExpLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::StringLiteral(it) => {
+                JSXExpression::StringLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::TemplateLiteral(it) => {
+                JSXExpression::TemplateLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::Identifier(it) => JSXExpression::Identifier(CloneIn::clone_in(it, allocator)),
+            Self::MetaProperty(it) => JSXExpression::MetaProperty(CloneIn::clone_in(it, allocator)),
+            Self::Super(it) => JSXExpression::Super(CloneIn::clone_in(it, allocator)),
+            Self::ArrayExpression(it) => {
+                JSXExpression::ArrayExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ArrowFunctionExpression(it) => {
+                JSXExpression::ArrowFunctionExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::AssignmentExpression(it) => {
+                JSXExpression::AssignmentExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::AwaitExpression(it) => {
+                JSXExpression::AwaitExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::BinaryExpression(it) => {
+                JSXExpression::BinaryExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::CallExpression(it) => {
+                JSXExpression::CallExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ChainExpression(it) => {
+                JSXExpression::ChainExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ClassExpression(it) => {
+                JSXExpression::ClassExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ConditionalExpression(it) => {
+                JSXExpression::ConditionalExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::FunctionExpression(it) => {
+                JSXExpression::FunctionExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ImportExpression(it) => {
+                JSXExpression::ImportExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::LogicalExpression(it) => {
+                JSXExpression::LogicalExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::NewExpression(it) => {
+                JSXExpression::NewExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ObjectExpression(it) => {
+                JSXExpression::ObjectExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ParenthesizedExpression(it) => {
+                JSXExpression::ParenthesizedExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::SequenceExpression(it) => {
+                JSXExpression::SequenceExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::TaggedTemplateExpression(it) => {
+                JSXExpression::TaggedTemplateExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ThisExpression(it) => {
+                JSXExpression::ThisExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::UnaryExpression(it) => {
+                JSXExpression::UnaryExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::UpdateExpression(it) => {
+                JSXExpression::UpdateExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::YieldExpression(it) => {
+                JSXExpression::YieldExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::PrivateInExpression(it) => {
+                JSXExpression::PrivateInExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::JSXElement(it) => JSXExpression::JSXElement(CloneIn::clone_in(it, allocator)),
+            Self::JSXFragment(it) => JSXExpression::JSXFragment(CloneIn::clone_in(it, allocator)),
+            Self::TSAsExpression(it) => {
+                JSXExpression::TSAsExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSSatisfiesExpression(it) => {
+                JSXExpression::TSSatisfiesExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSTypeAssertion(it) => {
+                JSXExpression::TSTypeAssertion(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSNonNullExpression(it) => {
+                JSXExpression::TSNonNullExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::TSInstantiationExpression(it) => {
+                JSXExpression::TSInstantiationExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::ComputedMemberExpression(it) => {
+                JSXExpression::ComputedMemberExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::StaticMemberExpression(it) => {
+                JSXExpression::StaticMemberExpression(CloneIn::clone_in(it, allocator))
+            }
+            Self::PrivateFieldExpression(it) => {
+                JSXExpression::PrivateFieldExpression(CloneIn::clone_in(it, allocator))
+            }
+        }
+    }
+}
+
+impl<'alloc> CloneIn<'alloc> for JSXEmptyExpression {
+    type Cloned = JSXEmptyExpression;
+    fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
+        JSXEmptyExpression { span: CloneIn::clone_in(&self.span, allocator) }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for JSXAttributeItem<'_> {
+    type Cloned = JSXAttributeItem<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        match self {
+            Self::Attribute(it) => JSXAttributeItem::Attribute(CloneIn::clone_in(it, allocator)),
+            Self::SpreadAttribute(it) => {
+                JSXAttributeItem::SpreadAttribute(CloneIn::clone_in(it, allocator))
+            }
+        }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for JSXAttribute<'_> {
+    type Cloned = JSXAttribute<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        JSXAttribute {
+            span: CloneIn::clone_in(&self.span, allocator),
+            name: CloneIn::clone_in(&self.name, allocator),
+            value: CloneIn::clone_in(&self.value, allocator),
+        }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for JSXSpreadAttribute<'_> {
+    type Cloned = JSXSpreadAttribute<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        JSXSpreadAttribute {
+            span: CloneIn::clone_in(&self.span, allocator),
+            argument: CloneIn::clone_in(&self.argument, allocator),
+        }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for JSXAttributeName<'_> {
+    type Cloned = JSXAttributeName<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        match self {
+            Self::Identifier(it) => JSXAttributeName::Identifier(CloneIn::clone_in(it, allocator)),
+            Self::NamespacedName(it) => {
+                JSXAttributeName::NamespacedName(CloneIn::clone_in(it, allocator))
+            }
+        }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for JSXAttributeValue<'_> {
+    type Cloned = JSXAttributeValue<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        match self {
+            Self::StringLiteral(it) => {
+                JSXAttributeValue::StringLiteral(CloneIn::clone_in(it, allocator))
+            }
+            Self::ExpressionContainer(it) => {
+                JSXAttributeValue::ExpressionContainer(CloneIn::clone_in(it, allocator))
+            }
+            Self::Element(it) => JSXAttributeValue::Element(CloneIn::clone_in(it, allocator)),
+            Self::Fragment(it) => JSXAttributeValue::Fragment(CloneIn::clone_in(it, allocator)),
+        }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for JSXIdentifier<'_> {
+    type Cloned = JSXIdentifier<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        JSXIdentifier {
+            span: CloneIn::clone_in(&self.span, allocator),
+            name: CloneIn::clone_in(&self.name, allocator),
+        }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for JSXChild<'_> {
+    type Cloned = JSXChild<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        match self {
+            Self::Text(it) => JSXChild::Text(CloneIn::clone_in(it, allocator)),
+            Self::Element(it) => JSXChild::Element(CloneIn::clone_in(it, allocator)),
+            Self::Fragment(it) => JSXChild::Fragment(CloneIn::clone_in(it, allocator)),
+            Self::ExpressionContainer(it) => {
+                JSXChild::ExpressionContainer(CloneIn::clone_in(it, allocator))
+            }
+            Self::Spread(it) => JSXChild::Spread(CloneIn::clone_in(it, allocator)),
+        }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for JSXSpreadChild<'_> {
+    type Cloned = JSXSpreadChild<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        JSXSpreadChild {
+            span: CloneIn::clone_in(&self.span, allocator),
+            expression: CloneIn::clone_in(&self.expression, allocator),
+        }
+    }
+}
+
+impl<'new_alloc> CloneIn<'new_alloc> for JSXText<'_> {
+    type Cloned = JSXText<'new_alloc>;
+    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
+        JSXText {
+            span: CloneIn::clone_in(&self.span, allocator),
+            value: CloneIn::clone_in(&self.value, allocator),
+        }
+    }
+}
+
 impl<'new_alloc> CloneIn<'new_alloc> for TSThisParameter<'_> {
     type Cloned = TSThisParameter<'new_alloc>;
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
@@ -3733,375 +4102,6 @@ impl<'alloc> CloneIn<'alloc> for JSDocUnknownType {
     type Cloned = JSDocUnknownType;
     fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
         JSDocUnknownType { span: CloneIn::clone_in(&self.span, allocator) }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for JSXElement<'_> {
-    type Cloned = JSXElement<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXElement {
-            span: CloneIn::clone_in(&self.span, allocator),
-            opening_element: CloneIn::clone_in(&self.opening_element, allocator),
-            closing_element: CloneIn::clone_in(&self.closing_element, allocator),
-            children: CloneIn::clone_in(&self.children, allocator),
-        }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for JSXOpeningElement<'_> {
-    type Cloned = JSXOpeningElement<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXOpeningElement {
-            span: CloneIn::clone_in(&self.span, allocator),
-            self_closing: CloneIn::clone_in(&self.self_closing, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
-            attributes: CloneIn::clone_in(&self.attributes, allocator),
-            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
-        }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for JSXClosingElement<'_> {
-    type Cloned = JSXClosingElement<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXClosingElement {
-            span: CloneIn::clone_in(&self.span, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
-        }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for JSXFragment<'_> {
-    type Cloned = JSXFragment<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXFragment {
-            span: CloneIn::clone_in(&self.span, allocator),
-            opening_fragment: CloneIn::clone_in(&self.opening_fragment, allocator),
-            closing_fragment: CloneIn::clone_in(&self.closing_fragment, allocator),
-            children: CloneIn::clone_in(&self.children, allocator),
-        }
-    }
-}
-
-impl<'alloc> CloneIn<'alloc> for JSXOpeningFragment {
-    type Cloned = JSXOpeningFragment;
-    fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        JSXOpeningFragment { span: CloneIn::clone_in(&self.span, allocator) }
-    }
-}
-
-impl<'alloc> CloneIn<'alloc> for JSXClosingFragment {
-    type Cloned = JSXClosingFragment;
-    fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        JSXClosingFragment { span: CloneIn::clone_in(&self.span, allocator) }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for JSXElementName<'_> {
-    type Cloned = JSXElementName<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Identifier(it) => JSXElementName::Identifier(CloneIn::clone_in(it, allocator)),
-            Self::IdentifierReference(it) => {
-                JSXElementName::IdentifierReference(CloneIn::clone_in(it, allocator))
-            }
-            Self::NamespacedName(it) => {
-                JSXElementName::NamespacedName(CloneIn::clone_in(it, allocator))
-            }
-            Self::MemberExpression(it) => {
-                JSXElementName::MemberExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::ThisExpression(it) => {
-                JSXElementName::ThisExpression(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for JSXNamespacedName<'_> {
-    type Cloned = JSXNamespacedName<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXNamespacedName {
-            span: CloneIn::clone_in(&self.span, allocator),
-            namespace: CloneIn::clone_in(&self.namespace, allocator),
-            property: CloneIn::clone_in(&self.property, allocator),
-        }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for JSXMemberExpression<'_> {
-    type Cloned = JSXMemberExpression<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXMemberExpression {
-            span: CloneIn::clone_in(&self.span, allocator),
-            object: CloneIn::clone_in(&self.object, allocator),
-            property: CloneIn::clone_in(&self.property, allocator),
-        }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for JSXMemberExpressionObject<'_> {
-    type Cloned = JSXMemberExpressionObject<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::IdentifierReference(it) => {
-                JSXMemberExpressionObject::IdentifierReference(CloneIn::clone_in(it, allocator))
-            }
-            Self::MemberExpression(it) => {
-                JSXMemberExpressionObject::MemberExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::ThisExpression(it) => {
-                JSXMemberExpressionObject::ThisExpression(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for JSXExpressionContainer<'_> {
-    type Cloned = JSXExpressionContainer<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXExpressionContainer {
-            span: CloneIn::clone_in(&self.span, allocator),
-            expression: CloneIn::clone_in(&self.expression, allocator),
-        }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for JSXExpression<'_> {
-    type Cloned = JSXExpression<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::EmptyExpression(it) => {
-                JSXExpression::EmptyExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::BooleanLiteral(it) => {
-                JSXExpression::BooleanLiteral(CloneIn::clone_in(it, allocator))
-            }
-            Self::NullLiteral(it) => JSXExpression::NullLiteral(CloneIn::clone_in(it, allocator)),
-            Self::NumericLiteral(it) => {
-                JSXExpression::NumericLiteral(CloneIn::clone_in(it, allocator))
-            }
-            Self::BigIntLiteral(it) => {
-                JSXExpression::BigIntLiteral(CloneIn::clone_in(it, allocator))
-            }
-            Self::RegExpLiteral(it) => {
-                JSXExpression::RegExpLiteral(CloneIn::clone_in(it, allocator))
-            }
-            Self::StringLiteral(it) => {
-                JSXExpression::StringLiteral(CloneIn::clone_in(it, allocator))
-            }
-            Self::TemplateLiteral(it) => {
-                JSXExpression::TemplateLiteral(CloneIn::clone_in(it, allocator))
-            }
-            Self::Identifier(it) => JSXExpression::Identifier(CloneIn::clone_in(it, allocator)),
-            Self::MetaProperty(it) => JSXExpression::MetaProperty(CloneIn::clone_in(it, allocator)),
-            Self::Super(it) => JSXExpression::Super(CloneIn::clone_in(it, allocator)),
-            Self::ArrayExpression(it) => {
-                JSXExpression::ArrayExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::ArrowFunctionExpression(it) => {
-                JSXExpression::ArrowFunctionExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::AssignmentExpression(it) => {
-                JSXExpression::AssignmentExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::AwaitExpression(it) => {
-                JSXExpression::AwaitExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::BinaryExpression(it) => {
-                JSXExpression::BinaryExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::CallExpression(it) => {
-                JSXExpression::CallExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::ChainExpression(it) => {
-                JSXExpression::ChainExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::ClassExpression(it) => {
-                JSXExpression::ClassExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::ConditionalExpression(it) => {
-                JSXExpression::ConditionalExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::FunctionExpression(it) => {
-                JSXExpression::FunctionExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::ImportExpression(it) => {
-                JSXExpression::ImportExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::LogicalExpression(it) => {
-                JSXExpression::LogicalExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::NewExpression(it) => {
-                JSXExpression::NewExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::ObjectExpression(it) => {
-                JSXExpression::ObjectExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::ParenthesizedExpression(it) => {
-                JSXExpression::ParenthesizedExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::SequenceExpression(it) => {
-                JSXExpression::SequenceExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::TaggedTemplateExpression(it) => {
-                JSXExpression::TaggedTemplateExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::ThisExpression(it) => {
-                JSXExpression::ThisExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::UnaryExpression(it) => {
-                JSXExpression::UnaryExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::UpdateExpression(it) => {
-                JSXExpression::UpdateExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::YieldExpression(it) => {
-                JSXExpression::YieldExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::PrivateInExpression(it) => {
-                JSXExpression::PrivateInExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::JSXElement(it) => JSXExpression::JSXElement(CloneIn::clone_in(it, allocator)),
-            Self::JSXFragment(it) => JSXExpression::JSXFragment(CloneIn::clone_in(it, allocator)),
-            Self::TSAsExpression(it) => {
-                JSXExpression::TSAsExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSSatisfiesExpression(it) => {
-                JSXExpression::TSSatisfiesExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSTypeAssertion(it) => {
-                JSXExpression::TSTypeAssertion(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSNonNullExpression(it) => {
-                JSXExpression::TSNonNullExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::TSInstantiationExpression(it) => {
-                JSXExpression::TSInstantiationExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::ComputedMemberExpression(it) => {
-                JSXExpression::ComputedMemberExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::StaticMemberExpression(it) => {
-                JSXExpression::StaticMemberExpression(CloneIn::clone_in(it, allocator))
-            }
-            Self::PrivateFieldExpression(it) => {
-                JSXExpression::PrivateFieldExpression(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-}
-
-impl<'alloc> CloneIn<'alloc> for JSXEmptyExpression {
-    type Cloned = JSXEmptyExpression;
-    fn clone_in(&self, allocator: &'alloc Allocator) -> Self::Cloned {
-        JSXEmptyExpression { span: CloneIn::clone_in(&self.span, allocator) }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for JSXAttributeItem<'_> {
-    type Cloned = JSXAttributeItem<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Attribute(it) => JSXAttributeItem::Attribute(CloneIn::clone_in(it, allocator)),
-            Self::SpreadAttribute(it) => {
-                JSXAttributeItem::SpreadAttribute(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for JSXAttribute<'_> {
-    type Cloned = JSXAttribute<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXAttribute {
-            span: CloneIn::clone_in(&self.span, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
-            value: CloneIn::clone_in(&self.value, allocator),
-        }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for JSXSpreadAttribute<'_> {
-    type Cloned = JSXSpreadAttribute<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXSpreadAttribute {
-            span: CloneIn::clone_in(&self.span, allocator),
-            argument: CloneIn::clone_in(&self.argument, allocator),
-        }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for JSXAttributeName<'_> {
-    type Cloned = JSXAttributeName<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Identifier(it) => JSXAttributeName::Identifier(CloneIn::clone_in(it, allocator)),
-            Self::NamespacedName(it) => {
-                JSXAttributeName::NamespacedName(CloneIn::clone_in(it, allocator))
-            }
-        }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for JSXAttributeValue<'_> {
-    type Cloned = JSXAttributeValue<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::StringLiteral(it) => {
-                JSXAttributeValue::StringLiteral(CloneIn::clone_in(it, allocator))
-            }
-            Self::ExpressionContainer(it) => {
-                JSXAttributeValue::ExpressionContainer(CloneIn::clone_in(it, allocator))
-            }
-            Self::Element(it) => JSXAttributeValue::Element(CloneIn::clone_in(it, allocator)),
-            Self::Fragment(it) => JSXAttributeValue::Fragment(CloneIn::clone_in(it, allocator)),
-        }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for JSXIdentifier<'_> {
-    type Cloned = JSXIdentifier<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXIdentifier {
-            span: CloneIn::clone_in(&self.span, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
-        }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for JSXChild<'_> {
-    type Cloned = JSXChild<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Text(it) => JSXChild::Text(CloneIn::clone_in(it, allocator)),
-            Self::Element(it) => JSXChild::Element(CloneIn::clone_in(it, allocator)),
-            Self::Fragment(it) => JSXChild::Fragment(CloneIn::clone_in(it, allocator)),
-            Self::ExpressionContainer(it) => {
-                JSXChild::ExpressionContainer(CloneIn::clone_in(it, allocator))
-            }
-            Self::Spread(it) => JSXChild::Spread(CloneIn::clone_in(it, allocator)),
-        }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for JSXSpreadChild<'_> {
-    type Cloned = JSXSpreadChild<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXSpreadChild {
-            span: CloneIn::clone_in(&self.span, allocator),
-            expression: CloneIn::clone_in(&self.expression, allocator),
-        }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for JSXText<'_> {
-    type Cloned = JSXText<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        JSXText {
-            span: CloneIn::clone_in(&self.span, allocator),
-            value: CloneIn::clone_in(&self.value, allocator),
-        }
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -11,25 +11,6 @@ use crate::ast::jsx::*;
 use crate::ast::literal::*;
 use crate::ast::ts::*;
 
-impl ContentEq for BooleanLiteral {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.value, &other.value)
-    }
-}
-
-impl ContentEq for NullLiteral {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
-    }
-}
-
-impl ContentEq for RegExp<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.pattern, &other.pattern)
-            && ContentEq::content_eq(&self.flags, &other.flags)
-    }
-}
-
 impl ContentEq for Program<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.source_type, &other.source_type)
@@ -1465,6 +1446,251 @@ impl ContentEq for ModuleExportName<'_> {
     }
 }
 
+impl ContentEq for BooleanLiteral {
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.value, &other.value)
+    }
+}
+
+impl ContentEq for NullLiteral {
+    fn content_eq(&self, _: &Self) -> bool {
+        true
+    }
+}
+
+impl ContentEq for RegExp<'_> {
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.pattern, &other.pattern)
+            && ContentEq::content_eq(&self.flags, &other.flags)
+    }
+}
+
+impl ContentEq for JSXElement<'_> {
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.opening_element, &other.opening_element)
+            && ContentEq::content_eq(&self.closing_element, &other.closing_element)
+            && ContentEq::content_eq(&self.children, &other.children)
+    }
+}
+
+impl ContentEq for JSXOpeningElement<'_> {
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.self_closing, &other.self_closing)
+            && ContentEq::content_eq(&self.name, &other.name)
+            && ContentEq::content_eq(&self.attributes, &other.attributes)
+            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
+    }
+}
+
+impl ContentEq for JSXClosingElement<'_> {
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.name, &other.name)
+    }
+}
+
+impl ContentEq for JSXFragment<'_> {
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.opening_fragment, &other.opening_fragment)
+            && ContentEq::content_eq(&self.closing_fragment, &other.closing_fragment)
+            && ContentEq::content_eq(&self.children, &other.children)
+    }
+}
+
+impl ContentEq for JSXOpeningFragment {
+    fn content_eq(&self, _: &Self) -> bool {
+        true
+    }
+}
+
+impl ContentEq for JSXClosingFragment {
+    fn content_eq(&self, _: &Self) -> bool {
+        true
+    }
+}
+
+impl ContentEq for JSXElementName<'_> {
+    fn content_eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Identifier(a), Self::Identifier(b)) => a.content_eq(b),
+            (Self::IdentifierReference(a), Self::IdentifierReference(b)) => a.content_eq(b),
+            (Self::NamespacedName(a), Self::NamespacedName(b)) => a.content_eq(b),
+            (Self::MemberExpression(a), Self::MemberExpression(b)) => a.content_eq(b),
+            (Self::ThisExpression(a), Self::ThisExpression(b)) => a.content_eq(b),
+            _ => false,
+        }
+    }
+}
+
+impl ContentEq for JSXNamespacedName<'_> {
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.namespace, &other.namespace)
+            && ContentEq::content_eq(&self.property, &other.property)
+    }
+}
+
+impl ContentEq for JSXMemberExpression<'_> {
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.object, &other.object)
+            && ContentEq::content_eq(&self.property, &other.property)
+    }
+}
+
+impl ContentEq for JSXMemberExpressionObject<'_> {
+    fn content_eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::IdentifierReference(a), Self::IdentifierReference(b)) => a.content_eq(b),
+            (Self::MemberExpression(a), Self::MemberExpression(b)) => a.content_eq(b),
+            (Self::ThisExpression(a), Self::ThisExpression(b)) => a.content_eq(b),
+            _ => false,
+        }
+    }
+}
+
+impl ContentEq for JSXExpressionContainer<'_> {
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.expression, &other.expression)
+    }
+}
+
+impl ContentEq for JSXExpression<'_> {
+    fn content_eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::EmptyExpression(a), Self::EmptyExpression(b)) => a.content_eq(b),
+            (Self::BooleanLiteral(a), Self::BooleanLiteral(b)) => a.content_eq(b),
+            (Self::NullLiteral(a), Self::NullLiteral(b)) => a.content_eq(b),
+            (Self::NumericLiteral(a), Self::NumericLiteral(b)) => a.content_eq(b),
+            (Self::BigIntLiteral(a), Self::BigIntLiteral(b)) => a.content_eq(b),
+            (Self::RegExpLiteral(a), Self::RegExpLiteral(b)) => a.content_eq(b),
+            (Self::StringLiteral(a), Self::StringLiteral(b)) => a.content_eq(b),
+            (Self::TemplateLiteral(a), Self::TemplateLiteral(b)) => a.content_eq(b),
+            (Self::Identifier(a), Self::Identifier(b)) => a.content_eq(b),
+            (Self::MetaProperty(a), Self::MetaProperty(b)) => a.content_eq(b),
+            (Self::Super(a), Self::Super(b)) => a.content_eq(b),
+            (Self::ArrayExpression(a), Self::ArrayExpression(b)) => a.content_eq(b),
+            (Self::ArrowFunctionExpression(a), Self::ArrowFunctionExpression(b)) => a.content_eq(b),
+            (Self::AssignmentExpression(a), Self::AssignmentExpression(b)) => a.content_eq(b),
+            (Self::AwaitExpression(a), Self::AwaitExpression(b)) => a.content_eq(b),
+            (Self::BinaryExpression(a), Self::BinaryExpression(b)) => a.content_eq(b),
+            (Self::CallExpression(a), Self::CallExpression(b)) => a.content_eq(b),
+            (Self::ChainExpression(a), Self::ChainExpression(b)) => a.content_eq(b),
+            (Self::ClassExpression(a), Self::ClassExpression(b)) => a.content_eq(b),
+            (Self::ConditionalExpression(a), Self::ConditionalExpression(b)) => a.content_eq(b),
+            (Self::FunctionExpression(a), Self::FunctionExpression(b)) => a.content_eq(b),
+            (Self::ImportExpression(a), Self::ImportExpression(b)) => a.content_eq(b),
+            (Self::LogicalExpression(a), Self::LogicalExpression(b)) => a.content_eq(b),
+            (Self::NewExpression(a), Self::NewExpression(b)) => a.content_eq(b),
+            (Self::ObjectExpression(a), Self::ObjectExpression(b)) => a.content_eq(b),
+            (Self::ParenthesizedExpression(a), Self::ParenthesizedExpression(b)) => a.content_eq(b),
+            (Self::SequenceExpression(a), Self::SequenceExpression(b)) => a.content_eq(b),
+            (Self::TaggedTemplateExpression(a), Self::TaggedTemplateExpression(b)) => {
+                a.content_eq(b)
+            }
+            (Self::ThisExpression(a), Self::ThisExpression(b)) => a.content_eq(b),
+            (Self::UnaryExpression(a), Self::UnaryExpression(b)) => a.content_eq(b),
+            (Self::UpdateExpression(a), Self::UpdateExpression(b)) => a.content_eq(b),
+            (Self::YieldExpression(a), Self::YieldExpression(b)) => a.content_eq(b),
+            (Self::PrivateInExpression(a), Self::PrivateInExpression(b)) => a.content_eq(b),
+            (Self::JSXElement(a), Self::JSXElement(b)) => a.content_eq(b),
+            (Self::JSXFragment(a), Self::JSXFragment(b)) => a.content_eq(b),
+            (Self::TSAsExpression(a), Self::TSAsExpression(b)) => a.content_eq(b),
+            (Self::TSSatisfiesExpression(a), Self::TSSatisfiesExpression(b)) => a.content_eq(b),
+            (Self::TSTypeAssertion(a), Self::TSTypeAssertion(b)) => a.content_eq(b),
+            (Self::TSNonNullExpression(a), Self::TSNonNullExpression(b)) => a.content_eq(b),
+            (Self::TSInstantiationExpression(a), Self::TSInstantiationExpression(b)) => {
+                a.content_eq(b)
+            }
+            (Self::ComputedMemberExpression(a), Self::ComputedMemberExpression(b)) => {
+                a.content_eq(b)
+            }
+            (Self::StaticMemberExpression(a), Self::StaticMemberExpression(b)) => a.content_eq(b),
+            (Self::PrivateFieldExpression(a), Self::PrivateFieldExpression(b)) => a.content_eq(b),
+            _ => false,
+        }
+    }
+}
+
+impl ContentEq for JSXEmptyExpression {
+    fn content_eq(&self, _: &Self) -> bool {
+        true
+    }
+}
+
+impl ContentEq for JSXAttributeItem<'_> {
+    fn content_eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Attribute(a), Self::Attribute(b)) => a.content_eq(b),
+            (Self::SpreadAttribute(a), Self::SpreadAttribute(b)) => a.content_eq(b),
+            _ => false,
+        }
+    }
+}
+
+impl ContentEq for JSXAttribute<'_> {
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.name, &other.name)
+            && ContentEq::content_eq(&self.value, &other.value)
+    }
+}
+
+impl ContentEq for JSXSpreadAttribute<'_> {
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.argument, &other.argument)
+    }
+}
+
+impl ContentEq for JSXAttributeName<'_> {
+    fn content_eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Identifier(a), Self::Identifier(b)) => a.content_eq(b),
+            (Self::NamespacedName(a), Self::NamespacedName(b)) => a.content_eq(b),
+            _ => false,
+        }
+    }
+}
+
+impl ContentEq for JSXAttributeValue<'_> {
+    fn content_eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::StringLiteral(a), Self::StringLiteral(b)) => a.content_eq(b),
+            (Self::ExpressionContainer(a), Self::ExpressionContainer(b)) => a.content_eq(b),
+            (Self::Element(a), Self::Element(b)) => a.content_eq(b),
+            (Self::Fragment(a), Self::Fragment(b)) => a.content_eq(b),
+            _ => false,
+        }
+    }
+}
+
+impl ContentEq for JSXIdentifier<'_> {
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.name, &other.name)
+    }
+}
+
+impl ContentEq for JSXChild<'_> {
+    fn content_eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Text(a), Self::Text(b)) => a.content_eq(b),
+            (Self::Element(a), Self::Element(b)) => a.content_eq(b),
+            (Self::Fragment(a), Self::Fragment(b)) => a.content_eq(b),
+            (Self::ExpressionContainer(a), Self::ExpressionContainer(b)) => a.content_eq(b),
+            (Self::Spread(a), Self::Spread(b)) => a.content_eq(b),
+            _ => false,
+        }
+    }
+}
+
+impl ContentEq for JSXSpreadChild<'_> {
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.expression, &other.expression)
+    }
+}
+
+impl ContentEq for JSXText<'_> {
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.value, &other.value)
+    }
+}
+
 impl ContentEq for TSThisParameter<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.type_annotation, &other.type_annotation)
@@ -2219,232 +2445,6 @@ impl ContentEq for JSDocNonNullableType<'_> {
 impl ContentEq for JSDocUnknownType {
     fn content_eq(&self, _: &Self) -> bool {
         true
-    }
-}
-
-impl ContentEq for JSXElement<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.opening_element, &other.opening_element)
-            && ContentEq::content_eq(&self.closing_element, &other.closing_element)
-            && ContentEq::content_eq(&self.children, &other.children)
-    }
-}
-
-impl ContentEq for JSXOpeningElement<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.self_closing, &other.self_closing)
-            && ContentEq::content_eq(&self.name, &other.name)
-            && ContentEq::content_eq(&self.attributes, &other.attributes)
-            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
-    }
-}
-
-impl ContentEq for JSXClosingElement<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.name, &other.name)
-    }
-}
-
-impl ContentEq for JSXFragment<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.opening_fragment, &other.opening_fragment)
-            && ContentEq::content_eq(&self.closing_fragment, &other.closing_fragment)
-            && ContentEq::content_eq(&self.children, &other.children)
-    }
-}
-
-impl ContentEq for JSXOpeningFragment {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
-    }
-}
-
-impl ContentEq for JSXClosingFragment {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
-    }
-}
-
-impl ContentEq for JSXElementName<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Identifier(a), Self::Identifier(b)) => a.content_eq(b),
-            (Self::IdentifierReference(a), Self::IdentifierReference(b)) => a.content_eq(b),
-            (Self::NamespacedName(a), Self::NamespacedName(b)) => a.content_eq(b),
-            (Self::MemberExpression(a), Self::MemberExpression(b)) => a.content_eq(b),
-            (Self::ThisExpression(a), Self::ThisExpression(b)) => a.content_eq(b),
-            _ => false,
-        }
-    }
-}
-
-impl ContentEq for JSXNamespacedName<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.namespace, &other.namespace)
-            && ContentEq::content_eq(&self.property, &other.property)
-    }
-}
-
-impl ContentEq for JSXMemberExpression<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.object, &other.object)
-            && ContentEq::content_eq(&self.property, &other.property)
-    }
-}
-
-impl ContentEq for JSXMemberExpressionObject<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::IdentifierReference(a), Self::IdentifierReference(b)) => a.content_eq(b),
-            (Self::MemberExpression(a), Self::MemberExpression(b)) => a.content_eq(b),
-            (Self::ThisExpression(a), Self::ThisExpression(b)) => a.content_eq(b),
-            _ => false,
-        }
-    }
-}
-
-impl ContentEq for JSXExpressionContainer<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.expression, &other.expression)
-    }
-}
-
-impl ContentEq for JSXExpression<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::EmptyExpression(a), Self::EmptyExpression(b)) => a.content_eq(b),
-            (Self::BooleanLiteral(a), Self::BooleanLiteral(b)) => a.content_eq(b),
-            (Self::NullLiteral(a), Self::NullLiteral(b)) => a.content_eq(b),
-            (Self::NumericLiteral(a), Self::NumericLiteral(b)) => a.content_eq(b),
-            (Self::BigIntLiteral(a), Self::BigIntLiteral(b)) => a.content_eq(b),
-            (Self::RegExpLiteral(a), Self::RegExpLiteral(b)) => a.content_eq(b),
-            (Self::StringLiteral(a), Self::StringLiteral(b)) => a.content_eq(b),
-            (Self::TemplateLiteral(a), Self::TemplateLiteral(b)) => a.content_eq(b),
-            (Self::Identifier(a), Self::Identifier(b)) => a.content_eq(b),
-            (Self::MetaProperty(a), Self::MetaProperty(b)) => a.content_eq(b),
-            (Self::Super(a), Self::Super(b)) => a.content_eq(b),
-            (Self::ArrayExpression(a), Self::ArrayExpression(b)) => a.content_eq(b),
-            (Self::ArrowFunctionExpression(a), Self::ArrowFunctionExpression(b)) => a.content_eq(b),
-            (Self::AssignmentExpression(a), Self::AssignmentExpression(b)) => a.content_eq(b),
-            (Self::AwaitExpression(a), Self::AwaitExpression(b)) => a.content_eq(b),
-            (Self::BinaryExpression(a), Self::BinaryExpression(b)) => a.content_eq(b),
-            (Self::CallExpression(a), Self::CallExpression(b)) => a.content_eq(b),
-            (Self::ChainExpression(a), Self::ChainExpression(b)) => a.content_eq(b),
-            (Self::ClassExpression(a), Self::ClassExpression(b)) => a.content_eq(b),
-            (Self::ConditionalExpression(a), Self::ConditionalExpression(b)) => a.content_eq(b),
-            (Self::FunctionExpression(a), Self::FunctionExpression(b)) => a.content_eq(b),
-            (Self::ImportExpression(a), Self::ImportExpression(b)) => a.content_eq(b),
-            (Self::LogicalExpression(a), Self::LogicalExpression(b)) => a.content_eq(b),
-            (Self::NewExpression(a), Self::NewExpression(b)) => a.content_eq(b),
-            (Self::ObjectExpression(a), Self::ObjectExpression(b)) => a.content_eq(b),
-            (Self::ParenthesizedExpression(a), Self::ParenthesizedExpression(b)) => a.content_eq(b),
-            (Self::SequenceExpression(a), Self::SequenceExpression(b)) => a.content_eq(b),
-            (Self::TaggedTemplateExpression(a), Self::TaggedTemplateExpression(b)) => {
-                a.content_eq(b)
-            }
-            (Self::ThisExpression(a), Self::ThisExpression(b)) => a.content_eq(b),
-            (Self::UnaryExpression(a), Self::UnaryExpression(b)) => a.content_eq(b),
-            (Self::UpdateExpression(a), Self::UpdateExpression(b)) => a.content_eq(b),
-            (Self::YieldExpression(a), Self::YieldExpression(b)) => a.content_eq(b),
-            (Self::PrivateInExpression(a), Self::PrivateInExpression(b)) => a.content_eq(b),
-            (Self::JSXElement(a), Self::JSXElement(b)) => a.content_eq(b),
-            (Self::JSXFragment(a), Self::JSXFragment(b)) => a.content_eq(b),
-            (Self::TSAsExpression(a), Self::TSAsExpression(b)) => a.content_eq(b),
-            (Self::TSSatisfiesExpression(a), Self::TSSatisfiesExpression(b)) => a.content_eq(b),
-            (Self::TSTypeAssertion(a), Self::TSTypeAssertion(b)) => a.content_eq(b),
-            (Self::TSNonNullExpression(a), Self::TSNonNullExpression(b)) => a.content_eq(b),
-            (Self::TSInstantiationExpression(a), Self::TSInstantiationExpression(b)) => {
-                a.content_eq(b)
-            }
-            (Self::ComputedMemberExpression(a), Self::ComputedMemberExpression(b)) => {
-                a.content_eq(b)
-            }
-            (Self::StaticMemberExpression(a), Self::StaticMemberExpression(b)) => a.content_eq(b),
-            (Self::PrivateFieldExpression(a), Self::PrivateFieldExpression(b)) => a.content_eq(b),
-            _ => false,
-        }
-    }
-}
-
-impl ContentEq for JSXEmptyExpression {
-    fn content_eq(&self, _: &Self) -> bool {
-        true
-    }
-}
-
-impl ContentEq for JSXAttributeItem<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Attribute(a), Self::Attribute(b)) => a.content_eq(b),
-            (Self::SpreadAttribute(a), Self::SpreadAttribute(b)) => a.content_eq(b),
-            _ => false,
-        }
-    }
-}
-
-impl ContentEq for JSXAttribute<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.name, &other.name)
-            && ContentEq::content_eq(&self.value, &other.value)
-    }
-}
-
-impl ContentEq for JSXSpreadAttribute<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.argument, &other.argument)
-    }
-}
-
-impl ContentEq for JSXAttributeName<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Identifier(a), Self::Identifier(b)) => a.content_eq(b),
-            (Self::NamespacedName(a), Self::NamespacedName(b)) => a.content_eq(b),
-            _ => false,
-        }
-    }
-}
-
-impl ContentEq for JSXAttributeValue<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::StringLiteral(a), Self::StringLiteral(b)) => a.content_eq(b),
-            (Self::ExpressionContainer(a), Self::ExpressionContainer(b)) => a.content_eq(b),
-            (Self::Element(a), Self::Element(b)) => a.content_eq(b),
-            (Self::Fragment(a), Self::Fragment(b)) => a.content_eq(b),
-            _ => false,
-        }
-    }
-}
-
-impl ContentEq for JSXIdentifier<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.name, &other.name)
-    }
-}
-
-impl ContentEq for JSXChild<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Text(a), Self::Text(b)) => a.content_eq(b),
-            (Self::Element(a), Self::Element(b)) => a.content_eq(b),
-            (Self::Fragment(a), Self::Fragment(b)) => a.content_eq(b),
-            (Self::ExpressionContainer(a), Self::ExpressionContainer(b)) => a.content_eq(b),
-            (Self::Spread(a), Self::Spread(b)) => a.content_eq(b),
-            _ => false,
-        }
-    }
-}
-
-impl ContentEq for JSXSpreadChild<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.expression, &other.expression)
-    }
-}
-
-impl ContentEq for JSXText<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.value, &other.value)
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -10,61 +10,6 @@ use crate::ast::jsx::*;
 use crate::ast::literal::*;
 use crate::ast::ts::*;
 
-impl Serialize for BooleanLiteral {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        crate::serialize::ESTreeLiteral::from(self).serialize(serializer)
-    }
-}
-
-impl Serialize for NullLiteral {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        crate::serialize::ESTreeLiteral::from(self).serialize(serializer)
-    }
-}
-
-impl Serialize for NumericLiteral<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        crate::serialize::ESTreeLiteral::from(self).serialize(serializer)
-    }
-}
-
-impl Serialize for StringLiteral<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        crate::serialize::ESTreeLiteral::from(self).serialize(serializer)
-    }
-}
-
-impl Serialize for BigIntLiteral<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        crate::serialize::ESTreeLiteral::from(self).serialize(serializer)
-    }
-}
-
-impl Serialize for RegExpLiteral<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        crate::serialize::ESTreeLiteral::from(self).serialize(serializer)
-    }
-}
-
-impl Serialize for RegExp<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("pattern", &self.pattern)?;
-        map.serialize_entry("flags", &self.flags)?;
-        map.end()
-    }
-}
-
-impl Serialize for RegExpPattern<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        match self {
-            RegExpPattern::Raw(it) => Serialize::serialize(it, serializer),
-            RegExpPattern::Invalid(it) => Serialize::serialize(it, serializer),
-            RegExpPattern::Pattern(it) => Serialize::serialize(it, serializer),
-        }
-    }
-}
-
 impl Serialize for Program<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(None)?;
@@ -1986,6 +1931,309 @@ impl Serialize for ModuleExportName<'_> {
     }
 }
 
+impl Serialize for BooleanLiteral {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        crate::serialize::ESTreeLiteral::from(self).serialize(serializer)
+    }
+}
+
+impl Serialize for NullLiteral {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        crate::serialize::ESTreeLiteral::from(self).serialize(serializer)
+    }
+}
+
+impl Serialize for NumericLiteral<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        crate::serialize::ESTreeLiteral::from(self).serialize(serializer)
+    }
+}
+
+impl Serialize for StringLiteral<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        crate::serialize::ESTreeLiteral::from(self).serialize(serializer)
+    }
+}
+
+impl Serialize for BigIntLiteral<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        crate::serialize::ESTreeLiteral::from(self).serialize(serializer)
+    }
+}
+
+impl Serialize for RegExpLiteral<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        crate::serialize::ESTreeLiteral::from(self).serialize(serializer)
+    }
+}
+
+impl Serialize for RegExp<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("pattern", &self.pattern)?;
+        map.serialize_entry("flags", &self.flags)?;
+        map.end()
+    }
+}
+
+impl Serialize for RegExpPattern<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            RegExpPattern::Raw(it) => Serialize::serialize(it, serializer),
+            RegExpPattern::Invalid(it) => Serialize::serialize(it, serializer),
+            RegExpPattern::Pattern(it) => Serialize::serialize(it, serializer),
+        }
+    }
+}
+
+impl Serialize for JSXElement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "JSXElement")?;
+        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
+        map.serialize_entry("openingElement", &self.opening_element)?;
+        map.serialize_entry("closingElement", &self.closing_element)?;
+        map.serialize_entry("children", &self.children)?;
+        map.end()
+    }
+}
+
+impl Serialize for JSXOpeningElement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "JSXOpeningElement")?;
+        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
+        map.serialize_entry("selfClosing", &self.self_closing)?;
+        map.serialize_entry("name", &self.name)?;
+        map.serialize_entry("attributes", &self.attributes)?;
+        map.serialize_entry("typeParameters", &self.type_parameters)?;
+        map.end()
+    }
+}
+
+impl Serialize for JSXClosingElement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "JSXClosingElement")?;
+        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
+        map.serialize_entry("name", &self.name)?;
+        map.end()
+    }
+}
+
+impl Serialize for JSXFragment<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "JSXFragment")?;
+        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
+        map.serialize_entry("openingFragment", &self.opening_fragment)?;
+        map.serialize_entry("closingFragment", &self.closing_fragment)?;
+        map.serialize_entry("children", &self.children)?;
+        map.end()
+    }
+}
+
+impl Serialize for JSXOpeningFragment {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "JSXOpeningFragment")?;
+        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
+        map.end()
+    }
+}
+
+impl Serialize for JSXClosingFragment {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "JSXClosingFragment")?;
+        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
+        map.end()
+    }
+}
+
+impl Serialize for JSXNamespacedName<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "JSXNamespacedName")?;
+        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
+        map.serialize_entry("namespace", &self.namespace)?;
+        map.serialize_entry("property", &self.property)?;
+        map.end()
+    }
+}
+
+impl Serialize for JSXMemberExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "JSXMemberExpression")?;
+        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
+        map.serialize_entry("object", &self.object)?;
+        map.serialize_entry("property", &self.property)?;
+        map.end()
+    }
+}
+
+impl Serialize for JSXExpressionContainer<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "JSXExpressionContainer")?;
+        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
+        map.serialize_entry("expression", &self.expression)?;
+        map.end()
+    }
+}
+
+impl Serialize for JSXExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            JSXExpression::EmptyExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::BooleanLiteral(it) => Serialize::serialize(it, serializer),
+            JSXExpression::NullLiteral(it) => Serialize::serialize(it, serializer),
+            JSXExpression::NumericLiteral(it) => Serialize::serialize(it, serializer),
+            JSXExpression::BigIntLiteral(it) => Serialize::serialize(it, serializer),
+            JSXExpression::RegExpLiteral(it) => Serialize::serialize(it, serializer),
+            JSXExpression::StringLiteral(it) => Serialize::serialize(it, serializer),
+            JSXExpression::TemplateLiteral(it) => Serialize::serialize(it, serializer),
+            JSXExpression::Identifier(it) => Serialize::serialize(it, serializer),
+            JSXExpression::MetaProperty(it) => Serialize::serialize(it, serializer),
+            JSXExpression::Super(it) => Serialize::serialize(it, serializer),
+            JSXExpression::ArrayExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::ArrowFunctionExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::AssignmentExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::AwaitExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::BinaryExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::CallExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::ChainExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::ClassExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::ConditionalExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::FunctionExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::ImportExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::LogicalExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::NewExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::ObjectExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::ParenthesizedExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::SequenceExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::TaggedTemplateExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::ThisExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::UnaryExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::UpdateExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::YieldExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::PrivateInExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::JSXElement(it) => Serialize::serialize(it, serializer),
+            JSXExpression::JSXFragment(it) => Serialize::serialize(it, serializer),
+            JSXExpression::TSAsExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::TSSatisfiesExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::TSTypeAssertion(it) => Serialize::serialize(it, serializer),
+            JSXExpression::TSNonNullExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::TSInstantiationExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::ComputedMemberExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::StaticMemberExpression(it) => Serialize::serialize(it, serializer),
+            JSXExpression::PrivateFieldExpression(it) => Serialize::serialize(it, serializer),
+        }
+    }
+}
+
+impl Serialize for JSXEmptyExpression {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "JSXEmptyExpression")?;
+        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
+        map.end()
+    }
+}
+
+impl Serialize for JSXAttributeItem<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            JSXAttributeItem::Attribute(it) => Serialize::serialize(it, serializer),
+            JSXAttributeItem::SpreadAttribute(it) => Serialize::serialize(it, serializer),
+        }
+    }
+}
+
+impl Serialize for JSXAttribute<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "JSXAttribute")?;
+        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
+        map.serialize_entry("name", &self.name)?;
+        map.serialize_entry("value", &self.value)?;
+        map.end()
+    }
+}
+
+impl Serialize for JSXSpreadAttribute<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "JSXSpreadAttribute")?;
+        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
+        map.serialize_entry("argument", &self.argument)?;
+        map.end()
+    }
+}
+
+impl Serialize for JSXAttributeName<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            JSXAttributeName::Identifier(it) => Serialize::serialize(it, serializer),
+            JSXAttributeName::NamespacedName(it) => Serialize::serialize(it, serializer),
+        }
+    }
+}
+
+impl Serialize for JSXAttributeValue<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            JSXAttributeValue::StringLiteral(it) => Serialize::serialize(it, serializer),
+            JSXAttributeValue::ExpressionContainer(it) => Serialize::serialize(it, serializer),
+            JSXAttributeValue::Element(it) => Serialize::serialize(it, serializer),
+            JSXAttributeValue::Fragment(it) => Serialize::serialize(it, serializer),
+        }
+    }
+}
+
+impl Serialize for JSXIdentifier<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "JSXIdentifier")?;
+        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
+        map.serialize_entry("name", &self.name)?;
+        map.end()
+    }
+}
+
+impl Serialize for JSXChild<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self {
+            JSXChild::Text(it) => Serialize::serialize(it, serializer),
+            JSXChild::Element(it) => Serialize::serialize(it, serializer),
+            JSXChild::Fragment(it) => Serialize::serialize(it, serializer),
+            JSXChild::ExpressionContainer(it) => Serialize::serialize(it, serializer),
+            JSXChild::Spread(it) => Serialize::serialize(it, serializer),
+        }
+    }
+}
+
+impl Serialize for JSXSpreadChild<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "JSXSpreadChild")?;
+        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
+        map.serialize_entry("expression", &self.expression)?;
+        map.end()
+    }
+}
+
+impl Serialize for JSXText<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "JSXText")?;
+        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
+        map.serialize_entry("value", &self.value)?;
+        map.end()
+    }
+}
+
 impl Serialize for TSThisParameter<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(None)?;
@@ -3048,254 +3296,6 @@ impl Serialize for JSDocUnknownType {
         let mut map = serializer.serialize_map(None)?;
         map.serialize_entry("type", "JSDocUnknownType")?;
         self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.end()
-    }
-}
-
-impl Serialize for JSXElement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXElement")?;
-        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.serialize_entry("openingElement", &self.opening_element)?;
-        map.serialize_entry("closingElement", &self.closing_element)?;
-        map.serialize_entry("children", &self.children)?;
-        map.end()
-    }
-}
-
-impl Serialize for JSXOpeningElement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXOpeningElement")?;
-        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.serialize_entry("selfClosing", &self.self_closing)?;
-        map.serialize_entry("name", &self.name)?;
-        map.serialize_entry("attributes", &self.attributes)?;
-        map.serialize_entry("typeParameters", &self.type_parameters)?;
-        map.end()
-    }
-}
-
-impl Serialize for JSXClosingElement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXClosingElement")?;
-        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.serialize_entry("name", &self.name)?;
-        map.end()
-    }
-}
-
-impl Serialize for JSXFragment<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXFragment")?;
-        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.serialize_entry("openingFragment", &self.opening_fragment)?;
-        map.serialize_entry("closingFragment", &self.closing_fragment)?;
-        map.serialize_entry("children", &self.children)?;
-        map.end()
-    }
-}
-
-impl Serialize for JSXOpeningFragment {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXOpeningFragment")?;
-        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.end()
-    }
-}
-
-impl Serialize for JSXClosingFragment {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXClosingFragment")?;
-        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.end()
-    }
-}
-
-impl Serialize for JSXNamespacedName<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXNamespacedName")?;
-        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.serialize_entry("namespace", &self.namespace)?;
-        map.serialize_entry("property", &self.property)?;
-        map.end()
-    }
-}
-
-impl Serialize for JSXMemberExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXMemberExpression")?;
-        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.serialize_entry("object", &self.object)?;
-        map.serialize_entry("property", &self.property)?;
-        map.end()
-    }
-}
-
-impl Serialize for JSXExpressionContainer<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXExpressionContainer")?;
-        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.serialize_entry("expression", &self.expression)?;
-        map.end()
-    }
-}
-
-impl Serialize for JSXExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        match self {
-            JSXExpression::EmptyExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::BooleanLiteral(it) => Serialize::serialize(it, serializer),
-            JSXExpression::NullLiteral(it) => Serialize::serialize(it, serializer),
-            JSXExpression::NumericLiteral(it) => Serialize::serialize(it, serializer),
-            JSXExpression::BigIntLiteral(it) => Serialize::serialize(it, serializer),
-            JSXExpression::RegExpLiteral(it) => Serialize::serialize(it, serializer),
-            JSXExpression::StringLiteral(it) => Serialize::serialize(it, serializer),
-            JSXExpression::TemplateLiteral(it) => Serialize::serialize(it, serializer),
-            JSXExpression::Identifier(it) => Serialize::serialize(it, serializer),
-            JSXExpression::MetaProperty(it) => Serialize::serialize(it, serializer),
-            JSXExpression::Super(it) => Serialize::serialize(it, serializer),
-            JSXExpression::ArrayExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::ArrowFunctionExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::AssignmentExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::AwaitExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::BinaryExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::CallExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::ChainExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::ClassExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::ConditionalExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::FunctionExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::ImportExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::LogicalExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::NewExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::ObjectExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::ParenthesizedExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::SequenceExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::TaggedTemplateExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::ThisExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::UnaryExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::UpdateExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::YieldExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::PrivateInExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::JSXElement(it) => Serialize::serialize(it, serializer),
-            JSXExpression::JSXFragment(it) => Serialize::serialize(it, serializer),
-            JSXExpression::TSAsExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::TSSatisfiesExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::TSTypeAssertion(it) => Serialize::serialize(it, serializer),
-            JSXExpression::TSNonNullExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::TSInstantiationExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::ComputedMemberExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::StaticMemberExpression(it) => Serialize::serialize(it, serializer),
-            JSXExpression::PrivateFieldExpression(it) => Serialize::serialize(it, serializer),
-        }
-    }
-}
-
-impl Serialize for JSXEmptyExpression {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXEmptyExpression")?;
-        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.end()
-    }
-}
-
-impl Serialize for JSXAttributeItem<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        match self {
-            JSXAttributeItem::Attribute(it) => Serialize::serialize(it, serializer),
-            JSXAttributeItem::SpreadAttribute(it) => Serialize::serialize(it, serializer),
-        }
-    }
-}
-
-impl Serialize for JSXAttribute<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXAttribute")?;
-        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.serialize_entry("name", &self.name)?;
-        map.serialize_entry("value", &self.value)?;
-        map.end()
-    }
-}
-
-impl Serialize for JSXSpreadAttribute<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXSpreadAttribute")?;
-        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.serialize_entry("argument", &self.argument)?;
-        map.end()
-    }
-}
-
-impl Serialize for JSXAttributeName<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        match self {
-            JSXAttributeName::Identifier(it) => Serialize::serialize(it, serializer),
-            JSXAttributeName::NamespacedName(it) => Serialize::serialize(it, serializer),
-        }
-    }
-}
-
-impl Serialize for JSXAttributeValue<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        match self {
-            JSXAttributeValue::StringLiteral(it) => Serialize::serialize(it, serializer),
-            JSXAttributeValue::ExpressionContainer(it) => Serialize::serialize(it, serializer),
-            JSXAttributeValue::Element(it) => Serialize::serialize(it, serializer),
-            JSXAttributeValue::Fragment(it) => Serialize::serialize(it, serializer),
-        }
-    }
-}
-
-impl Serialize for JSXIdentifier<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXIdentifier")?;
-        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.serialize_entry("name", &self.name)?;
-        map.end()
-    }
-}
-
-impl Serialize for JSXChild<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        match self {
-            JSXChild::Text(it) => Serialize::serialize(it, serializer),
-            JSXChild::Element(it) => Serialize::serialize(it, serializer),
-            JSXChild::Fragment(it) => Serialize::serialize(it, serializer),
-            JSXChild::ExpressionContainer(it) => Serialize::serialize(it, serializer),
-            JSXChild::Spread(it) => Serialize::serialize(it, serializer),
-        }
-    }
-}
-
-impl Serialize for JSXSpreadChild<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXSpreadChild")?;
-        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.serialize_entry("expression", &self.expression)?;
-        map.end()
-    }
-}
-
-impl Serialize for JSXText<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXText")?;
-        self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.serialize_entry("value", &self.value)?;
         map.end()
     }
 }

--- a/crates/oxc_ast/src/generated/derive_get_address.rs
+++ b/crates/oxc_ast/src/generated/derive_get_address.rs
@@ -522,6 +522,81 @@ impl GetAddress for ExportDefaultDeclarationKind<'_> {
     }
 }
 
+impl GetAddress for JSXElementName<'_> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::Identifier(it) => GetAddress::address(it),
+            Self::IdentifierReference(it) => GetAddress::address(it),
+            Self::NamespacedName(it) => GetAddress::address(it),
+            Self::MemberExpression(it) => GetAddress::address(it),
+            Self::ThisExpression(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl GetAddress for JSXMemberExpressionObject<'_> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::IdentifierReference(it) => GetAddress::address(it),
+            Self::MemberExpression(it) => GetAddress::address(it),
+            Self::ThisExpression(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl GetAddress for JSXAttributeItem<'_> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::Attribute(it) => GetAddress::address(it),
+            Self::SpreadAttribute(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl GetAddress for JSXAttributeName<'_> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::Identifier(it) => GetAddress::address(it),
+            Self::NamespacedName(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl GetAddress for JSXAttributeValue<'_> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::StringLiteral(it) => GetAddress::address(it),
+            Self::ExpressionContainer(it) => GetAddress::address(it),
+            Self::Element(it) => GetAddress::address(it),
+            Self::Fragment(it) => GetAddress::address(it),
+        }
+    }
+}
+
+impl GetAddress for JSXChild<'_> {
+    // `#[inline]` because compiler should boil this down to a single assembly instruction
+    #[inline]
+    fn address(&self) -> Address {
+        match self {
+            Self::Text(it) => GetAddress::address(it),
+            Self::Element(it) => GetAddress::address(it),
+            Self::Fragment(it) => GetAddress::address(it),
+            Self::ExpressionContainer(it) => GetAddress::address(it),
+            Self::Spread(it) => GetAddress::address(it),
+        }
+    }
+}
+
 impl GetAddress for TSEnumMemberName<'_> {
     // `#[inline]` because compiler should boil this down to a single assembly instruction
     #[inline]
@@ -702,81 +777,6 @@ impl GetAddress for TSModuleReference<'_> {
             Self::ExternalModuleReference(it) => GetAddress::address(it),
             Self::IdentifierReference(it) => GetAddress::address(it),
             Self::QualifiedName(it) => GetAddress::address(it),
-        }
-    }
-}
-
-impl GetAddress for JSXElementName<'_> {
-    // `#[inline]` because compiler should boil this down to a single assembly instruction
-    #[inline]
-    fn address(&self) -> Address {
-        match self {
-            Self::Identifier(it) => GetAddress::address(it),
-            Self::IdentifierReference(it) => GetAddress::address(it),
-            Self::NamespacedName(it) => GetAddress::address(it),
-            Self::MemberExpression(it) => GetAddress::address(it),
-            Self::ThisExpression(it) => GetAddress::address(it),
-        }
-    }
-}
-
-impl GetAddress for JSXMemberExpressionObject<'_> {
-    // `#[inline]` because compiler should boil this down to a single assembly instruction
-    #[inline]
-    fn address(&self) -> Address {
-        match self {
-            Self::IdentifierReference(it) => GetAddress::address(it),
-            Self::MemberExpression(it) => GetAddress::address(it),
-            Self::ThisExpression(it) => GetAddress::address(it),
-        }
-    }
-}
-
-impl GetAddress for JSXAttributeItem<'_> {
-    // `#[inline]` because compiler should boil this down to a single assembly instruction
-    #[inline]
-    fn address(&self) -> Address {
-        match self {
-            Self::Attribute(it) => GetAddress::address(it),
-            Self::SpreadAttribute(it) => GetAddress::address(it),
-        }
-    }
-}
-
-impl GetAddress for JSXAttributeName<'_> {
-    // `#[inline]` because compiler should boil this down to a single assembly instruction
-    #[inline]
-    fn address(&self) -> Address {
-        match self {
-            Self::Identifier(it) => GetAddress::address(it),
-            Self::NamespacedName(it) => GetAddress::address(it),
-        }
-    }
-}
-
-impl GetAddress for JSXAttributeValue<'_> {
-    // `#[inline]` because compiler should boil this down to a single assembly instruction
-    #[inline]
-    fn address(&self) -> Address {
-        match self {
-            Self::StringLiteral(it) => GetAddress::address(it),
-            Self::ExpressionContainer(it) => GetAddress::address(it),
-            Self::Element(it) => GetAddress::address(it),
-            Self::Fragment(it) => GetAddress::address(it),
-        }
-    }
-}
-
-impl GetAddress for JSXChild<'_> {
-    // `#[inline]` because compiler should boil this down to a single assembly instruction
-    #[inline]
-    fn address(&self) -> Address {
-        match self {
-            Self::Text(it) => GetAddress::address(it),
-            Self::Element(it) => GetAddress::address(it),
-            Self::Fragment(it) => GetAddress::address(it),
-            Self::ExpressionContainer(it) => GetAddress::address(it),
-            Self::Spread(it) => GetAddress::address(it),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_get_span.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span.rs
@@ -10,48 +10,6 @@ use crate::ast::jsx::*;
 use crate::ast::literal::*;
 use crate::ast::ts::*;
 
-impl GetSpan for BooleanLiteral {
-    #[inline]
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
-impl GetSpan for NullLiteral {
-    #[inline]
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
-impl GetSpan for NumericLiteral<'_> {
-    #[inline]
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
-impl GetSpan for StringLiteral<'_> {
-    #[inline]
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
-impl GetSpan for BigIntLiteral<'_> {
-    #[inline]
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
-impl GetSpan for RegExpLiteral<'_> {
-    #[inline]
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
 impl GetSpan for Program<'_> {
     #[inline]
     fn span(&self) -> Span {
@@ -1246,6 +1204,266 @@ impl GetSpan for ModuleExportName<'_> {
     }
 }
 
+impl GetSpan for BooleanLiteral {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl GetSpan for NullLiteral {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl GetSpan for NumericLiteral<'_> {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl GetSpan for StringLiteral<'_> {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl GetSpan for BigIntLiteral<'_> {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl GetSpan for RegExpLiteral<'_> {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl GetSpan for JSXElement<'_> {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl GetSpan for JSXOpeningElement<'_> {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl GetSpan for JSXClosingElement<'_> {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl GetSpan for JSXFragment<'_> {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl GetSpan for JSXOpeningFragment {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl GetSpan for JSXClosingFragment {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl GetSpan for JSXElementName<'_> {
+    fn span(&self) -> Span {
+        match self {
+            Self::Identifier(it) => GetSpan::span(it.as_ref()),
+            Self::IdentifierReference(it) => GetSpan::span(it.as_ref()),
+            Self::NamespacedName(it) => GetSpan::span(it.as_ref()),
+            Self::MemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ThisExpression(it) => GetSpan::span(it.as_ref()),
+        }
+    }
+}
+
+impl GetSpan for JSXNamespacedName<'_> {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl GetSpan for JSXMemberExpression<'_> {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl GetSpan for JSXMemberExpressionObject<'_> {
+    fn span(&self) -> Span {
+        match self {
+            Self::IdentifierReference(it) => GetSpan::span(it.as_ref()),
+            Self::MemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ThisExpression(it) => GetSpan::span(it.as_ref()),
+        }
+    }
+}
+
+impl GetSpan for JSXExpressionContainer<'_> {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl GetSpan for JSXExpression<'_> {
+    fn span(&self) -> Span {
+        match self {
+            Self::EmptyExpression(it) => GetSpan::span(it),
+            Self::BooleanLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::NullLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::NumericLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::BigIntLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::RegExpLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::StringLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::TemplateLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::Identifier(it) => GetSpan::span(it.as_ref()),
+            Self::MetaProperty(it) => GetSpan::span(it.as_ref()),
+            Self::Super(it) => GetSpan::span(it.as_ref()),
+            Self::ArrayExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ArrowFunctionExpression(it) => GetSpan::span(it.as_ref()),
+            Self::AssignmentExpression(it) => GetSpan::span(it.as_ref()),
+            Self::AwaitExpression(it) => GetSpan::span(it.as_ref()),
+            Self::BinaryExpression(it) => GetSpan::span(it.as_ref()),
+            Self::CallExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ChainExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ClassExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ConditionalExpression(it) => GetSpan::span(it.as_ref()),
+            Self::FunctionExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ImportExpression(it) => GetSpan::span(it.as_ref()),
+            Self::LogicalExpression(it) => GetSpan::span(it.as_ref()),
+            Self::NewExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ObjectExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ParenthesizedExpression(it) => GetSpan::span(it.as_ref()),
+            Self::SequenceExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TaggedTemplateExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ThisExpression(it) => GetSpan::span(it.as_ref()),
+            Self::UnaryExpression(it) => GetSpan::span(it.as_ref()),
+            Self::UpdateExpression(it) => GetSpan::span(it.as_ref()),
+            Self::YieldExpression(it) => GetSpan::span(it.as_ref()),
+            Self::PrivateInExpression(it) => GetSpan::span(it.as_ref()),
+            Self::JSXElement(it) => GetSpan::span(it.as_ref()),
+            Self::JSXFragment(it) => GetSpan::span(it.as_ref()),
+            Self::TSAsExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSSatisfiesExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSTypeAssertion(it) => GetSpan::span(it.as_ref()),
+            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
+            Self::TSInstantiationExpression(it) => GetSpan::span(it.as_ref()),
+            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
+            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
+        }
+    }
+}
+
+impl GetSpan for JSXEmptyExpression {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl GetSpan for JSXAttributeItem<'_> {
+    fn span(&self) -> Span {
+        match self {
+            Self::Attribute(it) => GetSpan::span(it.as_ref()),
+            Self::SpreadAttribute(it) => GetSpan::span(it.as_ref()),
+        }
+    }
+}
+
+impl GetSpan for JSXAttribute<'_> {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl GetSpan for JSXSpreadAttribute<'_> {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl GetSpan for JSXAttributeName<'_> {
+    fn span(&self) -> Span {
+        match self {
+            Self::Identifier(it) => GetSpan::span(it.as_ref()),
+            Self::NamespacedName(it) => GetSpan::span(it.as_ref()),
+        }
+    }
+}
+
+impl GetSpan for JSXAttributeValue<'_> {
+    fn span(&self) -> Span {
+        match self {
+            Self::StringLiteral(it) => GetSpan::span(it.as_ref()),
+            Self::ExpressionContainer(it) => GetSpan::span(it.as_ref()),
+            Self::Element(it) => GetSpan::span(it.as_ref()),
+            Self::Fragment(it) => GetSpan::span(it.as_ref()),
+        }
+    }
+}
+
+impl GetSpan for JSXIdentifier<'_> {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl GetSpan for JSXChild<'_> {
+    fn span(&self) -> Span {
+        match self {
+            Self::Text(it) => GetSpan::span(it.as_ref()),
+            Self::Element(it) => GetSpan::span(it.as_ref()),
+            Self::Fragment(it) => GetSpan::span(it.as_ref()),
+            Self::ExpressionContainer(it) => GetSpan::span(it.as_ref()),
+            Self::Spread(it) => GetSpan::span(it.as_ref()),
+        }
+    }
+}
+
+impl GetSpan for JSXSpreadChild<'_> {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
+impl GetSpan for JSXText<'_> {
+    #[inline]
+    fn span(&self) -> Span {
+        self.span
+    }
+}
+
 impl GetSpan for TSThisParameter<'_> {
     #[inline]
     fn span(&self) -> Span {
@@ -1937,224 +2155,6 @@ impl GetSpan for JSDocNonNullableType<'_> {
 }
 
 impl GetSpan for JSDocUnknownType {
-    #[inline]
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
-impl GetSpan for JSXElement<'_> {
-    #[inline]
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
-impl GetSpan for JSXOpeningElement<'_> {
-    #[inline]
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
-impl GetSpan for JSXClosingElement<'_> {
-    #[inline]
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
-impl GetSpan for JSXFragment<'_> {
-    #[inline]
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
-impl GetSpan for JSXOpeningFragment {
-    #[inline]
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
-impl GetSpan for JSXClosingFragment {
-    #[inline]
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
-impl GetSpan for JSXElementName<'_> {
-    fn span(&self) -> Span {
-        match self {
-            Self::Identifier(it) => GetSpan::span(it.as_ref()),
-            Self::IdentifierReference(it) => GetSpan::span(it.as_ref()),
-            Self::NamespacedName(it) => GetSpan::span(it.as_ref()),
-            Self::MemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ThisExpression(it) => GetSpan::span(it.as_ref()),
-        }
-    }
-}
-
-impl GetSpan for JSXNamespacedName<'_> {
-    #[inline]
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
-impl GetSpan for JSXMemberExpression<'_> {
-    #[inline]
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
-impl GetSpan for JSXMemberExpressionObject<'_> {
-    fn span(&self) -> Span {
-        match self {
-            Self::IdentifierReference(it) => GetSpan::span(it.as_ref()),
-            Self::MemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ThisExpression(it) => GetSpan::span(it.as_ref()),
-        }
-    }
-}
-
-impl GetSpan for JSXExpressionContainer<'_> {
-    #[inline]
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
-impl GetSpan for JSXExpression<'_> {
-    fn span(&self) -> Span {
-        match self {
-            Self::EmptyExpression(it) => GetSpan::span(it),
-            Self::BooleanLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::NullLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::NumericLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::BigIntLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::RegExpLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::StringLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::TemplateLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::Identifier(it) => GetSpan::span(it.as_ref()),
-            Self::MetaProperty(it) => GetSpan::span(it.as_ref()),
-            Self::Super(it) => GetSpan::span(it.as_ref()),
-            Self::ArrayExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ArrowFunctionExpression(it) => GetSpan::span(it.as_ref()),
-            Self::AssignmentExpression(it) => GetSpan::span(it.as_ref()),
-            Self::AwaitExpression(it) => GetSpan::span(it.as_ref()),
-            Self::BinaryExpression(it) => GetSpan::span(it.as_ref()),
-            Self::CallExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ChainExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ClassExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ConditionalExpression(it) => GetSpan::span(it.as_ref()),
-            Self::FunctionExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ImportExpression(it) => GetSpan::span(it.as_ref()),
-            Self::LogicalExpression(it) => GetSpan::span(it.as_ref()),
-            Self::NewExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ObjectExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ParenthesizedExpression(it) => GetSpan::span(it.as_ref()),
-            Self::SequenceExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TaggedTemplateExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ThisExpression(it) => GetSpan::span(it.as_ref()),
-            Self::UnaryExpression(it) => GetSpan::span(it.as_ref()),
-            Self::UpdateExpression(it) => GetSpan::span(it.as_ref()),
-            Self::YieldExpression(it) => GetSpan::span(it.as_ref()),
-            Self::PrivateInExpression(it) => GetSpan::span(it.as_ref()),
-            Self::JSXElement(it) => GetSpan::span(it.as_ref()),
-            Self::JSXFragment(it) => GetSpan::span(it.as_ref()),
-            Self::TSAsExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSSatisfiesExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSTypeAssertion(it) => GetSpan::span(it.as_ref()),
-            Self::TSNonNullExpression(it) => GetSpan::span(it.as_ref()),
-            Self::TSInstantiationExpression(it) => GetSpan::span(it.as_ref()),
-            Self::ComputedMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::StaticMemberExpression(it) => GetSpan::span(it.as_ref()),
-            Self::PrivateFieldExpression(it) => GetSpan::span(it.as_ref()),
-        }
-    }
-}
-
-impl GetSpan for JSXEmptyExpression {
-    #[inline]
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
-impl GetSpan for JSXAttributeItem<'_> {
-    fn span(&self) -> Span {
-        match self {
-            Self::Attribute(it) => GetSpan::span(it.as_ref()),
-            Self::SpreadAttribute(it) => GetSpan::span(it.as_ref()),
-        }
-    }
-}
-
-impl GetSpan for JSXAttribute<'_> {
-    #[inline]
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
-impl GetSpan for JSXSpreadAttribute<'_> {
-    #[inline]
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
-impl GetSpan for JSXAttributeName<'_> {
-    fn span(&self) -> Span {
-        match self {
-            Self::Identifier(it) => GetSpan::span(it.as_ref()),
-            Self::NamespacedName(it) => GetSpan::span(it.as_ref()),
-        }
-    }
-}
-
-impl GetSpan for JSXAttributeValue<'_> {
-    fn span(&self) -> Span {
-        match self {
-            Self::StringLiteral(it) => GetSpan::span(it.as_ref()),
-            Self::ExpressionContainer(it) => GetSpan::span(it.as_ref()),
-            Self::Element(it) => GetSpan::span(it.as_ref()),
-            Self::Fragment(it) => GetSpan::span(it.as_ref()),
-        }
-    }
-}
-
-impl GetSpan for JSXIdentifier<'_> {
-    #[inline]
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
-impl GetSpan for JSXChild<'_> {
-    fn span(&self) -> Span {
-        match self {
-            Self::Text(it) => GetSpan::span(it.as_ref()),
-            Self::Element(it) => GetSpan::span(it.as_ref()),
-            Self::Fragment(it) => GetSpan::span(it.as_ref()),
-            Self::ExpressionContainer(it) => GetSpan::span(it.as_ref()),
-            Self::Spread(it) => GetSpan::span(it.as_ref()),
-        }
-    }
-}
-
-impl GetSpan for JSXSpreadChild<'_> {
-    #[inline]
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
-impl GetSpan for JSXText<'_> {
     #[inline]
     fn span(&self) -> Span {
         self.span

--- a/crates/oxc_ast/src/generated/derive_get_span_mut.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span_mut.rs
@@ -10,48 +10,6 @@ use crate::ast::jsx::*;
 use crate::ast::literal::*;
 use crate::ast::ts::*;
 
-impl GetSpanMut for BooleanLiteral {
-    #[inline]
-    fn span_mut(&mut self) -> &mut Span {
-        &mut self.span
-    }
-}
-
-impl GetSpanMut for NullLiteral {
-    #[inline]
-    fn span_mut(&mut self) -> &mut Span {
-        &mut self.span
-    }
-}
-
-impl GetSpanMut for NumericLiteral<'_> {
-    #[inline]
-    fn span_mut(&mut self) -> &mut Span {
-        &mut self.span
-    }
-}
-
-impl GetSpanMut for StringLiteral<'_> {
-    #[inline]
-    fn span_mut(&mut self) -> &mut Span {
-        &mut self.span
-    }
-}
-
-impl GetSpanMut for BigIntLiteral<'_> {
-    #[inline]
-    fn span_mut(&mut self) -> &mut Span {
-        &mut self.span
-    }
-}
-
-impl GetSpanMut for RegExpLiteral<'_> {
-    #[inline]
-    fn span_mut(&mut self) -> &mut Span {
-        &mut self.span
-    }
-}
-
 impl GetSpanMut for Program<'_> {
     #[inline]
     fn span_mut(&mut self) -> &mut Span {
@@ -1246,6 +1204,266 @@ impl GetSpanMut for ModuleExportName<'_> {
     }
 }
 
+impl GetSpanMut for BooleanLiteral {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
+impl GetSpanMut for NullLiteral {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
+impl GetSpanMut for NumericLiteral<'_> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
+impl GetSpanMut for StringLiteral<'_> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
+impl GetSpanMut for BigIntLiteral<'_> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
+impl GetSpanMut for RegExpLiteral<'_> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
+impl GetSpanMut for JSXElement<'_> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
+impl GetSpanMut for JSXOpeningElement<'_> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
+impl GetSpanMut for JSXClosingElement<'_> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
+impl GetSpanMut for JSXFragment<'_> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
+impl GetSpanMut for JSXOpeningFragment {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
+impl GetSpanMut for JSXClosingFragment {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
+impl GetSpanMut for JSXElementName<'_> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::IdentifierReference(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NamespacedName(it) => GetSpanMut::span_mut(&mut **it),
+            Self::MemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
+        }
+    }
+}
+
+impl GetSpanMut for JSXNamespacedName<'_> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
+impl GetSpanMut for JSXMemberExpression<'_> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
+impl GetSpanMut for JSXMemberExpressionObject<'_> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::IdentifierReference(it) => GetSpanMut::span_mut(&mut **it),
+            Self::MemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
+        }
+    }
+}
+
+impl GetSpanMut for JSXExpressionContainer<'_> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
+impl GetSpanMut for JSXExpression<'_> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::EmptyExpression(it) => GetSpanMut::span_mut(it),
+            Self::BooleanLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NullLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NumericLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BigIntLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::RegExpLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StringLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TemplateLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::MetaProperty(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Super(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ArrayExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ArrowFunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AssignmentExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::AwaitExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::BinaryExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::CallExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ChainExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ClassExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ConditionalExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::FunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ImportExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::LogicalExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NewExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ObjectExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ParenthesizedExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::SequenceExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TaggedTemplateExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::UnaryExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::UpdateExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::YieldExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PrivateInExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::JSXElement(it) => GetSpanMut::span_mut(&mut **it),
+            Self::JSXFragment(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSAsExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSSatisfiesExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSTypeAssertion(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::TSInstantiationExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
+            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
+        }
+    }
+}
+
+impl GetSpanMut for JSXEmptyExpression {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
+impl GetSpanMut for JSXAttributeItem<'_> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::Attribute(it) => GetSpanMut::span_mut(&mut **it),
+            Self::SpreadAttribute(it) => GetSpanMut::span_mut(&mut **it),
+        }
+    }
+}
+
+impl GetSpanMut for JSXAttribute<'_> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
+impl GetSpanMut for JSXSpreadAttribute<'_> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
+impl GetSpanMut for JSXAttributeName<'_> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
+            Self::NamespacedName(it) => GetSpanMut::span_mut(&mut **it),
+        }
+    }
+}
+
+impl GetSpanMut for JSXAttributeValue<'_> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::StringLiteral(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ExpressionContainer(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Element(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Fragment(it) => GetSpanMut::span_mut(&mut **it),
+        }
+    }
+}
+
+impl GetSpanMut for JSXIdentifier<'_> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
+impl GetSpanMut for JSXChild<'_> {
+    fn span_mut(&mut self) -> &mut Span {
+        match self {
+            Self::Text(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Element(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Fragment(it) => GetSpanMut::span_mut(&mut **it),
+            Self::ExpressionContainer(it) => GetSpanMut::span_mut(&mut **it),
+            Self::Spread(it) => GetSpanMut::span_mut(&mut **it),
+        }
+    }
+}
+
+impl GetSpanMut for JSXSpreadChild<'_> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
+impl GetSpanMut for JSXText<'_> {
+    #[inline]
+    fn span_mut(&mut self) -> &mut Span {
+        &mut self.span
+    }
+}
+
 impl GetSpanMut for TSThisParameter<'_> {
     #[inline]
     fn span_mut(&mut self) -> &mut Span {
@@ -1937,224 +2155,6 @@ impl GetSpanMut for JSDocNonNullableType<'_> {
 }
 
 impl GetSpanMut for JSDocUnknownType {
-    #[inline]
-    fn span_mut(&mut self) -> &mut Span {
-        &mut self.span
-    }
-}
-
-impl GetSpanMut for JSXElement<'_> {
-    #[inline]
-    fn span_mut(&mut self) -> &mut Span {
-        &mut self.span
-    }
-}
-
-impl GetSpanMut for JSXOpeningElement<'_> {
-    #[inline]
-    fn span_mut(&mut self) -> &mut Span {
-        &mut self.span
-    }
-}
-
-impl GetSpanMut for JSXClosingElement<'_> {
-    #[inline]
-    fn span_mut(&mut self) -> &mut Span {
-        &mut self.span
-    }
-}
-
-impl GetSpanMut for JSXFragment<'_> {
-    #[inline]
-    fn span_mut(&mut self) -> &mut Span {
-        &mut self.span
-    }
-}
-
-impl GetSpanMut for JSXOpeningFragment {
-    #[inline]
-    fn span_mut(&mut self) -> &mut Span {
-        &mut self.span
-    }
-}
-
-impl GetSpanMut for JSXClosingFragment {
-    #[inline]
-    fn span_mut(&mut self) -> &mut Span {
-        &mut self.span
-    }
-}
-
-impl GetSpanMut for JSXElementName<'_> {
-    fn span_mut(&mut self) -> &mut Span {
-        match self {
-            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::IdentifierReference(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NamespacedName(it) => GetSpanMut::span_mut(&mut **it),
-            Self::MemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
-        }
-    }
-}
-
-impl GetSpanMut for JSXNamespacedName<'_> {
-    #[inline]
-    fn span_mut(&mut self) -> &mut Span {
-        &mut self.span
-    }
-}
-
-impl GetSpanMut for JSXMemberExpression<'_> {
-    #[inline]
-    fn span_mut(&mut self) -> &mut Span {
-        &mut self.span
-    }
-}
-
-impl GetSpanMut for JSXMemberExpressionObject<'_> {
-    fn span_mut(&mut self) -> &mut Span {
-        match self {
-            Self::IdentifierReference(it) => GetSpanMut::span_mut(&mut **it),
-            Self::MemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
-        }
-    }
-}
-
-impl GetSpanMut for JSXExpressionContainer<'_> {
-    #[inline]
-    fn span_mut(&mut self) -> &mut Span {
-        &mut self.span
-    }
-}
-
-impl GetSpanMut for JSXExpression<'_> {
-    fn span_mut(&mut self) -> &mut Span {
-        match self {
-            Self::EmptyExpression(it) => GetSpanMut::span_mut(it),
-            Self::BooleanLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NullLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NumericLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::BigIntLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::RegExpLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::StringLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TemplateLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::MetaProperty(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Super(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ArrayExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ArrowFunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::AssignmentExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::AwaitExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::BinaryExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::CallExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ChainExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ClassExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ConditionalExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::FunctionExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ImportExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::LogicalExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NewExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ObjectExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ParenthesizedExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::SequenceExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TaggedTemplateExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ThisExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::UnaryExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::UpdateExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::YieldExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::PrivateInExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::JSXElement(it) => GetSpanMut::span_mut(&mut **it),
-            Self::JSXFragment(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSAsExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSSatisfiesExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSTypeAssertion(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSNonNullExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::TSInstantiationExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ComputedMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::StaticMemberExpression(it) => GetSpanMut::span_mut(&mut **it),
-            Self::PrivateFieldExpression(it) => GetSpanMut::span_mut(&mut **it),
-        }
-    }
-}
-
-impl GetSpanMut for JSXEmptyExpression {
-    #[inline]
-    fn span_mut(&mut self) -> &mut Span {
-        &mut self.span
-    }
-}
-
-impl GetSpanMut for JSXAttributeItem<'_> {
-    fn span_mut(&mut self) -> &mut Span {
-        match self {
-            Self::Attribute(it) => GetSpanMut::span_mut(&mut **it),
-            Self::SpreadAttribute(it) => GetSpanMut::span_mut(&mut **it),
-        }
-    }
-}
-
-impl GetSpanMut for JSXAttribute<'_> {
-    #[inline]
-    fn span_mut(&mut self) -> &mut Span {
-        &mut self.span
-    }
-}
-
-impl GetSpanMut for JSXSpreadAttribute<'_> {
-    #[inline]
-    fn span_mut(&mut self) -> &mut Span {
-        &mut self.span
-    }
-}
-
-impl GetSpanMut for JSXAttributeName<'_> {
-    fn span_mut(&mut self) -> &mut Span {
-        match self {
-            Self::Identifier(it) => GetSpanMut::span_mut(&mut **it),
-            Self::NamespacedName(it) => GetSpanMut::span_mut(&mut **it),
-        }
-    }
-}
-
-impl GetSpanMut for JSXAttributeValue<'_> {
-    fn span_mut(&mut self) -> &mut Span {
-        match self {
-            Self::StringLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ExpressionContainer(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Element(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Fragment(it) => GetSpanMut::span_mut(&mut **it),
-        }
-    }
-}
-
-impl GetSpanMut for JSXIdentifier<'_> {
-    #[inline]
-    fn span_mut(&mut self) -> &mut Span {
-        &mut self.span
-    }
-}
-
-impl GetSpanMut for JSXChild<'_> {
-    fn span_mut(&mut self) -> &mut Span {
-        match self {
-            Self::Text(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Element(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Fragment(it) => GetSpanMut::span_mut(&mut **it),
-            Self::ExpressionContainer(it) => GetSpanMut::span_mut(&mut **it),
-            Self::Spread(it) => GetSpanMut::span_mut(&mut **it),
-        }
-    }
-}
-
-impl GetSpanMut for JSXSpreadChild<'_> {
-    #[inline]
-    fn span_mut(&mut self) -> &mut Span {
-        &mut self.span
-    }
-}
-
-impl GetSpanMut for JSXText<'_> {
     #[inline]
     fn span_mut(&mut self) -> &mut Span {
         &mut self.span

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -1,51 +1,6 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/typescript.rs`
 
-export interface BooleanLiteral extends Span {
-  type: 'Literal';
-  value: boolean;
-  raw: string | null;
-}
-
-export interface NullLiteral extends Span {
-  type: 'Literal';
-  value: null;
-  raw: 'null' | null;
-}
-
-export interface NumericLiteral extends Span {
-  type: 'Literal';
-  value: number;
-  raw: string | null;
-}
-
-export interface StringLiteral extends Span {
-  type: 'Literal';
-  value: string;
-  raw: string | null;
-}
-
-export interface BigIntLiteral extends Span {
-  type: 'Literal';
-  raw: string | null;
-  value: null;
-  bigint: string;
-}
-
-export interface RegExpLiteral extends Span {
-  type: 'Literal';
-  raw: string | null;
-  value: {} | null;
-  regex: { pattern: string; flags: string };
-}
-
-export interface RegExp {
-  pattern: RegExpPattern;
-  flags: RegExpFlags;
-}
-
-export type RegExpPattern = string | string | Pattern;
-
 export interface Program extends Span {
   type: 'Program';
   sourceType: SourceType;
@@ -1032,6 +987,186 @@ export type ExportDefaultDeclarationKind =
 
 export type ModuleExportName = IdentifierName | IdentifierReference | StringLiteral;
 
+export interface BooleanLiteral extends Span {
+  type: 'Literal';
+  value: boolean;
+  raw: string | null;
+}
+
+export interface NullLiteral extends Span {
+  type: 'Literal';
+  value: null;
+  raw: 'null' | null;
+}
+
+export interface NumericLiteral extends Span {
+  type: 'Literal';
+  value: number;
+  raw: string | null;
+}
+
+export interface StringLiteral extends Span {
+  type: 'Literal';
+  value: string;
+  raw: string | null;
+}
+
+export interface BigIntLiteral extends Span {
+  type: 'Literal';
+  raw: string | null;
+  value: null;
+  bigint: string;
+}
+
+export interface RegExpLiteral extends Span {
+  type: 'Literal';
+  raw: string | null;
+  value: {} | null;
+  regex: { pattern: string; flags: string };
+}
+
+export interface RegExp {
+  pattern: RegExpPattern;
+  flags: RegExpFlags;
+}
+
+export type RegExpPattern = string | string | Pattern;
+
+export interface JSXElement extends Span {
+  type: 'JSXElement';
+  openingElement: JSXOpeningElement;
+  closingElement: JSXClosingElement | null;
+  children: Array<JSXChild>;
+}
+
+export interface JSXOpeningElement extends Span {
+  type: 'JSXOpeningElement';
+  selfClosing: boolean;
+  name: JSXElementName;
+  attributes: Array<JSXAttributeItem>;
+  typeParameters: TSTypeParameterInstantiation | null;
+}
+
+export interface JSXClosingElement extends Span {
+  type: 'JSXClosingElement';
+  name: JSXElementName;
+}
+
+export interface JSXFragment extends Span {
+  type: 'JSXFragment';
+  openingFragment: JSXOpeningFragment;
+  closingFragment: JSXClosingFragment;
+  children: Array<JSXChild>;
+}
+
+export interface JSXOpeningFragment extends Span {
+  type: 'JSXOpeningFragment';
+}
+
+export interface JSXClosingFragment extends Span {
+  type: 'JSXClosingFragment';
+}
+
+export interface JSXNamespacedName extends Span {
+  type: 'JSXNamespacedName';
+  namespace: JSXIdentifier;
+  property: JSXIdentifier;
+}
+
+export interface JSXMemberExpression extends Span {
+  type: 'JSXMemberExpression';
+  object: JSXMemberExpressionObject;
+  property: JSXIdentifier;
+}
+
+export interface JSXExpressionContainer extends Span {
+  type: 'JSXExpressionContainer';
+  expression: JSXExpression;
+}
+
+export type JSXExpression =
+  | JSXEmptyExpression
+  | BooleanLiteral
+  | NullLiteral
+  | NumericLiteral
+  | BigIntLiteral
+  | RegExpLiteral
+  | StringLiteral
+  | TemplateLiteral
+  | IdentifierReference
+  | MetaProperty
+  | Super
+  | ArrayExpression
+  | ArrowFunctionExpression
+  | AssignmentExpression
+  | AwaitExpression
+  | BinaryExpression
+  | CallExpression
+  | ChainExpression
+  | Class
+  | ConditionalExpression
+  | Function
+  | ImportExpression
+  | LogicalExpression
+  | NewExpression
+  | ObjectExpression
+  | ParenthesizedExpression
+  | SequenceExpression
+  | TaggedTemplateExpression
+  | ThisExpression
+  | UnaryExpression
+  | UpdateExpression
+  | YieldExpression
+  | PrivateInExpression
+  | JSXElement
+  | JSXFragment
+  | TSAsExpression
+  | TSSatisfiesExpression
+  | TSTypeAssertion
+  | TSNonNullExpression
+  | TSInstantiationExpression
+  | ComputedMemberExpression
+  | StaticMemberExpression
+  | PrivateFieldExpression;
+
+export interface JSXEmptyExpression extends Span {
+  type: 'JSXEmptyExpression';
+}
+
+export type JSXAttributeItem = JSXAttribute | JSXSpreadAttribute;
+
+export interface JSXAttribute extends Span {
+  type: 'JSXAttribute';
+  name: JSXAttributeName;
+  value: JSXAttributeValue | null;
+}
+
+export interface JSXSpreadAttribute extends Span {
+  type: 'JSXSpreadAttribute';
+  argument: Expression;
+}
+
+export type JSXAttributeName = JSXIdentifier | JSXNamespacedName;
+
+export type JSXAttributeValue = StringLiteral | JSXExpressionContainer | JSXElement | JSXFragment;
+
+export interface JSXIdentifier extends Span {
+  type: 'JSXIdentifier';
+  name: string;
+}
+
+export type JSXChild = JSXText | JSXElement | JSXFragment | JSXExpressionContainer | JSXSpreadChild;
+
+export interface JSXSpreadChild extends Span {
+  type: 'JSXSpreadChild';
+  expression: Expression;
+}
+
+export interface JSXText extends Span {
+  type: 'JSXText';
+  value: string;
+}
+
 export interface TSThisParameter extends Span {
   type: 'TSThisParameter';
   typeAnnotation: TSTypeAnnotation | null;
@@ -1580,141 +1715,6 @@ export interface JSDocNonNullableType extends Span {
 
 export interface JSDocUnknownType extends Span {
   type: 'JSDocUnknownType';
-}
-
-export interface JSXElement extends Span {
-  type: 'JSXElement';
-  openingElement: JSXOpeningElement;
-  closingElement: JSXClosingElement | null;
-  children: Array<JSXChild>;
-}
-
-export interface JSXOpeningElement extends Span {
-  type: 'JSXOpeningElement';
-  selfClosing: boolean;
-  name: JSXElementName;
-  attributes: Array<JSXAttributeItem>;
-  typeParameters: TSTypeParameterInstantiation | null;
-}
-
-export interface JSXClosingElement extends Span {
-  type: 'JSXClosingElement';
-  name: JSXElementName;
-}
-
-export interface JSXFragment extends Span {
-  type: 'JSXFragment';
-  openingFragment: JSXOpeningFragment;
-  closingFragment: JSXClosingFragment;
-  children: Array<JSXChild>;
-}
-
-export interface JSXOpeningFragment extends Span {
-  type: 'JSXOpeningFragment';
-}
-
-export interface JSXClosingFragment extends Span {
-  type: 'JSXClosingFragment';
-}
-
-export interface JSXNamespacedName extends Span {
-  type: 'JSXNamespacedName';
-  namespace: JSXIdentifier;
-  property: JSXIdentifier;
-}
-
-export interface JSXMemberExpression extends Span {
-  type: 'JSXMemberExpression';
-  object: JSXMemberExpressionObject;
-  property: JSXIdentifier;
-}
-
-export interface JSXExpressionContainer extends Span {
-  type: 'JSXExpressionContainer';
-  expression: JSXExpression;
-}
-
-export type JSXExpression =
-  | JSXEmptyExpression
-  | BooleanLiteral
-  | NullLiteral
-  | NumericLiteral
-  | BigIntLiteral
-  | RegExpLiteral
-  | StringLiteral
-  | TemplateLiteral
-  | IdentifierReference
-  | MetaProperty
-  | Super
-  | ArrayExpression
-  | ArrowFunctionExpression
-  | AssignmentExpression
-  | AwaitExpression
-  | BinaryExpression
-  | CallExpression
-  | ChainExpression
-  | Class
-  | ConditionalExpression
-  | Function
-  | ImportExpression
-  | LogicalExpression
-  | NewExpression
-  | ObjectExpression
-  | ParenthesizedExpression
-  | SequenceExpression
-  | TaggedTemplateExpression
-  | ThisExpression
-  | UnaryExpression
-  | UpdateExpression
-  | YieldExpression
-  | PrivateInExpression
-  | JSXElement
-  | JSXFragment
-  | TSAsExpression
-  | TSSatisfiesExpression
-  | TSTypeAssertion
-  | TSNonNullExpression
-  | TSInstantiationExpression
-  | ComputedMemberExpression
-  | StaticMemberExpression
-  | PrivateFieldExpression;
-
-export interface JSXEmptyExpression extends Span {
-  type: 'JSXEmptyExpression';
-}
-
-export type JSXAttributeItem = JSXAttribute | JSXSpreadAttribute;
-
-export interface JSXAttribute extends Span {
-  type: 'JSXAttribute';
-  name: JSXAttributeName;
-  value: JSXAttributeValue | null;
-}
-
-export interface JSXSpreadAttribute extends Span {
-  type: 'JSXSpreadAttribute';
-  argument: Expression;
-}
-
-export type JSXAttributeName = JSXIdentifier | JSXNamespacedName;
-
-export type JSXAttributeValue = StringLiteral | JSXExpressionContainer | JSXElement | JSXFragment;
-
-export interface JSXIdentifier extends Span {
-  type: 'JSXIdentifier';
-  name: string;
-}
-
-export type JSXChild = JSXText | JSXElement | JSXFragment | JSXExpressionContainer | JSXSpreadChild;
-
-export interface JSXSpreadChild extends Span {
-  type: 'JSXSpreadChild';
-  expression: Expression;
-}
-
-export interface JSXText extends Span {
-  type: 'JSXText';
-  value: string;
 }
 
 export type AssignmentOperator =

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -193,10 +193,10 @@ use schema::Schema;
 
 /// Paths to source files containing AST types
 static SOURCE_PATHS: &[&str] = &[
-    "crates/oxc_ast/src/ast/literal.rs",
     "crates/oxc_ast/src/ast/js.rs",
-    "crates/oxc_ast/src/ast/ts.rs",
+    "crates/oxc_ast/src/ast/literal.rs",
     "crates/oxc_ast/src/ast/jsx.rs",
+    "crates/oxc_ast/src/ast/ts.rs",
     "crates/oxc_ast/src/ast/comment.rs",
     "crates/oxc_syntax/src/number.rs",
     "crates/oxc_syntax/src/operator.rs",


### PR DESCRIPTION
Change order in which source files are processed by `oxc_ast_tools`, so `oxc_ast/src/ast/js.rs` is first. This doesn't modify any code, just changes the order of generated methods. Notably `Program` appears first. This will be useful later, for simplifying generation of `Visit` trait.