### PR TITLE
refactor(data_structures)!: rename `Stack::last_unchecked_mut` method

### DIFF
--- a/crates/oxc_data_structures/src/stack/sparse.rs
+++ b/crates/oxc_data_structures/src/stack/sparse.rs
@@ -177,7 +177,7 @@ impl<T> SparseStack<T> {
             debug_assert!(!self.values.is_empty());
             // SAFETY: Last `self.has_values` is only `true` if there's a corresponding value in `self.values`.
             // This invariant is maintained in `push`, `pop`, `take_last`, `last_or_init`, and `last_mut_or_init`.
-            let value = unsafe { self.values.last_mut_unchecked() };
+            let value = unsafe { self.values.last_unchecked_mut() };
             Some(value)
         } else {
             None
@@ -236,7 +236,7 @@ impl<T> SparseStack<T> {
         // This invariant is maintained in `push`, `pop`, `take_last`, and `last_or_init`.
         // Here either last `self.has_values` was already `true`, or it's just been set to `true`
         // and a value pushed to `self.values` above.
-        unsafe { self.values.last_mut_unchecked() }
+        unsafe { self.values.last_unchecked_mut() }
     }
 
     /// Get number of entries on the stack.

--- a/crates/oxc_data_structures/src/stack/standard.rs
+++ b/crates/oxc_data_structures/src/stack/standard.rs
@@ -224,7 +224,7 @@ impl<T> Stack<T> {
         #[expect(clippy::if_not_else)]
         if !self.is_empty() {
             // SAFETY: Stack is not empty
-            Some(unsafe { self.last_mut_unchecked() })
+            Some(unsafe { self.last_unchecked_mut() })
         } else {
             None
         }
@@ -236,7 +236,7 @@ impl<T> Stack<T> {
     ///
     /// * Stack must not be empty.
     #[inline]
-    pub unsafe fn last_mut_unchecked(&mut self) -> &mut T {
+    pub unsafe fn last_unchecked_mut(&mut self) -> &mut T {
         debug_assert!(self.end > self.start);
         debug_assert!(self.cursor > self.start);
         debug_assert!(self.cursor <= self.end);


### PR DESCRIPTION
Rename `Stack::last_mut_unchecked` to `Stack::last_unchecked_mut`. This matches `std`'s naming convention e.g. `get_unchecked_mut` on slices.