### PR TITLE
refactor(ast): use `=` syntax for `#[scope]` attrs

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -24,8 +24,8 @@ use super::{macros::inherit_variants, *};
 /// Represents the root of a JavaScript abstract syntax tree (AST), containing metadata about the source, directives, top-level statements, and scope information.
 #[ast(visit)]
 #[scope(
-    flags(ScopeFlags::Top),
-    strict_if(self.source_type.is_strict() || self.has_use_strict_directive()),
+    flags = ScopeFlags::Top,
+    strict_if = self.source_type.is_strict() || self.has_use_strict_directive(),
 )]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
@@ -1365,7 +1365,7 @@ pub struct TryStatement<'a> {
 /// }
 /// ```
 #[ast(visit)]
-#[scope(flags(ScopeFlags::CatchClause))]
+#[scope(flags = ScopeFlags::CatchClause)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct CatchClause<'a> {
@@ -1546,8 +1546,8 @@ pub struct BindingRestElement<'a> {
 #[ast(visit)]
 #[scope(
     // `flags` passed in to visitor via parameter defined by `#[visit(args(flags = ...))]` on parents
-    flags(flags),
-    strict_if(self.has_use_strict_directive()),
+    flags = flags,
+    strict_if = self.has_use_strict_directive(),
 )]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
@@ -1679,8 +1679,8 @@ pub struct FunctionBody<'a> {
 /// Arrow Function Definitions
 #[ast(visit)]
 #[scope(
-    flags(ScopeFlags::Function | ScopeFlags::Arrow),
-    strict_if(self.has_use_strict_directive()),
+    flags = ScopeFlags::Function | ScopeFlags::Arrow,
+    strict_if = self.has_use_strict_directive(),
 )]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
@@ -1711,7 +1711,7 @@ pub struct YieldExpression<'a> {
 
 /// Class Definitions
 #[ast(visit)]
-#[scope(flags(ScopeFlags::StrictMode))]
+#[scope(flags = ScopeFlags::StrictMode)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct Class<'a> {
@@ -2025,7 +2025,7 @@ pub struct PrivateIdentifier<'a> {
 /// }
 /// ```
 #[ast(visit)]
-#[scope(flags(ScopeFlags::ClassStaticBlock))]
+#[scope(flags = ScopeFlags::ClassStaticBlock)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct StaticBlock<'a> {

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1119,8 +1119,8 @@ pub enum TSTypePredicateName<'a> {
 /// * [TypeScript Handbook - Global Augmentation](https://www.typescriptlang.org/docs/handbook/declaration-merging.html#global-augmentation)
 #[ast(visit)]
 #[scope(
-    flags(ScopeFlags::TsModuleBlock),
-    strict_if(self.body.as_ref().is_some_and(TSModuleDeclarationBody::has_use_strict_directive)),
+    flags = ScopeFlags::TsModuleBlock,
+    strict_if = self.body.as_ref().is_some_and(TSModuleDeclarationBody::has_use_strict_directive),
 )]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]

--- a/crates/oxc_traverse/scripts/lib/parse.mjs
+++ b/crates/oxc_traverse/scripts/lib/parse.mjs
@@ -325,11 +325,11 @@ function parseScopeArgsStr(argsStr, args, position) {
 
   try {
     while (true) {
-      const [keyRaw] = matchAndConsume(/^([a-z_]+)\(/);
+      const [keyRaw] = matchAndConsume(/^([a-z_]+) *= */);
       const key = SCOPE_ARGS_KEYS[keyRaw];
       position.assert(key, `Unexpected scope macro arg: ${key}`);
 
-      let bracketCount = 1,
+      let bracketCount = 0,
         index = 0;
       for (; index < argsStr.length; index++) {
         const char = argsStr[index];
@@ -337,20 +337,23 @@ function parseScopeArgsStr(argsStr, args, position) {
           bracketCount++;
         } else if (char === ')') {
           bracketCount--;
-          if (bracketCount === 0) break;
+        } else if (char === ',' && bracketCount === 0) {
+          break;
         }
       }
       position.assert(bracketCount === 0);
 
       args[key] = argsStr.slice(0, index).trim();
-      argsStr = argsStr.slice(index + 1);
+      argsStr = argsStr.slice(index);
       if (argsStr === '') break;
 
-      matchAndConsume(/^ ?, ?/);
+      matchAndConsume(/^\s*,\s*/);
     }
   } catch (err) {
     position.throw(`Cannot parse scope args: '${argsStr}': ${err?.message || 'Unknown error'}`);
   }
+
+  console.log(args);
 
   return args;
 }


### PR DESCRIPTION
Change the attributes which specify the scope flags for types from `#[scope(flags(ScopeFlags::Class)]` to `#[scope(flags = ScopeFlags::Class)]`. Ditto `strict_if`. This makes their syntax consistent with other attributes, and will allow simplifying attribute parsing.