### PR TITLE
refactor(ast_tools): make `AttrPart::List` never empty

### DIFF
--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -114,9 +114,6 @@ fn parse_estree_attr(location: AttrLocation, part: AttrPart) -> Result<()> {
                         _ => Err(()),
                     })
                     .collect::<Result<Vec<_>>>()?;
-                if args.is_empty() {
-                    return Err(());
-                }
                 struct_def.estree.add_entry = Some(args);
             }
             AttrPart::String("add_ts", value) => struct_def.estree.add_ts = Some(value),

--- a/tasks/ast_tools/src/generators/visit.rs
+++ b/tasks/ast_tools/src/generators/visit.rs
@@ -110,9 +110,6 @@ fn parse_visit_attr(location: AttrLocation, part: AttrPart) -> Result<()> {
                     _ => Err(()),
                 })
                 .collect::<Result<Vec<(String, String)>>>()?;
-            if args.is_empty() {
-                return Err(());
-            }
 
             match location {
                 AttrLocation::Struct(struct_def) => {

--- a/tasks/ast_tools/src/parse/attr.rs
+++ b/tasks/ast_tools/src/parse/attr.rs
@@ -144,6 +144,7 @@ pub enum AttrPart<'p> {
     /// e.g. `#[estree(rename = "Foo")]` or `#[estree(via = crate::serialize::OptionVecDefault)]`.
     String(&'p str, String),
     /// List part.
+    /// This `Vec` is never empty.
     /// e.g. `#[visit(args(flags = ScopeFlags::Function))]`.
     List(&'p str, Vec<AttrPartListElement>),
 }

--- a/tasks/ast_tools/src/parse/parse.rs
+++ b/tasks/ast_tools/src/parse/parse.rs
@@ -757,7 +757,7 @@ fn process_attr(
 fn parse_attr_part_list(meta_list: &MetaList) -> Result<Vec<AttrPartListElement>> {
     let metas =
         meta_list.parse_args_with(Punctuated::<Meta, Comma>::parse_terminated).map_err(|_| ())?;
-    metas
+    let list_elements = metas
         .into_iter()
         .map(|meta| match meta {
             Meta::Path(path) => {
@@ -775,7 +775,13 @@ fn parse_attr_part_list(meta_list: &MetaList) -> Result<Vec<AttrPartListElement>
                 Ok(AttrPartListElement::List(part_name, list))
             }
         })
-        .collect()
+        .collect::<Result<Vec<_>>>()?;
+
+    if list_elements.is_empty() {
+        return Err(());
+    }
+
+    Ok(list_elements)
 }
 
 /// Convert an [`Expr`] to a string.


### PR DESCRIPTION
Make invalid attribute syntax like `#[visit(args()]` (nothing inside `args()`) an error in parser, so individual generators don't need to handle it.