### PR TITLE
refactor(ast): estree `via` on struct fields implement `From`

### DIFF
--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1650,7 +1650,10 @@ impl Serialize for ImportDeclaration<'_> {
         let mut map = serializer.serialize_map(None)?;
         map.serialize_entry("type", "ImportDeclaration")?;
         self.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.serialize_entry("specifiers", &crate::serialize::OptionVecDefault(&self.specifiers))?;
+        map.serialize_entry(
+            "specifiers",
+            &crate::serialize::OptionVecDefault::from(&self.specifiers),
+        )?;
         map.serialize_entry("source", &self.source)?;
         map.serialize_entry("phase", &self.phase)?;
         map.serialize_entry("withClause", &self.with_clause)?;

--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -218,7 +218,7 @@ fn generate_stmt_for_struct_field(
     let mut value = quote!( &self.#field_name_ident );
     if let Some(via_str) = field.estree.via.as_deref() {
         let via_ty = parse_str::<Type>(via_str).unwrap();
-        value = quote!( &#via_ty(#value) );
+        value = quote!( &#via_ty::from(#value) );
     } else if let Some(append_field_index) = field.estree.append_field_index {
         let append_from_ident = struct_def.fields[append_field_index].ident();
         value = quote! {


### PR DESCRIPTION
Align the behavior of custom serialization to ESTree using the `#[estree(via)]` attribute. Change its behavior on struct fields to match structs - the "via" type must implement `From` to convert from the original type to itself.

The future goal is to use these same "via" types to go back in the other direction (JS -> Rust), so we need to have a casting system.
