### PR TITLE
fix(ast): estree compat `Program.sourceType`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -31,7 +31,7 @@ use super::{macros::inherit_variants, *};
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct Program<'a> {
     pub span: Span,
-    #[estree(via = crate::serialize::ESTreeSourceType, ts_type = "SourceType")]
+    #[estree(via = crate::serialize::ESTreeSourceType, ts_type = "ModuleKind")]
     pub source_type: SourceType,
     #[estree(skip)]
     pub source_text: &'a str,

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -31,6 +31,7 @@ use super::{macros::inherit_variants, *};
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct Program<'a> {
     pub span: Span,
+    #[estree(via = crate::serialize::ESTreeSourceType, ts_type = "SourceType")]
     pub source_type: SourceType,
     #[estree(skip)]
     pub source_text: &'a str,

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -18,7 +18,10 @@ impl Serialize for Program<'_> {
         map.serialize_entry("type", "Program")?;
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("sourceType", &self.source_type)?;
+        map.serialize_entry(
+            "sourceType",
+            &crate::serialize::ESTreeSourceType::from(&self.source_type),
+        )?;
         map.serialize_entry("hashbang", &self.hashbang)?;
         map.serialize_entry("directives", &self.directives)?;
         map.serialize_entry("body", &self.body)?;

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -7,7 +7,7 @@ use serde::{
 };
 
 use oxc_allocator::{Box as ArenaBox, Vec as ArenaVec};
-use oxc_span::{Atom, Span};
+use oxc_span::{Atom, SourceType, Span};
 use oxc_syntax::number::BigintBase;
 
 use crate::ast::{
@@ -321,5 +321,19 @@ impl Serialize for JSXMemberExpressionObject<'_> {
                 JSXIdentifier { span: expr.span, name: "this".into() }.serialize(serializer)
             }
         }
+    }
+}
+
+pub struct ESTreeSourceType<'a>(pub &'a SourceType);
+
+impl<'a> From<&'a SourceType> for ESTreeSourceType<'a> {
+    fn from(inner: &'a SourceType) -> Self {
+        Self(inner)
+    }
+}
+
+impl Serialize for ESTreeSourceType<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.module_kind().serialize(serializer)
     }
 }

--- a/napi/parser/test/parse.test.ts
+++ b/napi/parser/test/parse.test.ts
@@ -33,6 +33,7 @@ describe('parse', () => {
       `async function test(x, { y }, [ z ], ...rest) {}`,
     );
     expect(ret.program.body[0]).matchSnapshot();
+    expect(ret.program.sourceType).toMatchInlineSnapshot(`"module"`);
   });
 });
 

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -3,7 +3,7 @@
 
 export interface Program extends Span {
   type: 'Program';
-  sourceType: SourceType;
+  sourceType: ModuleKind;
   hashbang: Hashbang | null;
   directives: Array<Directive>;
   body: Array<Statement>;


### PR DESCRIPTION
part of https://github.com/oxc-project/oxc/issues/2854
ref: https://github.com/estree/estree/blob/master/es2015.md#programs

I tried to move `via` customization on `struct SourceType`, but couldn't find a way maybe because struct is defined in `oxc_span`. For now, I made this as `via` on `Program::source_type` field.