### PR TITLE
fix(oxc_laguage_server): code actions if report range overlap request

### DIFF
--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -259,13 +259,10 @@ impl LanguageServer for Backend {
 
         let mut code_actions_vec: Vec<CodeActionOrCommand> = vec![];
         if let Some(value) = self.diagnostics_report_map.get(&uri.to_string()) {
-            let reports = value
-                .iter()
-                .filter(|r| {
-                    r.diagnostic.range == params.range
-                        || range_overlaps(params.range, r.diagnostic.range)
-                })
-                .collect::<Vec<_>>();
+            let reports = value.iter().filter(|r| {
+                r.diagnostic.range == params.range
+                    || range_overlaps(params.range, r.diagnostic.range)
+            });
             for report in reports {
                 // TODO: Would be better if we had exact rule name from the diagnostic instead of having to parse it.
                 let mut rule_name: Option<String> = None;

--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -263,7 +263,7 @@ impl LanguageServer for Backend {
                 .iter()
                 .filter(|r| {
                     r.diagnostic.range == params.range
-                        || range_includes(params.range, r.diagnostic.range)
+                        || range_overlaps(params.range, r.diagnostic.range)
                 })
                 .collect::<Vec<_>>();
             for report in reports {
@@ -579,12 +579,6 @@ async fn main() {
     Server::new(stdin, stdout, socket).serve(service).await;
 }
 
-fn range_includes(range: Range, to_include: Range) -> bool {
-    if range.start >= to_include.start {
-        return false;
-    }
-    if range.end <= to_include.end {
-        return false;
-    }
-    true
+fn range_overlaps(a: Range, b: Range) -> bool {
+    a.start <= b.end && a.end >= b.start
 }


### PR DESCRIPTION
Requesting code actions in neovim's normal mode doesn't return any code action, as the report range isn't fully contained in the requested range - which is only the current cursor position. Filtering based on overlap seems to be done by most relevant language servers (based on my tesing) - such as `rust-analyzer` or `ts_ls`. `eslint` filters code actions based on intercepted lines.