### PR TITLE
refactor(span)!: export `ContentEq` trait from root of `oxc_span` crate

### DIFF
--- a/crates/oxc_ast/src/ast/comment.rs
+++ b/crates/oxc_ast/src/ast/comment.rs
@@ -1,7 +1,7 @@
 #![warn(missing_docs)]
 use oxc_allocator::CloneIn;
 use oxc_ast_macros::ast;
-use oxc_span::{cmp::ContentEq, Span};
+use oxc_span::{ContentEq, Span};
 
 /// Indicates a line or block comment.
 #[ast]

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -9,7 +9,7 @@ use std::cell::Cell;
 use oxc_allocator::{Box, CloneIn, GetAddress, Vec};
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
-use oxc_span::{cmp::ContentEq, Atom, GetSpan, GetSpanMut, SourceType, Span};
+use oxc_span::{Atom, ContentEq, GetSpan, GetSpanMut, SourceType, Span};
 use oxc_syntax::{
     operator::{
         AssignmentOperator, BinaryOperator, LogicalOperator, UnaryOperator, UpdateOperator,

--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -7,7 +7,7 @@
 use oxc_allocator::{Box, CloneIn, GetAddress, Vec};
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
-use oxc_span::{cmp::ContentEq, Atom, GetSpan, GetSpanMut, Span};
+use oxc_span::{Atom, ContentEq, GetSpan, GetSpanMut, Span};
 
 use super::{inherit_variants, js::*, literal::*, ts::*};
 

--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -11,7 +11,7 @@ use oxc_allocator::{Box, CloneIn};
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
 use oxc_regular_expression::ast::Pattern;
-use oxc_span::{cmp::ContentEq, Atom, GetSpan, GetSpanMut, Span};
+use oxc_span::{Atom, ContentEq, GetSpan, GetSpanMut, Span};
 use oxc_syntax::number::{BigintBase, NumberBase};
 
 /// Boolean literal

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -13,7 +13,7 @@ use std::cell::Cell;
 use oxc_allocator::{Box, CloneIn, GetAddress, Vec};
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
-use oxc_span::{cmp::ContentEq, Atom, GetSpan, GetSpanMut, Span};
+use oxc_span::{Atom, ContentEq, GetSpan, GetSpanMut, Span};
 use oxc_syntax::scope::ScopeId;
 
 use super::{inherit_variants, js::*, literal::*};

--- a/crates/oxc_ast/src/ast_impl/literal.rs
+++ b/crates/oxc_ast/src/ast_impl/literal.rs
@@ -4,7 +4,7 @@ use std::{borrow::Cow, fmt};
 
 use oxc_allocator::CloneIn;
 use oxc_regular_expression::ast::Pattern;
-use oxc_span::cmp::ContentEq;
+use oxc_span::ContentEq;
 
 use crate::ast::*;
 

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::match_same_arms)]
 
-use oxc_span::cmp::ContentEq;
+use oxc_span::ContentEq;
 
 use crate::ast::comment::*;
 use crate::ast::js::*;

