### PR TITLE
refactor(ast): move `#[clone_in(default)]` to types

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -41,7 +41,6 @@ pub struct Program<'a> {
     pub directives: Vec<'a, Directive<'a>>,
     pub body: Vec<'a, Statement<'a>>,
     #[estree(skip)]
-    #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -227,7 +226,6 @@ pub struct IdentifierReference<'a> {
     /// set in the bind step of semantic analysis, and will always be [`None`]
     /// immediately after parsing.
     #[estree(skip)]
-    #[clone_in(default)]
     pub reference_id: Cell<Option<ReferenceId>>,
 }
 
@@ -251,7 +249,6 @@ pub struct BindingIdentifier<'a> {
     ///
     /// [`semantic analysis`]: <https://docs.rs/oxc_semantic/latest/oxc_semantic/struct.SemanticBuilder.html>
     #[estree(skip)]
-    #[clone_in(default)]
     pub symbol_id: Cell<Option<SymbolId>>,
 }
 
@@ -1043,7 +1040,6 @@ pub struct BlockStatement<'a> {
     pub span: Span,
     pub body: Vec<'a, Statement<'a>>,
     #[estree(skip)]
-    #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -1187,7 +1183,6 @@ pub struct ForStatement<'a> {
     pub update: Option<Expression<'a>>,
     pub body: Statement<'a>,
     #[estree(skip)]
-    #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -1218,7 +1213,6 @@ pub struct ForInStatement<'a> {
     pub right: Expression<'a>,
     pub body: Statement<'a>,
     #[estree(skip)]
-    #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -1249,7 +1243,6 @@ pub struct ForOfStatement<'a> {
     pub right: Expression<'a>,
     pub body: Statement<'a>,
     #[estree(skip)]
-    #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -1301,7 +1294,6 @@ pub struct SwitchStatement<'a> {
     #[scope(enter_before)]
     pub cases: Vec<'a, SwitchCase<'a>>,
     #[estree(skip)]
-    #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -1391,7 +1383,6 @@ pub struct CatchClause<'a> {
     /// The statements run when an error is caught
     pub body: Box<'a, BlockStatement<'a>>,
     #[estree(skip)]
-    #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -1625,7 +1616,6 @@ pub struct Function<'a> {
     /// ```
     pub body: Option<Box<'a, FunctionBody<'a>>>,
     #[estree(skip)]
-    #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -1717,7 +1707,6 @@ pub struct ArrowFunctionExpression<'a> {
     /// See `expression` for whether this arrow expression returns an expression.
     pub body: Box<'a, FunctionBody<'a>>,
     #[estree(skip)]
-    #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -1804,7 +1793,6 @@ pub struct Class<'a> {
     /// Id of the scope created by the [`Class`], including type parameters and
     /// statements within the [`ClassBody`].
     #[estree(skip)]
-    #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -2056,7 +2044,6 @@ pub struct StaticBlock<'a> {
     pub span: Span,
     pub body: Vec<'a, Statement<'a>>,
     #[estree(skip)]
-    #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -72,7 +72,6 @@ pub struct TSEnumDeclaration<'a> {
     pub r#const: bool,
     pub declare: bool,
     #[estree(skip)]
-    #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -304,7 +303,6 @@ pub struct TSConditionalType<'a> {
     #[scope(exit_before)]
     pub false_type: TSType<'a>,
     #[estree(skip)]
-    #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -837,7 +835,6 @@ pub struct TSTypeAliasDeclaration<'a> {
     pub type_annotation: TSType<'a>,
     pub declare: bool,
     #[estree(skip)]
-    #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -901,7 +898,6 @@ pub struct TSInterfaceDeclaration<'a> {
     /// `true` for `declare interface Foo {}`
     pub declare: bool,
     #[estree(skip)]
-    #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -1020,7 +1016,6 @@ pub struct TSMethodSignature<'a> {
     pub params: Box<'a, FormalParameters<'a>>,
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
     #[estree(skip)]
-    #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -1035,7 +1030,6 @@ pub struct TSConstructSignatureDeclaration<'a> {
     pub params: Box<'a, FormalParameters<'a>>,
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
     #[estree(skip)]
