### PR TITLE
fix(mangler, prettier, ast_tools): remove methods which are unstable in our MSRV

### DIFF
--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -201,8 +201,9 @@ impl Mangler {
         let allocator = Allocator::default();
 
         // All symbols with their assigned slots. Keyed by symbol id.
+        // TODO: Use `iter::repeat_n` once our MSRV reaches 1.82.0.
         let mut slots: Vec<'_, Slot> =
-            Vec::from_iter_in(iter::repeat_n(0, symbol_table.len()), &allocator);
+            Vec::from_iter_in(iter::repeat(0).take(symbol_table.len()), &allocator);
 
         // Stores the lived scope ids for each slot. Keyed by slot number.
         let mut slot_liveness: std::vec::Vec<FixedBitSet> = vec![];

--- a/tasks/ast_tools/src/generators/assert_layouts.rs
+++ b/tasks/ast_tools/src/generators/assert_layouts.rs
@@ -164,7 +164,10 @@ fn calculate_layout_for_struct(type_id: TypeId, schema: &mut Schema) -> Layout {
             // Update niche.
             // Take the largest niche. Preference for earlier niche if 2 fields have niches of same size.
             if let Some(field_niche) = &field_layout.niche {
-                if layout.niche.as_ref().is_none_or(|niche| field_niche.count > niche.count) {
+                // TODO: Use `Option::is_none_or` once our MSRV reaches 1.82.0
+                if layout.niche.is_none()
+                    || field_niche.count > layout.niche.as_ref().unwrap().count
+                {
                     let mut niche = field_niche.clone();
                     niche.offset += offset;
                     layout.niche = Some(niche);

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -172,7 +172,13 @@ fn collect_test_files(dir: &Path, filter: Option<&String>) -> Vec<PathBuf> {
         .into_iter()
         .filter_map(Result::ok)
         .filter(|e| !e.file_type().is_dir())
-        .filter(|e| e.path().file_name().is_none_or(|name| name != FORMAT_TEST_SPEC_NAME))
+        .filter(|e| {
+            // TODO: Use `Option::is_none_or` once our MSRV reaches 1.82.0
+            match e.path().file_name() {
+                Some(name) => name != FORMAT_TEST_SPEC_NAME,
+                None => true,
+            }
+        })
         .filter(|e| !IGNORE_TESTS.iter().any(|s| e.path().to_string_lossy().contains(s)))
         .filter(|e| filter.map_or(true, |name| e.path().to_string_lossy().contains(name)))
         .map(|e| e.path().to_path_buf())


### PR DESCRIPTION
Prompted by #8913, I ran `cargo check` on Rust 1.81.0 and found some other places where we use language features which are not stable in our MSRV. This PR fixes them.

Note: The `#[expect]` attribute did not become stable until 1.81.0, and we use it liberally throughout the codebase. So Oxc still won't compile at present on our advertised MSRV (1.80.0).