### PR TITLE
refactor(ast): move `#[estree(skip)]` to types

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -40,7 +40,6 @@ pub struct Program<'a> {
     pub hashbang: Option<Hashbang<'a>>,
     pub directives: Vec<'a, Directive<'a>>,
     pub body: Vec<'a, Statement<'a>>,
-    #[estree(skip)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -225,7 +224,6 @@ pub struct IdentifierReference<'a> {
     /// Identifies what identifier this refers to, and how it is used. This is
     /// set in the bind step of semantic analysis, and will always be [`None`]
     /// immediately after parsing.
-    #[estree(skip)]
     pub reference_id: Cell<Option<ReferenceId>>,
 }
 
@@ -248,7 +246,6 @@ pub struct BindingIdentifier<'a> {
     /// you choose to skip semantic analysis, this will always be [`None`].
     ///
     /// [`semantic analysis`]: <https://docs.rs/oxc_semantic/latest/oxc_semantic/struct.SemanticBuilder.html>
-    #[estree(skip)]
     pub symbol_id: Cell<Option<SymbolId>>,
 }
 
@@ -1039,7 +1036,6 @@ pub struct Hashbang<'a> {
 pub struct BlockStatement<'a> {
     pub span: Span,
     pub body: Vec<'a, Statement<'a>>,
-    #[estree(skip)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -1182,7 +1178,6 @@ pub struct ForStatement<'a> {
     pub test: Option<Expression<'a>>,
     pub update: Option<Expression<'a>>,
     pub body: Statement<'a>,
-    #[estree(skip)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -1212,7 +1207,6 @@ pub struct ForInStatement<'a> {
     pub left: ForStatementLeft<'a>,
     pub right: Expression<'a>,
     pub body: Statement<'a>,
-    #[estree(skip)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -1242,7 +1236,6 @@ pub struct ForOfStatement<'a> {
     pub left: ForStatementLeft<'a>,
     pub right: Expression<'a>,
     pub body: Statement<'a>,
-    #[estree(skip)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -1293,7 +1286,6 @@ pub struct SwitchStatement<'a> {
     pub discriminant: Expression<'a>,
     #[scope(enter_before)]
     pub cases: Vec<'a, SwitchCase<'a>>,
-    #[estree(skip)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -1382,7 +1374,6 @@ pub struct CatchClause<'a> {
     pub param: Option<CatchParameter<'a>>,
     /// The statements run when an error is caught
     pub body: Box<'a, BlockStatement<'a>>,
-    #[estree(skip)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -1615,7 +1606,6 @@ pub struct Function<'a> {
     /// }
     /// ```
     pub body: Option<Box<'a, FunctionBody<'a>>>,
-    #[estree(skip)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -1706,7 +1696,6 @@ pub struct ArrowFunctionExpression<'a> {
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
     /// See `expression` for whether this arrow expression returns an expression.
     pub body: Box<'a, FunctionBody<'a>>,
-    #[estree(skip)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -1792,7 +1781,6 @@ pub struct Class<'a> {
     pub declare: bool,
     /// Id of the scope created by the [`Class`], including type parameters and
     /// statements within the [`ClassBody`].
-    #[estree(skip)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -2043,7 +2031,6 @@ pub struct PrivateIdentifier<'a> {
 pub struct StaticBlock<'a> {
     pub span: Span,
     pub body: Vec<'a, Statement<'a>>,
-    #[estree(skip)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -71,7 +71,6 @@ pub struct TSEnumDeclaration<'a> {
     /// `true` for const enums
     pub r#const: bool,
     pub declare: bool,
-    #[estree(skip)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -302,7 +301,6 @@ pub struct TSConditionalType<'a> {
     /// The type evaluated to if the test is false.
     #[scope(exit_before)]
     pub false_type: TSType<'a>,
-    #[estree(skip)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -834,7 +832,6 @@ pub struct TSTypeAliasDeclaration<'a> {
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
     pub type_annotation: TSType<'a>,
     pub declare: bool,
