### PR TITLE
fix(ast): estree compat `MemberExpression`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -488,6 +488,7 @@ pub use match_member_expression;
 pub struct ComputedMemberExpression<'a> {
     pub span: Span,
     pub object: Expression<'a>,
+    #[estree(rename = "property")]
     pub expression: Expression<'a>,
     pub optional: bool, // for optional chaining
 }

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -483,7 +483,7 @@ pub use match_member_expression;
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(via = crate::serialize::ESTreeComputedMemberExpression)]
+#[estree(via = crate::serialize::ESTreeComputedMemberExpression, rename = "MemberExpression", add_ts = "computed: true")]
 
 pub struct ComputedMemberExpression<'a> {
     pub span: Span,
@@ -498,7 +498,7 @@ pub struct ComputedMemberExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(via = crate::serialize::ESTreeStaticMemberExpression)]
+#[estree(via = crate::serialize::ESTreeStaticMemberExpression, rename = "MemberExpression", add_ts = "computed: false")]
 pub struct StaticMemberExpression<'a> {
     pub span: Span,
     pub object: Expression<'a>,
@@ -512,6 +512,7 @@ pub struct StaticMemberExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[estree(rename = "MemberExpression", add_ts = "computed: false")]
 pub struct PrivateFieldExpression<'a> {
     pub span: Span,
     pub object: Expression<'a>,

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -483,7 +483,7 @@ pub use match_member_expression;
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(via = crate::serialize::ESTreeComputedMemberExpression, rename = "MemberExpression", add_ts = "computed: true")]
+#[estree(rename = "MemberExpression", add_ts = "computed: true", add_entry(computed = true))]
 
 pub struct ComputedMemberExpression<'a> {
     pub span: Span,
@@ -498,7 +498,7 @@ pub struct ComputedMemberExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(via = crate::serialize::ESTreeStaticMemberExpression, rename = "MemberExpression", add_ts = "computed: false")]
+#[estree(rename = "MemberExpression", add_ts = "computed: false", add_entry(computed = false))]
 pub struct StaticMemberExpression<'a> {
     pub span: Span,
     pub object: Expression<'a>,
@@ -512,7 +512,7 @@ pub struct StaticMemberExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "MemberExpression", add_ts = "computed: false")]
+#[estree(rename = "MemberExpression", add_ts = "computed: false", add_entry(computed = false))]
 pub struct PrivateFieldExpression<'a> {
     pub span: Span,
     pub object: Expression<'a>,

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -483,6 +483,8 @@ pub use match_member_expression;
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[estree(via = crate::serialize::ESTreeComputedMemberExpression)]
+
 pub struct ComputedMemberExpression<'a> {
     pub span: Span,
     pub object: Expression<'a>,
@@ -496,6 +498,7 @@ pub struct ComputedMemberExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[estree(via = crate::serialize::ESTreeStaticMemberExpression)]
 pub struct StaticMemberExpression<'a> {
     pub span: Span,
     pub object: Expression<'a>,

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -484,7 +484,6 @@ pub use match_member_expression;
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(rename = "MemberExpression", add_ts = "computed: true", add_entry(computed = true))]
-
 pub struct ComputedMemberExpression<'a> {
     pub span: Span,
     pub object: Expression<'a>,

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -346,27 +346,13 @@ impl Serialize for MemberExpression<'_> {
 
 impl Serialize for ComputedMemberExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ComputedMemberExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("object", &self.object)?;
-        map.serialize_entry("expression", &self.expression)?;
-        map.serialize_entry("optional", &self.optional)?;
-        map.end()
+        crate::serialize::ESTreeComputedMemberExpression::from(self).serialize(serializer)
     }
 }
 
 impl Serialize for StaticMemberExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "StaticMemberExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("object", &self.object)?;
