### PR TITLE
feat(ast_tools): allow defining foreign types with `#[ast(foreign = ...)]`

### DIFF
--- a/tasks/ast_tools/src/parse/parse.rs
+++ b/tasks/ast_tools/src/parse/parse.rs
@@ -601,6 +601,10 @@ impl<'c> Parser<'c> {
 
         for meta in &parts {
             let attr_name = meta.path().get_ident().unwrap().to_string();
+            if attr_name == "foreign" {
+                continue;
+            }
+
             if let Some((processor, positions)) = self.codegen.attr_processor(&attr_name) {
                 // Check attribute is legal in this position
                 // and has the relevant trait `#[generate_derive]`-ed on it


### PR DESCRIPTION
Allow informing `oxc_ast_tools` about foreign types in AST (e.g. `NonMaxU32`) and other types which it otherwise can't parse (e.g. `RegExpFlags`, which is generated by `bitflags!` macro).

Mechanism is `#[ast(foreign = ...)]` attr on another type which acts as a "stand-in" for the real one, similar to `serde`'s [remote derive feature](https://serde.rs/remote-derive.html).

```rs
bitflags! {
    pub struct RegExpFlags: u8 { /* ... */ }
}

/// This dummy type tells `oxc_ast_tools` about `RegExpFlags`
#[ast(foreign = RegExpFlags)]
struct RegExpFlagsAlias(u8);
```
