### PR TITLE
fix(minifier): should not merge conditional function calls if referencing the function has a side-effect

### DIFF
--- a/crates/oxc_minifier/tests/peephole/mod.rs
+++ b/crates/oxc_minifier/tests/peephole/mod.rs
@@ -22,7 +22,7 @@ fn integration() {
     return console.log(JSON.stringify(os))
     })",
         r#"require("./index.js")(function(e, os) {
-    return console.log(e || JSON.stringify(os));
+    return e ? console.log(e) : console.log(JSON.stringify(os));
     });"#,
     );
 

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -13,15 +13,15 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 
 555.77 kB  | 271.20 kB  | 270.13 kB  | 88.30 kB   | 90.80 kB   | d3.js     
 
-1.01 MB    | 440.93 kB  | 458.89 kB  | 122.52 kB  | 126.71 kB  | bundle.min.js
+1.01 MB    | 440.94 kB  | 458.89 kB  | 122.52 kB  | 126.71 kB  | bundle.min.js
 
-1.25 MB    | 650.33 kB  | 646.76 kB  | 160.96 kB  | 163.73 kB  | three.js  
+1.25 MB    | 650.34 kB  | 646.76 kB  | 160.96 kB  | 163.73 kB  | three.js  
 
-2.14 MB    | 717.02 kB  | 724.14 kB  | 162.02 kB  | 181.07 kB  | victory.js
+2.14 MB    | 717.04 kB  | 724.14 kB  | 162.02 kB  | 181.07 kB  | victory.js
 
-3.20 MB    | 1.01 MB    | 1.01 MB    | 324.33 kB  | 331.56 kB  | echarts.js
+3.20 MB    | 1.01 MB    | 1.01 MB    | 324.34 kB  | 331.56 kB  | echarts.js
 
-6.69 MB    | 2.28 MB    | 2.31 MB    | 467.74 kB  | 488.28 kB  | antd.js   
+6.69 MB    | 2.28 MB    | 2.31 MB    | 467.77 kB  | 488.28 kB  | antd.js   
 
-10.95 MB   | 3.36 MB    | 3.49 MB    | 861.78 kB  | 915.50 kB  | typescript.js
+10.95 MB   | 3.36 MB    | 3.49 MB    | 861.80 kB  | 915.50 kB  | typescript.js
 


### PR DESCRIPTION
`a ? b(c, d) : b(e, d)` should not be compressed to `b(a ? c : e, d)` if `b` has a side effect.
Because `b` may update `a` variable.

For example, compressing the following code changes the behavior.
```js
var foo = () => console.log('foo')
var bar = () => { foo = () => console.log('foo2') }
bar() ? foo(1, 2) : foo(3, 2) // outputs 'foo'

// was compressed into
var foo = () => console.log('foo')
var bar = () => { foo = () => console.log('foo2') }
foo(bar() ? 1 : 3, 2); // outputs 'foo2'
```

We can improve this if we know that `foo` is not updated after it was declared (i.e. `foo` is a const). But I didn't implement it for now.

<details>
<summary>evaluation steps in detail</summary>

Before the compression, the code is evaluated in the following steps:
1. Evaluate `a`
1. Evaluate `b`
1. Evaluate `c` / `e`
1. Evaluate `d`
1. Evaluate `b(c,d)` / `b(e,d)`

After the compression, the code is evaluated in the following steps:
1. Evaluate `b`
1. Evaluate `a`
1. Evaluate `c` / `e`
1. Evaluate `d`
1. Evaluate `b(c,d)` / `b(e,d)`

The steps of 1 and 2 are reversed.

</details>

**References**
- [Spec of conditional expression](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-conditional-operator-runtime-semantics-evaluation)
- [Spec of call expression](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-function-calls-runtime-semantics-evaluation)
