### PR TITLE
refactor(ast): rename `#[estree(add_entry)]` to `#[estree(add_fields)]`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -484,7 +484,7 @@ pub use match_member_expression;
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "MemberExpression", add_ts = "computed: true", add_entry(computed = true))]
+#[estree(rename = "MemberExpression", add_fields(computed = true), add_ts = "computed: true")]
 pub struct ComputedMemberExpression<'a> {
     pub span: Span,
     pub object: Expression<'a>,
@@ -499,7 +499,7 @@ pub struct ComputedMemberExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "MemberExpression", add_ts = "computed: false", add_entry(computed = false))]
+#[estree(rename = "MemberExpression", add_fields(computed = false), add_ts = "computed: false")]
 pub struct StaticMemberExpression<'a> {
     pub span: Span,
     pub object: Expression<'a>,
@@ -513,7 +513,7 @@ pub struct StaticMemberExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "MemberExpression", add_ts = "computed: false", add_entry(computed = false))]
+#[estree(rename = "MemberExpression", add_fields(computed = false), add_ts = "computed: false")]
 pub struct PrivateFieldExpression<'a> {
     pub span: Span,
     pub object: Expression<'a>,

--- a/tasks/ast_tools/src/schema/extensions/estree.rs
+++ b/tasks/ast_tools/src/schema/extensions/estree.rs
@@ -8,7 +8,9 @@ pub struct ESTreeStruct {
     pub no_type: bool,
     /// `true` if serializer is implemented manually and should not be generated
     pub custom_serialize: bool,
-    pub add_entry: Vec<(String, String)>,
+    /// Additional fields to add to struct in ESTree AST.
+    /// `(name, value)` where `value` is a string which should be parsed as a Rust expression.
+    pub add_fields: Vec<(String, String)>,
     /// Additional fields to add to TS type definition
     pub add_ts: Option<String>,
     /// Custom TS type definition. Does not include `export`.


### PR DESCRIPTION
#8921 introduced attribute to add extra fields to a struct in ESTree AST `#[estree(add_entry(...))]`. Rename it to `#[estree(add_fields(...))]`, as that's more descriptive of what it does.