### PR TITLE
refactor(ast_tools): improve correctness and performance of idents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1614,6 +1614,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "oxc_index",
+ "phf",
  "prettyplease",
  "proc-macro2",
  "quote",

--- a/tasks/ast_tools/Cargo.toml
+++ b/tasks/ast_tools/Cargo.toml
@@ -22,6 +22,7 @@ indexmap = { workspace = true }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 oxc_index = { workspace = true }
+phf = { workspace = true, features = ["macros"] }
 prettyplease = { workspace = true }
 proc-macro2 = { workspace = true }
 quote = { workspace = true }

--- a/tasks/ast_tools/src/derives/clone_in.rs
+++ b/tasks/ast_tools/src/derives/clone_in.rs
@@ -1,11 +1,12 @@
 //! Derive for `CloneIn` trait.
 
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
+use quote::quote;
 use syn::Ident;
 
 use crate::{
     schema::{Def, EnumDef, FieldDef, Schema, StructDef, TypeDef},
+    utils::create_safe_ident,
     Result,
 };
 
@@ -151,7 +152,7 @@ fn generate_impl(
     has_lifetime: bool,
     uses_allocator: bool,
 ) -> TokenStream {
-    let alloc_ident = format_ident!("{}", if uses_allocator { "allocator" } else { "_" });
+    let alloc_ident = create_safe_ident(if uses_allocator { "allocator" } else { "_" });
 
     if has_lifetime {
         quote! {

--- a/tasks/ast_tools/src/derives/get_span.rs
+++ b/tasks/ast_tools/src/derives/get_span.rs
@@ -1,11 +1,12 @@
 //! Derive for `GetSpan` trait.
 
 use proc_macro2::TokenStream;
-use quote::{format_ident, quote};
+use quote::quote;
 use syn::Ident;
 
 use crate::{
     schema::{Def, EnumDef, Schema, StructDef},
+    utils::create_safe_ident,
     Result,
 };
 
@@ -54,6 +55,8 @@ impl Derive for DeriveGetSpan {
     }
 
     fn derive(&self, type_def: StructOrEnum, schema: &Schema) -> TokenStream {
+        let trait_ident = create_safe_ident("GetSpan");
+        let method_ident = create_safe_ident("span");
         let self_ty = quote!(&self);
         let result_ty = quote!(Span);
         let result_expr = quote!(self.span);
@@ -61,8 +64,8 @@ impl Derive for DeriveGetSpan {
 
         derive_type(
             type_def,
-            "GetSpan",
-            "span",
+            &trait_ident,
+            &method_ident,
             &self_ty,
             &result_ty,
             &result_expr,
@@ -96,6 +99,8 @@ impl Derive for DeriveGetSpanMut {
     }
 
     fn derive(&self, type_def: StructOrEnum, schema: &Schema) -> TokenStream {
+        let trait_ident = create_safe_ident("GetSpanMut");
+        let method_ident = create_safe_ident("span_mut");
         let self_ty = quote!(&mut self);
         let result_ty = quote!(&mut Span);
         let result_expr = quote!(&mut self.span);
@@ -103,8 +108,8 @@ impl Derive for DeriveGetSpanMut {
 
         derive_type(
             type_def,
-            "GetSpanMut",
-            "span_mut",
+            &trait_ident,
+            &method_ident,
             &self_ty,
             &result_ty,
             &result_expr,
@@ -118,36 +123,28 @@ impl Derive for DeriveGetSpanMut {
 #[expect(clippy::too_many_arguments)]
 fn derive_type(
     type_def: StructOrEnum,
-    trait_name: &str,
-    method_name: &str,
+    trait_ident: &Ident,
+    method_ident: &Ident,
     self_ty: &TokenStream,
     result_ty: &TokenStream,
     result_expr: &TokenStream,
     reference: &TokenStream,
     schema: &Schema,
 ) -> TokenStream {
-    let trait_ident = format_ident!("{trait_name}");
-    let method_ident = format_ident!("{method_name}");
     match type_def {
         StructOrEnum::Struct(struct_def) => derive_struct(
             struct_def,
-            &trait_ident,
-            &method_ident,
+            trait_ident,
+            method_ident,
             self_ty,
             result_ty,
             result_expr,
             reference,
             schema,
         ),
-        StructOrEnum::Enum(enum_def) => derive_enum(
-            enum_def,
-            &trait_ident,
-            &method_ident,
-            self_ty,
-            result_ty,
-            reference,
-            schema,
-        ),
+        StructOrEnum::Enum(enum_def) => {
+            derive_enum(enum_def, trait_ident, method_ident, self_ty, result_ty, reference, schema)
+        }
     }
 }
 

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -8,7 +8,7 @@ use syn::Ident;
 use crate::{
     output::{output_path, Output},
     schema::{Def, EnumDef, FieldDef, Schema, StructDef, TypeDef, VariantDef},
-    utils::is_reserved_name,
+    utils::{create_safe_ident, is_reserved_name},
     Codegen, Generator, AST_CRATE_PATH,
 };
 
@@ -276,11 +276,11 @@ fn get_struct_params<'s>(
                 TypeDef::Primitive(primitive_def) => match primitive_def.name() {
                     "Atom" if !has_atom_generic => {
                         has_atom_generic = true;
-                        Some(format_ident!("A"))
+                        Some(create_safe_ident("A"))
                     }
                     "&str" if !has_str_generic => {
                         has_str_generic = true;
-                        Some(format_ident!("S"))
+                        Some(create_safe_ident("S"))
                     }
                     _ => None,
                 },
@@ -450,7 +450,8 @@ fn struct_builder_name(snake_name: &str, does_alloc: bool) -> Ident {
     } else if is_reserved_name(snake_name) {
         format_ident!("{snake_name}_")
     } else {
-        format_ident!("{snake_name}")
+        // We just checked name is not a reserved word
+        create_safe_ident(snake_name)
     }
 }
 

--- a/tasks/ast_tools/src/schema/extensions/visit.rs
+++ b/tasks/ast_tools/src/schema/extensions/visit.rs
@@ -1,3 +1,7 @@
+use syn::Ident;
+
+use crate::utils::create_safe_ident;
+
 /// Details of visiting on a struct.
 #[derive(Default, Debug)]
 pub struct VisitStruct {
@@ -14,9 +18,11 @@ impl VisitStruct {
         self.visitor_names.is_some()
     }
 
-    /// Get name of visitor method for this struct, if it has a visitor.
-    pub fn visitor_name(&self) -> Option<&str> {
-        self.visitor_names.as_ref().map(|names| names.visit.as_str())
+    /// Get visitor method name for this struct as an [`Ident`], if it has a visitor.
+    ///
+    /// [`Ident`]: struct@Ident
+    pub fn visitor_ident(&self) -> Option<Ident> {
+        self.visitor_names.as_ref().map(VisitorNames::visitor_ident)
     }
 }
 
@@ -34,9 +40,11 @@ impl VisitEnum {
         self.visitor_names.is_some()
     }
 
-    /// Get name of visitor method for this enum, if it has a visitor.
-    pub fn visitor_name(&self) -> Option<&str> {
-        self.visitor_names.as_ref().map(|names| names.visit.as_str())
+    /// Get visitor method name for this enum as an [`Ident`], if it has a visitor.
+    ///
+    /// [`Ident`]: struct@Ident
+    pub fn visitor_ident(&self) -> Option<Ident> {
+        self.visitor_names.as_ref().map(VisitorNames::visitor_ident)
     }
 }
 
@@ -55,9 +63,11 @@ impl VisitVec {
         self.visitor_names.is_some()
     }
 
-    /// Get name of visitor method for this `Vec`, if it has a visitor.
-    pub fn visitor_name(&self) -> Option<&str> {
-        self.visitor_names.as_ref().map(|names| names.visit.as_str())
+    /// Get visitor method name for this `Vec` as an [`Ident`], if it has a visitor.
+    ///
+    /// [`Ident`]: struct@Ident
+    pub fn visitor_ident(&self) -> Option<Ident> {
+        self.visitor_names.as_ref().map(VisitorNames::visitor_ident)
     }
 }
 
@@ -77,6 +87,22 @@ pub struct VisitorNames {
 impl VisitorNames {
     pub fn from_snake_name(snake_name: &str) -> Self {
         Self { visit: format!("visit_{snake_name}"), walk: format!("walk_{snake_name}") }
+    }
+
+    /// Get name of visitor method as an [`Ident`].
+    ///
+    /// [`Ident`]: struct@Ident
+    pub fn visitor_ident(&self) -> Ident {
+        // Visitor method names cannot be reserved words, as they begin with `visit_`
+        create_safe_ident(&self.visit)
+    }
+
+    /// Get name of walk function as an [`Ident`].
+    ///
+    /// [`Ident`]: struct@Ident
+    pub fn walk_ident(&self) -> Ident {
+        // Walk function names cannot be reserved words, as they begin with `walk_`
+        create_safe_ident(&self.walk)
     }
 }
 

--- a/tasks/ast_tools/src/utils.rs
+++ b/tasks/ast_tools/src/utils.rs
@@ -1,11 +1,11 @@
+use phf::{phf_set, Set as PhfSet};
 use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote};
 use syn::{Ident, LitInt};
 
 /// Reserved word in Rust.
 /// From <https://doc.rust-lang.org/reference/keywords.html>.
-#[rustfmt::skip]
-static RESERVED_NAMES: &[&str] = &[
+static RESERVED_NAMES: PhfSet<&'static str> = phf_set! {
     // Strict keywords
     "as", "break", "const", "continue", "crate", "else", "enum", "extern", "false", "fn", "for", "if",
     "impl", "in", "let", "loop", "match", "mod", "move", "mut", "pub", "ref", "return", "self", "Self",
@@ -16,11 +16,11 @@ static RESERVED_NAMES: &[&str] = &[
     "virtual", "yield", "try",
     // Weak keywords
     "macro_rules", "union", // "dyn" also listed as a weak keyword, but is already on strict list
-];
+};
 
 /// Returns `true` if `name` is a reserved word in Rust.
 pub fn is_reserved_name(name: &str) -> bool {
-    RESERVED_NAMES.contains(&name)
+    RESERVED_NAMES.contains(name)
 }
 
 /// Create an [`Ident`] from a string.
@@ -33,8 +33,17 @@ pub fn create_ident(name: &str) -> Ident {
     if is_reserved_name(name) {
         format_ident!("r#{name}")
     } else {
-        format_ident!("{name}")
+        create_safe_ident(name)
     }
+}
+
+/// Create an [`Ident`] from a string, without checking it's not a reserved word.
+///
+/// The provided `name` for the ident must not be a reserved word.
+///
+/// [`Ident`]: struct@Ident
+pub fn create_safe_ident(name: &str) -> Ident {
+    Ident::new(name, Span::call_site())
 }
 
 /// Create an identifier from a string.


### PR DESCRIPTION
Refactor. Codegen produces lots of identifiers in the generated code. Ensure they're always prepended with `r#` if they're reserved words. Speed up checking if a name is a reserved word by using a perfect hash set, rather than iterating through an array.