-        map.serialize_entry("property", &self.property)?;
-        map.serialize_entry("optional", &self.optional)?;
-        map.end()
+        crate::serialize::ESTreeStaticMemberExpression::from(self).serialize(serializer)
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -351,7 +351,7 @@ impl Serialize for ComputedMemberExpression<'_> {
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
         map.serialize_entry("object", &self.object)?;
-        map.serialize_entry("expression", &self.expression)?;
+        map.serialize_entry("property", &self.expression)?;
         map.serialize_entry("optional", &self.optional)?;
         map.serialize_entry("computed", &true)?;
         map.end()

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -346,13 +346,29 @@ impl Serialize for MemberExpression<'_> {
 
 impl Serialize for ComputedMemberExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        crate::serialize::ESTreeComputedMemberExpression::from(self).serialize(serializer)
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "MemberExpression")?;
+        map.serialize_entry("start", &self.span.start)?;
+        map.serialize_entry("end", &self.span.end)?;
+        map.serialize_entry("object", &self.object)?;
+        map.serialize_entry("expression", &self.expression)?;
+        map.serialize_entry("optional", &self.optional)?;
+        map.serialize_entry("computed", &true)?;
+        map.end()
     }
 }
 
 impl Serialize for StaticMemberExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        crate::serialize::ESTreeStaticMemberExpression::from(self).serialize(serializer)
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "MemberExpression")?;
+        map.serialize_entry("start", &self.span.start)?;
+        map.serialize_entry("end", &self.span.end)?;
+        map.serialize_entry("object", &self.object)?;
+        map.serialize_entry("property", &self.property)?;
+        map.serialize_entry("optional", &self.optional)?;
+        map.serialize_entry("computed", &false)?;
+        map.end()
     }
 }
 
@@ -365,6 +381,7 @@ impl Serialize for PrivateFieldExpression<'_> {
         map.serialize_entry("object", &self.object)?;
         map.serialize_entry("field", &self.field)?;
         map.serialize_entry("optional", &self.optional)?;
+        map.serialize_entry("computed", &false)?;
         map.end()
     }
 }

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -359,7 +359,7 @@ impl Serialize for StaticMemberExpression<'_> {
 impl Serialize for PrivateFieldExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "PrivateFieldExpression")?;
+        map.serialize_entry("type", "MemberExpression")?;
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
         map.serialize_entry("object", &self.object)?;

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -11,7 +11,10 @@ use oxc_span::{Atom, Span};
 use oxc_syntax::number::BigintBase;
 
 use crate::ast::{
-    BigIntLiteral, BindingPatternKind, BooleanLiteral, ComputedMemberExpression, Directive, Elision, FormalParameters, JSXElementName, JSXIdentifier, JSXMemberExpressionObject, NullLiteral, NumericLiteral, Program, RegExpFlags, RegExpLiteral, RegExpPattern, Statement, StaticMemberExpression, StringLiteral, TSModuleBlock, TSTypeAnnotation
+    BigIntLiteral, BindingPatternKind, BooleanLiteral, ComputedMemberExpression, Directive,
+    Elision, FormalParameters, JSXElementName, JSXIdentifier, JSXMemberExpressionObject,
+    NullLiteral, NumericLiteral, Program, RegExpFlags, RegExpLiteral, RegExpPattern, Statement,
+    StaticMemberExpression, StringLiteral, TSModuleBlock, TSTypeAnnotation,
 };
 
 #[derive(Serialize)]

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -2,7 +2,7 @@ use cow_utils::CowUtils;
 use num_bigint::BigInt;
 use num_traits::Num;
 use serde::{
-    ser::{SerializeMap, SerializeSeq, Serializer},
+    ser::{SerializeSeq, Serializer},
     Serialize,
 };
 