--- a/crates/oxc_ast_macros/src/ast.rs
+++ b/crates/oxc_ast_macros/src/ast.rs
@@ -80,7 +80,7 @@ fn abs_trait(
     } else if ident == "GetAddress" {
         (quote!(::oxc_allocator::GetAddress), TokenStream::default())
     } else if ident == "ContentEq" {
-        (quote!(::oxc_span::cmp::ContentEq), TokenStream::default())
+        (quote!(::oxc_span::ContentEq), TokenStream::default())
     } else if ident == "ESTree" {
         (quote!(::oxc_estree::ESTree), TokenStream::default())
     } else {

--- a/crates/oxc_linter/src/rules/eslint/no_dupe_else_if.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_dupe_else_if.rs
@@ -4,7 +4,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{cmp::ContentEq, GetSpan, Span};
+use oxc_span::{ContentEq, GetSpan, Span};
 use oxc_syntax::operator::LogicalOperator;
 
 use crate::{context::LintContext, rule::Rule, AstNode};

--- a/crates/oxc_linter/src/rules/eslint/no_duplicate_case.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_duplicate_case.rs
@@ -1,7 +1,7 @@
 use oxc_ast::ast::Expression;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{cmp::ContentEq, GetSpan, Span};
+use oxc_span::{ContentEq, GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 

--- a/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_extend_native.rs
@@ -4,7 +4,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{cmp::ContentEq, CompactStr, GetSpan};
+use oxc_span::{CompactStr, ContentEq, GetSpan};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 

--- a/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
@@ -1,7 +1,7 @@
 use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{cmp::ContentEq, GetSpan, Span};
+use oxc_span::{ContentEq, GetSpan, Span};
 
 use crate::{context::LintContext, rule::Rule, AstNode};
 

--- a/crates/oxc_linter/src/rules/eslint/no_useless_call.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_call.rs
@@ -4,7 +4,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::cmp::ContentEq;
+use oxc_span::ContentEq;
 use oxc_span::Span;
 
 use crate::{context::LintContext, rule::Rule, AstNode};

--- a/crates/oxc_linter/src/rules/eslint/prefer_spread.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_spread.rs
@@ -4,7 +4,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{cmp::ContentEq, Span};
+use oxc_span::{ContentEq, Span};
 
 use crate::{ast_util::is_method_call, context::LintContext, rule::Rule, AstNode};
 

--- a/crates/oxc_linter/src/utils/unicorn.rs
+++ b/crates/oxc_linter/src/utils/unicorn.rs
@@ -7,7 +7,7 @@ use oxc_ast::{
     AstKind,
 };
 use oxc_semantic::AstNode;
-use oxc_span::cmp::ContentEq;
+use oxc_span::ContentEq;
 use oxc_syntax::operator::LogicalOperator;
 
 pub use self::boolean::*;

--- a/crates/oxc_minifier/src/ctx.rs
+++ b/crates/oxc_minifier/src/ctx.rs
@@ -82,7 +82,7 @@ impl<'a> Ctx<'a, '_> {
     /// If two expressions are equal.
     /// Special case `undefined` == `void 0`
     pub fn expr_eq(self, a: &Expression<'a>, b: &Expression<'a>) -> bool {
-        use oxc_span::cmp::ContentEq;
+        use oxc_span::ContentEq;
         a.content_eq(b) || (self.is_expression_undefined(a) && self.is_expression_undefined(b))
     }
 

--- a/crates/oxc_minifier/src/peephole/minimize_conditional_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditional_expression.rs
@@ -1,5 +1,5 @@
 use oxc_ast::{ast::*, NONE};
-use oxc_span::{cmp::ContentEq, GetSpan};
+use oxc_span::{ContentEq, GetSpan};
 use oxc_syntax::es_target::ESTarget;
 
 use crate::ctx::Ctx;

--- a/crates/oxc_minifier/src/peephole/minimize_conditions.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditions.rs
@@ -1,6 +1,6 @@
 use oxc_ast::ast::*;
 use oxc_ecmascript::{constant_evaluation::ValueType, ToInt32};
-use oxc_span::{cmp::ContentEq, GetSpan};
+use oxc_span::{ContentEq, GetSpan};
 use oxc_syntax::es_target::ESTarget;
 
 use crate::ctx::Ctx;

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::{Box, Vec};
 use oxc_ast::{ast::*, Visit};
 use oxc_ecmascript::side_effects::MayHaveSideEffects;
-use oxc_span::{cmp::ContentEq, GetSpan};
+use oxc_span::{ContentEq, GetSpan};
 use oxc_traverse::Ancestor;
 
 use crate::{ctx::Ctx, keep_var::KeepVar};

--- a/crates/oxc_regular_expression/src/ast.rs
+++ b/crates/oxc_regular_expression/src/ast.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::{Box, CloneIn, GetAddress, Vec};
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
-use oxc_span::{cmp::ContentEq, Atom, GetSpan, Span};
+use oxc_span::{Atom, ContentEq, GetSpan, Span};
 
 /// The root of the `PatternParser` result.
 #[ast]

--- a/crates/oxc_regular_expression/src/generated/derive_content_eq.rs
+++ b/crates/oxc_regular_expression/src/generated/derive_content_eq.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::match_same_arms)]
 
-use oxc_span::cmp::ContentEq;
+use oxc_span::ContentEq;
 
 use crate::ast::*;
 

--- a/crates/oxc_span/src/atom.rs
+++ b/crates/oxc_span/src/atom.rs
@@ -8,7 +8,7 @@ use oxc_allocator::{Allocator, CloneIn, FromIn};
 #[cfg(feature = "serialize")]
 use serde::Serialize;
 
