### PR TITLE
feat(ast_tools): get extra params for visitor methods from `#[visit(args)]` attr

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1544,6 +1544,7 @@ pub struct BindingRestElement<'a> {
 /// }
 /// ```
 #[ast(visit)]
+#[visit(args(flags = ScopeFlags))]
 #[scope(
     // `flags` passed in to visitor via parameter defined by `#[visit(args(flags = ...))]` on parents
     flags = flags,

--- a/tasks/ast_tools/src/schema/extensions/visit.rs
+++ b/tasks/ast_tools/src/schema/extensions/visit.rs
@@ -1,6 +1,7 @@
 /// Details of visiting on a struct.
 #[derive(Default, Debug)]
 pub struct VisitStruct {
+    pub visit_args: Option<Vec<(String, String)>>,
     pub is_visited: bool,
     pub scope: Option<Scope>,
 }


### PR DESCRIPTION
Instead of hard-coding a special case in the `Visit` codegen for the extra `flags` param to `visit_function`, specify that param in an attribute on the type `#[visit(args(flags = ScopeFlags))] struct Function { ... }`.