@@ -11,10 +11,10 @@ use oxc_span::{Atom, Span};
 use oxc_syntax::number::BigintBase;
 
 use crate::ast::{
-    BigIntLiteral, BindingPatternKind, BooleanLiteral, ComputedMemberExpression, Directive,
-    Elision, FormalParameters, JSXElementName, JSXIdentifier, JSXMemberExpressionObject,
-    NullLiteral, NumericLiteral, Program, RegExpFlags, RegExpLiteral, RegExpPattern, Statement,
-    StaticMemberExpression, StringLiteral, TSModuleBlock, TSTypeAnnotation,
+    BigIntLiteral, BindingPatternKind, BooleanLiteral, Directive, Elision, FormalParameters,
+    JSXElementName, JSXIdentifier, JSXMemberExpressionObject, NullLiteral, NumericLiteral, Program,
+    RegExpFlags, RegExpLiteral, RegExpPattern, Statement, StringLiteral, TSModuleBlock,
+    TSTypeAnnotation,
 };
 
 #[derive(Serialize)]
@@ -321,46 +321,5 @@ impl Serialize for JSXMemberExpressionObject<'_> {
                 JSXIdentifier { span: expr.span, name: "this".into() }.serialize(serializer)
             }
         }
-    }
-}
-
-// TODO: come up with a macro to add `computed: true/false` constant?
-pub struct ESTreeStaticMemberExpression<'a, 'b>(&'a StaticMemberExpression<'b>);
-
-pub struct ESTreeComputedMemberExpression<'a, 'b>(&'a ComputedMemberExpression<'b>);
-
-impl<'a, 'b> From<&'a StaticMemberExpression<'b>> for ESTreeStaticMemberExpression<'a, 'b> {
-    fn from(inner: &'a StaticMemberExpression<'b>) -> Self {
-        Self(inner)
-    }
-}
-
-impl<'a, 'b> From<&'a ComputedMemberExpression<'b>> for ESTreeComputedMemberExpression<'a, 'b> {
-    fn from(inner: &'a ComputedMemberExpression<'b>) -> Self {
-        Self(inner)
-    }
-}
-impl Serialize for ESTreeStaticMemberExpression<'_, '_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "MemberExpression")?;
-        self.0.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.serialize_entry("object", &self.0.object)?;
-        map.serialize_entry("property", &self.0.property)?;
-        map.serialize_entry("optional", &self.0.optional)?;
-        map.serialize_entry("computed", &false)?;
-        map.end()
-    }
-}
-impl Serialize for ESTreeComputedMemberExpression<'_, '_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "MemberExpression")?;
-        self.0.span.serialize(serde::__private::ser::FlatMapSerializer(&mut map))?;
-        map.serialize_entry("object", &self.0.object)?;
-        map.serialize_entry("property", &self.0.expression)?;
-        map.serialize_entry("optional", &self.0.optional)?;
-        map.serialize_entry("computed", &true)?;
-        map.end()
     }
 }

