### PR TITLE
refactor(ast_tools): store lists as `Vec`s not `Option<Vec>`s

### DIFF
--- a/tasks/ast_tools/src/derives/mod.rs
+++ b/tasks/ast_tools/src/derives/mod.rs
@@ -6,7 +6,7 @@ use syn::{parse_str, Path};
 
 use crate::{
     output::{output_path, Output},
-    parse::attr::{attr_positions, AttrLocation, AttrPart, AttrPartListElement, AttrPositions},
+    parse::attr::{attr_positions, AttrLocation, AttrPart, AttrPositions},
     schema::{Def, Derives, EnumDef, FileId, Schema, StructDef, TypeDef, TypeId},
     Codegen, Result, Runner,
 };

--- a/tasks/ast_tools/src/generators/mod.rs
+++ b/tasks/ast_tools/src/generators/mod.rs
@@ -1,6 +1,6 @@
 use crate::{
     output::Output,
-    parse::attr::{attr_positions, AttrLocation, AttrPart, AttrPartListElement, AttrPositions},
+    parse::attr::{attr_positions, AttrLocation, AttrPart, AttrPositions},
     Codegen, Result, Runner, Schema,
 };
 

--- a/tasks/ast_tools/src/schema/extensions/estree.rs
+++ b/tasks/ast_tools/src/schema/extensions/estree.rs
@@ -8,7 +8,7 @@ pub struct ESTreeStruct {
     pub no_type: bool,
     /// `true` if serializer is implemented manually and should not be generated
     pub custom_serialize: bool,
-    pub add_entry: Option<Vec<(String, String)>>,
+    pub add_entry: Vec<(String, String)>,
     /// Additional fields to add to TS type definition
     pub add_ts: Option<String>,
     /// Custom TS type definition. Does not include `export`.

--- a/tasks/ast_tools/src/schema/extensions/visit.rs
+++ b/tasks/ast_tools/src/schema/extensions/visit.rs
@@ -8,7 +8,7 @@ pub struct VisitStruct {
     /// Name of `visit_*` method and `walk_*` function.
     /// `None` if this struct is not visited.
     pub visitor_names: Option<VisitorNames>,
-    pub visit_args: Option<Vec<(String, String)>>,
+    pub visit_args: Vec<(String, String)>,
     pub scope: Option<Scope>,
 }
 
@@ -74,7 +74,7 @@ impl VisitVec {
 /// Details of visiting on a struct field or enum variant.
 #[derive(Default, Debug)]
 pub struct VisitFieldOrVariant {
-    pub visit_args: Option<Vec<(String, String)>>,
+    pub visit_args: Vec<(String, String)>,
 }
 
 /// Names for visitor method and walk function.


### PR DESCRIPTION
In `Schema`, store lists of name-value pairs from attributes (e.g. `#[visit(args(x = 1, y = 2))]`, `#[estree(add_entry(x = 1, y = 2))]`) as `Vec`s, instead of `Option<Vec>`.

This has 3 effects:

1. Attribute parsers can append to the `Vec`. So now these 2 syntaxes are both supported, and equivalent:

```rs
#[estree(add_entry(x = 1, y = 2))]
```

```rs
#[estree(add_entry(x = 1))]
#[estree(add_entry(y = 2))]
```

2. Make multiple items in `#[estree(add_entry(...))]` supported. Previously all except the first were ignored.

3. Shorten code in generators.