-use crate::{cmp::ContentEq, CompactStr};
+use crate::{CompactStr, ContentEq};
 
 /// An inlinable string for oxc_allocator.
 ///

--- a/crates/oxc_span/src/lib.rs
+++ b/crates/oxc_span/src/lib.rs
@@ -5,14 +5,14 @@
 #![warn(missing_docs)]
 
 mod atom;
+mod cmp;
 mod compact_str;
 mod source_type;
 mod span;
 
-pub mod cmp;
-
 pub use crate::{
     atom::Atom,
+    cmp::ContentEq,
     compact_str::{CompactStr, MAX_INLINE_LEN as ATOM_MAX_INLINE_LEN},
     source_type::{
         Language, LanguageVariant, ModuleKind, SourceType, UnknownExtension, VALID_EXTENSIONS,

--- a/crates/oxc_span/src/source_type/mod.rs
+++ b/crates/oxc_span/src/source_type/mod.rs
@@ -4,7 +4,7 @@ use oxc_allocator::{Allocator, CloneIn};
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
 
-use crate::cmp::ContentEq;
+use crate::ContentEq;
 
 mod error;
 pub use error::UnknownExtension;

--- a/crates/oxc_span/src/span/types.rs
+++ b/crates/oxc_span/src/span/types.rs
@@ -50,7 +50,7 @@ use super::PointerAlign;
 /// ## Comparison
 /// [`Span`] has a normal implementation of [`PartialEq`]. If you want to compare two
 /// AST nodes without considering their locations (e.g. to see if they have the
-/// same content), use [`ContentEq`](crate::cmp::ContentEq) instead.
+/// same content), use [`ContentEq`](crate::ContentEq) instead.
 ///
 /// ## Implementation Notes
 /// See the [`text-size`](https://docs.rs/text-size) crate for details.

--- a/crates/oxc_syntax/src/generated/derive_content_eq.rs
+++ b/crates/oxc_syntax/src/generated/derive_content_eq.rs
@@ -3,7 +3,7 @@
 
 #![allow(clippy::match_same_arms)]
 
-use oxc_span::cmp::ContentEq;
+use oxc_span::ContentEq;
 
 use crate::number::*;
 use crate::operator::*;

--- a/crates/oxc_syntax/src/number.rs
+++ b/crates/oxc_syntax/src/number.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)] // fixme
 use oxc_allocator::CloneIn;
 use oxc_ast_macros::ast;
-use oxc_span::cmp::ContentEq;
+use oxc_span::ContentEq;
 
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/crates/oxc_syntax/src/operator.rs
+++ b/crates/oxc_syntax/src/operator.rs
@@ -5,7 +5,7 @@
 use oxc_allocator::CloneIn;
 use oxc_ast_macros::ast;
 use oxc_estree::ESTree;
-use oxc_span::cmp::ContentEq;
+use oxc_span::ContentEq;
 
 use crate::precedence::{GetPrecedence, Precedence};
 

--- a/tasks/ast_tools/src/derives/content_eq.rs
+++ b/tasks/ast_tools/src/derives/content_eq.rs
@@ -24,7 +24,7 @@ impl Derive for DeriveContentEq {
             #![allow(clippy::match_same_arms)]
 
             ///@@line_break
-            use oxc_span::cmp::ContentEq;
+            use oxc_span::ContentEq;
         }
     }
 

--- a/tasks/coverage/src/driver.rs
+++ b/tasks/coverage/src/driver.rs
@@ -11,7 +11,7 @@ use oxc::{
     parser::{ParseOptions, ParserReturn},
     regular_expression::{LiteralParser, Options},
     semantic::{Semantic, SemanticBuilderReturn},
-    span::{cmp::ContentEq, SourceType, Span},
+    span::{ContentEq, SourceType, Span},
     transformer::{TransformOptions, TransformerReturn},
     CompilerInterface,
 };


### PR DESCRIPTION
Export `ContentEq` as `oxc_span::ContentEq`. Previously was within a sub-module `oxc_span::cmp::ContentEq`. This made sense when we also had `ContentHash`, but now that's removed, it makes more sense for `ContentEq` to be exported from root of the crate.