### PR TITLE
refactor(ast): generate `Visit` methods in order of type definitions

### DIFF
--- a/crates/oxc_ast/src/generated/visit.rs
+++ b/crates/oxc_ast/src/generated/visit.rs
@@ -45,128 +45,8 @@ pub trait Visit<'a>: Sized {
     }
 
     #[inline]
-    fn visit_span(&mut self, it: &Span) {
-        walk_span(self, it);
-    }
-
-    #[inline]
-    fn visit_hashbang(&mut self, it: &Hashbang<'a>) {
-        walk_hashbang(self, it);
-    }
-
-    #[inline]
-    fn visit_directives(&mut self, it: &Vec<'a, Directive<'a>>) {
-        walk_directives(self, it);
-    }
-
-    #[inline]
-    fn visit_directive(&mut self, it: &Directive<'a>) {
-        walk_directive(self, it);
-    }
-
-    #[inline]
-    fn visit_string_literal(&mut self, it: &StringLiteral<'a>) {
-        walk_string_literal(self, it);
-    }
-
-    #[inline]
-    fn visit_statements(&mut self, it: &Vec<'a, Statement<'a>>) {
-        walk_statements(self, it);
-    }
-
-    #[inline]
-    fn visit_statement(&mut self, it: &Statement<'a>) {
-        walk_statement(self, it);
-    }
-
-    #[inline]
-    fn visit_block_statement(&mut self, it: &BlockStatement<'a>) {
-        walk_block_statement(self, it);
-    }
-
-    #[inline]
-    fn visit_break_statement(&mut self, it: &BreakStatement<'a>) {
-        walk_break_statement(self, it);
-    }
-
-    #[inline]
-    fn visit_label_identifier(&mut self, it: &LabelIdentifier<'a>) {
-        walk_label_identifier(self, it);
-    }
-
-    #[inline]
-    fn visit_continue_statement(&mut self, it: &ContinueStatement<'a>) {
-        walk_continue_statement(self, it);
-    }
-
-    #[inline]
-    fn visit_debugger_statement(&mut self, it: &DebuggerStatement) {
-        walk_debugger_statement(self, it);
-    }
-
-    #[inline]
-    fn visit_do_while_statement(&mut self, it: &DoWhileStatement<'a>) {
-        walk_do_while_statement(self, it);
-    }
-
-    #[inline]
     fn visit_expression(&mut self, it: &Expression<'a>) {
         walk_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_boolean_literal(&mut self, it: &BooleanLiteral) {
-        walk_boolean_literal(self, it);
-    }
-
-    #[inline]
-    fn visit_null_literal(&mut self, it: &NullLiteral) {
-        walk_null_literal(self, it);
-    }
-
-    #[inline]
-    fn visit_numeric_literal(&mut self, it: &NumericLiteral<'a>) {
-        walk_numeric_literal(self, it);
-    }
-
-    #[inline]
-    fn visit_big_int_literal(&mut self, it: &BigIntLiteral<'a>) {
-        walk_big_int_literal(self, it);
-    }
-
-    #[inline]
-    fn visit_reg_exp_literal(&mut self, it: &RegExpLiteral<'a>) {
-        walk_reg_exp_literal(self, it);
-    }
-
-    #[inline]
-    fn visit_template_literal(&mut self, it: &TemplateLiteral<'a>) {
-        walk_template_literal(self, it);
-    }
-
-    #[inline]
-    fn visit_template_elements(&mut self, it: &Vec<'a, TemplateElement<'a>>) {
-        walk_template_elements(self, it);
-    }
-
-    #[inline]
-    fn visit_template_element(&mut self, it: &TemplateElement<'a>) {
-        walk_template_element(self, it);
-    }
-
-    #[inline]
-    fn visit_expressions(&mut self, it: &Vec<'a, Expression<'a>>) {
-        walk_expressions(self, it);
-    }
-
-    #[inline]
-    fn visit_identifier_reference(&mut self, it: &IdentifierReference<'a>) {
-        walk_identifier_reference(self, it);
-    }
-
-    #[inline]
-    fn visit_meta_property(&mut self, it: &MetaProperty<'a>) {
-        walk_meta_property(self, it);
     }
 
     #[inline]
@@ -175,53 +55,8 @@ pub trait Visit<'a>: Sized {
     }
 
     #[inline]
-    fn visit_super(&mut self, it: &Super) {
-        walk_super(self, it);
-    }
-
-    #[inline]
-    fn visit_array_expression(&mut self, it: &ArrayExpression<'a>) {
-        walk_array_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_array_expression_elements(&mut self, it: &Vec<'a, ArrayExpressionElement<'a>>) {
-        walk_array_expression_elements(self, it);
-    }
-
-    #[inline]
-    fn visit_array_expression_element(&mut self, it: &ArrayExpressionElement<'a>) {
-        walk_array_expression_element(self, it);
-    }
-
-    #[inline]
-    fn visit_spread_element(&mut self, it: &SpreadElement<'a>) {
-        walk_spread_element(self, it);
-    }
-
-    #[inline]
-    fn visit_elision(&mut self, it: &Elision) {
-        walk_elision(self, it);
-    }
-
-    #[inline]
-    fn visit_arrow_function_expression(&mut self, it: &ArrowFunctionExpression<'a>) {
-        walk_arrow_function_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_parameter_declaration(&mut self, it: &TSTypeParameterDeclaration<'a>) {
-        walk_ts_type_parameter_declaration(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_parameters(&mut self, it: &Vec<'a, TSTypeParameter<'a>>) {
-        walk_ts_type_parameters(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_parameter(&mut self, it: &TSTypeParameter<'a>) {
-        walk_ts_type_parameter(self, it);
+    fn visit_identifier_reference(&mut self, it: &IdentifierReference<'a>) {
+        walk_identifier_reference(self, it);
     }
 
     #[inline]
@@ -230,138 +65,43 @@ pub trait Visit<'a>: Sized {
     }
 
     #[inline]
-    fn visit_ts_type(&mut self, it: &TSType<'a>) {
-        walk_ts_type(self, it);
+    fn visit_label_identifier(&mut self, it: &LabelIdentifier<'a>) {
+        walk_label_identifier(self, it);
     }
 
     #[inline]
-    fn visit_ts_any_keyword(&mut self, it: &TSAnyKeyword) {
-        walk_ts_any_keyword(self, it);
+    fn visit_this_expression(&mut self, it: &ThisExpression) {
+        walk_this_expression(self, it);
     }
 
     #[inline]
-    fn visit_ts_big_int_keyword(&mut self, it: &TSBigIntKeyword) {
-        walk_ts_big_int_keyword(self, it);
+    fn visit_array_expression(&mut self, it: &ArrayExpression<'a>) {
+        walk_array_expression(self, it);
     }
 
     #[inline]
-    fn visit_ts_boolean_keyword(&mut self, it: &TSBooleanKeyword) {
-        walk_ts_boolean_keyword(self, it);
+    fn visit_array_expression_element(&mut self, it: &ArrayExpressionElement<'a>) {
+        walk_array_expression_element(self, it);
     }
 
     #[inline]
-    fn visit_ts_intrinsic_keyword(&mut self, it: &TSIntrinsicKeyword) {
-        walk_ts_intrinsic_keyword(self, it);
+    fn visit_elision(&mut self, it: &Elision) {
+        walk_elision(self, it);
     }
 
     #[inline]
-    fn visit_ts_never_keyword(&mut self, it: &TSNeverKeyword) {
-        walk_ts_never_keyword(self, it);
+    fn visit_object_expression(&mut self, it: &ObjectExpression<'a>) {
+        walk_object_expression(self, it);
     }
 
     #[inline]
-    fn visit_ts_null_keyword(&mut self, it: &TSNullKeyword) {
-        walk_ts_null_keyword(self, it);
+    fn visit_object_property_kind(&mut self, it: &ObjectPropertyKind<'a>) {
+        walk_object_property_kind(self, it);
     }
 
     #[inline]
-    fn visit_ts_number_keyword(&mut self, it: &TSNumberKeyword) {
-        walk_ts_number_keyword(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_object_keyword(&mut self, it: &TSObjectKeyword) {
-        walk_ts_object_keyword(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_string_keyword(&mut self, it: &TSStringKeyword) {
-        walk_ts_string_keyword(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_symbol_keyword(&mut self, it: &TSSymbolKeyword) {
-        walk_ts_symbol_keyword(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_undefined_keyword(&mut self, it: &TSUndefinedKeyword) {
-        walk_ts_undefined_keyword(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_unknown_keyword(&mut self, it: &TSUnknownKeyword) {
-        walk_ts_unknown_keyword(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_void_keyword(&mut self, it: &TSVoidKeyword) {
-        walk_ts_void_keyword(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_array_type(&mut self, it: &TSArrayType<'a>) {
-        walk_ts_array_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_conditional_type(&mut self, it: &TSConditionalType<'a>) {
-        walk_ts_conditional_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_constructor_type(&mut self, it: &TSConstructorType<'a>) {
-        walk_ts_constructor_type(self, it);
-    }
-
-    #[inline]
-    fn visit_formal_parameters(&mut self, it: &FormalParameters<'a>) {
-        walk_formal_parameters(self, it);
-    }
-
-    #[inline]
-    fn visit_formal_parameter_list(&mut self, it: &Vec<'a, FormalParameter<'a>>) {
-        walk_formal_parameter_list(self, it);
-    }
-
-    #[inline]
-    fn visit_formal_parameter(&mut self, it: &FormalParameter<'a>) {
-        walk_formal_parameter(self, it);
-    }
-
-    #[inline]
-    fn visit_decorators(&mut self, it: &Vec<'a, Decorator<'a>>) {
-        walk_decorators(self, it);
-    }
-
-    #[inline]
-    fn visit_decorator(&mut self, it: &Decorator<'a>) {
-        walk_decorator(self, it);
-    }
-
-    #[inline]
-    fn visit_binding_pattern(&mut self, it: &BindingPattern<'a>) {
-        walk_binding_pattern(self, it);
-    }
-
-    #[inline]
-    fn visit_binding_pattern_kind(&mut self, it: &BindingPatternKind<'a>) {
-        walk_binding_pattern_kind(self, it);
-    }
-
-    #[inline]
-    fn visit_object_pattern(&mut self, it: &ObjectPattern<'a>) {
-        walk_object_pattern(self, it);
-    }
-
-    #[inline]
-    fn visit_binding_properties(&mut self, it: &Vec<'a, BindingProperty<'a>>) {
-        walk_binding_properties(self, it);
-    }
-
-    #[inline]
-    fn visit_binding_property(&mut self, it: &BindingProperty<'a>) {
-        walk_binding_property(self, it);
+    fn visit_object_property(&mut self, it: &ObjectProperty<'a>) {
+        walk_object_property(self, it);
     }
 
     #[inline]
@@ -370,311 +110,18 @@ pub trait Visit<'a>: Sized {
     }
 
     #[inline]
-    fn visit_private_identifier(&mut self, it: &PrivateIdentifier<'a>) {
-        walk_private_identifier(self, it);
+    fn visit_template_literal(&mut self, it: &TemplateLiteral<'a>) {
+        walk_template_literal(self, it);
     }
 
     #[inline]
-    fn visit_binding_rest_element(&mut self, it: &BindingRestElement<'a>) {
-        walk_binding_rest_element(self, it);
+    fn visit_tagged_template_expression(&mut self, it: &TaggedTemplateExpression<'a>) {
+        walk_tagged_template_expression(self, it);
     }
 
     #[inline]
-    fn visit_array_pattern(&mut self, it: &ArrayPattern<'a>) {
-        walk_array_pattern(self, it);
-    }
-
-    #[inline]
-    fn visit_assignment_pattern(&mut self, it: &AssignmentPattern<'a>) {
-        walk_assignment_pattern(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_annotation(&mut self, it: &TSTypeAnnotation<'a>) {
-        walk_ts_type_annotation(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_function_type(&mut self, it: &TSFunctionType<'a>) {
-        walk_ts_function_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_this_parameter(&mut self, it: &TSThisParameter<'a>) {
-        walk_ts_this_parameter(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_import_type(&mut self, it: &TSImportType<'a>) {
-        walk_ts_import_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_name(&mut self, it: &TSTypeName<'a>) {
-        walk_ts_type_name(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_qualified_name(&mut self, it: &TSQualifiedName<'a>) {
-        walk_ts_qualified_name(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_import_attributes(&mut self, it: &TSImportAttributes<'a>) {
-        walk_ts_import_attributes(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_import_attribute_list(&mut self, it: &Vec<'a, TSImportAttribute<'a>>) {
-        walk_ts_import_attribute_list(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_import_attribute(&mut self, it: &TSImportAttribute<'a>) {
-        walk_ts_import_attribute(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_import_attribute_name(&mut self, it: &TSImportAttributeName<'a>) {
-        walk_ts_import_attribute_name(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_parameter_instantiation(&mut self, it: &TSTypeParameterInstantiation<'a>) {
-        walk_ts_type_parameter_instantiation(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_types(&mut self, it: &Vec<'a, TSType<'a>>) {
-        walk_ts_types(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_indexed_access_type(&mut self, it: &TSIndexedAccessType<'a>) {
-        walk_ts_indexed_access_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_infer_type(&mut self, it: &TSInferType<'a>) {
-        walk_ts_infer_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_intersection_type(&mut self, it: &TSIntersectionType<'a>) {
-        walk_ts_intersection_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_literal_type(&mut self, it: &TSLiteralType<'a>) {
-        walk_ts_literal_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_literal(&mut self, it: &TSLiteral<'a>) {
-        walk_ts_literal(self, it);
-    }
-
-    #[inline]
-    fn visit_unary_expression(&mut self, it: &UnaryExpression<'a>) {
-        walk_unary_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_mapped_type(&mut self, it: &TSMappedType<'a>) {
-        walk_ts_mapped_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_named_tuple_member(&mut self, it: &TSNamedTupleMember<'a>) {
-        walk_ts_named_tuple_member(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_tuple_element(&mut self, it: &TSTupleElement<'a>) {
-        walk_ts_tuple_element(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_optional_type(&mut self, it: &TSOptionalType<'a>) {
-        walk_ts_optional_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_rest_type(&mut self, it: &TSRestType<'a>) {
-        walk_ts_rest_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_template_literal_type(&mut self, it: &TSTemplateLiteralType<'a>) {
-        walk_ts_template_literal_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_this_type(&mut self, it: &TSThisType) {
-        walk_ts_this_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_tuple_type(&mut self, it: &TSTupleType<'a>) {
-        walk_ts_tuple_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_tuple_elements(&mut self, it: &Vec<'a, TSTupleElement<'a>>) {
-        walk_ts_tuple_elements(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_literal(&mut self, it: &TSTypeLiteral<'a>) {
-        walk_ts_type_literal(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_signatures(&mut self, it: &Vec<'a, TSSignature<'a>>) {
-        walk_ts_signatures(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_signature(&mut self, it: &TSSignature<'a>) {
-        walk_ts_signature(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_index_signature(&mut self, it: &TSIndexSignature<'a>) {
-        walk_ts_index_signature(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_index_signature_names(&mut self, it: &Vec<'a, TSIndexSignatureName<'a>>) {
-        walk_ts_index_signature_names(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_index_signature_name(&mut self, it: &TSIndexSignatureName<'a>) {
-        walk_ts_index_signature_name(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_property_signature(&mut self, it: &TSPropertySignature<'a>) {
-        walk_ts_property_signature(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_call_signature_declaration(&mut self, it: &TSCallSignatureDeclaration<'a>) {
-        walk_ts_call_signature_declaration(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_construct_signature_declaration(
-        &mut self,
-        it: &TSConstructSignatureDeclaration<'a>,
-    ) {
-        walk_ts_construct_signature_declaration(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_method_signature(&mut self, it: &TSMethodSignature<'a>) {
-        walk_ts_method_signature(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_operator(&mut self, it: &TSTypeOperator<'a>) {
-        walk_ts_type_operator(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_predicate(&mut self, it: &TSTypePredicate<'a>) {
-        walk_ts_type_predicate(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_predicate_name(&mut self, it: &TSTypePredicateName<'a>) {
-        walk_ts_type_predicate_name(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_query(&mut self, it: &TSTypeQuery<'a>) {
-        walk_ts_type_query(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_query_expr_name(&mut self, it: &TSTypeQueryExprName<'a>) {
-        walk_ts_type_query_expr_name(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_reference(&mut self, it: &TSTypeReference<'a>) {
-        walk_ts_type_reference(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_union_type(&mut self, it: &TSUnionType<'a>) {
-        walk_ts_union_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_parenthesized_type(&mut self, it: &TSParenthesizedType<'a>) {
-        walk_ts_parenthesized_type(self, it);
-    }
-
-    #[inline]
-    fn visit_js_doc_nullable_type(&mut self, it: &JSDocNullableType<'a>) {
-        walk_js_doc_nullable_type(self, it);
-    }
-
-    #[inline]
-    fn visit_js_doc_non_nullable_type(&mut self, it: &JSDocNonNullableType<'a>) {
-        walk_js_doc_non_nullable_type(self, it);
-    }
-
-    #[inline]
-    fn visit_js_doc_unknown_type(&mut self, it: &JSDocUnknownType) {
-        walk_js_doc_unknown_type(self, it);
-    }
-
-    #[inline]
-    fn visit_function_body(&mut self, it: &FunctionBody<'a>) {
-        walk_function_body(self, it);
-    }
-
-    #[inline]
-    fn visit_assignment_expression(&mut self, it: &AssignmentExpression<'a>) {
-        walk_assignment_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_assignment_target(&mut self, it: &AssignmentTarget<'a>) {
-        walk_assignment_target(self, it);
-    }
-
-    #[inline]
-    fn visit_simple_assignment_target(&mut self, it: &SimpleAssignmentTarget<'a>) {
-        walk_simple_assignment_target(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_as_expression(&mut self, it: &TSAsExpression<'a>) {
-        walk_ts_as_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_satisfies_expression(&mut self, it: &TSSatisfiesExpression<'a>) {
-        walk_ts_satisfies_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_non_null_expression(&mut self, it: &TSNonNullExpression<'a>) {
-        walk_ts_non_null_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_assertion(&mut self, it: &TSTypeAssertion<'a>) {
-        walk_ts_type_assertion(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_instantiation_expression(&mut self, it: &TSInstantiationExpression<'a>) {
-        walk_ts_instantiation_expression(self, it);
+    fn visit_template_element(&mut self, it: &TemplateElement<'a>) {
+        walk_template_element(self, it);
     }
 
     #[inline]
@@ -698,6 +145,76 @@ pub trait Visit<'a>: Sized {
     }
 
     #[inline]
+    fn visit_call_expression(&mut self, it: &CallExpression<'a>) {
+        walk_call_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_new_expression(&mut self, it: &NewExpression<'a>) {
+        walk_new_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_meta_property(&mut self, it: &MetaProperty<'a>) {
+        walk_meta_property(self, it);
+    }
+
+    #[inline]
+    fn visit_spread_element(&mut self, it: &SpreadElement<'a>) {
+        walk_spread_element(self, it);
+    }
+
+    #[inline]
+    fn visit_argument(&mut self, it: &Argument<'a>) {
+        walk_argument(self, it);
+    }
+
+    #[inline]
+    fn visit_update_expression(&mut self, it: &UpdateExpression<'a>) {
+        walk_update_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_unary_expression(&mut self, it: &UnaryExpression<'a>) {
+        walk_unary_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_binary_expression(&mut self, it: &BinaryExpression<'a>) {
+        walk_binary_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_private_in_expression(&mut self, it: &PrivateInExpression<'a>) {
+        walk_private_in_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_logical_expression(&mut self, it: &LogicalExpression<'a>) {
+        walk_logical_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_conditional_expression(&mut self, it: &ConditionalExpression<'a>) {
+        walk_conditional_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_assignment_expression(&mut self, it: &AssignmentExpression<'a>) {
+        walk_assignment_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_assignment_target(&mut self, it: &AssignmentTarget<'a>) {
+        walk_assignment_target(self, it);
+    }
+
+    #[inline]
+    fn visit_simple_assignment_target(&mut self, it: &SimpleAssignmentTarget<'a>) {
+        walk_simple_assignment_target(self, it);
+    }
+
+    #[inline]
     fn visit_assignment_target_pattern(&mut self, it: &AssignmentTargetPattern<'a>) {
         walk_assignment_target_pattern(self, it);
     }
@@ -708,13 +225,8 @@ pub trait Visit<'a>: Sized {
     }
 
     #[inline]
-    fn visit_assignment_target_maybe_default(&mut self, it: &AssignmentTargetMaybeDefault<'a>) {
-        walk_assignment_target_maybe_default(self, it);
-    }
-
-    #[inline]
-    fn visit_assignment_target_with_default(&mut self, it: &AssignmentTargetWithDefault<'a>) {
-        walk_assignment_target_with_default(self, it);
+    fn visit_object_assignment_target(&mut self, it: &ObjectAssignmentTarget<'a>) {
+        walk_object_assignment_target(self, it);
     }
 
     #[inline]
@@ -723,13 +235,13 @@ pub trait Visit<'a>: Sized {
     }
 
     #[inline]
-    fn visit_object_assignment_target(&mut self, it: &ObjectAssignmentTarget<'a>) {
-        walk_object_assignment_target(self, it);
+    fn visit_assignment_target_maybe_default(&mut self, it: &AssignmentTargetMaybeDefault<'a>) {
+        walk_assignment_target_maybe_default(self, it);
     }
 
     #[inline]
-    fn visit_assignment_target_properties(&mut self, it: &Vec<'a, AssignmentTargetProperty<'a>>) {
-        walk_assignment_target_properties(self, it);
+    fn visit_assignment_target_with_default(&mut self, it: &AssignmentTargetWithDefault<'a>) {
+        walk_assignment_target_with_default(self, it);
     }
 
     #[inline]
@@ -754,28 +266,18 @@ pub trait Visit<'a>: Sized {
     }
 
     #[inline]
+    fn visit_sequence_expression(&mut self, it: &SequenceExpression<'a>) {
+        walk_sequence_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_super(&mut self, it: &Super) {
+        walk_super(self, it);
+    }
+
+    #[inline]
     fn visit_await_expression(&mut self, it: &AwaitExpression<'a>) {
         walk_await_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_binary_expression(&mut self, it: &BinaryExpression<'a>) {
-        walk_binary_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_call_expression(&mut self, it: &CallExpression<'a>) {
-        walk_call_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_arguments(&mut self, it: &Vec<'a, Argument<'a>>) {
-        walk_arguments(self, it);
-    }
-
-    #[inline]
-    fn visit_argument(&mut self, it: &Argument<'a>) {
-        walk_argument(self, it);
     }
 
     #[inline]
@@ -789,243 +291,43 @@ pub trait Visit<'a>: Sized {
     }
 
     #[inline]
-    fn visit_class(&mut self, it: &Class<'a>) {
-        walk_class(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_class_implementses(&mut self, it: &Vec<'a, TSClassImplements<'a>>) {
-        walk_ts_class_implementses(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_class_implements(&mut self, it: &TSClassImplements<'a>) {
-        walk_ts_class_implements(self, it);
-    }
-
-    #[inline]
-    fn visit_class_body(&mut self, it: &ClassBody<'a>) {
-        walk_class_body(self, it);
-    }
-
-    #[inline]
-    fn visit_class_elements(&mut self, it: &Vec<'a, ClassElement<'a>>) {
-        walk_class_elements(self, it);
-    }
-
-    #[inline]
-    fn visit_class_element(&mut self, it: &ClassElement<'a>) {
-        walk_class_element(self, it);
-    }
-
-    #[inline]
-    fn visit_static_block(&mut self, it: &StaticBlock<'a>) {
-        walk_static_block(self, it);
-    }
-
-    #[inline]
-    fn visit_method_definition(&mut self, it: &MethodDefinition<'a>) {
-        walk_method_definition(self, it);
-    }
-
-    #[inline]
-    fn visit_function(&mut self, it: &Function<'a>, flags: ScopeFlags) {
-        walk_function(self, it, flags);
-    }
-
-    #[inline]
-    fn visit_property_definition(&mut self, it: &PropertyDefinition<'a>) {
-        walk_property_definition(self, it);
-    }
-
-    #[inline]
-    fn visit_accessor_property(&mut self, it: &AccessorProperty<'a>) {
-        walk_accessor_property(self, it);
-    }
-
-    #[inline]
-    fn visit_conditional_expression(&mut self, it: &ConditionalExpression<'a>) {
-        walk_conditional_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_import_expression(&mut self, it: &ImportExpression<'a>) {
-        walk_import_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_logical_expression(&mut self, it: &LogicalExpression<'a>) {
-        walk_logical_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_new_expression(&mut self, it: &NewExpression<'a>) {
-        walk_new_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_object_expression(&mut self, it: &ObjectExpression<'a>) {
-        walk_object_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_object_property_kinds(&mut self, it: &Vec<'a, ObjectPropertyKind<'a>>) {
-        walk_object_property_kinds(self, it);
-    }
-
-    #[inline]
-    fn visit_object_property_kind(&mut self, it: &ObjectPropertyKind<'a>) {
-        walk_object_property_kind(self, it);
-    }
-
-    #[inline]
-    fn visit_object_property(&mut self, it: &ObjectProperty<'a>) {
-        walk_object_property(self, it);
-    }
-
-    #[inline]
     fn visit_parenthesized_expression(&mut self, it: &ParenthesizedExpression<'a>) {
         walk_parenthesized_expression(self, it);
     }
 
     #[inline]
-    fn visit_sequence_expression(&mut self, it: &SequenceExpression<'a>) {
-        walk_sequence_expression(self, it);
+    fn visit_statement(&mut self, it: &Statement<'a>) {
+        walk_statement(self, it);
     }
 
     #[inline]
-    fn visit_tagged_template_expression(&mut self, it: &TaggedTemplateExpression<'a>) {
-        walk_tagged_template_expression(self, it);
+    fn visit_directive(&mut self, it: &Directive<'a>) {
+        walk_directive(self, it);
     }
 
     #[inline]
-    fn visit_this_expression(&mut self, it: &ThisExpression) {
-        walk_this_expression(self, it);
+    fn visit_hashbang(&mut self, it: &Hashbang<'a>) {
+        walk_hashbang(self, it);
     }
 
     #[inline]
-    fn visit_update_expression(&mut self, it: &UpdateExpression<'a>) {
-        walk_update_expression(self, it);
+    fn visit_block_statement(&mut self, it: &BlockStatement<'a>) {
+        walk_block_statement(self, it);
     }
 
     #[inline]
-    fn visit_yield_expression(&mut self, it: &YieldExpression<'a>) {
-        walk_yield_expression(self, it);
+    fn visit_declaration(&mut self, it: &Declaration<'a>) {
+        walk_declaration(self, it);
     }
 
     #[inline]
-    fn visit_private_in_expression(&mut self, it: &PrivateInExpression<'a>) {
-        walk_private_in_expression(self, it);
+    fn visit_variable_declaration(&mut self, it: &VariableDeclaration<'a>) {
+        walk_variable_declaration(self, it);
     }
 
     #[inline]
-    fn visit_jsx_element(&mut self, it: &JSXElement<'a>) {
-        walk_jsx_element(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_opening_element(&mut self, it: &JSXOpeningElement<'a>) {
-        walk_jsx_opening_element(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_element_name(&mut self, it: &JSXElementName<'a>) {
-        walk_jsx_element_name(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_identifier(&mut self, it: &JSXIdentifier<'a>) {
-        walk_jsx_identifier(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_namespaced_name(&mut self, it: &JSXNamespacedName<'a>) {
-        walk_jsx_namespaced_name(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_member_expression(&mut self, it: &JSXMemberExpression<'a>) {
-        walk_jsx_member_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_member_expression_object(&mut self, it: &JSXMemberExpressionObject<'a>) {
-        walk_jsx_member_expression_object(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_attribute_items(&mut self, it: &Vec<'a, JSXAttributeItem<'a>>) {
-        walk_jsx_attribute_items(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_attribute_item(&mut self, it: &JSXAttributeItem<'a>) {
-        walk_jsx_attribute_item(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_attribute(&mut self, it: &JSXAttribute<'a>) {
-        walk_jsx_attribute(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_attribute_name(&mut self, it: &JSXAttributeName<'a>) {
-        walk_jsx_attribute_name(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_attribute_value(&mut self, it: &JSXAttributeValue<'a>) {
-        walk_jsx_attribute_value(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_expression_container(&mut self, it: &JSXExpressionContainer<'a>) {
-        walk_jsx_expression_container(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_expression(&mut self, it: &JSXExpression<'a>) {
-        walk_jsx_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_empty_expression(&mut self, it: &JSXEmptyExpression) {
-        walk_jsx_empty_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_fragment(&mut self, it: &JSXFragment<'a>) {
-        walk_jsx_fragment(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_children(&mut self, it: &Vec<'a, JSXChild<'a>>) {
-        walk_jsx_children(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_child(&mut self, it: &JSXChild<'a>) {
-        walk_jsx_child(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_text(&mut self, it: &JSXText<'a>) {
-        walk_jsx_text(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_spread_child(&mut self, it: &JSXSpreadChild<'a>) {
-        walk_jsx_spread_child(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_spread_attribute(&mut self, it: &JSXSpreadAttribute<'a>) {
-        walk_jsx_spread_attribute(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_closing_element(&mut self, it: &JSXClosingElement<'a>) {
-        walk_jsx_closing_element(self, it);
+    fn visit_variable_declarator(&mut self, it: &VariableDeclarator<'a>) {
+        walk_variable_declarator(self, it);
     }
 
     #[inline]
@@ -1039,33 +341,18 @@ pub trait Visit<'a>: Sized {
     }
 
     #[inline]
-    fn visit_for_in_statement(&mut self, it: &ForInStatement<'a>) {
-        walk_for_in_statement(self, it);
+    fn visit_if_statement(&mut self, it: &IfStatement<'a>) {
+        walk_if_statement(self, it);
     }
 
     #[inline]
-    fn visit_for_statement_left(&mut self, it: &ForStatementLeft<'a>) {
-        walk_for_statement_left(self, it);
+    fn visit_do_while_statement(&mut self, it: &DoWhileStatement<'a>) {
+        walk_do_while_statement(self, it);
     }
 
     #[inline]
-    fn visit_variable_declaration(&mut self, it: &VariableDeclaration<'a>) {
-        walk_variable_declaration(self, it);
-    }
-
-    #[inline]
-    fn visit_variable_declarators(&mut self, it: &Vec<'a, VariableDeclarator<'a>>) {
-        walk_variable_declarators(self, it);
-    }
-
-    #[inline]
-    fn visit_variable_declarator(&mut self, it: &VariableDeclarator<'a>) {
-        walk_variable_declarator(self, it);
-    }
-
-    #[inline]
-    fn visit_for_of_statement(&mut self, it: &ForOfStatement<'a>) {
-        walk_for_of_statement(self, it);
+    fn visit_while_statement(&mut self, it: &WhileStatement<'a>) {
+        walk_while_statement(self, it);
     }
 
     #[inline]
@@ -1079,13 +366,28 @@ pub trait Visit<'a>: Sized {
     }
 
     #[inline]
-    fn visit_if_statement(&mut self, it: &IfStatement<'a>) {
-        walk_if_statement(self, it);
+    fn visit_for_in_statement(&mut self, it: &ForInStatement<'a>) {
+        walk_for_in_statement(self, it);
     }
 
     #[inline]
-    fn visit_labeled_statement(&mut self, it: &LabeledStatement<'a>) {
-        walk_labeled_statement(self, it);
+    fn visit_for_statement_left(&mut self, it: &ForStatementLeft<'a>) {
+        walk_for_statement_left(self, it);
+    }
+
+    #[inline]
+    fn visit_for_of_statement(&mut self, it: &ForOfStatement<'a>) {
+        walk_for_of_statement(self, it);
+    }
+
+    #[inline]
+    fn visit_continue_statement(&mut self, it: &ContinueStatement<'a>) {
+        walk_continue_statement(self, it);
+    }
+
+    #[inline]
+    fn visit_break_statement(&mut self, it: &BreakStatement<'a>) {
+        walk_break_statement(self, it);
     }
 
     #[inline]
@@ -1094,18 +396,23 @@ pub trait Visit<'a>: Sized {
     }
 
     #[inline]
+    fn visit_with_statement(&mut self, it: &WithStatement<'a>) {
+        walk_with_statement(self, it);
+    }
+
+    #[inline]
     fn visit_switch_statement(&mut self, it: &SwitchStatement<'a>) {
         walk_switch_statement(self, it);
     }
 
     #[inline]
-    fn visit_switch_cases(&mut self, it: &Vec<'a, SwitchCase<'a>>) {
-        walk_switch_cases(self, it);
+    fn visit_switch_case(&mut self, it: &SwitchCase<'a>) {
+        walk_switch_case(self, it);
     }
 
     #[inline]
-    fn visit_switch_case(&mut self, it: &SwitchCase<'a>) {
-        walk_switch_case(self, it);
+    fn visit_labeled_statement(&mut self, it: &LabeledStatement<'a>) {
+        walk_labeled_statement(self, it);
     }
 
     #[inline]
@@ -1129,53 +436,333 @@ pub trait Visit<'a>: Sized {
     }
 
     #[inline]
-    fn visit_while_statement(&mut self, it: &WhileStatement<'a>) {
-        walk_while_statement(self, it);
+    fn visit_debugger_statement(&mut self, it: &DebuggerStatement) {
+        walk_debugger_statement(self, it);
     }
 
     #[inline]
-    fn visit_with_statement(&mut self, it: &WithStatement<'a>) {
-        walk_with_statement(self, it);
+    fn visit_binding_pattern(&mut self, it: &BindingPattern<'a>) {
+        walk_binding_pattern(self, it);
     }
 
     #[inline]
-    fn visit_declaration(&mut self, it: &Declaration<'a>) {
-        walk_declaration(self, it);
+    fn visit_binding_pattern_kind(&mut self, it: &BindingPatternKind<'a>) {
+        walk_binding_pattern_kind(self, it);
     }
 
     #[inline]
-    fn visit_ts_type_alias_declaration(&mut self, it: &TSTypeAliasDeclaration<'a>) {
-        walk_ts_type_alias_declaration(self, it);
+    fn visit_assignment_pattern(&mut self, it: &AssignmentPattern<'a>) {
+        walk_assignment_pattern(self, it);
     }
 
     #[inline]
-    fn visit_ts_interface_declaration(&mut self, it: &TSInterfaceDeclaration<'a>) {
-        walk_ts_interface_declaration(self, it);
+    fn visit_object_pattern(&mut self, it: &ObjectPattern<'a>) {
+        walk_object_pattern(self, it);
     }
 
     #[inline]
-    fn visit_ts_interface_heritages(&mut self, it: &Vec<'a, TSInterfaceHeritage<'a>>) {
-        walk_ts_interface_heritages(self, it);
+    fn visit_binding_property(&mut self, it: &BindingProperty<'a>) {
+        walk_binding_property(self, it);
     }
 
     #[inline]
-    fn visit_ts_interface_heritage(&mut self, it: &TSInterfaceHeritage<'a>) {
-        walk_ts_interface_heritage(self, it);
+    fn visit_array_pattern(&mut self, it: &ArrayPattern<'a>) {
+        walk_array_pattern(self, it);
     }
 
     #[inline]
-    fn visit_ts_interface_body(&mut self, it: &TSInterfaceBody<'a>) {
-        walk_ts_interface_body(self, it);
+    fn visit_binding_rest_element(&mut self, it: &BindingRestElement<'a>) {
+        walk_binding_rest_element(self, it);
+    }
+
+    #[inline]
+    fn visit_function(&mut self, it: &Function<'a>, flags: ScopeFlags) {
+        walk_function(self, it, flags);
+    }
+
+    #[inline]
+    fn visit_formal_parameters(&mut self, it: &FormalParameters<'a>) {
+        walk_formal_parameters(self, it);
+    }
+
+    #[inline]
+    fn visit_formal_parameter(&mut self, it: &FormalParameter<'a>) {
+        walk_formal_parameter(self, it);
+    }
+
+    #[inline]
+    fn visit_function_body(&mut self, it: &FunctionBody<'a>) {
+        walk_function_body(self, it);
+    }
+
+    #[inline]
+    fn visit_arrow_function_expression(&mut self, it: &ArrowFunctionExpression<'a>) {
+        walk_arrow_function_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_yield_expression(&mut self, it: &YieldExpression<'a>) {
+        walk_yield_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_class(&mut self, it: &Class<'a>) {
+        walk_class(self, it);
+    }
+
+    #[inline]
+    fn visit_class_body(&mut self, it: &ClassBody<'a>) {
+        walk_class_body(self, it);
+    }
+
+    #[inline]
+    fn visit_class_element(&mut self, it: &ClassElement<'a>) {
+        walk_class_element(self, it);
+    }
+
+    #[inline]
+    fn visit_method_definition(&mut self, it: &MethodDefinition<'a>) {
+        walk_method_definition(self, it);
+    }
+
+    #[inline]
+    fn visit_property_definition(&mut self, it: &PropertyDefinition<'a>) {
+        walk_property_definition(self, it);
+    }
+
+    #[inline]
+    fn visit_private_identifier(&mut self, it: &PrivateIdentifier<'a>) {
+        walk_private_identifier(self, it);
+    }
+
+    #[inline]
+    fn visit_static_block(&mut self, it: &StaticBlock<'a>) {
+        walk_static_block(self, it);
+    }
+
+    #[inline]
+    fn visit_module_declaration(&mut self, it: &ModuleDeclaration<'a>) {
+        walk_module_declaration(self, it);
+    }
+
+    #[inline]
+    fn visit_accessor_property(&mut self, it: &AccessorProperty<'a>) {
+        walk_accessor_property(self, it);
+    }
+
+    #[inline]
+    fn visit_import_expression(&mut self, it: &ImportExpression<'a>) {
+        walk_import_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_import_declaration(&mut self, it: &ImportDeclaration<'a>) {
+        walk_import_declaration(self, it);
+    }
+
+    #[inline]
+    fn visit_import_declaration_specifier(&mut self, it: &ImportDeclarationSpecifier<'a>) {
+        walk_import_declaration_specifier(self, it);
+    }
+
+    #[inline]
+    fn visit_import_specifier(&mut self, it: &ImportSpecifier<'a>) {
+        walk_import_specifier(self, it);
+    }
+
+    #[inline]
+    fn visit_import_default_specifier(&mut self, it: &ImportDefaultSpecifier<'a>) {
+        walk_import_default_specifier(self, it);
+    }
+
+    #[inline]
+    fn visit_import_namespace_specifier(&mut self, it: &ImportNamespaceSpecifier<'a>) {
+        walk_import_namespace_specifier(self, it);
+    }
+
+    #[inline]
+    fn visit_with_clause(&mut self, it: &WithClause<'a>) {
+        walk_with_clause(self, it);
+    }
+
+    #[inline]
+    fn visit_import_attribute(&mut self, it: &ImportAttribute<'a>) {
+        walk_import_attribute(self, it);
+    }
+
+    #[inline]
+    fn visit_import_attribute_key(&mut self, it: &ImportAttributeKey<'a>) {
+        walk_import_attribute_key(self, it);
+    }
+
+    #[inline]
+    fn visit_export_named_declaration(&mut self, it: &ExportNamedDeclaration<'a>) {
+        walk_export_named_declaration(self, it);
+    }
+
+    #[inline]
+    fn visit_export_default_declaration(&mut self, it: &ExportDefaultDeclaration<'a>) {
+        walk_export_default_declaration(self, it);
+    }
+
+    #[inline]
+    fn visit_export_all_declaration(&mut self, it: &ExportAllDeclaration<'a>) {
+        walk_export_all_declaration(self, it);
+    }
+
+    #[inline]
+    fn visit_export_specifier(&mut self, it: &ExportSpecifier<'a>) {
+        walk_export_specifier(self, it);
+    }
+
+    #[inline]
+    fn visit_export_default_declaration_kind(&mut self, it: &ExportDefaultDeclarationKind<'a>) {
+        walk_export_default_declaration_kind(self, it);
+    }
+
+    #[inline]
+    fn visit_module_export_name(&mut self, it: &ModuleExportName<'a>) {
+        walk_module_export_name(self, it);
+    }
+
+    #[inline]
+    fn visit_boolean_literal(&mut self, it: &BooleanLiteral) {
+        walk_boolean_literal(self, it);
+    }
+
+    #[inline]
+    fn visit_null_literal(&mut self, it: &NullLiteral) {
+        walk_null_literal(self, it);
+    }
+
+    #[inline]
+    fn visit_numeric_literal(&mut self, it: &NumericLiteral<'a>) {
+        walk_numeric_literal(self, it);
+    }
+
+    #[inline]
+    fn visit_string_literal(&mut self, it: &StringLiteral<'a>) {
+        walk_string_literal(self, it);
+    }
+
+    #[inline]
+    fn visit_big_int_literal(&mut self, it: &BigIntLiteral<'a>) {
+        walk_big_int_literal(self, it);
+    }
+
+    #[inline]
+    fn visit_reg_exp_literal(&mut self, it: &RegExpLiteral<'a>) {
+        walk_reg_exp_literal(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_element(&mut self, it: &JSXElement<'a>) {
+        walk_jsx_element(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_opening_element(&mut self, it: &JSXOpeningElement<'a>) {
+        walk_jsx_opening_element(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_closing_element(&mut self, it: &JSXClosingElement<'a>) {
+        walk_jsx_closing_element(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_fragment(&mut self, it: &JSXFragment<'a>) {
+        walk_jsx_fragment(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_element_name(&mut self, it: &JSXElementName<'a>) {
+        walk_jsx_element_name(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_namespaced_name(&mut self, it: &JSXNamespacedName<'a>) {
+        walk_jsx_namespaced_name(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_member_expression(&mut self, it: &JSXMemberExpression<'a>) {
+        walk_jsx_member_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_member_expression_object(&mut self, it: &JSXMemberExpressionObject<'a>) {
+        walk_jsx_member_expression_object(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_expression_container(&mut self, it: &JSXExpressionContainer<'a>) {
+        walk_jsx_expression_container(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_expression(&mut self, it: &JSXExpression<'a>) {
+        walk_jsx_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_empty_expression(&mut self, it: &JSXEmptyExpression) {
+        walk_jsx_empty_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_attribute_item(&mut self, it: &JSXAttributeItem<'a>) {
+        walk_jsx_attribute_item(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_attribute(&mut self, it: &JSXAttribute<'a>) {
+        walk_jsx_attribute(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_spread_attribute(&mut self, it: &JSXSpreadAttribute<'a>) {
+        walk_jsx_spread_attribute(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_attribute_name(&mut self, it: &JSXAttributeName<'a>) {
+        walk_jsx_attribute_name(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_attribute_value(&mut self, it: &JSXAttributeValue<'a>) {
+        walk_jsx_attribute_value(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_identifier(&mut self, it: &JSXIdentifier<'a>) {
+        walk_jsx_identifier(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_child(&mut self, it: &JSXChild<'a>) {
+        walk_jsx_child(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_spread_child(&mut self, it: &JSXSpreadChild<'a>) {
+        walk_jsx_spread_child(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_text(&mut self, it: &JSXText<'a>) {
+        walk_jsx_text(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_this_parameter(&mut self, it: &TSThisParameter<'a>) {
+        walk_ts_this_parameter(self, it);
     }
 
     #[inline]
     fn visit_ts_enum_declaration(&mut self, it: &TSEnumDeclaration<'a>) {
         walk_ts_enum_declaration(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_enum_members(&mut self, it: &Vec<'a, TSEnumMember<'a>>) {
-        walk_ts_enum_members(self, it);
     }
 
     #[inline]
@@ -1186,6 +773,259 @@ pub trait Visit<'a>: Sized {
     #[inline]
     fn visit_ts_enum_member_name(&mut self, it: &TSEnumMemberName<'a>) {
         walk_ts_enum_member_name(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_annotation(&mut self, it: &TSTypeAnnotation<'a>) {
+        walk_ts_type_annotation(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_literal_type(&mut self, it: &TSLiteralType<'a>) {
+        walk_ts_literal_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_literal(&mut self, it: &TSLiteral<'a>) {
+        walk_ts_literal(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type(&mut self, it: &TSType<'a>) {
+        walk_ts_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_conditional_type(&mut self, it: &TSConditionalType<'a>) {
+        walk_ts_conditional_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_union_type(&mut self, it: &TSUnionType<'a>) {
+        walk_ts_union_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_intersection_type(&mut self, it: &TSIntersectionType<'a>) {
+        walk_ts_intersection_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_parenthesized_type(&mut self, it: &TSParenthesizedType<'a>) {
+        walk_ts_parenthesized_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_operator(&mut self, it: &TSTypeOperator<'a>) {
+        walk_ts_type_operator(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_array_type(&mut self, it: &TSArrayType<'a>) {
+        walk_ts_array_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_indexed_access_type(&mut self, it: &TSIndexedAccessType<'a>) {
+        walk_ts_indexed_access_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_tuple_type(&mut self, it: &TSTupleType<'a>) {
+        walk_ts_tuple_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_named_tuple_member(&mut self, it: &TSNamedTupleMember<'a>) {
+        walk_ts_named_tuple_member(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_optional_type(&mut self, it: &TSOptionalType<'a>) {
+        walk_ts_optional_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_rest_type(&mut self, it: &TSRestType<'a>) {
+        walk_ts_rest_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_tuple_element(&mut self, it: &TSTupleElement<'a>) {
+        walk_ts_tuple_element(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_any_keyword(&mut self, it: &TSAnyKeyword) {
+        walk_ts_any_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_string_keyword(&mut self, it: &TSStringKeyword) {
+        walk_ts_string_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_boolean_keyword(&mut self, it: &TSBooleanKeyword) {
+        walk_ts_boolean_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_number_keyword(&mut self, it: &TSNumberKeyword) {
+        walk_ts_number_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_never_keyword(&mut self, it: &TSNeverKeyword) {
+        walk_ts_never_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_intrinsic_keyword(&mut self, it: &TSIntrinsicKeyword) {
+        walk_ts_intrinsic_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_unknown_keyword(&mut self, it: &TSUnknownKeyword) {
+        walk_ts_unknown_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_null_keyword(&mut self, it: &TSNullKeyword) {
+        walk_ts_null_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_undefined_keyword(&mut self, it: &TSUndefinedKeyword) {
+        walk_ts_undefined_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_void_keyword(&mut self, it: &TSVoidKeyword) {
+        walk_ts_void_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_symbol_keyword(&mut self, it: &TSSymbolKeyword) {
+        walk_ts_symbol_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_this_type(&mut self, it: &TSThisType) {
+        walk_ts_this_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_object_keyword(&mut self, it: &TSObjectKeyword) {
+        walk_ts_object_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_big_int_keyword(&mut self, it: &TSBigIntKeyword) {
+        walk_ts_big_int_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_reference(&mut self, it: &TSTypeReference<'a>) {
+        walk_ts_type_reference(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_name(&mut self, it: &TSTypeName<'a>) {
+        walk_ts_type_name(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_qualified_name(&mut self, it: &TSQualifiedName<'a>) {
+        walk_ts_qualified_name(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_parameter_instantiation(&mut self, it: &TSTypeParameterInstantiation<'a>) {
+        walk_ts_type_parameter_instantiation(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_parameter(&mut self, it: &TSTypeParameter<'a>) {
+        walk_ts_type_parameter(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_parameter_declaration(&mut self, it: &TSTypeParameterDeclaration<'a>) {
+        walk_ts_type_parameter_declaration(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_alias_declaration(&mut self, it: &TSTypeAliasDeclaration<'a>) {
+        walk_ts_type_alias_declaration(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_class_implements(&mut self, it: &TSClassImplements<'a>) {
+        walk_ts_class_implements(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_interface_declaration(&mut self, it: &TSInterfaceDeclaration<'a>) {
+        walk_ts_interface_declaration(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_interface_body(&mut self, it: &TSInterfaceBody<'a>) {
+        walk_ts_interface_body(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_property_signature(&mut self, it: &TSPropertySignature<'a>) {
+        walk_ts_property_signature(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_signature(&mut self, it: &TSSignature<'a>) {
+        walk_ts_signature(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_index_signature(&mut self, it: &TSIndexSignature<'a>) {
+        walk_ts_index_signature(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_call_signature_declaration(&mut self, it: &TSCallSignatureDeclaration<'a>) {
+        walk_ts_call_signature_declaration(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_method_signature(&mut self, it: &TSMethodSignature<'a>) {
+        walk_ts_method_signature(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_construct_signature_declaration(
+        &mut self,
+        it: &TSConstructSignatureDeclaration<'a>,
+    ) {
+        walk_ts_construct_signature_declaration(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_index_signature_name(&mut self, it: &TSIndexSignatureName<'a>) {
+        walk_ts_index_signature_name(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_interface_heritage(&mut self, it: &TSInterfaceHeritage<'a>) {
+        walk_ts_interface_heritage(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_predicate(&mut self, it: &TSTypePredicate<'a>) {
+        walk_ts_type_predicate(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_predicate_name(&mut self, it: &TSTypePredicateName<'a>) {
+        walk_ts_type_predicate_name(self, it);
     }
 
     #[inline]
@@ -1209,6 +1049,81 @@ pub trait Visit<'a>: Sized {
     }
 
     #[inline]
+    fn visit_ts_type_literal(&mut self, it: &TSTypeLiteral<'a>) {
+        walk_ts_type_literal(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_infer_type(&mut self, it: &TSInferType<'a>) {
+        walk_ts_infer_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_query(&mut self, it: &TSTypeQuery<'a>) {
+        walk_ts_type_query(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_query_expr_name(&mut self, it: &TSTypeQueryExprName<'a>) {
+        walk_ts_type_query_expr_name(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_import_type(&mut self, it: &TSImportType<'a>) {
+        walk_ts_import_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_import_attributes(&mut self, it: &TSImportAttributes<'a>) {
+        walk_ts_import_attributes(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_import_attribute(&mut self, it: &TSImportAttribute<'a>) {
+        walk_ts_import_attribute(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_import_attribute_name(&mut self, it: &TSImportAttributeName<'a>) {
+        walk_ts_import_attribute_name(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_function_type(&mut self, it: &TSFunctionType<'a>) {
+        walk_ts_function_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_constructor_type(&mut self, it: &TSConstructorType<'a>) {
+        walk_ts_constructor_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_mapped_type(&mut self, it: &TSMappedType<'a>) {
+        walk_ts_mapped_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_template_literal_type(&mut self, it: &TSTemplateLiteralType<'a>) {
+        walk_ts_template_literal_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_as_expression(&mut self, it: &TSAsExpression<'a>) {
+        walk_ts_as_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_satisfies_expression(&mut self, it: &TSSatisfiesExpression<'a>) {
+        walk_ts_satisfies_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_assertion(&mut self, it: &TSTypeAssertion<'a>) {
+        walk_ts_type_assertion(self, it);
+    }
+
+    #[inline]
     fn visit_ts_import_equals_declaration(&mut self, it: &TSImportEqualsDeclaration<'a>) {
         walk_ts_import_equals_declaration(self, it);
     }
@@ -1224,13 +1139,123 @@ pub trait Visit<'a>: Sized {
     }
 
     #[inline]
-    fn visit_module_declaration(&mut self, it: &ModuleDeclaration<'a>) {
-        walk_module_declaration(self, it);
+    fn visit_ts_non_null_expression(&mut self, it: &TSNonNullExpression<'a>) {
+        walk_ts_non_null_expression(self, it);
     }
 
     #[inline]
-    fn visit_import_declaration(&mut self, it: &ImportDeclaration<'a>) {
-        walk_import_declaration(self, it);
+    fn visit_decorator(&mut self, it: &Decorator<'a>) {
+        walk_decorator(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_export_assignment(&mut self, it: &TSExportAssignment<'a>) {
+        walk_ts_export_assignment(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_namespace_export_declaration(&mut self, it: &TSNamespaceExportDeclaration<'a>) {
+        walk_ts_namespace_export_declaration(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_instantiation_expression(&mut self, it: &TSInstantiationExpression<'a>) {
+        walk_ts_instantiation_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_js_doc_nullable_type(&mut self, it: &JSDocNullableType<'a>) {
+        walk_js_doc_nullable_type(self, it);
+    }
+
+    #[inline]
+    fn visit_js_doc_non_nullable_type(&mut self, it: &JSDocNonNullableType<'a>) {
+        walk_js_doc_non_nullable_type(self, it);
+    }
+
+    #[inline]
+    fn visit_js_doc_unknown_type(&mut self, it: &JSDocUnknownType) {
+        walk_js_doc_unknown_type(self, it);
+    }
+
+    #[inline]
+    fn visit_span(&mut self, it: &Span) {
+        walk_span(self, it);
+    }
+
+    #[inline]
+    fn visit_directives(&mut self, it: &Vec<'a, Directive<'a>>) {
+        walk_directives(self, it);
+    }
+
+    #[inline]
+    fn visit_statements(&mut self, it: &Vec<'a, Statement<'a>>) {
+        walk_statements(self, it);
+    }
+
+    #[inline]
+    fn visit_array_expression_elements(&mut self, it: &Vec<'a, ArrayExpressionElement<'a>>) {
+        walk_array_expression_elements(self, it);
+    }
+
+    #[inline]
+    fn visit_object_property_kinds(&mut self, it: &Vec<'a, ObjectPropertyKind<'a>>) {
+        walk_object_property_kinds(self, it);
+    }
+
+    #[inline]
+    fn visit_template_elements(&mut self, it: &Vec<'a, TemplateElement<'a>>) {
+        walk_template_elements(self, it);
+    }
+
+    #[inline]
+    fn visit_expressions(&mut self, it: &Vec<'a, Expression<'a>>) {
+        walk_expressions(self, it);
+    }
+
+    #[inline]
+    fn visit_arguments(&mut self, it: &Vec<'a, Argument<'a>>) {
+        walk_arguments(self, it);
+    }
+
+    #[inline]
+    fn visit_assignment_target_properties(&mut self, it: &Vec<'a, AssignmentTargetProperty<'a>>) {
+        walk_assignment_target_properties(self, it);
+    }
+
+    #[inline]
+    fn visit_variable_declarators(&mut self, it: &Vec<'a, VariableDeclarator<'a>>) {
+        walk_variable_declarators(self, it);
+    }
+
+    #[inline]
+    fn visit_switch_cases(&mut self, it: &Vec<'a, SwitchCase<'a>>) {
+        walk_switch_cases(self, it);
+    }
+
+    #[inline]
+    fn visit_binding_properties(&mut self, it: &Vec<'a, BindingProperty<'a>>) {
+        walk_binding_properties(self, it);
+    }
+
+    #[inline]
+    fn visit_formal_parameter_list(&mut self, it: &Vec<'a, FormalParameter<'a>>) {
+        walk_formal_parameter_list(self, it);
+    }
+
+    #[inline]
+    fn visit_decorators(&mut self, it: &Vec<'a, Decorator<'a>>) {
+        walk_decorators(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_class_implementses(&mut self, it: &Vec<'a, TSClassImplements<'a>>) {
+        walk_ts_class_implementses(self, it);
+    }
+
+    #[inline]
+    fn visit_class_elements(&mut self, it: &Vec<'a, ClassElement<'a>>) {
+        walk_class_elements(self, it);
     }
 
     #[inline]
@@ -1242,68 +1267,8 @@ pub trait Visit<'a>: Sized {
     }
 
     #[inline]
-    fn visit_import_declaration_specifier(&mut self, it: &ImportDeclarationSpecifier<'a>) {
-        walk_import_declaration_specifier(self, it);
-    }
-
-    #[inline]
-    fn visit_import_specifier(&mut self, it: &ImportSpecifier<'a>) {
-        walk_import_specifier(self, it);
-    }
-
-    #[inline]
-    fn visit_module_export_name(&mut self, it: &ModuleExportName<'a>) {
-        walk_module_export_name(self, it);
-    }
-
-    #[inline]
-    fn visit_import_default_specifier(&mut self, it: &ImportDefaultSpecifier<'a>) {
-        walk_import_default_specifier(self, it);
-    }
-
-    #[inline]
-    fn visit_import_namespace_specifier(&mut self, it: &ImportNamespaceSpecifier<'a>) {
-        walk_import_namespace_specifier(self, it);
-    }
-
-    #[inline]
-    fn visit_with_clause(&mut self, it: &WithClause<'a>) {
-        walk_with_clause(self, it);
-    }
-
-    #[inline]
     fn visit_import_attributes(&mut self, it: &Vec<'a, ImportAttribute<'a>>) {
         walk_import_attributes(self, it);
-    }
-
-    #[inline]
-    fn visit_import_attribute(&mut self, it: &ImportAttribute<'a>) {
-        walk_import_attribute(self, it);
-    }
-
-    #[inline]
-    fn visit_import_attribute_key(&mut self, it: &ImportAttributeKey<'a>) {
-        walk_import_attribute_key(self, it);
-    }
-
-    #[inline]
-    fn visit_export_all_declaration(&mut self, it: &ExportAllDeclaration<'a>) {
-        walk_export_all_declaration(self, it);
-    }
-
-    #[inline]
-    fn visit_export_default_declaration(&mut self, it: &ExportDefaultDeclaration<'a>) {
-        walk_export_default_declaration(self, it);
-    }
-
-    #[inline]
-    fn visit_export_default_declaration_kind(&mut self, it: &ExportDefaultDeclarationKind<'a>) {
-        walk_export_default_declaration_kind(self, it);
-    }
-
-    #[inline]
-    fn visit_export_named_declaration(&mut self, it: &ExportNamedDeclaration<'a>) {
-        walk_export_named_declaration(self, it);
     }
 
     #[inline]
@@ -1312,18 +1277,53 @@ pub trait Visit<'a>: Sized {
     }
 
     #[inline]
-    fn visit_export_specifier(&mut self, it: &ExportSpecifier<'a>) {
-        walk_export_specifier(self, it);
+    fn visit_jsx_children(&mut self, it: &Vec<'a, JSXChild<'a>>) {
+        walk_jsx_children(self, it);
     }
 
     #[inline]
-    fn visit_ts_export_assignment(&mut self, it: &TSExportAssignment<'a>) {
-        walk_ts_export_assignment(self, it);
+    fn visit_jsx_attribute_items(&mut self, it: &Vec<'a, JSXAttributeItem<'a>>) {
+        walk_jsx_attribute_items(self, it);
     }
 
     #[inline]
-    fn visit_ts_namespace_export_declaration(&mut self, it: &TSNamespaceExportDeclaration<'a>) {
-        walk_ts_namespace_export_declaration(self, it);
+    fn visit_ts_enum_members(&mut self, it: &Vec<'a, TSEnumMember<'a>>) {
+        walk_ts_enum_members(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_types(&mut self, it: &Vec<'a, TSType<'a>>) {
+        walk_ts_types(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_tuple_elements(&mut self, it: &Vec<'a, TSTupleElement<'a>>) {
+        walk_ts_tuple_elements(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_parameters(&mut self, it: &Vec<'a, TSTypeParameter<'a>>) {
+        walk_ts_type_parameters(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_interface_heritages(&mut self, it: &Vec<'a, TSInterfaceHeritage<'a>>) {
+        walk_ts_interface_heritages(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_signatures(&mut self, it: &Vec<'a, TSSignature<'a>>) {
+        walk_ts_signatures(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_index_signature_names(&mut self, it: &Vec<'a, TSIndexSignatureName<'a>>) {
+        walk_ts_index_signature_names(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_import_attribute_list(&mut self, it: &Vec<'a, TSImportAttribute<'a>>) {
+        walk_ts_import_attribute_list(self, it);
     }
 }
 
@@ -1351,137 +1351,6 @@ pub mod walk {
         visitor.visit_directives(&it.directives);
         visitor.visit_statements(&it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_span<'a, V: Visit<'a>>(visitor: &mut V, it: &Span) {
-        // No `AstKind` for this type
-    }
-
-    #[inline]
-    pub fn walk_hashbang<'a, V: Visit<'a>>(visitor: &mut V, it: &Hashbang<'a>) {
-        let kind = AstKind::Hashbang(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_directives<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Directive<'a>>) {
-        for el in it {
-            visitor.visit_directive(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_directive<'a, V: Visit<'a>>(visitor: &mut V, it: &Directive<'a>) {
-        let kind = AstKind::Directive(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_string_literal(&it.expression);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_string_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &StringLiteral<'a>) {
-        let kind = AstKind::StringLiteral(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_statements<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Statement<'a>>) {
-        for el in it {
-            visitor.visit_statement(el);
-        }
-    }
-
-    pub fn walk_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &Statement<'a>) {
-        // No `AstKind` for this type
-        match it {
-            Statement::BlockStatement(it) => visitor.visit_block_statement(it),
-            Statement::BreakStatement(it) => visitor.visit_break_statement(it),
-            Statement::ContinueStatement(it) => visitor.visit_continue_statement(it),
-            Statement::DebuggerStatement(it) => visitor.visit_debugger_statement(it),
-            Statement::DoWhileStatement(it) => visitor.visit_do_while_statement(it),
-            Statement::EmptyStatement(it) => visitor.visit_empty_statement(it),
-            Statement::ExpressionStatement(it) => visitor.visit_expression_statement(it),
-            Statement::ForInStatement(it) => visitor.visit_for_in_statement(it),
-            Statement::ForOfStatement(it) => visitor.visit_for_of_statement(it),
-            Statement::ForStatement(it) => visitor.visit_for_statement(it),
-            Statement::IfStatement(it) => visitor.visit_if_statement(it),
-            Statement::LabeledStatement(it) => visitor.visit_labeled_statement(it),
-            Statement::ReturnStatement(it) => visitor.visit_return_statement(it),
-            Statement::SwitchStatement(it) => visitor.visit_switch_statement(it),
-            Statement::ThrowStatement(it) => visitor.visit_throw_statement(it),
-            Statement::TryStatement(it) => visitor.visit_try_statement(it),
-            Statement::WhileStatement(it) => visitor.visit_while_statement(it),
-            Statement::WithStatement(it) => visitor.visit_with_statement(it),
-            match_declaration!(Statement) => visitor.visit_declaration(it.to_declaration()),
-            match_module_declaration!(Statement) => {
-                visitor.visit_module_declaration(it.to_module_declaration())
-            }
-        }
-    }
-
-    #[inline]
-    pub fn walk_block_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &BlockStatement<'a>) {
-        let kind = AstKind::BlockStatement(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
-        visitor.visit_span(&it.span);
-        visitor.visit_statements(&it.body);
-        visitor.leave_scope();
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_break_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &BreakStatement<'a>) {
-        let kind = AstKind::BreakStatement(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        if let Some(label) = &it.label {
-            visitor.visit_label_identifier(label);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_label_identifier<'a, V: Visit<'a>>(visitor: &mut V, it: &LabelIdentifier<'a>) {
-        let kind = AstKind::LabelIdentifier(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_continue_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &ContinueStatement<'a>) {
-        let kind = AstKind::ContinueStatement(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        if let Some(label) = &it.label {
-            visitor.visit_label_identifier(label);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_debugger_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &DebuggerStatement) {
-        let kind = AstKind::DebuggerStatement(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_do_while_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &DoWhileStatement<'a>) {
-        let kind = AstKind::DoWhileStatement(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_statement(&it.body);
-        visitor.visit_expression(&it.test);
         visitor.leave_node(kind);
     }
 
@@ -1541,76 +1410,11 @@ pub mod walk {
     }
 
     #[inline]
-    pub fn walk_boolean_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &BooleanLiteral) {
-        let kind = AstKind::BooleanLiteral(visitor.alloc(it));
+    pub fn walk_identifier_name<'a, V: Visit<'a>>(visitor: &mut V, it: &IdentifierName<'a>) {
+        let kind = AstKind::IdentifierName(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
         visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_null_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &NullLiteral) {
-        let kind = AstKind::NullLiteral(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_numeric_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &NumericLiteral<'a>) {
-        let kind = AstKind::NumericLiteral(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_big_int_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &BigIntLiteral<'a>) {
-        let kind = AstKind::BigIntLiteral(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_reg_exp_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &RegExpLiteral<'a>) {
-        let kind = AstKind::RegExpLiteral(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_template_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &TemplateLiteral<'a>) {
-        let kind = AstKind::TemplateLiteral(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_template_elements(&it.quasis);
-        visitor.visit_expressions(&it.expressions);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_template_elements<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &Vec<'a, TemplateElement<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_template_element(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_template_element<'a, V: Visit<'a>>(visitor: &mut V, it: &TemplateElement<'a>) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-    }
-
-    #[inline]
-    pub fn walk_expressions<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Expression<'a>>) {
-        for el in it {
-            visitor.visit_expression(el);
-        }
     }
 
     #[inline]
@@ -1625,26 +1429,24 @@ pub mod walk {
     }
 
     #[inline]
-    pub fn walk_meta_property<'a, V: Visit<'a>>(visitor: &mut V, it: &MetaProperty<'a>) {
-        let kind = AstKind::MetaProperty(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_identifier_name(&it.meta);
-        visitor.visit_identifier_name(&it.property);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_identifier_name<'a, V: Visit<'a>>(visitor: &mut V, it: &IdentifierName<'a>) {
-        let kind = AstKind::IdentifierName(visitor.alloc(it));
+    pub fn walk_binding_identifier<'a, V: Visit<'a>>(visitor: &mut V, it: &BindingIdentifier<'a>) {
+        let kind = AstKind::BindingIdentifier(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_super<'a, V: Visit<'a>>(visitor: &mut V, it: &Super) {
-        let kind = AstKind::Super(visitor.alloc(it));
+    pub fn walk_label_identifier<'a, V: Visit<'a>>(visitor: &mut V, it: &LabelIdentifier<'a>) {
+        let kind = AstKind::LabelIdentifier(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_this_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &ThisExpression) {
+        let kind = AstKind::ThisExpression(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
         visitor.leave_node(kind);
@@ -1660,16 +1462,6 @@ pub mod walk {
             visitor.visit_span(trailing_comma);
         }
         visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_array_expression_elements<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &Vec<'a, ArrayExpressionElement<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_array_expression_element(el);
-        }
     }
 
     #[inline]
@@ -1690,15 +1482,6 @@ pub mod walk {
     }
 
     #[inline]
-    pub fn walk_spread_element<'a, V: Visit<'a>>(visitor: &mut V, it: &SpreadElement<'a>) {
-        let kind = AstKind::SpreadElement(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_expression(&it.argument);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
     pub fn walk_elision<'a, V: Visit<'a>>(visitor: &mut V, it: &Elision) {
         let kind = AstKind::Elision(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -1707,359 +1490,37 @@ pub mod walk {
     }
 
     #[inline]
-    pub fn walk_arrow_function_expression<'a, V: Visit<'a>>(
+    pub fn walk_object_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &ObjectExpression<'a>) {
+        let kind = AstKind::ObjectExpression(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_object_property_kinds(&it.properties);
+        if let Some(trailing_comma) = &it.trailing_comma {
+            visitor.visit_span(trailing_comma);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_object_property_kind<'a, V: Visit<'a>>(
         visitor: &mut V,
-        it: &ArrowFunctionExpression<'a>,
-    ) {
-        let kind = AstKind::ArrowFunctionExpression(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.enter_scope(
-            {
-                let mut flags = ScopeFlags::Function | ScopeFlags::Arrow;
-                if it.has_use_strict_directive() {
-                    flags |= ScopeFlags::StrictMode;
-                }
-                flags
-            },
-            &it.scope_id,
-        );
-        visitor.visit_span(&it.span);
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_declaration(type_parameters);
-        }
-        visitor.visit_formal_parameters(&it.params);
-        if let Some(return_type) = &it.return_type {
-            visitor.visit_ts_type_annotation(return_type);
-        }
-        visitor.visit_function_body(&it.body);
-        visitor.leave_scope();
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_type_parameter_declaration<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &TSTypeParameterDeclaration<'a>,
-    ) {
-        let kind = AstKind::TSTypeParameterDeclaration(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_type_parameters(&it.params);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_type_parameters<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &Vec<'a, TSTypeParameter<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_ts_type_parameter(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_type_parameter<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeParameter<'a>) {
-        let kind = AstKind::TSTypeParameter(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_binding_identifier(&it.name);
-        if let Some(constraint) = &it.constraint {
-            visitor.visit_ts_type(constraint);
-        }
-        if let Some(default) = &it.default {
-            visitor.visit_ts_type(default);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_binding_identifier<'a, V: Visit<'a>>(visitor: &mut V, it: &BindingIdentifier<'a>) {
-        let kind = AstKind::BindingIdentifier(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    pub fn walk_ts_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSType<'a>) {
-        // No `AstKind` for this type
-        match it {
-            TSType::TSAnyKeyword(it) => visitor.visit_ts_any_keyword(it),
-            TSType::TSBigIntKeyword(it) => visitor.visit_ts_big_int_keyword(it),
-            TSType::TSBooleanKeyword(it) => visitor.visit_ts_boolean_keyword(it),
-            TSType::TSIntrinsicKeyword(it) => visitor.visit_ts_intrinsic_keyword(it),
-            TSType::TSNeverKeyword(it) => visitor.visit_ts_never_keyword(it),
-            TSType::TSNullKeyword(it) => visitor.visit_ts_null_keyword(it),
-            TSType::TSNumberKeyword(it) => visitor.visit_ts_number_keyword(it),
-            TSType::TSObjectKeyword(it) => visitor.visit_ts_object_keyword(it),
-            TSType::TSStringKeyword(it) => visitor.visit_ts_string_keyword(it),
-            TSType::TSSymbolKeyword(it) => visitor.visit_ts_symbol_keyword(it),
-            TSType::TSUndefinedKeyword(it) => visitor.visit_ts_undefined_keyword(it),
-            TSType::TSUnknownKeyword(it) => visitor.visit_ts_unknown_keyword(it),
-            TSType::TSVoidKeyword(it) => visitor.visit_ts_void_keyword(it),
-            TSType::TSArrayType(it) => visitor.visit_ts_array_type(it),
-            TSType::TSConditionalType(it) => visitor.visit_ts_conditional_type(it),
-            TSType::TSConstructorType(it) => visitor.visit_ts_constructor_type(it),
-            TSType::TSFunctionType(it) => visitor.visit_ts_function_type(it),
-            TSType::TSImportType(it) => visitor.visit_ts_import_type(it),
-            TSType::TSIndexedAccessType(it) => visitor.visit_ts_indexed_access_type(it),
-            TSType::TSInferType(it) => visitor.visit_ts_infer_type(it),
-            TSType::TSIntersectionType(it) => visitor.visit_ts_intersection_type(it),
-            TSType::TSLiteralType(it) => visitor.visit_ts_literal_type(it),
-            TSType::TSMappedType(it) => visitor.visit_ts_mapped_type(it),
-            TSType::TSNamedTupleMember(it) => visitor.visit_ts_named_tuple_member(it),
-            TSType::TSQualifiedName(it) => visitor.visit_ts_qualified_name(it),
-            TSType::TSTemplateLiteralType(it) => visitor.visit_ts_template_literal_type(it),
-            TSType::TSThisType(it) => visitor.visit_ts_this_type(it),
-            TSType::TSTupleType(it) => visitor.visit_ts_tuple_type(it),
-            TSType::TSTypeLiteral(it) => visitor.visit_ts_type_literal(it),
-            TSType::TSTypeOperatorType(it) => visitor.visit_ts_type_operator(it),
-            TSType::TSTypePredicate(it) => visitor.visit_ts_type_predicate(it),
-            TSType::TSTypeQuery(it) => visitor.visit_ts_type_query(it),
-            TSType::TSTypeReference(it) => visitor.visit_ts_type_reference(it),
-            TSType::TSUnionType(it) => visitor.visit_ts_union_type(it),
-            TSType::TSParenthesizedType(it) => visitor.visit_ts_parenthesized_type(it),
-            TSType::JSDocNullableType(it) => visitor.visit_js_doc_nullable_type(it),
-            TSType::JSDocNonNullableType(it) => visitor.visit_js_doc_non_nullable_type(it),
-            TSType::JSDocUnknownType(it) => visitor.visit_js_doc_unknown_type(it),
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_any_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSAnyKeyword) {
-        let kind = AstKind::TSAnyKeyword(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_big_int_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSBigIntKeyword) {
-        let kind = AstKind::TSBigIntKeyword(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_boolean_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSBooleanKeyword) {
-        let kind = AstKind::TSBooleanKeyword(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_intrinsic_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSIntrinsicKeyword) {
-        let kind = AstKind::TSIntrinsicKeyword(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_never_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSNeverKeyword) {
-        let kind = AstKind::TSNeverKeyword(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_null_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSNullKeyword) {
-        let kind = AstKind::TSNullKeyword(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_number_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSNumberKeyword) {
-        let kind = AstKind::TSNumberKeyword(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_object_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSObjectKeyword) {
-        let kind = AstKind::TSObjectKeyword(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_string_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSStringKeyword) {
-        let kind = AstKind::TSStringKeyword(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_symbol_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSSymbolKeyword) {
-        let kind = AstKind::TSSymbolKeyword(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_undefined_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSUndefinedKeyword) {
-        let kind = AstKind::TSUndefinedKeyword(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_unknown_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSUnknownKeyword) {
-        let kind = AstKind::TSUnknownKeyword(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_void_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSVoidKeyword) {
-        let kind = AstKind::TSVoidKeyword(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_array_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSArrayType<'a>) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_type(&it.element_type);
-    }
-
-    #[inline]
-    pub fn walk_ts_conditional_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSConditionalType<'a>) {
-        let kind = AstKind::TSConditionalType(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_type(&it.check_type);
-        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
-        visitor.visit_ts_type(&it.extends_type);
-        visitor.visit_ts_type(&it.true_type);
-        visitor.leave_scope();
-        visitor.visit_ts_type(&it.false_type);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_constructor_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSConstructorType<'a>) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_declaration(type_parameters);
-        }
-        visitor.visit_formal_parameters(&it.params);
-        visitor.visit_ts_type_annotation(&it.return_type);
-    }
-
-    #[inline]
-    pub fn walk_formal_parameters<'a, V: Visit<'a>>(visitor: &mut V, it: &FormalParameters<'a>) {
-        let kind = AstKind::FormalParameters(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_formal_parameter_list(&it.items);
-        if let Some(rest) = &it.rest {
-            visitor.visit_binding_rest_element(rest);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_formal_parameter_list<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &Vec<'a, FormalParameter<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_formal_parameter(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_formal_parameter<'a, V: Visit<'a>>(visitor: &mut V, it: &FormalParameter<'a>) {
-        let kind = AstKind::FormalParameter(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_decorators(&it.decorators);
-        visitor.visit_binding_pattern(&it.pattern);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_decorators<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Decorator<'a>>) {
-        for el in it {
-            visitor.visit_decorator(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_decorator<'a, V: Visit<'a>>(visitor: &mut V, it: &Decorator<'a>) {
-        let kind = AstKind::Decorator(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_expression(&it.expression);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_binding_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &BindingPattern<'a>) {
-        // No `AstKind` for this type
-        visitor.visit_binding_pattern_kind(&it.kind);
-        if let Some(type_annotation) = &it.type_annotation {
-            visitor.visit_ts_type_annotation(type_annotation);
-        }
-    }
-
-    #[inline]
-    pub fn walk_binding_pattern_kind<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &BindingPatternKind<'a>,
+        it: &ObjectPropertyKind<'a>,
     ) {
         // No `AstKind` for this type
         match it {
-            BindingPatternKind::BindingIdentifier(it) => visitor.visit_binding_identifier(it),
-            BindingPatternKind::ObjectPattern(it) => visitor.visit_object_pattern(it),
-            BindingPatternKind::ArrayPattern(it) => visitor.visit_array_pattern(it),
-            BindingPatternKind::AssignmentPattern(it) => visitor.visit_assignment_pattern(it),
+            ObjectPropertyKind::ObjectProperty(it) => visitor.visit_object_property(it),
+            ObjectPropertyKind::SpreadProperty(it) => visitor.visit_spread_element(it),
         }
     }
 
     #[inline]
-    pub fn walk_object_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &ObjectPattern<'a>) {
-        let kind = AstKind::ObjectPattern(visitor.alloc(it));
+    pub fn walk_object_property<'a, V: Visit<'a>>(visitor: &mut V, it: &ObjectProperty<'a>) {
+        let kind = AstKind::ObjectProperty(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_binding_properties(&it.properties);
-        if let Some(rest) = &it.rest {
-            visitor.visit_binding_rest_element(rest);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_binding_properties<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &Vec<'a, BindingProperty<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_binding_property(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_binding_property<'a, V: Visit<'a>>(visitor: &mut V, it: &BindingProperty<'a>) {
-        // No `AstKind` for this type
         visitor.visit_span(&it.span);
         visitor.visit_property_key(&it.key);
-        visitor.visit_binding_pattern(&it.value);
+        visitor.visit_expression(&it.value);
+        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2075,96 +1536,25 @@ pub mod walk {
     }
 
     #[inline]
-    pub fn walk_private_identifier<'a, V: Visit<'a>>(visitor: &mut V, it: &PrivateIdentifier<'a>) {
-        let kind = AstKind::PrivateIdentifier(visitor.alloc(it));
+    pub fn walk_template_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &TemplateLiteral<'a>) {
+        let kind = AstKind::TemplateLiteral(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
+        visitor.visit_template_elements(&it.quasis);
+        visitor.visit_expressions(&it.expressions);
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_binding_rest_element<'a, V: Visit<'a>>(
+    pub fn walk_tagged_template_expression<'a, V: Visit<'a>>(
         visitor: &mut V,
-        it: &BindingRestElement<'a>,
+        it: &TaggedTemplateExpression<'a>,
     ) {
-        let kind = AstKind::BindingRestElement(visitor.alloc(it));
+        let kind = AstKind::TaggedTemplateExpression(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
-        visitor.visit_binding_pattern(&it.argument);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_array_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &ArrayPattern<'a>) {
-        let kind = AstKind::ArrayPattern(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        for el in it.elements.iter().flatten() {
-            visitor.visit_binding_pattern(el);
-        }
-        if let Some(rest) = &it.rest {
-            visitor.visit_binding_rest_element(rest);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_assignment_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &AssignmentPattern<'a>) {
-        let kind = AstKind::AssignmentPattern(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_binding_pattern(&it.left);
-        visitor.visit_expression(&it.right);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_type_annotation<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeAnnotation<'a>) {
-        let kind = AstKind::TSTypeAnnotation(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_type(&it.type_annotation);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_function_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSFunctionType<'a>) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_declaration(type_parameters);
-        }
-        if let Some(this_param) = &it.this_param {
-            visitor.visit_ts_this_parameter(this_param);
-        }
-        visitor.visit_formal_parameters(&it.params);
-        visitor.visit_ts_type_annotation(&it.return_type);
-    }
-
-    #[inline]
-    pub fn walk_ts_this_parameter<'a, V: Visit<'a>>(visitor: &mut V, it: &TSThisParameter<'a>) {
-        let kind = AstKind::TSThisParameter(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_span(&it.this_span);
-        if let Some(type_annotation) = &it.type_annotation {
-            visitor.visit_ts_type_annotation(type_annotation);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_import_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSImportType<'a>) {
-        let kind = AstKind::TSImportType(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_type(&it.parameter);
-        if let Some(qualifier) = &it.qualifier {
-            visitor.visit_ts_type_name(qualifier);
-        }
-        if let Some(attributes) = &it.attributes {
-            visitor.visit_ts_import_attributes(attributes);
-        }
+        visitor.visit_expression(&it.tag);
+        visitor.visit_template_literal(&it.quasi);
         if let Some(type_parameters) = &it.type_parameters {
             visitor.visit_ts_type_parameter_instantiation(type_parameters);
         }
@@ -2172,141 +1562,125 @@ pub mod walk {
     }
 
     #[inline]
-    pub fn walk_ts_type_name<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeName<'a>) {
-        let kind = AstKind::TSTypeName(visitor.alloc(it));
+    pub fn walk_template_element<'a, V: Visit<'a>>(visitor: &mut V, it: &TemplateElement<'a>) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+    }
+
+    #[inline]
+    pub fn walk_member_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &MemberExpression<'a>) {
+        let kind = AstKind::MemberExpression(visitor.alloc(it));
         visitor.enter_node(kind);
         match it {
-            TSTypeName::IdentifierReference(it) => visitor.visit_identifier_reference(it),
-            TSTypeName::QualifiedName(it) => visitor.visit_ts_qualified_name(it),
+            MemberExpression::ComputedMemberExpression(it) => {
+                visitor.visit_computed_member_expression(it)
+            }
+            MemberExpression::StaticMemberExpression(it) => {
+                visitor.visit_static_member_expression(it)
+            }
+            MemberExpression::PrivateFieldExpression(it) => {
+                visitor.visit_private_field_expression(it)
+            }
         }
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_ts_qualified_name<'a, V: Visit<'a>>(visitor: &mut V, it: &TSQualifiedName<'a>) {
-        let kind = AstKind::TSQualifiedName(visitor.alloc(it));
+    pub fn walk_computed_member_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ComputedMemberExpression<'a>,
+    ) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+        visitor.visit_expression(&it.object);
+        visitor.visit_expression(&it.expression);
+    }
+
+    #[inline]
+    pub fn walk_static_member_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &StaticMemberExpression<'a>,
+    ) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+        visitor.visit_expression(&it.object);
+        visitor.visit_identifier_name(&it.property);
+    }
+
+    #[inline]
+    pub fn walk_private_field_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &PrivateFieldExpression<'a>,
+    ) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+        visitor.visit_expression(&it.object);
+        visitor.visit_private_identifier(&it.field);
+    }
+
+    #[inline]
+    pub fn walk_call_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &CallExpression<'a>) {
+        let kind = AstKind::CallExpression(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
-        visitor.visit_ts_type_name(&it.left);
-        visitor.visit_identifier_name(&it.right);
+        visitor.visit_expression(&it.callee);
+        if let Some(type_parameters) = &it.type_parameters {
+            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        }
+        visitor.visit_arguments(&it.arguments);
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_ts_import_attributes<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &TSImportAttributes<'a>,
-    ) {
-        // No `AstKind` for this type
+    pub fn walk_new_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &NewExpression<'a>) {
+        let kind = AstKind::NewExpression(visitor.alloc(it));
+        visitor.enter_node(kind);
         visitor.visit_span(&it.span);
-        visitor.visit_identifier_name(&it.attributes_keyword);
-        visitor.visit_ts_import_attribute_list(&it.elements);
-    }
-
-    #[inline]
-    pub fn walk_ts_import_attribute_list<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &Vec<'a, TSImportAttribute<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_ts_import_attribute(el);
+        visitor.visit_expression(&it.callee);
+        visitor.visit_arguments(&it.arguments);
+        if let Some(type_parameters) = &it.type_parameters {
+            visitor.visit_ts_type_parameter_instantiation(type_parameters);
         }
+        visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_ts_import_attribute<'a, V: Visit<'a>>(visitor: &mut V, it: &TSImportAttribute<'a>) {
-        // No `AstKind` for this type
+    pub fn walk_meta_property<'a, V: Visit<'a>>(visitor: &mut V, it: &MetaProperty<'a>) {
+        let kind = AstKind::MetaProperty(visitor.alloc(it));
+        visitor.enter_node(kind);
         visitor.visit_span(&it.span);
-        visitor.visit_ts_import_attribute_name(&it.name);
-        visitor.visit_expression(&it.value);
+        visitor.visit_identifier_name(&it.meta);
+        visitor.visit_identifier_name(&it.property);
+        visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_ts_import_attribute_name<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &TSImportAttributeName<'a>,
-    ) {
-        // No `AstKind` for this type
+    pub fn walk_spread_element<'a, V: Visit<'a>>(visitor: &mut V, it: &SpreadElement<'a>) {
+        let kind = AstKind::SpreadElement(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_expression(&it.argument);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_argument<'a, V: Visit<'a>>(visitor: &mut V, it: &Argument<'a>) {
+        let kind = AstKind::Argument(visitor.alloc(it));
+        visitor.enter_node(kind);
         match it {
-            TSImportAttributeName::Identifier(it) => visitor.visit_identifier_name(it),
-            TSImportAttributeName::StringLiteral(it) => visitor.visit_string_literal(it),
+            Argument::SpreadElement(it) => visitor.visit_spread_element(it),
+            match_expression!(Argument) => visitor.visit_expression(it.to_expression()),
         }
-    }
-
-    #[inline]
-    pub fn walk_ts_type_parameter_instantiation<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &TSTypeParameterInstantiation<'a>,
-    ) {
-        let kind = AstKind::TSTypeParameterInstantiation(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_types(&it.params);
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_ts_types<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, TSType<'a>>) {
-        for el in it {
-            visitor.visit_ts_type(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_indexed_access_type<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &TSIndexedAccessType<'a>,
-    ) {
-        let kind = AstKind::TSIndexedAccessType(visitor.alloc(it));
+    pub fn walk_update_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &UpdateExpression<'a>) {
+        let kind = AstKind::UpdateExpression(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
-        visitor.visit_ts_type(&it.object_type);
-        visitor.visit_ts_type(&it.index_type);
+        visitor.visit_simple_assignment_target(&it.argument);
         visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_infer_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSInferType<'a>) {
-        let kind = AstKind::TSInferType(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_type_parameter(&it.type_parameter);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_intersection_type<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &TSIntersectionType<'a>,
-    ) {
-        let kind = AstKind::TSIntersectionType(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_types(&it.types);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_literal_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSLiteralType<'a>) {
-        let kind = AstKind::TSLiteralType(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_literal(&it.literal);
-        visitor.leave_node(kind);
-    }
-
-    pub fn walk_ts_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &TSLiteral<'a>) {
-        // No `AstKind` for this type
-        match it {
-            TSLiteral::BooleanLiteral(it) => visitor.visit_boolean_literal(it),
-            TSLiteral::NullLiteral(it) => visitor.visit_null_literal(it),
-            TSLiteral::NumericLiteral(it) => visitor.visit_numeric_literal(it),
-            TSLiteral::BigIntLiteral(it) => visitor.visit_big_int_literal(it),
-            TSLiteral::RegExpLiteral(it) => visitor.visit_reg_exp_literal(it),
-            TSLiteral::StringLiteral(it) => visitor.visit_string_literal(it),
-            TSLiteral::TemplateLiteral(it) => visitor.visit_template_literal(it),
-            TSLiteral::UnaryExpression(it) => visitor.visit_unary_expression(it),
-        }
     }
 
     #[inline]
@@ -2319,352 +1693,49 @@ pub mod walk {
     }
 
     #[inline]
-    pub fn walk_ts_mapped_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSMappedType<'a>) {
-        let kind = AstKind::TSMappedType(visitor.alloc(it));
+    pub fn walk_binary_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &BinaryExpression<'a>) {
+        let kind = AstKind::BinaryExpression(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_span(&it.span);
-        visitor.visit_ts_type_parameter(&it.type_parameter);
-        if let Some(name_type) = &it.name_type {
-            visitor.visit_ts_type(name_type);
-        }
-        if let Some(type_annotation) = &it.type_annotation {
-            visitor.visit_ts_type(type_annotation);
-        }
-        visitor.leave_scope();
+        visitor.visit_expression(&it.left);
+        visitor.visit_expression(&it.right);
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_ts_named_tuple_member<'a, V: Visit<'a>>(
+    pub fn walk_private_in_expression<'a, V: Visit<'a>>(
         visitor: &mut V,
-        it: &TSNamedTupleMember<'a>,
+        it: &PrivateInExpression<'a>,
     ) {
-        let kind = AstKind::TSNamedTupleMember(visitor.alloc(it));
+        let kind = AstKind::PrivateInExpression(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
-        visitor.visit_ts_tuple_element(&it.element_type);
-        visitor.visit_identifier_name(&it.label);
+        visitor.visit_private_identifier(&it.left);
+        visitor.visit_expression(&it.right);
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_ts_tuple_element<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTupleElement<'a>) {
-        // No `AstKind` for this type
-        match it {
-            TSTupleElement::TSOptionalType(it) => visitor.visit_ts_optional_type(it),
-            TSTupleElement::TSRestType(it) => visitor.visit_ts_rest_type(it),
-            match_ts_type!(TSTupleElement) => visitor.visit_ts_type(it.to_ts_type()),
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_optional_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSOptionalType<'a>) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_type(&it.type_annotation);
-    }
-
-    #[inline]
-    pub fn walk_ts_rest_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSRestType<'a>) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_type(&it.type_annotation);
-    }
-
-    #[inline]
-    pub fn walk_ts_template_literal_type<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &TSTemplateLiteralType<'a>,
-    ) {
-        let kind = AstKind::TSTemplateLiteralType(visitor.alloc(it));
+    pub fn walk_logical_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &LogicalExpression<'a>) {
+        let kind = AstKind::LogicalExpression(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
-        visitor.visit_template_elements(&it.quasis);
-        visitor.visit_ts_types(&it.types);
+        visitor.visit_expression(&it.left);
+        visitor.visit_expression(&it.right);
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_ts_this_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSThisType) {
-        let kind = AstKind::TSThisType(visitor.alloc(it));
+    pub fn walk_conditional_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ConditionalExpression<'a>,
+    ) {
+        let kind = AstKind::ConditionalExpression(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_tuple_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTupleType<'a>) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_tuple_elements(&it.element_types);
-    }
-
-    #[inline]
-    pub fn walk_ts_tuple_elements<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &Vec<'a, TSTupleElement<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_ts_tuple_element(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_type_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeLiteral<'a>) {
-        let kind = AstKind::TSTypeLiteral(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_signatures(&it.members);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_signatures<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, TSSignature<'a>>) {
-        for el in it {
-            visitor.visit_ts_signature(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_signature<'a, V: Visit<'a>>(visitor: &mut V, it: &TSSignature<'a>) {
-        // No `AstKind` for this type
-        match it {
-            TSSignature::TSIndexSignature(it) => visitor.visit_ts_index_signature(it),
-            TSSignature::TSPropertySignature(it) => visitor.visit_ts_property_signature(it),
-            TSSignature::TSCallSignatureDeclaration(it) => {
-                visitor.visit_ts_call_signature_declaration(it)
-            }
-            TSSignature::TSConstructSignatureDeclaration(it) => {
-                visitor.visit_ts_construct_signature_declaration(it)
-            }
-            TSSignature::TSMethodSignature(it) => visitor.visit_ts_method_signature(it),
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_index_signature<'a, V: Visit<'a>>(visitor: &mut V, it: &TSIndexSignature<'a>) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_index_signature_names(&it.parameters);
-        visitor.visit_ts_type_annotation(&it.type_annotation);
-    }
-
-    #[inline]
-    pub fn walk_ts_index_signature_names<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &Vec<'a, TSIndexSignatureName<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_ts_index_signature_name(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_index_signature_name<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &TSIndexSignatureName<'a>,
-    ) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_type_annotation(&it.type_annotation);
-    }
-
-    #[inline]
-    pub fn walk_ts_property_signature<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &TSPropertySignature<'a>,
-    ) {
-        let kind = AstKind::TSPropertySignature(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_property_key(&it.key);
-        if let Some(type_annotation) = &it.type_annotation {
-            visitor.visit_ts_type_annotation(type_annotation);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_call_signature_declaration<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &TSCallSignatureDeclaration<'a>,
-    ) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_declaration(type_parameters);
-        }
-        if let Some(this_param) = &it.this_param {
-            visitor.visit_ts_this_parameter(this_param);
-        }
-        visitor.visit_formal_parameters(&it.params);
-        if let Some(return_type) = &it.return_type {
-            visitor.visit_ts_type_annotation(return_type);
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_construct_signature_declaration<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &TSConstructSignatureDeclaration<'a>,
-    ) {
-        let kind = AstKind::TSConstructSignatureDeclaration(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
-        visitor.visit_span(&it.span);
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_declaration(type_parameters);
-        }
-        visitor.visit_formal_parameters(&it.params);
-        if let Some(return_type) = &it.return_type {
-            visitor.visit_ts_type_annotation(return_type);
-        }
-        visitor.leave_scope();
-        visitor.leave_node(kind);
-    }
-
-    pub fn walk_ts_method_signature<'a, V: Visit<'a>>(visitor: &mut V, it: &TSMethodSignature<'a>) {
-        let kind = AstKind::TSMethodSignature(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
-        visitor.visit_span(&it.span);
-        visitor.visit_property_key(&it.key);
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_declaration(type_parameters);
-        }
-        if let Some(this_param) = &it.this_param {
-            visitor.visit_ts_this_parameter(this_param);
-        }
-        visitor.visit_formal_parameters(&it.params);
-        if let Some(return_type) = &it.return_type {
-            visitor.visit_ts_type_annotation(return_type);
-        }
-        visitor.leave_scope();
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_type_operator<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeOperator<'a>) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_type(&it.type_annotation);
-    }
-
-    #[inline]
-    pub fn walk_ts_type_predicate<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypePredicate<'a>) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_type_predicate_name(&it.parameter_name);
-        if let Some(type_annotation) = &it.type_annotation {
-            visitor.visit_ts_type_annotation(type_annotation);
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_type_predicate_name<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &TSTypePredicateName<'a>,
-    ) {
-        // No `AstKind` for this type
-        match it {
-            TSTypePredicateName::Identifier(it) => visitor.visit_identifier_name(it),
-            TSTypePredicateName::This(it) => visitor.visit_ts_this_type(it),
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_type_query<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeQuery<'a>) {
-        let kind = AstKind::TSTypeQuery(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_type_query_expr_name(&it.expr_name);
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_type_query_expr_name<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &TSTypeQueryExprName<'a>,
-    ) {
-        // No `AstKind` for this type
-        match it {
-            TSTypeQueryExprName::TSImportType(it) => visitor.visit_ts_import_type(it),
-            match_ts_type_name!(TSTypeQueryExprName) => {
-                visitor.visit_ts_type_name(it.to_ts_type_name())
-            }
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_type_reference<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeReference<'a>) {
-        let kind = AstKind::TSTypeReference(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_type_name(&it.type_name);
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_union_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSUnionType<'a>) {
-        let kind = AstKind::TSUnionType(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_types(&it.types);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_parenthesized_type<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &TSParenthesizedType<'a>,
-    ) {
-        let kind = AstKind::TSParenthesizedType(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_type(&it.type_annotation);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_js_doc_nullable_type<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &JSDocNullableType<'a>,
-    ) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_type(&it.type_annotation);
-    }
-
-    #[inline]
-    pub fn walk_js_doc_non_nullable_type<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &JSDocNonNullableType<'a>,
-    ) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_type(&it.type_annotation);
-    }
-
-    #[inline]
-    pub fn walk_js_doc_unknown_type<'a, V: Visit<'a>>(visitor: &mut V, it: &JSDocUnknownType) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-    }
-
-    #[inline]
-    pub fn walk_function_body<'a, V: Visit<'a>>(visitor: &mut V, it: &FunctionBody<'a>) {
-        let kind = AstKind::FunctionBody(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_directives(&it.directives);
-        visitor.visit_statements(&it.statements);
+        visitor.visit_expression(&it.test);
+        visitor.visit_expression(&it.consequent);
+        visitor.visit_expression(&it.alternate);
         visitor.leave_node(kind);
     }
 
@@ -2725,115 +1796,6 @@ pub mod walk {
     }
 
     #[inline]
-    pub fn walk_ts_as_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &TSAsExpression<'a>) {
-        let kind = AstKind::TSAsExpression(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_expression(&it.expression);
-        visitor.visit_ts_type(&it.type_annotation);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_satisfies_expression<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &TSSatisfiesExpression<'a>,
-    ) {
-        let kind = AstKind::TSSatisfiesExpression(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_expression(&it.expression);
-        visitor.visit_ts_type(&it.type_annotation);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_non_null_expression<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &TSNonNullExpression<'a>,
-    ) {
-        let kind = AstKind::TSNonNullExpression(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_expression(&it.expression);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_type_assertion<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeAssertion<'a>) {
-        let kind = AstKind::TSTypeAssertion(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_expression(&it.expression);
-        visitor.visit_ts_type(&it.type_annotation);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_instantiation_expression<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &TSInstantiationExpression<'a>,
-    ) {
-        let kind = AstKind::TSInstantiationExpression(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_expression(&it.expression);
-        visitor.visit_ts_type_parameter_instantiation(&it.type_parameters);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_member_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &MemberExpression<'a>) {
-        let kind = AstKind::MemberExpression(visitor.alloc(it));
-        visitor.enter_node(kind);
-        match it {
-            MemberExpression::ComputedMemberExpression(it) => {
-                visitor.visit_computed_member_expression(it)
-            }
-            MemberExpression::StaticMemberExpression(it) => {
-                visitor.visit_static_member_expression(it)
-            }
-            MemberExpression::PrivateFieldExpression(it) => {
-                visitor.visit_private_field_expression(it)
-            }
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_computed_member_expression<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &ComputedMemberExpression<'a>,
-    ) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-        visitor.visit_expression(&it.object);
-        visitor.visit_expression(&it.expression);
-    }
-
-    #[inline]
-    pub fn walk_static_member_expression<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &StaticMemberExpression<'a>,
-    ) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-        visitor.visit_expression(&it.object);
-        visitor.visit_identifier_name(&it.property);
-    }
-
-    #[inline]
-    pub fn walk_private_field_expression<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &PrivateFieldExpression<'a>,
-    ) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-        visitor.visit_expression(&it.object);
-        visitor.visit_private_identifier(&it.field);
-    }
-
-    #[inline]
     pub fn walk_assignment_target_pattern<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &AssignmentTargetPattern<'a>,
@@ -2872,6 +1834,31 @@ pub mod walk {
     }
 
     #[inline]
+    pub fn walk_object_assignment_target<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ObjectAssignmentTarget<'a>,
+    ) {
+        let kind = AstKind::ObjectAssignmentTarget(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_assignment_target_properties(&it.properties);
+        if let Some(rest) = &it.rest {
+            visitor.visit_assignment_target_rest(rest);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_assignment_target_rest<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &AssignmentTargetRest<'a>,
+    ) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+        visitor.visit_assignment_target(&it.target);
+    }
+
+    #[inline]
     pub fn walk_assignment_target_maybe_default<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &AssignmentTargetMaybeDefault<'a>,
@@ -2898,41 +1885,6 @@ pub mod walk {
         visitor.visit_assignment_target(&it.binding);
         visitor.visit_expression(&it.init);
         visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_assignment_target_rest<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &AssignmentTargetRest<'a>,
-    ) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-        visitor.visit_assignment_target(&it.target);
-    }
-
-    #[inline]
-    pub fn walk_object_assignment_target<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &ObjectAssignmentTarget<'a>,
-    ) {
-        let kind = AstKind::ObjectAssignmentTarget(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_assignment_target_properties(&it.properties);
-        if let Some(rest) = &it.rest {
-            visitor.visit_assignment_target_rest(rest);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_assignment_target_properties<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &Vec<'a, AssignmentTargetProperty<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_assignment_target_property(el);
-        }
     }
 
     #[inline]
@@ -2976,52 +1928,31 @@ pub mod walk {
     }
 
     #[inline]
+    pub fn walk_sequence_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &SequenceExpression<'a>,
+    ) {
+        let kind = AstKind::SequenceExpression(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_expressions(&it.expressions);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_super<'a, V: Visit<'a>>(visitor: &mut V, it: &Super) {
+        let kind = AstKind::Super(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
     pub fn walk_await_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &AwaitExpression<'a>) {
         let kind = AstKind::AwaitExpression(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.argument);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_binary_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &BinaryExpression<'a>) {
-        let kind = AstKind::BinaryExpression(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_expression(&it.left);
-        visitor.visit_expression(&it.right);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_call_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &CallExpression<'a>) {
-        let kind = AstKind::CallExpression(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_expression(&it.callee);
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
-        }
-        visitor.visit_arguments(&it.arguments);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_arguments<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Argument<'a>>) {
-        for el in it {
-            visitor.visit_argument(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_argument<'a, V: Visit<'a>>(visitor: &mut V, it: &Argument<'a>) {
-        let kind = AstKind::Argument(visitor.alloc(it));
-        visitor.enter_node(kind);
-        match it {
-            Argument::SpreadElement(it) => visitor.visit_spread_element(it),
-            match_expression!(Argument) => visitor.visit_expression(it.to_expression()),
-        }
         visitor.leave_node(kind);
     }
 
@@ -3046,270 +1977,6 @@ pub mod walk {
         }
     }
 
-    pub fn walk_class<'a, V: Visit<'a>>(visitor: &mut V, it: &Class<'a>) {
-        let kind = AstKind::Class(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_decorators(&it.decorators);
-        if let Some(id) = &it.id {
-            visitor.visit_binding_identifier(id);
-        }
-        visitor.enter_scope(ScopeFlags::StrictMode, &it.scope_id);
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_declaration(type_parameters);
-        }
-        if let Some(super_class) = &it.super_class {
-            visitor.visit_expression(super_class);
-        }
-        if let Some(super_type_parameters) = &it.super_type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(super_type_parameters);
-        }
-        if let Some(implements) = &it.implements {
-            visitor.visit_ts_class_implementses(implements);
-        }
-        visitor.visit_class_body(&it.body);
-        visitor.leave_scope();
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_class_implementses<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &Vec<'a, TSClassImplements<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_ts_class_implements(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_class_implements<'a, V: Visit<'a>>(visitor: &mut V, it: &TSClassImplements<'a>) {
-        let kind = AstKind::TSClassImplements(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_type_name(&it.expression);
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_class_body<'a, V: Visit<'a>>(visitor: &mut V, it: &ClassBody<'a>) {
-        let kind = AstKind::ClassBody(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_class_elements(&it.body);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_class_elements<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, ClassElement<'a>>) {
-        for el in it {
-            visitor.visit_class_element(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_class_element<'a, V: Visit<'a>>(visitor: &mut V, it: &ClassElement<'a>) {
-        // No `AstKind` for this type
-        match it {
-            ClassElement::StaticBlock(it) => visitor.visit_static_block(it),
-            ClassElement::MethodDefinition(it) => visitor.visit_method_definition(it),
-            ClassElement::PropertyDefinition(it) => visitor.visit_property_definition(it),
-            ClassElement::AccessorProperty(it) => visitor.visit_accessor_property(it),
-            ClassElement::TSIndexSignature(it) => visitor.visit_ts_index_signature(it),
-        }
-    }
-
-    #[inline]
-    pub fn walk_static_block<'a, V: Visit<'a>>(visitor: &mut V, it: &StaticBlock<'a>) {
-        let kind = AstKind::StaticBlock(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.enter_scope(ScopeFlags::ClassStaticBlock, &it.scope_id);
-        visitor.visit_span(&it.span);
-        visitor.visit_statements(&it.body);
-        visitor.leave_scope();
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_method_definition<'a, V: Visit<'a>>(visitor: &mut V, it: &MethodDefinition<'a>) {
-        let kind = AstKind::MethodDefinition(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_decorators(&it.decorators);
-        visitor.visit_property_key(&it.key);
-        {
-            let flags = match it.kind {
-                MethodDefinitionKind::Get => ScopeFlags::Function | ScopeFlags::GetAccessor,
-                MethodDefinitionKind::Set => ScopeFlags::Function | ScopeFlags::SetAccessor,
-                MethodDefinitionKind::Constructor => ScopeFlags::Function | ScopeFlags::Constructor,
-                MethodDefinitionKind::Method => ScopeFlags::Function,
-            };
-            visitor.visit_function(&it.value, flags);
-        }
-        visitor.leave_node(kind);
-    }
-
-    pub fn walk_function<'a, V: Visit<'a>>(visitor: &mut V, it: &Function<'a>, flags: ScopeFlags) {
-        let kind = AstKind::Function(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.enter_scope(
-            {
-                let mut flags = flags;
-                if it.has_use_strict_directive() {
-                    flags |= ScopeFlags::StrictMode;
-                }
-                flags
-            },
-            &it.scope_id,
-        );
-        visitor.visit_span(&it.span);
-        if let Some(id) = &it.id {
-            visitor.visit_binding_identifier(id);
-        }
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_declaration(type_parameters);
-        }
-        if let Some(this_param) = &it.this_param {
-            visitor.visit_ts_this_parameter(this_param);
-        }
-        visitor.visit_formal_parameters(&it.params);
-        if let Some(return_type) = &it.return_type {
-            visitor.visit_ts_type_annotation(return_type);
-        }
-        if let Some(body) = &it.body {
-            visitor.visit_function_body(body);
-        }
-        visitor.leave_scope();
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_property_definition<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &PropertyDefinition<'a>,
-    ) {
-        let kind = AstKind::PropertyDefinition(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_decorators(&it.decorators);
-        visitor.visit_property_key(&it.key);
-        if let Some(value) = &it.value {
-            visitor.visit_expression(value);
-        }
-        if let Some(type_annotation) = &it.type_annotation {
-            visitor.visit_ts_type_annotation(type_annotation);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_accessor_property<'a, V: Visit<'a>>(visitor: &mut V, it: &AccessorProperty<'a>) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-        visitor.visit_decorators(&it.decorators);
-        visitor.visit_property_key(&it.key);
-        if let Some(value) = &it.value {
-            visitor.visit_expression(value);
-        }
-        if let Some(type_annotation) = &it.type_annotation {
-            visitor.visit_ts_type_annotation(type_annotation);
-        }
-    }
-
-    #[inline]
-    pub fn walk_conditional_expression<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &ConditionalExpression<'a>,
-    ) {
-        let kind = AstKind::ConditionalExpression(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_expression(&it.test);
-        visitor.visit_expression(&it.consequent);
-        visitor.visit_expression(&it.alternate);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_import_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &ImportExpression<'a>) {
-        let kind = AstKind::ImportExpression(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_expression(&it.source);
-        visitor.visit_expressions(&it.arguments);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_logical_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &LogicalExpression<'a>) {
-        let kind = AstKind::LogicalExpression(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_expression(&it.left);
-        visitor.visit_expression(&it.right);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_new_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &NewExpression<'a>) {
-        let kind = AstKind::NewExpression(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_expression(&it.callee);
-        visitor.visit_arguments(&it.arguments);
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_object_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &ObjectExpression<'a>) {
-        let kind = AstKind::ObjectExpression(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_object_property_kinds(&it.properties);
-        if let Some(trailing_comma) = &it.trailing_comma {
-            visitor.visit_span(trailing_comma);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_object_property_kinds<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &Vec<'a, ObjectPropertyKind<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_object_property_kind(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_object_property_kind<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &ObjectPropertyKind<'a>,
-    ) {
-        // No `AstKind` for this type
-        match it {
-            ObjectPropertyKind::ObjectProperty(it) => visitor.visit_object_property(it),
-            ObjectPropertyKind::SpreadProperty(it) => visitor.visit_spread_element(it),
-        }
-    }
-
-    #[inline]
-    pub fn walk_object_property<'a, V: Visit<'a>>(visitor: &mut V, it: &ObjectProperty<'a>) {
-        let kind = AstKind::ObjectProperty(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_property_key(&it.key);
-        visitor.visit_expression(&it.value);
-        visitor.leave_node(kind);
-    }
-
     #[inline]
     pub fn walk_parenthesized_expression<'a, V: Visit<'a>>(
         visitor: &mut V,
@@ -3322,306 +1989,105 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
-    #[inline]
-    pub fn walk_sequence_expression<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &SequenceExpression<'a>,
-    ) {
-        let kind = AstKind::SequenceExpression(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_expressions(&it.expressions);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_tagged_template_expression<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &TaggedTemplateExpression<'a>,
-    ) {
-        let kind = AstKind::TaggedTemplateExpression(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_expression(&it.tag);
-        visitor.visit_template_literal(&it.quasi);
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_this_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &ThisExpression) {
-        let kind = AstKind::ThisExpression(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_update_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &UpdateExpression<'a>) {
-        let kind = AstKind::UpdateExpression(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_simple_assignment_target(&it.argument);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_yield_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &YieldExpression<'a>) {
-        let kind = AstKind::YieldExpression(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        if let Some(argument) = &it.argument {
-            visitor.visit_expression(argument);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_private_in_expression<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &PrivateInExpression<'a>,
-    ) {
-        let kind = AstKind::PrivateInExpression(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_private_identifier(&it.left);
-        visitor.visit_expression(&it.right);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_jsx_element<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXElement<'a>) {
-        let kind = AstKind::JSXElement(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_jsx_opening_element(&it.opening_element);
-        if let Some(closing_element) = &it.closing_element {
-            visitor.visit_jsx_closing_element(closing_element);
-        }
-        visitor.visit_jsx_children(&it.children);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_jsx_opening_element<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXOpeningElement<'a>) {
-        let kind = AstKind::JSXOpeningElement(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_jsx_element_name(&it.name);
-        visitor.visit_jsx_attribute_items(&it.attributes);
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_jsx_element_name<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXElementName<'a>) {
-        let kind = AstKind::JSXElementName(visitor.alloc(it));
-        visitor.enter_node(kind);
+    pub fn walk_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &Statement<'a>) {
+        // No `AstKind` for this type
         match it {
-            JSXElementName::Identifier(it) => visitor.visit_jsx_identifier(it),
-            JSXElementName::IdentifierReference(it) => visitor.visit_identifier_reference(it),
-            JSXElementName::NamespacedName(it) => visitor.visit_jsx_namespaced_name(it),
-            JSXElementName::MemberExpression(it) => visitor.visit_jsx_member_expression(it),
-            JSXElementName::ThisExpression(it) => visitor.visit_this_expression(it),
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_jsx_identifier<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXIdentifier<'a>) {
-        let kind = AstKind::JSXIdentifier(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_jsx_namespaced_name<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXNamespacedName<'a>) {
-        let kind = AstKind::JSXNamespacedName(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_jsx_identifier(&it.namespace);
-        visitor.visit_jsx_identifier(&it.property);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_jsx_member_expression<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &JSXMemberExpression<'a>,
-    ) {
-        let kind = AstKind::JSXMemberExpression(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_jsx_member_expression_object(&it.object);
-        visitor.visit_jsx_identifier(&it.property);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_jsx_member_expression_object<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &JSXMemberExpressionObject<'a>,
-    ) {
-        let kind = AstKind::JSXMemberExpressionObject(visitor.alloc(it));
-        visitor.enter_node(kind);
-        match it {
-            JSXMemberExpressionObject::IdentifierReference(it) => {
-                visitor.visit_identifier_reference(it)
+            Statement::BlockStatement(it) => visitor.visit_block_statement(it),
+            Statement::BreakStatement(it) => visitor.visit_break_statement(it),
+            Statement::ContinueStatement(it) => visitor.visit_continue_statement(it),
+            Statement::DebuggerStatement(it) => visitor.visit_debugger_statement(it),
+            Statement::DoWhileStatement(it) => visitor.visit_do_while_statement(it),
+            Statement::EmptyStatement(it) => visitor.visit_empty_statement(it),
+            Statement::ExpressionStatement(it) => visitor.visit_expression_statement(it),
+            Statement::ForInStatement(it) => visitor.visit_for_in_statement(it),
+            Statement::ForOfStatement(it) => visitor.visit_for_of_statement(it),
+            Statement::ForStatement(it) => visitor.visit_for_statement(it),
+            Statement::IfStatement(it) => visitor.visit_if_statement(it),
+            Statement::LabeledStatement(it) => visitor.visit_labeled_statement(it),
+            Statement::ReturnStatement(it) => visitor.visit_return_statement(it),
+            Statement::SwitchStatement(it) => visitor.visit_switch_statement(it),
+            Statement::ThrowStatement(it) => visitor.visit_throw_statement(it),
+            Statement::TryStatement(it) => visitor.visit_try_statement(it),
+            Statement::WhileStatement(it) => visitor.visit_while_statement(it),
+            Statement::WithStatement(it) => visitor.visit_with_statement(it),
+            match_declaration!(Statement) => visitor.visit_declaration(it.to_declaration()),
+            match_module_declaration!(Statement) => {
+                visitor.visit_module_declaration(it.to_module_declaration())
             }
-            JSXMemberExpressionObject::MemberExpression(it) => {
-                visitor.visit_jsx_member_expression(it)
+        }
+    }
+
+    #[inline]
+    pub fn walk_directive<'a, V: Visit<'a>>(visitor: &mut V, it: &Directive<'a>) {
+        let kind = AstKind::Directive(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_string_literal(&it.expression);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_hashbang<'a, V: Visit<'a>>(visitor: &mut V, it: &Hashbang<'a>) {
+        let kind = AstKind::Hashbang(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_block_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &BlockStatement<'a>) {
+        let kind = AstKind::BlockStatement(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
+        visitor.visit_span(&it.span);
+        visitor.visit_statements(&it.body);
+        visitor.leave_scope();
+        visitor.leave_node(kind);
+    }
+
+    pub fn walk_declaration<'a, V: Visit<'a>>(visitor: &mut V, it: &Declaration<'a>) {
+        // No `AstKind` for this type
+        match it {
+            Declaration::VariableDeclaration(it) => visitor.visit_variable_declaration(it),
+            Declaration::FunctionDeclaration(it) => {
+                let flags = ScopeFlags::Function;
+                visitor.visit_function(it, flags)
             }
-            JSXMemberExpressionObject::ThisExpression(it) => visitor.visit_this_expression(it),
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_jsx_attribute_items<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &Vec<'a, JSXAttributeItem<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_jsx_attribute_item(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_jsx_attribute_item<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXAttributeItem<'a>) {
-        let kind = AstKind::JSXAttributeItem(visitor.alloc(it));
-        visitor.enter_node(kind);
-        match it {
-            JSXAttributeItem::Attribute(it) => visitor.visit_jsx_attribute(it),
-            JSXAttributeItem::SpreadAttribute(it) => visitor.visit_jsx_spread_attribute(it),
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_jsx_attribute<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXAttribute<'a>) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-        visitor.visit_jsx_attribute_name(&it.name);
-        if let Some(value) = &it.value {
-            visitor.visit_jsx_attribute_value(value);
-        }
-    }
-
-    #[inline]
-    pub fn walk_jsx_attribute_name<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXAttributeName<'a>) {
-        // No `AstKind` for this type
-        match it {
-            JSXAttributeName::Identifier(it) => visitor.visit_jsx_identifier(it),
-            JSXAttributeName::NamespacedName(it) => visitor.visit_jsx_namespaced_name(it),
-        }
-    }
-
-    #[inline]
-    pub fn walk_jsx_attribute_value<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXAttributeValue<'a>) {
-        // No `AstKind` for this type
-        match it {
-            JSXAttributeValue::StringLiteral(it) => visitor.visit_string_literal(it),
-            JSXAttributeValue::ExpressionContainer(it) => {
-                visitor.visit_jsx_expression_container(it)
+            Declaration::ClassDeclaration(it) => visitor.visit_class(it),
+            Declaration::TSTypeAliasDeclaration(it) => visitor.visit_ts_type_alias_declaration(it),
+            Declaration::TSInterfaceDeclaration(it) => visitor.visit_ts_interface_declaration(it),
+            Declaration::TSEnumDeclaration(it) => visitor.visit_ts_enum_declaration(it),
+            Declaration::TSModuleDeclaration(it) => visitor.visit_ts_module_declaration(it),
+            Declaration::TSImportEqualsDeclaration(it) => {
+                visitor.visit_ts_import_equals_declaration(it)
             }
-            JSXAttributeValue::Element(it) => visitor.visit_jsx_element(it),
-            JSXAttributeValue::Fragment(it) => visitor.visit_jsx_fragment(it),
         }
     }
 
     #[inline]
-    pub fn walk_jsx_expression_container<'a, V: Visit<'a>>(
+    pub fn walk_variable_declaration<'a, V: Visit<'a>>(
         visitor: &mut V,
-        it: &JSXExpressionContainer<'a>,
+        it: &VariableDeclaration<'a>,
     ) {
-        let kind = AstKind::JSXExpressionContainer(visitor.alloc(it));
+        let kind = AstKind::VariableDeclaration(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
-        visitor.visit_jsx_expression(&it.expression);
+        visitor.visit_variable_declarators(&it.declarations);
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_jsx_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXExpression<'a>) {
-        // No `AstKind` for this type
-        match it {
-            JSXExpression::EmptyExpression(it) => visitor.visit_jsx_empty_expression(it),
-            match_expression!(JSXExpression) => visitor.visit_expression(it.to_expression()),
-        }
-    }
-
-    #[inline]
-    pub fn walk_jsx_empty_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXEmptyExpression) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-    }
-
-    #[inline]
-    pub fn walk_jsx_fragment<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXFragment<'a>) {
-        let kind = AstKind::JSXFragment(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_jsx_children(&it.children);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_jsx_children<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, JSXChild<'a>>) {
-        for el in it {
-            visitor.visit_jsx_child(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_jsx_child<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXChild<'a>) {
-        // No `AstKind` for this type
-        match it {
-            JSXChild::Text(it) => visitor.visit_jsx_text(it),
-            JSXChild::Element(it) => visitor.visit_jsx_element(it),
-            JSXChild::Fragment(it) => visitor.visit_jsx_fragment(it),
-            JSXChild::ExpressionContainer(it) => visitor.visit_jsx_expression_container(it),
-            JSXChild::Spread(it) => visitor.visit_jsx_spread_child(it),
-        }
-    }
-
-    #[inline]
-    pub fn walk_jsx_text<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXText<'a>) {
-        let kind = AstKind::JSXText(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_jsx_spread_child<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXSpreadChild<'a>) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-        visitor.visit_expression(&it.expression);
-    }
-
-    #[inline]
-    pub fn walk_jsx_spread_attribute<'a, V: Visit<'a>>(
+    pub fn walk_variable_declarator<'a, V: Visit<'a>>(
         visitor: &mut V,
-        it: &JSXSpreadAttribute<'a>,
+        it: &VariableDeclarator<'a>,
     ) {
-        let kind = AstKind::JSXSpreadAttribute(visitor.alloc(it));
+        let kind = AstKind::VariableDeclarator(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
-        visitor.visit_expression(&it.argument);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_jsx_closing_element<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXClosingElement<'a>) {
-        let kind = AstKind::JSXClosingElement(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_jsx_element_name(&it.name);
+        visitor.visit_binding_pattern(&it.id);
+        if let Some(init) = &it.init {
+            visitor.visit_expression(init);
+        }
         visitor.leave_node(kind);
     }
 
@@ -3646,76 +2112,35 @@ pub mod walk {
     }
 
     #[inline]
-    pub fn walk_for_in_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &ForInStatement<'a>) {
-        let kind = AstKind::ForInStatement(visitor.alloc(it));
+    pub fn walk_if_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &IfStatement<'a>) {
+        let kind = AstKind::IfStatement(visitor.alloc(it));
         visitor.enter_node(kind);
-        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_span(&it.span);
-        visitor.visit_for_statement_left(&it.left);
-        visitor.visit_expression(&it.right);
+        visitor.visit_expression(&it.test);
+        visitor.visit_statement(&it.consequent);
+        if let Some(alternate) = &it.alternate {
+            visitor.visit_statement(alternate);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_do_while_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &DoWhileStatement<'a>) {
+        let kind = AstKind::DoWhileStatement(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
         visitor.visit_statement(&it.body);
-        visitor.leave_scope();
+        visitor.visit_expression(&it.test);
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_for_statement_left<'a, V: Visit<'a>>(visitor: &mut V, it: &ForStatementLeft<'a>) {
-        // No `AstKind` for this type
-        match it {
-            ForStatementLeft::VariableDeclaration(it) => visitor.visit_variable_declaration(it),
-            match_assignment_target!(ForStatementLeft) => {
-                visitor.visit_assignment_target(it.to_assignment_target())
-            }
-        }
-    }
-
-    #[inline]
-    pub fn walk_variable_declaration<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &VariableDeclaration<'a>,
-    ) {
-        let kind = AstKind::VariableDeclaration(visitor.alloc(it));
+    pub fn walk_while_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &WhileStatement<'a>) {
+        let kind = AstKind::WhileStatement(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
-        visitor.visit_variable_declarators(&it.declarations);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_variable_declarators<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &Vec<'a, VariableDeclarator<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_variable_declarator(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_variable_declarator<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &VariableDeclarator<'a>,
-    ) {
-        let kind = AstKind::VariableDeclarator(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_binding_pattern(&it.id);
-        if let Some(init) = &it.init {
-            visitor.visit_expression(init);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_for_of_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &ForOfStatement<'a>) {
-        let kind = AstKind::ForOfStatement(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
-        visitor.visit_span(&it.span);
-        visitor.visit_for_statement_left(&it.left);
-        visitor.visit_expression(&it.right);
+        visitor.visit_expression(&it.test);
         visitor.visit_statement(&it.body);
-        visitor.leave_scope();
         visitor.leave_node(kind);
     }
 
@@ -3751,25 +2176,61 @@ pub mod walk {
     }
 
     #[inline]
-    pub fn walk_if_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &IfStatement<'a>) {
-        let kind = AstKind::IfStatement(visitor.alloc(it));
+    pub fn walk_for_in_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &ForInStatement<'a>) {
+        let kind = AstKind::ForInStatement(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
+        visitor.visit_span(&it.span);
+        visitor.visit_for_statement_left(&it.left);
+        visitor.visit_expression(&it.right);
+        visitor.visit_statement(&it.body);
+        visitor.leave_scope();
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_for_statement_left<'a, V: Visit<'a>>(visitor: &mut V, it: &ForStatementLeft<'a>) {
+        // No `AstKind` for this type
+        match it {
+            ForStatementLeft::VariableDeclaration(it) => visitor.visit_variable_declaration(it),
+            match_assignment_target!(ForStatementLeft) => {
+                visitor.visit_assignment_target(it.to_assignment_target())
+            }
+        }
+    }
+
+    #[inline]
+    pub fn walk_for_of_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &ForOfStatement<'a>) {
+        let kind = AstKind::ForOfStatement(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
+        visitor.visit_span(&it.span);
+        visitor.visit_for_statement_left(&it.left);
+        visitor.visit_expression(&it.right);
+        visitor.visit_statement(&it.body);
+        visitor.leave_scope();
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_continue_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &ContinueStatement<'a>) {
+        let kind = AstKind::ContinueStatement(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
-        visitor.visit_expression(&it.test);
-        visitor.visit_statement(&it.consequent);
-        if let Some(alternate) = &it.alternate {
-            visitor.visit_statement(alternate);
+        if let Some(label) = &it.label {
+            visitor.visit_label_identifier(label);
         }
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_labeled_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &LabeledStatement<'a>) {
-        let kind = AstKind::LabeledStatement(visitor.alloc(it));
+    pub fn walk_break_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &BreakStatement<'a>) {
+        let kind = AstKind::BreakStatement(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
-        visitor.visit_label_identifier(&it.label);
-        visitor.visit_statement(&it.body);
+        if let Some(label) = &it.label {
+            visitor.visit_label_identifier(label);
+        }
         visitor.leave_node(kind);
     }
 
@@ -3781,6 +2242,16 @@ pub mod walk {
         if let Some(argument) = &it.argument {
             visitor.visit_expression(argument);
         }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_with_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &WithStatement<'a>) {
+        let kind = AstKind::WithStatement(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_expression(&it.object);
+        visitor.visit_statement(&it.body);
         visitor.leave_node(kind);
     }
 
@@ -3797,13 +2268,6 @@ pub mod walk {
     }
 
     #[inline]
-    pub fn walk_switch_cases<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, SwitchCase<'a>>) {
-        for el in it {
-            visitor.visit_switch_case(el);
-        }
-    }
-
-    #[inline]
     pub fn walk_switch_case<'a, V: Visit<'a>>(visitor: &mut V, it: &SwitchCase<'a>) {
         let kind = AstKind::SwitchCase(visitor.alloc(it));
         visitor.enter_node(kind);
@@ -3812,6 +2276,16 @@ pub mod walk {
             visitor.visit_expression(test);
         }
         visitor.visit_statements(&it.consequent);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_labeled_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &LabeledStatement<'a>) {
+        let kind = AstKind::LabeledStatement(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_label_identifier(&it.label);
+        visitor.visit_statement(&it.body);
         visitor.leave_node(kind);
     }
 
@@ -3863,42 +2337,1220 @@ pub mod walk {
     }
 
     #[inline]
-    pub fn walk_while_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &WhileStatement<'a>) {
-        let kind = AstKind::WhileStatement(visitor.alloc(it));
+    pub fn walk_debugger_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &DebuggerStatement) {
+        let kind = AstKind::DebuggerStatement(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
-        visitor.visit_expression(&it.test);
-        visitor.visit_statement(&it.body);
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_with_statement<'a, V: Visit<'a>>(visitor: &mut V, it: &WithStatement<'a>) {
-        let kind = AstKind::WithStatement(visitor.alloc(it));
+    pub fn walk_binding_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &BindingPattern<'a>) {
+        // No `AstKind` for this type
+        visitor.visit_binding_pattern_kind(&it.kind);
+        if let Some(type_annotation) = &it.type_annotation {
+            visitor.visit_ts_type_annotation(type_annotation);
+        }
+    }
+
+    #[inline]
+    pub fn walk_binding_pattern_kind<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &BindingPatternKind<'a>,
+    ) {
+        // No `AstKind` for this type
+        match it {
+            BindingPatternKind::BindingIdentifier(it) => visitor.visit_binding_identifier(it),
+            BindingPatternKind::ObjectPattern(it) => visitor.visit_object_pattern(it),
+            BindingPatternKind::ArrayPattern(it) => visitor.visit_array_pattern(it),
+            BindingPatternKind::AssignmentPattern(it) => visitor.visit_assignment_pattern(it),
+        }
+    }
+
+    #[inline]
+    pub fn walk_assignment_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &AssignmentPattern<'a>) {
+        let kind = AstKind::AssignmentPattern(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
-        visitor.visit_expression(&it.object);
-        visitor.visit_statement(&it.body);
+        visitor.visit_binding_pattern(&it.left);
+        visitor.visit_expression(&it.right);
         visitor.leave_node(kind);
     }
 
-    pub fn walk_declaration<'a, V: Visit<'a>>(visitor: &mut V, it: &Declaration<'a>) {
+    #[inline]
+    pub fn walk_object_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &ObjectPattern<'a>) {
+        let kind = AstKind::ObjectPattern(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_binding_properties(&it.properties);
+        if let Some(rest) = &it.rest {
+            visitor.visit_binding_rest_element(rest);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_binding_property<'a, V: Visit<'a>>(visitor: &mut V, it: &BindingProperty<'a>) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+        visitor.visit_property_key(&it.key);
+        visitor.visit_binding_pattern(&it.value);
+    }
+
+    #[inline]
+    pub fn walk_array_pattern<'a, V: Visit<'a>>(visitor: &mut V, it: &ArrayPattern<'a>) {
+        let kind = AstKind::ArrayPattern(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        for el in it.elements.iter().flatten() {
+            visitor.visit_binding_pattern(el);
+        }
+        if let Some(rest) = &it.rest {
+            visitor.visit_binding_rest_element(rest);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_binding_rest_element<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &BindingRestElement<'a>,
+    ) {
+        let kind = AstKind::BindingRestElement(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_binding_pattern(&it.argument);
+        visitor.leave_node(kind);
+    }
+
+    pub fn walk_function<'a, V: Visit<'a>>(visitor: &mut V, it: &Function<'a>, flags: ScopeFlags) {
+        let kind = AstKind::Function(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.enter_scope(
+            {
+                let mut flags = flags;
+                if it.has_use_strict_directive() {
+                    flags |= ScopeFlags::StrictMode;
+                }
+                flags
+            },
+            &it.scope_id,
+        );
+        visitor.visit_span(&it.span);
+        if let Some(id) = &it.id {
+            visitor.visit_binding_identifier(id);
+        }
+        if let Some(type_parameters) = &it.type_parameters {
+            visitor.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        if let Some(this_param) = &it.this_param {
+            visitor.visit_ts_this_parameter(this_param);
+        }
+        visitor.visit_formal_parameters(&it.params);
+        if let Some(return_type) = &it.return_type {
+            visitor.visit_ts_type_annotation(return_type);
+        }
+        if let Some(body) = &it.body {
+            visitor.visit_function_body(body);
+        }
+        visitor.leave_scope();
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_formal_parameters<'a, V: Visit<'a>>(visitor: &mut V, it: &FormalParameters<'a>) {
+        let kind = AstKind::FormalParameters(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_formal_parameter_list(&it.items);
+        if let Some(rest) = &it.rest {
+            visitor.visit_binding_rest_element(rest);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_formal_parameter<'a, V: Visit<'a>>(visitor: &mut V, it: &FormalParameter<'a>) {
+        let kind = AstKind::FormalParameter(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_decorators(&it.decorators);
+        visitor.visit_binding_pattern(&it.pattern);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_function_body<'a, V: Visit<'a>>(visitor: &mut V, it: &FunctionBody<'a>) {
+        let kind = AstKind::FunctionBody(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_directives(&it.directives);
+        visitor.visit_statements(&it.statements);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_arrow_function_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ArrowFunctionExpression<'a>,
+    ) {
+        let kind = AstKind::ArrowFunctionExpression(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.enter_scope(
+            {
+                let mut flags = ScopeFlags::Function | ScopeFlags::Arrow;
+                if it.has_use_strict_directive() {
+                    flags |= ScopeFlags::StrictMode;
+                }
+                flags
+            },
+            &it.scope_id,
+        );
+        visitor.visit_span(&it.span);
+        if let Some(type_parameters) = &it.type_parameters {
+            visitor.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        visitor.visit_formal_parameters(&it.params);
+        if let Some(return_type) = &it.return_type {
+            visitor.visit_ts_type_annotation(return_type);
+        }
+        visitor.visit_function_body(&it.body);
+        visitor.leave_scope();
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_yield_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &YieldExpression<'a>) {
+        let kind = AstKind::YieldExpression(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        if let Some(argument) = &it.argument {
+            visitor.visit_expression(argument);
+        }
+        visitor.leave_node(kind);
+    }
+
+    pub fn walk_class<'a, V: Visit<'a>>(visitor: &mut V, it: &Class<'a>) {
+        let kind = AstKind::Class(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_decorators(&it.decorators);
+        if let Some(id) = &it.id {
+            visitor.visit_binding_identifier(id);
+        }
+        visitor.enter_scope(ScopeFlags::StrictMode, &it.scope_id);
+        if let Some(type_parameters) = &it.type_parameters {
+            visitor.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        if let Some(super_class) = &it.super_class {
+            visitor.visit_expression(super_class);
+        }
+        if let Some(super_type_parameters) = &it.super_type_parameters {
+            visitor.visit_ts_type_parameter_instantiation(super_type_parameters);
+        }
+        if let Some(implements) = &it.implements {
+            visitor.visit_ts_class_implementses(implements);
+        }
+        visitor.visit_class_body(&it.body);
+        visitor.leave_scope();
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_class_body<'a, V: Visit<'a>>(visitor: &mut V, it: &ClassBody<'a>) {
+        let kind = AstKind::ClassBody(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_class_elements(&it.body);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_class_element<'a, V: Visit<'a>>(visitor: &mut V, it: &ClassElement<'a>) {
         // No `AstKind` for this type
         match it {
-            Declaration::VariableDeclaration(it) => visitor.visit_variable_declaration(it),
-            Declaration::FunctionDeclaration(it) => {
+            ClassElement::StaticBlock(it) => visitor.visit_static_block(it),
+            ClassElement::MethodDefinition(it) => visitor.visit_method_definition(it),
+            ClassElement::PropertyDefinition(it) => visitor.visit_property_definition(it),
+            ClassElement::AccessorProperty(it) => visitor.visit_accessor_property(it),
+            ClassElement::TSIndexSignature(it) => visitor.visit_ts_index_signature(it),
+        }
+    }
+
+    #[inline]
+    pub fn walk_method_definition<'a, V: Visit<'a>>(visitor: &mut V, it: &MethodDefinition<'a>) {
+        let kind = AstKind::MethodDefinition(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_decorators(&it.decorators);
+        visitor.visit_property_key(&it.key);
+        {
+            let flags = match it.kind {
+                MethodDefinitionKind::Get => ScopeFlags::Function | ScopeFlags::GetAccessor,
+                MethodDefinitionKind::Set => ScopeFlags::Function | ScopeFlags::SetAccessor,
+                MethodDefinitionKind::Constructor => ScopeFlags::Function | ScopeFlags::Constructor,
+                MethodDefinitionKind::Method => ScopeFlags::Function,
+            };
+            visitor.visit_function(&it.value, flags);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_property_definition<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &PropertyDefinition<'a>,
+    ) {
+        let kind = AstKind::PropertyDefinition(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_decorators(&it.decorators);
+        visitor.visit_property_key(&it.key);
+        if let Some(value) = &it.value {
+            visitor.visit_expression(value);
+        }
+        if let Some(type_annotation) = &it.type_annotation {
+            visitor.visit_ts_type_annotation(type_annotation);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_private_identifier<'a, V: Visit<'a>>(visitor: &mut V, it: &PrivateIdentifier<'a>) {
+        let kind = AstKind::PrivateIdentifier(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_static_block<'a, V: Visit<'a>>(visitor: &mut V, it: &StaticBlock<'a>) {
+        let kind = AstKind::StaticBlock(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.enter_scope(ScopeFlags::ClassStaticBlock, &it.scope_id);
+        visitor.visit_span(&it.span);
+        visitor.visit_statements(&it.body);
+        visitor.leave_scope();
+        visitor.leave_node(kind);
+    }
+
+    pub fn walk_module_declaration<'a, V: Visit<'a>>(visitor: &mut V, it: &ModuleDeclaration<'a>) {
+        let kind = AstKind::ModuleDeclaration(visitor.alloc(it));
+        visitor.enter_node(kind);
+        match it {
+            ModuleDeclaration::ImportDeclaration(it) => visitor.visit_import_declaration(it),
+            ModuleDeclaration::ExportAllDeclaration(it) => visitor.visit_export_all_declaration(it),
+            ModuleDeclaration::ExportDefaultDeclaration(it) => {
+                visitor.visit_export_default_declaration(it)
+            }
+            ModuleDeclaration::ExportNamedDeclaration(it) => {
+                visitor.visit_export_named_declaration(it)
+            }
+            ModuleDeclaration::TSExportAssignment(it) => visitor.visit_ts_export_assignment(it),
+            ModuleDeclaration::TSNamespaceExportDeclaration(it) => {
+                visitor.visit_ts_namespace_export_declaration(it)
+            }
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_accessor_property<'a, V: Visit<'a>>(visitor: &mut V, it: &AccessorProperty<'a>) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+        visitor.visit_decorators(&it.decorators);
+        visitor.visit_property_key(&it.key);
+        if let Some(value) = &it.value {
+            visitor.visit_expression(value);
+        }
+        if let Some(type_annotation) = &it.type_annotation {
+            visitor.visit_ts_type_annotation(type_annotation);
+        }
+    }
+
+    #[inline]
+    pub fn walk_import_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &ImportExpression<'a>) {
+        let kind = AstKind::ImportExpression(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_expression(&it.source);
+        visitor.visit_expressions(&it.arguments);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_import_declaration<'a, V: Visit<'a>>(visitor: &mut V, it: &ImportDeclaration<'a>) {
+        let kind = AstKind::ImportDeclaration(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        if let Some(specifiers) = &it.specifiers {
+            visitor.visit_import_declaration_specifiers(specifiers);
+        }
+        visitor.visit_string_literal(&it.source);
+        if let Some(with_clause) = &it.with_clause {
+            visitor.visit_with_clause(with_clause);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_import_declaration_specifier<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ImportDeclarationSpecifier<'a>,
+    ) {
+        // No `AstKind` for this type
+        match it {
+            ImportDeclarationSpecifier::ImportSpecifier(it) => visitor.visit_import_specifier(it),
+            ImportDeclarationSpecifier::ImportDefaultSpecifier(it) => {
+                visitor.visit_import_default_specifier(it)
+            }
+            ImportDeclarationSpecifier::ImportNamespaceSpecifier(it) => {
+                visitor.visit_import_namespace_specifier(it)
+            }
+        }
+    }
+
+    #[inline]
+    pub fn walk_import_specifier<'a, V: Visit<'a>>(visitor: &mut V, it: &ImportSpecifier<'a>) {
+        let kind = AstKind::ImportSpecifier(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_module_export_name(&it.imported);
+        visitor.visit_binding_identifier(&it.local);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_import_default_specifier<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ImportDefaultSpecifier<'a>,
+    ) {
+        let kind = AstKind::ImportDefaultSpecifier(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_binding_identifier(&it.local);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_import_namespace_specifier<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ImportNamespaceSpecifier<'a>,
+    ) {
+        let kind = AstKind::ImportNamespaceSpecifier(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_binding_identifier(&it.local);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_with_clause<'a, V: Visit<'a>>(visitor: &mut V, it: &WithClause<'a>) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+        visitor.visit_identifier_name(&it.attributes_keyword);
+        visitor.visit_import_attributes(&it.with_entries);
+    }
+
+    #[inline]
+    pub fn walk_import_attribute<'a, V: Visit<'a>>(visitor: &mut V, it: &ImportAttribute<'a>) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+        visitor.visit_import_attribute_key(&it.key);
+        visitor.visit_string_literal(&it.value);
+    }
+
+    #[inline]
+    pub fn walk_import_attribute_key<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ImportAttributeKey<'a>,
+    ) {
+        // No `AstKind` for this type
+        match it {
+            ImportAttributeKey::Identifier(it) => visitor.visit_identifier_name(it),
+            ImportAttributeKey::StringLiteral(it) => visitor.visit_string_literal(it),
+        }
+    }
+
+    #[inline]
+    pub fn walk_export_named_declaration<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ExportNamedDeclaration<'a>,
+    ) {
+        let kind = AstKind::ExportNamedDeclaration(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        if let Some(declaration) = &it.declaration {
+            visitor.visit_declaration(declaration);
+        }
+        visitor.visit_export_specifiers(&it.specifiers);
+        if let Some(source) = &it.source {
+            visitor.visit_string_literal(source);
+        }
+        if let Some(with_clause) = &it.with_clause {
+            visitor.visit_with_clause(with_clause);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_export_default_declaration<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ExportDefaultDeclaration<'a>,
+    ) {
+        let kind = AstKind::ExportDefaultDeclaration(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_export_default_declaration_kind(&it.declaration);
+        visitor.visit_module_export_name(&it.exported);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_export_all_declaration<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ExportAllDeclaration<'a>,
+    ) {
+        let kind = AstKind::ExportAllDeclaration(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        if let Some(exported) = &it.exported {
+            visitor.visit_module_export_name(exported);
+        }
+        visitor.visit_string_literal(&it.source);
+        if let Some(with_clause) = &it.with_clause {
+            visitor.visit_with_clause(with_clause);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_export_specifier<'a, V: Visit<'a>>(visitor: &mut V, it: &ExportSpecifier<'a>) {
+        let kind = AstKind::ExportSpecifier(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_module_export_name(&it.local);
+        visitor.visit_module_export_name(&it.exported);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_export_default_declaration_kind<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &ExportDefaultDeclarationKind<'a>,
+    ) {
+        // No `AstKind` for this type
+        match it {
+            ExportDefaultDeclarationKind::FunctionDeclaration(it) => {
                 let flags = ScopeFlags::Function;
                 visitor.visit_function(it, flags)
             }
-            Declaration::ClassDeclaration(it) => visitor.visit_class(it),
-            Declaration::TSTypeAliasDeclaration(it) => visitor.visit_ts_type_alias_declaration(it),
-            Declaration::TSInterfaceDeclaration(it) => visitor.visit_ts_interface_declaration(it),
-            Declaration::TSEnumDeclaration(it) => visitor.visit_ts_enum_declaration(it),
-            Declaration::TSModuleDeclaration(it) => visitor.visit_ts_module_declaration(it),
-            Declaration::TSImportEqualsDeclaration(it) => {
-                visitor.visit_ts_import_equals_declaration(it)
+            ExportDefaultDeclarationKind::ClassDeclaration(it) => visitor.visit_class(it),
+            ExportDefaultDeclarationKind::TSInterfaceDeclaration(it) => {
+                visitor.visit_ts_interface_declaration(it)
+            }
+            match_expression!(ExportDefaultDeclarationKind) => {
+                visitor.visit_expression(it.to_expression())
             }
         }
+    }
+
+    #[inline]
+    pub fn walk_module_export_name<'a, V: Visit<'a>>(visitor: &mut V, it: &ModuleExportName<'a>) {
+        // No `AstKind` for this type
+        match it {
+            ModuleExportName::IdentifierName(it) => visitor.visit_identifier_name(it),
+            ModuleExportName::IdentifierReference(it) => visitor.visit_identifier_reference(it),
+            ModuleExportName::StringLiteral(it) => visitor.visit_string_literal(it),
+        }
+    }
+
+    #[inline]
+    pub fn walk_boolean_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &BooleanLiteral) {
+        let kind = AstKind::BooleanLiteral(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_null_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &NullLiteral) {
+        let kind = AstKind::NullLiteral(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_numeric_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &NumericLiteral<'a>) {
+        let kind = AstKind::NumericLiteral(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_string_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &StringLiteral<'a>) {
+        let kind = AstKind::StringLiteral(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_big_int_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &BigIntLiteral<'a>) {
+        let kind = AstKind::BigIntLiteral(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_reg_exp_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &RegExpLiteral<'a>) {
+        let kind = AstKind::RegExpLiteral(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_element<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXElement<'a>) {
+        let kind = AstKind::JSXElement(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_jsx_opening_element(&it.opening_element);
+        if let Some(closing_element) = &it.closing_element {
+            visitor.visit_jsx_closing_element(closing_element);
+        }
+        visitor.visit_jsx_children(&it.children);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_opening_element<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXOpeningElement<'a>) {
+        let kind = AstKind::JSXOpeningElement(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_jsx_element_name(&it.name);
+        visitor.visit_jsx_attribute_items(&it.attributes);
+        if let Some(type_parameters) = &it.type_parameters {
+            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_closing_element<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXClosingElement<'a>) {
+        let kind = AstKind::JSXClosingElement(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_jsx_element_name(&it.name);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_fragment<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXFragment<'a>) {
+        let kind = AstKind::JSXFragment(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_jsx_children(&it.children);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_element_name<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXElementName<'a>) {
+        let kind = AstKind::JSXElementName(visitor.alloc(it));
+        visitor.enter_node(kind);
+        match it {
+            JSXElementName::Identifier(it) => visitor.visit_jsx_identifier(it),
+            JSXElementName::IdentifierReference(it) => visitor.visit_identifier_reference(it),
+            JSXElementName::NamespacedName(it) => visitor.visit_jsx_namespaced_name(it),
+            JSXElementName::MemberExpression(it) => visitor.visit_jsx_member_expression(it),
+            JSXElementName::ThisExpression(it) => visitor.visit_this_expression(it),
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_namespaced_name<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXNamespacedName<'a>) {
+        let kind = AstKind::JSXNamespacedName(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_jsx_identifier(&it.namespace);
+        visitor.visit_jsx_identifier(&it.property);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_member_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &JSXMemberExpression<'a>,
+    ) {
+        let kind = AstKind::JSXMemberExpression(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_jsx_member_expression_object(&it.object);
+        visitor.visit_jsx_identifier(&it.property);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_member_expression_object<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &JSXMemberExpressionObject<'a>,
+    ) {
+        let kind = AstKind::JSXMemberExpressionObject(visitor.alloc(it));
+        visitor.enter_node(kind);
+        match it {
+            JSXMemberExpressionObject::IdentifierReference(it) => {
+                visitor.visit_identifier_reference(it)
+            }
+            JSXMemberExpressionObject::MemberExpression(it) => {
+                visitor.visit_jsx_member_expression(it)
+            }
+            JSXMemberExpressionObject::ThisExpression(it) => visitor.visit_this_expression(it),
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_expression_container<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &JSXExpressionContainer<'a>,
+    ) {
+        let kind = AstKind::JSXExpressionContainer(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_jsx_expression(&it.expression);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXExpression<'a>) {
+        // No `AstKind` for this type
+        match it {
+            JSXExpression::EmptyExpression(it) => visitor.visit_jsx_empty_expression(it),
+            match_expression!(JSXExpression) => visitor.visit_expression(it.to_expression()),
+        }
+    }
+
+    #[inline]
+    pub fn walk_jsx_empty_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXEmptyExpression) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+    }
+
+    #[inline]
+    pub fn walk_jsx_attribute_item<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXAttributeItem<'a>) {
+        let kind = AstKind::JSXAttributeItem(visitor.alloc(it));
+        visitor.enter_node(kind);
+        match it {
+            JSXAttributeItem::Attribute(it) => visitor.visit_jsx_attribute(it),
+            JSXAttributeItem::SpreadAttribute(it) => visitor.visit_jsx_spread_attribute(it),
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_attribute<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXAttribute<'a>) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+        visitor.visit_jsx_attribute_name(&it.name);
+        if let Some(value) = &it.value {
+            visitor.visit_jsx_attribute_value(value);
+        }
+    }
+
+    #[inline]
+    pub fn walk_jsx_spread_attribute<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &JSXSpreadAttribute<'a>,
+    ) {
+        let kind = AstKind::JSXSpreadAttribute(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_expression(&it.argument);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_attribute_name<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXAttributeName<'a>) {
+        // No `AstKind` for this type
+        match it {
+            JSXAttributeName::Identifier(it) => visitor.visit_jsx_identifier(it),
+            JSXAttributeName::NamespacedName(it) => visitor.visit_jsx_namespaced_name(it),
+        }
+    }
+
+    #[inline]
+    pub fn walk_jsx_attribute_value<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXAttributeValue<'a>) {
+        // No `AstKind` for this type
+        match it {
+            JSXAttributeValue::StringLiteral(it) => visitor.visit_string_literal(it),
+            JSXAttributeValue::ExpressionContainer(it) => {
+                visitor.visit_jsx_expression_container(it)
+            }
+            JSXAttributeValue::Element(it) => visitor.visit_jsx_element(it),
+            JSXAttributeValue::Fragment(it) => visitor.visit_jsx_fragment(it),
+        }
+    }
+
+    #[inline]
+    pub fn walk_jsx_identifier<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXIdentifier<'a>) {
+        let kind = AstKind::JSXIdentifier(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_child<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXChild<'a>) {
+        // No `AstKind` for this type
+        match it {
+            JSXChild::Text(it) => visitor.visit_jsx_text(it),
+            JSXChild::Element(it) => visitor.visit_jsx_element(it),
+            JSXChild::Fragment(it) => visitor.visit_jsx_fragment(it),
+            JSXChild::ExpressionContainer(it) => visitor.visit_jsx_expression_container(it),
+            JSXChild::Spread(it) => visitor.visit_jsx_spread_child(it),
+        }
+    }
+
+    #[inline]
+    pub fn walk_jsx_spread_child<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXSpreadChild<'a>) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+        visitor.visit_expression(&it.expression);
+    }
+
+    #[inline]
+    pub fn walk_jsx_text<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXText<'a>) {
+        let kind = AstKind::JSXText(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_this_parameter<'a, V: Visit<'a>>(visitor: &mut V, it: &TSThisParameter<'a>) {
+        let kind = AstKind::TSThisParameter(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_span(&it.this_span);
+        if let Some(type_annotation) = &it.type_annotation {
+            visitor.visit_ts_type_annotation(type_annotation);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_enum_declaration<'a, V: Visit<'a>>(visitor: &mut V, it: &TSEnumDeclaration<'a>) {
+        let kind = AstKind::TSEnumDeclaration(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_binding_identifier(&it.id);
+        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
+        visitor.visit_ts_enum_members(&it.members);
+        visitor.leave_scope();
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_enum_member<'a, V: Visit<'a>>(visitor: &mut V, it: &TSEnumMember<'a>) {
+        let kind = AstKind::TSEnumMember(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_enum_member_name(&it.id);
+        if let Some(initializer) = &it.initializer {
+            visitor.visit_expression(initializer);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_enum_member_name<'a, V: Visit<'a>>(visitor: &mut V, it: &TSEnumMemberName<'a>) {
+        // No `AstKind` for this type
+        match it {
+            TSEnumMemberName::Identifier(it) => visitor.visit_identifier_name(it),
+            TSEnumMemberName::String(it) => visitor.visit_string_literal(it),
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_type_annotation<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeAnnotation<'a>) {
+        let kind = AstKind::TSTypeAnnotation(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_type(&it.type_annotation);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_literal_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSLiteralType<'a>) {
+        let kind = AstKind::TSLiteralType(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_literal(&it.literal);
+        visitor.leave_node(kind);
+    }
+
+    pub fn walk_ts_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &TSLiteral<'a>) {
+        // No `AstKind` for this type
+        match it {
+            TSLiteral::BooleanLiteral(it) => visitor.visit_boolean_literal(it),
+            TSLiteral::NullLiteral(it) => visitor.visit_null_literal(it),
+            TSLiteral::NumericLiteral(it) => visitor.visit_numeric_literal(it),
+            TSLiteral::BigIntLiteral(it) => visitor.visit_big_int_literal(it),
+            TSLiteral::RegExpLiteral(it) => visitor.visit_reg_exp_literal(it),
+            TSLiteral::StringLiteral(it) => visitor.visit_string_literal(it),
+            TSLiteral::TemplateLiteral(it) => visitor.visit_template_literal(it),
+            TSLiteral::UnaryExpression(it) => visitor.visit_unary_expression(it),
+        }
+    }
+
+    pub fn walk_ts_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSType<'a>) {
+        // No `AstKind` for this type
+        match it {
+            TSType::TSAnyKeyword(it) => visitor.visit_ts_any_keyword(it),
+            TSType::TSBigIntKeyword(it) => visitor.visit_ts_big_int_keyword(it),
+            TSType::TSBooleanKeyword(it) => visitor.visit_ts_boolean_keyword(it),
+            TSType::TSIntrinsicKeyword(it) => visitor.visit_ts_intrinsic_keyword(it),
+            TSType::TSNeverKeyword(it) => visitor.visit_ts_never_keyword(it),
+            TSType::TSNullKeyword(it) => visitor.visit_ts_null_keyword(it),
+            TSType::TSNumberKeyword(it) => visitor.visit_ts_number_keyword(it),
+            TSType::TSObjectKeyword(it) => visitor.visit_ts_object_keyword(it),
+            TSType::TSStringKeyword(it) => visitor.visit_ts_string_keyword(it),
+            TSType::TSSymbolKeyword(it) => visitor.visit_ts_symbol_keyword(it),
+            TSType::TSUndefinedKeyword(it) => visitor.visit_ts_undefined_keyword(it),
+            TSType::TSUnknownKeyword(it) => visitor.visit_ts_unknown_keyword(it),
+            TSType::TSVoidKeyword(it) => visitor.visit_ts_void_keyword(it),
+            TSType::TSArrayType(it) => visitor.visit_ts_array_type(it),
+            TSType::TSConditionalType(it) => visitor.visit_ts_conditional_type(it),
+            TSType::TSConstructorType(it) => visitor.visit_ts_constructor_type(it),
+            TSType::TSFunctionType(it) => visitor.visit_ts_function_type(it),
+            TSType::TSImportType(it) => visitor.visit_ts_import_type(it),
+            TSType::TSIndexedAccessType(it) => visitor.visit_ts_indexed_access_type(it),
+            TSType::TSInferType(it) => visitor.visit_ts_infer_type(it),
+            TSType::TSIntersectionType(it) => visitor.visit_ts_intersection_type(it),
+            TSType::TSLiteralType(it) => visitor.visit_ts_literal_type(it),
+            TSType::TSMappedType(it) => visitor.visit_ts_mapped_type(it),
+            TSType::TSNamedTupleMember(it) => visitor.visit_ts_named_tuple_member(it),
+            TSType::TSQualifiedName(it) => visitor.visit_ts_qualified_name(it),
+            TSType::TSTemplateLiteralType(it) => visitor.visit_ts_template_literal_type(it),
+            TSType::TSThisType(it) => visitor.visit_ts_this_type(it),
+            TSType::TSTupleType(it) => visitor.visit_ts_tuple_type(it),
+            TSType::TSTypeLiteral(it) => visitor.visit_ts_type_literal(it),
+            TSType::TSTypeOperatorType(it) => visitor.visit_ts_type_operator(it),
+            TSType::TSTypePredicate(it) => visitor.visit_ts_type_predicate(it),
+            TSType::TSTypeQuery(it) => visitor.visit_ts_type_query(it),
+            TSType::TSTypeReference(it) => visitor.visit_ts_type_reference(it),
+            TSType::TSUnionType(it) => visitor.visit_ts_union_type(it),
+            TSType::TSParenthesizedType(it) => visitor.visit_ts_parenthesized_type(it),
+            TSType::JSDocNullableType(it) => visitor.visit_js_doc_nullable_type(it),
+            TSType::JSDocNonNullableType(it) => visitor.visit_js_doc_non_nullable_type(it),
+            TSType::JSDocUnknownType(it) => visitor.visit_js_doc_unknown_type(it),
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_conditional_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSConditionalType<'a>) {
+        let kind = AstKind::TSConditionalType(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_type(&it.check_type);
+        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
+        visitor.visit_ts_type(&it.extends_type);
+        visitor.visit_ts_type(&it.true_type);
+        visitor.leave_scope();
+        visitor.visit_ts_type(&it.false_type);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_union_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSUnionType<'a>) {
+        let kind = AstKind::TSUnionType(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_types(&it.types);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_intersection_type<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSIntersectionType<'a>,
+    ) {
+        let kind = AstKind::TSIntersectionType(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_types(&it.types);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_parenthesized_type<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSParenthesizedType<'a>,
+    ) {
+        let kind = AstKind::TSParenthesizedType(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_type(&it.type_annotation);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_type_operator<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeOperator<'a>) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_type(&it.type_annotation);
+    }
+
+    #[inline]
+    pub fn walk_ts_array_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSArrayType<'a>) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_type(&it.element_type);
+    }
+
+    #[inline]
+    pub fn walk_ts_indexed_access_type<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSIndexedAccessType<'a>,
+    ) {
+        let kind = AstKind::TSIndexedAccessType(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_type(&it.object_type);
+        visitor.visit_ts_type(&it.index_type);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_tuple_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTupleType<'a>) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_tuple_elements(&it.element_types);
+    }
+
+    #[inline]
+    pub fn walk_ts_named_tuple_member<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSNamedTupleMember<'a>,
+    ) {
+        let kind = AstKind::TSNamedTupleMember(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_tuple_element(&it.element_type);
+        visitor.visit_identifier_name(&it.label);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_optional_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSOptionalType<'a>) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_type(&it.type_annotation);
+    }
+
+    #[inline]
+    pub fn walk_ts_rest_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSRestType<'a>) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_type(&it.type_annotation);
+    }
+
+    #[inline]
+    pub fn walk_ts_tuple_element<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTupleElement<'a>) {
+        // No `AstKind` for this type
+        match it {
+            TSTupleElement::TSOptionalType(it) => visitor.visit_ts_optional_type(it),
+            TSTupleElement::TSRestType(it) => visitor.visit_ts_rest_type(it),
+            match_ts_type!(TSTupleElement) => visitor.visit_ts_type(it.to_ts_type()),
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_any_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSAnyKeyword) {
+        let kind = AstKind::TSAnyKeyword(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_string_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSStringKeyword) {
+        let kind = AstKind::TSStringKeyword(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_boolean_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSBooleanKeyword) {
+        let kind = AstKind::TSBooleanKeyword(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_number_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSNumberKeyword) {
+        let kind = AstKind::TSNumberKeyword(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_never_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSNeverKeyword) {
+        let kind = AstKind::TSNeverKeyword(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_intrinsic_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSIntrinsicKeyword) {
+        let kind = AstKind::TSIntrinsicKeyword(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_unknown_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSUnknownKeyword) {
+        let kind = AstKind::TSUnknownKeyword(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_null_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSNullKeyword) {
+        let kind = AstKind::TSNullKeyword(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_undefined_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSUndefinedKeyword) {
+        let kind = AstKind::TSUndefinedKeyword(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_void_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSVoidKeyword) {
+        let kind = AstKind::TSVoidKeyword(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_symbol_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSSymbolKeyword) {
+        let kind = AstKind::TSSymbolKeyword(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_this_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSThisType) {
+        let kind = AstKind::TSThisType(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_object_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSObjectKeyword) {
+        let kind = AstKind::TSObjectKeyword(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_big_int_keyword<'a, V: Visit<'a>>(visitor: &mut V, it: &TSBigIntKeyword) {
+        let kind = AstKind::TSBigIntKeyword(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_type_reference<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeReference<'a>) {
+        let kind = AstKind::TSTypeReference(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_type_name(&it.type_name);
+        if let Some(type_parameters) = &it.type_parameters {
+            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_type_name<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeName<'a>) {
+        let kind = AstKind::TSTypeName(visitor.alloc(it));
+        visitor.enter_node(kind);
+        match it {
+            TSTypeName::IdentifierReference(it) => visitor.visit_identifier_reference(it),
+            TSTypeName::QualifiedName(it) => visitor.visit_ts_qualified_name(it),
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_qualified_name<'a, V: Visit<'a>>(visitor: &mut V, it: &TSQualifiedName<'a>) {
+        let kind = AstKind::TSQualifiedName(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_type_name(&it.left);
+        visitor.visit_identifier_name(&it.right);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_type_parameter_instantiation<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSTypeParameterInstantiation<'a>,
+    ) {
+        let kind = AstKind::TSTypeParameterInstantiation(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_types(&it.params);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_type_parameter<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeParameter<'a>) {
+        let kind = AstKind::TSTypeParameter(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_binding_identifier(&it.name);
+        if let Some(constraint) = &it.constraint {
+            visitor.visit_ts_type(constraint);
+        }
+        if let Some(default) = &it.default {
+            visitor.visit_ts_type(default);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_type_parameter_declaration<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSTypeParameterDeclaration<'a>,
+    ) {
+        let kind = AstKind::TSTypeParameterDeclaration(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_type_parameters(&it.params);
+        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -3916,6 +3568,18 @@ pub mod walk {
         }
         visitor.visit_ts_type(&it.type_annotation);
         visitor.leave_scope();
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_class_implements<'a, V: Visit<'a>>(visitor: &mut V, it: &TSClassImplements<'a>) {
+        let kind = AstKind::TSClassImplements(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_type_name(&it.expression);
+        if let Some(type_parameters) = &it.type_parameters {
+            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        }
         visitor.leave_node(kind);
     }
 
@@ -3941,13 +3605,118 @@ pub mod walk {
     }
 
     #[inline]
-    pub fn walk_ts_interface_heritages<'a, V: Visit<'a>>(
+    pub fn walk_ts_interface_body<'a, V: Visit<'a>>(visitor: &mut V, it: &TSInterfaceBody<'a>) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_signatures(&it.body);
+    }
+
+    #[inline]
+    pub fn walk_ts_property_signature<'a, V: Visit<'a>>(
         visitor: &mut V,
-        it: &Vec<'a, TSInterfaceHeritage<'a>>,
+        it: &TSPropertySignature<'a>,
     ) {
-        for el in it {
-            visitor.visit_ts_interface_heritage(el);
+        let kind = AstKind::TSPropertySignature(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_property_key(&it.key);
+        if let Some(type_annotation) = &it.type_annotation {
+            visitor.visit_ts_type_annotation(type_annotation);
         }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_signature<'a, V: Visit<'a>>(visitor: &mut V, it: &TSSignature<'a>) {
+        // No `AstKind` for this type
+        match it {
+            TSSignature::TSIndexSignature(it) => visitor.visit_ts_index_signature(it),
+            TSSignature::TSPropertySignature(it) => visitor.visit_ts_property_signature(it),
+            TSSignature::TSCallSignatureDeclaration(it) => {
+                visitor.visit_ts_call_signature_declaration(it)
+            }
+            TSSignature::TSConstructSignatureDeclaration(it) => {
+                visitor.visit_ts_construct_signature_declaration(it)
+            }
+            TSSignature::TSMethodSignature(it) => visitor.visit_ts_method_signature(it),
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_index_signature<'a, V: Visit<'a>>(visitor: &mut V, it: &TSIndexSignature<'a>) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_index_signature_names(&it.parameters);
+        visitor.visit_ts_type_annotation(&it.type_annotation);
+    }
+
+    #[inline]
+    pub fn walk_ts_call_signature_declaration<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSCallSignatureDeclaration<'a>,
+    ) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+        if let Some(type_parameters) = &it.type_parameters {
+            visitor.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        if let Some(this_param) = &it.this_param {
+            visitor.visit_ts_this_parameter(this_param);
+        }
+        visitor.visit_formal_parameters(&it.params);
+        if let Some(return_type) = &it.return_type {
+            visitor.visit_ts_type_annotation(return_type);
+        }
+    }
+
+    pub fn walk_ts_method_signature<'a, V: Visit<'a>>(visitor: &mut V, it: &TSMethodSignature<'a>) {
+        let kind = AstKind::TSMethodSignature(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
+        visitor.visit_span(&it.span);
+        visitor.visit_property_key(&it.key);
+        if let Some(type_parameters) = &it.type_parameters {
+            visitor.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        if let Some(this_param) = &it.this_param {
+            visitor.visit_ts_this_parameter(this_param);
+        }
+        visitor.visit_formal_parameters(&it.params);
+        if let Some(return_type) = &it.return_type {
+            visitor.visit_ts_type_annotation(return_type);
+        }
+        visitor.leave_scope();
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_construct_signature_declaration<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSConstructSignatureDeclaration<'a>,
+    ) {
+        let kind = AstKind::TSConstructSignatureDeclaration(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
+        visitor.visit_span(&it.span);
+        if let Some(type_parameters) = &it.type_parameters {
+            visitor.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        visitor.visit_formal_parameters(&it.params);
+        if let Some(return_type) = &it.return_type {
+            visitor.visit_ts_type_annotation(return_type);
+        }
+        visitor.leave_scope();
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_index_signature_name<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSIndexSignatureName<'a>,
+    ) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_type_annotation(&it.type_annotation);
     }
 
     #[inline]
@@ -3966,49 +3735,24 @@ pub mod walk {
     }
 
     #[inline]
-    pub fn walk_ts_interface_body<'a, V: Visit<'a>>(visitor: &mut V, it: &TSInterfaceBody<'a>) {
+    pub fn walk_ts_type_predicate<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypePredicate<'a>) {
         // No `AstKind` for this type
         visitor.visit_span(&it.span);
-        visitor.visit_ts_signatures(&it.body);
-    }
-
-    #[inline]
-    pub fn walk_ts_enum_declaration<'a, V: Visit<'a>>(visitor: &mut V, it: &TSEnumDeclaration<'a>) {
-        let kind = AstKind::TSEnumDeclaration(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_binding_identifier(&it.id);
-        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
-        visitor.visit_ts_enum_members(&it.members);
-        visitor.leave_scope();
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_enum_members<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, TSEnumMember<'a>>) {
-        for el in it {
-            visitor.visit_ts_enum_member(el);
+        visitor.visit_ts_type_predicate_name(&it.parameter_name);
+        if let Some(type_annotation) = &it.type_annotation {
+            visitor.visit_ts_type_annotation(type_annotation);
         }
     }
 
     #[inline]
-    pub fn walk_ts_enum_member<'a, V: Visit<'a>>(visitor: &mut V, it: &TSEnumMember<'a>) {
-        let kind = AstKind::TSEnumMember(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_enum_member_name(&it.id);
-        if let Some(initializer) = &it.initializer {
-            visitor.visit_expression(initializer);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_enum_member_name<'a, V: Visit<'a>>(visitor: &mut V, it: &TSEnumMemberName<'a>) {
+    pub fn walk_ts_type_predicate_name<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSTypePredicateName<'a>,
+    ) {
         // No `AstKind` for this type
         match it {
-            TSEnumMemberName::Identifier(it) => visitor.visit_identifier_name(it),
-            TSEnumMemberName::String(it) => visitor.visit_string_literal(it),
+            TSTypePredicateName::Identifier(it) => visitor.visit_identifier_name(it),
+            TSTypePredicateName::This(it) => visitor.visit_ts_this_type(it),
         }
     }
 
@@ -4075,6 +3819,187 @@ pub mod walk {
     }
 
     #[inline]
+    pub fn walk_ts_type_literal<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeLiteral<'a>) {
+        let kind = AstKind::TSTypeLiteral(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_signatures(&it.members);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_infer_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSInferType<'a>) {
+        let kind = AstKind::TSInferType(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_type_parameter(&it.type_parameter);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_type_query<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeQuery<'a>) {
+        let kind = AstKind::TSTypeQuery(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_type_query_expr_name(&it.expr_name);
+        if let Some(type_parameters) = &it.type_parameters {
+            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_type_query_expr_name<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSTypeQueryExprName<'a>,
+    ) {
+        // No `AstKind` for this type
+        match it {
+            TSTypeQueryExprName::TSImportType(it) => visitor.visit_ts_import_type(it),
+            match_ts_type_name!(TSTypeQueryExprName) => {
+                visitor.visit_ts_type_name(it.to_ts_type_name())
+            }
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_import_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSImportType<'a>) {
+        let kind = AstKind::TSImportType(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_type(&it.parameter);
+        if let Some(qualifier) = &it.qualifier {
+            visitor.visit_ts_type_name(qualifier);
+        }
+        if let Some(attributes) = &it.attributes {
+            visitor.visit_ts_import_attributes(attributes);
+        }
+        if let Some(type_parameters) = &it.type_parameters {
+            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_import_attributes<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSImportAttributes<'a>,
+    ) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+        visitor.visit_identifier_name(&it.attributes_keyword);
+        visitor.visit_ts_import_attribute_list(&it.elements);
+    }
+
+    #[inline]
+    pub fn walk_ts_import_attribute<'a, V: Visit<'a>>(visitor: &mut V, it: &TSImportAttribute<'a>) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_import_attribute_name(&it.name);
+        visitor.visit_expression(&it.value);
+    }
+
+    #[inline]
+    pub fn walk_ts_import_attribute_name<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSImportAttributeName<'a>,
+    ) {
+        // No `AstKind` for this type
+        match it {
+            TSImportAttributeName::Identifier(it) => visitor.visit_identifier_name(it),
+            TSImportAttributeName::StringLiteral(it) => visitor.visit_string_literal(it),
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_function_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSFunctionType<'a>) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+        if let Some(type_parameters) = &it.type_parameters {
+            visitor.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        if let Some(this_param) = &it.this_param {
+            visitor.visit_ts_this_parameter(this_param);
+        }
+        visitor.visit_formal_parameters(&it.params);
+        visitor.visit_ts_type_annotation(&it.return_type);
+    }
+
+    #[inline]
+    pub fn walk_ts_constructor_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSConstructorType<'a>) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+        if let Some(type_parameters) = &it.type_parameters {
+            visitor.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        visitor.visit_formal_parameters(&it.params);
+        visitor.visit_ts_type_annotation(&it.return_type);
+    }
+
+    #[inline]
+    pub fn walk_ts_mapped_type<'a, V: Visit<'a>>(visitor: &mut V, it: &TSMappedType<'a>) {
+        let kind = AstKind::TSMappedType(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_type_parameter(&it.type_parameter);
+        if let Some(name_type) = &it.name_type {
+            visitor.visit_ts_type(name_type);
+        }
+        if let Some(type_annotation) = &it.type_annotation {
+            visitor.visit_ts_type(type_annotation);
+        }
+        visitor.leave_scope();
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_template_literal_type<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSTemplateLiteralType<'a>,
+    ) {
+        let kind = AstKind::TSTemplateLiteralType(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_template_elements(&it.quasis);
+        visitor.visit_ts_types(&it.types);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_as_expression<'a, V: Visit<'a>>(visitor: &mut V, it: &TSAsExpression<'a>) {
+        let kind = AstKind::TSAsExpression(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_expression(&it.expression);
+        visitor.visit_ts_type(&it.type_annotation);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_satisfies_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSSatisfiesExpression<'a>,
+    ) {
+        let kind = AstKind::TSSatisfiesExpression(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_expression(&it.expression);
+        visitor.visit_ts_type(&it.type_annotation);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_type_assertion<'a, V: Visit<'a>>(visitor: &mut V, it: &TSTypeAssertion<'a>) {
+        let kind = AstKind::TSTypeAssertion(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_expression(&it.expression);
+        visitor.visit_ts_type(&it.type_annotation);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
     pub fn walk_ts_import_equals_declaration<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &TSImportEqualsDeclaration<'a>,
@@ -4114,240 +4039,24 @@ pub mod walk {
         visitor.leave_node(kind);
     }
 
-    pub fn walk_module_declaration<'a, V: Visit<'a>>(visitor: &mut V, it: &ModuleDeclaration<'a>) {
-        let kind = AstKind::ModuleDeclaration(visitor.alloc(it));
+    #[inline]
+    pub fn walk_ts_non_null_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSNonNullExpression<'a>,
+    ) {
+        let kind = AstKind::TSNonNullExpression(visitor.alloc(it));
         visitor.enter_node(kind);
-        match it {
-            ModuleDeclaration::ImportDeclaration(it) => visitor.visit_import_declaration(it),
-            ModuleDeclaration::ExportAllDeclaration(it) => visitor.visit_export_all_declaration(it),
-            ModuleDeclaration::ExportDefaultDeclaration(it) => {
-                visitor.visit_export_default_declaration(it)
-            }
-            ModuleDeclaration::ExportNamedDeclaration(it) => {
-                visitor.visit_export_named_declaration(it)
-            }
-            ModuleDeclaration::TSExportAssignment(it) => visitor.visit_ts_export_assignment(it),
-            ModuleDeclaration::TSNamespaceExportDeclaration(it) => {
-                visitor.visit_ts_namespace_export_declaration(it)
-            }
-        }
+        visitor.visit_span(&it.span);
+        visitor.visit_expression(&it.expression);
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_import_declaration<'a, V: Visit<'a>>(visitor: &mut V, it: &ImportDeclaration<'a>) {
-        let kind = AstKind::ImportDeclaration(visitor.alloc(it));
+    pub fn walk_decorator<'a, V: Visit<'a>>(visitor: &mut V, it: &Decorator<'a>) {
+        let kind = AstKind::Decorator(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
-        if let Some(specifiers) = &it.specifiers {
-            visitor.visit_import_declaration_specifiers(specifiers);
-        }
-        visitor.visit_string_literal(&it.source);
-        if let Some(with_clause) = &it.with_clause {
-            visitor.visit_with_clause(with_clause);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_import_declaration_specifiers<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &Vec<'a, ImportDeclarationSpecifier<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_import_declaration_specifier(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_import_declaration_specifier<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &ImportDeclarationSpecifier<'a>,
-    ) {
-        // No `AstKind` for this type
-        match it {
-            ImportDeclarationSpecifier::ImportSpecifier(it) => visitor.visit_import_specifier(it),
-            ImportDeclarationSpecifier::ImportDefaultSpecifier(it) => {
-                visitor.visit_import_default_specifier(it)
-            }
-            ImportDeclarationSpecifier::ImportNamespaceSpecifier(it) => {
-                visitor.visit_import_namespace_specifier(it)
-            }
-        }
-    }
-
-    #[inline]
-    pub fn walk_import_specifier<'a, V: Visit<'a>>(visitor: &mut V, it: &ImportSpecifier<'a>) {
-        let kind = AstKind::ImportSpecifier(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_module_export_name(&it.imported);
-        visitor.visit_binding_identifier(&it.local);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_module_export_name<'a, V: Visit<'a>>(visitor: &mut V, it: &ModuleExportName<'a>) {
-        // No `AstKind` for this type
-        match it {
-            ModuleExportName::IdentifierName(it) => visitor.visit_identifier_name(it),
-            ModuleExportName::IdentifierReference(it) => visitor.visit_identifier_reference(it),
-            ModuleExportName::StringLiteral(it) => visitor.visit_string_literal(it),
-        }
-    }
-
-    #[inline]
-    pub fn walk_import_default_specifier<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &ImportDefaultSpecifier<'a>,
-    ) {
-        let kind = AstKind::ImportDefaultSpecifier(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_binding_identifier(&it.local);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_import_namespace_specifier<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &ImportNamespaceSpecifier<'a>,
-    ) {
-        let kind = AstKind::ImportNamespaceSpecifier(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_binding_identifier(&it.local);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_with_clause<'a, V: Visit<'a>>(visitor: &mut V, it: &WithClause<'a>) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-        visitor.visit_identifier_name(&it.attributes_keyword);
-        visitor.visit_import_attributes(&it.with_entries);
-    }
-
-    #[inline]
-    pub fn walk_import_attributes<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &Vec<'a, ImportAttribute<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_import_attribute(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_import_attribute<'a, V: Visit<'a>>(visitor: &mut V, it: &ImportAttribute<'a>) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-        visitor.visit_import_attribute_key(&it.key);
-        visitor.visit_string_literal(&it.value);
-    }
-
-    #[inline]
-    pub fn walk_import_attribute_key<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &ImportAttributeKey<'a>,
-    ) {
-        // No `AstKind` for this type
-        match it {
-            ImportAttributeKey::Identifier(it) => visitor.visit_identifier_name(it),
-            ImportAttributeKey::StringLiteral(it) => visitor.visit_string_literal(it),
-        }
-    }
-
-    #[inline]
-    pub fn walk_export_all_declaration<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &ExportAllDeclaration<'a>,
-    ) {
-        let kind = AstKind::ExportAllDeclaration(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        if let Some(exported) = &it.exported {
-            visitor.visit_module_export_name(exported);
-        }
-        visitor.visit_string_literal(&it.source);
-        if let Some(with_clause) = &it.with_clause {
-            visitor.visit_with_clause(with_clause);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_export_default_declaration<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &ExportDefaultDeclaration<'a>,
-    ) {
-        let kind = AstKind::ExportDefaultDeclaration(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_export_default_declaration_kind(&it.declaration);
-        visitor.visit_module_export_name(&it.exported);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_export_default_declaration_kind<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &ExportDefaultDeclarationKind<'a>,
-    ) {
-        // No `AstKind` for this type
-        match it {
-            ExportDefaultDeclarationKind::FunctionDeclaration(it) => {
-                let flags = ScopeFlags::Function;
-                visitor.visit_function(it, flags)
-            }
-            ExportDefaultDeclarationKind::ClassDeclaration(it) => visitor.visit_class(it),
-            ExportDefaultDeclarationKind::TSInterfaceDeclaration(it) => {
-                visitor.visit_ts_interface_declaration(it)
-            }
-            match_expression!(ExportDefaultDeclarationKind) => {
-                visitor.visit_expression(it.to_expression())
-            }
-        }
-    }
-
-    #[inline]
-    pub fn walk_export_named_declaration<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &ExportNamedDeclaration<'a>,
-    ) {
-        let kind = AstKind::ExportNamedDeclaration(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        if let Some(declaration) = &it.declaration {
-            visitor.visit_declaration(declaration);
-        }
-        visitor.visit_export_specifiers(&it.specifiers);
-        if let Some(source) = &it.source {
-            visitor.visit_string_literal(source);
-        }
-        if let Some(with_clause) = &it.with_clause {
-            visitor.visit_with_clause(with_clause);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_export_specifiers<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &Vec<'a, ExportSpecifier<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_export_specifier(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_export_specifier<'a, V: Visit<'a>>(visitor: &mut V, it: &ExportSpecifier<'a>) {
-        let kind = AstKind::ExportSpecifier(visitor.alloc(it));
-        visitor.enter_node(kind);
-        visitor.visit_span(&it.span);
-        visitor.visit_module_export_name(&it.local);
-        visitor.visit_module_export_name(&it.exported);
+        visitor.visit_expression(&it.expression);
         visitor.leave_node(kind);
     }
 
@@ -4371,5 +4080,296 @@ pub mod walk {
         // No `AstKind` for this type
         visitor.visit_span(&it.span);
         visitor.visit_identifier_name(&it.id);
+    }
+
+    #[inline]
+    pub fn walk_ts_instantiation_expression<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &TSInstantiationExpression<'a>,
+    ) {
+        let kind = AstKind::TSInstantiationExpression(visitor.alloc(it));
+        visitor.enter_node(kind);
+        visitor.visit_span(&it.span);
+        visitor.visit_expression(&it.expression);
+        visitor.visit_ts_type_parameter_instantiation(&it.type_parameters);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_js_doc_nullable_type<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &JSDocNullableType<'a>,
+    ) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_type(&it.type_annotation);
+    }
+
+    #[inline]
+    pub fn walk_js_doc_non_nullable_type<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &JSDocNonNullableType<'a>,
+    ) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+        visitor.visit_ts_type(&it.type_annotation);
+    }
+
+    #[inline]
+    pub fn walk_js_doc_unknown_type<'a, V: Visit<'a>>(visitor: &mut V, it: &JSDocUnknownType) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+    }
+
+    #[inline]
+    pub fn walk_span<'a, V: Visit<'a>>(visitor: &mut V, it: &Span) {
+        // No `AstKind` for this type
+    }
+
+    #[inline]
+    pub fn walk_directives<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Directive<'a>>) {
+        for el in it {
+            visitor.visit_directive(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_statements<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Statement<'a>>) {
+        for el in it {
+            visitor.visit_statement(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_array_expression_elements<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &Vec<'a, ArrayExpressionElement<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_array_expression_element(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_object_property_kinds<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &Vec<'a, ObjectPropertyKind<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_object_property_kind(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_template_elements<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &Vec<'a, TemplateElement<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_template_element(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_expressions<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Expression<'a>>) {
+        for el in it {
+            visitor.visit_expression(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_arguments<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Argument<'a>>) {
+        for el in it {
+            visitor.visit_argument(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_assignment_target_properties<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &Vec<'a, AssignmentTargetProperty<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_assignment_target_property(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_variable_declarators<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &Vec<'a, VariableDeclarator<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_variable_declarator(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_switch_cases<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, SwitchCase<'a>>) {
+        for el in it {
+            visitor.visit_switch_case(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_binding_properties<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &Vec<'a, BindingProperty<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_binding_property(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_formal_parameter_list<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &Vec<'a, FormalParameter<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_formal_parameter(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_decorators<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, Decorator<'a>>) {
+        for el in it {
+            visitor.visit_decorator(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_class_implementses<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &Vec<'a, TSClassImplements<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_ts_class_implements(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_class_elements<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, ClassElement<'a>>) {
+        for el in it {
+            visitor.visit_class_element(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_import_declaration_specifiers<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &Vec<'a, ImportDeclarationSpecifier<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_import_declaration_specifier(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_import_attributes<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &Vec<'a, ImportAttribute<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_import_attribute(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_export_specifiers<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &Vec<'a, ExportSpecifier<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_export_specifier(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_jsx_children<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, JSXChild<'a>>) {
+        for el in it {
+            visitor.visit_jsx_child(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_jsx_attribute_items<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &Vec<'a, JSXAttributeItem<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_jsx_attribute_item(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_enum_members<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, TSEnumMember<'a>>) {
+        for el in it {
+            visitor.visit_ts_enum_member(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_types<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, TSType<'a>>) {
+        for el in it {
+            visitor.visit_ts_type(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_tuple_elements<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &Vec<'a, TSTupleElement<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_ts_tuple_element(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_type_parameters<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &Vec<'a, TSTypeParameter<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_ts_type_parameter(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_interface_heritages<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &Vec<'a, TSInterfaceHeritage<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_ts_interface_heritage(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_signatures<'a, V: Visit<'a>>(visitor: &mut V, it: &Vec<'a, TSSignature<'a>>) {
+        for el in it {
+            visitor.visit_ts_signature(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_index_signature_names<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &Vec<'a, TSIndexSignatureName<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_ts_index_signature_name(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_import_attribute_list<'a, V: Visit<'a>>(
+        visitor: &mut V,
+        it: &Vec<'a, TSImportAttribute<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_ts_import_attribute(el);
+        }
     }
 }

--- a/crates/oxc_ast/src/generated/visit_mut.rs
+++ b/crates/oxc_ast/src/generated/visit_mut.rs
@@ -37,128 +37,8 @@ pub trait VisitMut<'a>: Sized {
     }
 
     #[inline]
-    fn visit_span(&mut self, it: &mut Span) {
-        walk_span(self, it);
-    }
-
-    #[inline]
-    fn visit_hashbang(&mut self, it: &mut Hashbang<'a>) {
-        walk_hashbang(self, it);
-    }
-
-    #[inline]
-    fn visit_directives(&mut self, it: &mut Vec<'a, Directive<'a>>) {
-        walk_directives(self, it);
-    }
-
-    #[inline]
-    fn visit_directive(&mut self, it: &mut Directive<'a>) {
-        walk_directive(self, it);
-    }
-
-    #[inline]
-    fn visit_string_literal(&mut self, it: &mut StringLiteral<'a>) {
-        walk_string_literal(self, it);
-    }
-
-    #[inline]
-    fn visit_statements(&mut self, it: &mut Vec<'a, Statement<'a>>) {
-        walk_statements(self, it);
-    }
-
-    #[inline]
-    fn visit_statement(&mut self, it: &mut Statement<'a>) {
-        walk_statement(self, it);
-    }
-
-    #[inline]
-    fn visit_block_statement(&mut self, it: &mut BlockStatement<'a>) {
-        walk_block_statement(self, it);
-    }
-
-    #[inline]
-    fn visit_break_statement(&mut self, it: &mut BreakStatement<'a>) {
-        walk_break_statement(self, it);
-    }
-
-    #[inline]
-    fn visit_label_identifier(&mut self, it: &mut LabelIdentifier<'a>) {
-        walk_label_identifier(self, it);
-    }
-
-    #[inline]
-    fn visit_continue_statement(&mut self, it: &mut ContinueStatement<'a>) {
-        walk_continue_statement(self, it);
-    }
-
-    #[inline]
-    fn visit_debugger_statement(&mut self, it: &mut DebuggerStatement) {
-        walk_debugger_statement(self, it);
-    }
-
-    #[inline]
-    fn visit_do_while_statement(&mut self, it: &mut DoWhileStatement<'a>) {
-        walk_do_while_statement(self, it);
-    }
-
-    #[inline]
     fn visit_expression(&mut self, it: &mut Expression<'a>) {
         walk_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_boolean_literal(&mut self, it: &mut BooleanLiteral) {
-        walk_boolean_literal(self, it);
-    }
-
-    #[inline]
-    fn visit_null_literal(&mut self, it: &mut NullLiteral) {
-        walk_null_literal(self, it);
-    }
-
-    #[inline]
-    fn visit_numeric_literal(&mut self, it: &mut NumericLiteral<'a>) {
-        walk_numeric_literal(self, it);
-    }
-
-    #[inline]
-    fn visit_big_int_literal(&mut self, it: &mut BigIntLiteral<'a>) {
-        walk_big_int_literal(self, it);
-    }
-
-    #[inline]
-    fn visit_reg_exp_literal(&mut self, it: &mut RegExpLiteral<'a>) {
-        walk_reg_exp_literal(self, it);
-    }
-
-    #[inline]
-    fn visit_template_literal(&mut self, it: &mut TemplateLiteral<'a>) {
-        walk_template_literal(self, it);
-    }
-
-    #[inline]
-    fn visit_template_elements(&mut self, it: &mut Vec<'a, TemplateElement<'a>>) {
-        walk_template_elements(self, it);
-    }
-
-    #[inline]
-    fn visit_template_element(&mut self, it: &mut TemplateElement<'a>) {
-        walk_template_element(self, it);
-    }
-
-    #[inline]
-    fn visit_expressions(&mut self, it: &mut Vec<'a, Expression<'a>>) {
-        walk_expressions(self, it);
-    }
-
-    #[inline]
-    fn visit_identifier_reference(&mut self, it: &mut IdentifierReference<'a>) {
-        walk_identifier_reference(self, it);
-    }
-
-    #[inline]
-    fn visit_meta_property(&mut self, it: &mut MetaProperty<'a>) {
-        walk_meta_property(self, it);
     }
 
     #[inline]
@@ -167,53 +47,8 @@ pub trait VisitMut<'a>: Sized {
     }
 
     #[inline]
-    fn visit_super(&mut self, it: &mut Super) {
-        walk_super(self, it);
-    }
-
-    #[inline]
-    fn visit_array_expression(&mut self, it: &mut ArrayExpression<'a>) {
-        walk_array_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_array_expression_elements(&mut self, it: &mut Vec<'a, ArrayExpressionElement<'a>>) {
-        walk_array_expression_elements(self, it);
-    }
-
-    #[inline]
-    fn visit_array_expression_element(&mut self, it: &mut ArrayExpressionElement<'a>) {
-        walk_array_expression_element(self, it);
-    }
-
-    #[inline]
-    fn visit_spread_element(&mut self, it: &mut SpreadElement<'a>) {
-        walk_spread_element(self, it);
-    }
-
-    #[inline]
-    fn visit_elision(&mut self, it: &mut Elision) {
-        walk_elision(self, it);
-    }
-
-    #[inline]
-    fn visit_arrow_function_expression(&mut self, it: &mut ArrowFunctionExpression<'a>) {
-        walk_arrow_function_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_parameter_declaration(&mut self, it: &mut TSTypeParameterDeclaration<'a>) {
-        walk_ts_type_parameter_declaration(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_parameters(&mut self, it: &mut Vec<'a, TSTypeParameter<'a>>) {
-        walk_ts_type_parameters(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_parameter(&mut self, it: &mut TSTypeParameter<'a>) {
-        walk_ts_type_parameter(self, it);
+    fn visit_identifier_reference(&mut self, it: &mut IdentifierReference<'a>) {
+        walk_identifier_reference(self, it);
     }
 
     #[inline]
@@ -222,138 +57,43 @@ pub trait VisitMut<'a>: Sized {
     }
 
     #[inline]
-    fn visit_ts_type(&mut self, it: &mut TSType<'a>) {
-        walk_ts_type(self, it);
+    fn visit_label_identifier(&mut self, it: &mut LabelIdentifier<'a>) {
+        walk_label_identifier(self, it);
     }
 
     #[inline]
-    fn visit_ts_any_keyword(&mut self, it: &mut TSAnyKeyword) {
-        walk_ts_any_keyword(self, it);
+    fn visit_this_expression(&mut self, it: &mut ThisExpression) {
+        walk_this_expression(self, it);
     }
 
     #[inline]
-    fn visit_ts_big_int_keyword(&mut self, it: &mut TSBigIntKeyword) {
-        walk_ts_big_int_keyword(self, it);
+    fn visit_array_expression(&mut self, it: &mut ArrayExpression<'a>) {
+        walk_array_expression(self, it);
     }
 
     #[inline]
-    fn visit_ts_boolean_keyword(&mut self, it: &mut TSBooleanKeyword) {
-        walk_ts_boolean_keyword(self, it);
+    fn visit_array_expression_element(&mut self, it: &mut ArrayExpressionElement<'a>) {
+        walk_array_expression_element(self, it);
     }
 
     #[inline]
-    fn visit_ts_intrinsic_keyword(&mut self, it: &mut TSIntrinsicKeyword) {
-        walk_ts_intrinsic_keyword(self, it);
+    fn visit_elision(&mut self, it: &mut Elision) {
+        walk_elision(self, it);
     }
 
     #[inline]
-    fn visit_ts_never_keyword(&mut self, it: &mut TSNeverKeyword) {
-        walk_ts_never_keyword(self, it);
+    fn visit_object_expression(&mut self, it: &mut ObjectExpression<'a>) {
+        walk_object_expression(self, it);
     }
 
     #[inline]
-    fn visit_ts_null_keyword(&mut self, it: &mut TSNullKeyword) {
-        walk_ts_null_keyword(self, it);
+    fn visit_object_property_kind(&mut self, it: &mut ObjectPropertyKind<'a>) {
+        walk_object_property_kind(self, it);
     }
 
     #[inline]
-    fn visit_ts_number_keyword(&mut self, it: &mut TSNumberKeyword) {
-        walk_ts_number_keyword(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_object_keyword(&mut self, it: &mut TSObjectKeyword) {
-        walk_ts_object_keyword(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_string_keyword(&mut self, it: &mut TSStringKeyword) {
-        walk_ts_string_keyword(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_symbol_keyword(&mut self, it: &mut TSSymbolKeyword) {
-        walk_ts_symbol_keyword(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_undefined_keyword(&mut self, it: &mut TSUndefinedKeyword) {
-        walk_ts_undefined_keyword(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_unknown_keyword(&mut self, it: &mut TSUnknownKeyword) {
-        walk_ts_unknown_keyword(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_void_keyword(&mut self, it: &mut TSVoidKeyword) {
-        walk_ts_void_keyword(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_array_type(&mut self, it: &mut TSArrayType<'a>) {
-        walk_ts_array_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_conditional_type(&mut self, it: &mut TSConditionalType<'a>) {
-        walk_ts_conditional_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_constructor_type(&mut self, it: &mut TSConstructorType<'a>) {
-        walk_ts_constructor_type(self, it);
-    }
-
-    #[inline]
-    fn visit_formal_parameters(&mut self, it: &mut FormalParameters<'a>) {
-        walk_formal_parameters(self, it);
-    }
-
-    #[inline]
-    fn visit_formal_parameter_list(&mut self, it: &mut Vec<'a, FormalParameter<'a>>) {
-        walk_formal_parameter_list(self, it);
-    }
-
-    #[inline]
-    fn visit_formal_parameter(&mut self, it: &mut FormalParameter<'a>) {
-        walk_formal_parameter(self, it);
-    }
-
-    #[inline]
-    fn visit_decorators(&mut self, it: &mut Vec<'a, Decorator<'a>>) {
-        walk_decorators(self, it);
-    }
-
-    #[inline]
-    fn visit_decorator(&mut self, it: &mut Decorator<'a>) {
-        walk_decorator(self, it);
-    }
-
-    #[inline]
-    fn visit_binding_pattern(&mut self, it: &mut BindingPattern<'a>) {
-        walk_binding_pattern(self, it);
-    }
-
-    #[inline]
-    fn visit_binding_pattern_kind(&mut self, it: &mut BindingPatternKind<'a>) {
-        walk_binding_pattern_kind(self, it);
-    }
-
-    #[inline]
-    fn visit_object_pattern(&mut self, it: &mut ObjectPattern<'a>) {
-        walk_object_pattern(self, it);
-    }
-
-    #[inline]
-    fn visit_binding_properties(&mut self, it: &mut Vec<'a, BindingProperty<'a>>) {
-        walk_binding_properties(self, it);
-    }
-
-    #[inline]
-    fn visit_binding_property(&mut self, it: &mut BindingProperty<'a>) {
-        walk_binding_property(self, it);
+    fn visit_object_property(&mut self, it: &mut ObjectProperty<'a>) {
+        walk_object_property(self, it);
     }
 
     #[inline]
@@ -362,311 +102,18 @@ pub trait VisitMut<'a>: Sized {
     }
 
     #[inline]
-    fn visit_private_identifier(&mut self, it: &mut PrivateIdentifier<'a>) {
-        walk_private_identifier(self, it);
+    fn visit_template_literal(&mut self, it: &mut TemplateLiteral<'a>) {
+        walk_template_literal(self, it);
     }
 
     #[inline]
-    fn visit_binding_rest_element(&mut self, it: &mut BindingRestElement<'a>) {
-        walk_binding_rest_element(self, it);
+    fn visit_tagged_template_expression(&mut self, it: &mut TaggedTemplateExpression<'a>) {
+        walk_tagged_template_expression(self, it);
     }
 
     #[inline]
-    fn visit_array_pattern(&mut self, it: &mut ArrayPattern<'a>) {
-        walk_array_pattern(self, it);
-    }
-
-    #[inline]
-    fn visit_assignment_pattern(&mut self, it: &mut AssignmentPattern<'a>) {
-        walk_assignment_pattern(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_annotation(&mut self, it: &mut TSTypeAnnotation<'a>) {
-        walk_ts_type_annotation(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_function_type(&mut self, it: &mut TSFunctionType<'a>) {
-        walk_ts_function_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_this_parameter(&mut self, it: &mut TSThisParameter<'a>) {
-        walk_ts_this_parameter(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_import_type(&mut self, it: &mut TSImportType<'a>) {
-        walk_ts_import_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_name(&mut self, it: &mut TSTypeName<'a>) {
-        walk_ts_type_name(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_qualified_name(&mut self, it: &mut TSQualifiedName<'a>) {
-        walk_ts_qualified_name(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_import_attributes(&mut self, it: &mut TSImportAttributes<'a>) {
-        walk_ts_import_attributes(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_import_attribute_list(&mut self, it: &mut Vec<'a, TSImportAttribute<'a>>) {
-        walk_ts_import_attribute_list(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_import_attribute(&mut self, it: &mut TSImportAttribute<'a>) {
-        walk_ts_import_attribute(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_import_attribute_name(&mut self, it: &mut TSImportAttributeName<'a>) {
-        walk_ts_import_attribute_name(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_parameter_instantiation(&mut self, it: &mut TSTypeParameterInstantiation<'a>) {
-        walk_ts_type_parameter_instantiation(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_types(&mut self, it: &mut Vec<'a, TSType<'a>>) {
-        walk_ts_types(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_indexed_access_type(&mut self, it: &mut TSIndexedAccessType<'a>) {
-        walk_ts_indexed_access_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_infer_type(&mut self, it: &mut TSInferType<'a>) {
-        walk_ts_infer_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_intersection_type(&mut self, it: &mut TSIntersectionType<'a>) {
-        walk_ts_intersection_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_literal_type(&mut self, it: &mut TSLiteralType<'a>) {
-        walk_ts_literal_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_literal(&mut self, it: &mut TSLiteral<'a>) {
-        walk_ts_literal(self, it);
-    }
-
-    #[inline]
-    fn visit_unary_expression(&mut self, it: &mut UnaryExpression<'a>) {
-        walk_unary_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_mapped_type(&mut self, it: &mut TSMappedType<'a>) {
-        walk_ts_mapped_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_named_tuple_member(&mut self, it: &mut TSNamedTupleMember<'a>) {
-        walk_ts_named_tuple_member(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_tuple_element(&mut self, it: &mut TSTupleElement<'a>) {
-        walk_ts_tuple_element(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_optional_type(&mut self, it: &mut TSOptionalType<'a>) {
-        walk_ts_optional_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_rest_type(&mut self, it: &mut TSRestType<'a>) {
-        walk_ts_rest_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_template_literal_type(&mut self, it: &mut TSTemplateLiteralType<'a>) {
-        walk_ts_template_literal_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_this_type(&mut self, it: &mut TSThisType) {
-        walk_ts_this_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_tuple_type(&mut self, it: &mut TSTupleType<'a>) {
-        walk_ts_tuple_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_tuple_elements(&mut self, it: &mut Vec<'a, TSTupleElement<'a>>) {
-        walk_ts_tuple_elements(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_literal(&mut self, it: &mut TSTypeLiteral<'a>) {
-        walk_ts_type_literal(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_signatures(&mut self, it: &mut Vec<'a, TSSignature<'a>>) {
-        walk_ts_signatures(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_signature(&mut self, it: &mut TSSignature<'a>) {
-        walk_ts_signature(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_index_signature(&mut self, it: &mut TSIndexSignature<'a>) {
-        walk_ts_index_signature(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_index_signature_names(&mut self, it: &mut Vec<'a, TSIndexSignatureName<'a>>) {
-        walk_ts_index_signature_names(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_index_signature_name(&mut self, it: &mut TSIndexSignatureName<'a>) {
-        walk_ts_index_signature_name(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_property_signature(&mut self, it: &mut TSPropertySignature<'a>) {
-        walk_ts_property_signature(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_call_signature_declaration(&mut self, it: &mut TSCallSignatureDeclaration<'a>) {
-        walk_ts_call_signature_declaration(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_construct_signature_declaration(
-        &mut self,
-        it: &mut TSConstructSignatureDeclaration<'a>,
-    ) {
-        walk_ts_construct_signature_declaration(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_method_signature(&mut self, it: &mut TSMethodSignature<'a>) {
-        walk_ts_method_signature(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_operator(&mut self, it: &mut TSTypeOperator<'a>) {
-        walk_ts_type_operator(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_predicate(&mut self, it: &mut TSTypePredicate<'a>) {
-        walk_ts_type_predicate(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_predicate_name(&mut self, it: &mut TSTypePredicateName<'a>) {
-        walk_ts_type_predicate_name(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_query(&mut self, it: &mut TSTypeQuery<'a>) {
-        walk_ts_type_query(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_query_expr_name(&mut self, it: &mut TSTypeQueryExprName<'a>) {
-        walk_ts_type_query_expr_name(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_reference(&mut self, it: &mut TSTypeReference<'a>) {
-        walk_ts_type_reference(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_union_type(&mut self, it: &mut TSUnionType<'a>) {
-        walk_ts_union_type(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_parenthesized_type(&mut self, it: &mut TSParenthesizedType<'a>) {
-        walk_ts_parenthesized_type(self, it);
-    }
-
-    #[inline]
-    fn visit_js_doc_nullable_type(&mut self, it: &mut JSDocNullableType<'a>) {
-        walk_js_doc_nullable_type(self, it);
-    }
-
-    #[inline]
-    fn visit_js_doc_non_nullable_type(&mut self, it: &mut JSDocNonNullableType<'a>) {
-        walk_js_doc_non_nullable_type(self, it);
-    }
-
-    #[inline]
-    fn visit_js_doc_unknown_type(&mut self, it: &mut JSDocUnknownType) {
-        walk_js_doc_unknown_type(self, it);
-    }
-
-    #[inline]
-    fn visit_function_body(&mut self, it: &mut FunctionBody<'a>) {
-        walk_function_body(self, it);
-    }
-
-    #[inline]
-    fn visit_assignment_expression(&mut self, it: &mut AssignmentExpression<'a>) {
-        walk_assignment_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_assignment_target(&mut self, it: &mut AssignmentTarget<'a>) {
-        walk_assignment_target(self, it);
-    }
-
-    #[inline]
-    fn visit_simple_assignment_target(&mut self, it: &mut SimpleAssignmentTarget<'a>) {
-        walk_simple_assignment_target(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_as_expression(&mut self, it: &mut TSAsExpression<'a>) {
-        walk_ts_as_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_satisfies_expression(&mut self, it: &mut TSSatisfiesExpression<'a>) {
-        walk_ts_satisfies_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_non_null_expression(&mut self, it: &mut TSNonNullExpression<'a>) {
-        walk_ts_non_null_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_type_assertion(&mut self, it: &mut TSTypeAssertion<'a>) {
-        walk_ts_type_assertion(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_instantiation_expression(&mut self, it: &mut TSInstantiationExpression<'a>) {
-        walk_ts_instantiation_expression(self, it);
+    fn visit_template_element(&mut self, it: &mut TemplateElement<'a>) {
+        walk_template_element(self, it);
     }
 
     #[inline]
@@ -690,6 +137,76 @@ pub trait VisitMut<'a>: Sized {
     }
 
     #[inline]
+    fn visit_call_expression(&mut self, it: &mut CallExpression<'a>) {
+        walk_call_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_new_expression(&mut self, it: &mut NewExpression<'a>) {
+        walk_new_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_meta_property(&mut self, it: &mut MetaProperty<'a>) {
+        walk_meta_property(self, it);
+    }
+
+    #[inline]
+    fn visit_spread_element(&mut self, it: &mut SpreadElement<'a>) {
+        walk_spread_element(self, it);
+    }
+
+    #[inline]
+    fn visit_argument(&mut self, it: &mut Argument<'a>) {
+        walk_argument(self, it);
+    }
+
+    #[inline]
+    fn visit_update_expression(&mut self, it: &mut UpdateExpression<'a>) {
+        walk_update_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_unary_expression(&mut self, it: &mut UnaryExpression<'a>) {
+        walk_unary_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_binary_expression(&mut self, it: &mut BinaryExpression<'a>) {
+        walk_binary_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_private_in_expression(&mut self, it: &mut PrivateInExpression<'a>) {
+        walk_private_in_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_logical_expression(&mut self, it: &mut LogicalExpression<'a>) {
+        walk_logical_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_conditional_expression(&mut self, it: &mut ConditionalExpression<'a>) {
+        walk_conditional_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_assignment_expression(&mut self, it: &mut AssignmentExpression<'a>) {
+        walk_assignment_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_assignment_target(&mut self, it: &mut AssignmentTarget<'a>) {
+        walk_assignment_target(self, it);
+    }
+
+    #[inline]
+    fn visit_simple_assignment_target(&mut self, it: &mut SimpleAssignmentTarget<'a>) {
+        walk_simple_assignment_target(self, it);
+    }
+
+    #[inline]
     fn visit_assignment_target_pattern(&mut self, it: &mut AssignmentTargetPattern<'a>) {
         walk_assignment_target_pattern(self, it);
     }
@@ -700,13 +217,8 @@ pub trait VisitMut<'a>: Sized {
     }
 
     #[inline]
-    fn visit_assignment_target_maybe_default(&mut self, it: &mut AssignmentTargetMaybeDefault<'a>) {
-        walk_assignment_target_maybe_default(self, it);
-    }
-
-    #[inline]
-    fn visit_assignment_target_with_default(&mut self, it: &mut AssignmentTargetWithDefault<'a>) {
-        walk_assignment_target_with_default(self, it);
+    fn visit_object_assignment_target(&mut self, it: &mut ObjectAssignmentTarget<'a>) {
+        walk_object_assignment_target(self, it);
     }
 
     #[inline]
@@ -715,16 +227,13 @@ pub trait VisitMut<'a>: Sized {
     }
 
     #[inline]
-    fn visit_object_assignment_target(&mut self, it: &mut ObjectAssignmentTarget<'a>) {
-        walk_object_assignment_target(self, it);
+    fn visit_assignment_target_maybe_default(&mut self, it: &mut AssignmentTargetMaybeDefault<'a>) {
+        walk_assignment_target_maybe_default(self, it);
     }
 
     #[inline]
-    fn visit_assignment_target_properties(
-        &mut self,
-        it: &mut Vec<'a, AssignmentTargetProperty<'a>>,
-    ) {
-        walk_assignment_target_properties(self, it);
+    fn visit_assignment_target_with_default(&mut self, it: &mut AssignmentTargetWithDefault<'a>) {
+        walk_assignment_target_with_default(self, it);
     }
 
     #[inline]
@@ -749,28 +258,18 @@ pub trait VisitMut<'a>: Sized {
     }
 
     #[inline]
+    fn visit_sequence_expression(&mut self, it: &mut SequenceExpression<'a>) {
+        walk_sequence_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_super(&mut self, it: &mut Super) {
+        walk_super(self, it);
+    }
+
+    #[inline]
     fn visit_await_expression(&mut self, it: &mut AwaitExpression<'a>) {
         walk_await_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_binary_expression(&mut self, it: &mut BinaryExpression<'a>) {
-        walk_binary_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_call_expression(&mut self, it: &mut CallExpression<'a>) {
-        walk_call_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_arguments(&mut self, it: &mut Vec<'a, Argument<'a>>) {
-        walk_arguments(self, it);
-    }
-
-    #[inline]
-    fn visit_argument(&mut self, it: &mut Argument<'a>) {
-        walk_argument(self, it);
     }
 
     #[inline]
@@ -784,243 +283,43 @@ pub trait VisitMut<'a>: Sized {
     }
 
     #[inline]
-    fn visit_class(&mut self, it: &mut Class<'a>) {
-        walk_class(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_class_implementses(&mut self, it: &mut Vec<'a, TSClassImplements<'a>>) {
-        walk_ts_class_implementses(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_class_implements(&mut self, it: &mut TSClassImplements<'a>) {
-        walk_ts_class_implements(self, it);
-    }
-
-    #[inline]
-    fn visit_class_body(&mut self, it: &mut ClassBody<'a>) {
-        walk_class_body(self, it);
-    }
-
-    #[inline]
-    fn visit_class_elements(&mut self, it: &mut Vec<'a, ClassElement<'a>>) {
-        walk_class_elements(self, it);
-    }
-
-    #[inline]
-    fn visit_class_element(&mut self, it: &mut ClassElement<'a>) {
-        walk_class_element(self, it);
-    }
-
-    #[inline]
-    fn visit_static_block(&mut self, it: &mut StaticBlock<'a>) {
-        walk_static_block(self, it);
-    }
-
-    #[inline]
-    fn visit_method_definition(&mut self, it: &mut MethodDefinition<'a>) {
-        walk_method_definition(self, it);
-    }
-
-    #[inline]
-    fn visit_function(&mut self, it: &mut Function<'a>, flags: ScopeFlags) {
-        walk_function(self, it, flags);
-    }
-
-    #[inline]
-    fn visit_property_definition(&mut self, it: &mut PropertyDefinition<'a>) {
-        walk_property_definition(self, it);
-    }
-
-    #[inline]
-    fn visit_accessor_property(&mut self, it: &mut AccessorProperty<'a>) {
-        walk_accessor_property(self, it);
-    }
-
-    #[inline]
-    fn visit_conditional_expression(&mut self, it: &mut ConditionalExpression<'a>) {
-        walk_conditional_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_import_expression(&mut self, it: &mut ImportExpression<'a>) {
-        walk_import_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_logical_expression(&mut self, it: &mut LogicalExpression<'a>) {
-        walk_logical_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_new_expression(&mut self, it: &mut NewExpression<'a>) {
-        walk_new_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_object_expression(&mut self, it: &mut ObjectExpression<'a>) {
-        walk_object_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_object_property_kinds(&mut self, it: &mut Vec<'a, ObjectPropertyKind<'a>>) {
-        walk_object_property_kinds(self, it);
-    }
-
-    #[inline]
-    fn visit_object_property_kind(&mut self, it: &mut ObjectPropertyKind<'a>) {
-        walk_object_property_kind(self, it);
-    }
-
-    #[inline]
-    fn visit_object_property(&mut self, it: &mut ObjectProperty<'a>) {
-        walk_object_property(self, it);
-    }
-
-    #[inline]
     fn visit_parenthesized_expression(&mut self, it: &mut ParenthesizedExpression<'a>) {
         walk_parenthesized_expression(self, it);
     }
 
     #[inline]
-    fn visit_sequence_expression(&mut self, it: &mut SequenceExpression<'a>) {
-        walk_sequence_expression(self, it);
+    fn visit_statement(&mut self, it: &mut Statement<'a>) {
+        walk_statement(self, it);
     }
 
     #[inline]
-    fn visit_tagged_template_expression(&mut self, it: &mut TaggedTemplateExpression<'a>) {
-        walk_tagged_template_expression(self, it);
+    fn visit_directive(&mut self, it: &mut Directive<'a>) {
+        walk_directive(self, it);
     }
 
     #[inline]
-    fn visit_this_expression(&mut self, it: &mut ThisExpression) {
-        walk_this_expression(self, it);
+    fn visit_hashbang(&mut self, it: &mut Hashbang<'a>) {
+        walk_hashbang(self, it);
     }
 
     #[inline]
-    fn visit_update_expression(&mut self, it: &mut UpdateExpression<'a>) {
-        walk_update_expression(self, it);
+    fn visit_block_statement(&mut self, it: &mut BlockStatement<'a>) {
+        walk_block_statement(self, it);
     }
 
     #[inline]
-    fn visit_yield_expression(&mut self, it: &mut YieldExpression<'a>) {
-        walk_yield_expression(self, it);
+    fn visit_declaration(&mut self, it: &mut Declaration<'a>) {
+        walk_declaration(self, it);
     }
 
     #[inline]
-    fn visit_private_in_expression(&mut self, it: &mut PrivateInExpression<'a>) {
-        walk_private_in_expression(self, it);
+    fn visit_variable_declaration(&mut self, it: &mut VariableDeclaration<'a>) {
+        walk_variable_declaration(self, it);
     }
 
     #[inline]
-    fn visit_jsx_element(&mut self, it: &mut JSXElement<'a>) {
-        walk_jsx_element(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_opening_element(&mut self, it: &mut JSXOpeningElement<'a>) {
-        walk_jsx_opening_element(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_element_name(&mut self, it: &mut JSXElementName<'a>) {
-        walk_jsx_element_name(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_identifier(&mut self, it: &mut JSXIdentifier<'a>) {
-        walk_jsx_identifier(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_namespaced_name(&mut self, it: &mut JSXNamespacedName<'a>) {
-        walk_jsx_namespaced_name(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_member_expression(&mut self, it: &mut JSXMemberExpression<'a>) {
-        walk_jsx_member_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_member_expression_object(&mut self, it: &mut JSXMemberExpressionObject<'a>) {
-        walk_jsx_member_expression_object(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_attribute_items(&mut self, it: &mut Vec<'a, JSXAttributeItem<'a>>) {
-        walk_jsx_attribute_items(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_attribute_item(&mut self, it: &mut JSXAttributeItem<'a>) {
-        walk_jsx_attribute_item(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_attribute(&mut self, it: &mut JSXAttribute<'a>) {
-        walk_jsx_attribute(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_attribute_name(&mut self, it: &mut JSXAttributeName<'a>) {
-        walk_jsx_attribute_name(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_attribute_value(&mut self, it: &mut JSXAttributeValue<'a>) {
-        walk_jsx_attribute_value(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_expression_container(&mut self, it: &mut JSXExpressionContainer<'a>) {
-        walk_jsx_expression_container(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_expression(&mut self, it: &mut JSXExpression<'a>) {
-        walk_jsx_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_empty_expression(&mut self, it: &mut JSXEmptyExpression) {
-        walk_jsx_empty_expression(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_fragment(&mut self, it: &mut JSXFragment<'a>) {
-        walk_jsx_fragment(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_children(&mut self, it: &mut Vec<'a, JSXChild<'a>>) {
-        walk_jsx_children(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_child(&mut self, it: &mut JSXChild<'a>) {
-        walk_jsx_child(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_text(&mut self, it: &mut JSXText<'a>) {
-        walk_jsx_text(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_spread_child(&mut self, it: &mut JSXSpreadChild<'a>) {
-        walk_jsx_spread_child(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_spread_attribute(&mut self, it: &mut JSXSpreadAttribute<'a>) {
-        walk_jsx_spread_attribute(self, it);
-    }
-
-    #[inline]
-    fn visit_jsx_closing_element(&mut self, it: &mut JSXClosingElement<'a>) {
-        walk_jsx_closing_element(self, it);
+    fn visit_variable_declarator(&mut self, it: &mut VariableDeclarator<'a>) {
+        walk_variable_declarator(self, it);
     }
 
     #[inline]
@@ -1034,33 +333,18 @@ pub trait VisitMut<'a>: Sized {
     }
 
     #[inline]
-    fn visit_for_in_statement(&mut self, it: &mut ForInStatement<'a>) {
-        walk_for_in_statement(self, it);
+    fn visit_if_statement(&mut self, it: &mut IfStatement<'a>) {
+        walk_if_statement(self, it);
     }
 
     #[inline]
-    fn visit_for_statement_left(&mut self, it: &mut ForStatementLeft<'a>) {
-        walk_for_statement_left(self, it);
+    fn visit_do_while_statement(&mut self, it: &mut DoWhileStatement<'a>) {
+        walk_do_while_statement(self, it);
     }
 
     #[inline]
-    fn visit_variable_declaration(&mut self, it: &mut VariableDeclaration<'a>) {
-        walk_variable_declaration(self, it);
-    }
-
-    #[inline]
-    fn visit_variable_declarators(&mut self, it: &mut Vec<'a, VariableDeclarator<'a>>) {
-        walk_variable_declarators(self, it);
-    }
-
-    #[inline]
-    fn visit_variable_declarator(&mut self, it: &mut VariableDeclarator<'a>) {
-        walk_variable_declarator(self, it);
-    }
-
-    #[inline]
-    fn visit_for_of_statement(&mut self, it: &mut ForOfStatement<'a>) {
-        walk_for_of_statement(self, it);
+    fn visit_while_statement(&mut self, it: &mut WhileStatement<'a>) {
+        walk_while_statement(self, it);
     }
 
     #[inline]
@@ -1074,13 +358,28 @@ pub trait VisitMut<'a>: Sized {
     }
 
     #[inline]
-    fn visit_if_statement(&mut self, it: &mut IfStatement<'a>) {
-        walk_if_statement(self, it);
+    fn visit_for_in_statement(&mut self, it: &mut ForInStatement<'a>) {
+        walk_for_in_statement(self, it);
     }
 
     #[inline]
-    fn visit_labeled_statement(&mut self, it: &mut LabeledStatement<'a>) {
-        walk_labeled_statement(self, it);
+    fn visit_for_statement_left(&mut self, it: &mut ForStatementLeft<'a>) {
+        walk_for_statement_left(self, it);
+    }
+
+    #[inline]
+    fn visit_for_of_statement(&mut self, it: &mut ForOfStatement<'a>) {
+        walk_for_of_statement(self, it);
+    }
+
+    #[inline]
+    fn visit_continue_statement(&mut self, it: &mut ContinueStatement<'a>) {
+        walk_continue_statement(self, it);
+    }
+
+    #[inline]
+    fn visit_break_statement(&mut self, it: &mut BreakStatement<'a>) {
+        walk_break_statement(self, it);
     }
 
     #[inline]
@@ -1089,18 +388,23 @@ pub trait VisitMut<'a>: Sized {
     }
 
     #[inline]
+    fn visit_with_statement(&mut self, it: &mut WithStatement<'a>) {
+        walk_with_statement(self, it);
+    }
+
+    #[inline]
     fn visit_switch_statement(&mut self, it: &mut SwitchStatement<'a>) {
         walk_switch_statement(self, it);
     }
 
     #[inline]
-    fn visit_switch_cases(&mut self, it: &mut Vec<'a, SwitchCase<'a>>) {
-        walk_switch_cases(self, it);
+    fn visit_switch_case(&mut self, it: &mut SwitchCase<'a>) {
+        walk_switch_case(self, it);
     }
 
     #[inline]
-    fn visit_switch_case(&mut self, it: &mut SwitchCase<'a>) {
-        walk_switch_case(self, it);
+    fn visit_labeled_statement(&mut self, it: &mut LabeledStatement<'a>) {
+        walk_labeled_statement(self, it);
     }
 
     #[inline]
@@ -1124,53 +428,333 @@ pub trait VisitMut<'a>: Sized {
     }
 
     #[inline]
-    fn visit_while_statement(&mut self, it: &mut WhileStatement<'a>) {
-        walk_while_statement(self, it);
+    fn visit_debugger_statement(&mut self, it: &mut DebuggerStatement) {
+        walk_debugger_statement(self, it);
     }
 
     #[inline]
-    fn visit_with_statement(&mut self, it: &mut WithStatement<'a>) {
-        walk_with_statement(self, it);
+    fn visit_binding_pattern(&mut self, it: &mut BindingPattern<'a>) {
+        walk_binding_pattern(self, it);
     }
 
     #[inline]
-    fn visit_declaration(&mut self, it: &mut Declaration<'a>) {
-        walk_declaration(self, it);
+    fn visit_binding_pattern_kind(&mut self, it: &mut BindingPatternKind<'a>) {
+        walk_binding_pattern_kind(self, it);
     }
 
     #[inline]
-    fn visit_ts_type_alias_declaration(&mut self, it: &mut TSTypeAliasDeclaration<'a>) {
-        walk_ts_type_alias_declaration(self, it);
+    fn visit_assignment_pattern(&mut self, it: &mut AssignmentPattern<'a>) {
+        walk_assignment_pattern(self, it);
     }
 
     #[inline]
-    fn visit_ts_interface_declaration(&mut self, it: &mut TSInterfaceDeclaration<'a>) {
-        walk_ts_interface_declaration(self, it);
+    fn visit_object_pattern(&mut self, it: &mut ObjectPattern<'a>) {
+        walk_object_pattern(self, it);
     }
 
     #[inline]
-    fn visit_ts_interface_heritages(&mut self, it: &mut Vec<'a, TSInterfaceHeritage<'a>>) {
-        walk_ts_interface_heritages(self, it);
+    fn visit_binding_property(&mut self, it: &mut BindingProperty<'a>) {
+        walk_binding_property(self, it);
     }
 
     #[inline]
-    fn visit_ts_interface_heritage(&mut self, it: &mut TSInterfaceHeritage<'a>) {
-        walk_ts_interface_heritage(self, it);
+    fn visit_array_pattern(&mut self, it: &mut ArrayPattern<'a>) {
+        walk_array_pattern(self, it);
     }
 
     #[inline]
-    fn visit_ts_interface_body(&mut self, it: &mut TSInterfaceBody<'a>) {
-        walk_ts_interface_body(self, it);
+    fn visit_binding_rest_element(&mut self, it: &mut BindingRestElement<'a>) {
+        walk_binding_rest_element(self, it);
+    }
+
+    #[inline]
+    fn visit_function(&mut self, it: &mut Function<'a>, flags: ScopeFlags) {
+        walk_function(self, it, flags);
+    }
+
+    #[inline]
+    fn visit_formal_parameters(&mut self, it: &mut FormalParameters<'a>) {
+        walk_formal_parameters(self, it);
+    }
+
+    #[inline]
+    fn visit_formal_parameter(&mut self, it: &mut FormalParameter<'a>) {
+        walk_formal_parameter(self, it);
+    }
+
+    #[inline]
+    fn visit_function_body(&mut self, it: &mut FunctionBody<'a>) {
+        walk_function_body(self, it);
+    }
+
+    #[inline]
+    fn visit_arrow_function_expression(&mut self, it: &mut ArrowFunctionExpression<'a>) {
+        walk_arrow_function_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_yield_expression(&mut self, it: &mut YieldExpression<'a>) {
+        walk_yield_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_class(&mut self, it: &mut Class<'a>) {
+        walk_class(self, it);
+    }
+
+    #[inline]
+    fn visit_class_body(&mut self, it: &mut ClassBody<'a>) {
+        walk_class_body(self, it);
+    }
+
+    #[inline]
+    fn visit_class_element(&mut self, it: &mut ClassElement<'a>) {
+        walk_class_element(self, it);
+    }
+
+    #[inline]
+    fn visit_method_definition(&mut self, it: &mut MethodDefinition<'a>) {
+        walk_method_definition(self, it);
+    }
+
+    #[inline]
+    fn visit_property_definition(&mut self, it: &mut PropertyDefinition<'a>) {
+        walk_property_definition(self, it);
+    }
+
+    #[inline]
+    fn visit_private_identifier(&mut self, it: &mut PrivateIdentifier<'a>) {
+        walk_private_identifier(self, it);
+    }
+
+    #[inline]
+    fn visit_static_block(&mut self, it: &mut StaticBlock<'a>) {
+        walk_static_block(self, it);
+    }
+
+    #[inline]
+    fn visit_module_declaration(&mut self, it: &mut ModuleDeclaration<'a>) {
+        walk_module_declaration(self, it);
+    }
+
+    #[inline]
+    fn visit_accessor_property(&mut self, it: &mut AccessorProperty<'a>) {
+        walk_accessor_property(self, it);
+    }
+
+    #[inline]
+    fn visit_import_expression(&mut self, it: &mut ImportExpression<'a>) {
+        walk_import_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_import_declaration(&mut self, it: &mut ImportDeclaration<'a>) {
+        walk_import_declaration(self, it);
+    }
+
+    #[inline]
+    fn visit_import_declaration_specifier(&mut self, it: &mut ImportDeclarationSpecifier<'a>) {
+        walk_import_declaration_specifier(self, it);
+    }
+
+    #[inline]
+    fn visit_import_specifier(&mut self, it: &mut ImportSpecifier<'a>) {
+        walk_import_specifier(self, it);
+    }
+
+    #[inline]
+    fn visit_import_default_specifier(&mut self, it: &mut ImportDefaultSpecifier<'a>) {
+        walk_import_default_specifier(self, it);
+    }
+
+    #[inline]
+    fn visit_import_namespace_specifier(&mut self, it: &mut ImportNamespaceSpecifier<'a>) {
+        walk_import_namespace_specifier(self, it);
+    }
+
+    #[inline]
+    fn visit_with_clause(&mut self, it: &mut WithClause<'a>) {
+        walk_with_clause(self, it);
+    }
+
+    #[inline]
+    fn visit_import_attribute(&mut self, it: &mut ImportAttribute<'a>) {
+        walk_import_attribute(self, it);
+    }
+
+    #[inline]
+    fn visit_import_attribute_key(&mut self, it: &mut ImportAttributeKey<'a>) {
+        walk_import_attribute_key(self, it);
+    }
+
+    #[inline]
+    fn visit_export_named_declaration(&mut self, it: &mut ExportNamedDeclaration<'a>) {
+        walk_export_named_declaration(self, it);
+    }
+
+    #[inline]
+    fn visit_export_default_declaration(&mut self, it: &mut ExportDefaultDeclaration<'a>) {
+        walk_export_default_declaration(self, it);
+    }
+
+    #[inline]
+    fn visit_export_all_declaration(&mut self, it: &mut ExportAllDeclaration<'a>) {
+        walk_export_all_declaration(self, it);
+    }
+
+    #[inline]
+    fn visit_export_specifier(&mut self, it: &mut ExportSpecifier<'a>) {
+        walk_export_specifier(self, it);
+    }
+
+    #[inline]
+    fn visit_export_default_declaration_kind(&mut self, it: &mut ExportDefaultDeclarationKind<'a>) {
+        walk_export_default_declaration_kind(self, it);
+    }
+
+    #[inline]
+    fn visit_module_export_name(&mut self, it: &mut ModuleExportName<'a>) {
+        walk_module_export_name(self, it);
+    }
+
+    #[inline]
+    fn visit_boolean_literal(&mut self, it: &mut BooleanLiteral) {
+        walk_boolean_literal(self, it);
+    }
+
+    #[inline]
+    fn visit_null_literal(&mut self, it: &mut NullLiteral) {
+        walk_null_literal(self, it);
+    }
+
+    #[inline]
+    fn visit_numeric_literal(&mut self, it: &mut NumericLiteral<'a>) {
+        walk_numeric_literal(self, it);
+    }
+
+    #[inline]
+    fn visit_string_literal(&mut self, it: &mut StringLiteral<'a>) {
+        walk_string_literal(self, it);
+    }
+
+    #[inline]
+    fn visit_big_int_literal(&mut self, it: &mut BigIntLiteral<'a>) {
+        walk_big_int_literal(self, it);
+    }
+
+    #[inline]
+    fn visit_reg_exp_literal(&mut self, it: &mut RegExpLiteral<'a>) {
+        walk_reg_exp_literal(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_element(&mut self, it: &mut JSXElement<'a>) {
+        walk_jsx_element(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_opening_element(&mut self, it: &mut JSXOpeningElement<'a>) {
+        walk_jsx_opening_element(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_closing_element(&mut self, it: &mut JSXClosingElement<'a>) {
+        walk_jsx_closing_element(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_fragment(&mut self, it: &mut JSXFragment<'a>) {
+        walk_jsx_fragment(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_element_name(&mut self, it: &mut JSXElementName<'a>) {
+        walk_jsx_element_name(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_namespaced_name(&mut self, it: &mut JSXNamespacedName<'a>) {
+        walk_jsx_namespaced_name(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_member_expression(&mut self, it: &mut JSXMemberExpression<'a>) {
+        walk_jsx_member_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_member_expression_object(&mut self, it: &mut JSXMemberExpressionObject<'a>) {
+        walk_jsx_member_expression_object(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_expression_container(&mut self, it: &mut JSXExpressionContainer<'a>) {
+        walk_jsx_expression_container(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_expression(&mut self, it: &mut JSXExpression<'a>) {
+        walk_jsx_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_empty_expression(&mut self, it: &mut JSXEmptyExpression) {
+        walk_jsx_empty_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_attribute_item(&mut self, it: &mut JSXAttributeItem<'a>) {
+        walk_jsx_attribute_item(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_attribute(&mut self, it: &mut JSXAttribute<'a>) {
+        walk_jsx_attribute(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_spread_attribute(&mut self, it: &mut JSXSpreadAttribute<'a>) {
+        walk_jsx_spread_attribute(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_attribute_name(&mut self, it: &mut JSXAttributeName<'a>) {
+        walk_jsx_attribute_name(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_attribute_value(&mut self, it: &mut JSXAttributeValue<'a>) {
+        walk_jsx_attribute_value(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_identifier(&mut self, it: &mut JSXIdentifier<'a>) {
+        walk_jsx_identifier(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_child(&mut self, it: &mut JSXChild<'a>) {
+        walk_jsx_child(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_spread_child(&mut self, it: &mut JSXSpreadChild<'a>) {
+        walk_jsx_spread_child(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_text(&mut self, it: &mut JSXText<'a>) {
+        walk_jsx_text(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_this_parameter(&mut self, it: &mut TSThisParameter<'a>) {
+        walk_ts_this_parameter(self, it);
     }
 
     #[inline]
     fn visit_ts_enum_declaration(&mut self, it: &mut TSEnumDeclaration<'a>) {
         walk_ts_enum_declaration(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_enum_members(&mut self, it: &mut Vec<'a, TSEnumMember<'a>>) {
-        walk_ts_enum_members(self, it);
     }
 
     #[inline]
@@ -1181,6 +765,259 @@ pub trait VisitMut<'a>: Sized {
     #[inline]
     fn visit_ts_enum_member_name(&mut self, it: &mut TSEnumMemberName<'a>) {
         walk_ts_enum_member_name(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_annotation(&mut self, it: &mut TSTypeAnnotation<'a>) {
+        walk_ts_type_annotation(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_literal_type(&mut self, it: &mut TSLiteralType<'a>) {
+        walk_ts_literal_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_literal(&mut self, it: &mut TSLiteral<'a>) {
+        walk_ts_literal(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type(&mut self, it: &mut TSType<'a>) {
+        walk_ts_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_conditional_type(&mut self, it: &mut TSConditionalType<'a>) {
+        walk_ts_conditional_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_union_type(&mut self, it: &mut TSUnionType<'a>) {
+        walk_ts_union_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_intersection_type(&mut self, it: &mut TSIntersectionType<'a>) {
+        walk_ts_intersection_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_parenthesized_type(&mut self, it: &mut TSParenthesizedType<'a>) {
+        walk_ts_parenthesized_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_operator(&mut self, it: &mut TSTypeOperator<'a>) {
+        walk_ts_type_operator(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_array_type(&mut self, it: &mut TSArrayType<'a>) {
+        walk_ts_array_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_indexed_access_type(&mut self, it: &mut TSIndexedAccessType<'a>) {
+        walk_ts_indexed_access_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_tuple_type(&mut self, it: &mut TSTupleType<'a>) {
+        walk_ts_tuple_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_named_tuple_member(&mut self, it: &mut TSNamedTupleMember<'a>) {
+        walk_ts_named_tuple_member(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_optional_type(&mut self, it: &mut TSOptionalType<'a>) {
+        walk_ts_optional_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_rest_type(&mut self, it: &mut TSRestType<'a>) {
+        walk_ts_rest_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_tuple_element(&mut self, it: &mut TSTupleElement<'a>) {
+        walk_ts_tuple_element(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_any_keyword(&mut self, it: &mut TSAnyKeyword) {
+        walk_ts_any_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_string_keyword(&mut self, it: &mut TSStringKeyword) {
+        walk_ts_string_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_boolean_keyword(&mut self, it: &mut TSBooleanKeyword) {
+        walk_ts_boolean_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_number_keyword(&mut self, it: &mut TSNumberKeyword) {
+        walk_ts_number_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_never_keyword(&mut self, it: &mut TSNeverKeyword) {
+        walk_ts_never_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_intrinsic_keyword(&mut self, it: &mut TSIntrinsicKeyword) {
+        walk_ts_intrinsic_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_unknown_keyword(&mut self, it: &mut TSUnknownKeyword) {
+        walk_ts_unknown_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_null_keyword(&mut self, it: &mut TSNullKeyword) {
+        walk_ts_null_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_undefined_keyword(&mut self, it: &mut TSUndefinedKeyword) {
+        walk_ts_undefined_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_void_keyword(&mut self, it: &mut TSVoidKeyword) {
+        walk_ts_void_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_symbol_keyword(&mut self, it: &mut TSSymbolKeyword) {
+        walk_ts_symbol_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_this_type(&mut self, it: &mut TSThisType) {
+        walk_ts_this_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_object_keyword(&mut self, it: &mut TSObjectKeyword) {
+        walk_ts_object_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_big_int_keyword(&mut self, it: &mut TSBigIntKeyword) {
+        walk_ts_big_int_keyword(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_reference(&mut self, it: &mut TSTypeReference<'a>) {
+        walk_ts_type_reference(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_name(&mut self, it: &mut TSTypeName<'a>) {
+        walk_ts_type_name(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_qualified_name(&mut self, it: &mut TSQualifiedName<'a>) {
+        walk_ts_qualified_name(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_parameter_instantiation(&mut self, it: &mut TSTypeParameterInstantiation<'a>) {
+        walk_ts_type_parameter_instantiation(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_parameter(&mut self, it: &mut TSTypeParameter<'a>) {
+        walk_ts_type_parameter(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_parameter_declaration(&mut self, it: &mut TSTypeParameterDeclaration<'a>) {
+        walk_ts_type_parameter_declaration(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_alias_declaration(&mut self, it: &mut TSTypeAliasDeclaration<'a>) {
+        walk_ts_type_alias_declaration(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_class_implements(&mut self, it: &mut TSClassImplements<'a>) {
+        walk_ts_class_implements(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_interface_declaration(&mut self, it: &mut TSInterfaceDeclaration<'a>) {
+        walk_ts_interface_declaration(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_interface_body(&mut self, it: &mut TSInterfaceBody<'a>) {
+        walk_ts_interface_body(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_property_signature(&mut self, it: &mut TSPropertySignature<'a>) {
+        walk_ts_property_signature(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_signature(&mut self, it: &mut TSSignature<'a>) {
+        walk_ts_signature(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_index_signature(&mut self, it: &mut TSIndexSignature<'a>) {
+        walk_ts_index_signature(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_call_signature_declaration(&mut self, it: &mut TSCallSignatureDeclaration<'a>) {
+        walk_ts_call_signature_declaration(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_method_signature(&mut self, it: &mut TSMethodSignature<'a>) {
+        walk_ts_method_signature(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_construct_signature_declaration(
+        &mut self,
+        it: &mut TSConstructSignatureDeclaration<'a>,
+    ) {
+        walk_ts_construct_signature_declaration(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_index_signature_name(&mut self, it: &mut TSIndexSignatureName<'a>) {
+        walk_ts_index_signature_name(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_interface_heritage(&mut self, it: &mut TSInterfaceHeritage<'a>) {
+        walk_ts_interface_heritage(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_predicate(&mut self, it: &mut TSTypePredicate<'a>) {
+        walk_ts_type_predicate(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_predicate_name(&mut self, it: &mut TSTypePredicateName<'a>) {
+        walk_ts_type_predicate_name(self, it);
     }
 
     #[inline]
@@ -1204,6 +1041,81 @@ pub trait VisitMut<'a>: Sized {
     }
 
     #[inline]
+    fn visit_ts_type_literal(&mut self, it: &mut TSTypeLiteral<'a>) {
+        walk_ts_type_literal(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_infer_type(&mut self, it: &mut TSInferType<'a>) {
+        walk_ts_infer_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_query(&mut self, it: &mut TSTypeQuery<'a>) {
+        walk_ts_type_query(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_query_expr_name(&mut self, it: &mut TSTypeQueryExprName<'a>) {
+        walk_ts_type_query_expr_name(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_import_type(&mut self, it: &mut TSImportType<'a>) {
+        walk_ts_import_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_import_attributes(&mut self, it: &mut TSImportAttributes<'a>) {
+        walk_ts_import_attributes(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_import_attribute(&mut self, it: &mut TSImportAttribute<'a>) {
+        walk_ts_import_attribute(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_import_attribute_name(&mut self, it: &mut TSImportAttributeName<'a>) {
+        walk_ts_import_attribute_name(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_function_type(&mut self, it: &mut TSFunctionType<'a>) {
+        walk_ts_function_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_constructor_type(&mut self, it: &mut TSConstructorType<'a>) {
+        walk_ts_constructor_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_mapped_type(&mut self, it: &mut TSMappedType<'a>) {
+        walk_ts_mapped_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_template_literal_type(&mut self, it: &mut TSTemplateLiteralType<'a>) {
+        walk_ts_template_literal_type(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_as_expression(&mut self, it: &mut TSAsExpression<'a>) {
+        walk_ts_as_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_satisfies_expression(&mut self, it: &mut TSSatisfiesExpression<'a>) {
+        walk_ts_satisfies_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_assertion(&mut self, it: &mut TSTypeAssertion<'a>) {
+        walk_ts_type_assertion(self, it);
+    }
+
+    #[inline]
     fn visit_ts_import_equals_declaration(&mut self, it: &mut TSImportEqualsDeclaration<'a>) {
         walk_ts_import_equals_declaration(self, it);
     }
@@ -1219,13 +1131,126 @@ pub trait VisitMut<'a>: Sized {
     }
 
     #[inline]
-    fn visit_module_declaration(&mut self, it: &mut ModuleDeclaration<'a>) {
-        walk_module_declaration(self, it);
+    fn visit_ts_non_null_expression(&mut self, it: &mut TSNonNullExpression<'a>) {
+        walk_ts_non_null_expression(self, it);
     }
 
     #[inline]
-    fn visit_import_declaration(&mut self, it: &mut ImportDeclaration<'a>) {
-        walk_import_declaration(self, it);
+    fn visit_decorator(&mut self, it: &mut Decorator<'a>) {
+        walk_decorator(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_export_assignment(&mut self, it: &mut TSExportAssignment<'a>) {
+        walk_ts_export_assignment(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_namespace_export_declaration(&mut self, it: &mut TSNamespaceExportDeclaration<'a>) {
+        walk_ts_namespace_export_declaration(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_instantiation_expression(&mut self, it: &mut TSInstantiationExpression<'a>) {
+        walk_ts_instantiation_expression(self, it);
+    }
+
+    #[inline]
+    fn visit_js_doc_nullable_type(&mut self, it: &mut JSDocNullableType<'a>) {
+        walk_js_doc_nullable_type(self, it);
+    }
+
+    #[inline]
+    fn visit_js_doc_non_nullable_type(&mut self, it: &mut JSDocNonNullableType<'a>) {
+        walk_js_doc_non_nullable_type(self, it);
+    }
+
+    #[inline]
+    fn visit_js_doc_unknown_type(&mut self, it: &mut JSDocUnknownType) {
+        walk_js_doc_unknown_type(self, it);
+    }
+
+    #[inline]
+    fn visit_span(&mut self, it: &mut Span) {
+        walk_span(self, it);
+    }
+
+    #[inline]
+    fn visit_directives(&mut self, it: &mut Vec<'a, Directive<'a>>) {
+        walk_directives(self, it);
+    }
+
+    #[inline]
+    fn visit_statements(&mut self, it: &mut Vec<'a, Statement<'a>>) {
+        walk_statements(self, it);
+    }
+
+    #[inline]
+    fn visit_array_expression_elements(&mut self, it: &mut Vec<'a, ArrayExpressionElement<'a>>) {
+        walk_array_expression_elements(self, it);
+    }
+
+    #[inline]
+    fn visit_object_property_kinds(&mut self, it: &mut Vec<'a, ObjectPropertyKind<'a>>) {
+        walk_object_property_kinds(self, it);
+    }
+
+    #[inline]
+    fn visit_template_elements(&mut self, it: &mut Vec<'a, TemplateElement<'a>>) {
+        walk_template_elements(self, it);
+    }
+
+    #[inline]
+    fn visit_expressions(&mut self, it: &mut Vec<'a, Expression<'a>>) {
+        walk_expressions(self, it);
+    }
+
+    #[inline]
+    fn visit_arguments(&mut self, it: &mut Vec<'a, Argument<'a>>) {
+        walk_arguments(self, it);
+    }
+
+    #[inline]
+    fn visit_assignment_target_properties(
+        &mut self,
+        it: &mut Vec<'a, AssignmentTargetProperty<'a>>,
+    ) {
+        walk_assignment_target_properties(self, it);
+    }
+
+    #[inline]
+    fn visit_variable_declarators(&mut self, it: &mut Vec<'a, VariableDeclarator<'a>>) {
+        walk_variable_declarators(self, it);
+    }
+
+    #[inline]
+    fn visit_switch_cases(&mut self, it: &mut Vec<'a, SwitchCase<'a>>) {
+        walk_switch_cases(self, it);
+    }
+
+    #[inline]
+    fn visit_binding_properties(&mut self, it: &mut Vec<'a, BindingProperty<'a>>) {
+        walk_binding_properties(self, it);
+    }
+
+    #[inline]
+    fn visit_formal_parameter_list(&mut self, it: &mut Vec<'a, FormalParameter<'a>>) {
+        walk_formal_parameter_list(self, it);
+    }
+
+    #[inline]
+    fn visit_decorators(&mut self, it: &mut Vec<'a, Decorator<'a>>) {
+        walk_decorators(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_class_implementses(&mut self, it: &mut Vec<'a, TSClassImplements<'a>>) {
+        walk_ts_class_implementses(self, it);
+    }
+
+    #[inline]
+    fn visit_class_elements(&mut self, it: &mut Vec<'a, ClassElement<'a>>) {
+        walk_class_elements(self, it);
     }
 
     #[inline]
@@ -1237,68 +1262,8 @@ pub trait VisitMut<'a>: Sized {
     }
 
     #[inline]
-    fn visit_import_declaration_specifier(&mut self, it: &mut ImportDeclarationSpecifier<'a>) {
-        walk_import_declaration_specifier(self, it);
-    }
-
-    #[inline]
-    fn visit_import_specifier(&mut self, it: &mut ImportSpecifier<'a>) {
-        walk_import_specifier(self, it);
-    }
-
-    #[inline]
-    fn visit_module_export_name(&mut self, it: &mut ModuleExportName<'a>) {
-        walk_module_export_name(self, it);
-    }
-
-    #[inline]
-    fn visit_import_default_specifier(&mut self, it: &mut ImportDefaultSpecifier<'a>) {
-        walk_import_default_specifier(self, it);
-    }
-
-    #[inline]
-    fn visit_import_namespace_specifier(&mut self, it: &mut ImportNamespaceSpecifier<'a>) {
-        walk_import_namespace_specifier(self, it);
-    }
-
-    #[inline]
-    fn visit_with_clause(&mut self, it: &mut WithClause<'a>) {
-        walk_with_clause(self, it);
-    }
-
-    #[inline]
     fn visit_import_attributes(&mut self, it: &mut Vec<'a, ImportAttribute<'a>>) {
         walk_import_attributes(self, it);
-    }
-
-    #[inline]
-    fn visit_import_attribute(&mut self, it: &mut ImportAttribute<'a>) {
-        walk_import_attribute(self, it);
-    }
-
-    #[inline]
-    fn visit_import_attribute_key(&mut self, it: &mut ImportAttributeKey<'a>) {
-        walk_import_attribute_key(self, it);
-    }
-
-    #[inline]
-    fn visit_export_all_declaration(&mut self, it: &mut ExportAllDeclaration<'a>) {
-        walk_export_all_declaration(self, it);
-    }
-
-    #[inline]
-    fn visit_export_default_declaration(&mut self, it: &mut ExportDefaultDeclaration<'a>) {
-        walk_export_default_declaration(self, it);
-    }
-
-    #[inline]
-    fn visit_export_default_declaration_kind(&mut self, it: &mut ExportDefaultDeclarationKind<'a>) {
-        walk_export_default_declaration_kind(self, it);
-    }
-
-    #[inline]
-    fn visit_export_named_declaration(&mut self, it: &mut ExportNamedDeclaration<'a>) {
-        walk_export_named_declaration(self, it);
     }
 
     #[inline]
@@ -1307,18 +1272,53 @@ pub trait VisitMut<'a>: Sized {
     }
 
     #[inline]
-    fn visit_export_specifier(&mut self, it: &mut ExportSpecifier<'a>) {
-        walk_export_specifier(self, it);
+    fn visit_jsx_children(&mut self, it: &mut Vec<'a, JSXChild<'a>>) {
+        walk_jsx_children(self, it);
     }
 
     #[inline]
-    fn visit_ts_export_assignment(&mut self, it: &mut TSExportAssignment<'a>) {
-        walk_ts_export_assignment(self, it);
+    fn visit_jsx_attribute_items(&mut self, it: &mut Vec<'a, JSXAttributeItem<'a>>) {
+        walk_jsx_attribute_items(self, it);
     }
 
     #[inline]
-    fn visit_ts_namespace_export_declaration(&mut self, it: &mut TSNamespaceExportDeclaration<'a>) {
-        walk_ts_namespace_export_declaration(self, it);
+    fn visit_ts_enum_members(&mut self, it: &mut Vec<'a, TSEnumMember<'a>>) {
+        walk_ts_enum_members(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_types(&mut self, it: &mut Vec<'a, TSType<'a>>) {
+        walk_ts_types(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_tuple_elements(&mut self, it: &mut Vec<'a, TSTupleElement<'a>>) {
+        walk_ts_tuple_elements(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_type_parameters(&mut self, it: &mut Vec<'a, TSTypeParameter<'a>>) {
+        walk_ts_type_parameters(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_interface_heritages(&mut self, it: &mut Vec<'a, TSInterfaceHeritage<'a>>) {
+        walk_ts_interface_heritages(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_signatures(&mut self, it: &mut Vec<'a, TSSignature<'a>>) {
+        walk_ts_signatures(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_index_signature_names(&mut self, it: &mut Vec<'a, TSIndexSignatureName<'a>>) {
+        walk_ts_index_signature_names(self, it);
+    }
+
+    #[inline]
+    fn visit_ts_import_attribute_list(&mut self, it: &mut Vec<'a, TSImportAttribute<'a>>) {
+        walk_ts_import_attribute_list(self, it);
     }
 }
 
@@ -1346,149 +1346,6 @@ pub mod walk_mut {
         visitor.visit_directives(&mut it.directives);
         visitor.visit_statements(&mut it.body);
         visitor.leave_scope();
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_span<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Span) {
-        // No `AstType` for this type
-    }
-
-    #[inline]
-    pub fn walk_hashbang<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Hashbang<'a>) {
-        let kind = AstType::Hashbang;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_directives<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, Directive<'a>>) {
-        for el in it {
-            visitor.visit_directive(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_directive<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Directive<'a>) {
-        let kind = AstType::Directive;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_string_literal(&mut it.expression);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_string_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut StringLiteral<'a>) {
-        let kind = AstType::StringLiteral;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_statements<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, Statement<'a>>) {
-        for el in it {
-            visitor.visit_statement(el);
-        }
-    }
-
-    pub fn walk_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Statement<'a>) {
-        // No `AstType` for this type
-        match it {
-            Statement::BlockStatement(it) => visitor.visit_block_statement(it),
-            Statement::BreakStatement(it) => visitor.visit_break_statement(it),
-            Statement::ContinueStatement(it) => visitor.visit_continue_statement(it),
-            Statement::DebuggerStatement(it) => visitor.visit_debugger_statement(it),
-            Statement::DoWhileStatement(it) => visitor.visit_do_while_statement(it),
-            Statement::EmptyStatement(it) => visitor.visit_empty_statement(it),
-            Statement::ExpressionStatement(it) => visitor.visit_expression_statement(it),
-            Statement::ForInStatement(it) => visitor.visit_for_in_statement(it),
-            Statement::ForOfStatement(it) => visitor.visit_for_of_statement(it),
-            Statement::ForStatement(it) => visitor.visit_for_statement(it),
-            Statement::IfStatement(it) => visitor.visit_if_statement(it),
-            Statement::LabeledStatement(it) => visitor.visit_labeled_statement(it),
-            Statement::ReturnStatement(it) => visitor.visit_return_statement(it),
-            Statement::SwitchStatement(it) => visitor.visit_switch_statement(it),
-            Statement::ThrowStatement(it) => visitor.visit_throw_statement(it),
-            Statement::TryStatement(it) => visitor.visit_try_statement(it),
-            Statement::WhileStatement(it) => visitor.visit_while_statement(it),
-            Statement::WithStatement(it) => visitor.visit_with_statement(it),
-            match_declaration!(Statement) => visitor.visit_declaration(it.to_declaration_mut()),
-            match_module_declaration!(Statement) => {
-                visitor.visit_module_declaration(it.to_module_declaration_mut())
-            }
-        }
-    }
-
-    #[inline]
-    pub fn walk_block_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut BlockStatement<'a>) {
-        let kind = AstType::BlockStatement;
-        visitor.enter_node(kind);
-        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_statements(&mut it.body);
-        visitor.leave_scope();
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_break_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut BreakStatement<'a>) {
-        let kind = AstType::BreakStatement;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        if let Some(label) = &mut it.label {
-            visitor.visit_label_identifier(label);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_label_identifier<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut LabelIdentifier<'a>,
-    ) {
-        let kind = AstType::LabelIdentifier;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_continue_statement<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut ContinueStatement<'a>,
-    ) {
-        let kind = AstType::ContinueStatement;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        if let Some(label) = &mut it.label {
-            visitor.visit_label_identifier(label);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_debugger_statement<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut DebuggerStatement,
-    ) {
-        let kind = AstType::DebuggerStatement;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_do_while_statement<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut DoWhileStatement<'a>,
-    ) {
-        let kind = AstType::DoWhileStatement;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_statement(&mut it.body);
-        visitor.visit_expression(&mut it.test);
         visitor.leave_node(kind);
     }
 
@@ -1548,85 +1405,11 @@ pub mod walk_mut {
     }
 
     #[inline]
-    pub fn walk_boolean_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut BooleanLiteral) {
-        let kind = AstType::BooleanLiteral;
+    pub fn walk_identifier_name<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut IdentifierName<'a>) {
+        let kind = AstType::IdentifierName;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
         visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_null_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut NullLiteral) {
-        let kind = AstType::NullLiteral;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_numeric_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut NumericLiteral<'a>) {
-        let kind = AstType::NumericLiteral;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_big_int_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut BigIntLiteral<'a>) {
-        let kind = AstType::BigIntLiteral;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_reg_exp_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut RegExpLiteral<'a>) {
-        let kind = AstType::RegExpLiteral;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_template_literal<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TemplateLiteral<'a>,
-    ) {
-        let kind = AstType::TemplateLiteral;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_template_elements(&mut it.quasis);
-        visitor.visit_expressions(&mut it.expressions);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_template_elements<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut Vec<'a, TemplateElement<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_template_element(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_template_element<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TemplateElement<'a>,
-    ) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-    }
-
-    #[inline]
-    pub fn walk_expressions<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut Vec<'a, Expression<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_expression(el);
-        }
     }
 
     #[inline]
@@ -1641,26 +1424,30 @@ pub mod walk_mut {
     }
 
     #[inline]
-    pub fn walk_meta_property<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut MetaProperty<'a>) {
-        let kind = AstType::MetaProperty;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_identifier_name(&mut it.meta);
-        visitor.visit_identifier_name(&mut it.property);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_identifier_name<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut IdentifierName<'a>) {
-        let kind = AstType::IdentifierName;
+    pub fn walk_binding_identifier<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut BindingIdentifier<'a>,
+    ) {
+        let kind = AstType::BindingIdentifier;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_super<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Super) {
-        let kind = AstType::Super;
+    pub fn walk_label_identifier<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut LabelIdentifier<'a>,
+    ) {
+        let kind = AstType::LabelIdentifier;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_this_expression<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ThisExpression) {
+        let kind = AstType::ThisExpression;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
         visitor.leave_node(kind);
@@ -1682,16 +1469,6 @@ pub mod walk_mut {
     }
 
     #[inline]
-    pub fn walk_array_expression_elements<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut Vec<'a, ArrayExpressionElement<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_array_expression_element(el);
-        }
-    }
-
-    #[inline]
     pub fn walk_array_expression_element<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut ArrayExpressionElement<'a>,
@@ -1709,15 +1486,6 @@ pub mod walk_mut {
     }
 
     #[inline]
-    pub fn walk_spread_element<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut SpreadElement<'a>) {
-        let kind = AstType::SpreadElement;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_expression(&mut it.argument);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
     pub fn walk_elision<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Elision) {
         let kind = AstType::Elision;
         visitor.enter_node(kind);
@@ -1726,392 +1494,40 @@ pub mod walk_mut {
     }
 
     #[inline]
-    pub fn walk_arrow_function_expression<'a, V: VisitMut<'a>>(
+    pub fn walk_object_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut ArrowFunctionExpression<'a>,
+        it: &mut ObjectExpression<'a>,
     ) {
-        let kind = AstType::ArrowFunctionExpression;
-        visitor.enter_node(kind);
-        visitor.enter_scope(
-            {
-                let mut flags = ScopeFlags::Function | ScopeFlags::Arrow;
-                if it.has_use_strict_directive() {
-                    flags |= ScopeFlags::StrictMode;
-                }
-                flags
-            },
-            &it.scope_id,
-        );
-        visitor.visit_span(&mut it.span);
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_declaration(type_parameters);
-        }
-        visitor.visit_formal_parameters(&mut it.params);
-        if let Some(return_type) = &mut it.return_type {
-            visitor.visit_ts_type_annotation(return_type);
-        }
-        visitor.visit_function_body(&mut it.body);
-        visitor.leave_scope();
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_type_parameter_declaration<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSTypeParameterDeclaration<'a>,
-    ) {
-        let kind = AstType::TSTypeParameterDeclaration;
+        let kind = AstType::ObjectExpression;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
-        visitor.visit_ts_type_parameters(&mut it.params);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_type_parameters<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut Vec<'a, TSTypeParameter<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_ts_type_parameter(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_type_parameter<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSTypeParameter<'a>,
-    ) {
-        let kind = AstType::TSTypeParameter;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_binding_identifier(&mut it.name);
-        if let Some(constraint) = &mut it.constraint {
-            visitor.visit_ts_type(constraint);
-        }
-        if let Some(default) = &mut it.default {
-            visitor.visit_ts_type(default);
+        visitor.visit_object_property_kinds(&mut it.properties);
+        if let Some(trailing_comma) = &mut it.trailing_comma {
+            visitor.visit_span(trailing_comma);
         }
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_binding_identifier<'a, V: VisitMut<'a>>(
+    pub fn walk_object_property_kind<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut BindingIdentifier<'a>,
-    ) {
-        let kind = AstType::BindingIdentifier;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    pub fn walk_ts_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSType<'a>) {
-        // No `AstType` for this type
-        match it {
-            TSType::TSAnyKeyword(it) => visitor.visit_ts_any_keyword(it),
-            TSType::TSBigIntKeyword(it) => visitor.visit_ts_big_int_keyword(it),
-            TSType::TSBooleanKeyword(it) => visitor.visit_ts_boolean_keyword(it),
-            TSType::TSIntrinsicKeyword(it) => visitor.visit_ts_intrinsic_keyword(it),
-            TSType::TSNeverKeyword(it) => visitor.visit_ts_never_keyword(it),
-            TSType::TSNullKeyword(it) => visitor.visit_ts_null_keyword(it),
-            TSType::TSNumberKeyword(it) => visitor.visit_ts_number_keyword(it),
-            TSType::TSObjectKeyword(it) => visitor.visit_ts_object_keyword(it),
-            TSType::TSStringKeyword(it) => visitor.visit_ts_string_keyword(it),
-            TSType::TSSymbolKeyword(it) => visitor.visit_ts_symbol_keyword(it),
-            TSType::TSUndefinedKeyword(it) => visitor.visit_ts_undefined_keyword(it),
-            TSType::TSUnknownKeyword(it) => visitor.visit_ts_unknown_keyword(it),
-            TSType::TSVoidKeyword(it) => visitor.visit_ts_void_keyword(it),
-            TSType::TSArrayType(it) => visitor.visit_ts_array_type(it),
-            TSType::TSConditionalType(it) => visitor.visit_ts_conditional_type(it),
-            TSType::TSConstructorType(it) => visitor.visit_ts_constructor_type(it),
-            TSType::TSFunctionType(it) => visitor.visit_ts_function_type(it),
-            TSType::TSImportType(it) => visitor.visit_ts_import_type(it),
-            TSType::TSIndexedAccessType(it) => visitor.visit_ts_indexed_access_type(it),
-            TSType::TSInferType(it) => visitor.visit_ts_infer_type(it),
-            TSType::TSIntersectionType(it) => visitor.visit_ts_intersection_type(it),
-            TSType::TSLiteralType(it) => visitor.visit_ts_literal_type(it),
-            TSType::TSMappedType(it) => visitor.visit_ts_mapped_type(it),
-            TSType::TSNamedTupleMember(it) => visitor.visit_ts_named_tuple_member(it),
-            TSType::TSQualifiedName(it) => visitor.visit_ts_qualified_name(it),
-            TSType::TSTemplateLiteralType(it) => visitor.visit_ts_template_literal_type(it),
-            TSType::TSThisType(it) => visitor.visit_ts_this_type(it),
-            TSType::TSTupleType(it) => visitor.visit_ts_tuple_type(it),
-            TSType::TSTypeLiteral(it) => visitor.visit_ts_type_literal(it),
-            TSType::TSTypeOperatorType(it) => visitor.visit_ts_type_operator(it),
-            TSType::TSTypePredicate(it) => visitor.visit_ts_type_predicate(it),
-            TSType::TSTypeQuery(it) => visitor.visit_ts_type_query(it),
-            TSType::TSTypeReference(it) => visitor.visit_ts_type_reference(it),
-            TSType::TSUnionType(it) => visitor.visit_ts_union_type(it),
-            TSType::TSParenthesizedType(it) => visitor.visit_ts_parenthesized_type(it),
-            TSType::JSDocNullableType(it) => visitor.visit_js_doc_nullable_type(it),
-            TSType::JSDocNonNullableType(it) => visitor.visit_js_doc_non_nullable_type(it),
-            TSType::JSDocUnknownType(it) => visitor.visit_js_doc_unknown_type(it),
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_any_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSAnyKeyword) {
-        let kind = AstType::TSAnyKeyword;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_big_int_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSBigIntKeyword) {
-        let kind = AstType::TSBigIntKeyword;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_boolean_keyword<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSBooleanKeyword,
-    ) {
-        let kind = AstType::TSBooleanKeyword;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_intrinsic_keyword<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSIntrinsicKeyword,
-    ) {
-        let kind = AstType::TSIntrinsicKeyword;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_never_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSNeverKeyword) {
-        let kind = AstType::TSNeverKeyword;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_null_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSNullKeyword) {
-        let kind = AstType::TSNullKeyword;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_number_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSNumberKeyword) {
-        let kind = AstType::TSNumberKeyword;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_object_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSObjectKeyword) {
-        let kind = AstType::TSObjectKeyword;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_string_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSStringKeyword) {
-        let kind = AstType::TSStringKeyword;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_symbol_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSSymbolKeyword) {
-        let kind = AstType::TSSymbolKeyword;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_undefined_keyword<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSUndefinedKeyword,
-    ) {
-        let kind = AstType::TSUndefinedKeyword;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_unknown_keyword<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSUnknownKeyword,
-    ) {
-        let kind = AstType::TSUnknownKeyword;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_void_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSVoidKeyword) {
-        let kind = AstType::TSVoidKeyword;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_array_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSArrayType<'a>) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-        visitor.visit_ts_type(&mut it.element_type);
-    }
-
-    #[inline]
-    pub fn walk_ts_conditional_type<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSConditionalType<'a>,
-    ) {
-        let kind = AstType::TSConditionalType;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_ts_type(&mut it.check_type);
-        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
-        visitor.visit_ts_type(&mut it.extends_type);
-        visitor.visit_ts_type(&mut it.true_type);
-        visitor.leave_scope();
-        visitor.visit_ts_type(&mut it.false_type);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_constructor_type<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSConstructorType<'a>,
-    ) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_declaration(type_parameters);
-        }
-        visitor.visit_formal_parameters(&mut it.params);
-        visitor.visit_ts_type_annotation(&mut it.return_type);
-    }
-
-    #[inline]
-    pub fn walk_formal_parameters<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut FormalParameters<'a>,
-    ) {
-        let kind = AstType::FormalParameters;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_formal_parameter_list(&mut it.items);
-        if let Some(rest) = &mut it.rest {
-            visitor.visit_binding_rest_element(rest);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_formal_parameter_list<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut Vec<'a, FormalParameter<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_formal_parameter(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_formal_parameter<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut FormalParameter<'a>,
-    ) {
-        let kind = AstType::FormalParameter;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_decorators(&mut it.decorators);
-        visitor.visit_binding_pattern(&mut it.pattern);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_decorators<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, Decorator<'a>>) {
-        for el in it {
-            visitor.visit_decorator(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_decorator<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Decorator<'a>) {
-        let kind = AstType::Decorator;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_expression(&mut it.expression);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_binding_pattern<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut BindingPattern<'a>) {
-        // No `AstType` for this type
-        visitor.visit_binding_pattern_kind(&mut it.kind);
-        if let Some(type_annotation) = &mut it.type_annotation {
-            visitor.visit_ts_type_annotation(type_annotation);
-        }
-    }
-
-    #[inline]
-    pub fn walk_binding_pattern_kind<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut BindingPatternKind<'a>,
+        it: &mut ObjectPropertyKind<'a>,
     ) {
         // No `AstType` for this type
         match it {
-            BindingPatternKind::BindingIdentifier(it) => visitor.visit_binding_identifier(it),
-            BindingPatternKind::ObjectPattern(it) => visitor.visit_object_pattern(it),
-            BindingPatternKind::ArrayPattern(it) => visitor.visit_array_pattern(it),
-            BindingPatternKind::AssignmentPattern(it) => visitor.visit_assignment_pattern(it),
+            ObjectPropertyKind::ObjectProperty(it) => visitor.visit_object_property(it),
+            ObjectPropertyKind::SpreadProperty(it) => visitor.visit_spread_element(it),
         }
     }
 
     #[inline]
-    pub fn walk_object_pattern<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ObjectPattern<'a>) {
-        let kind = AstType::ObjectPattern;
+    pub fn walk_object_property<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ObjectProperty<'a>) {
+        let kind = AstType::ObjectProperty;
         visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_binding_properties(&mut it.properties);
-        if let Some(rest) = &mut it.rest {
-            visitor.visit_binding_rest_element(rest);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_binding_properties<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut Vec<'a, BindingProperty<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_binding_property(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_binding_property<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut BindingProperty<'a>,
-    ) {
-        // No `AstType` for this type
         visitor.visit_span(&mut it.span);
         visitor.visit_property_key(&mut it.key);
-        visitor.visit_binding_pattern(&mut it.value);
+        visitor.visit_expression(&mut it.value);
+        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -2127,111 +1543,28 @@ pub mod walk_mut {
     }
 
     #[inline]
-    pub fn walk_private_identifier<'a, V: VisitMut<'a>>(
+    pub fn walk_template_literal<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut PrivateIdentifier<'a>,
+        it: &mut TemplateLiteral<'a>,
     ) {
-        let kind = AstType::PrivateIdentifier;
+        let kind = AstType::TemplateLiteral;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
+        visitor.visit_template_elements(&mut it.quasis);
+        visitor.visit_expressions(&mut it.expressions);
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_binding_rest_element<'a, V: VisitMut<'a>>(
+    pub fn walk_tagged_template_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut BindingRestElement<'a>,
+        it: &mut TaggedTemplateExpression<'a>,
     ) {
-        let kind = AstType::BindingRestElement;
+        let kind = AstType::TaggedTemplateExpression;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
-        visitor.visit_binding_pattern(&mut it.argument);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_array_pattern<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ArrayPattern<'a>) {
-        let kind = AstType::ArrayPattern;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        for el in it.elements.iter_mut().flatten() {
-            visitor.visit_binding_pattern(el);
-        }
-        if let Some(rest) = &mut it.rest {
-            visitor.visit_binding_rest_element(rest);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_assignment_pattern<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut AssignmentPattern<'a>,
-    ) {
-        let kind = AstType::AssignmentPattern;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_binding_pattern(&mut it.left);
-        visitor.visit_expression(&mut it.right);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_type_annotation<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSTypeAnnotation<'a>,
-    ) {
-        let kind = AstType::TSTypeAnnotation;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_ts_type(&mut it.type_annotation);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_function_type<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSFunctionType<'a>,
-    ) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_declaration(type_parameters);
-        }
-        if let Some(this_param) = &mut it.this_param {
-            visitor.visit_ts_this_parameter(this_param);
-        }
-        visitor.visit_formal_parameters(&mut it.params);
-        visitor.visit_ts_type_annotation(&mut it.return_type);
-    }
-
-    #[inline]
-    pub fn walk_ts_this_parameter<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSThisParameter<'a>,
-    ) {
-        let kind = AstType::TSThisParameter;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_span(&mut it.this_span);
-        if let Some(type_annotation) = &mut it.type_annotation {
-            visitor.visit_ts_type_annotation(type_annotation);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_import_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSImportType<'a>) {
-        let kind = AstType::TSImportType;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_ts_type(&mut it.parameter);
-        if let Some(qualifier) = &mut it.qualifier {
-            visitor.visit_ts_type_name(qualifier);
-        }
-        if let Some(attributes) = &mut it.attributes {
-            visitor.visit_ts_import_attributes(attributes);
-        }
+        visitor.visit_expression(&mut it.tag);
+        visitor.visit_template_literal(&mut it.quasi);
         if let Some(type_parameters) = &mut it.type_parameters {
             visitor.visit_ts_type_parameter_instantiation(type_parameters);
         }
@@ -2239,147 +1572,134 @@ pub mod walk_mut {
     }
 
     #[inline]
-    pub fn walk_ts_type_name<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSTypeName<'a>) {
-        let kind = AstType::TSTypeName;
+    pub fn walk_template_element<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TemplateElement<'a>,
+    ) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+    }
+
+    #[inline]
+    pub fn walk_member_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut MemberExpression<'a>,
+    ) {
+        let kind = AstType::MemberExpression;
         visitor.enter_node(kind);
         match it {
-            TSTypeName::IdentifierReference(it) => visitor.visit_identifier_reference(it),
-            TSTypeName::QualifiedName(it) => visitor.visit_ts_qualified_name(it),
+            MemberExpression::ComputedMemberExpression(it) => {
+                visitor.visit_computed_member_expression(it)
+            }
+            MemberExpression::StaticMemberExpression(it) => {
+                visitor.visit_static_member_expression(it)
+            }
+            MemberExpression::PrivateFieldExpression(it) => {
+                visitor.visit_private_field_expression(it)
+            }
         }
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_ts_qualified_name<'a, V: VisitMut<'a>>(
+    pub fn walk_computed_member_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut TSQualifiedName<'a>,
+        it: &mut ComputedMemberExpression<'a>,
     ) {
-        let kind = AstType::TSQualifiedName;
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+        visitor.visit_expression(&mut it.object);
+        visitor.visit_expression(&mut it.expression);
+    }
+
+    #[inline]
+    pub fn walk_static_member_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut StaticMemberExpression<'a>,
+    ) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+        visitor.visit_expression(&mut it.object);
+        visitor.visit_identifier_name(&mut it.property);
+    }
+
+    #[inline]
+    pub fn walk_private_field_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut PrivateFieldExpression<'a>,
+    ) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+        visitor.visit_expression(&mut it.object);
+        visitor.visit_private_identifier(&mut it.field);
+    }
+
+    #[inline]
+    pub fn walk_call_expression<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut CallExpression<'a>) {
+        let kind = AstType::CallExpression;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
-        visitor.visit_ts_type_name(&mut it.left);
-        visitor.visit_identifier_name(&mut it.right);
+        visitor.visit_expression(&mut it.callee);
+        if let Some(type_parameters) = &mut it.type_parameters {
+            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        }
+        visitor.visit_arguments(&mut it.arguments);
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_ts_import_attributes<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSImportAttributes<'a>,
-    ) {
-        // No `AstType` for this type
+    pub fn walk_new_expression<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut NewExpression<'a>) {
+        let kind = AstType::NewExpression;
+        visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
-        visitor.visit_identifier_name(&mut it.attributes_keyword);
-        visitor.visit_ts_import_attribute_list(&mut it.elements);
-    }
-
-    #[inline]
-    pub fn walk_ts_import_attribute_list<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut Vec<'a, TSImportAttribute<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_ts_import_attribute(el);
+        visitor.visit_expression(&mut it.callee);
+        visitor.visit_arguments(&mut it.arguments);
+        if let Some(type_parameters) = &mut it.type_parameters {
+            visitor.visit_ts_type_parameter_instantiation(type_parameters);
         }
+        visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_ts_import_attribute<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSImportAttribute<'a>,
-    ) {
-        // No `AstType` for this type
+    pub fn walk_meta_property<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut MetaProperty<'a>) {
+        let kind = AstType::MetaProperty;
+        visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
-        visitor.visit_ts_import_attribute_name(&mut it.name);
-        visitor.visit_expression(&mut it.value);
+        visitor.visit_identifier_name(&mut it.meta);
+        visitor.visit_identifier_name(&mut it.property);
+        visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_ts_import_attribute_name<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSImportAttributeName<'a>,
-    ) {
-        // No `AstType` for this type
+    pub fn walk_spread_element<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut SpreadElement<'a>) {
+        let kind = AstType::SpreadElement;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_expression(&mut it.argument);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_argument<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Argument<'a>) {
+        let kind = AstType::Argument;
+        visitor.enter_node(kind);
         match it {
-            TSImportAttributeName::Identifier(it) => visitor.visit_identifier_name(it),
-            TSImportAttributeName::StringLiteral(it) => visitor.visit_string_literal(it),
+            Argument::SpreadElement(it) => visitor.visit_spread_element(it),
+            match_expression!(Argument) => visitor.visit_expression(it.to_expression_mut()),
         }
+        visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_ts_type_parameter_instantiation<'a, V: VisitMut<'a>>(
+    pub fn walk_update_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut TSTypeParameterInstantiation<'a>,
+        it: &mut UpdateExpression<'a>,
     ) {
-        let kind = AstType::TSTypeParameterInstantiation;
+        let kind = AstType::UpdateExpression;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
-        visitor.visit_ts_types(&mut it.params);
+        visitor.visit_simple_assignment_target(&mut it.argument);
         visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_types<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, TSType<'a>>) {
-        for el in it {
-            visitor.visit_ts_type(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_indexed_access_type<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSIndexedAccessType<'a>,
-    ) {
-        let kind = AstType::TSIndexedAccessType;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_ts_type(&mut it.object_type);
-        visitor.visit_ts_type(&mut it.index_type);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_infer_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSInferType<'a>) {
-        let kind = AstType::TSInferType;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_ts_type_parameter(&mut it.type_parameter);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_intersection_type<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSIntersectionType<'a>,
-    ) {
-        let kind = AstType::TSIntersectionType;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_ts_types(&mut it.types);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_literal_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSLiteralType<'a>) {
-        let kind = AstType::TSLiteralType;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_ts_literal(&mut it.literal);
-        visitor.leave_node(kind);
-    }
-
-    pub fn walk_ts_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSLiteral<'a>) {
-        // No `AstType` for this type
-        match it {
-            TSLiteral::BooleanLiteral(it) => visitor.visit_boolean_literal(it),
-            TSLiteral::NullLiteral(it) => visitor.visit_null_literal(it),
-            TSLiteral::NumericLiteral(it) => visitor.visit_numeric_literal(it),
-            TSLiteral::BigIntLiteral(it) => visitor.visit_big_int_literal(it),
-            TSLiteral::RegExpLiteral(it) => visitor.visit_reg_exp_literal(it),
-            TSLiteral::StringLiteral(it) => visitor.visit_string_literal(it),
-            TSLiteral::TemplateLiteral(it) => visitor.visit_template_literal(it),
-            TSLiteral::UnaryExpression(it) => visitor.visit_unary_expression(it),
-        }
     }
 
     #[inline]
@@ -2395,379 +1715,55 @@ pub mod walk_mut {
     }
 
     #[inline]
-    pub fn walk_ts_mapped_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSMappedType<'a>) {
-        let kind = AstType::TSMappedType;
+    pub fn walk_binary_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut BinaryExpression<'a>,
+    ) {
+        let kind = AstType::BinaryExpression;
         visitor.enter_node(kind);
-        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_span(&mut it.span);
-        visitor.visit_ts_type_parameter(&mut it.type_parameter);
-        if let Some(name_type) = &mut it.name_type {
-            visitor.visit_ts_type(name_type);
-        }
-        if let Some(type_annotation) = &mut it.type_annotation {
-            visitor.visit_ts_type(type_annotation);
-        }
-        visitor.leave_scope();
+        visitor.visit_expression(&mut it.left);
+        visitor.visit_expression(&mut it.right);
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_ts_named_tuple_member<'a, V: VisitMut<'a>>(
+    pub fn walk_private_in_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut TSNamedTupleMember<'a>,
+        it: &mut PrivateInExpression<'a>,
     ) {
-        let kind = AstType::TSNamedTupleMember;
+        let kind = AstType::PrivateInExpression;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
-        visitor.visit_ts_tuple_element(&mut it.element_type);
-        visitor.visit_identifier_name(&mut it.label);
+        visitor.visit_private_identifier(&mut it.left);
+        visitor.visit_expression(&mut it.right);
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_ts_tuple_element<'a, V: VisitMut<'a>>(
+    pub fn walk_logical_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut TSTupleElement<'a>,
+        it: &mut LogicalExpression<'a>,
     ) {
-        // No `AstType` for this type
-        match it {
-            TSTupleElement::TSOptionalType(it) => visitor.visit_ts_optional_type(it),
-            TSTupleElement::TSRestType(it) => visitor.visit_ts_rest_type(it),
-            match_ts_type!(TSTupleElement) => visitor.visit_ts_type(it.to_ts_type_mut()),
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_optional_type<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSOptionalType<'a>,
-    ) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-        visitor.visit_ts_type(&mut it.type_annotation);
-    }
-
-    #[inline]
-    pub fn walk_ts_rest_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSRestType<'a>) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-        visitor.visit_ts_type(&mut it.type_annotation);
-    }
-
-    #[inline]
-    pub fn walk_ts_template_literal_type<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSTemplateLiteralType<'a>,
-    ) {
-        let kind = AstType::TSTemplateLiteralType;
+        let kind = AstType::LogicalExpression;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
-        visitor.visit_template_elements(&mut it.quasis);
-        visitor.visit_ts_types(&mut it.types);
+        visitor.visit_expression(&mut it.left);
+        visitor.visit_expression(&mut it.right);
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_ts_this_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSThisType) {
-        let kind = AstType::TSThisType;
+    pub fn walk_conditional_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ConditionalExpression<'a>,
+    ) {
+        let kind = AstType::ConditionalExpression;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_tuple_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSTupleType<'a>) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-        visitor.visit_ts_tuple_elements(&mut it.element_types);
-    }
-
-    #[inline]
-    pub fn walk_ts_tuple_elements<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut Vec<'a, TSTupleElement<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_ts_tuple_element(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_type_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSTypeLiteral<'a>) {
-        let kind = AstType::TSTypeLiteral;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_ts_signatures(&mut it.members);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_signatures<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut Vec<'a, TSSignature<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_ts_signature(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_signature<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSSignature<'a>) {
-        // No `AstType` for this type
-        match it {
-            TSSignature::TSIndexSignature(it) => visitor.visit_ts_index_signature(it),
-            TSSignature::TSPropertySignature(it) => visitor.visit_ts_property_signature(it),
-            TSSignature::TSCallSignatureDeclaration(it) => {
-                visitor.visit_ts_call_signature_declaration(it)
-            }
-            TSSignature::TSConstructSignatureDeclaration(it) => {
-                visitor.visit_ts_construct_signature_declaration(it)
-            }
-            TSSignature::TSMethodSignature(it) => visitor.visit_ts_method_signature(it),
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_index_signature<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSIndexSignature<'a>,
-    ) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-        visitor.visit_ts_index_signature_names(&mut it.parameters);
-        visitor.visit_ts_type_annotation(&mut it.type_annotation);
-    }
-
-    #[inline]
-    pub fn walk_ts_index_signature_names<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut Vec<'a, TSIndexSignatureName<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_ts_index_signature_name(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_index_signature_name<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSIndexSignatureName<'a>,
-    ) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-        visitor.visit_ts_type_annotation(&mut it.type_annotation);
-    }
-
-    #[inline]
-    pub fn walk_ts_property_signature<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSPropertySignature<'a>,
-    ) {
-        let kind = AstType::TSPropertySignature;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_property_key(&mut it.key);
-        if let Some(type_annotation) = &mut it.type_annotation {
-            visitor.visit_ts_type_annotation(type_annotation);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_call_signature_declaration<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSCallSignatureDeclaration<'a>,
-    ) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_declaration(type_parameters);
-        }
-        if let Some(this_param) = &mut it.this_param {
-            visitor.visit_ts_this_parameter(this_param);
-        }
-        visitor.visit_formal_parameters(&mut it.params);
-        if let Some(return_type) = &mut it.return_type {
-            visitor.visit_ts_type_annotation(return_type);
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_construct_signature_declaration<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSConstructSignatureDeclaration<'a>,
-    ) {
-        let kind = AstType::TSConstructSignatureDeclaration;
-        visitor.enter_node(kind);
-        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
-        visitor.visit_span(&mut it.span);
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_declaration(type_parameters);
-        }
-        visitor.visit_formal_parameters(&mut it.params);
-        if let Some(return_type) = &mut it.return_type {
-            visitor.visit_ts_type_annotation(return_type);
-        }
-        visitor.leave_scope();
-        visitor.leave_node(kind);
-    }
-
-    pub fn walk_ts_method_signature<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSMethodSignature<'a>,
-    ) {
-        let kind = AstType::TSMethodSignature;
-        visitor.enter_node(kind);
-        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_property_key(&mut it.key);
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_declaration(type_parameters);
-        }
-        if let Some(this_param) = &mut it.this_param {
-            visitor.visit_ts_this_parameter(this_param);
-        }
-        visitor.visit_formal_parameters(&mut it.params);
-        if let Some(return_type) = &mut it.return_type {
-            visitor.visit_ts_type_annotation(return_type);
-        }
-        visitor.leave_scope();
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_type_operator<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSTypeOperator<'a>,
-    ) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-        visitor.visit_ts_type(&mut it.type_annotation);
-    }
-
-    #[inline]
-    pub fn walk_ts_type_predicate<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSTypePredicate<'a>,
-    ) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-        visitor.visit_ts_type_predicate_name(&mut it.parameter_name);
-        if let Some(type_annotation) = &mut it.type_annotation {
-            visitor.visit_ts_type_annotation(type_annotation);
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_type_predicate_name<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSTypePredicateName<'a>,
-    ) {
-        // No `AstType` for this type
-        match it {
-            TSTypePredicateName::Identifier(it) => visitor.visit_identifier_name(it),
-            TSTypePredicateName::This(it) => visitor.visit_ts_this_type(it),
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_type_query<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSTypeQuery<'a>) {
-        let kind = AstType::TSTypeQuery;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_ts_type_query_expr_name(&mut it.expr_name);
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_type_query_expr_name<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSTypeQueryExprName<'a>,
-    ) {
-        // No `AstType` for this type
-        match it {
-            TSTypeQueryExprName::TSImportType(it) => visitor.visit_ts_import_type(it),
-            match_ts_type_name!(TSTypeQueryExprName) => {
-                visitor.visit_ts_type_name(it.to_ts_type_name_mut())
-            }
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_type_reference<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSTypeReference<'a>,
-    ) {
-        let kind = AstType::TSTypeReference;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_ts_type_name(&mut it.type_name);
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_union_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSUnionType<'a>) {
-        let kind = AstType::TSUnionType;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_ts_types(&mut it.types);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_parenthesized_type<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSParenthesizedType<'a>,
-    ) {
-        let kind = AstType::TSParenthesizedType;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_ts_type(&mut it.type_annotation);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_js_doc_nullable_type<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut JSDocNullableType<'a>,
-    ) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-        visitor.visit_ts_type(&mut it.type_annotation);
-    }
-
-    #[inline]
-    pub fn walk_js_doc_non_nullable_type<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut JSDocNonNullableType<'a>,
-    ) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-        visitor.visit_ts_type(&mut it.type_annotation);
-    }
-
-    #[inline]
-    pub fn walk_js_doc_unknown_type<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut JSDocUnknownType,
-    ) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-    }
-
-    #[inline]
-    pub fn walk_function_body<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut FunctionBody<'a>) {
-        let kind = AstType::FunctionBody;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_directives(&mut it.directives);
-        visitor.visit_statements(&mut it.statements);
+        visitor.visit_expression(&mut it.test);
+        visitor.visit_expression(&mut it.consequent);
+        visitor.visit_expression(&mut it.alternate);
         visitor.leave_node(kind);
     }
 
@@ -2831,124 +1827,6 @@ pub mod walk_mut {
     }
 
     #[inline]
-    pub fn walk_ts_as_expression<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSAsExpression<'a>,
-    ) {
-        let kind = AstType::TSAsExpression;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_expression(&mut it.expression);
-        visitor.visit_ts_type(&mut it.type_annotation);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_satisfies_expression<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSSatisfiesExpression<'a>,
-    ) {
-        let kind = AstType::TSSatisfiesExpression;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_expression(&mut it.expression);
-        visitor.visit_ts_type(&mut it.type_annotation);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_non_null_expression<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSNonNullExpression<'a>,
-    ) {
-        let kind = AstType::TSNonNullExpression;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_expression(&mut it.expression);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_type_assertion<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSTypeAssertion<'a>,
-    ) {
-        let kind = AstType::TSTypeAssertion;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_expression(&mut it.expression);
-        visitor.visit_ts_type(&mut it.type_annotation);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_instantiation_expression<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSInstantiationExpression<'a>,
-    ) {
-        let kind = AstType::TSInstantiationExpression;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_expression(&mut it.expression);
-        visitor.visit_ts_type_parameter_instantiation(&mut it.type_parameters);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_member_expression<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut MemberExpression<'a>,
-    ) {
-        let kind = AstType::MemberExpression;
-        visitor.enter_node(kind);
-        match it {
-            MemberExpression::ComputedMemberExpression(it) => {
-                visitor.visit_computed_member_expression(it)
-            }
-            MemberExpression::StaticMemberExpression(it) => {
-                visitor.visit_static_member_expression(it)
-            }
-            MemberExpression::PrivateFieldExpression(it) => {
-                visitor.visit_private_field_expression(it)
-            }
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_computed_member_expression<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut ComputedMemberExpression<'a>,
-    ) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-        visitor.visit_expression(&mut it.object);
-        visitor.visit_expression(&mut it.expression);
-    }
-
-    #[inline]
-    pub fn walk_static_member_expression<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut StaticMemberExpression<'a>,
-    ) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-        visitor.visit_expression(&mut it.object);
-        visitor.visit_identifier_name(&mut it.property);
-    }
-
-    #[inline]
-    pub fn walk_private_field_expression<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut PrivateFieldExpression<'a>,
-    ) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-        visitor.visit_expression(&mut it.object);
-        visitor.visit_private_identifier(&mut it.field);
-    }
-
-    #[inline]
     pub fn walk_assignment_target_pattern<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut AssignmentTargetPattern<'a>,
@@ -2987,6 +1865,31 @@ pub mod walk_mut {
     }
 
     #[inline]
+    pub fn walk_object_assignment_target<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ObjectAssignmentTarget<'a>,
+    ) {
+        let kind = AstType::ObjectAssignmentTarget;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_assignment_target_properties(&mut it.properties);
+        if let Some(rest) = &mut it.rest {
+            visitor.visit_assignment_target_rest(rest);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_assignment_target_rest<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut AssignmentTargetRest<'a>,
+    ) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+        visitor.visit_assignment_target(&mut it.target);
+    }
+
+    #[inline]
     pub fn walk_assignment_target_maybe_default<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut AssignmentTargetMaybeDefault<'a>,
@@ -3013,41 +1916,6 @@ pub mod walk_mut {
         visitor.visit_assignment_target(&mut it.binding);
         visitor.visit_expression(&mut it.init);
         visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_assignment_target_rest<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut AssignmentTargetRest<'a>,
-    ) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-        visitor.visit_assignment_target(&mut it.target);
-    }
-
-    #[inline]
-    pub fn walk_object_assignment_target<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut ObjectAssignmentTarget<'a>,
-    ) {
-        let kind = AstType::ObjectAssignmentTarget;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_assignment_target_properties(&mut it.properties);
-        if let Some(rest) = &mut it.rest {
-            visitor.visit_assignment_target_rest(rest);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_assignment_target_properties<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut Vec<'a, AssignmentTargetProperty<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_assignment_target_property(el);
-        }
     }
 
     #[inline]
@@ -3091,6 +1959,26 @@ pub mod walk_mut {
     }
 
     #[inline]
+    pub fn walk_sequence_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut SequenceExpression<'a>,
+    ) {
+        let kind = AstType::SequenceExpression;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_expressions(&mut it.expressions);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_super<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Super) {
+        let kind = AstType::Super;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
     pub fn walk_await_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut AwaitExpression<'a>,
@@ -3099,50 +1987,6 @@ pub mod walk_mut {
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.argument);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_binary_expression<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut BinaryExpression<'a>,
-    ) {
-        let kind = AstType::BinaryExpression;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_expression(&mut it.left);
-        visitor.visit_expression(&mut it.right);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_call_expression<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut CallExpression<'a>) {
-        let kind = AstType::CallExpression;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_expression(&mut it.callee);
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
-        }
-        visitor.visit_arguments(&mut it.arguments);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_arguments<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, Argument<'a>>) {
-        for el in it {
-            visitor.visit_argument(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_argument<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Argument<'a>) {
-        let kind = AstType::Argument;
-        visitor.enter_node(kind);
-        match it {
-            Argument::SpreadElement(it) => visitor.visit_spread_element(it),
-            match_expression!(Argument) => visitor.visit_expression(it.to_expression_mut()),
-        }
         visitor.leave_node(kind);
     }
 
@@ -3170,295 +2014,6 @@ pub mod walk_mut {
         }
     }
 
-    pub fn walk_class<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Class<'a>) {
-        let kind = AstType::Class;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_decorators(&mut it.decorators);
-        if let Some(id) = &mut it.id {
-            visitor.visit_binding_identifier(id);
-        }
-        visitor.enter_scope(ScopeFlags::StrictMode, &it.scope_id);
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_declaration(type_parameters);
-        }
-        if let Some(super_class) = &mut it.super_class {
-            visitor.visit_expression(super_class);
-        }
-        if let Some(super_type_parameters) = &mut it.super_type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(super_type_parameters);
-        }
-        if let Some(implements) = &mut it.implements {
-            visitor.visit_ts_class_implementses(implements);
-        }
-        visitor.visit_class_body(&mut it.body);
-        visitor.leave_scope();
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_class_implementses<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut Vec<'a, TSClassImplements<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_ts_class_implements(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_class_implements<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSClassImplements<'a>,
-    ) {
-        let kind = AstType::TSClassImplements;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_ts_type_name(&mut it.expression);
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_class_body<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ClassBody<'a>) {
-        let kind = AstType::ClassBody;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_class_elements(&mut it.body);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_class_elements<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut Vec<'a, ClassElement<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_class_element(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_class_element<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ClassElement<'a>) {
-        // No `AstType` for this type
-        match it {
-            ClassElement::StaticBlock(it) => visitor.visit_static_block(it),
-            ClassElement::MethodDefinition(it) => visitor.visit_method_definition(it),
-            ClassElement::PropertyDefinition(it) => visitor.visit_property_definition(it),
-            ClassElement::AccessorProperty(it) => visitor.visit_accessor_property(it),
-            ClassElement::TSIndexSignature(it) => visitor.visit_ts_index_signature(it),
-        }
-    }
-
-    #[inline]
-    pub fn walk_static_block<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut StaticBlock<'a>) {
-        let kind = AstType::StaticBlock;
-        visitor.enter_node(kind);
-        visitor.enter_scope(ScopeFlags::ClassStaticBlock, &it.scope_id);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_statements(&mut it.body);
-        visitor.leave_scope();
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_method_definition<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut MethodDefinition<'a>,
-    ) {
-        let kind = AstType::MethodDefinition;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_decorators(&mut it.decorators);
-        visitor.visit_property_key(&mut it.key);
-        {
-            let flags = match it.kind {
-                MethodDefinitionKind::Get => ScopeFlags::Function | ScopeFlags::GetAccessor,
-                MethodDefinitionKind::Set => ScopeFlags::Function | ScopeFlags::SetAccessor,
-                MethodDefinitionKind::Constructor => ScopeFlags::Function | ScopeFlags::Constructor,
-                MethodDefinitionKind::Method => ScopeFlags::Function,
-            };
-            visitor.visit_function(&mut it.value, flags);
-        }
-        visitor.leave_node(kind);
-    }
-
-    pub fn walk_function<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut Function<'a>,
-        flags: ScopeFlags,
-    ) {
-        let kind = AstType::Function;
-        visitor.enter_node(kind);
-        visitor.enter_scope(
-            {
-                let mut flags = flags;
-                if it.has_use_strict_directive() {
-                    flags |= ScopeFlags::StrictMode;
-                }
-                flags
-            },
-            &it.scope_id,
-        );
-        visitor.visit_span(&mut it.span);
-        if let Some(id) = &mut it.id {
-            visitor.visit_binding_identifier(id);
-        }
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_declaration(type_parameters);
-        }
-        if let Some(this_param) = &mut it.this_param {
-            visitor.visit_ts_this_parameter(this_param);
-        }
-        visitor.visit_formal_parameters(&mut it.params);
-        if let Some(return_type) = &mut it.return_type {
-            visitor.visit_ts_type_annotation(return_type);
-        }
-        if let Some(body) = &mut it.body {
-            visitor.visit_function_body(body);
-        }
-        visitor.leave_scope();
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_property_definition<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut PropertyDefinition<'a>,
-    ) {
-        let kind = AstType::PropertyDefinition;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_decorators(&mut it.decorators);
-        visitor.visit_property_key(&mut it.key);
-        if let Some(value) = &mut it.value {
-            visitor.visit_expression(value);
-        }
-        if let Some(type_annotation) = &mut it.type_annotation {
-            visitor.visit_ts_type_annotation(type_annotation);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_accessor_property<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut AccessorProperty<'a>,
-    ) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-        visitor.visit_decorators(&mut it.decorators);
-        visitor.visit_property_key(&mut it.key);
-        if let Some(value) = &mut it.value {
-            visitor.visit_expression(value);
-        }
-        if let Some(type_annotation) = &mut it.type_annotation {
-            visitor.visit_ts_type_annotation(type_annotation);
-        }
-    }
-
-    #[inline]
-    pub fn walk_conditional_expression<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut ConditionalExpression<'a>,
-    ) {
-        let kind = AstType::ConditionalExpression;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_expression(&mut it.test);
-        visitor.visit_expression(&mut it.consequent);
-        visitor.visit_expression(&mut it.alternate);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_import_expression<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut ImportExpression<'a>,
-    ) {
-        let kind = AstType::ImportExpression;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_expression(&mut it.source);
-        visitor.visit_expressions(&mut it.arguments);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_logical_expression<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut LogicalExpression<'a>,
-    ) {
-        let kind = AstType::LogicalExpression;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_expression(&mut it.left);
-        visitor.visit_expression(&mut it.right);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_new_expression<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut NewExpression<'a>) {
-        let kind = AstType::NewExpression;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_expression(&mut it.callee);
-        visitor.visit_arguments(&mut it.arguments);
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_object_expression<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut ObjectExpression<'a>,
-    ) {
-        let kind = AstType::ObjectExpression;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_object_property_kinds(&mut it.properties);
-        if let Some(trailing_comma) = &mut it.trailing_comma {
-            visitor.visit_span(trailing_comma);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_object_property_kinds<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut Vec<'a, ObjectPropertyKind<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_object_property_kind(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_object_property_kind<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut ObjectPropertyKind<'a>,
-    ) {
-        // No `AstType` for this type
-        match it {
-            ObjectPropertyKind::ObjectProperty(it) => visitor.visit_object_property(it),
-            ObjectPropertyKind::SpreadProperty(it) => visitor.visit_spread_element(it),
-        }
-    }
-
-    #[inline]
-    pub fn walk_object_property<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ObjectProperty<'a>) {
-        let kind = AstType::ObjectProperty;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_property_key(&mut it.key);
-        visitor.visit_expression(&mut it.value);
-        visitor.leave_node(kind);
-    }
-
     #[inline]
     pub fn walk_parenthesized_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
@@ -3471,339 +2026,105 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
-    #[inline]
-    pub fn walk_sequence_expression<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut SequenceExpression<'a>,
-    ) {
-        let kind = AstType::SequenceExpression;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_expressions(&mut it.expressions);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_tagged_template_expression<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TaggedTemplateExpression<'a>,
-    ) {
-        let kind = AstType::TaggedTemplateExpression;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_expression(&mut it.tag);
-        visitor.visit_template_literal(&mut it.quasi);
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_this_expression<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ThisExpression) {
-        let kind = AstType::ThisExpression;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_update_expression<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut UpdateExpression<'a>,
-    ) {
-        let kind = AstType::UpdateExpression;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_simple_assignment_target(&mut it.argument);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_yield_expression<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut YieldExpression<'a>,
-    ) {
-        let kind = AstType::YieldExpression;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        if let Some(argument) = &mut it.argument {
-            visitor.visit_expression(argument);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_private_in_expression<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut PrivateInExpression<'a>,
-    ) {
-        let kind = AstType::PrivateInExpression;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_private_identifier(&mut it.left);
-        visitor.visit_expression(&mut it.right);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_jsx_element<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXElement<'a>) {
-        let kind = AstType::JSXElement;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_jsx_opening_element(&mut it.opening_element);
-        if let Some(closing_element) = &mut it.closing_element {
-            visitor.visit_jsx_closing_element(closing_element);
-        }
-        visitor.visit_jsx_children(&mut it.children);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_jsx_opening_element<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut JSXOpeningElement<'a>,
-    ) {
-        let kind = AstType::JSXOpeningElement;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_jsx_element_name(&mut it.name);
-        visitor.visit_jsx_attribute_items(&mut it.attributes);
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_jsx_element_name<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut JSXElementName<'a>,
-    ) {
-        let kind = AstType::JSXElementName;
-        visitor.enter_node(kind);
+    pub fn walk_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Statement<'a>) {
+        // No `AstType` for this type
         match it {
-            JSXElementName::Identifier(it) => visitor.visit_jsx_identifier(it),
-            JSXElementName::IdentifierReference(it) => visitor.visit_identifier_reference(it),
-            JSXElementName::NamespacedName(it) => visitor.visit_jsx_namespaced_name(it),
-            JSXElementName::MemberExpression(it) => visitor.visit_jsx_member_expression(it),
-            JSXElementName::ThisExpression(it) => visitor.visit_this_expression(it),
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_jsx_identifier<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXIdentifier<'a>) {
-        let kind = AstType::JSXIdentifier;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_jsx_namespaced_name<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut JSXNamespacedName<'a>,
-    ) {
-        let kind = AstType::JSXNamespacedName;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_jsx_identifier(&mut it.namespace);
-        visitor.visit_jsx_identifier(&mut it.property);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_jsx_member_expression<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut JSXMemberExpression<'a>,
-    ) {
-        let kind = AstType::JSXMemberExpression;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_jsx_member_expression_object(&mut it.object);
-        visitor.visit_jsx_identifier(&mut it.property);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_jsx_member_expression_object<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut JSXMemberExpressionObject<'a>,
-    ) {
-        let kind = AstType::JSXMemberExpressionObject;
-        visitor.enter_node(kind);
-        match it {
-            JSXMemberExpressionObject::IdentifierReference(it) => {
-                visitor.visit_identifier_reference(it)
+            Statement::BlockStatement(it) => visitor.visit_block_statement(it),
+            Statement::BreakStatement(it) => visitor.visit_break_statement(it),
+            Statement::ContinueStatement(it) => visitor.visit_continue_statement(it),
+            Statement::DebuggerStatement(it) => visitor.visit_debugger_statement(it),
+            Statement::DoWhileStatement(it) => visitor.visit_do_while_statement(it),
+            Statement::EmptyStatement(it) => visitor.visit_empty_statement(it),
+            Statement::ExpressionStatement(it) => visitor.visit_expression_statement(it),
+            Statement::ForInStatement(it) => visitor.visit_for_in_statement(it),
+            Statement::ForOfStatement(it) => visitor.visit_for_of_statement(it),
+            Statement::ForStatement(it) => visitor.visit_for_statement(it),
+            Statement::IfStatement(it) => visitor.visit_if_statement(it),
+            Statement::LabeledStatement(it) => visitor.visit_labeled_statement(it),
+            Statement::ReturnStatement(it) => visitor.visit_return_statement(it),
+            Statement::SwitchStatement(it) => visitor.visit_switch_statement(it),
+            Statement::ThrowStatement(it) => visitor.visit_throw_statement(it),
+            Statement::TryStatement(it) => visitor.visit_try_statement(it),
+            Statement::WhileStatement(it) => visitor.visit_while_statement(it),
+            Statement::WithStatement(it) => visitor.visit_with_statement(it),
+            match_declaration!(Statement) => visitor.visit_declaration(it.to_declaration_mut()),
+            match_module_declaration!(Statement) => {
+                visitor.visit_module_declaration(it.to_module_declaration_mut())
             }
-            JSXMemberExpressionObject::MemberExpression(it) => {
-                visitor.visit_jsx_member_expression(it)
+        }
+    }
+
+    #[inline]
+    pub fn walk_directive<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Directive<'a>) {
+        let kind = AstType::Directive;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_string_literal(&mut it.expression);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_hashbang<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Hashbang<'a>) {
+        let kind = AstType::Hashbang;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_block_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut BlockStatement<'a>) {
+        let kind = AstType::BlockStatement;
+        visitor.enter_node(kind);
+        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_statements(&mut it.body);
+        visitor.leave_scope();
+        visitor.leave_node(kind);
+    }
+
+    pub fn walk_declaration<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Declaration<'a>) {
+        // No `AstType` for this type
+        match it {
+            Declaration::VariableDeclaration(it) => visitor.visit_variable_declaration(it),
+            Declaration::FunctionDeclaration(it) => {
+                let flags = ScopeFlags::Function;
+                visitor.visit_function(it, flags)
             }
-            JSXMemberExpressionObject::ThisExpression(it) => visitor.visit_this_expression(it),
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_jsx_attribute_items<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut Vec<'a, JSXAttributeItem<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_jsx_attribute_item(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_jsx_attribute_item<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut JSXAttributeItem<'a>,
-    ) {
-        let kind = AstType::JSXAttributeItem;
-        visitor.enter_node(kind);
-        match it {
-            JSXAttributeItem::Attribute(it) => visitor.visit_jsx_attribute(it),
-            JSXAttributeItem::SpreadAttribute(it) => visitor.visit_jsx_spread_attribute(it),
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_jsx_attribute<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXAttribute<'a>) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-        visitor.visit_jsx_attribute_name(&mut it.name);
-        if let Some(value) = &mut it.value {
-            visitor.visit_jsx_attribute_value(value);
-        }
-    }
-
-    #[inline]
-    pub fn walk_jsx_attribute_name<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut JSXAttributeName<'a>,
-    ) {
-        // No `AstType` for this type
-        match it {
-            JSXAttributeName::Identifier(it) => visitor.visit_jsx_identifier(it),
-            JSXAttributeName::NamespacedName(it) => visitor.visit_jsx_namespaced_name(it),
-        }
-    }
-
-    #[inline]
-    pub fn walk_jsx_attribute_value<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut JSXAttributeValue<'a>,
-    ) {
-        // No `AstType` for this type
-        match it {
-            JSXAttributeValue::StringLiteral(it) => visitor.visit_string_literal(it),
-            JSXAttributeValue::ExpressionContainer(it) => {
-                visitor.visit_jsx_expression_container(it)
+            Declaration::ClassDeclaration(it) => visitor.visit_class(it),
+            Declaration::TSTypeAliasDeclaration(it) => visitor.visit_ts_type_alias_declaration(it),
+            Declaration::TSInterfaceDeclaration(it) => visitor.visit_ts_interface_declaration(it),
+            Declaration::TSEnumDeclaration(it) => visitor.visit_ts_enum_declaration(it),
+            Declaration::TSModuleDeclaration(it) => visitor.visit_ts_module_declaration(it),
+            Declaration::TSImportEqualsDeclaration(it) => {
+                visitor.visit_ts_import_equals_declaration(it)
             }
-            JSXAttributeValue::Element(it) => visitor.visit_jsx_element(it),
-            JSXAttributeValue::Fragment(it) => visitor.visit_jsx_fragment(it),
         }
     }
 
     #[inline]
-    pub fn walk_jsx_expression_container<'a, V: VisitMut<'a>>(
+    pub fn walk_variable_declaration<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut JSXExpressionContainer<'a>,
+        it: &mut VariableDeclaration<'a>,
     ) {
-        let kind = AstType::JSXExpressionContainer;
+        let kind = AstType::VariableDeclaration;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
-        visitor.visit_jsx_expression(&mut it.expression);
+        visitor.visit_variable_declarators(&mut it.declarations);
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_jsx_expression<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXExpression<'a>) {
-        // No `AstType` for this type
-        match it {
-            JSXExpression::EmptyExpression(it) => visitor.visit_jsx_empty_expression(it),
-            match_expression!(JSXExpression) => visitor.visit_expression(it.to_expression_mut()),
+    pub fn walk_variable_declarator<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut VariableDeclarator<'a>,
+    ) {
+        let kind = AstType::VariableDeclarator;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_binding_pattern(&mut it.id);
+        if let Some(init) = &mut it.init {
+            visitor.visit_expression(init);
         }
-    }
-
-    #[inline]
-    pub fn walk_jsx_empty_expression<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut JSXEmptyExpression,
-    ) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-    }
-
-    #[inline]
-    pub fn walk_jsx_fragment<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXFragment<'a>) {
-        let kind = AstType::JSXFragment;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_jsx_children(&mut it.children);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_jsx_children<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, JSXChild<'a>>) {
-        for el in it {
-            visitor.visit_jsx_child(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_jsx_child<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXChild<'a>) {
-        // No `AstType` for this type
-        match it {
-            JSXChild::Text(it) => visitor.visit_jsx_text(it),
-            JSXChild::Element(it) => visitor.visit_jsx_element(it),
-            JSXChild::Fragment(it) => visitor.visit_jsx_fragment(it),
-            JSXChild::ExpressionContainer(it) => visitor.visit_jsx_expression_container(it),
-            JSXChild::Spread(it) => visitor.visit_jsx_spread_child(it),
-        }
-    }
-
-    #[inline]
-    pub fn walk_jsx_text<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXText<'a>) {
-        let kind = AstType::JSXText;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_jsx_spread_child<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut JSXSpreadChild<'a>,
-    ) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-        visitor.visit_expression(&mut it.expression);
-    }
-
-    #[inline]
-    pub fn walk_jsx_spread_attribute<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut JSXSpreadAttribute<'a>,
-    ) {
-        let kind = AstType::JSXSpreadAttribute;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_expression(&mut it.argument);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_jsx_closing_element<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut JSXClosingElement<'a>,
-    ) {
-        let kind = AstType::JSXClosingElement;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_jsx_element_name(&mut it.name);
         visitor.leave_node(kind);
     }
 
@@ -3828,85 +2149,38 @@ pub mod walk_mut {
     }
 
     #[inline]
-    pub fn walk_for_in_statement<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut ForInStatement<'a>,
-    ) {
-        let kind = AstType::ForInStatement;
+    pub fn walk_if_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut IfStatement<'a>) {
+        let kind = AstType::IfStatement;
         visitor.enter_node(kind);
-        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
         visitor.visit_span(&mut it.span);
-        visitor.visit_for_statement_left(&mut it.left);
-        visitor.visit_expression(&mut it.right);
+        visitor.visit_expression(&mut it.test);
+        visitor.visit_statement(&mut it.consequent);
+        if let Some(alternate) = &mut it.alternate {
+            visitor.visit_statement(alternate);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_do_while_statement<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut DoWhileStatement<'a>,
+    ) {
+        let kind = AstType::DoWhileStatement;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
         visitor.visit_statement(&mut it.body);
-        visitor.leave_scope();
+        visitor.visit_expression(&mut it.test);
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_for_statement_left<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut ForStatementLeft<'a>,
-    ) {
-        // No `AstType` for this type
-        match it {
-            ForStatementLeft::VariableDeclaration(it) => visitor.visit_variable_declaration(it),
-            match_assignment_target!(ForStatementLeft) => {
-                visitor.visit_assignment_target(it.to_assignment_target_mut())
-            }
-        }
-    }
-
-    #[inline]
-    pub fn walk_variable_declaration<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut VariableDeclaration<'a>,
-    ) {
-        let kind = AstType::VariableDeclaration;
+    pub fn walk_while_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut WhileStatement<'a>) {
+        let kind = AstType::WhileStatement;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
-        visitor.visit_variable_declarators(&mut it.declarations);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_variable_declarators<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut Vec<'a, VariableDeclarator<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_variable_declarator(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_variable_declarator<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut VariableDeclarator<'a>,
-    ) {
-        let kind = AstType::VariableDeclarator;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_binding_pattern(&mut it.id);
-        if let Some(init) = &mut it.init {
-            visitor.visit_expression(init);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_for_of_statement<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut ForOfStatement<'a>,
-    ) {
-        let kind = AstType::ForOfStatement;
-        visitor.enter_node(kind);
-        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_for_statement_left(&mut it.left);
-        visitor.visit_expression(&mut it.right);
+        visitor.visit_expression(&mut it.test);
         visitor.visit_statement(&mut it.body);
-        visitor.leave_scope();
         visitor.leave_node(kind);
     }
 
@@ -3945,28 +2219,73 @@ pub mod walk_mut {
     }
 
     #[inline]
-    pub fn walk_if_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut IfStatement<'a>) {
-        let kind = AstType::IfStatement;
+    pub fn walk_for_in_statement<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ForInStatement<'a>,
+    ) {
+        let kind = AstType::ForInStatement;
+        visitor.enter_node(kind);
+        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_for_statement_left(&mut it.left);
+        visitor.visit_expression(&mut it.right);
+        visitor.visit_statement(&mut it.body);
+        visitor.leave_scope();
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_for_statement_left<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ForStatementLeft<'a>,
+    ) {
+        // No `AstType` for this type
+        match it {
+            ForStatementLeft::VariableDeclaration(it) => visitor.visit_variable_declaration(it),
+            match_assignment_target!(ForStatementLeft) => {
+                visitor.visit_assignment_target(it.to_assignment_target_mut())
+            }
+        }
+    }
+
+    #[inline]
+    pub fn walk_for_of_statement<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ForOfStatement<'a>,
+    ) {
+        let kind = AstType::ForOfStatement;
+        visitor.enter_node(kind);
+        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_for_statement_left(&mut it.left);
+        visitor.visit_expression(&mut it.right);
+        visitor.visit_statement(&mut it.body);
+        visitor.leave_scope();
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_continue_statement<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ContinueStatement<'a>,
+    ) {
+        let kind = AstType::ContinueStatement;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
-        visitor.visit_expression(&mut it.test);
-        visitor.visit_statement(&mut it.consequent);
-        if let Some(alternate) = &mut it.alternate {
-            visitor.visit_statement(alternate);
+        if let Some(label) = &mut it.label {
+            visitor.visit_label_identifier(label);
         }
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_labeled_statement<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut LabeledStatement<'a>,
-    ) {
-        let kind = AstType::LabeledStatement;
+    pub fn walk_break_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut BreakStatement<'a>) {
+        let kind = AstType::BreakStatement;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
-        visitor.visit_label_identifier(&mut it.label);
-        visitor.visit_statement(&mut it.body);
+        if let Some(label) = &mut it.label {
+            visitor.visit_label_identifier(label);
+        }
         visitor.leave_node(kind);
     }
 
@@ -3981,6 +2300,16 @@ pub mod walk_mut {
         if let Some(argument) = &mut it.argument {
             visitor.visit_expression(argument);
         }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_with_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut WithStatement<'a>) {
+        let kind = AstType::WithStatement;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_expression(&mut it.object);
+        visitor.visit_statement(&mut it.body);
         visitor.leave_node(kind);
     }
 
@@ -4000,16 +2329,6 @@ pub mod walk_mut {
     }
 
     #[inline]
-    pub fn walk_switch_cases<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut Vec<'a, SwitchCase<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_switch_case(el);
-        }
-    }
-
-    #[inline]
     pub fn walk_switch_case<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut SwitchCase<'a>) {
         let kind = AstType::SwitchCase;
         visitor.enter_node(kind);
@@ -4018,6 +2337,19 @@ pub mod walk_mut {
             visitor.visit_expression(test);
         }
         visitor.visit_statements(&mut it.consequent);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_labeled_statement<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut LabeledStatement<'a>,
+    ) {
+        let kind = AstType::LabeledStatement;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_label_identifier(&mut it.label);
+        visitor.visit_statement(&mut it.body);
         visitor.leave_node(kind);
     }
 
@@ -4069,42 +2401,1344 @@ pub mod walk_mut {
     }
 
     #[inline]
-    pub fn walk_while_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut WhileStatement<'a>) {
-        let kind = AstType::WhileStatement;
+    pub fn walk_debugger_statement<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut DebuggerStatement,
+    ) {
+        let kind = AstType::DebuggerStatement;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
-        visitor.visit_expression(&mut it.test);
-        visitor.visit_statement(&mut it.body);
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_with_statement<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut WithStatement<'a>) {
-        let kind = AstType::WithStatement;
+    pub fn walk_binding_pattern<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut BindingPattern<'a>) {
+        // No `AstType` for this type
+        visitor.visit_binding_pattern_kind(&mut it.kind);
+        if let Some(type_annotation) = &mut it.type_annotation {
+            visitor.visit_ts_type_annotation(type_annotation);
+        }
+    }
+
+    #[inline]
+    pub fn walk_binding_pattern_kind<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut BindingPatternKind<'a>,
+    ) {
+        // No `AstType` for this type
+        match it {
+            BindingPatternKind::BindingIdentifier(it) => visitor.visit_binding_identifier(it),
+            BindingPatternKind::ObjectPattern(it) => visitor.visit_object_pattern(it),
+            BindingPatternKind::ArrayPattern(it) => visitor.visit_array_pattern(it),
+            BindingPatternKind::AssignmentPattern(it) => visitor.visit_assignment_pattern(it),
+        }
+    }
+
+    #[inline]
+    pub fn walk_assignment_pattern<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut AssignmentPattern<'a>,
+    ) {
+        let kind = AstType::AssignmentPattern;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
-        visitor.visit_expression(&mut it.object);
-        visitor.visit_statement(&mut it.body);
+        visitor.visit_binding_pattern(&mut it.left);
+        visitor.visit_expression(&mut it.right);
         visitor.leave_node(kind);
     }
 
-    pub fn walk_declaration<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Declaration<'a>) {
+    #[inline]
+    pub fn walk_object_pattern<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ObjectPattern<'a>) {
+        let kind = AstType::ObjectPattern;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_binding_properties(&mut it.properties);
+        if let Some(rest) = &mut it.rest {
+            visitor.visit_binding_rest_element(rest);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_binding_property<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut BindingProperty<'a>,
+    ) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+        visitor.visit_property_key(&mut it.key);
+        visitor.visit_binding_pattern(&mut it.value);
+    }
+
+    #[inline]
+    pub fn walk_array_pattern<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ArrayPattern<'a>) {
+        let kind = AstType::ArrayPattern;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        for el in it.elements.iter_mut().flatten() {
+            visitor.visit_binding_pattern(el);
+        }
+        if let Some(rest) = &mut it.rest {
+            visitor.visit_binding_rest_element(rest);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_binding_rest_element<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut BindingRestElement<'a>,
+    ) {
+        let kind = AstType::BindingRestElement;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_binding_pattern(&mut it.argument);
+        visitor.leave_node(kind);
+    }
+
+    pub fn walk_function<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut Function<'a>,
+        flags: ScopeFlags,
+    ) {
+        let kind = AstType::Function;
+        visitor.enter_node(kind);
+        visitor.enter_scope(
+            {
+                let mut flags = flags;
+                if it.has_use_strict_directive() {
+                    flags |= ScopeFlags::StrictMode;
+                }
+                flags
+            },
+            &it.scope_id,
+        );
+        visitor.visit_span(&mut it.span);
+        if let Some(id) = &mut it.id {
+            visitor.visit_binding_identifier(id);
+        }
+        if let Some(type_parameters) = &mut it.type_parameters {
+            visitor.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        if let Some(this_param) = &mut it.this_param {
+            visitor.visit_ts_this_parameter(this_param);
+        }
+        visitor.visit_formal_parameters(&mut it.params);
+        if let Some(return_type) = &mut it.return_type {
+            visitor.visit_ts_type_annotation(return_type);
+        }
+        if let Some(body) = &mut it.body {
+            visitor.visit_function_body(body);
+        }
+        visitor.leave_scope();
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_formal_parameters<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut FormalParameters<'a>,
+    ) {
+        let kind = AstType::FormalParameters;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_formal_parameter_list(&mut it.items);
+        if let Some(rest) = &mut it.rest {
+            visitor.visit_binding_rest_element(rest);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_formal_parameter<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut FormalParameter<'a>,
+    ) {
+        let kind = AstType::FormalParameter;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_decorators(&mut it.decorators);
+        visitor.visit_binding_pattern(&mut it.pattern);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_function_body<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut FunctionBody<'a>) {
+        let kind = AstType::FunctionBody;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_directives(&mut it.directives);
+        visitor.visit_statements(&mut it.statements);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_arrow_function_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ArrowFunctionExpression<'a>,
+    ) {
+        let kind = AstType::ArrowFunctionExpression;
+        visitor.enter_node(kind);
+        visitor.enter_scope(
+            {
+                let mut flags = ScopeFlags::Function | ScopeFlags::Arrow;
+                if it.has_use_strict_directive() {
+                    flags |= ScopeFlags::StrictMode;
+                }
+                flags
+            },
+            &it.scope_id,
+        );
+        visitor.visit_span(&mut it.span);
+        if let Some(type_parameters) = &mut it.type_parameters {
+            visitor.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        visitor.visit_formal_parameters(&mut it.params);
+        if let Some(return_type) = &mut it.return_type {
+            visitor.visit_ts_type_annotation(return_type);
+        }
+        visitor.visit_function_body(&mut it.body);
+        visitor.leave_scope();
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_yield_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut YieldExpression<'a>,
+    ) {
+        let kind = AstType::YieldExpression;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        if let Some(argument) = &mut it.argument {
+            visitor.visit_expression(argument);
+        }
+        visitor.leave_node(kind);
+    }
+
+    pub fn walk_class<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Class<'a>) {
+        let kind = AstType::Class;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_decorators(&mut it.decorators);
+        if let Some(id) = &mut it.id {
+            visitor.visit_binding_identifier(id);
+        }
+        visitor.enter_scope(ScopeFlags::StrictMode, &it.scope_id);
+        if let Some(type_parameters) = &mut it.type_parameters {
+            visitor.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        if let Some(super_class) = &mut it.super_class {
+            visitor.visit_expression(super_class);
+        }
+        if let Some(super_type_parameters) = &mut it.super_type_parameters {
+            visitor.visit_ts_type_parameter_instantiation(super_type_parameters);
+        }
+        if let Some(implements) = &mut it.implements {
+            visitor.visit_ts_class_implementses(implements);
+        }
+        visitor.visit_class_body(&mut it.body);
+        visitor.leave_scope();
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_class_body<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ClassBody<'a>) {
+        let kind = AstType::ClassBody;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_class_elements(&mut it.body);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_class_element<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut ClassElement<'a>) {
         // No `AstType` for this type
         match it {
-            Declaration::VariableDeclaration(it) => visitor.visit_variable_declaration(it),
-            Declaration::FunctionDeclaration(it) => {
+            ClassElement::StaticBlock(it) => visitor.visit_static_block(it),
+            ClassElement::MethodDefinition(it) => visitor.visit_method_definition(it),
+            ClassElement::PropertyDefinition(it) => visitor.visit_property_definition(it),
+            ClassElement::AccessorProperty(it) => visitor.visit_accessor_property(it),
+            ClassElement::TSIndexSignature(it) => visitor.visit_ts_index_signature(it),
+        }
+    }
+
+    #[inline]
+    pub fn walk_method_definition<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut MethodDefinition<'a>,
+    ) {
+        let kind = AstType::MethodDefinition;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_decorators(&mut it.decorators);
+        visitor.visit_property_key(&mut it.key);
+        {
+            let flags = match it.kind {
+                MethodDefinitionKind::Get => ScopeFlags::Function | ScopeFlags::GetAccessor,
+                MethodDefinitionKind::Set => ScopeFlags::Function | ScopeFlags::SetAccessor,
+                MethodDefinitionKind::Constructor => ScopeFlags::Function | ScopeFlags::Constructor,
+                MethodDefinitionKind::Method => ScopeFlags::Function,
+            };
+            visitor.visit_function(&mut it.value, flags);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_property_definition<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut PropertyDefinition<'a>,
+    ) {
+        let kind = AstType::PropertyDefinition;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_decorators(&mut it.decorators);
+        visitor.visit_property_key(&mut it.key);
+        if let Some(value) = &mut it.value {
+            visitor.visit_expression(value);
+        }
+        if let Some(type_annotation) = &mut it.type_annotation {
+            visitor.visit_ts_type_annotation(type_annotation);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_private_identifier<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut PrivateIdentifier<'a>,
+    ) {
+        let kind = AstType::PrivateIdentifier;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_static_block<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut StaticBlock<'a>) {
+        let kind = AstType::StaticBlock;
+        visitor.enter_node(kind);
+        visitor.enter_scope(ScopeFlags::ClassStaticBlock, &it.scope_id);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_statements(&mut it.body);
+        visitor.leave_scope();
+        visitor.leave_node(kind);
+    }
+
+    pub fn walk_module_declaration<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ModuleDeclaration<'a>,
+    ) {
+        let kind = AstType::ModuleDeclaration;
+        visitor.enter_node(kind);
+        match it {
+            ModuleDeclaration::ImportDeclaration(it) => visitor.visit_import_declaration(it),
+            ModuleDeclaration::ExportAllDeclaration(it) => visitor.visit_export_all_declaration(it),
+            ModuleDeclaration::ExportDefaultDeclaration(it) => {
+                visitor.visit_export_default_declaration(it)
+            }
+            ModuleDeclaration::ExportNamedDeclaration(it) => {
+                visitor.visit_export_named_declaration(it)
+            }
+            ModuleDeclaration::TSExportAssignment(it) => visitor.visit_ts_export_assignment(it),
+            ModuleDeclaration::TSNamespaceExportDeclaration(it) => {
+                visitor.visit_ts_namespace_export_declaration(it)
+            }
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_accessor_property<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut AccessorProperty<'a>,
+    ) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+        visitor.visit_decorators(&mut it.decorators);
+        visitor.visit_property_key(&mut it.key);
+        if let Some(value) = &mut it.value {
+            visitor.visit_expression(value);
+        }
+        if let Some(type_annotation) = &mut it.type_annotation {
+            visitor.visit_ts_type_annotation(type_annotation);
+        }
+    }
+
+    #[inline]
+    pub fn walk_import_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ImportExpression<'a>,
+    ) {
+        let kind = AstType::ImportExpression;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_expression(&mut it.source);
+        visitor.visit_expressions(&mut it.arguments);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_import_declaration<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ImportDeclaration<'a>,
+    ) {
+        let kind = AstType::ImportDeclaration;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        if let Some(specifiers) = &mut it.specifiers {
+            visitor.visit_import_declaration_specifiers(specifiers);
+        }
+        visitor.visit_string_literal(&mut it.source);
+        if let Some(with_clause) = &mut it.with_clause {
+            visitor.visit_with_clause(with_clause);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_import_declaration_specifier<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ImportDeclarationSpecifier<'a>,
+    ) {
+        // No `AstType` for this type
+        match it {
+            ImportDeclarationSpecifier::ImportSpecifier(it) => visitor.visit_import_specifier(it),
+            ImportDeclarationSpecifier::ImportDefaultSpecifier(it) => {
+                visitor.visit_import_default_specifier(it)
+            }
+            ImportDeclarationSpecifier::ImportNamespaceSpecifier(it) => {
+                visitor.visit_import_namespace_specifier(it)
+            }
+        }
+    }
+
+    #[inline]
+    pub fn walk_import_specifier<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ImportSpecifier<'a>,
+    ) {
+        let kind = AstType::ImportSpecifier;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_module_export_name(&mut it.imported);
+        visitor.visit_binding_identifier(&mut it.local);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_import_default_specifier<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ImportDefaultSpecifier<'a>,
+    ) {
+        let kind = AstType::ImportDefaultSpecifier;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_binding_identifier(&mut it.local);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_import_namespace_specifier<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ImportNamespaceSpecifier<'a>,
+    ) {
+        let kind = AstType::ImportNamespaceSpecifier;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_binding_identifier(&mut it.local);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_with_clause<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut WithClause<'a>) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+        visitor.visit_identifier_name(&mut it.attributes_keyword);
+        visitor.visit_import_attributes(&mut it.with_entries);
+    }
+
+    #[inline]
+    pub fn walk_import_attribute<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ImportAttribute<'a>,
+    ) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+        visitor.visit_import_attribute_key(&mut it.key);
+        visitor.visit_string_literal(&mut it.value);
+    }
+
+    #[inline]
+    pub fn walk_import_attribute_key<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ImportAttributeKey<'a>,
+    ) {
+        // No `AstType` for this type
+        match it {
+            ImportAttributeKey::Identifier(it) => visitor.visit_identifier_name(it),
+            ImportAttributeKey::StringLiteral(it) => visitor.visit_string_literal(it),
+        }
+    }
+
+    #[inline]
+    pub fn walk_export_named_declaration<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ExportNamedDeclaration<'a>,
+    ) {
+        let kind = AstType::ExportNamedDeclaration;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        if let Some(declaration) = &mut it.declaration {
+            visitor.visit_declaration(declaration);
+        }
+        visitor.visit_export_specifiers(&mut it.specifiers);
+        if let Some(source) = &mut it.source {
+            visitor.visit_string_literal(source);
+        }
+        if let Some(with_clause) = &mut it.with_clause {
+            visitor.visit_with_clause(with_clause);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_export_default_declaration<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ExportDefaultDeclaration<'a>,
+    ) {
+        let kind = AstType::ExportDefaultDeclaration;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_export_default_declaration_kind(&mut it.declaration);
+        visitor.visit_module_export_name(&mut it.exported);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_export_all_declaration<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ExportAllDeclaration<'a>,
+    ) {
+        let kind = AstType::ExportAllDeclaration;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        if let Some(exported) = &mut it.exported {
+            visitor.visit_module_export_name(exported);
+        }
+        visitor.visit_string_literal(&mut it.source);
+        if let Some(with_clause) = &mut it.with_clause {
+            visitor.visit_with_clause(with_clause);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_export_specifier<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ExportSpecifier<'a>,
+    ) {
+        let kind = AstType::ExportSpecifier;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_module_export_name(&mut it.local);
+        visitor.visit_module_export_name(&mut it.exported);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_export_default_declaration_kind<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ExportDefaultDeclarationKind<'a>,
+    ) {
+        // No `AstType` for this type
+        match it {
+            ExportDefaultDeclarationKind::FunctionDeclaration(it) => {
                 let flags = ScopeFlags::Function;
                 visitor.visit_function(it, flags)
             }
-            Declaration::ClassDeclaration(it) => visitor.visit_class(it),
-            Declaration::TSTypeAliasDeclaration(it) => visitor.visit_ts_type_alias_declaration(it),
-            Declaration::TSInterfaceDeclaration(it) => visitor.visit_ts_interface_declaration(it),
-            Declaration::TSEnumDeclaration(it) => visitor.visit_ts_enum_declaration(it),
-            Declaration::TSModuleDeclaration(it) => visitor.visit_ts_module_declaration(it),
-            Declaration::TSImportEqualsDeclaration(it) => {
-                visitor.visit_ts_import_equals_declaration(it)
+            ExportDefaultDeclarationKind::ClassDeclaration(it) => visitor.visit_class(it),
+            ExportDefaultDeclarationKind::TSInterfaceDeclaration(it) => {
+                visitor.visit_ts_interface_declaration(it)
+            }
+            match_expression!(ExportDefaultDeclarationKind) => {
+                visitor.visit_expression(it.to_expression_mut())
             }
         }
+    }
+
+    #[inline]
+    pub fn walk_module_export_name<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut ModuleExportName<'a>,
+    ) {
+        // No `AstType` for this type
+        match it {
+            ModuleExportName::IdentifierName(it) => visitor.visit_identifier_name(it),
+            ModuleExportName::IdentifierReference(it) => visitor.visit_identifier_reference(it),
+            ModuleExportName::StringLiteral(it) => visitor.visit_string_literal(it),
+        }
+    }
+
+    #[inline]
+    pub fn walk_boolean_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut BooleanLiteral) {
+        let kind = AstType::BooleanLiteral;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_null_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut NullLiteral) {
+        let kind = AstType::NullLiteral;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_numeric_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut NumericLiteral<'a>) {
+        let kind = AstType::NumericLiteral;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_string_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut StringLiteral<'a>) {
+        let kind = AstType::StringLiteral;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_big_int_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut BigIntLiteral<'a>) {
+        let kind = AstType::BigIntLiteral;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_reg_exp_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut RegExpLiteral<'a>) {
+        let kind = AstType::RegExpLiteral;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_element<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXElement<'a>) {
+        let kind = AstType::JSXElement;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_jsx_opening_element(&mut it.opening_element);
+        if let Some(closing_element) = &mut it.closing_element {
+            visitor.visit_jsx_closing_element(closing_element);
+        }
+        visitor.visit_jsx_children(&mut it.children);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_opening_element<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXOpeningElement<'a>,
+    ) {
+        let kind = AstType::JSXOpeningElement;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_jsx_element_name(&mut it.name);
+        visitor.visit_jsx_attribute_items(&mut it.attributes);
+        if let Some(type_parameters) = &mut it.type_parameters {
+            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_closing_element<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXClosingElement<'a>,
+    ) {
+        let kind = AstType::JSXClosingElement;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_jsx_element_name(&mut it.name);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_fragment<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXFragment<'a>) {
+        let kind = AstType::JSXFragment;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_jsx_children(&mut it.children);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_element_name<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXElementName<'a>,
+    ) {
+        let kind = AstType::JSXElementName;
+        visitor.enter_node(kind);
+        match it {
+            JSXElementName::Identifier(it) => visitor.visit_jsx_identifier(it),
+            JSXElementName::IdentifierReference(it) => visitor.visit_identifier_reference(it),
+            JSXElementName::NamespacedName(it) => visitor.visit_jsx_namespaced_name(it),
+            JSXElementName::MemberExpression(it) => visitor.visit_jsx_member_expression(it),
+            JSXElementName::ThisExpression(it) => visitor.visit_this_expression(it),
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_namespaced_name<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXNamespacedName<'a>,
+    ) {
+        let kind = AstType::JSXNamespacedName;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_jsx_identifier(&mut it.namespace);
+        visitor.visit_jsx_identifier(&mut it.property);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_member_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXMemberExpression<'a>,
+    ) {
+        let kind = AstType::JSXMemberExpression;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_jsx_member_expression_object(&mut it.object);
+        visitor.visit_jsx_identifier(&mut it.property);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_member_expression_object<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXMemberExpressionObject<'a>,
+    ) {
+        let kind = AstType::JSXMemberExpressionObject;
+        visitor.enter_node(kind);
+        match it {
+            JSXMemberExpressionObject::IdentifierReference(it) => {
+                visitor.visit_identifier_reference(it)
+            }
+            JSXMemberExpressionObject::MemberExpression(it) => {
+                visitor.visit_jsx_member_expression(it)
+            }
+            JSXMemberExpressionObject::ThisExpression(it) => visitor.visit_this_expression(it),
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_expression_container<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXExpressionContainer<'a>,
+    ) {
+        let kind = AstType::JSXExpressionContainer;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_jsx_expression(&mut it.expression);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_expression<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXExpression<'a>) {
+        // No `AstType` for this type
+        match it {
+            JSXExpression::EmptyExpression(it) => visitor.visit_jsx_empty_expression(it),
+            match_expression!(JSXExpression) => visitor.visit_expression(it.to_expression_mut()),
+        }
+    }
+
+    #[inline]
+    pub fn walk_jsx_empty_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXEmptyExpression,
+    ) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+    }
+
+    #[inline]
+    pub fn walk_jsx_attribute_item<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXAttributeItem<'a>,
+    ) {
+        let kind = AstType::JSXAttributeItem;
+        visitor.enter_node(kind);
+        match it {
+            JSXAttributeItem::Attribute(it) => visitor.visit_jsx_attribute(it),
+            JSXAttributeItem::SpreadAttribute(it) => visitor.visit_jsx_spread_attribute(it),
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_attribute<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXAttribute<'a>) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+        visitor.visit_jsx_attribute_name(&mut it.name);
+        if let Some(value) = &mut it.value {
+            visitor.visit_jsx_attribute_value(value);
+        }
+    }
+
+    #[inline]
+    pub fn walk_jsx_spread_attribute<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXSpreadAttribute<'a>,
+    ) {
+        let kind = AstType::JSXSpreadAttribute;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_expression(&mut it.argument);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_attribute_name<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXAttributeName<'a>,
+    ) {
+        // No `AstType` for this type
+        match it {
+            JSXAttributeName::Identifier(it) => visitor.visit_jsx_identifier(it),
+            JSXAttributeName::NamespacedName(it) => visitor.visit_jsx_namespaced_name(it),
+        }
+    }
+
+    #[inline]
+    pub fn walk_jsx_attribute_value<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXAttributeValue<'a>,
+    ) {
+        // No `AstType` for this type
+        match it {
+            JSXAttributeValue::StringLiteral(it) => visitor.visit_string_literal(it),
+            JSXAttributeValue::ExpressionContainer(it) => {
+                visitor.visit_jsx_expression_container(it)
+            }
+            JSXAttributeValue::Element(it) => visitor.visit_jsx_element(it),
+            JSXAttributeValue::Fragment(it) => visitor.visit_jsx_fragment(it),
+        }
+    }
+
+    #[inline]
+    pub fn walk_jsx_identifier<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXIdentifier<'a>) {
+        let kind = AstType::JSXIdentifier;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_child<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXChild<'a>) {
+        // No `AstType` for this type
+        match it {
+            JSXChild::Text(it) => visitor.visit_jsx_text(it),
+            JSXChild::Element(it) => visitor.visit_jsx_element(it),
+            JSXChild::Fragment(it) => visitor.visit_jsx_fragment(it),
+            JSXChild::ExpressionContainer(it) => visitor.visit_jsx_expression_container(it),
+            JSXChild::Spread(it) => visitor.visit_jsx_spread_child(it),
+        }
+    }
+
+    #[inline]
+    pub fn walk_jsx_spread_child<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXSpreadChild<'a>,
+    ) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+        visitor.visit_expression(&mut it.expression);
+    }
+
+    #[inline]
+    pub fn walk_jsx_text<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut JSXText<'a>) {
+        let kind = AstType::JSXText;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_this_parameter<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSThisParameter<'a>,
+    ) {
+        let kind = AstType::TSThisParameter;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_span(&mut it.this_span);
+        if let Some(type_annotation) = &mut it.type_annotation {
+            visitor.visit_ts_type_annotation(type_annotation);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_enum_declaration<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSEnumDeclaration<'a>,
+    ) {
+        let kind = AstType::TSEnumDeclaration;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_binding_identifier(&mut it.id);
+        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
+        visitor.visit_ts_enum_members(&mut it.members);
+        visitor.leave_scope();
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_enum_member<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSEnumMember<'a>) {
+        let kind = AstType::TSEnumMember;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_enum_member_name(&mut it.id);
+        if let Some(initializer) = &mut it.initializer {
+            visitor.visit_expression(initializer);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_enum_member_name<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSEnumMemberName<'a>,
+    ) {
+        // No `AstType` for this type
+        match it {
+            TSEnumMemberName::Identifier(it) => visitor.visit_identifier_name(it),
+            TSEnumMemberName::String(it) => visitor.visit_string_literal(it),
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_type_annotation<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSTypeAnnotation<'a>,
+    ) {
+        let kind = AstType::TSTypeAnnotation;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_type(&mut it.type_annotation);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_literal_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSLiteralType<'a>) {
+        let kind = AstType::TSLiteralType;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_literal(&mut it.literal);
+        visitor.leave_node(kind);
+    }
+
+    pub fn walk_ts_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSLiteral<'a>) {
+        // No `AstType` for this type
+        match it {
+            TSLiteral::BooleanLiteral(it) => visitor.visit_boolean_literal(it),
+            TSLiteral::NullLiteral(it) => visitor.visit_null_literal(it),
+            TSLiteral::NumericLiteral(it) => visitor.visit_numeric_literal(it),
+            TSLiteral::BigIntLiteral(it) => visitor.visit_big_int_literal(it),
+            TSLiteral::RegExpLiteral(it) => visitor.visit_reg_exp_literal(it),
+            TSLiteral::StringLiteral(it) => visitor.visit_string_literal(it),
+            TSLiteral::TemplateLiteral(it) => visitor.visit_template_literal(it),
+            TSLiteral::UnaryExpression(it) => visitor.visit_unary_expression(it),
+        }
+    }
+
+    pub fn walk_ts_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSType<'a>) {
+        // No `AstType` for this type
+        match it {
+            TSType::TSAnyKeyword(it) => visitor.visit_ts_any_keyword(it),
+            TSType::TSBigIntKeyword(it) => visitor.visit_ts_big_int_keyword(it),
+            TSType::TSBooleanKeyword(it) => visitor.visit_ts_boolean_keyword(it),
+            TSType::TSIntrinsicKeyword(it) => visitor.visit_ts_intrinsic_keyword(it),
+            TSType::TSNeverKeyword(it) => visitor.visit_ts_never_keyword(it),
+            TSType::TSNullKeyword(it) => visitor.visit_ts_null_keyword(it),
+            TSType::TSNumberKeyword(it) => visitor.visit_ts_number_keyword(it),
+            TSType::TSObjectKeyword(it) => visitor.visit_ts_object_keyword(it),
+            TSType::TSStringKeyword(it) => visitor.visit_ts_string_keyword(it),
+            TSType::TSSymbolKeyword(it) => visitor.visit_ts_symbol_keyword(it),
+            TSType::TSUndefinedKeyword(it) => visitor.visit_ts_undefined_keyword(it),
+            TSType::TSUnknownKeyword(it) => visitor.visit_ts_unknown_keyword(it),
+            TSType::TSVoidKeyword(it) => visitor.visit_ts_void_keyword(it),
+            TSType::TSArrayType(it) => visitor.visit_ts_array_type(it),
+            TSType::TSConditionalType(it) => visitor.visit_ts_conditional_type(it),
+            TSType::TSConstructorType(it) => visitor.visit_ts_constructor_type(it),
+            TSType::TSFunctionType(it) => visitor.visit_ts_function_type(it),
+            TSType::TSImportType(it) => visitor.visit_ts_import_type(it),
+            TSType::TSIndexedAccessType(it) => visitor.visit_ts_indexed_access_type(it),
+            TSType::TSInferType(it) => visitor.visit_ts_infer_type(it),
+            TSType::TSIntersectionType(it) => visitor.visit_ts_intersection_type(it),
+            TSType::TSLiteralType(it) => visitor.visit_ts_literal_type(it),
+            TSType::TSMappedType(it) => visitor.visit_ts_mapped_type(it),
+            TSType::TSNamedTupleMember(it) => visitor.visit_ts_named_tuple_member(it),
+            TSType::TSQualifiedName(it) => visitor.visit_ts_qualified_name(it),
+            TSType::TSTemplateLiteralType(it) => visitor.visit_ts_template_literal_type(it),
+            TSType::TSThisType(it) => visitor.visit_ts_this_type(it),
+            TSType::TSTupleType(it) => visitor.visit_ts_tuple_type(it),
+            TSType::TSTypeLiteral(it) => visitor.visit_ts_type_literal(it),
+            TSType::TSTypeOperatorType(it) => visitor.visit_ts_type_operator(it),
+            TSType::TSTypePredicate(it) => visitor.visit_ts_type_predicate(it),
+            TSType::TSTypeQuery(it) => visitor.visit_ts_type_query(it),
+            TSType::TSTypeReference(it) => visitor.visit_ts_type_reference(it),
+            TSType::TSUnionType(it) => visitor.visit_ts_union_type(it),
+            TSType::TSParenthesizedType(it) => visitor.visit_ts_parenthesized_type(it),
+            TSType::JSDocNullableType(it) => visitor.visit_js_doc_nullable_type(it),
+            TSType::JSDocNonNullableType(it) => visitor.visit_js_doc_non_nullable_type(it),
+            TSType::JSDocUnknownType(it) => visitor.visit_js_doc_unknown_type(it),
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_conditional_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSConditionalType<'a>,
+    ) {
+        let kind = AstType::TSConditionalType;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_type(&mut it.check_type);
+        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
+        visitor.visit_ts_type(&mut it.extends_type);
+        visitor.visit_ts_type(&mut it.true_type);
+        visitor.leave_scope();
+        visitor.visit_ts_type(&mut it.false_type);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_union_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSUnionType<'a>) {
+        let kind = AstType::TSUnionType;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_types(&mut it.types);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_intersection_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSIntersectionType<'a>,
+    ) {
+        let kind = AstType::TSIntersectionType;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_types(&mut it.types);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_parenthesized_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSParenthesizedType<'a>,
+    ) {
+        let kind = AstType::TSParenthesizedType;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_type(&mut it.type_annotation);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_type_operator<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSTypeOperator<'a>,
+    ) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_type(&mut it.type_annotation);
+    }
+
+    #[inline]
+    pub fn walk_ts_array_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSArrayType<'a>) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_type(&mut it.element_type);
+    }
+
+    #[inline]
+    pub fn walk_ts_indexed_access_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSIndexedAccessType<'a>,
+    ) {
+        let kind = AstType::TSIndexedAccessType;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_type(&mut it.object_type);
+        visitor.visit_ts_type(&mut it.index_type);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_tuple_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSTupleType<'a>) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_tuple_elements(&mut it.element_types);
+    }
+
+    #[inline]
+    pub fn walk_ts_named_tuple_member<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSNamedTupleMember<'a>,
+    ) {
+        let kind = AstType::TSNamedTupleMember;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_tuple_element(&mut it.element_type);
+        visitor.visit_identifier_name(&mut it.label);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_optional_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSOptionalType<'a>,
+    ) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_type(&mut it.type_annotation);
+    }
+
+    #[inline]
+    pub fn walk_ts_rest_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSRestType<'a>) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_type(&mut it.type_annotation);
+    }
+
+    #[inline]
+    pub fn walk_ts_tuple_element<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSTupleElement<'a>,
+    ) {
+        // No `AstType` for this type
+        match it {
+            TSTupleElement::TSOptionalType(it) => visitor.visit_ts_optional_type(it),
+            TSTupleElement::TSRestType(it) => visitor.visit_ts_rest_type(it),
+            match_ts_type!(TSTupleElement) => visitor.visit_ts_type(it.to_ts_type_mut()),
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_any_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSAnyKeyword) {
+        let kind = AstType::TSAnyKeyword;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_string_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSStringKeyword) {
+        let kind = AstType::TSStringKeyword;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_boolean_keyword<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSBooleanKeyword,
+    ) {
+        let kind = AstType::TSBooleanKeyword;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_number_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSNumberKeyword) {
+        let kind = AstType::TSNumberKeyword;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_never_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSNeverKeyword) {
+        let kind = AstType::TSNeverKeyword;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_intrinsic_keyword<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSIntrinsicKeyword,
+    ) {
+        let kind = AstType::TSIntrinsicKeyword;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_unknown_keyword<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSUnknownKeyword,
+    ) {
+        let kind = AstType::TSUnknownKeyword;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_null_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSNullKeyword) {
+        let kind = AstType::TSNullKeyword;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_undefined_keyword<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSUndefinedKeyword,
+    ) {
+        let kind = AstType::TSUndefinedKeyword;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_void_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSVoidKeyword) {
+        let kind = AstType::TSVoidKeyword;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_symbol_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSSymbolKeyword) {
+        let kind = AstType::TSSymbolKeyword;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_this_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSThisType) {
+        let kind = AstType::TSThisType;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_object_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSObjectKeyword) {
+        let kind = AstType::TSObjectKeyword;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_big_int_keyword<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSBigIntKeyword) {
+        let kind = AstType::TSBigIntKeyword;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_type_reference<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSTypeReference<'a>,
+    ) {
+        let kind = AstType::TSTypeReference;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_type_name(&mut it.type_name);
+        if let Some(type_parameters) = &mut it.type_parameters {
+            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_type_name<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSTypeName<'a>) {
+        let kind = AstType::TSTypeName;
+        visitor.enter_node(kind);
+        match it {
+            TSTypeName::IdentifierReference(it) => visitor.visit_identifier_reference(it),
+            TSTypeName::QualifiedName(it) => visitor.visit_ts_qualified_name(it),
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_qualified_name<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSQualifiedName<'a>,
+    ) {
+        let kind = AstType::TSQualifiedName;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_type_name(&mut it.left);
+        visitor.visit_identifier_name(&mut it.right);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_type_parameter_instantiation<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSTypeParameterInstantiation<'a>,
+    ) {
+        let kind = AstType::TSTypeParameterInstantiation;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_types(&mut it.params);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_type_parameter<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSTypeParameter<'a>,
+    ) {
+        let kind = AstType::TSTypeParameter;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_binding_identifier(&mut it.name);
+        if let Some(constraint) = &mut it.constraint {
+            visitor.visit_ts_type(constraint);
+        }
+        if let Some(default) = &mut it.default {
+            visitor.visit_ts_type(default);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_type_parameter_declaration<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSTypeParameterDeclaration<'a>,
+    ) {
+        let kind = AstType::TSTypeParameterDeclaration;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_type_parameters(&mut it.params);
+        visitor.leave_node(kind);
     }
 
     #[inline]
@@ -4122,6 +3756,21 @@ pub mod walk_mut {
         }
         visitor.visit_ts_type(&mut it.type_annotation);
         visitor.leave_scope();
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_class_implements<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSClassImplements<'a>,
+    ) {
+        let kind = AstType::TSClassImplements;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_type_name(&mut it.expression);
+        if let Some(type_parameters) = &mut it.type_parameters {
+            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        }
         visitor.leave_node(kind);
     }
 
@@ -4147,13 +3796,127 @@ pub mod walk_mut {
     }
 
     #[inline]
-    pub fn walk_ts_interface_heritages<'a, V: VisitMut<'a>>(
+    pub fn walk_ts_interface_body<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut Vec<'a, TSInterfaceHeritage<'a>>,
+        it: &mut TSInterfaceBody<'a>,
     ) {
-        for el in it {
-            visitor.visit_ts_interface_heritage(el);
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_signatures(&mut it.body);
+    }
+
+    #[inline]
+    pub fn walk_ts_property_signature<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSPropertySignature<'a>,
+    ) {
+        let kind = AstType::TSPropertySignature;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_property_key(&mut it.key);
+        if let Some(type_annotation) = &mut it.type_annotation {
+            visitor.visit_ts_type_annotation(type_annotation);
         }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_signature<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSSignature<'a>) {
+        // No `AstType` for this type
+        match it {
+            TSSignature::TSIndexSignature(it) => visitor.visit_ts_index_signature(it),
+            TSSignature::TSPropertySignature(it) => visitor.visit_ts_property_signature(it),
+            TSSignature::TSCallSignatureDeclaration(it) => {
+                visitor.visit_ts_call_signature_declaration(it)
+            }
+            TSSignature::TSConstructSignatureDeclaration(it) => {
+                visitor.visit_ts_construct_signature_declaration(it)
+            }
+            TSSignature::TSMethodSignature(it) => visitor.visit_ts_method_signature(it),
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_index_signature<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSIndexSignature<'a>,
+    ) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_index_signature_names(&mut it.parameters);
+        visitor.visit_ts_type_annotation(&mut it.type_annotation);
+    }
+
+    #[inline]
+    pub fn walk_ts_call_signature_declaration<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSCallSignatureDeclaration<'a>,
+    ) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+        if let Some(type_parameters) = &mut it.type_parameters {
+            visitor.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        if let Some(this_param) = &mut it.this_param {
+            visitor.visit_ts_this_parameter(this_param);
+        }
+        visitor.visit_formal_parameters(&mut it.params);
+        if let Some(return_type) = &mut it.return_type {
+            visitor.visit_ts_type_annotation(return_type);
+        }
+    }
+
+    pub fn walk_ts_method_signature<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSMethodSignature<'a>,
+    ) {
+        let kind = AstType::TSMethodSignature;
+        visitor.enter_node(kind);
+        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_property_key(&mut it.key);
+        if let Some(type_parameters) = &mut it.type_parameters {
+            visitor.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        if let Some(this_param) = &mut it.this_param {
+            visitor.visit_ts_this_parameter(this_param);
+        }
+        visitor.visit_formal_parameters(&mut it.params);
+        if let Some(return_type) = &mut it.return_type {
+            visitor.visit_ts_type_annotation(return_type);
+        }
+        visitor.leave_scope();
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_construct_signature_declaration<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSConstructSignatureDeclaration<'a>,
+    ) {
+        let kind = AstType::TSConstructSignatureDeclaration;
+        visitor.enter_node(kind);
+        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
+        visitor.visit_span(&mut it.span);
+        if let Some(type_parameters) = &mut it.type_parameters {
+            visitor.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        visitor.visit_formal_parameters(&mut it.params);
+        if let Some(return_type) = &mut it.return_type {
+            visitor.visit_ts_type_annotation(return_type);
+        }
+        visitor.leave_scope();
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_index_signature_name<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSIndexSignatureName<'a>,
+    ) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_type_annotation(&mut it.type_annotation);
     }
 
     #[inline]
@@ -4172,61 +3935,27 @@ pub mod walk_mut {
     }
 
     #[inline]
-    pub fn walk_ts_interface_body<'a, V: VisitMut<'a>>(
+    pub fn walk_ts_type_predicate<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut TSInterfaceBody<'a>,
+        it: &mut TSTypePredicate<'a>,
     ) {
         // No `AstType` for this type
         visitor.visit_span(&mut it.span);
-        visitor.visit_ts_signatures(&mut it.body);
-    }
-
-    #[inline]
-    pub fn walk_ts_enum_declaration<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSEnumDeclaration<'a>,
-    ) {
-        let kind = AstType::TSEnumDeclaration;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_binding_identifier(&mut it.id);
-        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
-        visitor.visit_ts_enum_members(&mut it.members);
-        visitor.leave_scope();
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_enum_members<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut Vec<'a, TSEnumMember<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_ts_enum_member(el);
+        visitor.visit_ts_type_predicate_name(&mut it.parameter_name);
+        if let Some(type_annotation) = &mut it.type_annotation {
+            visitor.visit_ts_type_annotation(type_annotation);
         }
     }
 
     #[inline]
-    pub fn walk_ts_enum_member<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSEnumMember<'a>) {
-        let kind = AstType::TSEnumMember;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_ts_enum_member_name(&mut it.id);
-        if let Some(initializer) = &mut it.initializer {
-            visitor.visit_expression(initializer);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_enum_member_name<'a, V: VisitMut<'a>>(
+    pub fn walk_ts_type_predicate_name<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut TSEnumMemberName<'a>,
+        it: &mut TSTypePredicateName<'a>,
     ) {
         // No `AstType` for this type
         match it {
-            TSEnumMemberName::Identifier(it) => visitor.visit_identifier_name(it),
-            TSEnumMemberName::String(it) => visitor.visit_string_literal(it),
+            TSTypePredicateName::Identifier(it) => visitor.visit_identifier_name(it),
+            TSTypePredicateName::This(it) => visitor.visit_ts_this_type(it),
         }
     }
 
@@ -4293,6 +4022,202 @@ pub mod walk_mut {
     }
 
     #[inline]
+    pub fn walk_ts_type_literal<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSTypeLiteral<'a>) {
+        let kind = AstType::TSTypeLiteral;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_signatures(&mut it.members);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_infer_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSInferType<'a>) {
+        let kind = AstType::TSInferType;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_type_parameter(&mut it.type_parameter);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_type_query<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSTypeQuery<'a>) {
+        let kind = AstType::TSTypeQuery;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_type_query_expr_name(&mut it.expr_name);
+        if let Some(type_parameters) = &mut it.type_parameters {
+            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_type_query_expr_name<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSTypeQueryExprName<'a>,
+    ) {
+        // No `AstType` for this type
+        match it {
+            TSTypeQueryExprName::TSImportType(it) => visitor.visit_ts_import_type(it),
+            match_ts_type_name!(TSTypeQueryExprName) => {
+                visitor.visit_ts_type_name(it.to_ts_type_name_mut())
+            }
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_import_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSImportType<'a>) {
+        let kind = AstType::TSImportType;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_type(&mut it.parameter);
+        if let Some(qualifier) = &mut it.qualifier {
+            visitor.visit_ts_type_name(qualifier);
+        }
+        if let Some(attributes) = &mut it.attributes {
+            visitor.visit_ts_import_attributes(attributes);
+        }
+        if let Some(type_parameters) = &mut it.type_parameters {
+            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        }
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_import_attributes<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSImportAttributes<'a>,
+    ) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+        visitor.visit_identifier_name(&mut it.attributes_keyword);
+        visitor.visit_ts_import_attribute_list(&mut it.elements);
+    }
+
+    #[inline]
+    pub fn walk_ts_import_attribute<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSImportAttribute<'a>,
+    ) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_import_attribute_name(&mut it.name);
+        visitor.visit_expression(&mut it.value);
+    }
+
+    #[inline]
+    pub fn walk_ts_import_attribute_name<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSImportAttributeName<'a>,
+    ) {
+        // No `AstType` for this type
+        match it {
+            TSImportAttributeName::Identifier(it) => visitor.visit_identifier_name(it),
+            TSImportAttributeName::StringLiteral(it) => visitor.visit_string_literal(it),
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_function_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSFunctionType<'a>,
+    ) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+        if let Some(type_parameters) = &mut it.type_parameters {
+            visitor.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        if let Some(this_param) = &mut it.this_param {
+            visitor.visit_ts_this_parameter(this_param);
+        }
+        visitor.visit_formal_parameters(&mut it.params);
+        visitor.visit_ts_type_annotation(&mut it.return_type);
+    }
+
+    #[inline]
+    pub fn walk_ts_constructor_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSConstructorType<'a>,
+    ) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+        if let Some(type_parameters) = &mut it.type_parameters {
+            visitor.visit_ts_type_parameter_declaration(type_parameters);
+        }
+        visitor.visit_formal_parameters(&mut it.params);
+        visitor.visit_ts_type_annotation(&mut it.return_type);
+    }
+
+    #[inline]
+    pub fn walk_ts_mapped_type<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut TSMappedType<'a>) {
+        let kind = AstType::TSMappedType;
+        visitor.enter_node(kind);
+        visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_type_parameter(&mut it.type_parameter);
+        if let Some(name_type) = &mut it.name_type {
+            visitor.visit_ts_type(name_type);
+        }
+        if let Some(type_annotation) = &mut it.type_annotation {
+            visitor.visit_ts_type(type_annotation);
+        }
+        visitor.leave_scope();
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_template_literal_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSTemplateLiteralType<'a>,
+    ) {
+        let kind = AstType::TSTemplateLiteralType;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_template_elements(&mut it.quasis);
+        visitor.visit_ts_types(&mut it.types);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_as_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSAsExpression<'a>,
+    ) {
+        let kind = AstType::TSAsExpression;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_expression(&mut it.expression);
+        visitor.visit_ts_type(&mut it.type_annotation);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_satisfies_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSSatisfiesExpression<'a>,
+    ) {
+        let kind = AstType::TSSatisfiesExpression;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_expression(&mut it.expression);
+        visitor.visit_ts_type(&mut it.type_annotation);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_ts_type_assertion<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSTypeAssertion<'a>,
+    ) {
+        let kind = AstType::TSTypeAssertion;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_expression(&mut it.expression);
+        visitor.visit_ts_type(&mut it.type_annotation);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
     pub fn walk_ts_import_equals_declaration<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut TSImportEqualsDeclaration<'a>,
@@ -4335,258 +4260,24 @@ pub mod walk_mut {
         visitor.leave_node(kind);
     }
 
-    pub fn walk_module_declaration<'a, V: VisitMut<'a>>(
+    #[inline]
+    pub fn walk_ts_non_null_expression<'a, V: VisitMut<'a>>(
         visitor: &mut V,
-        it: &mut ModuleDeclaration<'a>,
+        it: &mut TSNonNullExpression<'a>,
     ) {
-        let kind = AstType::ModuleDeclaration;
+        let kind = AstType::TSNonNullExpression;
         visitor.enter_node(kind);
-        match it {
-            ModuleDeclaration::ImportDeclaration(it) => visitor.visit_import_declaration(it),
-            ModuleDeclaration::ExportAllDeclaration(it) => visitor.visit_export_all_declaration(it),
-            ModuleDeclaration::ExportDefaultDeclaration(it) => {
-                visitor.visit_export_default_declaration(it)
-            }
-            ModuleDeclaration::ExportNamedDeclaration(it) => {
-                visitor.visit_export_named_declaration(it)
-            }
-            ModuleDeclaration::TSExportAssignment(it) => visitor.visit_ts_export_assignment(it),
-            ModuleDeclaration::TSNamespaceExportDeclaration(it) => {
-                visitor.visit_ts_namespace_export_declaration(it)
-            }
-        }
+        visitor.visit_span(&mut it.span);
+        visitor.visit_expression(&mut it.expression);
         visitor.leave_node(kind);
     }
 
     #[inline]
-    pub fn walk_import_declaration<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut ImportDeclaration<'a>,
-    ) {
-        let kind = AstType::ImportDeclaration;
+    pub fn walk_decorator<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Decorator<'a>) {
+        let kind = AstType::Decorator;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
-        if let Some(specifiers) = &mut it.specifiers {
-            visitor.visit_import_declaration_specifiers(specifiers);
-        }
-        visitor.visit_string_literal(&mut it.source);
-        if let Some(with_clause) = &mut it.with_clause {
-            visitor.visit_with_clause(with_clause);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_import_declaration_specifiers<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut Vec<'a, ImportDeclarationSpecifier<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_import_declaration_specifier(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_import_declaration_specifier<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut ImportDeclarationSpecifier<'a>,
-    ) {
-        // No `AstType` for this type
-        match it {
-            ImportDeclarationSpecifier::ImportSpecifier(it) => visitor.visit_import_specifier(it),
-            ImportDeclarationSpecifier::ImportDefaultSpecifier(it) => {
-                visitor.visit_import_default_specifier(it)
-            }
-            ImportDeclarationSpecifier::ImportNamespaceSpecifier(it) => {
-                visitor.visit_import_namespace_specifier(it)
-            }
-        }
-    }
-
-    #[inline]
-    pub fn walk_import_specifier<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut ImportSpecifier<'a>,
-    ) {
-        let kind = AstType::ImportSpecifier;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_module_export_name(&mut it.imported);
-        visitor.visit_binding_identifier(&mut it.local);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_module_export_name<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut ModuleExportName<'a>,
-    ) {
-        // No `AstType` for this type
-        match it {
-            ModuleExportName::IdentifierName(it) => visitor.visit_identifier_name(it),
-            ModuleExportName::IdentifierReference(it) => visitor.visit_identifier_reference(it),
-            ModuleExportName::StringLiteral(it) => visitor.visit_string_literal(it),
-        }
-    }
-
-    #[inline]
-    pub fn walk_import_default_specifier<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut ImportDefaultSpecifier<'a>,
-    ) {
-        let kind = AstType::ImportDefaultSpecifier;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_binding_identifier(&mut it.local);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_import_namespace_specifier<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut ImportNamespaceSpecifier<'a>,
-    ) {
-        let kind = AstType::ImportNamespaceSpecifier;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_binding_identifier(&mut it.local);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_with_clause<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut WithClause<'a>) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-        visitor.visit_identifier_name(&mut it.attributes_keyword);
-        visitor.visit_import_attributes(&mut it.with_entries);
-    }
-
-    #[inline]
-    pub fn walk_import_attributes<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut Vec<'a, ImportAttribute<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_import_attribute(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_import_attribute<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut ImportAttribute<'a>,
-    ) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-        visitor.visit_import_attribute_key(&mut it.key);
-        visitor.visit_string_literal(&mut it.value);
-    }
-
-    #[inline]
-    pub fn walk_import_attribute_key<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut ImportAttributeKey<'a>,
-    ) {
-        // No `AstType` for this type
-        match it {
-            ImportAttributeKey::Identifier(it) => visitor.visit_identifier_name(it),
-            ImportAttributeKey::StringLiteral(it) => visitor.visit_string_literal(it),
-        }
-    }
-
-    #[inline]
-    pub fn walk_export_all_declaration<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut ExportAllDeclaration<'a>,
-    ) {
-        let kind = AstType::ExportAllDeclaration;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        if let Some(exported) = &mut it.exported {
-            visitor.visit_module_export_name(exported);
-        }
-        visitor.visit_string_literal(&mut it.source);
-        if let Some(with_clause) = &mut it.with_clause {
-            visitor.visit_with_clause(with_clause);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_export_default_declaration<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut ExportDefaultDeclaration<'a>,
-    ) {
-        let kind = AstType::ExportDefaultDeclaration;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_export_default_declaration_kind(&mut it.declaration);
-        visitor.visit_module_export_name(&mut it.exported);
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_export_default_declaration_kind<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut ExportDefaultDeclarationKind<'a>,
-    ) {
-        // No `AstType` for this type
-        match it {
-            ExportDefaultDeclarationKind::FunctionDeclaration(it) => {
-                let flags = ScopeFlags::Function;
-                visitor.visit_function(it, flags)
-            }
-            ExportDefaultDeclarationKind::ClassDeclaration(it) => visitor.visit_class(it),
-            ExportDefaultDeclarationKind::TSInterfaceDeclaration(it) => {
-                visitor.visit_ts_interface_declaration(it)
-            }
-            match_expression!(ExportDefaultDeclarationKind) => {
-                visitor.visit_expression(it.to_expression_mut())
-            }
-        }
-    }
-
-    #[inline]
-    pub fn walk_export_named_declaration<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut ExportNamedDeclaration<'a>,
-    ) {
-        let kind = AstType::ExportNamedDeclaration;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        if let Some(declaration) = &mut it.declaration {
-            visitor.visit_declaration(declaration);
-        }
-        visitor.visit_export_specifiers(&mut it.specifiers);
-        if let Some(source) = &mut it.source {
-            visitor.visit_string_literal(source);
-        }
-        if let Some(with_clause) = &mut it.with_clause {
-            visitor.visit_with_clause(with_clause);
-        }
-        visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_export_specifiers<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut Vec<'a, ExportSpecifier<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_export_specifier(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_export_specifier<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut ExportSpecifier<'a>,
-    ) {
-        let kind = AstType::ExportSpecifier;
-        visitor.enter_node(kind);
-        visitor.visit_span(&mut it.span);
-        visitor.visit_module_export_name(&mut it.local);
-        visitor.visit_module_export_name(&mut it.exported);
+        visitor.visit_expression(&mut it.expression);
         visitor.leave_node(kind);
     }
 
@@ -4610,5 +4301,314 @@ pub mod walk_mut {
         // No `AstType` for this type
         visitor.visit_span(&mut it.span);
         visitor.visit_identifier_name(&mut it.id);
+    }
+
+    #[inline]
+    pub fn walk_ts_instantiation_expression<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut TSInstantiationExpression<'a>,
+    ) {
+        let kind = AstType::TSInstantiationExpression;
+        visitor.enter_node(kind);
+        visitor.visit_span(&mut it.span);
+        visitor.visit_expression(&mut it.expression);
+        visitor.visit_ts_type_parameter_instantiation(&mut it.type_parameters);
+        visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_js_doc_nullable_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSDocNullableType<'a>,
+    ) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_type(&mut it.type_annotation);
+    }
+
+    #[inline]
+    pub fn walk_js_doc_non_nullable_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSDocNonNullableType<'a>,
+    ) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+        visitor.visit_ts_type(&mut it.type_annotation);
+    }
+
+    #[inline]
+    pub fn walk_js_doc_unknown_type<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSDocUnknownType,
+    ) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+    }
+
+    #[inline]
+    pub fn walk_span<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Span) {
+        // No `AstType` for this type
+    }
+
+    #[inline]
+    pub fn walk_directives<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, Directive<'a>>) {
+        for el in it {
+            visitor.visit_directive(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_statements<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, Statement<'a>>) {
+        for el in it {
+            visitor.visit_statement(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_array_expression_elements<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut Vec<'a, ArrayExpressionElement<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_array_expression_element(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_object_property_kinds<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut Vec<'a, ObjectPropertyKind<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_object_property_kind(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_template_elements<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut Vec<'a, TemplateElement<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_template_element(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_expressions<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut Vec<'a, Expression<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_expression(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_arguments<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, Argument<'a>>) {
+        for el in it {
+            visitor.visit_argument(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_assignment_target_properties<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut Vec<'a, AssignmentTargetProperty<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_assignment_target_property(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_variable_declarators<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut Vec<'a, VariableDeclarator<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_variable_declarator(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_switch_cases<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut Vec<'a, SwitchCase<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_switch_case(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_binding_properties<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut Vec<'a, BindingProperty<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_binding_property(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_formal_parameter_list<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut Vec<'a, FormalParameter<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_formal_parameter(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_decorators<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, Decorator<'a>>) {
+        for el in it {
+            visitor.visit_decorator(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_class_implementses<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut Vec<'a, TSClassImplements<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_ts_class_implements(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_class_elements<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut Vec<'a, ClassElement<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_class_element(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_import_declaration_specifiers<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut Vec<'a, ImportDeclarationSpecifier<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_import_declaration_specifier(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_import_attributes<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut Vec<'a, ImportAttribute<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_import_attribute(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_export_specifiers<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut Vec<'a, ExportSpecifier<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_export_specifier(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_jsx_children<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, JSXChild<'a>>) {
+        for el in it {
+            visitor.visit_jsx_child(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_jsx_attribute_items<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut Vec<'a, JSXAttributeItem<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_jsx_attribute_item(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_enum_members<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut Vec<'a, TSEnumMember<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_ts_enum_member(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_types<'a, V: VisitMut<'a>>(visitor: &mut V, it: &mut Vec<'a, TSType<'a>>) {
+        for el in it {
+            visitor.visit_ts_type(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_tuple_elements<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut Vec<'a, TSTupleElement<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_ts_tuple_element(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_type_parameters<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut Vec<'a, TSTypeParameter<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_ts_type_parameter(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_interface_heritages<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut Vec<'a, TSInterfaceHeritage<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_ts_interface_heritage(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_signatures<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut Vec<'a, TSSignature<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_ts_signature(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_index_signature_names<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut Vec<'a, TSIndexSignatureName<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_ts_index_signature_name(el);
+        }
+    }
+
+    #[inline]
+    pub fn walk_ts_import_attribute_list<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut Vec<'a, TSImportAttribute<'a>>,
+    ) {
+        for el in it {
+            visitor.visit_ts_import_attribute(el);
+        }
     }
 }

--- a/tasks/ast_tools/src/schema/mod.rs
+++ b/tasks/ast_tools/src/schema/mod.rs
@@ -52,6 +52,7 @@ impl Schema {
     ///
     /// # Panics
     /// Panics if no type with supplied name.
+    #[expect(dead_code)]
     pub fn type_by_name(&self, name: &str) -> &TypeDef {
         let type_id = self.type_names[name];
         &self.types[type_id]


### PR DESCRIPTION
Pure refactor. Re-order the methods in generated `Visit` and `VisitMut` traits to be in same order they appear in source code.

This simplifies and improves performance of the codegen considerably. Previously it walked the AST types recursively, with loads of checks "did I generate visitor for this type already?". Now it's just a single loop over the type definitions.

I've double-checked that this does not result in new/missing visit methods. This change purely results in the same methods being output in a different order.