--- a/napi/parser/test/__snapshots__/parse.test.ts.snap
+++ b/napi/parser/test/__snapshots__/parse.test.ts.snap
@@ -1,5 +1,59 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`parse > estree MemberExpression 1`] = `
+[
+  {
+    "end": 15,
+    "expression": {
+      "computed": false,
+      "end": 14,
+      "object": {
+        "end": 3,
+        "name": "obj",
+        "start": 0,
+        "type": "Identifier",
+      },
+      "optional": false,
+      "property": {
+        "end": 14,
+        "name": "staticProp",
+        "start": 4,
+        "type": "Identifier",
+      },
+      "start": 0,
+      "type": "MemberExpression",
+    },
+    "start": 0,
+    "type": "ExpressionStatement",
+  },
+  {
+    "end": 36,
+    "expression": {
+      "computed": true,
+      "end": 35,
+      "object": {
+        "end": 19,
+        "name": "obj",
+        "start": 16,
+        "type": "Identifier",
+      },
+      "optional": false,
+      "property": {
+        "end": 34,
+        "raw": ""computedProp"",
+        "start": 20,
+        "type": "Literal",
+        "value": "computedProp",
+      },
+      "start": 16,
+      "type": "MemberExpression",
+    },
+    "start": 16,
+    "type": "ExpressionStatement",
+  },
+]
+`;
+
 exports[`parse > estree function params 1`] = `
 {
   "async": true,

--- a/napi/parser/test/parse.test.ts
+++ b/napi/parser/test/parse.test.ts
@@ -34,6 +34,17 @@ describe('parse', () => {
     );
     expect(ret.program.body[0]).matchSnapshot();
   });
+
+  it('estree MemberExpression', async () => {
+    const ret = await parseAsync(
+      'test.js',
+      `\
+obj.staticProp;
+obj["computedProp"];
+`,
+    );
+    expect(ret.program.body).matchSnapshot();
+  });
 });
 
 describe('error', () => {

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -176,7 +176,7 @@ export type MemberExpression = ComputedMemberExpression | StaticMemberExpression
 export interface ComputedMemberExpression extends Span {
   type: 'MemberExpression';
   object: Expression;
-  expression: Expression;
+  property: Expression;
   optional: boolean;
   computed: true;
 }

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -174,24 +174,27 @@ export interface TemplateElementValue {
 export type MemberExpression = ComputedMemberExpression | StaticMemberExpression | PrivateFieldExpression;
 
 export interface ComputedMemberExpression extends Span {
-  type: 'ComputedMemberExpression';
+  type: 'MemberExpression';
   object: Expression;
   expression: Expression;
   optional: boolean;
+  computed: true;
 }
 
 export interface StaticMemberExpression extends Span {
-  type: 'StaticMemberExpression';
+  type: 'MemberExpression';
   object: Expression;
   property: IdentifierName;
   optional: boolean;
+  computed: false;
 }
 
 export interface PrivateFieldExpression extends Span {
-  type: 'PrivateFieldExpression';
+  type: 'MemberExpression';
   object: Expression;
   field: PrivateIdentifier;
   optional: boolean;
+  computed: false;
 }
 
 export interface CallExpression extends Span {

--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -7,6 +7,7 @@ use quote::quote;
 use syn::{parse_str, Type};
 
 use crate::{
+    parse::attr::AttrPartListElement,
     schema::{Def, EnumDef, FieldDef, Schema, StructDef, TypeDef, VariantDef},
     utils::number_lit,
     Result,
@@ -105,6 +106,21 @@ fn parse_estree_attr(location: AttrLocation, part: AttrPart) -> Result<()> {
             AttrPart::Tag("no_type") => struct_def.estree.no_type = true,
             AttrPart::Tag("custom_serialize") => struct_def.estree.custom_serialize = true,
             AttrPart::Tag("no_ts_def") => struct_def.estree.custom_ts_def = Some(String::new()),
+            AttrPart::List("add_entry", args) => {
+                struct_def.estree.add_entry = {
+                    let args = args
+                        .into_iter()
+                        .map(|list_element| match list_element {
+                            AttrPartListElement::String(name, value) => Ok((name, value)),
+                            _ => Err(()),
+                        })
+                        .collect::<Result<Vec<(String, String)>>>()?;
+                    if args.is_empty() {
+                        return Err(());
+                    }
+                    Some(args)
+                }
+            }
             AttrPart::String("add_ts", value) => struct_def.estree.add_ts = Some(value),
             AttrPart::String("custom_ts_def", value) => {
                 struct_def.estree.custom_ts_def = Some(value);
@@ -198,11 +214,23 @@ fn generate_body_for_struct(struct_def: &StructDef, schema: &Schema) -> TokenStr
         quote!()
     };
 
+    let add_entry = match &struct_def.estree.add_entry {
+        Some(add_entry) => {
+            let key = &add_entry[0].0;
+            let value = parse_str::<syn::Expr>(&add_entry[0].1).unwrap();
+            quote! {
+                map.serialize_entry(#key, &#value)?;
+            }
+        }
+        None => quote!(),
+    };
+
     let stmts = gen.stmts;
     quote! {
         let mut map = serializer.serialize_map(None)?;
         #type_field
         #stmts
+        #add_entry
         map.end()
     }
 }

--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -107,19 +107,17 @@ fn parse_estree_attr(location: AttrLocation, part: AttrPart) -> Result<()> {
             AttrPart::Tag("custom_serialize") => struct_def.estree.custom_serialize = true,
             AttrPart::Tag("no_ts_def") => struct_def.estree.custom_ts_def = Some(String::new()),
             AttrPart::List("add_entry", args) => {
-                struct_def.estree.add_entry = {
-                    let args = args
-                        .into_iter()
-                        .map(|list_element| match list_element {
-                            AttrPartListElement::String(name, value) => Ok((name, value)),
-                            _ => Err(()),
-                        })
-                        .collect::<Result<Vec<(String, String)>>>()?;
-                    if args.is_empty() {
-                        return Err(());
-                    }
-                    Some(args)
+                let args = args
+                    .into_iter()
+                    .map(|list_element| match list_element {
+                        AttrPartListElement::String(name, value) => Ok((name, value)),
+                        _ => Err(()),
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+                if args.is_empty() {
+                    return Err(());
                 }
+                struct_def.estree.add_entry = Some(args);
             }
             AttrPart::String("add_ts", value) => struct_def.estree.add_ts = Some(value),
             AttrPart::String("custom_ts_def", value) => {

--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -216,8 +216,8 @@ fn generate_body_for_struct(struct_def: &StructDef, schema: &Schema) -> TokenStr
 
     let add_entry = match &struct_def.estree.add_entry {
         Some(add_entry) => {
-            let key = &add_entry[0].0;
-            let value = parse_str::<syn::Expr>(&add_entry[0].1).unwrap();
+            let (key, value) = &add_entry[0];
+            let value = parse_str::<syn::Expr>(value).unwrap();
             quote! {
                 map.serialize_entry(#key, &#value)?;
             }

--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -212,15 +212,12 @@ fn generate_body_for_struct(struct_def: &StructDef, schema: &Schema) -> TokenStr
         quote!()
     };
 
-    let add_entry = match &struct_def.estree.add_entry {
-        Some(add_entry) => {
-            let (name, value) = &add_entry[0];
-            let value = parse_str::<syn::Expr>(value).unwrap();
-            quote! {
-                map.serialize_entry(#name, &#value)?;
-            }
-        }
-        None => quote!(),
+    let add_entry = if let Some(add_entry) = &struct_def.estree.add_entry {
+        let (name, value) = &add_entry[0];
+        let value = parse_str::<syn::Expr>(value).unwrap();
+        quote!( map.serialize_entry(#name, &#value)?; )
+    } else {
+        quote!()
     };
 
     let stmts = gen.stmts;

--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -214,10 +214,10 @@ fn generate_body_for_struct(struct_def: &StructDef, schema: &Schema) -> TokenStr
 
     let add_entry = match &struct_def.estree.add_entry {
         Some(add_entry) => {
-            let (key, value) = &add_entry[0];
+            let (name, value) = &add_entry[0];
             let value = parse_str::<syn::Expr>(value).unwrap();
             quote! {
-                map.serialize_entry(#key, &#value)?;
+                map.serialize_entry(#name, &#value)?;
             }
         }
         None => quote!(),

--- a/tasks/ast_tools/src/schema/extensions/estree.rs
+++ b/tasks/ast_tools/src/schema/extensions/estree.rs
@@ -8,6 +8,7 @@ pub struct ESTreeStruct {
     pub no_type: bool,
     /// `true` if serializer is implemented manually and should not be generated
     pub custom_serialize: bool,
+    pub add_entry: Option<Vec<(String, String)>>,
     /// Additional fields to add to TS type definition
     pub add_ts: Option<String>,
     /// Custom TS type definition. Does not include `export`.


### PR DESCRIPTION
Part of https://github.com/oxc-project/oxc/issues/2854

I added a bit weird macro `add_entry(computed = true)` to add constant. Likely this is not the best way. I would appreciate any suggestion for a better approach :pray: 