### PR TITLE
refactor(ast): record plural names in `#[plural]` attr

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1639,6 +1639,8 @@ pub struct FormalParameters<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+// Pluralize as `FormalParameterList` to avoid naming clash with `FormalParameters`.
+#[plural(FormalParameterList)]
 pub struct FormalParameter<'a> {
     pub span: Span,
     #[ts]

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1299,6 +1299,8 @@ pub struct TSImportAttributes<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+// Pluralize as `TSImportAttributeList` to avoid naming clash with `TSImportAttributes`.
+#[plural(TSImportAttributeList)]
 pub struct TSImportAttribute<'a> {
     pub span: Span,
     pub name: TSImportAttributeName<'a>,

--- a/crates/oxc_ast_macros/src/lib.rs
+++ b/crates/oxc_ast_macros/src/lib.rs
@@ -49,7 +49,7 @@ pub fn ast(_args: TokenStream, input: TokenStream) -> TokenStream {
 /// See [`macro@ast`] for further details.
 #[proc_macro_derive(
     Ast,
-    attributes(clone_in, content_eq, estree, generate_derive, scope, span, ts, visit)
+    attributes(clone_in, content_eq, estree, generate_derive, plural, scope, span, ts, visit)
 )]
 pub fn ast_derive(_input: TokenStream) -> TokenStream {
     TokenStream::new()

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -34,8 +34,8 @@ impl Generator for AstBuilderGenerator {
             .iter()
             .filter(|&type_def| {
                 let is_visited = match type_def {
-                    TypeDef::Struct(struct_def) => struct_def.visit.is_visited,
-                    TypeDef::Enum(enum_def) => enum_def.visit.is_visited,
+                    TypeDef::Struct(struct_def) => struct_def.visit.is_visited(),
+                    TypeDef::Enum(enum_def) => enum_def.visit.is_visited(),
                     _ => false,
                 };
                 let is_blacklisted = BLACK_LIST.contains(&type_def.name());

--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -99,10 +99,10 @@ impl Generator for AstKindGenerator {
         for type_def in &mut schema.types {
             match type_def {
                 TypeDef::Struct(struct_def) => {
-                    struct_def.kind.has_kind = struct_def.visit.is_visited;
+                    struct_def.kind.has_kind = struct_def.visit.is_visited();
                 }
                 TypeDef::Enum(enum_def) => {
-                    enum_def.kind.has_kind = enum_def.visit.is_visited;
+                    enum_def.kind.has_kind = enum_def.visit.is_visited();
                 }
                 _ => {}
             }

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -243,6 +243,9 @@ const GENERATORS: &[&(dyn Generator + Sync)] = &[
     &generators::TypescriptGenerator,
 ];
 
+/// Attributes on structs and enums (not including those defined by derives/generators)
+const ATTRIBUTES: [&str; 2] = ["generate_derive", "plural"];
+
 type Result<R> = std::result::Result<R, ()>;
 
 /// CLI options.
@@ -379,7 +382,7 @@ fn generate_proc_macro() -> RawOutput {
 fn generate_updated_proc_macro(codegen: &Codegen) -> RawOutput {
     // Get all attrs which derives/generators use
     let mut attrs = codegen.attrs();
-    attrs.push("generate_derive");
+    attrs.extend(ATTRIBUTES);
     attrs.sort_unstable();
     let attrs = attrs.join(", ");
 

--- a/tasks/ast_tools/src/schema/defs/enum.rs
+++ b/tasks/ast_tools/src/schema/defs/enum.rs
@@ -5,7 +5,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::Ident;
 
-use crate::utils::create_ident;
+use crate::utils::{create_ident, pluralize};
 
 use super::{
     extensions::{
@@ -26,6 +26,7 @@ pub type Discriminant = u8;
 pub struct EnumDef {
     pub id: TypeId,
     pub name: String,
+    pub plural_name: Option<String>,
     pub has_lifetime: bool,
     pub file_id: FileId,
     pub generated_derives: Derives,
@@ -42,9 +43,11 @@ pub struct EnumDef {
 
 impl EnumDef {
     /// Create new [`EnumDef`].
+    #[expect(clippy::too_many_arguments)]
     pub fn new(
         id: TypeId,
         name: String,
+        plural_name: Option<String>,
         has_lifetime: bool,
         file_id: FileId,
         generated_derives: Derives,
@@ -54,6 +57,7 @@ impl EnumDef {
         Self {
             id,
             name,
+            plural_name,
             has_lifetime,
             file_id,
             generated_derives,
@@ -66,6 +70,16 @@ impl EnumDef {
             content_eq: ContentEqType::default(),
             estree: ESTreeEnum::default(),
         }
+    }
+
+    /// Get plural type name.
+    pub fn plural_name(&self) -> String {
+        self.plural_name.clone().unwrap_or_else(|| pluralize(self.name()))
+    }
+
+    /// Get plural type name in snake case.
+    pub fn plural_snake_name(&self) -> String {
+        self.plural_name().to_case(Case::Snake)
     }
 
     /// Get iterator over all enum's variants (including inherited)

--- a/tasks/ast_tools/src/schema/defs/struct.rs
+++ b/tasks/ast_tools/src/schema/defs/struct.rs
@@ -4,7 +4,7 @@ use convert_case::{Case, Casing};
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use crate::utils::create_ident_tokens;
+use crate::utils::{create_ident_tokens, pluralize};
 
 use super::{
     extensions::{
@@ -24,6 +24,7 @@ use super::{
 pub struct StructDef {
     pub id: TypeId,
     pub name: String,
+    pub plural_name: Option<String>,
     pub has_lifetime: bool,
     pub file_id: FileId,
     pub generated_derives: Derives,
@@ -42,6 +43,7 @@ impl StructDef {
     pub fn new(
         id: TypeId,
         name: String,
+        plural_name: Option<String>,
         has_lifetime: bool,
         file_id: FileId,
         generated_derives: Derives,
@@ -50,6 +52,7 @@ impl StructDef {
         Self {
             id,
             name,
+            plural_name,
             has_lifetime,
             file_id,
             generated_derives,
@@ -62,6 +65,16 @@ impl StructDef {
             content_eq: ContentEqType::default(),
             estree: ESTreeStruct::default(),
         }
+    }
+
+    /// Get plural type name.
+    pub fn plural_name(&self) -> String {
+        self.plural_name.clone().unwrap_or_else(|| pluralize(self.name()))
+    }
+
+    /// Get plural type name in snake case.
+    pub fn plural_snake_name(&self) -> String {
+        self.plural_name().to_case(Case::Snake)
     }
 
     /// Get iterator over field indexes.

--- a/tasks/ast_tools/src/schema/defs/vec.rs
+++ b/tasks/ast_tools/src/schema/defs/vec.rs
@@ -1,7 +1,10 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use super::{extensions::layout::Layout, Def, Derives, FileId, Schema, TypeDef, TypeId};
+use super::{
+    extensions::{layout::Layout, visit::VisitVec},
+    Def, Derives, FileId, Schema, TypeDef, TypeId,
+};
 
 /// Type definition for a `Vec`.
 #[derive(Debug)]
@@ -9,13 +12,20 @@ pub struct VecDef {
     pub id: TypeId,
     pub name: String,
     pub inner_type_id: TypeId,
+    pub visit: VisitVec,
     pub layout: Layout,
 }
 
 impl VecDef {
     /// Create new [`VecDef`].
     pub fn new(name: String, inner_type_id: TypeId) -> Self {
-        Self { id: TypeId::DUMMY, name, inner_type_id, layout: Layout::default() }
+        Self {
+            id: TypeId::DUMMY,
+            name,
+            inner_type_id,
+            visit: VisitVec::default(),
+            layout: Layout::default(),
+        }
     }
 
     /// Get inner type.

--- a/tasks/ast_tools/src/schema/extensions/visit.rs
+++ b/tasks/ast_tools/src/schema/extensions/visit.rs
@@ -1,21 +1,83 @@
 /// Details of visiting on a struct.
 #[derive(Default, Debug)]
 pub struct VisitStruct {
+    /// Name of `visit_*` method and `walk_*` function.
+    /// `None` if this struct is not visited.
+    pub visitor_names: Option<VisitorNames>,
     pub visit_args: Option<Vec<(String, String)>>,
-    pub is_visited: bool,
     pub scope: Option<Scope>,
+}
+
+impl VisitStruct {
+    /// Returns `true` if this struct is visited.
+    pub fn is_visited(&self) -> bool {
+        self.visitor_names.is_some()
+    }
+
+    /// Get name of visitor method for this struct, if it is visited.
+    pub fn visitor_name(&self) -> Option<&str> {
+        self.visitor_names.as_ref().map(|names| names.visit.as_str())
+    }
 }
 
 /// Details of visiting on an enum.
 #[derive(Default, Debug)]
 pub struct VisitEnum {
-    pub is_visited: bool,
+    /// Name of `visit_*` method and `walk_*` function.
+    /// `None` if this enum is not visited.
+    pub visitor_names: Option<VisitorNames>,
+}
+
+impl VisitEnum {
+    /// Returns `true` if this enum is visited.
+    pub fn is_visited(&self) -> bool {
+        self.visitor_names.is_some()
+    }
+
+    /// Get name of visitor method for this enum, if it is visited.
+    pub fn visitor_name(&self) -> Option<&str> {
+        self.visitor_names.as_ref().map(|names| names.visit.as_str())
+    }
+}
+
+/// Details of visiting on a `Vec`.
+#[derive(Default, Debug)]
+pub struct VisitVec {
+    /// Name of `visit_*` method and `walk_*` function.
+    /// `None` if this `Vec` does not have a visitor.
+    pub visitor_names: Option<VisitorNames>,
+}
+
+impl VisitVec {
+    /// Returns `true` if this `Vec` is visited.
+    #[expect(dead_code)]
+    pub fn is_visited(&self) -> bool {
+        self.visitor_names.is_some()
+    }
+
+    /// Get name of visitor method for this `Vec`, if it is visited.
+    pub fn visitor_name(&self) -> Option<&str> {
+        self.visitor_names.as_ref().map(|names| names.visit.as_str())
+    }
 }
 
 /// Details of visiting on a struct field or enum variant.
 #[derive(Default, Debug)]
 pub struct VisitFieldOrVariant {
     pub visit_args: Option<Vec<(String, String)>>,
+}
+
+/// Names for visitor method and walk function.
+#[derive(Debug)]
+pub struct VisitorNames {
+    pub visit: String,
+    pub walk: String,
+}
+
+impl VisitorNames {
+    pub fn from_snake_name(snake_name: &str) -> Self {
+        Self { visit: format!("visit_{snake_name}"), walk: format!("walk_{snake_name}") }
+    }
 }
 
 /// Details of scope on a struct.

--- a/tasks/ast_tools/src/utils.rs
+++ b/tasks/ast_tools/src/utils.rs
@@ -59,3 +59,16 @@ pub fn create_ident_tokens(name: &str) -> TokenStream {
 pub fn number_lit<N: Into<u64>>(n: N) -> LitInt {
     LitInt::new(&n.into().to_string(), Span::call_site())
 }
+
+/// Pluralize name.
+pub fn pluralize(name: &str) -> String {
+    if name.ends_with("child") || name.ends_with("Child") {
+        format!("{name}ren")
+    } else {
+        match name.as_bytes().last() {
+            Some(b's') => format!("{name}es"),
+            Some(b'y') => format!("{}ies", &name[..name.len() - 1]),
+            _ => format!("{name}s"),
+        }
+    }
+}


### PR DESCRIPTION
Instead of hard-coding pluralized type names in `Visit` generator, specify the special cases with a `#[plural]` attribute on the type. This makes them available for other generators e.g. codegen for AST transfer.

Also pre-compute names of `visit_*` and `walk_*` methods and store them in the `Schema`, to avoid re-calculating them each time. This will also make it easier to add other code generators which produce `Visit` implementations.
