### PR TITLE
feat(linter): support `env` and `globals` in `overrides` configuration

### DIFF
--- a/apps/oxlint/fixtures/overrides/.oxlintrc.json
+++ b/apps/oxlint/fixtures/overrides/.oxlintrc.json
@@ -5,19 +5,25 @@
   },
   "overrides": [
     {
-      "files": ["*.js"],
+      "files": [
+        "*.js"
+      ],
       "rules": {
         "no-console": "warn"
       }
     },
     {
-      "files": ["*.{js,jsx}"],
+      "files": [
+        "*.{js,jsx}"
+      ],
       "rules": {
         "no-console": "off"
       }
     },
     {
-      "files": ["*.ts"],
+      "files": [
+        "*.ts"
+      ],
       "rules": {
         "no-console": "warn"
       }

--- a/apps/oxlint/fixtures/overrides/directories-config.json
+++ b/apps/oxlint/fixtures/overrides/directories-config.json
@@ -4,13 +4,18 @@
   },
   "overrides": [
     {
-      "files": ["lib/*.{js,ts}", "src/*"],
+      "files": [
+        "lib/*.{js,ts}",
+        "src/*"
+      ],
       "rules": {
         "no-debugger": "error"
       }
     },
     {
-      "files": ["**/tests/*"],
+      "files": [
+        "**/tests/*"
+      ],
       "rules": {
         "no-debugger": "warn"
       }

--- a/apps/oxlint/fixtures/overrides_env_globals/.oxlintrc.json
+++ b/apps/oxlint/fixtures/overrides_env_globals/.oxlintrc.json
@@ -1,0 +1,32 @@
+{
+  "env": {
+    "jquery": true
+  },
+  "globals": {
+    "Foo": "readonly"
+  },
+  "overrides": [
+    {
+      "files": [
+        "*.ts"
+      ],
+      "env": {
+        "jquery": false
+      },
+      "globals": {
+        "Foo": "writeable"
+      }
+    },
+    {
+      "files": [
+        "src/*"
+      ],
+      "env": {
+        "jquery": false
+      },
+      "globals": {
+        "Foo": "writeable"
+      }
+    }
+  ]
+}

--- a/apps/oxlint/fixtures/overrides_env_globals/src/test.js
+++ b/apps/oxlint/fixtures/overrides_env_globals/src/test.js
@@ -1,0 +1,6 @@
+// for env detection
+globalThis = 'abc';
+$ = 'abc';
+
+// for globals detection
+Foo = 'readable';

--- a/apps/oxlint/fixtures/overrides_env_globals/test.js
+++ b/apps/oxlint/fixtures/overrides_env_globals/test.js
@@ -1,0 +1,6 @@
+// for env detection
+globalThis = 'abc';
+$ = 'abc';
+
+// for globals detection
+Foo = 'readable';

--- a/apps/oxlint/fixtures/overrides_env_globals/test.ts
+++ b/apps/oxlint/fixtures/overrides_env_globals/test.ts
@@ -1,0 +1,6 @@
+// for env detection
+globalThis = 'abc';
+$ = 'abc';
+
+// for globals detection
+Foo = 'readable';

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -756,6 +756,12 @@ mod test {
     }
 
     #[test]
+    fn test_overrides_envs_and_global() {
+        let args = &["-c", ".oxlintrc.json", "."];
+        Tester::new().with_cwd("fixtures/overrides_env_globals".into()).test_and_snapshot(args);
+    }
+
+    #[test]
     fn test_ignore_patterns() {
         let args = &["-c", "./test/eslintrc.json", "--ignore-pattern", "*.ts", "."];
 

--- a/apps/oxlint/src/snapshots/fixtures__overrides_env_globals_-c .oxlintrc.json .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__overrides_env_globals_-c .oxlintrc.json .@oxlint.snap
@@ -1,0 +1,57 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: -c .oxlintrc.json .
+working directory: fixtures/overrides_env_globals
+----------
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-global-assign.html\eslint(no-global-assign)]8;;\: Read-only global 'globalThis' should not be modified.
+   ,-[src/test.js:2:1]
+ 1 | // for env detection
+ 2 | globalThis = 'abc';
+   : ^^^^^|^^^^
+   :      `-- Read-only global 'globalThis' should not be modified.
+ 3 | $ = 'abc';
+   `----
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-global-assign.html\eslint(no-global-assign)]8;;\: Read-only global 'globalThis' should not be modified.
+   ,-[test.js:2:1]
+ 1 | // for env detection
+ 2 | globalThis = 'abc';
+   : ^^^^^|^^^^
+   :      `-- Read-only global 'globalThis' should not be modified.
+ 3 | $ = 'abc';
+   `----
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-global-assign.html\eslint(no-global-assign)]8;;\: Read-only global 'globalThis' should not be modified.
+   ,-[test.ts:2:1]
+ 1 | // for env detection
+ 2 | globalThis = 'abc';
+   : ^^^^^|^^^^
+   :      `-- Read-only global 'globalThis' should not be modified.
+ 3 | $ = 'abc';
+   `----
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-global-assign.html\eslint(no-global-assign)]8;;\: Read-only global '$' should not be modified.
+   ,-[test.js:3:1]
+ 2 | globalThis = 'abc';
+ 3 | $ = 'abc';
+   : |
+   : `-- Read-only global '$' should not be modified.
+ 4 | 
+   `----
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-global-assign.html\eslint(no-global-assign)]8;;\: Read-only global 'Foo' should not be modified.
+   ,-[test.js:6:1]
+ 5 | // for globals detection
+ 6 | Foo = 'readable';
+   : ^|^
+   :  `-- Read-only global 'Foo' should not be modified.
+   `----
+
+Found 5 warnings and 0 errors.
+Finished in <variable>ms on 3 files with 97 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------

