### PR TITLE
chore(oxc_macros): remove commented-out unused code

### DIFF
--- a/crates/oxc_macros/src/declare_oxc_lint.rs
+++ b/crates/oxc_macros/src/declare_oxc_lint.rs
@@ -138,9 +138,6 @@ fn parse_fix(s: &str) -> proc_macro2::TokenStream {
         }
         "fix" => return quote! { RuleFixMeta::Fixable(FixKind::SafeFix) },
         "suggestion" => return quote! { RuleFixMeta::Fixable(FixKind::Suggestion) },
-        // "fix-dangerous" => quote! { RuleFixMeta::Fixable(FixKind::Fix.union(FixKind::Dangerous)) },
-        // "suggestion" => quote! { RuleFixMeta::Fixable(FixKind::Suggestion) },
-        // "suggestion-dangerous" => quote! { RuleFixMeta::Fixable(FixKind::Suggestion.union(FixKind::Dangerous)) },
         "conditional" => {
             panic!("Invalid fix capabilities: missing a fix kind. Did you mean 'fix-conditional'?")
         }

--- a/crates/oxc_macros/src/lib.rs
+++ b/crates/oxc_macros/src/lib.rs
@@ -57,9 +57,11 @@ mod declare_oxc_lint;
 ///
 /// declare_oxc_lint! {
 ///     /// ### What it does
+///     ///
 ///     /// Checks for usage of the `debugger` statement
 ///     ///
 ///     /// ### Why is this bad?
+///     ///
 ///     /// `debugger` statements do not affect functionality when a debugger isn't attached.
 ///     /// They're most commonly an accidental debugging leftover.
 ///     ///


### PR DESCRIPTION
- Add line breaks to `What it does` and `Why is this bad?` comments for consistency with `Examples`
- Remove commented-out unused code