### PR TITLE
refactor(ast_tools): add helper methods to `AttrPartListElement`

### DIFF
--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -7,14 +7,14 @@ use quote::quote;
 use syn::{parse_str, Type};
 
 use crate::{
-    parse::attr::AttrPartListElement,
     schema::{Def, EnumDef, FieldDef, Schema, StructDef, TypeDef, VariantDef},
     utils::number_lit,
     Result,
 };
 
 use super::{
-    attr_positions, define_derive, AttrLocation, AttrPart, AttrPositions, Derive, StructOrEnum,
+    attr_positions, define_derive, AttrLocation, AttrPart, AttrPartListElement, AttrPositions,
+    Derive, StructOrEnum,
 };
 
 /// Derive for `Serialize` impls, which serialize AST to ESTree format in JSON.
@@ -109,10 +109,7 @@ fn parse_estree_attr(location: AttrLocation, part: AttrPart) -> Result<()> {
             AttrPart::List("add_entry", args) => {
                 let args = args
                     .into_iter()
-                    .map(|list_element| match list_element {
-                        AttrPartListElement::String(name, value) => Ok((name, value)),
-                        _ => Err(()),
-                    })
+                    .map(AttrPartListElement::try_into_string)
                     .collect::<Result<Vec<_>>>()?;
                 struct_def.estree.add_entry = Some(args);
             }

--- a/tasks/ast_tools/src/derives/mod.rs
+++ b/tasks/ast_tools/src/derives/mod.rs
@@ -6,7 +6,7 @@ use syn::{parse_str, Path};
 
 use crate::{
     output::{output_path, Output},
-    parse::attr::{attr_positions, AttrLocation, AttrPart, AttrPositions},
+    parse::attr::{attr_positions, AttrLocation, AttrPart, AttrPartListElement, AttrPositions},
     schema::{Def, Derives, EnumDef, FileId, Schema, StructDef, TypeDef, TypeId},
     Codegen, Result, Runner,
 };

--- a/tasks/ast_tools/src/generators/visit.rs
+++ b/tasks/ast_tools/src/generators/visit.rs
@@ -105,10 +105,7 @@ fn parse_visit_attr(location: AttrLocation, part: AttrPart) -> Result<()> {
         (AttrPart::List("args", args), location) => {
             let args = args
                 .into_iter()
-                .map(|list_element| match list_element {
-                    AttrPartListElement::String(name, value) => Ok((name, value)),
-                    _ => Err(()),
-                })
+                .map(AttrPartListElement::try_into_string)
                 .collect::<Result<Vec<(String, String)>>>()?;
 
             match location {

--- a/tasks/ast_tools/src/parse/attr.rs
+++ b/tasks/ast_tools/src/parse/attr.rs
@@ -5,7 +5,7 @@ use bitflags::bitflags;
 use crate::{
     codegen::{DeriveId, GeneratorId},
     schema::{Def, EnumDef, StructDef},
-    DERIVES, GENERATORS,
+    Result, DERIVES, GENERATORS,
 };
 
 /// Processor of an attribute - either a derive or a generator.
@@ -154,13 +154,42 @@ pub enum AttrPart<'p> {
 pub enum AttrPartListElement {
     /// Named part.
     /// e.g. `qux` in `#[foo(bar(qux))]`.
-    #[expect(dead_code)]
     Tag(String),
     /// String part.
     /// e.g. `flags = ScopeFlags::Function` in `#[visit(args(flags = ScopeFlags::Function))]`.
     String(String, String),
     /// List part.
     /// e.g. `qux(doof, bing = donk)` in `#[foo(bar(qux(doof, bing = donk)))]`.
-    #[expect(dead_code)]
     List(String, Vec<AttrPartListElement>),
+}
+
+impl AttrPartListElement {
+    /// Unwrap this [`AttrPartListElement`] if it is an [`AttrPartListElement::Tag`].
+    #[expect(dead_code)]
+    pub fn try_into_tag(self) -> Result<String> {
+        if let Self::Tag(name) = self {
+            Ok(name)
+        } else {
+            Err(())
+        }
+    }
+
+    /// Unwrap this [`AttrPartListElement`] if it is an [`AttrPartListElement::String`].
+    pub fn try_into_string(self) -> Result<(String, String)> {
+        if let Self::String(name, value) = self {
+            Ok((name, value))
+        } else {
+            Err(())
+        }
+    }
+
+    /// Unwrap this [`AttrPartListElement`] if it is an [`AttrPartListElement::List`].
+    #[expect(dead_code)]
+    pub fn try_into_list(self) -> Result<(String, Vec<AttrPartListElement>)> {
+        if let Self::List(name, elements) = self {
+            Ok((name, elements))
+        } else {
+            Err(())
+        }
+    }
 }


### PR DESCRIPTION
Add helper methods to `AttrPartListElement` to convert to one of its variants.

Before:

```rs
match list_element {
    AttrPartListElement::String((name, value)) => Ok((name, value)),
    _ => Err(()),
}
```

After:

```rs
list_element.try_into_string()
```