--- a/crates/oxc_linter/src/config/env.rs
+++ b/crates/oxc_linter/src/config/env.rs
@@ -10,24 +10,8 @@ use serde::{Deserialize, Serialize};
 /// list of
 /// environments](https://eslint.org/docs/v8.x/use/configure/language-options#specifying-environments)
 /// for what environments are available and what each one provides.
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema)]
-#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub struct OxlintEnv(FxHashMap<String, bool>);
-
-impl OxlintEnv {
-    pub fn contains<Q>(&self, key: &Q) -> bool
-    where
-        String: Borrow<Q>,
-        Q: ?Sized + Hash + Eq,
-    {
-        self.0.get(key).is_some_and(|v| *v)
-    }
-
-    pub fn iter(&self) -> impl Iterator<Item = &str> + '_ {
-        // Filter out false values
-        self.0.iter().filter_map(|(k, v)| (*v).then_some(k.as_str()))
-    }
-}
 
 impl FromIterator<String> for OxlintEnv {
     fn from_iter<T: IntoIterator<Item = String>>(iter: T) -> Self {
@@ -43,6 +27,27 @@ impl Default for OxlintEnv {
         map.insert("builtin".to_string(), true);
 
         Self(map)
+    }
+}
+
+impl OxlintEnv {
+    pub fn contains<Q>(&self, key: &Q) -> bool
+    where
+        String: Borrow<Q>,
+        Q: ?Sized + Hash + Eq,
+    {
+        self.0.get(key).is_some_and(|v| *v)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &str> + '_ {
+        // Filter out false values
+        self.0.iter().filter_map(|(k, v)| (*v).then_some(k.as_str()))
+    }
+
+    pub(crate) fn override_envs(&self, envs_to_override: &mut OxlintEnv) {
+        for (env, supported) in self.0.clone() {
+            envs_to_override.0.insert(env, supported);
+        }
     }
 }
 
@@ -69,5 +74,18 @@ mod test {
         let env = OxlintEnv::default();
         assert_eq!(env.iter().count(), 1);
         assert!(env.contains("builtin"));
+    }
+
+    #[test]
+    fn test_override_envs() {
+        let mut env = OxlintEnv::default();
+        let override_env = OxlintEnv::deserialize(&serde_json::json!({
+            "browser": true,
+        }))
+        .unwrap();
+
+        override_env.override_envs(&mut env);
+
+        assert!(env.contains("browser"));
     }
 }

--- a/crates/oxc_linter/src/config/globals.rs
+++ b/crates/oxc_linter/src/config/globals.rs
@@ -30,7 +30,7 @@ use serde::{de::Visitor, Deserialize, Serialize};
 /// You may also use `"readable"` or `false` to represent `"readonly"`, and
 /// `"writeable"` or `true` to represent `"writable"`.
 // <https://eslint.org/docs/v8.x/use/configure/language-options#using-configuration-files-1>
-#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone)]
+#[derive(Debug, Default, PartialEq, Deserialize, Serialize, JsonSchema, Clone)]
 pub struct OxlintGlobals(FxHashMap<String, GlobalValue>);
 
 impl Deref for OxlintGlobals {
@@ -48,6 +48,12 @@ impl OxlintGlobals {
         Q: ?Sized + Eq + hash::Hash,
     {
         self.0.get(name).is_some_and(|value| *value != GlobalValue::Off)
+    }
+
+    pub(crate) fn override_globals(&self, globals_to_override: &mut OxlintGlobals) {
+        for (env, supported) in self.0.clone() {
+            globals_to_override.0.insert(env, supported);
+        }
     }
 }
 
@@ -173,5 +179,21 @@ mod test {
         });
         assert!(globals.is_enabled("foo"));
         assert!(globals.is_enabled("bar"));
