### PR TITLE
refactor(ast_tools): parse attributes more deeply

### DIFF
--- a/tasks/ast_tools/src/generators/mod.rs
+++ b/tasks/ast_tools/src/generators/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     output::Output,
-    parse::attr::{attr_positions, AttrLocation, AttrPart, AttrPositions},
+    parse::attr::{attr_positions, AttrLocation, AttrPart, AttrPartListElement, AttrPositions},
     Codegen, Result, Runner, Schema,
 };
 

--- a/tasks/ast_tools/src/parse/attr.rs
+++ b/tasks/ast_tools/src/parse/attr.rs
@@ -1,7 +1,6 @@
 use std::fmt::{self, Display};
 
 use bitflags::bitflags;
-use syn::MetaList;
 
 use crate::{
     codegen::{DeriveId, GeneratorId},
@@ -146,5 +145,21 @@ pub enum AttrPart<'p> {
     String(&'p str, String),
     /// List part.
     /// e.g. `#[visit(args(flags = ScopeFlags::Function))]`.
-    List(&'p str, &'p MetaList),
+    List(&'p str, Vec<AttrPartListElement>),
+}
+
+/// An element of an [`AttrPart::List`].
+#[derive(Debug)]
+pub enum AttrPartListElement {
+    /// Named part.
+    /// e.g. `qux` in `#[foo(bar(qux))]`.
+    #[expect(dead_code)]
+    Tag(String),
+    /// String part.
+    /// e.g. `flags = ScopeFlags::Function` in `#[visit(args(flags = ScopeFlags::Function))]`.
+    String(String, String),
+    /// List part.
+    /// e.g. `qux(doof, bing = donk)` in `#[foo(bar(qux(doof, bing = donk)))]`.
+    #[expect(dead_code)]
+    List(String, Vec<AttrPartListElement>),
 }

--- a/tasks/ast_tools/src/parse/mod.rs
+++ b/tasks/ast_tools/src/parse/mod.rs
@@ -65,7 +65,6 @@ mod load;
 mod parse;
 mod skeleton;
 use load::load_file;
-pub use parse::convert_expr_to_string;
 use parse::parse;
 use skeleton::Skeleton;
 


### PR DESCRIPTION
After #8878, all attributes follow the same pattern. Can now parse all attributes fully, and remove the last vestiges of `syn` types from code generators - they now work entirely with `oxc_ast_tools`'s types (which are simpler).