-    #[estree(skip)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -897,7 +894,6 @@ pub struct TSInterfaceDeclaration<'a> {
     pub body: Box<'a, TSInterfaceBody<'a>>,
     /// `true` for `declare interface Foo {}`
     pub declare: bool,
-    #[estree(skip)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -1015,7 +1011,6 @@ pub struct TSMethodSignature<'a> {
     pub this_param: Option<Box<'a, TSThisParameter<'a>>>,
     pub params: Box<'a, FormalParameters<'a>>,
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
-    #[estree(skip)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -1029,7 +1024,6 @@ pub struct TSConstructSignatureDeclaration<'a> {
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
     pub params: Box<'a, FormalParameters<'a>>,
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
-    #[estree(skip)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -1153,7 +1147,6 @@ pub struct TSModuleDeclaration<'a> {
     /// ```
     pub kind: TSModuleDeclarationKind,
     pub declare: bool,
-    #[estree(skip)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -1423,7 +1416,6 @@ pub struct TSMappedType<'a> {
     /// type Qux = { [P in keyof T]: T[P] }           // None
     /// ```
     pub readonly: TSMappedTypeModifierOperator,
-    #[estree(skip)]
     pub scope_id: Cell<Option<ScopeId>>,
 }
 

--- a/crates/oxc_syntax/src/reference.rs
+++ b/crates/oxc_syntax/src/reference.rs
@@ -15,6 +15,7 @@ use oxc_ast_macros::ast;
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[clone_in(default)]
 #[content_eq(skip)]
+#[estree(skip)]
 pub struct ReferenceId(NonMaxU32);
 
 impl Idx for ReferenceId {

--- a/crates/oxc_syntax/src/scope.rs
+++ b/crates/oxc_syntax/src/scope.rs
@@ -11,6 +11,7 @@ use oxc_ast_macros::ast;
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[clone_in(default)]
 #[content_eq(skip)]
+#[estree(skip)]
 pub struct ScopeId(NonMaxU32);
 
 impl ScopeId {

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -11,6 +11,7 @@ use oxc_ast_macros::ast;
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[clone_in(default)]
 #[content_eq(skip)]
+#[estree(skip)]
 pub struct SymbolId(NonMaxU32);
 
 impl SymbolId {

--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use crate::{
     derives::estree::{
         get_fieldless_variant_value, get_struct_field_name, should_add_type_field_to_struct,
-        should_flatten_field,
+        should_flatten_field, should_skip_field,
     },
     output::Output,
     schema::{Def, EnumDef, FieldDef, Schema, StructDef, TypeDef},
@@ -93,7 +93,7 @@ fn generate_ts_type_def_for_struct(struct_def: &StructDef, schema: &Schema) -> S
 
     let mut output_as_type = false;
     for field in &struct_def.fields {
-        if field.estree.skip {
+        if should_skip_field(field, schema) {
             continue;
         }
 

--- a/tasks/ast_tools/src/schema/extensions/estree.rs
+++ b/tasks/ast_tools/src/schema/extensions/estree.rs
@@ -4,6 +4,7 @@ pub struct ESTreeStruct {
     pub rename: Option<String>,
     pub via: Option<String>,
     pub add_ts: Option<String>,
+    pub skip: bool,
     pub flatten: bool,
     pub no_type: bool,
     pub custom_serialize: bool,
@@ -12,6 +13,7 @@ pub struct ESTreeStruct {
 /// Configuration for ESTree generator on an enum.
 #[derive(Default, Debug)]
 pub struct ESTreeEnum {
+    pub skip: bool,
     pub no_rename_variants: bool,
     pub custom_ts_def: bool,
 }


### PR DESCRIPTION
Similar to #8876. Remove `#[estree(skip)]` attributes from struct fields containing semantic IDs, and add that attribute to the `ScopeId`, `SymbolId` and `ReferenceId` types instead. This reduces pointless repetition in the AST type definitions.