### PR TITLE
refactor(ast): derive `ContentEq` on literal types

### DIFF
--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -45,7 +45,7 @@ pub struct NullLiteral {
 /// <https://tc39.es/ecma262/#sec-literals-numeric-literals>
 #[ast(visit)]
 #[derive(Debug, Clone)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ESTree)]
+#[generate_derive(CloneIn, ContentEq, GetSpan, GetSpanMut, ESTree)]
 #[estree(rename = "Literal", via = crate::serialize::ESTreeLiteral)]
 pub struct NumericLiteral<'a> {
     /// Node location in source code
@@ -55,8 +55,10 @@ pub struct NumericLiteral<'a> {
     /// The number as it appears in source code
     ///
     /// `None` when this ast node is not constructed from the parser.
+    #[content_eq(skip)]
     pub raw: Option<Atom<'a>>,
     /// The base representation used by the literal in source code
+    #[content_eq(skip)]
     #[estree(skip)]
     pub base: NumberBase,
 }
@@ -66,7 +68,7 @@ pub struct NumericLiteral<'a> {
 /// <https://tc39.es/ecma262/#sec-literals-string-literals>
 #[ast(visit)]
 #[derive(Debug, Clone)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ESTree)]
+#[generate_derive(CloneIn, ContentEq, GetSpan, GetSpanMut, ESTree)]
 #[estree(rename = "Literal", via = crate::serialize::ESTreeLiteral)]
 pub struct StringLiteral<'a> {
     /// Node location in source code
@@ -79,13 +81,14 @@ pub struct StringLiteral<'a> {
     /// The raw string as it appears in source code.
     ///
     /// `None` when this ast node is not constructed from the parser.
+    #[content_eq(skip)]
     pub raw: Option<Atom<'a>>,
 }
 
 /// BigInt literal
 #[ast(visit)]
 #[derive(Debug, Clone)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ESTree)]
+#[generate_derive(CloneIn, ContentEq, GetSpan, GetSpanMut, ESTree)]
 #[estree(rename = "Literal", via = crate::serialize::ESTreeLiteral, add_ts = "value: null, bigint: string")]
 pub struct BigIntLiteral<'a> {
     /// Node location in source code
@@ -94,6 +97,7 @@ pub struct BigIntLiteral<'a> {
     #[estree(ts_type = "string | null")]
     pub raw: Atom<'a>,
     /// The base representation used by the literal in source code
+    #[content_eq(skip)]
     #[estree(skip)]
     pub base: BigintBase,
 }
@@ -103,7 +107,7 @@ pub struct BigIntLiteral<'a> {
 /// <https://tc39.es/ecma262/#sec-literals-regular-expression-literals>
 #[ast(visit)]
 #[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ESTree)]
+#[generate_derive(CloneIn, ContentEq, GetSpan, GetSpanMut, ESTree)]
 #[estree(
 	rename = "Literal",
 	via = crate::serialize::ESTreeLiteral,
@@ -119,6 +123,7 @@ pub struct RegExpLiteral<'a> {
     /// The regular expression as it appears in source code
     ///
     /// `None` when this ast node is not constructed from the parser.
+    #[content_eq(skip)]
     pub raw: Option<Atom<'a>>,
 }
 

--- a/crates/oxc_ast/src/ast_impl/literal.rs
+++ b/crates/oxc_ast/src/ast_impl/literal.rs
@@ -71,14 +71,6 @@ impl NumericLiteral<'_> {
     }
 }
 
-impl ContentEq for NumericLiteral<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        // Note: `f64::content_eq` uses `==` equality.
-        // `f64::NAN != f64::NAN` and `0.0 == -0.0`, so we follow the same here.
-        ContentEq::content_eq(&self.value, &other.value)
-    }
-}
-
 impl fmt::Display for NumericLiteral<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // We have 2 choices here:
@@ -111,12 +103,6 @@ impl StringLiteral<'_> {
     }
 }
 
-impl ContentEq for StringLiteral<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.value, &other.value)
-    }
-}
-
 impl AsRef<str> for StringLiteral<'_> {
     #[inline]
     fn as_ref(&self) -> &str {
@@ -138,21 +124,9 @@ impl BigIntLiteral<'_> {
     }
 }
 
-impl ContentEq for BigIntLiteral<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.raw, &other.raw)
-    }
-}
-
 impl fmt::Display for BigIntLiteral<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.raw.fmt(f)
-    }
-}
-
-impl ContentEq for RegExpLiteral<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.regex, &other.regex)
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -1458,6 +1458,30 @@ impl ContentEq for NullLiteral {
     }
 }
 
+impl ContentEq for NumericLiteral<'_> {
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.value, &other.value)
+    }
+}
+
+impl ContentEq for StringLiteral<'_> {
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.value, &other.value)
+    }
+}
+
+impl ContentEq for BigIntLiteral<'_> {
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.raw, &other.raw)
+    }
+}
+
+impl ContentEq for RegExpLiteral<'_> {
+    fn content_eq(&self, other: &Self) -> bool {
+        ContentEq::content_eq(&self.regex, &other.regex)
+    }
+}
+
 impl ContentEq for RegExp<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.pattern, &other.pattern)


### PR DESCRIPTION
Generate implementations of `ContentEq` trait on literal types instead of writing them manually, using the `#[content_eq(skip)]` attribute introduced in #8875 to skip fields which shouldn't be included.