+    }
+
+    #[test]
+    fn test_override_globals() {
+        let mut globals = OxlintGlobals::deserialize(&serde_json::json!({
+            "Foo": "writeable",
+        }))
+        .unwrap();
+        let override_globals = OxlintGlobals::deserialize(&serde_json::json!({
+            "Foo": "off",
+        }))
+        .unwrap();
+
+        override_globals.override_globals(&mut globals);
+
+        assert!(!globals.is_enabled("Foo"));
     }
 }

--- a/crates/oxc_linter/src/config/overrides.rs
+++ b/crates/oxc_linter/src/config/overrides.rs
@@ -6,7 +6,7 @@ use serde::{de, ser, Deserialize, Serialize};
 
 use oxc_index::{Idx, IndexVec};
 
-use crate::{config::OxlintRules, LintPlugins};
+use crate::{config::OxlintRules, LintPlugins, OxlintEnv, OxlintGlobals};
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct OverrideId(NonMaxU32);
@@ -72,6 +72,12 @@ pub struct OxlintOverride {
     /// ## Example
     /// `[ "*.test.ts", "*.spec.ts" ]`
     pub files: GlobSet,
+
+    /// Environments enable and disable collections of global variables.
+    pub env: Option<OxlintEnv>,
+
+    /// Enabled or disabled specific global variables.
+    pub globals: Option<OxlintGlobals>,
 
     /// Optionally change what plugins are enabled for this override. When
     /// omitted, the base config's plugins are used.
@@ -153,13 +159,15 @@ impl JsonSchema for GlobSet {
     }
 }
 
+#[cfg(test)]
 mod test {
+    use crate::config::globals::GlobalValue;
+
+    use super::*;
+    use serde_json::{from_value, json};
+
     #[test]
     fn test_globset() {
-        use serde_json::{from_value, json};
-
-        use super::*;
-
         let config: OxlintOverride = from_value(json!({
             "files": ["*.tsx",],
         }))
@@ -177,10 +185,6 @@ mod test {
 
     #[test]
     fn test_parsing_plugins() {
-        use serde_json::{from_value, json};
-
-        use super::*;
-
         let config: OxlintOverride = from_value(json!({
             "files": ["*.tsx"],
         }))
@@ -200,5 +204,46 @@ mod test {
         }))
         .unwrap();
         assert_eq!(config.plugins, Some(LintPlugins::REACT | LintPlugins::TYPESCRIPT));
+    }
+
+    #[test]
+    fn test_parsing_globals() {
+        let config: OxlintOverride = from_value(json!({
+            "files": ["*.tsx"],
+        }))
+        .unwrap();
+        assert!(config.globals.is_none());
+
+        let config: OxlintOverride = from_value(json!({
+            "files": ["*.tsx"],
+            "globals": {
+                "Foo": "readable"
+            },
+        }))
+        .unwrap();
+
+        assert_eq!(*config.globals.unwrap().get("Foo").unwrap(), GlobalValue::Readonly);
+    }
+
+    #[test]
+    fn test_parsing_env() {
+        let config: OxlintOverride = from_value(json!({
+            "files": ["*.tsx"],
+        }))
+        .unwrap();
+        assert!(config.env.is_none());
+
+        let config: OxlintOverride = from_value(json!({
+            "files": ["*.tsx"],
+            "env": {
+                "es2022": true,
+                "es2023": false,
+            },
+        }))
+        .unwrap();
+
+        let env = &config.env.unwrap();
+        assert!(env.contains("es2022"));
+        assert!(!env.contains("es2023"));
     }
 }

--- a/crates/oxc_linter/src/snapshots/schema_json.snap
+++ b/crates/oxc_linter/src/snapshots/schema_json.snap
@@ -355,11 +355,33 @@ expression: json
         "files"
       ],
       "properties": {
+        "env": {
+          "description": "Environments enable and disable collections of global variables.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OxlintEnv"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "files": {
           "description": "A list of glob patterns to override.\n\n## Example `[ \"*.test.ts\", \"*.spec.ts\" ]`",
           "allOf": [
             {
               "$ref": "#/definitions/GlobSet"
+            }
+          ]
+        },
+        "globals": {
+          "description": "Enabled or disabled specific global variables.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OxlintGlobals"
+            },
+            {
+              "type": "null"
             }
           ]
         },

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -351,11 +351,33 @@
         "files"
       ],
       "properties": {
+        "env": {
+          "description": "Environments enable and disable collections of global variables.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OxlintEnv"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
         "files": {
           "description": "A list of glob patterns to override.\n\n## Example `[ \"*.test.ts\", \"*.spec.ts\" ]`",
           "allOf": [
             {
               "$ref": "#/definitions/GlobSet"
+            }
+          ]
+        },
+        "globals": {
+          "description": "Enabled or disabled specific global variables.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OxlintGlobals"
+            },
+            {
+              "type": "null"
             }
           ]
         },


### PR DESCRIPTION
This PR supports `env` and `globals` keys in `overrides[x]`.

I added tests where I could. Snapshot CLI tests are working 🥳 