### PR TITLE
fix(linter): correct the `is_reference_to_global_variable`

### DIFF
--- a/crates/oxc_linter/src/config/globals.rs
+++ b/crates/oxc_linter/src/config/globals.rs
@@ -1,4 +1,4 @@
-use std::{borrow, fmt, hash};
+use std::{borrow, fmt, hash, ops::Deref};
 
 use rustc_hash::FxHashMap;
 use schemars::JsonSchema;
@@ -32,6 +32,15 @@ use serde::{de::Visitor, Deserialize, Serialize};
 // <https://eslint.org/docs/v8.x/use/configure/language-options#using-configuration-files-1>
 #[derive(Debug, Default, Deserialize, Serialize, JsonSchema, Clone)]
 pub struct OxlintGlobals(FxHashMap<String, GlobalValue>);
+
+impl Deref for OxlintGlobals {
+    type Target = FxHashMap<String, GlobalValue>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 impl OxlintGlobals {
     pub fn is_enabled<Q>(&self, name: &Q) -> bool
     where

--- a/crates/oxc_linter/src/config/mod.rs
+++ b/crates/oxc_linter/src/config/mod.rs
@@ -14,7 +14,7 @@ pub use config_builder::{ConfigBuilderError, ConfigStoreBuilder};
 pub use config_store::ConfigStore;
 pub(crate) use config_store::ResolvedLinterState;
 pub use env::OxlintEnv;
-pub use globals::OxlintGlobals;
+pub use globals::{GlobalValue, OxlintGlobals};
 pub use overrides::OxlintOverrides;
 pub use oxlintrc::Oxlintrc;
 pub use plugins::LintPlugins;

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -2,6 +2,7 @@
 
 use std::{ops::Deref, path::Path, rc::Rc};
 
+use oxc_ast::ast::IdentifierReference;
 use oxc_cfg::ControlFlowGraph;
 use oxc_diagnostics::{OxcDiagnostic, Severity};
 use oxc_semantic::Semantic;
@@ -10,6 +11,7 @@ use oxc_span::{GetSpan, Span};
 #[cfg(debug_assertions)]
 use crate::rule::RuleFixMeta;
 use crate::{
+    config::GlobalValue,
     disable_directives::DisableDirectives,
     fixer::{FixKind, Message, RuleFix, RuleFixer},
     javascript_globals::GLOBALS,
@@ -146,6 +148,13 @@ impl<'a> LintContext<'a> {
     #[inline]
     pub fn globals(&self) -> &OxlintGlobals {
         &self.parent.config.globals
+    }
+
+    /// Checks if the provided identifier is a reference to a global variable.
+    pub fn is_reference_to_global_variable(&self, ident: &IdentifierReference) -> bool {
+        let name = ident.name.as_str();
+        self.scopes().root_unresolved_references().contains_key(name)
+            && !self.globals().get(name).is_some_and(|value| *value == GlobalValue::Off)
     }
 
     /// Runtime environments turned on/off by the user.

--- a/crates/oxc_linter/src/rules/eslint/no_alert.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_alert.rs
@@ -75,7 +75,7 @@ fn is_global_this_ref_or_global_window<'a>(
         return false;
     };
 
-    if ctx.semantic().is_reference_to_global_variable(ident)
+    if ctx.is_reference_to_global_variable(ident)
         && (expr.is_specific_id(GLOBAL_WINDOW) || (expr.is_specific_id(GLOBAL_THIS)))
     {
         return !is_shadowed(scope_id, ident.name.as_str(), ctx);

--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -84,7 +84,7 @@ impl Rule for NoConsole {
             return;
         };
 
-        if ctx.semantic().is_reference_to_global_variable(ident)
+        if ctx.is_reference_to_global_variable(ident)
             && ident.name == "console"
             && !self.allow.iter().any(|s| mem.static_property_name().is_some_and(|f| f == s))
         {

--- a/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_constant_binary_expression.rs
@@ -168,7 +168,7 @@ impl NoConstantBinaryExpression {
             Expression::CallExpression(call_expr) => {
                 if let Expression::Identifier(ident) = &call_expr.callee {
                     return ["Boolean", "String", "Number"].contains(&ident.name.as_str())
-                        && ctx.semantic().is_reference_to_global_variable(ident);
+                        && ctx.is_reference_to_global_variable(ident);
                 }
                 false
             }
@@ -292,15 +292,12 @@ impl NoConstantBinaryExpression {
             Expression::CallExpression(call_expr) => {
                 if let Expression::Identifier(ident) = &call_expr.callee {
                     if ident.name == "String"
-                        || ident.name == "Number"
-                            && ctx.semantic().is_reference_to_global_variable(ident)
+                        || ident.name == "Number" && ctx.is_reference_to_global_variable(ident)
                     {
                         return true;
                     }
 
-                    if ident.name == "Boolean"
-                        && ctx.semantic().is_reference_to_global_variable(ident)
-                    {
+                    if ident.name == "Boolean" && ctx.is_reference_to_global_variable(ident) {
                         return call_expr
                             .arguments
                             .iter()
@@ -342,7 +339,7 @@ impl NoConstantBinaryExpression {
             Expression::NewExpression(call_expr) => {
                 if let Expression::Identifier(ident) = &call_expr.callee {
                     return ctx.env_contains_var(ident.name.as_str())
-                        && ctx.semantic().is_reference_to_global_variable(ident);
+                        && ctx.is_reference_to_global_variable(ident);
                 }
                 false
             }

--- a/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_native_nonconstructor.rs
@@ -54,7 +54,7 @@ impl Rule for NoNewNativeNonconstructor {
             return;
         };
         if matches!(ident.name.as_str(), "Symbol" | "BigInt")
-            && ctx.semantic().is_reference_to_global_variable(ident)
+            && ctx.is_reference_to_global_variable(ident)
         {
             let start = expr.span.start;
             let end = start + 3;

--- a/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new_wrappers.rs
@@ -60,7 +60,7 @@ impl Rule for NoNewWrappers {
             return;
         };
         if (ident.name == "String" || ident.name == "Number" || ident.name == "Boolean")
-            && ctx.semantic().is_reference_to_global_variable(ident)
+            && ctx.is_reference_to_global_variable(ident)
         {
             ctx.diagnostic(no_new_wrappers_diagnostic(ident.name.as_str(), expr.span));
         }

--- a/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
@@ -88,7 +88,7 @@ fn resolve_global_binding<'a, 'b: 'a>(
     let nodes = ctx.nodes();
     let symbols = ctx.symbols();
 
-    if ctx.semantic().is_reference_to_global_variable(ident) {
+    if ctx.is_reference_to_global_variable(ident) {
         return Some(ident.name.as_str());
     }
 

--- a/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_globals.rs
@@ -86,7 +86,7 @@ impl Rule for NoRestrictedGlobals {
                 return;
             };
 
-            if ctx.semantic().is_reference_to_global_variable(ident) {
+            if ctx.is_reference_to_global_variable(ident) {
                 ctx.diagnostic(no_restricted_globals(&ident.name, message, ident.span));
             }
         }

--- a/crates/oxc_linter/src/rules/eslint/prefer_exponentiation_operator.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_exponentiation_operator.rs
@@ -53,9 +53,7 @@ impl Rule for PreferExponentiationOperator {
 
         match member_expor_obj {
             Expression::Identifier(ident) => {
-                if ident.name.as_str() == "Math"
-                    && ctx.semantic().is_reference_to_global_variable(ident)
-                {
+                if ident.name.as_str() == "Math" && ctx.is_reference_to_global_variable(ident) {
                     ctx.diagnostic(prefer_exponentian_operator_diagnostic(call_expr.span));
                 }
             }
@@ -70,7 +68,7 @@ impl Rule for PreferExponentiationOperator {
 
                 if let Expression::Identifier(ident) = member_expr.object().without_parentheses() {
                     if GLOBAL_OBJECT_NAMES.contains(ident.name.as_str())
-                        && ctx.semantic().is_reference_to_global_variable(ident)
+                        && ctx.is_reference_to_global_variable(ident)
                     {
                         ctx.diagnostic(prefer_exponentian_operator_diagnostic(call_expr.span));
                     }

--- a/crates/oxc_linter/src/rules/eslint/prefer_object_spread.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_object_spread.rs
@@ -91,16 +91,13 @@ impl Rule for PreferObjectSpread {
 
         match callee.object().get_inner_expression() {
             Expression::Identifier(ident) => {
-                if ident.name != "Object" || !ctx.semantic().is_reference_to_global_variable(ident)
-                {
+                if ident.name != "Object" || !ctx.is_reference_to_global_variable(ident) {
                     return;
                 }
             }
             Expression::StaticMemberExpression(member_expr) => {
                 if let Expression::Identifier(ident) = member_expr.object.get_inner_expression() {
-                    if ident.name != "globalThis"
-                        || !ctx.semantic().is_reference_to_global_variable(ident)
-                    {
+                    if ident.name != "globalThis" || !ctx.is_reference_to_global_variable(ident) {
                         return;
                     }
                 } else {

--- a/crates/oxc_linter/src/rules/eslint/symbol_description.rs
+++ b/crates/oxc_linter/src/rules/eslint/symbol_description.rs
@@ -59,7 +59,7 @@ impl Rule for SymbolDescription {
 
         if ident.name == "Symbol"
             && call_expr.arguments.len() == 0
-            && ctx.semantic().is_reference_to_global_variable(ident)
+            && ctx.is_reference_to_global_variable(ident)
         {
             ctx.diagnostic(symbol_description_diagnostic(call_expr.span));
         }

--- a/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
@@ -98,7 +98,7 @@ impl Rule for ValidTypeof {
         }
 
         if let Expression::Identifier(ident) = sibling {
-            if ident.name == "undefined" && ctx.semantic().is_reference_to_global_variable(ident) {
+            if ident.name == "undefined" && ctx.is_reference_to_global_variable(ident) {
                 ctx.diagnostic_with_fix(
                     if self.require_string_literals {
                         not_string(

--- a/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
+++ b/crates/oxc_linter/src/rules/jest/no_disabled_tests.rs
@@ -142,9 +142,7 @@ fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>)
                 ctx.diagnostic(no_disabled_tests_diagnostic(error, help, call_expr.callee.span()));
             }
         } else if let Expression::Identifier(ident) = &call_expr.callee {
-            if ident.name.as_str() == "pending"
-                && ctx.semantic().is_reference_to_global_variable(ident)
-            {
+            if ident.name.as_str() == "pending" && ctx.is_reference_to_global_variable(ident) {
                 // `describe('foo', function () { pending() })`
                 let (error, help) = Message::Pending.details();
                 ctx.diagnostic(no_disabled_tests_diagnostic(error, help, call_expr.span));
@@ -268,7 +266,7 @@ fn test() {
         r#"it("contains a call to pending", function () { pending() })"#,
         "pending();",
         r#"
-            import { describe } from 'vitest'; 
+            import { describe } from 'vitest';
             describe.skip("foo", function () {})
         "#,
     ];

--- a/crates/oxc_linter/src/rules/promise/avoid_new.rs
+++ b/crates/oxc_linter/src/rules/promise/avoid_new.rs
@@ -53,7 +53,7 @@ impl Rule for AvoidNew {
             return;
         };
 
-        if ident.name == "Promise" && ctx.semantic().is_reference_to_global_variable(ident) {
+        if ident.name == "Promise" && ctx.is_reference_to_global_variable(ident) {
             ctx.diagnostic(avoid_new_promise_diagnostic(expr.span));
         }
     }

--- a/crates/oxc_linter/src/rules/promise/no_new_statics.rs
+++ b/crates/oxc_linter/src/rules/promise/no_new_statics.rs
@@ -57,7 +57,7 @@ impl Rule for NoNewStatics {
             return;
         };
 
-        if ident.name != "Promise" || !ctx.semantic().is_reference_to_global_variable(ident) {
+        if ident.name != "Promise" || !ctx.is_reference_to_global_variable(ident) {
             return;
         }
 

--- a/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
@@ -355,7 +355,7 @@ impl Rule for ExhaustiveDeps {
                     Expression::ArrayExpression(array_expr) => Some(array_expr),
                     Expression::Identifier(ident)
                         if ident.name == "undefined"
-                            && ctx.semantic().is_reference_to_global_variable(ident) =>
+                            && ctx.is_reference_to_global_variable(ident) =>
                     {
                         None
                     }

--- a/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
+++ b/crates/oxc_linter/src/rules/unicorn/new_for_builtins.rs
@@ -101,7 +101,7 @@ fn is_expr_global_builtin<'a, 'b>(
 ) -> Option<&'b str> {
     match expr {
         Expression::Identifier(ident) => {
-            if !ctx.semantic().is_reference_to_global_variable(ident) {
+            if !ctx.is_reference_to_global_variable(ident) {
                 return None;
             }
             Some(ident.name.as_str())

--- a/crates/oxc_linter/src/snapshots/jest_no_disabled_tests.snap
+++ b/crates/oxc_linter/src/snapshots/jest_no_disabled_tests.snap
@@ -248,7 +248,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint-plugin-jest(no-disabled-tests): Disabled test suite
    ╭─[no_disabled_tests.tsx:3:13]
- 2 │             import { describe } from 'vitest'; 
+ 2 │             import { describe } from 'vitest';
  3 │             describe.skip("foo", function () {})
    ·             ─────────────
  4 │         


### PR DESCRIPTION
              Can you do a fix PR for the global reference problem (semantic + `globals`) to reduce the changes of this PR?

_Originally posted by @Boshen in https://github.com/oxc-project/oxc/pull/8845#pullrequestreview-2597750513_
            