### PR TITLE
refactor(ast_tools): rename `is_visited` to `has_visitor`

### DIFF
--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -33,13 +33,13 @@ impl Generator for AstBuilderGenerator {
             .types
             .iter()
             .filter(|&type_def| {
-                let is_visited = match type_def {
-                    TypeDef::Struct(struct_def) => struct_def.visit.is_visited(),
-                    TypeDef::Enum(enum_def) => enum_def.visit.is_visited(),
+                let has_visitor = match type_def {
+                    TypeDef::Struct(struct_def) => struct_def.visit.has_visitor(),
+                    TypeDef::Enum(enum_def) => enum_def.visit.has_visitor(),
                     _ => false,
                 };
                 let is_blacklisted = BLACK_LIST.contains(&type_def.name());
-                is_visited && !is_blacklisted
+                has_visitor && !is_blacklisted
             })
             .map(|type_def| generate_builder_methods(type_def, schema))
             .collect::<TokenStream>();

--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -99,10 +99,10 @@ impl Generator for AstKindGenerator {
         for type_def in &mut schema.types {
             match type_def {
                 TypeDef::Struct(struct_def) => {
-                    struct_def.kind.has_kind = struct_def.visit.is_visited();
+                    struct_def.kind.has_kind = struct_def.visit.has_visitor();
                 }
                 TypeDef::Enum(enum_def) => {
-                    enum_def.kind.has_kind = enum_def.visit.is_visited();
+                    enum_def.kind.has_kind = enum_def.visit.has_visitor();
                 }
                 _ => {}
             }

--- a/tasks/ast_tools/src/schema/extensions/visit.rs
+++ b/tasks/ast_tools/src/schema/extensions/visit.rs
@@ -9,12 +9,12 @@ pub struct VisitStruct {
 }
 
 impl VisitStruct {
-    /// Returns `true` if this struct is visited.
-    pub fn is_visited(&self) -> bool {
+    /// Returns `true` if this struct has a visitor.
+    pub fn has_visitor(&self) -> bool {
         self.visitor_names.is_some()
     }
 
-    /// Get name of visitor method for this struct, if it is visited.
+    /// Get name of visitor method for this struct, if it has a visitor.
     pub fn visitor_name(&self) -> Option<&str> {
         self.visitor_names.as_ref().map(|names| names.visit.as_str())
     }
@@ -29,12 +29,12 @@ pub struct VisitEnum {
 }
 
 impl VisitEnum {
-    /// Returns `true` if this enum is visited.
-    pub fn is_visited(&self) -> bool {
+    /// Returns `true` if this enum has a visitor.
+    pub fn has_visitor(&self) -> bool {
         self.visitor_names.is_some()
     }
 
-    /// Get name of visitor method for this enum, if it is visited.
+    /// Get name of visitor method for this enum, if it has a visitor.
     pub fn visitor_name(&self) -> Option<&str> {
         self.visitor_names.as_ref().map(|names| names.visit.as_str())
     }
@@ -49,13 +49,13 @@ pub struct VisitVec {
 }
 
 impl VisitVec {
-    /// Returns `true` if this `Vec` is visited.
+    /// Returns `true` if this `Vec` has a visitor.
     #[expect(dead_code)]
-    pub fn is_visited(&self) -> bool {
+    pub fn has_visitor(&self) -> bool {
         self.visitor_names.is_some()
     }
 
-    /// Get name of visitor method for this `Vec`, if it is visited.
+    /// Get name of visitor method for this `Vec`, if it has a visitor.
     pub fn visitor_name(&self) -> Option<&str> {
         self.visitor_names.as_ref().map(|names| names.visit.as_str())
     }


### PR DESCRIPTION
Pure refactor. Rename `is_visited` to `has_visitor`. The latter describes what it is more clearly. Some types e.g. `Option<Expression>` *are* visited, but they don't have their own visitor method, so having `is_visited = false` is misleading. `has_visitor = false` is more accurate.
