### PR TITLE
refactor(ast): `#[content_eq(skip)]` attr

### DIFF
--- a/crates/oxc_ast_macros/src/lib.rs
+++ b/crates/oxc_ast_macros/src/lib.rs
@@ -47,7 +47,10 @@ pub fn ast(_args: TokenStream, input: TokenStream) -> TokenStream {
 /// Its only purpose is to allow the occurrence of helper attributes used in `tasks/ast_tools`.
 ///
 /// See [`macro@ast`] for further details.
-#[proc_macro_derive(Ast, attributes(clone_in, estree, generate_derive, scope, span, ts, visit))]
+#[proc_macro_derive(
+    Ast,
+    attributes(clone_in, content_eq, estree, generate_derive, scope, span, ts, visit)
+)]
 pub fn ast_derive(_input: TokenStream) -> TokenStream {
     TokenStream::new()
 }

--- a/crates/oxc_span/src/span/types.rs
+++ b/crates/oxc_span/src/span/types.rs
@@ -61,6 +61,7 @@ use super::PointerAlign;
 #[ast(visit)]
 #[derive(Default, Clone, Copy, Eq, PartialOrd, Ord)]
 #[generate_derive(ESTree)]
+#[content_eq(skip)]
 #[estree(no_type, flatten)]
 pub struct Span {
     /// The zero-based start offset of the span

--- a/crates/oxc_syntax/src/reference.rs
+++ b/crates/oxc_syntax/src/reference.rs
@@ -1,10 +1,11 @@
 #![allow(missing_docs)] // fixme
 use bitflags::bitflags;
 use nonmax::NonMaxU32;
-use oxc_allocator::CloneIn;
 use oxc_index::Idx;
 #[cfg(feature = "serialize")]
 use serde::{Serialize, Serializer};
+
+use oxc_allocator::CloneIn;
 
 use crate::{node::NodeId, symbol::SymbolId};
 
@@ -12,6 +13,7 @@ use oxc_ast_macros::ast;
 
 #[ast]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[content_eq(skip)]
 pub struct ReferenceId(NonMaxU32);
 
 impl Idx for ReferenceId {

--- a/crates/oxc_syntax/src/scope.rs
+++ b/crates/oxc_syntax/src/scope.rs
@@ -9,6 +9,7 @@ use oxc_ast_macros::ast;
 
 #[ast]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[content_eq(skip)]
 pub struct ScopeId(NonMaxU32);
 
 impl ScopeId {

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -9,6 +9,7 @@ use oxc_ast_macros::ast;
 
 #[ast]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[content_eq(skip)]
 pub struct SymbolId(NonMaxU32);
 
 impl SymbolId {

--- a/tasks/ast_tools/src/schema/defs/enum.rs
+++ b/tasks/ast_tools/src/schema/defs/enum.rs
@@ -9,6 +9,7 @@ use crate::utils::create_ident;
 
 use super::{
     extensions::{
+        content_eq::ContentEqType,
         estree::{ESTreeEnum, ESTreeEnumVariant},
         kind::Kind,
         layout::Layout,
@@ -33,6 +34,7 @@ pub struct EnumDef {
     pub visit: VisitEnum,
     pub kind: Kind,
     pub layout: Layout,
+    pub content_eq: ContentEqType,
     pub estree: ESTreeEnum,
 }
 
@@ -58,6 +60,7 @@ impl EnumDef {
             visit: VisitEnum::default(),
             kind: Kind::default(),
             layout: Layout::default(),
+            content_eq: ContentEqType::default(),
             estree: ESTreeEnum::default(),
         }
     }

--- a/tasks/ast_tools/src/schema/defs/struct.rs
+++ b/tasks/ast_tools/src/schema/defs/struct.rs
@@ -9,6 +9,7 @@ use crate::utils::create_ident_tokens;
 use super::{
     extensions::{
         clone_in::CloneInStructField,
+        content_eq::{ContentEqStructField, ContentEqType},
         estree::{ESTreeStruct, ESTreeStructField},
         kind::Kind,
         layout::{Layout, Offset},
@@ -31,6 +32,7 @@ pub struct StructDef {
     pub kind: Kind,
     pub layout: Layout,
     pub span: SpanStruct,
+    pub content_eq: ContentEqType,
     pub estree: ESTreeStruct,
 }
 
@@ -55,6 +57,7 @@ impl StructDef {
             kind: Kind::default(),
             layout: Layout::default(),
             span: SpanStruct::default(),
+            content_eq: ContentEqType::default(),
             estree: ESTreeStruct::default(),
         }
     }
@@ -118,6 +121,7 @@ pub struct FieldDef {
     pub visit: VisitFieldOrVariant,
     pub offset: Offset,
     pub clone_in: CloneInStructField,
+    pub content_eq: ContentEqStructField,
     pub estree: ESTreeStructField,
 }
 
@@ -137,6 +141,7 @@ impl FieldDef {
             visit: VisitFieldOrVariant::default(),
             offset: Offset::default(),
             clone_in: CloneInStructField::default(),
+            content_eq: ContentEqStructField::default(),
             estree: ESTreeStructField::default(),
         }
     }

--- a/tasks/ast_tools/src/schema/extensions/content_eq.rs
+++ b/tasks/ast_tools/src/schema/extensions/content_eq.rs
@@ -1,0 +1,13 @@
+/// Details for `ContentEq` derive on a struct or enum.
+#[derive(Default, Debug)]
+pub struct ContentEqType {
+    /// `true` if type should ignored by `ContentEq`
+    pub skip: bool,
+}
+
+/// Details for `ContentEq` derive on a struct field.
+#[derive(Default, Debug)]
+pub struct ContentEqStructField {
+    /// `true` if field should ignored by `ContentEq`
+    pub skip: bool,
+}

--- a/tasks/ast_tools/src/schema/mod.rs
+++ b/tasks/ast_tools/src/schema/mod.rs
@@ -14,6 +14,7 @@ pub use file::File;
 /// Extensions to schema for specific derives / generators
 pub mod extensions {
     pub mod clone_in;
+    pub mod content_eq;
     pub mod estree;
     pub mod kind;
     pub mod layout;


### PR DESCRIPTION
Introduce custom attribute `#[content_eq(skip)]` to guide code generation for `ContentEq` trait. Instead of a hard-coded list of types to skip in codegen, use this attribute on types to control the behavior.