-    #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -1160,7 +1154,6 @@ pub struct TSModuleDeclaration<'a> {
     pub kind: TSModuleDeclarationKind,
     pub declare: bool,
     #[estree(skip)]
-    #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -1431,7 +1424,6 @@ pub struct TSMappedType<'a> {
     /// ```
     pub readonly: TSMappedTypeModifierOperator,
     #[estree(skip)]
-    #[clone_in(default)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 

--- a/crates/oxc_syntax/src/reference.rs
+++ b/crates/oxc_syntax/src/reference.rs
@@ -13,6 +13,7 @@ use oxc_ast_macros::ast;
 
 #[ast]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[clone_in(default)]
 #[content_eq(skip)]
 pub struct ReferenceId(NonMaxU32);
 

--- a/crates/oxc_syntax/src/scope.rs
+++ b/crates/oxc_syntax/src/scope.rs
@@ -9,6 +9,7 @@ use oxc_ast_macros::ast;
 
 #[ast]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[clone_in(default)]
 #[content_eq(skip)]
 pub struct ScopeId(NonMaxU32);
 

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -9,6 +9,7 @@ use oxc_ast_macros::ast;
 
 #[ast]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[clone_in(default)]
 #[content_eq(skip)]
 pub struct SymbolId(NonMaxU32);
 

--- a/tasks/ast_tools/src/schema/defs/enum.rs
+++ b/tasks/ast_tools/src/schema/defs/enum.rs
@@ -9,6 +9,7 @@ use crate::utils::create_ident;
 
 use super::{
     extensions::{
+        clone_in::CloneInType,
         content_eq::ContentEqType,
         estree::{ESTreeEnum, ESTreeEnumVariant},
         kind::Kind,
@@ -34,6 +35,7 @@ pub struct EnumDef {
     pub visit: VisitEnum,
     pub kind: Kind,
     pub layout: Layout,
+    pub clone_in: CloneInType,
     pub content_eq: ContentEqType,
     pub estree: ESTreeEnum,
 }
@@ -60,6 +62,7 @@ impl EnumDef {
             visit: VisitEnum::default(),
             kind: Kind::default(),
             layout: Layout::default(),
+            clone_in: CloneInType::default(),
             content_eq: ContentEqType::default(),
             estree: ESTreeEnum::default(),
         }

--- a/tasks/ast_tools/src/schema/defs/struct.rs
+++ b/tasks/ast_tools/src/schema/defs/struct.rs
@@ -8,7 +8,7 @@ use crate::utils::create_ident_tokens;
 
 use super::{
     extensions::{
-        clone_in::CloneInStructField,
+        clone_in::{CloneInStructField, CloneInType},
         content_eq::{ContentEqStructField, ContentEqType},
         estree::{ESTreeStruct, ESTreeStructField},
         kind::Kind,
@@ -32,6 +32,7 @@ pub struct StructDef {
     pub kind: Kind,
     pub layout: Layout,
     pub span: SpanStruct,
+    pub clone_in: CloneInType,
     pub content_eq: ContentEqType,
     pub estree: ESTreeStruct,
 }
@@ -57,6 +58,7 @@ impl StructDef {
             kind: Kind::default(),
             layout: Layout::default(),
             span: SpanStruct::default(),
+            clone_in: CloneInType::default(),
             content_eq: ContentEqType::default(),
             estree: ESTreeStruct::default(),
         }

--- a/tasks/ast_tools/src/schema/extensions/clone_in.rs
+++ b/tasks/ast_tools/src/schema/extensions/clone_in.rs
@@ -1,3 +1,10 @@
+/// Details for `CloneIn` derive on a struct or enum.
+#[derive(Default, Debug)]
+pub struct CloneInType {
+    /// `true` if should be replaced with default value when cloning
+    pub is_default: bool,
+}
+
 /// Details for `CloneIn` derive on a struct field.
 #[derive(Default, Debug)]
 pub struct CloneInStructField {


### PR DESCRIPTION
Remove `#[clone_in(default)]` attributes from struct fields containing semantic IDs, and add that attribute to the `ScopeId`, `SymbolId` and `ReferenceId` types instead. This reduces pointless repetition in the AST type definitions.