### PR TITLE
refactor(ast)!: name `AstBuilder` enum builders after variant name not type name

### DIFF
--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -130,7 +130,8 @@ impl<'a> AstBuilder<'a> {
     /// [`AssignmentTarget::AssignmentTargetIdentifier`] with no name and an empty [`Span`].
     #[inline]
     pub fn move_assignment_target(self, target: &mut AssignmentTarget<'a>) -> AssignmentTarget<'a> {
-        let dummy = self.simple_assignment_target_identifier_reference(SPAN, Atom::from(""));
+        let dummy =
+            self.simple_assignment_target_assignment_target_identifier(SPAN, Atom::from(""));
         mem::replace(target, dummy.into())
     }
 

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -306,7 +306,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     #[inline]
-    pub fn expression_identifier_reference<A>(self, span: Span, name: A) -> Expression<'a>
+    pub fn expression_identifier<A>(self, span: Span, name: A) -> Expression<'a>
     where
         A: IntoIn<'a, Atom<'a>>,
     {
@@ -1411,7 +1411,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `argument`: The expression being spread.
     #[inline]
-    pub fn object_property_kind_spread_element(
+    pub fn object_property_kind_spread_property(
         self,
         span: Span,
         argument: Expression<'a>,
@@ -1482,7 +1482,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn property_key_identifier_name<A>(self, span: Span, name: A) -> PropertyKey<'a>
+    pub fn property_key_static_identifier<A>(self, span: Span, name: A) -> PropertyKey<'a>
     where
         A: IntoIn<'a, Atom<'a>>,
     {
@@ -2289,7 +2289,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The name of the identifier being referenced.
     #[inline]
-    pub fn simple_assignment_target_identifier_reference<A>(
+    pub fn simple_assignment_target_assignment_target_identifier<A>(
         self,
         span: Span,
         name: A,
@@ -6965,11 +6965,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn import_attribute_key_identifier_name<A>(
-        self,
-        span: Span,
-        name: A,
-    ) -> ImportAttributeKey<'a>
+    pub fn import_attribute_key_identifier<A>(self, span: Span, name: A) -> ImportAttributeKey<'a>
     where
         A: IntoIn<'a, Atom<'a>>,
     {
@@ -7218,7 +7214,7 @@ impl<'a> AstBuilder<'a> {
     /// * `return_type`: The TypeScript return type annotation.
     /// * `body`: The function body.
     #[inline]
-    pub fn export_default_declaration_kind_function<T1, T2, T3, T4, T5>(
+    pub fn export_default_declaration_kind_function_declaration<T1, T2, T3, T4, T5>(
         self,
         span: Span,
         r#type: FunctionType,
@@ -7271,7 +7267,7 @@ impl<'a> AstBuilder<'a> {
     /// * `abstract`: Whether the class is abstract
     /// * `declare`: Whether the class was `declare`ed
     #[inline]
-    pub fn export_default_declaration_kind_class<T1, T2, T3>(
+    pub fn export_default_declaration_kind_class_declaration<T1, T2, T3>(
         self,
         span: Span,
         r#type: ClassType,
@@ -7783,7 +7779,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code
     /// * `name`: The name of the identifier.
     #[inline]
-    pub fn jsx_element_name_jsx_identifier<A>(self, span: Span, name: A) -> JSXElementName<'a>
+    pub fn jsx_element_name_identifier<A>(self, span: Span, name: A) -> JSXElementName<'a>
     where
         A: IntoIn<'a, Atom<'a>>,
     {
@@ -7814,7 +7810,7 @@ impl<'a> AstBuilder<'a> {
     /// * `namespace`: Namespace portion of the name, e.g. `Apple` in `<Apple:Orange />`
     /// * `property`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
     #[inline]
-    pub fn jsx_element_name_jsx_namespaced_name(
+    pub fn jsx_element_name_namespaced_name(
         self,
         span: Span,
         namespace: JSXIdentifier<'a>,
@@ -7832,7 +7828,7 @@ impl<'a> AstBuilder<'a> {
     /// * `object`: The object being accessed. This is everything before the last `.`.
     /// * `property`: The property being accessed. This is everything after the last `.`.
     #[inline]
-    pub fn jsx_element_name_jsx_member_expression(
+    pub fn jsx_element_name_member_expression(
         self,
         span: Span,
         object: JSXMemberExpressionObject<'a>,
@@ -7952,7 +7948,7 @@ impl<'a> AstBuilder<'a> {
     /// * `object`: The object being accessed. This is everything before the last `.`.
     /// * `property`: The property being accessed. This is everything after the last `.`.
     #[inline]
-    pub fn jsx_member_expression_object_jsx_member_expression(
+    pub fn jsx_member_expression_object_member_expression(
         self,
         span: Span,
         object: JSXMemberExpressionObject<'a>,
@@ -8014,7 +8010,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     #[inline]
-    pub fn jsx_expression_jsx_empty_expression(self, span: Span) -> JSXExpression<'a> {
+    pub fn jsx_expression_empty_expression(self, span: Span) -> JSXExpression<'a> {
         JSXExpression::EmptyExpression(self.jsx_empty_expression(span))
     }
 
@@ -8049,7 +8045,7 @@ impl<'a> AstBuilder<'a> {
     /// * `name`: The name of the attribute. This is a prop in React-like applications.
     /// * `value`: The value of the attribute. This can be a string literal, an expression,
     #[inline]
-    pub fn jsx_attribute_item_jsx_attribute(
+    pub fn jsx_attribute_item_attribute(
         self,
         span: Span,
         name: JSXAttributeName<'a>,
@@ -8066,7 +8062,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code
     /// * `argument`: The expression being spread.
     #[inline]
-    pub fn jsx_attribute_item_jsx_spread_attribute(
+    pub fn jsx_attribute_item_spread_attribute(
         self,
         span: Span,
         argument: Expression<'a>,
@@ -8150,7 +8146,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code
     /// * `name`: The name of the identifier.
     #[inline]
-    pub fn jsx_attribute_name_jsx_identifier<A>(self, span: Span, name: A) -> JSXAttributeName<'a>
+    pub fn jsx_attribute_name_identifier<A>(self, span: Span, name: A) -> JSXAttributeName<'a>
     where
         A: IntoIn<'a, Atom<'a>>,
     {
@@ -8166,7 +8162,7 @@ impl<'a> AstBuilder<'a> {
     /// * `namespace`: Namespace portion of the name, e.g. `Apple` in `<Apple:Orange />`
     /// * `property`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
     #[inline]
-    pub fn jsx_attribute_name_jsx_namespaced_name(
+    pub fn jsx_attribute_name_namespaced_name(
         self,
         span: Span,
         namespace: JSXIdentifier<'a>,
@@ -8204,7 +8200,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code
     /// * `expression`: The expression inside the container.
     #[inline]
-    pub fn jsx_attribute_value_jsx_expression_container(
+    pub fn jsx_attribute_value_expression_container(
         self,
         span: Span,
         expression: JSXExpression<'a>,
@@ -8224,7 +8220,7 @@ impl<'a> AstBuilder<'a> {
     /// * `closing_element`: Closing tag of the element. Will be [`None`] for self-closing tags.
     /// * `children`: Children of the element. This can be text, other elements, or expressions.
     #[inline]
-    pub fn jsx_attribute_value_jsx_element<T1, T2>(
+    pub fn jsx_attribute_value_element<T1, T2>(
         self,
         span: Span,
         opening_element: T1,
@@ -8253,7 +8249,7 @@ impl<'a> AstBuilder<'a> {
     /// * `closing_fragment`: `</>`
     /// * `children`: Elements inside the fragment.
     #[inline]
-    pub fn jsx_attribute_value_jsx_fragment(
+    pub fn jsx_attribute_value_fragment(
         self,
         span: Span,
         opening_fragment: JSXOpeningFragment,
@@ -8306,7 +8302,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code
     /// * `value`: The text content.
     #[inline]
-    pub fn jsx_child_jsx_text<A>(self, span: Span, value: A) -> JSXChild<'a>
+    pub fn jsx_child_text<A>(self, span: Span, value: A) -> JSXChild<'a>
     where
         A: IntoIn<'a, Atom<'a>>,
     {
@@ -8323,7 +8319,7 @@ impl<'a> AstBuilder<'a> {
     /// * `closing_element`: Closing tag of the element. Will be [`None`] for self-closing tags.
     /// * `children`: Children of the element. This can be text, other elements, or expressions.
     #[inline]
-    pub fn jsx_child_jsx_element<T1, T2>(
+    pub fn jsx_child_element<T1, T2>(
         self,
         span: Span,
         opening_element: T1,
@@ -8347,7 +8343,7 @@ impl<'a> AstBuilder<'a> {
     /// * `closing_fragment`: `</>`
     /// * `children`: Elements inside the fragment.
     #[inline]
-    pub fn jsx_child_jsx_fragment(
+    pub fn jsx_child_fragment(
         self,
         span: Span,
         opening_fragment: JSXOpeningFragment,
@@ -8370,7 +8366,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code
     /// * `expression`: The expression inside the container.
     #[inline]
-    pub fn jsx_child_jsx_expression_container(
+    pub fn jsx_child_expression_container(
         self,
         span: Span,
         expression: JSXExpression<'a>,
@@ -8386,11 +8382,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: Node location in source code
     /// * `expression`: The expression being spread.
     #[inline]
-    pub fn jsx_child_jsx_spread_child(
-        self,
-        span: Span,
-        expression: Expression<'a>,
-    ) -> JSXChild<'a> {
+    pub fn jsx_child_spread(self, span: Span, expression: Expression<'a>) -> JSXChild<'a> {
         JSXChild::Spread(self.alloc_jsx_spread_child(span, expression))
     }
 
@@ -8644,7 +8636,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn ts_enum_member_name_identifier_name<A>(self, span: Span, name: A) -> TSEnumMemberName<'a>
+    pub fn ts_enum_member_name_identifier<A>(self, span: Span, name: A) -> TSEnumMemberName<'a>
     where
         A: IntoIn<'a, Atom<'a>>,
     {
@@ -8660,7 +8652,7 @@ impl<'a> AstBuilder<'a> {
     /// * `value`: The value of the string.
     /// * `raw`: The raw string as it appears in source code.
     #[inline]
-    pub fn ts_enum_member_name_string_literal<A>(
+    pub fn ts_enum_member_name_string<A>(
         self,
         span: Span,
         value: A,
@@ -9360,7 +9352,7 @@ impl<'a> AstBuilder<'a> {
     /// * `operator`
     /// * `type_annotation`: The type being operated on
     #[inline]
-    pub fn ts_type_type_operator(
+    pub fn ts_type_type_operator_type(
         self,
         span: Span,
         operator: TSTypeOperatorOperator,
@@ -11729,7 +11721,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn ts_type_predicate_name_identifier_name<A>(
+    pub fn ts_type_predicate_name_identifier<A>(
         self,
         span: Span,
         name: A,
@@ -11745,7 +11737,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     #[inline]
-    pub fn ts_type_predicate_name_this_type(self, span: Span) -> TSTypePredicateName<'a> {
+    pub fn ts_type_predicate_name_this(self, span: Span) -> TSTypePredicateName<'a> {
         TSTypePredicateName::This(self.ts_this_type(span))
     }
 
@@ -11850,7 +11842,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`: The identifier name being bound.
     #[inline]
-    pub fn ts_module_declaration_name_binding_identifier<A>(
+    pub fn ts_module_declaration_name_identifier<A>(
         self,
         span: Span,
         name: A,
@@ -12248,7 +12240,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `name`
     #[inline]
-    pub fn ts_import_attribute_name_identifier_name<A>(
+    pub fn ts_import_attribute_name_identifier<A>(
         self,
         span: Span,
         name: A,

--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -203,7 +203,7 @@ impl<'a> IsolatedDeclarations<'a> {
             // A parameter property may not be declared using a binding pattern.(1187)
             return None;
         };
-        let key = self.ast.property_key_identifier_name(SPAN, ident_name);
+        let key = self.ast.property_key_static_identifier(SPAN, ident_name);
         Some(self.ast.class_element_property_definition(
             param.span,
             PropertyDefinitionType::PropertyDefinition,

--- a/crates/oxc_isolated_declarations/src/enum.rs
+++ b/crates/oxc_isolated_declarations/src/enum.rs
@@ -60,7 +60,7 @@ impl<'a> IsolatedDeclarations<'a> {
 
                         // Infinity
                         let expr = if v.is_infinite() {
-                            self.ast.expression_identifier_reference(SPAN, "Infinity")
+                            self.ast.expression_identifier(SPAN, "Infinity")
                         } else {
                             let value = if is_negative { -v } else { v };
                             self.ast.expression_numeric_literal(

--- a/crates/oxc_isolated_declarations/src/module.rs
+++ b/crates/oxc_isolated_declarations/src/module.rs
@@ -97,7 +97,7 @@ impl<'a> IsolatedDeclarations<'a> {
                 declarations,
                 self.is_declare(),
             ));
-            Some((Some(variable_statement), self.ast.expression_identifier_reference(SPAN, name)))
+            Some((Some(variable_statement), self.ast.expression_identifier(SPAN, name)))
         }
     }
 

--- a/crates/oxc_isolated_declarations/src/types.rs
+++ b/crates/oxc_isolated_declarations/src/types.rs
@@ -168,7 +168,7 @@ impl<'a> IsolatedDeclarations<'a> {
 
         let ts_type = self.ast.ts_type_tuple_type(SPAN, element_types);
         if is_const {
-            self.ast.ts_type_type_operator(SPAN, TSTypeOperatorOperator::Readonly, ts_type)
+            self.ast.ts_type_type_operator_type(SPAN, TSTypeOperatorOperator::Readonly, ts_type)
         } else {
             ts_type
         }

--- a/crates/oxc_minifier/src/peephole/minimize_conditions.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditions.rs
@@ -459,7 +459,8 @@ impl<'a> PeepholeOptimizations {
                 // The `_` will not be placed to the target code.
                 let target = std::mem::replace(
                     target,
-                    ctx.ast.simple_assignment_target_identifier_reference(target.span(), "_"),
+                    ctx.ast
+                        .simple_assignment_target_assignment_target_identifier(target.span(), "_"),
                 );
                 Some(ctx.ast.expression_update(expr.span, UpdateOperator::Decrement, true, target))
             }
@@ -471,7 +472,10 @@ impl<'a> PeepholeOptimizations {
                     // The `_` will not be placed to the target code.
                     let target = std::mem::replace(
                         target,
-                        ctx.ast.simple_assignment_target_identifier_reference(target.span(), "_"),
+                        ctx.ast.simple_assignment_target_assignment_target_identifier(
+                            target.span(),
+                            "_",
+                        ),
                     );
                     ctx.ast.expression_update(expr.span, UpdateOperator::Increment, true, target)
                 })

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -375,7 +375,7 @@ impl<'a> PeepholeOptimizations {
             ctx.ast.expression_unary(
                 SPAN,
                 UnaryOperator::LogicalNot,
-                ctx.ast.expression_identifier_reference(is_null_id_ref.span, is_null_id_ref.name),
+                ctx.ast.expression_identifier(is_null_id_ref.span, is_null_id_ref.name),
             )
         } else {
             ctx.ast.expression_unary(
@@ -384,8 +384,7 @@ impl<'a> PeepholeOptimizations {
                 ctx.ast.expression_unary(
                     SPAN,
                     UnaryOperator::LogicalNot,
-                    ctx.ast
-                        .expression_identifier_reference(is_null_id_ref.span, is_null_id_ref.name),
+                    ctx.ast.expression_identifier(is_null_id_ref.span, is_null_id_ref.name),
                 ),
             )
         };
@@ -611,7 +610,7 @@ impl<'a> PeepholeOptimizations {
                                 ));
                             }
                         }
-                        let callee = ctx.ast.expression_identifier_reference(n.span, "Array");
+                        let callee = ctx.ast.expression_identifier(n.span, "Array");
                         let args = ctx.ast.move_vec(args);
                         Some(ctx.ast.expression_call(span, callee, NONE, args, false))
                     }
@@ -624,7 +623,7 @@ impl<'a> PeepholeOptimizations {
                     }
                     // `new Array(x)` -> `Array(x)`
                     else {
-                        let callee = ctx.ast.expression_identifier_reference(span, "Array");
+                        let callee = ctx.ast.expression_identifier(span, "Array");
                         let args = ctx.ast.move_vec(args);
                         Some(ctx.ast.expression_call(span, callee, NONE, args, false))
                     }
@@ -714,8 +713,7 @@ impl<'a> PeepholeOptimizations {
                     .as_member_expression()
                     .is_some_and(|mem_expr| mem_expr.is_specific_member_access("window", "Object"))
             {
-                call_expr.callee =
-                    ctx.ast.expression_identifier_reference(call_expr.callee.span(), "Object");
+                call_expr.callee = ctx.ast.expression_identifier(call_expr.callee.span(), "Object");
                 self.mark_current_function_as_changed();
             }
         }

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -139,7 +139,7 @@ impl<'a> ParserImpl<'a> {
         // <namespace:property />
         if self.eat(Kind::Colon) {
             let property = self.parse_jsx_identifier()?;
-            return Ok(self.ast.jsx_element_name_jsx_namespaced_name(
+            return Ok(self.ast.jsx_element_name_namespaced_name(
                 self.end_span(span),
                 identifier,
                 property,
@@ -199,7 +199,7 @@ impl<'a> ParserImpl<'a> {
             // <foo.bar.baz>
             if let Some(prop) = property {
                 object =
-                    self.ast.jsx_member_expression_object_jsx_member_expression(span, object, prop);
+                    self.ast.jsx_member_expression_object_member_expression(span, object, prop);
             }
 
             // <foo.bar>
@@ -370,7 +370,7 @@ impl<'a> ParserImpl<'a> {
 
         if self.eat(Kind::Colon) {
             let property = self.parse_jsx_identifier()?;
-            return Ok(self.ast.jsx_attribute_name_jsx_namespaced_name(
+            return Ok(self.ast.jsx_attribute_name_namespaced_name(
                 self.end_span(span),
                 identifier,
                 property,

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -69,7 +69,7 @@ impl<'a> ParserImpl<'a> {
             Kind::LBrack => match self.parse_computed_property_name()? {
                 Expression::StringLiteral(literal) => Ok(TSEnumMemberName::String(literal)),
                 Expression::TemplateLiteral(template) if template.is_no_substitution_template() => {
-                    Ok(self.ast.ts_enum_member_name_string_literal(
+                    Ok(self.ast.ts_enum_member_name_string(
                         template.span,
                         template.quasi().unwrap(),
                         Some(Atom::from(

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -260,7 +260,7 @@ impl<'a> ParserImpl<'a> {
         {
             self.error(diagnostics::readonly_in_array_or_tuple_type(operator_span));
         }
-        Ok(self.ast.ts_type_type_operator(self.end_span(span), operator, ty))
+        Ok(self.ast.ts_type_type_operator_type(self.end_span(span), operator, ty))
     }
 
     fn parse_infer_type(&mut self) -> Result<TSType<'a>> {

--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -334,7 +334,7 @@ impl<'a> ClassProperties<'a, '_> {
                 ctx.ast.object_property_kind_object_property(
                     SPAN,
                     PropertyKind::Init,
-                    ctx.ast.property_key_identifier_name(SPAN, Atom::from("writable")),
+                    ctx.ast.property_key_static_identifier(SPAN, Atom::from("writable")),
                     ctx.ast.expression_boolean_literal(SPAN, true),
                     false,
                     false,
@@ -343,7 +343,7 @@ impl<'a> ClassProperties<'a, '_> {
                 ctx.ast.object_property_kind_object_property(
                     SPAN,
                     PropertyKind::Init,
-                    ctx.ast.property_key_identifier_name(SPAN, Atom::from("value")),
+                    ctx.ast.property_key_static_identifier(SPAN, Atom::from("value")),
                     value,
                     false,
                     false,

--- a/crates/oxc_transformer/src/jsx/display_name.rs
+++ b/crates/oxc_transformer/src/jsx/display_name.rs
@@ -172,7 +172,7 @@ impl<'a> ReactDisplayName<'a, '_> {
             ctx.ast.object_property_kind_object_property(
                 SPAN,
                 PropertyKind::Init,
-                ctx.ast.property_key_identifier_name(SPAN, DISPLAY_NAME),
+                ctx.ast.property_key_static_identifier(SPAN, DISPLAY_NAME),
                 ctx.ast.expression_string_literal(SPAN, name, None),
                 false,
                 false,

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -608,7 +608,7 @@ impl<'a> JsxImpl<'a, '_> {
                                 let argument = unsafe { ctx.ast.copy(expr) };
                                 let object_property = ctx
                                     .ast
-                                    .object_property_kind_spread_element(spread.span, argument);
+                                    .object_property_kind_spread_property(spread.span, argument);
                                 properties.push(object_property);
                             }
                         }
@@ -641,7 +641,7 @@ impl<'a> JsxImpl<'a, '_> {
                 properties.push(ctx.ast.object_property_kind_object_property(
                     SPAN,
                     PropertyKind::Init,
-                    ctx.ast.property_key_identifier_name(SPAN, "children"),
+                    ctx.ast.property_key_static_identifier(SPAN, "children"),
                     value,
                     false,
                     false,
@@ -945,7 +945,7 @@ impl<'a> JsxImpl<'a, '_> {
                 if ident.name.contains('-') {
                     PropertyKey::from(ctx.ast.expression_string_literal(ident.span, name, None))
                 } else {
-                    ctx.ast.property_key_identifier_name(ident.span, name)
+                    ctx.ast.property_key_static_identifier(ident.span, name)
                 }
             }
             JSXAttributeName::NamespacedName(namespaced) => {

--- a/crates/oxc_transformer/src/jsx/jsx_self.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_self.rs
@@ -87,7 +87,7 @@ impl<'a> JsxSelf<'a, '_> {
         ctx: &mut TraverseCtx<'a>,
     ) -> ObjectPropertyKind<'a> {
         let kind = PropertyKind::Init;
-        let key = ctx.ast.property_key_identifier_name(SPAN, SELF);
+        let key = ctx.ast.property_key_static_identifier(SPAN, SELF);
         let value = ctx.ast.expression_this(SPAN);
         ctx.ast.object_property_kind_object_property(SPAN, kind, key, value, false, false, false)
     }
@@ -111,12 +111,12 @@ impl<'a> JsxSelf<'a, '_> {
             }
         }
 
-        let name = ctx.ast.jsx_attribute_name_jsx_identifier(SPAN, SELF);
+        let name = ctx.ast.jsx_attribute_name_identifier(SPAN, SELF);
         let value = {
             let jsx_expr = JSXExpression::from(ctx.ast.expression_this(SPAN));
-            ctx.ast.jsx_attribute_value_jsx_expression_container(SPAN, jsx_expr)
+            ctx.ast.jsx_attribute_value_expression_container(SPAN, jsx_expr)
         };
-        let attribute = ctx.ast.jsx_attribute_item_jsx_attribute(SPAN, name, Some(value));
+        let attribute = ctx.ast.jsx_attribute_item_attribute(SPAN, name, Some(value));
         elem.attributes.push(attribute);
     }
 }

--- a/crates/oxc_transformer/src/jsx/jsx_source.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_source.rs
@@ -95,7 +95,7 @@ impl<'a> JsxSource<'a, '_> {
         ctx: &mut TraverseCtx<'a>,
     ) -> ObjectPropertyKind<'a> {
         let kind = PropertyKind::Init;
-        let key = ctx.ast.property_key_identifier_name(SPAN, SOURCE);
+        let key = ctx.ast.property_key_static_identifier(SPAN, SOURCE);
         let value = self.get_source_object(line, column, ctx);
         ctx.ast.object_property_kind_object_property(SPAN, kind, key, value, false, false, false)
     }
@@ -129,15 +129,15 @@ impl<'a> JsxSource<'a, '_> {
             }
         }
 
-        let key = ctx.ast.jsx_attribute_name_jsx_identifier(SPAN, SOURCE);
+        let key = ctx.ast.jsx_attribute_name_identifier(SPAN, SOURCE);
         // TODO: We shouldn't calculate line + column from scratch each time as it's expensive.
         // Build a table of byte indexes of each line's start on first usage, and save it.
         // Then calculate line and column from that.
         let (line, column) = self.get_line_column(elem.span.start);
         let object = self.get_source_object(line, column, ctx);
         let value =
-            ctx.ast.jsx_attribute_value_jsx_expression_container(SPAN, JSXExpression::from(object));
-        let attribute_item = ctx.ast.jsx_attribute_item_jsx_attribute(SPAN, key, Some(value));
+            ctx.ast.jsx_attribute_value_expression_container(SPAN, JSXExpression::from(object));
+        let attribute_item = ctx.ast.jsx_attribute_item_attribute(SPAN, key, Some(value));
         elem.attributes.push(attribute_item);
     }
 
@@ -151,14 +151,14 @@ impl<'a> JsxSource<'a, '_> {
         let kind = PropertyKind::Init;
 
         let filename = {
-            let key = ctx.ast.property_key_identifier_name(SPAN, "fileName");
+            let key = ctx.ast.property_key_static_identifier(SPAN, "fileName");
             let value = self.get_filename_var(ctx).create_read_expression(ctx);
             ctx.ast
                 .object_property_kind_object_property(SPAN, kind, key, value, false, false, false)
         };
 
         let line_number = {
-            let key = ctx.ast.property_key_identifier_name(SPAN, "lineNumber");
+            let key = ctx.ast.property_key_static_identifier(SPAN, "lineNumber");
             let value =
                 ctx.ast.expression_numeric_literal(SPAN, line as f64, None, NumberBase::Decimal);
             ctx.ast
@@ -166,7 +166,7 @@ impl<'a> JsxSource<'a, '_> {
         };
 
         let column_number = {
-            let key = ctx.ast.property_key_identifier_name(SPAN, "columnNumber");
+            let key = ctx.ast.property_key_static_identifier(SPAN, "columnNumber");
             let value =
                 ctx.ast.expression_numeric_literal(SPAN, column as f64, None, NumberBase::Decimal);
             ctx.ast

--- a/crates/oxc_transformer/src/plugins/inject_global_variables.rs
+++ b/crates/oxc_transformer/src/plugins/inject_global_variables.rs
@@ -255,7 +255,7 @@ impl<'a> InjectGlobalVariables<'a> {
                         self.ast.atom(dot_define.value.as_str())
                     });
 
-                    let value = self.ast.expression_identifier_reference(SPAN, value_atom);
+                    let value = self.ast.expression_identifier(SPAN, value_atom);
                     *expr = value;
                     break;
                 }

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -602,7 +602,7 @@ impl<'a> VisitMut<'a> for IdentifierReferenceRename<'a, '_> {
     fn visit_expression(&mut self, expr: &mut Expression<'a>) {
         match expr {
             Expression::Identifier(ident) if self.should_reference_enum_member(ident) => {
-                let object = self.ctx.ast.expression_identifier_reference(SPAN, self.enum_name);
+                let object = self.ctx.ast.expression_identifier(SPAN, self.enum_name);
                 let property = self.ctx.ast.identifier_name(SPAN, ident.name);
                 *expr = self.ctx.ast.member_expression_static(SPAN, object, property, false).into();
             }

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -410,7 +410,7 @@ fn generate_builder_method_for_enum_variant(
 
     let enum_ident = enum_def.ident();
     let enum_ty = enum_def.ty(schema);
-    let fn_name = enum_variant_builder_name(enum_def, variant, schema);
+    let fn_name = enum_variant_builder_name(enum_def, variant);
     let variant_ident = variant.ident();
     let inner_builder_name = struct_builder_name(&variant_type.snake_name(), is_boxed);
 
@@ -455,16 +455,10 @@ fn struct_builder_name(snake_name: &str, does_alloc: bool) -> Ident {
 }
 
 /// Get name of enum variant builder method.
-fn enum_variant_builder_name(enum_def: &EnumDef, variant: &VariantDef, schema: &Schema) -> Ident {
+fn enum_variant_builder_name(enum_def: &EnumDef, variant: &VariantDef) -> Ident {
     let enum_name = enum_def.snake_name();
 
-    // TODO: `let variant_name = variant.snake_name();` would be better
-    let mut variant_type = variant.field_type(schema).unwrap();
-    if let TypeDef::Box(box_def) = variant_type {
-        variant_type = box_def.inner_type(schema);
-    }
-    let variant_name = variant_type.snake_name();
-
+    let variant_name = variant.snake_name();
     let variant_name = if variant_name.len() > enum_name.len()
         && variant_name.ends_with(&enum_name)
         && variant_name.as_bytes()[variant_name.len() - enum_name.len() - 1] == b'_'

--- a/tasks/ast_tools/src/schema/defs/enum.rs
+++ b/tasks/ast_tools/src/schema/defs/enum.rs
@@ -183,6 +183,11 @@ impl VariantDef {
         &self.name
     }
 
+    /// Get variant name in snake case.
+    pub fn snake_name(&self) -> String {
+        self.name().to_case(Case::Snake)
+    }
+
     /// Get variant name in camel case.
     pub fn camel_name(&self) -> String {
         self.name().to_case(Case::Camel)


### PR DESCRIPTION
Correct what I think is a mistake in the naming of `AstBuilder` methods for enums. Name the builder methods after the enum *variant*, not the *type* of the variant. i.e. `AstBuilder::expression_identifier` not `AstBuilder::expression_identifier_reference`, following the variant's name:

https://github.com/oxc-project/oxc/blob/a302e321d5fb67b0619220b9af9bb179e31833d8/crates/oxc_ast/src/ast/js.rs#L71-L72

An enum can have 2 variants with the same type (`ExportDefaultDeclarationKind` does - `Function` and `Class` appear twice to represent function/class declarations and expressions), so naming conflicts are possible, and it's confusing.

Mostly this reduces the length of the methods (`jsx_child_jsx_text` -> `jsx_child_text`), but a small minority get longer (`export_default_declaration_kind_function` -> `export_default_declaration_kind_function_declaration`).
