### PR TITLE
refactor(ast): communicate type of `RegExpFlags` to `oxc_ast_tools` with alias type

### DIFF
--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -195,3 +195,8 @@ bitflags! {
         const V = 1 << 7;
     }
 }
+
+/// Dummy type to communicate the content of `RegExpFlags` to `oxc_ast_tools`.
+#[ast(foreign = RegExpFlags)]
+#[expect(dead_code)]
+struct RegExpFlagsAlias(u8);

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -791,6 +791,9 @@ const _: () = {
     assert!(size_of::<RegExpPattern>() == 24);
     assert!(align_of::<RegExpPattern>() == 8);
 
+    assert!(size_of::<RegExpFlags>() == 1);
+    assert!(align_of::<RegExpFlags>() == 1);
+
     assert!(size_of::<JSXElement>() == 56);
     assert!(align_of::<JSXElement>() == 8);
     assert!(offset_of!(JSXElement, span) == 0);
@@ -1583,9 +1586,6 @@ const _: () = {
     assert!(align_of::<NamedReference>() == 8);
     assert!(offset_of!(NamedReference, span) == 0);
     assert!(offset_of!(NamedReference, name) == 8);
-
-    assert!(size_of::<RegExpFlags>() == 1);
-    assert!(align_of::<RegExpFlags>() == 1);
 };
 
 #[cfg(target_pointer_width = "32")]
@@ -2368,6 +2368,9 @@ const _: () = {
 
     assert!(size_of::<RegExpPattern>() == 12);
     assert!(align_of::<RegExpPattern>() == 4);
+
+    assert!(size_of::<RegExpFlags>() == 1);
+    assert!(align_of::<RegExpFlags>() == 1);
 
     assert!(size_of::<JSXElement>() == 32);
     assert!(align_of::<JSXElement>() == 4);
@@ -3161,9 +3164,6 @@ const _: () = {
     assert!(align_of::<NamedReference>() == 4);
     assert!(offset_of!(NamedReference, span) == 0);
     assert!(offset_of!(NamedReference, name) == 8);
-
-    assert!(size_of::<RegExpFlags>() == 1);
-    assert!(align_of::<RegExpFlags>() == 1);
 };
 
 #[cfg(not(any(target_pointer_width = "64", target_pointer_width = "32")))]

--- a/tasks/ast_tools/src/parse/parse.rs
+++ b/tasks/ast_tools/src/parse/parse.rs
@@ -138,22 +138,6 @@ impl<'c> Parser<'c> {
             // TODO: Remove the need for this by adding
             // `#[cfg_attr(target_pointer_width = "64", repr(align(8)))]` to all AST types
             "PointerAlign" => primitive("PointerAlign"),
-            // Cannot be parsed normally as is defined inside `bitflags!` macro.
-            // TODO: Find a way to encode this in the actual file.
-            // e.g. `#[ast(alias_for(RegExpFlags))] struct RegExpFlagsAlias(u8);`
-            "RegExpFlags" => TypeDef::Struct(StructDef::new(
-                TypeId::DUMMY,
-                "RegExpFlags".to_string(),
-                false,
-                self.get_file_id("oxc_ast", "::ast::literal"),
-                Derives::none(),
-                vec![FieldDef::new(
-                    "inner".to_string(),
-                    self.type_id("u8"),
-                    Visibility::Private,
-                    None,
-                )],
-            )),
             _ => panic!("Unknown type: {name}"),
         };
         self.create_new_type(type_def)
@@ -184,18 +168,6 @@ impl<'c> Parser<'c> {
         self.extra_types.push(type_def);
 
         type_id
-    }
-
-    /// Get [`FileId`] for file with provided crate and import path.
-    fn get_file_id(&self, krate: &str, import_path: &str) -> FileId {
-        let file_and_id = self
-            .files
-            .iter_enumerated()
-            .find(|(_, file)| file.krate() == krate && file.import_path() == import_path);
-        match file_and_id {
-            Some((file_id, _)) => file_id,
-            None => panic!("Could not find file with import path: {import_path}"),
-        }
     }
 
     /// Parse [`Skeleton`] to yield a [`TypeDef`].


### PR DESCRIPTION
Use `#[ast(foreign = RegExpFlags)]` (introduced in #8866) on a dummy type to tell `oxc_ast_tools` about the properties of the `RegExpFlags` type.