### PR TITLE
feat(ast): improve TS type definitions for appended fields

### DIFF
--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -341,12 +341,12 @@ export type AssignmentTargetPattern = ArrayAssignmentTarget | ObjectAssignmentTa
 
 export interface ArrayAssignmentTarget extends Span {
   type: 'ArrayAssignmentTarget';
-  elements: Array<AssignmentTargetRest | AssignmentTargetMaybeDefault | null>;
+  elements: Array<AssignmentTargetMaybeDefault | AssignmentTargetRest | null>;
 }
 
 export interface ObjectAssignmentTarget extends Span {
   type: 'ObjectAssignmentTarget';
-  properties: Array<AssignmentTargetRest | AssignmentTargetProperty>;
+  properties: Array<AssignmentTargetProperty | AssignmentTargetRest>;
 }
 
 export interface AssignmentTargetRest extends Span {
@@ -689,7 +689,7 @@ export interface AssignmentPattern extends Span {
 
 export interface ObjectPattern extends Span {
   type: 'ObjectPattern';
-  properties: Array<BindingRestElement | BindingProperty>;
+  properties: Array<BindingProperty | BindingRestElement>;
 }
 
 export interface BindingProperty extends Span {
@@ -702,7 +702,7 @@ export interface BindingProperty extends Span {
 
 export interface ArrayPattern extends Span {
   type: 'ArrayPattern';
-  elements: Array<BindingRestElement | BindingPattern | null>;
+  elements: Array<BindingPattern | BindingRestElement | null>;
 }
 
 export interface BindingRestElement extends Span {

--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -115,13 +115,23 @@ fn generate_ts_type_def_for_struct(struct_def: &StructDef, schema: &Schema) -> S
                     field.name()
                 ),
             };
-            let inner_type_name = ts_type_name(vec_def.inner_type(schema), schema);
 
-            // TODO: Reverse these two
-            let mut field_type_name = format!("Array<{appended_type_name} | {inner_type_name}>");
+            let mut inner_type = vec_def.inner_type(schema);
+            let mut inner_is_option = false;
+            if let TypeDef::Option(option_def) = inner_type {
+                inner_is_option = true;
+                inner_type = option_def.inner_type(schema);
+            }
+            let inner_type_name = ts_type_name(inner_type, schema);
+            let mut field_type_name = format!("Array<{inner_type_name} | {appended_type_name}");
+            if inner_is_option {
+                field_type_name.push_str(" | null");
+            }
+            field_type_name.push('>');
             if is_option {
                 field_type_name.push_str(" | null");
             }
+
             Cow::Owned(field_type_name)
         } else {
             get_field_type_name(field, schema)


### PR DESCRIPTION
Cosmetic change. Preserve original order of fields in TS type definitions where a field is appended to a collection (e.g. `ObjectPattern`). If someone is consulting the type definitions, it makes more sense having the appended type listed last. e.g. `Array<BindingProperty | BindingRestElement>`, not the other way around.