### PR TITLE
perf(ast): assume `serde_json` output is valid UTF8 string

### DIFF
--- a/tasks/coverage/src/driver.rs
+++ b/tasks/coverage/src/driver.rs
@@ -76,7 +76,7 @@ impl CompilerInterface for Driver {
             self.errors.push(OxcDiagnostic::error("SourceType must not be unambiguous."));
         }
         // Make sure serialization doesn't crash; also for code coverage.
-        let _serializer = program.serializer();
+        program.test_to_json().unwrap();
         ControlFlow::Continue(())
     }
 


### PR DESCRIPTION
`serde_json` produces valid UTF8 output, so when converting serialized JSON to string, there's no need to check the output for UTF8 validity. Skipping that check is a speed-up.

Additionally, add a method to test the serializer without producing any output, and use it in conformance. This will hopefully speed up conformance a little.
