### PR TITLE
style(all): replace `#[allow]` with `#[expect]`

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -191,7 +191,7 @@ pub struct OutputOptions {
 }
 
 /// Enable Plugins
-#[allow(clippy::struct_field_names)]
+#[expect(clippy::struct_field_names)]
 #[derive(Debug, Default, Clone, Bpaf)]
 pub struct EnablePlugins {
     /// Disable react plugin, which is turned on by default
@@ -270,7 +270,6 @@ pub struct EnablePlugins {
 /// changing default behavior if they're not explicitly passed by the user. This scheme is a bit
 /// convoluted, but needed due to architectural constraints imposed by `bpaf`.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
-#[allow(clippy::enum_variant_names)]
 pub enum OverrideToggle {
     /// Override the option to enabled
     Enable,
@@ -439,7 +438,7 @@ mod lint_options {
     }
 
     #[test]
-    #[allow(clippy::similar_names)]
+    #[expect(clippy::similar_names)]
     fn multiple_paths() {
         let temp_dir = tempfile::tempdir().expect("Could not create a temp dir");
         let file_foo = temp_dir.path().join("foo.js");

--- a/apps/oxlint/src/command/mod.rs
+++ b/apps/oxlint/src/command/mod.rs
@@ -32,7 +32,7 @@ pub struct MiscOptions {
     pub print_config: bool,
 }
 
-#[allow(clippy::ptr_arg)]
+#[expect(clippy::ptr_arg)]
 fn validate_paths(paths: &Vec<PathBuf>) -> bool {
     if paths.is_empty() {
         true

--- a/apps/oxlint/src/output_formatter/json.rs
+++ b/apps/oxlint/src/output_formatter/json.rs
@@ -60,7 +60,6 @@ impl DiagnosticReporter for JsonReporter {
 }
 
 /// <https://github.com/fregante/eslint-formatters/tree/ae1fd9748596447d1fd09625c33d9e7ba9a3d06d/packages/eslint-formatter-json>
-#[allow(clippy::print_stdout)]
 fn format_json(diagnostics: &mut Vec<Error>) -> String {
     let handler = JSONReportHandler::new();
     let messages = diagnostics

--- a/apps/oxlint/src/result.rs
+++ b/apps/oxlint/src/result.rs
@@ -19,7 +19,6 @@ pub enum CliRunResult {
 }
 
 impl Termination for CliRunResult {
-    #[allow(clippy::print_stdout, clippy::print_stderr)]
     fn report(self) -> ExitCode {
         match self {
             Self::None

--- a/crates/oxc/examples/compiler.rs
+++ b/crates/oxc/examples/compiler.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout)]
+#![expect(clippy::print_stdout)]
 
 use std::{env, io, path::Path};
 

--- a/crates/oxc/src/compiler.rs
+++ b/crates/oxc/src/compiler.rs
@@ -263,7 +263,6 @@ pub trait CompilerInterface {
         self.after_isolated_declarations(ret);
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn transform<'a>(
         &self,
         options: &TransformOptions,

--- a/crates/oxc_allocator/src/boxed.rs
+++ b/crates/oxc_allocator/src/boxed.rs
@@ -64,7 +64,7 @@ impl<T> Box<'_, T> {
     /// # SAFETY
     /// Safe to create, but must never be dereferenced, as does not point to a valid `T`.
     /// Only purpose is for mocking types without allocating for const assertions.
-    #[allow(unsafe_code, clippy::missing_safety_doc)]
+    #[expect(unsafe_code, clippy::missing_safety_doc)]
     pub const unsafe fn dangling() -> Self {
         const { Self::ASSERT_T_IS_NOT_DROP };
 

--- a/crates/oxc_allocator/src/convert.rs
+++ b/crates/oxc_allocator/src/convert.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::inline_always)]
+#![expect(clippy::inline_always)]
 
 use crate::{Allocator, Box};
 

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs)] // FIXME
+#![expect(missing_docs)] // FIXME
 
 // NB: `#[span]`, `#[scope(...)]`,`#[visit(...)]` and `#[generate_derive(...)]` do NOT do anything to the code.
 // They are purely markers for codegen used in `tasks/ast_tools` and `crates/oxc_traverse/scripts`. See docs in those crates.

--- a/crates/oxc_ast/src/ast/macros.rs
+++ b/crates/oxc_ast/src/ast/macros.rs
@@ -891,7 +891,6 @@ macro_rules! shared_enum_variants {
             #[inline]
             pub fn $as_child(&self) -> Option<&$child<'a>> {
                 if self.$is_child() {
-                    #[allow(unsafe_code)]
                     // SAFETY: Transmute is safe because discriminants + types are identical between
                     // `$parent` and `$child` for $child variants
                     Some(unsafe { &*std::ptr::from_ref(self).cast::<$child>() })
@@ -904,7 +903,6 @@ macro_rules! shared_enum_variants {
             #[inline]
             pub fn $as_child_mut(&mut self) -> Option<&mut $child<'a>> {
                 if self.$is_child() {
-                    #[allow(unsafe_code)]
                     // SAFETY: Transmute is safe because discriminants + types are identical between
                     // `$parent` and `$child` for $child variants
                     Some(unsafe { &mut *std::ptr::from_mut(self).cast::<$child>() })
@@ -966,7 +964,7 @@ pub(crate) use shared_enum_variants;
 /// <https://doc.rust-lang.org/std/mem/fn.discriminant.html>
 macro_rules! discriminant {
     ($ty:ident :: $variant:ident) => {{
-        #[allow(unsafe_code, clippy::undocumented_unsafe_blocks)]
+        #[expect(clippy::undocumented_unsafe_blocks)]
         unsafe {
             let t = std::mem::ManuallyDrop::new($ty::$variant(oxc_allocator::Box::dangling()));
             *(std::ptr::addr_of!(t).cast::<u8>())

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -2,7 +2,7 @@
 //!
 //! - [AST Spec](https://github.com/typescript-eslint/typescript-eslint/tree/v8.9.0/packages/ast-spec)
 //! - [Archived TypeScript spec](https://github.com/microsoft/TypeScript/blob/3c99d50da5a579d9fa92d02664b1b66d4ff55944/doc/spec-ARCHIVED.md)
-#![allow(missing_docs)] // FIXME
+#![expect(missing_docs)] // FIXME
 
 // NB: `#[span]`, `#[scope(...)]`,`#[visit(...)]` and `#[generate_derive(...)]` do NOT do anything to the code.
 // They are purely markers for codegen used in `tasks/ast_tools` and `crates/oxc_traverse/scripts`. See docs in those crates.

--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -1,9 +1,3 @@
-#![allow(
-    clippy::fn_params_excessive_bools,
-    clippy::must_use_candidate, // must_use_candidate is too annoying for this file
-    clippy::too_many_arguments,
-    clippy::unused_self,
-)]
 #![warn(missing_docs)]
 
 use std::{borrow::Cow, mem};
@@ -16,7 +10,6 @@ use crate::{ast::*, AstBuilder};
 
 /// Type that can be used in any AST builder method call which requires an `IntoIn<'a, Anything<'a>>`.
 /// Pass `NONE` instead of `None::<Anything<'a>>`.
-#[allow(clippy::upper_case_acronyms)]
 pub struct NONE;
 
 impl<'a, T> FromIn<'a, NONE> for Option<Box<'a, T>> {
@@ -105,7 +98,7 @@ impl<'a> AstBuilder<'a> {
     /// This method is completely unsound and should not be used.
     /// We need to remove all uses of it. Please don't add any more!
     /// <https://github.com/oxc-project/oxc/issues/3483>
-    #[allow(clippy::missing_safety_doc)]
+    #[expect(clippy::missing_safety_doc)]
     #[inline]
     pub unsafe fn copy<T>(self, src: &T) -> T {
         // SAFETY: Not safe (see above)

--- a/crates/oxc_ast/src/ast_impl/jsx.rs
+++ b/crates/oxc_ast/src/ast_impl/jsx.rs
@@ -34,7 +34,7 @@ impl<'a> JSXElementName<'a> {
         }
     }
 
-    #[allow(missing_docs)]
+    #[expect(missing_docs)]
     pub fn get_identifier_name(&self) -> Option<Atom<'a>> {
         match self {
             Self::Identifier(id) => Some(id.as_ref().name),

--- a/crates/oxc_ast/src/ast_impl/literal.rs
+++ b/crates/oxc_ast/src/ast_impl/literal.rs
@@ -37,7 +37,7 @@ impl NumericLiteral<'_> {
     /// port from [closure compiler](https://github.com/google/closure-compiler/blob/a4c880032fba961f7a6c06ef99daa3641810bfdd/src/com/google/javascript/jscomp/base/JSCompDoubles.java#L113)
     ///
     /// <https://262.ecma-international.org/5.1/#sec-9.5>
-    #[allow(clippy::cast_possible_truncation)] // for `as i32`
+    #[expect(clippy::cast_possible_truncation)] // for `as i32`
     pub fn ecmascript_to_int32(num: f64) -> i32 {
         // Fast path for most common case. Also covers -0.0
         let int32_value = num as i32;

--- a/crates/oxc_ast/src/ast_kind_impl.rs
+++ b/crates/oxc_ast/src/ast_kind_impl.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs)] // FIXME
+#![expect(missing_docs)] // FIXME
 use oxc_span::Atom;
 use oxc_syntax::scope::ScopeId;
 
@@ -172,7 +172,6 @@ impl<'a> AstKind<'a> {
 }
 
 impl AstKind<'_> {
-    #[allow(clippy::match_same_arms)]
     /// Get the AST kind name with minimal details. Particularly useful for
     /// when debugging an iteration over an AST.
     ///

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -3,7 +3,7 @@
 
 //! AST node factories
 
-#![allow(
+#![expect(
     clippy::default_trait_access,
     clippy::too_many_arguments,
     clippy::fn_params_excessive_bools

--- a/crates/oxc_ast/src/generated/ast_kind.rs
+++ b/crates/oxc_ast/src/generated/ast_kind.rs
@@ -1,7 +1,7 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/generators/ast_kind.rs`
 
-#![allow(missing_docs)]
+#![expect(missing_docs)]
 // FIXME (in ast_tools/src/generators/ast_kind.rs)
 
 use std::ptr;

--- a/crates/oxc_ast/src/generated/derive_get_address.rs
+++ b/crates/oxc_ast/src/generated/derive_get_address.rs
@@ -1,7 +1,7 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/derives/get_address.rs`
 
-#![allow(clippy::match_same_arms)]
+#![expect(clippy::match_same_arms)]
 
 use oxc_allocator::{Address, GetAddress};
 

--- a/crates/oxc_ast/src/generated/derive_get_span.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span.rs
@@ -1,7 +1,7 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/derives/get_span.rs`
 
-#![allow(clippy::match_same_arms)]
+#![expect(clippy::match_same_arms)]
 
 use oxc_span::{GetSpan, Span};
 

--- a/crates/oxc_ast/src/generated/derive_get_span_mut.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span_mut.rs
@@ -1,7 +1,7 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/derives/get_span.rs`
 
-#![allow(clippy::match_same_arms)]
+#![expect(clippy::match_same_arms)]
 
 use oxc_span::{GetSpanMut, Span};
 

--- a/crates/oxc_ast/src/generated/visit.rs
+++ b/crates/oxc_ast/src/generated/visit.rs
@@ -7,7 +7,7 @@
 //! * [visitor pattern](https://rust-unofficial.github.io/patterns/patterns/behavioural/visitor.html)
 //! * [rustc visitor](https://github.com/rust-lang/rust/blob/1.82.0/compiler/rustc_ast/src/visit.rs)
 
-#![allow(unused_variables, clippy::semicolon_if_nothing_returned)]
+#![expect(unused_variables, clippy::semicolon_if_nothing_returned)]
 
 use std::cell::Cell;
 

--- a/crates/oxc_ast/src/generated/visit_mut.rs
+++ b/crates/oxc_ast/src/generated/visit_mut.rs
@@ -7,7 +7,7 @@
 //! * [visitor pattern](https://rust-unofficial.github.io/patterns/patterns/behavioural/visitor.html)
 //! * [rustc visitor](https://github.com/rust-lang/rust/blob/1.82.0/compiler/rustc_ast/src/visit.rs)
 
-#![allow(unused_variables, clippy::semicolon_if_nothing_returned)]
+#![expect(unused_variables, clippy::semicolon_if_nothing_returned)]
 
 use std::cell::Cell;
 

--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -39,9 +39,6 @@
 //! [tsc]: <https://github.com/microsoft/TypeScript>
 //! [`Traverse`]: <https://github.com/oxc-project/oxc/tree/main/crates/oxc_traverse>
 
-// TODO: I'm not sure if it is a but or intentional but clippy needs this allowed both on this
-// module and the generated one.
-#![allow(clippy::self_named_module_files)]
 #![warn(missing_docs)]
 
 #[cfg(feature = "serialize")]
@@ -57,7 +54,7 @@ mod trivia;
 pub mod utf8_to_utf16;
 
 mod generated {
-    #![allow(missing_docs)]
+    #![expect(missing_docs)]
     #[cfg(debug_assertions)]
     pub mod assert_layouts;
     pub mod ast_builder;
@@ -75,7 +72,7 @@ mod generated {
 }
 
 pub mod visit {
-    #![allow(missing_docs)]
+    #![expect(missing_docs)]
     pub use crate::generated::{visit::*, visit_mut::*};
 }
 

--- a/crates/oxc_ast/src/trivia.rs
+++ b/crates/oxc_ast/src/trivia.rs
@@ -1,5 +1,5 @@
 //! Trivias such as comments and irregular whitespaces
-#![allow(missing_docs)] // FIXME
+#![expect(missing_docs)] // FIXME
 
 use std::{
     iter::FusedIterator,

--- a/crates/oxc_ast/src/utf8_to_utf16.rs
+++ b/crates/oxc_ast/src/utf8_to_utf16.rs
@@ -41,7 +41,7 @@ impl Utf8ToUtf16 {
         }
     }
 
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn build_table(&mut self, source_text: &str) {
         // Translation from UTF-8 byte offset to UTF-16 char offset:
         //

--- a/crates/oxc_cfg/src/builder/context.rs
+++ b/crates/oxc_cfg/src/builder/context.rs
@@ -39,7 +39,7 @@ impl<'a> Ctx<'a> {
 }
 
 pub trait CtxCursor {
-    #![allow(clippy::return_self_not_must_use)]
+    #![expect(clippy::return_self_not_must_use)]
     /// Marks the break jump position in the current context.
     fn mark_break(self, jmp_pos: BlockNodeId) -> Self;
     /// Marks the continue jump position in the current context.
@@ -87,9 +87,9 @@ impl CtxCursor for QueryCtx<'_, '_> {
 impl<'a, 'c> QueryCtx<'a, 'c> {
     /// Creates a new `Ctx` with the given `CtxFlags` and returns a `RefCtxCursor` to it.
     #[inline]
-    #[allow(clippy::wrong_self_convention, clippy::new_ret_no_self)]
+    #[expect(clippy::wrong_self_convention, clippy::new_ret_no_self)]
     pub fn new(self, flags: CtxFlags) -> RefCtxCursor<'a, 'c> {
-        #![allow(unsafe_code)]
+        #![expect(unsafe_code)]
         self.0.ctx_stack.push(Ctx::new(self.1, flags));
         // SAFETY: we just pushed this `Ctx` into the stack.
         let ctx = unsafe { self.0.ctx_stack.last_mut().unwrap_unchecked() };

--- a/crates/oxc_cfg/src/lib.rs
+++ b/crates/oxc_cfg/src/lib.rs
@@ -32,7 +32,7 @@ pub type BlockNodeId = petgraph::stable_graph::NodeIndex;
 pub struct BasicBlockId(NonMaxU32);
 
 impl Idx for BasicBlockId {
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn from_usize(idx: usize) -> Self {
         assert!(idx < u32::MAX as usize);
         // SAFETY: We just checked `idx` is valid for `NonMaxU32`

--- a/crates/oxc_cfg/src/visit.rs
+++ b/crates/oxc_cfg/src/visit.rs
@@ -71,15 +71,16 @@ macro_rules! try_control {
     };
     ($e:expr, $p:stmt, $q:stmt) => {
         match $e {
-            x =>
-            {
-                #[allow(clippy::redundant_else)]
-                if x.should_break() {
-                    return x;
-                } else if x.should_prune() {
-                    $p
-                } else {
-                    $q
+            x => {
+                #[allow(clippy::redundant_else, clippy::allow_attributes)]
+                {
+                    if x.should_break() {
+                        return x;
+                    } else if x.should_prune() {
+                        $p
+                    } else {
+                        $q
+                    }
                 }
             }
         }

--- a/crates/oxc_codegen/examples/codegen.rs
+++ b/crates/oxc_codegen/examples/codegen.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout)]
+#![expect(clippy::print_stdout)]
 use std::path::Path;
 
 use oxc_allocator::Allocator;

--- a/crates/oxc_codegen/examples/sourcemap.rs
+++ b/crates/oxc_codegen/examples/sourcemap.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout)]
+#![expect(clippy::print_stdout)]
 use std::{env, path::Path};
 
 use base64::{prelude::BASE64_STANDARD, Engine};

--- a/crates/oxc_codegen/src/code_buffer.rs
+++ b/crates/oxc_codegen/src/code_buffer.rs
@@ -506,7 +506,7 @@ mod test {
     }
 
     #[test]
-    #[allow(clippy::byte_char_slices)]
+    #[expect(clippy::byte_char_slices)]
     fn print_ascii_byte() {
         let mut code = CodeBuffer::new();
         code.print_ascii_byte(b'f');
@@ -519,7 +519,7 @@ mod test {
     }
 
     #[test]
-    #[allow(clippy::byte_char_slices)]
+    #[expect(clippy::byte_char_slices)]
     fn print_byte_unchecked() {
         let mut code = CodeBuffer::new();
         // SAFETY: These bytes are all ASCII
@@ -535,7 +535,7 @@ mod test {
     }
 
     #[test]
-    #[allow(clippy::byte_char_slices)]
+    #[expect(clippy::byte_char_slices)]
     fn print_ascii_bytes() {
         let mut code = CodeBuffer::new();
         code.print_ascii_bytes([b'f', b'o', b'o']);

--- a/crates/oxc_codegen/src/context.rs
+++ b/crates/oxc_codegen/src/context.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs)] // FIXME
+#![expect(missing_docs)] // FIXME
 use bitflags::bitflags;
 
 bitflags! {

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -693,7 +693,7 @@ impl<'a> Codegen<'a> {
 
     // `get_minified_number` from terser
     // https://github.com/terser/terser/blob/c5315c3fd6321d6b2e076af35a70ef532f498505/lib/output.js#L2418
-    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_possible_wrap)]
+    #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_possible_wrap)]
     fn get_minified_number(num: f64, buffer: &mut ryu_js::Buffer) -> Cow<'_, str> {
         use cow_utils::CowUtils;
 

--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -19,7 +19,7 @@ const LINE_SEARCH_LINEAR_ITERATIONS: usize = 16;
 pub struct ColumnOffsetsId(NonMaxU32);
 
 impl Idx for ColumnOffsetsId {
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn from_usize(idx: usize) -> Self {
         assert!(idx < u32::MAX as usize);
         // SAFETY: We just checked `idx` is a legal value for `NonMaxU32`
@@ -64,7 +64,7 @@ pub struct ColumnOffsets {
     columns: Box<[u32]>,
 }
 
-#[allow(clippy::struct_field_names)]
+#[expect(clippy::struct_field_names)]
 pub struct SourcemapBuilder {
     source_id: u32,
     original_source: Arc<str>,
@@ -248,7 +248,7 @@ impl SourcemapBuilder {
         idx
     }
 
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn update_generated_line_and_column(&mut self, output: &[u8]) {
         let remaining = &output[self.last_generated_update..];
 
@@ -327,7 +327,7 @@ impl SourcemapBuilder {
 
             let remaining = &content.as_bytes()[line_byte_offset as usize..];
             for (byte_offset_from_line_start, b) in remaining.iter().enumerate() {
-                #[allow(clippy::cast_possible_truncation)]
+                #[expect(clippy::cast_possible_truncation)]
                 let mut byte_offset_from_line_start = byte_offset_from_line_start as u32;
                 match b {
                     b'\n' => {
@@ -359,7 +359,7 @@ impl SourcemapBuilder {
                         line_byte_offset += byte_offset_from_line_start;
                         let remaining = &content[line_byte_offset as usize..];
                         for (chunk_byte_offset, ch) in remaining.char_indices() {
-                            #[allow(clippy::cast_possible_truncation)]
+                            #[expect(clippy::cast_possible_truncation)]
                             let mut chunk_byte_offset = chunk_byte_offset as u32;
                             for _ in 0..ch.len_utf8() {
                                 columns.push(column);
@@ -382,7 +382,7 @@ impl SourcemapBuilder {
                                 LS | PS => {
                                     chunk_byte_offset += 3;
                                 }
-                                #[allow(clippy::cast_possible_truncation)]
+                                #[expect(clippy::cast_possible_truncation)]
                                 _ => {
                                     // Mozilla's "source-map" library counts columns using UTF-16 code units
                                     column += ch.len_utf16() as u32;
@@ -505,7 +505,7 @@ mod test {
             let mut builder = SourcemapBuilder::new(Path::new("x.js"), source);
             let output: Vec<u8> = source.as_bytes().into();
             for (i, _ch) in source.char_indices() {
-                #[allow(clippy::cast_possible_truncation)]
+                #[expect(clippy::cast_possible_truncation)]
                 builder.add_source_mapping(&output, i as u32, None);
                 assert!(
                     builder.generated_line == line && builder.generated_column == column,

--- a/crates/oxc_codegen/tests/integration/main.rs
+++ b/crates/oxc_codegen/tests/integration/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::missing_panics_doc)]
+#![expect(clippy::missing_panics_doc)]
 pub mod esbuild;
 pub mod jsdoc;
 pub mod legal_comments;

--- a/crates/oxc_ecmascript/src/to_int_32.rs
+++ b/crates/oxc_ecmascript/src/to_int_32.rs
@@ -8,7 +8,7 @@ pub trait ToInt32 {
 }
 
 impl ToInt32 for f64 {
-    #[allow(clippy::float_cmp, clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    #[expect(clippy::float_cmp, clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
     fn to_int_32(&self) -> i32 {
         const SIGN_MASK: u64 = 0x8000_0000_0000_0000;
         const EXPONENT_MASK: u64 = 0x7FF0_0000_0000_0000;

--- a/crates/oxc_isolated_declarations/examples/isolated_declarations.rs
+++ b/crates/oxc_isolated_declarations/examples/isolated_declarations.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout)]
+#![expect(clippy::print_stdout)]
 use std::{env, path::Path};
 
 use oxc_allocator::Allocator;

--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 impl<'a> IsolatedDeclarations<'a> {
-    #[allow(clippy::unused_self)]
+    #[expect(clippy::unused_self)]
     pub(crate) fn is_literal_key(&self, key: &PropertyKey<'a>) -> bool {
         match key {
             PropertyKey::StringLiteral(_)
@@ -63,7 +63,7 @@ impl<'a> IsolatedDeclarations<'a> {
         }
     }
 
-    #[allow(clippy::unused_self)]
+    #[expect(clippy::unused_self)]
     pub(crate) fn transform_accessibility(
         &self,
         accessibility: Option<TSAccessibility>,

--- a/crates/oxc_isolated_declarations/src/diagnostics.rs
+++ b/crates/oxc_isolated_declarations/src/diagnostics.rs
@@ -132,7 +132,6 @@ pub fn computed_property_name(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-#[allow(clippy::needless_pass_by_value)]
 pub fn type_containing_private_name(name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error(format!(
         "TS9039: Type containing private name '{name}' can't be used with --isolatedDeclarations."

--- a/crates/oxc_isolated_declarations/src/enum.rs
+++ b/crates/oxc_isolated_declarations/src/enum.rs
@@ -104,7 +104,7 @@ impl<'a> IsolatedDeclarations<'a> {
         self.evaluate(expr, enum_name, prev_members)
     }
 
-    #[allow(clippy::unused_self, clippy::needless_pass_by_value)]
+    #[expect(clippy::unused_self)]
     fn evaluate_ref(
         &self,
         expr: &Expression<'a>,
@@ -174,7 +174,6 @@ impl<'a> IsolatedDeclarations<'a> {
         }
     }
 
-    #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss, clippy::cast_sign_loss)]
     fn eval_binary_expression(
         &self,
         expr: &BinaryExpression<'a>,
@@ -211,6 +210,7 @@ impl<'a> IsolatedDeclarations<'a> {
             ConstantValue::String(_) => return None,
         };
 
+        #[expect(clippy::cast_sign_loss)]
         match expr.operator {
             BinaryOperator::ShiftRight => Some(ConstantValue::Number(f64::from(
                 left.to_int_32().wrapping_shr(right.to_int_32() as u32),
@@ -240,7 +240,6 @@ impl<'a> IsolatedDeclarations<'a> {
         }
     }
 
-    #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
     fn eval_unary_expression(
         &self,
         expr: &UnaryExpression<'a>,

--- a/crates/oxc_isolated_declarations/src/lib.rs
+++ b/crates/oxc_isolated_declarations/src/lib.rs
@@ -166,7 +166,6 @@ impl<'a> IsolatedDeclarations<'a> {
         }))
     }
 
-    #[allow(clippy::missing_panics_doc)]
     fn transform_statements_on_demand(
         &mut self,
         stmts: &oxc_allocator::Vec<'a, Statement<'a>>,

--- a/crates/oxc_isolated_declarations/src/return_type.rs
+++ b/crates/oxc_isolated_declarations/src/return_type.rs
@@ -36,7 +36,7 @@ use crate::{diagnostics::type_containing_private_name, IsolatedDeclarations};
 /// }
 /// // We can't infer return type if there are multiple return statements with different types
 /// ```
-#[allow(clippy::option_option)]
+#[expect(clippy::option_option)]
 pub struct FunctionReturnType<'a> {
     ast: AstBuilder<'a>,
     return_expression: Option<Option<Expression<'a>>>,

--- a/crates/oxc_language_server/src/capabilities.rs
+++ b/crates/oxc_language_server/src/capabilities.rs
@@ -97,7 +97,7 @@ mod test {
                             // Version: 1.95.3 (user setup)
                             // Commit: f1a4fb101478ce6ec82fe9627c43efbf9e98c813
                             value_set: vec![
-                                #[allow(clippy::manual_string_new)]
+                                #[expect(clippy::manual_string_new)]
                                 "".into(),
                                 "quickfix".into(),
                                 "refactor".into(),
@@ -132,7 +132,7 @@ mod test {
                             // Build #IU-243.22562.145, built on December 8, 2024
                             value_set: vec![
                                 "quickfix".into(),
-                                #[allow(clippy::manual_string_new)]
+                                #[expect(clippy::manual_string_new)]
                                 "".into(),
                                 "source".into(),
                                 "refactor".into(),
@@ -160,7 +160,7 @@ mod test {
                         code_action_kind: CodeActionKindLiteralSupport {
                             // nvim 0.10.3
                             value_set: vec![
-                                #[allow(clippy::manual_string_new)]
+                                #[expect(clippy::manual_string_new)]
                                 "".into(),
                                 "quickfix".into(),
                                 "refactor".into(),

--- a/crates/oxc_language_server/src/linter/mod.rs
+++ b/crates/oxc_language_server/src/linter/mod.rs
@@ -5,7 +5,7 @@ pub mod error_with_position;
 mod isolated_lint_handler;
 pub mod server_linter;
 
-#[allow(clippy::cast_possible_truncation)]
+#[expect(clippy::cast_possible_truncation)]
 pub fn offset_to_position(offset: usize, source_text: &str) -> Position {
     // TODO(perf): share a single instance of `Rope`
     let rope = Rope::from_str(source_text);

--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -463,7 +463,7 @@ impl Backend {
         }
     }
 
-    #[allow(clippy::ptr_arg)]
+    #[expect(clippy::ptr_arg)]
     async fn publish_all_diagnostics(&self, result: &Vec<(PathBuf, Vec<Diagnostic>)>) {
         join_all(result.iter().map(|(path, diagnostics)| {
             self.client.publish_diagnostics(

--- a/crates/oxc_linter/examples/linter.rs
+++ b/crates/oxc_linter/examples/linter.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout)]
+#![expect(clippy::print_stdout)]
 //! The simplest linter
 
 use std::{env, path::Path};

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -137,7 +137,7 @@ mod test {
         };
     }
 
-    #[allow(clippy::default_trait_access)]
+    #[expect(clippy::default_trait_access)]
     fn no_explicit_any() -> RuleWithSeverity {
         RuleWithSeverity::new(
             RuleEnum::TypescriptNoExplicitAny(Default::default()),

--- a/crates/oxc_linter/src/config/overrides.rs
+++ b/crates/oxc_linter/src/config/overrides.rs
@@ -12,7 +12,7 @@ use crate::{config::OxlintRules, LintPlugins};
 pub struct OverrideId(NonMaxU32);
 
 impl Idx for OverrideId {
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn from_usize(idx: usize) -> Self {
         assert!(idx < u32::MAX as usize);
         // SAFETY: We just checked `idx` is a legal value for `NonMaxU32`

--- a/crates/oxc_linter/src/config/rules.rs
+++ b/crates/oxc_linter/src/config/rules.rs
@@ -58,7 +58,6 @@ pub struct ESLintRule {
 }
 
 impl OxlintRules {
-    #[allow(clippy::option_if_let_else, clippy::print_stderr)]
     pub(crate) fn override_rules(&self, rules_for_override: &mut RuleSet, all_rules: &[RuleEnum]) {
         use itertools::Itertools;
         let mut rules_to_replace: Vec<RuleWithSeverity> = vec![];
@@ -187,7 +186,7 @@ impl JsonSchema for OxlintRules {
     }
 
     fn json_schema(gen: &mut SchemaGenerator) -> Schema {
-        #[allow(unused)]
+        #[expect(unused)]
         #[derive(Debug, Clone, JsonSchema)]
         #[serde(untagged)]
         enum DummyRule {
@@ -195,7 +194,7 @@ impl JsonSchema for OxlintRules {
             ToggleAndConfig(Vec<serde_json::Value>),
         }
 
-        #[allow(unused)]
+        #[expect(unused)]
         #[derive(Debug, JsonSchema)]
         #[schemars(
             description = "See [Oxlint Rules](https://oxc.rs/docs/guide/usage/linter/rules.html)"
@@ -354,7 +353,7 @@ impl ESLintRule {
 }
 
 #[cfg(test)]
-#[allow(clippy::default_trait_access)]
+#[expect(clippy::default_trait_access)]
 mod test {
     use serde::Deserialize;
     use serde_json::{json, Value};

--- a/crates/oxc_linter/src/config/settings/jsdoc.rs
+++ b/crates/oxc_linter/src/config/settings/jsdoc.rs
@@ -186,14 +186,8 @@ impl JSDocPluginSettings {
 #[serde(untagged)]
 enum TagNamePreference {
     TagNameOnly(String),
-    ObjectWithMessageAndReplacement {
-        message: String,
-        replacement: String,
-    },
-    ObjectWithMessage {
-        message: String,
-    },
-    #[allow(dead_code)]
+    ObjectWithMessageAndReplacement { message: String, replacement: String },
+    ObjectWithMessage { message: String },
     FalseOnly(bool), // Should care `true`...?
 }
 

--- a/crates/oxc_linter/src/context/host.rs
+++ b/crates/oxc_linter/src/context/host.rs
@@ -106,7 +106,7 @@ impl<'a> ContextHost<'a> {
 
     /// Set the linter configuration for this context.
     #[inline]
-    #[allow(dead_code)] // will be used in up-stack PR
+    #[expect(dead_code)] // will be used in up-stack PR
     pub fn with_config(mut self, config: &Arc<LintConfig>) -> Self {
         let plugins = config.plugins;
         self.config = Arc::clone(config);

--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -1,4 +1,4 @@
-#![allow(rustdoc::private_intra_doc_links)] // useful for intellisense
+#![expect(rustdoc::private_intra_doc_links)] // useful for intellisense
 
 use std::{ops::Deref, path::Path, rc::Rc};
 
@@ -293,7 +293,7 @@ impl<'a> LintContext<'a> {
     /// returns something that can turn into a [`RuleFix`].
     ///
     /// [closure]: <https://doc.rust-lang.org/book/ch13-01-closures.html>
-    #[allow(clippy::missing_panics_doc)] // only panics in debug mode
+    #[cfg_attr(debug_assertions, expect(clippy::missing_panics_doc))] // Only panics in debug mode
     pub fn diagnostic_with_fix_of_kind<C, F>(
         &self,
         diagnostic: OxcDiagnostic,

--- a/crates/oxc_linter/src/disable_directives.rs
+++ b/crates/oxc_linter/src/disable_directives.rs
@@ -84,7 +84,7 @@ impl<'a> DisableDirectivesBuilder<'a> {
         self.intervals.insert(Interval { start, stop, val });
     }
 
-    #[allow(clippy::cast_possible_truncation)] // for `as u32`
+    #[expect(clippy::cast_possible_truncation)] // for `as u32`
     fn build_impl(&mut self, source_text: &'a str, comments: &[Comment]) {
         let source_len = source_text.len() as u32;
         // This algorithm iterates through the comments and builds all intervals

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -83,7 +83,6 @@ impl<'c, 'a: 'c> RuleFixer<'c, 'a> {
     }
 
     /// Delete text covered by a [`Span`]
-    #[allow(clippy::unused_self)]
     pub fn delete_range(&self, span: Span) -> RuleFix<'a> {
         self.new_fix(
             CompositeFix::Single(Fix::delete(span)),
@@ -110,7 +109,6 @@ impl<'c, 'a: 'c> RuleFixer<'c, 'a> {
     }
 
     /// Replace a `target` AST node with a `replacement` string.
-    #[allow(clippy::unused_self)]
     pub fn replace<S: Into<Cow<'a, str>>>(&self, target: Span, replacement: S) -> RuleFix<'a> {
         // use an inner function to avoid megamorphic bloat
         fn inner<'a>(
@@ -171,7 +169,6 @@ impl<'c, 'a: 'c> RuleFixer<'c, 'a> {
     }
 
     /// Creates a fix command that inserts text at the specified index in the source text.
-    #[allow(clippy::unused_self)]
     fn insert_text_at(&self, index: u32, text: Cow<'a, str>) -> RuleFix<'a> {
         let fix = Fix::new(text, Span::new(index, index));
         let content = self.possibly_truncate_snippet(&fix.content);
@@ -179,14 +176,13 @@ impl<'c, 'a: 'c> RuleFixer<'c, 'a> {
         self.new_fix(CompositeFix::Single(fix), message)
     }
 
-    #[allow(clippy::unused_self)]
+    #[expect(clippy::unused_self)]
     #[must_use]
     pub fn codegen(self) -> CodeGenerator<'a> {
         CodeGenerator::new()
             .with_options(CodegenOptions { single_quote: true, ..CodegenOptions::default() })
     }
 
-    #[allow(clippy::unused_self)]
     pub fn noop(&self) -> RuleFix<'a> {
         self.new_fix(CompositeFix::None, None)
     }
@@ -196,7 +192,7 @@ impl<'c, 'a: 'c> RuleFixer<'c, 'a> {
         self.possibly_truncate_snippet(snippet)
     }
 
-    #[allow(clippy::unused_self)]
+    #[expect(clippy::unused_self)]
     fn possibly_truncate_snippet<'s>(&self, snippet: &'s str) -> Cow<'s, str>
     where
         'a: 's,
@@ -215,7 +211,6 @@ impl<'c, 'a: 'c> RuleFixer<'c, 'a> {
 }
 
 pub struct FixResult<'a> {
-    #[allow(unused)]
     pub fixed: bool,
     pub fixed_code: Cow<'a, str>,
     pub messages: Vec<Message<'a>>,
@@ -230,7 +225,7 @@ pub struct Message<'a> {
 }
 
 impl<'a> Message<'a> {
-    #[allow(clippy::cast_possible_truncation)] // for `as u32`
+    #[expect(clippy::cast_possible_truncation)] // for `as u32`
     pub fn new(error: OxcDiagnostic, fix: Option<Fix<'a>>) -> Self {
         let (start, end) = if let Some(labels) = &error.labels {
             let start = labels

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::self_named_module_files)] // for rules.rs
+#![expect(clippy::self_named_module_files)] // for rules.rs
 
 #[cfg(test)]
 mod tester;

--- a/crates/oxc_linter/src/loader/partial_loader/astro.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/astro.rs
@@ -25,7 +25,7 @@ impl<'a> AstroPartialLoader<'a> {
     }
 
     /// Parse `---` frontmatter block
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn parse_frontmatter(&self) -> Option<JavaScriptSource<'a>> {
         let split_finder = Finder::new(ASTRO_SPLIT);
         let offsets = split_finder.find_iter(self.source_text.as_bytes()).collect::<Vec<_>>();
@@ -87,7 +87,7 @@ impl<'a> AstroPartialLoader<'a> {
             };
 
             // NOTE: loader checked that source_text.len() is less than u32::MAX
-            #[allow(clippy::cast_possible_truncation)]
+            #[expect(clippy::cast_possible_truncation)]
             results.push(JavaScriptSource::partial(
                 &self.source_text[js_start..js_end],
                 SourceType::ts(),

--- a/crates/oxc_linter/src/loader/partial_loader/svelte.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/svelte.rs
@@ -45,7 +45,7 @@ impl<'a> SveltePartialLoader<'a> {
         let source_type = SourceType::mjs().with_typescript(is_ts);
 
         // NOTE: loader checked that source_text.len() is less than u32::MAX
-        #[allow(clippy::cast_possible_truncation)]
+        #[expect(clippy::cast_possible_truncation)]
         Some(JavaScriptSource::partial(source_text, source_type, js_start as u32))
     }
 }

--- a/crates/oxc_linter/src/loader/partial_loader/vue.rs
+++ b/crates/oxc_linter/src/loader/partial_loader/vue.rs
@@ -58,7 +58,7 @@ impl<'a> VuePartialLoader<'a> {
         let source_text = &self.source_text[js_start..js_end];
         let source_type = SourceType::mjs().with_typescript(is_ts).with_jsx(is_jsx);
         // NOTE: loader checked that source_text.len() is less than u32::MAX
-        #[allow(clippy::cast_possible_truncation)]
+        #[expect(clippy::cast_possible_truncation)]
         Some(JavaScriptSource::partial(source_text, source_type, js_start as u32))
     }
 }

--- a/crates/oxc_linter/src/loader/source.rs
+++ b/crates/oxc_linter/src/loader/source.rs
@@ -8,7 +8,7 @@ pub struct JavaScriptSource<'a> {
     /// The javascript source could be embedded in some file,
     /// use `start` to record start offset of js block in the original file.
     pub start: u32,
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     is_partial: bool,
 }
 

--- a/crates/oxc_linter/src/module_graph_visitor.rs
+++ b/crates/oxc_linter/src/module_graph_visitor.rs
@@ -1,4 +1,3 @@
-#![allow(missing_docs)] // fixme
 use std::{marker::PhantomData, path::PathBuf, sync::Arc};
 
 use oxc_span::CompactStr;
@@ -143,7 +142,7 @@ struct ModuleGraphVisitor {
 }
 
 impl ModuleGraphVisitor {
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn filter_fold_while<
         T,
         Filter: Fn(ModulePair, &ModuleRecord) -> bool,
@@ -173,7 +172,7 @@ impl ModuleGraphVisitor {
         .into_inner()
     }
 
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn filter_fold_recursive<
         T,
         Filter: Fn(ModulePair, &ModuleRecord) -> bool,

--- a/crates/oxc_linter/src/options/allow_warn_deny.rs
+++ b/crates/oxc_linter/src/options/allow_warn_deny.rs
@@ -97,7 +97,7 @@ impl TryFrom<i64> for AllowWarnDeny {
         if value < 0 {
             return Err(invalid_int_severity("a negative number"));
         }
-        #[allow(clippy::cast_sign_loss)]
+        #[expect(clippy::cast_sign_loss)]
         Self::try_from(value as u64)
     }
 }

--- a/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
+++ b/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
@@ -101,7 +101,7 @@ impl Rule for Eqeqeq {
         let (preferred_operator, preferred_operator_with_padding) =
             to_strict_eq_operator_str(binary_expr.operator);
 
-        #[allow(clippy::cast_possible_truncation)]
+        #[expect(clippy::cast_possible_truncation)]
         let operator_span = {
             let left_end = binary_expr.left.span().end;
             let right_start = binary_expr.right.span().start;

--- a/crates/oxc_linter/src/rules/eslint/max_lines.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_lines.rs
@@ -79,7 +79,7 @@ impl Rule for MaxLines {
         }
     }
 
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn run_once(&self, ctx: &LintContext) {
         let comment_lines = if self.skip_comments {
             let mut comment_lines: usize = 0;

--- a/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_cond_assign.rs
@@ -121,7 +121,7 @@ impl Rule for NoCondAssign {
 }
 
 impl NoCondAssign {
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn emit_diagnostic(ctx: &LintContext<'_>, expr: &AssignmentExpression<'_>) {
         let mut operator_span = Span::new(expr.left.span().end, expr.right.span().start);
         let start =

--- a/crates/oxc_linter/src/rules/eslint/no_else_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_else_return.rs
@@ -259,7 +259,7 @@ fn no_else_return_diagnostic_fix(
     });
 }
 
-#[allow(clippy::cast_possible_truncation)]
+#[expect(clippy::cast_possible_truncation)]
 fn left_offset_for_whitespace(ctx: &LintContext, position: u32) -> u32 {
     if position == 0 {
         return position;

--- a/crates/oxc_linter/src/rules/eslint/no_empty.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_empty.rs
@@ -112,7 +112,7 @@ fn find_finally_start(ctx: &LintContext, finally_clause: &BlockStatement) -> Opt
                         src_chars.get(start) == Some(&c)
                     })
                 {
-                    #[allow(clippy::cast_possible_truncation)]
+                    #[expect(clippy::cast_possible_truncation)]
                     return Some(start as u32);
                 }
                 return None;

--- a/crates/oxc_linter/src/rules/eslint/no_invalid_regexp.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_invalid_regexp.rs
@@ -99,7 +99,7 @@ impl Rule for NoInvalidRegexp {
 
             let mut unique_flags = FxHashSet::default();
             for (idx, ch) in flags_text.char_indices() {
-                #[allow(clippy::cast_possible_truncation)]
+                #[expect(clippy::cast_possible_truncation)]
                 let start = flags_span.start + 1 + idx as u32;
 
                 // Invalid combination: u+v

--- a/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_irregular_whitespace.rs
@@ -41,7 +41,7 @@ impl Rule for NoIrregularWhitespace {
     }
 }
 
-#[allow(clippy::unicode_not_nfc, clippy::invisible_characters)]
+#[expect(clippy::unicode_not_nfc, clippy::invisible_characters)]
 #[test]
 fn test() {
     use crate::tester::Tester;

--- a/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
@@ -128,7 +128,7 @@ impl<'a> RawNum<'a> {
         let precision = self.frac.len();
         if self.int.starts_with('0') {
             let frac_zeros = self.frac.chars().take_while(|&ch| ch == '0').count();
-            #[allow(clippy::cast_possible_wrap)]
+            #[expect(clippy::cast_possible_wrap)]
             let exp = self.exp - 1 - frac_zeros as isize;
             self.frac = &self.frac[frac_zeros..];
 
@@ -156,7 +156,7 @@ impl<'a> RawNum<'a> {
                 },
             }
         } else {
-            #[allow(clippy::cast_possible_wrap)]
+            #[expect(clippy::cast_possible_wrap)]
             let exp = self.exp + self.int.len() as isize - 1;
             if self.int.len() == 1 {
                 ScientificNotation {
@@ -187,7 +187,7 @@ impl NoLossOfPrecision {
     fn not_base_ten_loses_precision(node: &'_ NumericLiteral) -> bool {
         let raw = node.raw.as_ref().unwrap().as_str().cow_replace('_', "");
         let raw = raw.cow_to_ascii_uppercase();
-        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+        #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
         // AST always store number as f64, need a cast to format in bin/oct/hex
         let value = node.value as u64;
         let suffix = if raw.starts_with("0B") {

--- a/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
@@ -83,7 +83,7 @@ fn quick_test(s: &str) -> bool {
     false
 }
 
-#[allow(clippy::cast_possible_truncation)]
+#[expect(clippy::cast_possible_truncation)]
 fn check_string(ctx: &LintContext<'_>, string: &str) {
     lazy_static! {
         static ref NONOCTAL_REGEX: Regex =

--- a/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
@@ -128,7 +128,6 @@ fn resolve_global_binding<'a, 'b: 'a>(
 
 impl Rule for NoObjCalls {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
-        #[allow(clippy::needless_return)]
         let (callee, span) = match node.kind() {
             AstKind::NewExpression(expr) => (&expr.callee, expr.span),
             AstKind::CallExpression(expr) => (&expr.callee, expr.span),

--- a/crates/oxc_linter/src/rules/eslint/no_undef.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_undef.rs
@@ -12,7 +12,6 @@ fn no_undef_diagnostic(name: &str, span: Span) -> OxcDiagnostic {
 
 #[derive(Debug, Default, Clone)]
 pub struct NoUndef {
-    #[allow(dead_code)]
     type_of: bool,
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
@@ -78,7 +78,7 @@ fn is_ambient_namespace(namespace: &TSModuleDeclaration) -> bool {
 }
 
 impl NoUnusedVars {
-    #[allow(clippy::unused_self)]
+    #[expect(clippy::unused_self)]
     pub(super) fn is_allowed_ts_namespace<'a>(
         &self,
         symbol: &Symbol<'_, 'a>,
@@ -109,7 +109,7 @@ impl NoUnusedVars {
         false
     }
 
-    #[allow(clippy::unused_self)]
+    #[expect(clippy::unused_self)]
     pub(super) fn is_allowed_type_parameter(
         &self,
         symbol: &Symbol<'_, '_>,

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_imports.rs
@@ -5,7 +5,7 @@ use super::{count_whitespace_or_commas, NoUnusedVars, Symbol};
 use crate::fixer::{RuleFix, RuleFixer};
 
 impl NoUnusedVars {
-    #[allow(clippy::unused_self)]
+    #[expect(clippy::unused_self)]
     pub(in super::super) fn remove_unused_import_declaration<'a>(
         &self,
         fixer: RuleFixer<'_, 'a>,

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_symbol.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_symbol.rs
@@ -7,7 +7,6 @@ use crate::fixer::{Fix, RuleFix, RuleFixer};
 impl<'s, 'a> Symbol<'s, 'a> {
     /// Delete a single declarator from a [`VariableDeclaration`] list with more
     /// than one declarator.
-    #[allow(clippy::unused_self)]
     pub(super) fn delete_from_list<T>(
         &self,
         fixer: RuleFixer<'_, 'a>,

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_vars.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/fix_vars.rs
@@ -24,7 +24,6 @@ impl NoUnusedVars {
     ///
     /// Only a small set of `varsIgnorePattern` values are supported for
     /// renaming. Feel free to add support for more as needed.
-    #[allow(clippy::cast_possible_truncation)]
     pub(in super::super) fn rename_or_remove_var_declaration<'a>(
         &self,
         fixer: RuleFixer<'_, 'a>,

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/fixers/mod.rs
@@ -8,7 +8,7 @@ use super::{NoUnusedVars, Symbol};
 
 // source text will never be large enough for this usize to be truncated when
 // getting cast to a u32
-#[allow(clippy::cast_possible_truncation)]
+#[expect(clippy::cast_possible_truncation)]
 fn count_whitespace_or_commas<I: Iterator<Item = char>>(iter: I) -> u32 {
     iter.take_while(|c| *c == ',' || c.is_whitespace()).map(|c| c.len_utf8() as u32).sum()
 }

--- a/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_escape.rs
@@ -124,7 +124,7 @@ fn is_within_jsx_attribute_item(id: NodeId, ctx: &LintContext) -> bool {
     false
 }
 
-#[allow(clippy::cast_possible_truncation)]
+#[expect(clippy::cast_possible_truncation)]
 fn check(ctx: &LintContext<'_>, node_id: NodeId, start: u32, offsets: &[usize]) {
     let source_text = ctx.source_text();
     for offset in offsets {

--- a/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_rename.rs
@@ -19,7 +19,6 @@ fn no_useless_rename_diagnostic(span: Span) -> OxcDiagnostic {
 #[derive(Debug, Default, Clone)]
 pub struct NoUselessRename(Box<NoUselessRenameConfig>);
 
-#[allow(clippy::struct_field_names)]
 #[derive(Debug, Default, Clone)]
 pub struct NoUselessRenameConfig {
     ignore_destructuring: bool,

--- a/crates/oxc_linter/src/rules/eslint/prefer_promise_reject_errors.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_promise_reject_errors.rs
@@ -137,7 +137,7 @@ fn check_reject_call(call_expr: &CallExpression, ctx: &LintContext, allow_empty_
     }
 }
 
-#[allow(clippy::float_cmp, clippy::cast_precision_loss)]
+#[expect(clippy::float_cmp, clippy::cast_precision_loss)]
 fn check_reject_in_function(
     params: &Box<'_, FormalParameters<'_>>,
     ctx: &LintContext,

--- a/crates/oxc_linter/src/rules/eslint/yoda.rs
+++ b/crates/oxc_linter/src/rules/eslint/yoda.rs
@@ -264,7 +264,7 @@ fn is_not_yoda(expr: &BinaryExpression) -> bool {
         && is_literal_or_simple_template_literal(expr.right.get_inner_expression())
 }
 
-#[allow(clippy::cast_possible_truncation)]
+#[expect(clippy::cast_possible_truncation)]
 fn do_diagnostic_with_fix(expr: &BinaryExpression, ctx: &LintContext, never: bool) {
     ctx.diagnostic_with_fix(yoda_diagnostic(expr.span, never, expr.operator.as_str()), |fix| {
         let left_span = expr.left.span();

--- a/crates/oxc_linter/src/rules/import/no_cycle.rs
+++ b/crates/oxc_linter/src/rules/import/no_cycle.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::cast_possible_truncation)]
+#![expect(clippy::cast_possible_truncation)]
 use std::{ffi::OsStr, path::Component, sync::Arc};
 
 use cow_utils::CowUtils;
@@ -27,10 +27,8 @@ pub struct NoCycle {
     /// ignore type only imports
     ignore_types: bool,
     /// ignore external modules
-    #[allow(unused)]
     ignore_external: bool,
     /// Allow cyclic dependency if there is at least one dynamic import in the chain
-    #[allow(unused)]
     allow_unsafe_dynamic_cyclic_dependency: bool,
 }
 

--- a/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
+++ b/crates/oxc_linter/src/rules/jest/no_large_snapshots.rs
@@ -284,7 +284,6 @@ impl NoLargeSnapshots {
         ctx.source_text()[start..=end].lines().count() - 1
     }
 
-    #[allow(clippy::unnecessary_wraps)]
     pub fn compile_allowed_snapshots(
         matchers: &serde_json::Map<String, serde_json::Value>,
     ) -> Option<FxHashMap<CompactStr, Vec<CompactStr>>> {

--- a/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_jest_methods.rs
@@ -136,7 +136,6 @@ impl NoRestrictedJestMethods {
         }
     }
 
-    #[allow(clippy::unnecessary_wraps)]
     pub fn compile_restricted_jest_methods(
         matchers: &serde_json::Map<String, serde_json::Value>,
     ) -> Option<FxHashMap<String, String>> {

--- a/crates/oxc_linter/src/rules/jest/no_restricted_matchers.rs
+++ b/crates/oxc_linter/src/rules/jest/no_restricted_matchers.rs
@@ -151,7 +151,6 @@ impl NoRestrictedMatchers {
         chain_call == restriction
     }
 
-    #[allow(clippy::unnecessary_wraps)]
     pub fn compile_restricted_matchers(
         matchers: &serde_json::Map<String, serde_json::Value>,
     ) -> Option<FxHashMap<String, String>> {

--- a/crates/oxc_linter/src/rules/jest/prefer_lowercase_title/mod.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_lowercase_title/mod.rs
@@ -281,7 +281,7 @@ impl PreferLowercaseTitle {
             cow_utils::CowUtils::cow_to_ascii_lowercase(literal)
         };
 
-        #[allow(clippy::cast_possible_truncation)]
+        #[expect(clippy::cast_possible_truncation)]
         let replacement_len = replacement.len() as u32;
 
         ctx.diagnostic_with_fix(prefer_lowercase_title_diagnostic(literal, span), |fixer| {

--- a/crates/oxc_linter/src/rules/jsx_a11y/anchor_ambiguous_text.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/anchor_ambiguous_text.rs
@@ -132,7 +132,7 @@ impl Rule for AnchorAmbiguousText {
 fn normalize_str(text: &str) -> CompactStr {
     // `to_lowercase` is disallowed. however we need to remove certain chars later which requires converting to a String
     // the overhead of going &str -> cow string -> string is greater than just using to_lowercase
-    #[allow(clippy::disallowed_methods)]
+    #[expect(clippy::disallowed_methods)]
     let mut normalized_str = text.to_lowercase();
     normalized_str.retain(|c| {
         c != ','

--- a/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
@@ -87,7 +87,6 @@ impl Rule for NoDuplicateHead {
             }
 
             let node_id = reference.node_id();
-            #[allow(clippy::unnecessary_unwrap)]
             if first_node_id.is_none() {
                 // First `<Head>` found
                 first_node_id = Some(node_id);

--- a/crates/oxc_linter/src/rules/oxc/const_comparisons.rs
+++ b/crates/oxc_linter/src/rules/oxc/const_comparisons.rs
@@ -348,7 +348,7 @@ fn left_side_is_useless(left_cmp_op: CmpOp, ordering: Ordering) -> bool {
             CmpOp::Le | CmpOp::Ge => true,
         }
     } else {
-        #[allow(clippy::match_same_arms)]
+        #[expect(clippy::match_same_arms)]
         match (left_cmp_op.direction(), ordering) {
             (CmpOpDirection::Lesser, Ordering::Less) => false,
             (CmpOpDirection::Lesser, Ordering::Equal) => false,
@@ -361,7 +361,7 @@ fn left_side_is_useless(left_cmp_op: CmpOp, ordering: Ordering) -> bool {
 }
 
 fn comparison_is_possible(left_cmp_direction: CmpOpDirection, ordering: Ordering) -> bool {
-    #[allow(clippy::match_same_arms)]
+    #[expect(clippy::match_same_arms)]
     match (left_cmp_direction, ordering) {
         (CmpOpDirection::Lesser, Ordering::Less | Ordering::Equal) => false,
         (CmpOpDirection::Lesser, Ordering::Greater) => true,

--- a/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
+++ b/crates/oxc_linter/src/rules/oxc/double_comparisons.rs
@@ -46,7 +46,6 @@ declare_oxc_lint!(
     fix
 );
 
-#[allow(clippy::similar_names)]
 impl Rule for DoubleComparisons {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::LogicalExpression(logical_expr) = node.kind() else {

--- a/crates/oxc_linter/src/rules/oxc/no_async_await.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_async_await.rs
@@ -80,7 +80,7 @@ impl Rule for NoAsyncAwait {
 /// "async".len()
 const ASYNC_LEN: u32 = 5;
 
-#[allow(clippy::cast_possible_truncation)]
+#[expect(clippy::cast_possible_truncation)]
 fn report_on_async_span(async_span: Span, ctx: &LintContext<'_>) {
     // find the `async` keyword within the span and report on it
     let Some(async_keyword_offset) = ctx.source_range(async_span).find("async") else {

--- a/crates/oxc_linter/src/rules/oxc/no_async_endpoint_handlers.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_async_endpoint_handlers.rs
@@ -31,7 +31,7 @@ pub fn no_async_handlers(
     registered_span: Option<Span>,
     name: Option<&str>,
 ) -> OxcDiagnostic {
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     const ASYNC_LEN: u32 = "async".len() as u32;
 
     // Only cover "async" in "async function (req, res) {}" or "async (req, res) => {}"

--- a/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_barrel_file.rs
@@ -59,7 +59,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoBarrelFile {
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn from_configuration(value: serde_json::Value) -> Self {
         Self {
             threshold: value

--- a/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
+++ b/crates/oxc_linter/src/rules/oxc/only_used_in_recursion.rs
@@ -426,7 +426,7 @@ enum Direction {
 
 // Skips whitespace and commas in a given direction and
 // returns the next character if found.
-#[allow(clippy::cast_possible_truncation)]
+#[expect(clippy::cast_possible_truncation)]
 fn skip_to_next_char(s: &str, start: u32, direction: &Direction) -> Option<u32> {
     // span is a half-open interval: [start, end)
     // so we should return in that way.

--- a/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
@@ -370,7 +370,6 @@ impl Rule for ExhaustiveDeps {
             }
         });
 
-        #[allow(clippy::mutable_key_type)]
         let (found_dependencies, refs_inside_cleanups) = {
             let mut found_dependencies = ExhaustiveDepsVisitor::new(ctx.semantic());
 
@@ -464,7 +463,6 @@ impl Rule for ExhaustiveDeps {
                 }
             });
 
-        #[allow(clippy::mutable_key_type)]
         let declared_dependencies = {
             let mut declared_dependencies = FxHashSet::default();
             for item in declared_dependencies_iter {
@@ -700,7 +698,7 @@ impl PartialEq for Dependency<'_> {
 impl Eq for Dependency<'_> {}
 
 impl Dependency<'_> {
-    #[allow(clippy::inherent_to_string)]
+    #[expect(clippy::inherent_to_string)]
     fn to_string(&self) -> String {
         std::iter::once(&self.name).chain(self.chain.iter()).map(oxc_span::Atom::as_str).join(".")
     }
@@ -936,7 +934,6 @@ fn is_function_stable<'a, 'b>(
     ctx: &'b LintContext<'a>,
     component_scope_id: ScopeId,
 ) -> bool {
-    #[allow(clippy::mutable_key_type)]
     let deps = {
         let mut collector = ExhaustiveDepsVisitor::new(ctx.semantic());
         collector.visit_function_body(function_body);

--- a/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
+++ b/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
@@ -56,7 +56,7 @@ impl Rule for NoUnescapedEntities {
                     continue;
                 }
                 if let Some(escapes) = DEFAULTS.get(&char) {
-                    #[allow(clippy::cast_possible_truncation)]
+                    #[expect(clippy::cast_possible_truncation)]
                     ctx.diagnostic(no_unescaped_entities_diagnostic(
                         Span::new(
                             jsx_text.span.start + i as u32,

--- a/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
+++ b/crates/oxc_linter/src/rules/react/rules_of_hooks.rs
@@ -251,7 +251,7 @@ impl Rule for RulesOfHooks {
         }
 
         if has_conditional_path_accept_throw(cfg, parent_func, node) {
-            #[allow(clippy::needless_return)]
+            #[expect(clippy::needless_return)]
             return ctx.diagnostic(diagnostics::conditional_hook(span, hook_name));
         }
     }

--- a/crates/oxc_linter/src/rules/typescript/adjacent_overload_signatures.rs
+++ b/crates/oxc_linter/src/rules/typescript/adjacent_overload_signatures.rs
@@ -90,7 +90,7 @@ enum MethodKind {
 }
 
 fn get_kind_from_key(key: &PropertyKey) -> MethodKind {
-    #[allow(clippy::match_same_arms)]
+    #[expect(clippy::match_same_arms)]
     match key {
         PropertyKey::StaticIdentifier(_) => MethodKind::Normal,
         PropertyKey::PrivateIdentifier(_) => MethodKind::Private,

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -322,7 +322,7 @@ fn fixer_error<S: Into<String>, T>(message: S) -> FixerResult<T> {
 }
 
 // import { Foo, Bar } from 'foo' => import type { Foo, Bar } from 'foo'
-#[allow(clippy::unnecessary_cast, clippy::cast_possible_truncation)]
+#[expect(clippy::cast_possible_truncation)]
 fn fix_to_type_import_declaration<'a>(options: &FixOptions<'a, '_>) -> FixerResult<RuleFix<'a>> {
     let FixOptions { fixer, import_decl, type_names, fix_style, ctx } = options;
     let fixer = fixer.for_multifix();

--- a/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_duplicate_enum_values.rs
@@ -87,7 +87,7 @@ declare_oxc_lint!(
 );
 
 impl Rule for NoDuplicateEnumValues {
-    #[allow(clippy::float_cmp)]
+    #[expect(clippy::float_cmp)]
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::TSEnumDeclaration(enum_body) = node.kind() else {
             return;

--- a/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_empty_object_type.rs
@@ -23,7 +23,7 @@ fn no_empty_object_type_diagnostic<S: Into<Cow<'static, str>>>(
 #[derive(Debug, Default, Clone)]
 pub struct NoEmptyObjectType(Box<NoEmptyObjectTypeConfig>);
 
-#[allow(clippy::struct_field_names)]
+#[expect(clippy::struct_field_names)]
 #[derive(Debug, Default, Clone)]
 pub struct NoEmptyObjectTypeConfig {
     /** Whether to allow empty interfaces. */

--- a/crates/oxc_linter/src/rules/typescript/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_namespace.rs
@@ -61,7 +61,7 @@ impl Rule for NoNamespace {
         }
     }
 
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::TSModuleDeclaration(declaration) = node.kind() else {
             return;

--- a/crates/oxc_linter/src/rules/unicorn/empty_brace_spaces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/empty_brace_spaces.rs
@@ -81,7 +81,7 @@ fn remove_empty_braces_spaces(ctx: &LintContext, is_empty_body: bool, span: Span
     }
 }
 
-#[allow(clippy::cast_possible_truncation)]
+#[expect(clippy::cast_possible_truncation)]
 fn get_static_leading_count(span: Span, ctx: &LintContext) -> u32 {
     let src = span.source_text(ctx.source_text());
 

--- a/crates/oxc_linter/src/rules/unicorn/filename_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/filename_case.rs
@@ -44,7 +44,6 @@ fn filename_case_diagnostic(filename: &str, valid_cases: &[(&str, Case)]) -> Oxc
 }
 
 #[derive(Debug, Clone)]
-#[allow(clippy::struct_field_names)]
 pub struct FilenameCase {
     /// Whether kebab case is allowed.
     kebab_case: bool,

--- a/crates/oxc_linter/src/rules/unicorn/no_magic_array_flat_depth.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_magic_array_flat_depth.rs
@@ -85,7 +85,7 @@ impl Rule for NoMagicArrayFlatDepth {
 }
 
 // gets the opening `(` and closing `)` of the argument
-#[allow(clippy::cast_possible_truncation)]
+#[expect(clippy::cast_possible_truncation)]
 fn get_call_expression_parentheses_pos<'a>(
     call_expr: &CallExpression<'a>,
     ctx: &LintContext<'a>,

--- a/crates/oxc_linter/src/rules/unicorn/number_literal_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/number_literal_case.rs
@@ -95,7 +95,7 @@ impl Rule for NumberLiteralCase {
     }
 }
 
-#[allow(clippy::cast_possible_truncation)]
+#[expect(clippy::cast_possible_truncation)]
 fn check_number_literal(number_literal: &str, raw_span: Span) -> Option<(OxcDiagnostic, String)> {
     if number_literal.starts_with("0B") || number_literal.starts_with("0O") {
         return Some((

--- a/crates/oxc_linter/src/rules/unicorn/prefer_string_raw.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_string_raw.rs
@@ -67,7 +67,7 @@ fn unescape_backslash(input: &str, quote: char) -> String {
 }
 
 impl Rule for PreferStringRaw {
-    #[allow(clippy::cast_precision_loss)]
+    #[expect(clippy::cast_precision_loss)]
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let AstKind::StringLiteral(string_literal) = node.kind() else {
             return;

--- a/crates/oxc_linter/src/rules/unicorn/require_array_join_separator.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_array_join_separator.rs
@@ -77,7 +77,7 @@ impl Rule for RequireArrayJoinSeparator {
                         .position(|c| c == '(');
 
                     if let Some(open_bracket) = open_bracket {
-                        #[allow(clippy::cast_possible_truncation)]
+                        #[expect(clippy::cast_possible_truncation)]
                         fixer.insert_text_after_range(
                             Span::new(
                                 0,

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -104,7 +104,7 @@ impl Runtime {
 
     // clippy: the source field is checked and assumed to be less than 4GB, and
     // we assume that the fix offset will not exceed 2GB in either direction
-    #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+    #[expect(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
     pub(super) fn process_path(&self, path: &Path, tx_error: &DiagnosticSender) {
         if self.init_cache_state(path) {
             return;
@@ -192,7 +192,6 @@ impl Runtime {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub(super) fn process_source<'a>(
         &self,
         path: &Path,

--- a/crates/oxc_linter/src/utils/express.rs
+++ b/crates/oxc_linter/src/utils/express.rs
@@ -46,7 +46,7 @@ pub fn as_endpoint_registration<'a, 'n>(
 ///
 /// This will yield a lot of false positives if not called on the results of
 /// [`as_endpoint_registration`].
-#[allow(clippy::similar_names)]
+#[expect(clippy::similar_names)]
 pub fn is_endpoint_handler(maybe_handler: &Expression<'_>) -> bool {
     let params = match maybe_handler {
         Expression::FunctionExpression(f) => &f.params,

--- a/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
+++ b/crates/oxc_linter/src/utils/jest/parse_jest_fn.rs
@@ -354,7 +354,7 @@ pub struct ParsedGeneralJestFnCall<'a> {
     pub kind: JestFnKind,
     pub members: Vec<KnownMemberExpressionProperty<'a>>,
     pub name: Cow<'a, str>,
-    #[allow(unused)]
+    #[expect(unused)]
     pub local: Cow<'a, str>,
 }
 
@@ -362,7 +362,7 @@ pub struct ParsedGeneralJestFnCall<'a> {
 pub struct ParsedExpectFnCall<'a> {
     pub kind: JestFnKind,
     pub members: Vec<KnownMemberExpressionProperty<'a>>,
-    #[allow(unused)]
+    #[expect(unused)]
     pub name: Cow<'a, str>,
     pub local: Cow<'a, str>,
     pub head: KnownMemberExpressionProperty<'a>,

--- a/crates/oxc_linter/tests/integration_test.rs
+++ b/crates/oxc_linter/tests/integration_test.rs
@@ -12,7 +12,7 @@ declare_oxc_lint_test!(
 );
 
 struct TestRule2 {
-    #[allow(dead_code)]
+    #[expect(dead_code)]
     dummy_field: u8,
 }
 

--- a/crates/oxc_macros/src/declare_all_lint_rules.rs
+++ b/crates/oxc_macros/src/declare_all_lint_rules.rs
@@ -48,7 +48,7 @@ impl Parse for AllLintRulesMeta {
     }
 }
 
-#[allow(clippy::cognitive_complexity, clippy::too_many_lines)]
+#[expect(clippy::cognitive_complexity, clippy::too_many_lines)]
 pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
     let AllLintRulesMeta { rules } = metadata;
 
@@ -85,7 +85,7 @@ pub fn declare_all_lint_rules(metadata: AllLintRulesMeta) -> TokenStream {
         use oxc_semantic::SymbolId;
 
         #[derive(Debug, Clone)]
-        #[allow(clippy::enum_variant_names)]
+        #[expect(clippy::enum_variant_names)]
         pub enum RuleEnum {
             #(#struct_names(#struct_names)),*
         }

--- a/crates/oxc_minifier/examples/dce.rs
+++ b/crates/oxc_minifier/examples/dce.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout)]
+#![expect(clippy::print_stdout)]
 use std::path::Path;
 
 use oxc_allocator::Allocator;

--- a/crates/oxc_minifier/examples/mangler.rs
+++ b/crates/oxc_minifier/examples/mangler.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout)]
+#![expect(clippy::print_stdout)]
 use std::path::Path;
 
 use oxc_allocator::Allocator;

--- a/crates/oxc_minifier/examples/minifier.rs
+++ b/crates/oxc_minifier/examples/minifier.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout)]
+#![expect(clippy::print_stdout)]
 use std::path::Path;
 
 use oxc_allocator::Allocator;

--- a/crates/oxc_minifier/src/options.rs
+++ b/crates/oxc_minifier/src/options.rs
@@ -20,7 +20,7 @@ pub struct CompressOptions {
     pub drop_console: bool,
 }
 
-#[allow(clippy::derivable_impls)]
+#[expect(clippy::derivable_impls)]
 impl Default for CompressOptions {
     fn default() -> Self {
         Self { drop_console: false, ..Self::all_true() }

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -477,7 +477,7 @@ impl<'a> PeepholeOptimizations {
                     arg_val.round()
                 }
             }
-            #[allow(clippy::cast_possible_truncation)]
+            #[expect(clippy::cast_possible_truncation)]
             "fround" if arg_val.fract() == 0f64 || arg_val.is_nan() || arg_val.is_infinite() => {
                 f64::from(arg_val as f32)
             }
@@ -825,7 +825,6 @@ impl<'a> PeepholeOptimizations {
             "NEGATIVE_INFINITY" => num(span, f64::NEG_INFINITY),
             "NaN" => num(span, f64::NAN),
             "MAX_SAFE_INTEGER" => {
-                #[allow(clippy::cast_precision_loss)]
                 if self.target < ESTarget::ES2016 {
                     num(span, 2.0f64.powf(53.0) - 1.0)
                 } else {
@@ -834,7 +833,6 @@ impl<'a> PeepholeOptimizations {
                 }
             }
             "MIN_SAFE_INTEGER" => {
-                #[allow(clippy::cast_precision_loss)]
                 if self.target < ESTarget::ES2016 {
                     num(span, -(2.0f64.powf(53.0) - 1.0))
                 } else {

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -797,7 +797,6 @@ impl<'a> PeepholeOptimizations {
     }
 
     // <https://github.com/swc-project/swc/blob/4e2dae558f60a9f5c6d2eac860743e6c0b2ec562/crates/swc_ecma_minifier/src/compress/pure/properties.rs>
-    #[allow(clippy::cast_lossless)]
     fn try_compress_property_key(
         &mut self,
         key: &mut PropertyKey<'a>,

--- a/crates/oxc_napi/src/lib.rs
+++ b/crates/oxc_napi/src/lib.rs
@@ -40,7 +40,7 @@ pub struct ErrorLabel {
 }
 
 impl From<&LabeledSpan> for ErrorLabel {
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn from(label: &LabeledSpan) -> Self {
         Self {
             message: label.label().map(ToString::to_string),

--- a/crates/oxc_parser/examples/parser.rs
+++ b/crates/oxc_parser/examples/parser.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout)]
+#![expect(clippy::print_stdout)]
 use std::{fs, path::Path};
 
 use oxc_allocator::Allocator;

--- a/crates/oxc_parser/examples/regular_expression.rs
+++ b/crates/oxc_parser/examples/regular_expression.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout, clippy::cast_possible_truncation)]
+#![expect(clippy::print_stdout)]
 use std::{env, fs, path::Path, sync::Arc};
 
 use oxc_allocator::Allocator;

--- a/crates/oxc_parser/examples/visitor.rs
+++ b/crates/oxc_parser/examples/visitor.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout)]
+#![expect(clippy::print_stdout)]
 use std::{env, path::Path};
 
 use oxc_allocator::Allocator;

--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -316,7 +316,7 @@ impl<'a> ParserImpl<'a> {
         answer
     }
 
-    #[allow(clippy::inline_always)]
+    #[expect(clippy::inline_always)]
     #[inline(always)] // inline because this is always on a hot path
     pub(crate) fn context<F, T>(&mut self, add_flags: Context, remove_flags: Context, cb: F) -> T
     where

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -385,7 +385,7 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
-    #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
+    #[expect(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
     fn parse_class_method_definition(
         &mut self,
         span: Span,
@@ -450,7 +450,7 @@ impl<'a> ParserImpl<'a> {
     }
 
     /// `FieldDefinition`[?Yield, ?Await] ;
-    #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
+    #[expect(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
     fn parse_class_property_definition(
         &mut self,
         span: Span,
@@ -502,7 +502,7 @@ impl<'a> ParserImpl<'a> {
     }
 
     /// <https://github.com/tc39/proposal-decorators>
-    #[allow(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
+    #[expect(clippy::too_many_arguments, clippy::fn_params_excessive_bools)]
     fn parse_class_accessor_property(
         &mut self,
         span: Span,

--- a/crates/oxc_parser/src/js/grammar.rs
+++ b/crates/oxc_parser/src/js/grammar.rs
@@ -27,7 +27,7 @@ impl<'a> CoverGrammar<'a, Expression<'a>> for AssignmentTarget<'a> {
 }
 
 impl<'a> CoverGrammar<'a, Expression<'a>> for SimpleAssignmentTarget<'a> {
-    #[allow(clippy::only_used_in_recursion)]
+    #[expect(clippy::only_used_in_recursion)]
     fn cover(expr: Expression<'a>, p: &mut ParserImpl<'a>) -> Result<Self> {
         match expr {
             Expression::Identifier(ident) => {

--- a/crates/oxc_parser/src/js/mod.rs
+++ b/crates/oxc_parser/src/js/mod.rs
@@ -1,7 +1,5 @@
 //! JavaScript Parsing Functions
 
-#![allow(clippy::missing_errors_doc)]
-
 mod grammar;
 
 mod arrow;

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -1,7 +1,5 @@
 //! [JSX](https://facebook.github.io/jsx)
 
-#![allow(clippy::missing_errors_doc)]
-
 use oxc_allocator::{Box, Vec};
 use oxc_ast::ast::*;
 use oxc_diagnostics::Result;

--- a/crates/oxc_parser/src/lexer/byte_handlers.rs
+++ b/crates/oxc_parser/src/lexer/byte_handlers.rs
@@ -56,7 +56,7 @@ static BYTE_HANDLERS: [ByteHandler; 256] = [
 ///
 /// ```
 /// const UNI: ByteHandler = {
-///   #[allow(non_snake_case)]
+///   #[expect(non_snake_case)]
 ///   fn UNI(lexer: &mut Lexer) -> Kind {
 ///     lexer.unicode_char_handler()
 ///   }
@@ -66,7 +66,7 @@ static BYTE_HANDLERS: [ByteHandler; 256] = [
 macro_rules! byte_handler {
     ($id:ident($lex:ident) $body:expr) => {
         const $id: ByteHandler = {
-            #[allow(non_snake_case)]
+            #[expect(non_snake_case)]
             fn $id($lex: &mut Lexer) -> Kind {
                 $body
             }
@@ -103,7 +103,7 @@ macro_rules! byte_handler {
 ///
 /// ```
 /// const SPS: ByteHandler = {
-///   #[allow(non_snake_case)]
+///   #[expect(non_snake_case)]
 ///   fn SPS(lexer: &mut Lexer) {
 ///     // SAFETY: This macro is only used for ASCII characters
 ///     unsafe {
@@ -157,7 +157,7 @@ macro_rules! ascii_byte_handler {
 ///
 /// ```
 /// const L_G: ByteHandler = {
-///   #[allow(non_snake_case)]
+///   #[expect(non_snake_case)]
 ///   fn L_G(lexer: &mut Lexer) -> Kind {
 ///     // SAFETY: This macro is only used for ASCII characters
 ///     let id_without_first_char = unsafe { lexer.identifier_name_handler() };

--- a/crates/oxc_parser/src/lexer/kind.rs
+++ b/crates/oxc_parser/src/lexer/kind.rs
@@ -196,7 +196,7 @@ pub enum Kind {
     At,
 }
 
-#[allow(clippy::enum_glob_use)]
+#[allow(clippy::enum_glob_use, clippy::allow_attributes)]
 use Kind::*;
 
 impl Kind {

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -285,7 +285,7 @@ impl<'a> Lexer<'a> {
     /// Peek the next byte, and advance the current position if it matches
     /// the given ASCII char.
     // `#[inline(always)]` to make sure the `assert!` gets optimized out.
-    #[allow(clippy::inline_always)]
+    #[expect(clippy::inline_always)]
     #[inline(always)]
     fn next_ascii_byte_eq(&mut self, b: u8) -> bool {
         // TODO: can be replaced by `std::ascii:Char` once stabilized.

--- a/crates/oxc_parser/src/lexer/search.rs
+++ b/crates/oxc_parser/src/lexer/search.rs
@@ -79,7 +79,7 @@ impl ByteMatchTable {
 /// ```
 /// {
 ///   use crate::lexer::search::ByteMatchTable;
-///   #[allow(clippy::eq_op)]
+///   #[allow(clippy::eq_op, clippy::allow_attributes)]
 ///   const TABLE: ByteMatchTable = ByteMatchTable::new([
 ///     (0u8 < 3),
 ///     (1u8 < 3),
@@ -98,7 +98,7 @@ macro_rules! byte_match_table {
         use crate::lexer::search::ByteMatchTable;
         // Clippy creates warnings because e.g. `byte_match_table!(|b| b == 0)`
         // is expanded to `ByteMatchTable([(0 == 0), ... ])`
-        #[allow(clippy::eq_op)]
+        #[allow(clippy::eq_op, clippy::allow_attributes)]
         const TABLE: ByteMatchTable = seq_macro::seq!($byte in 0u8..=255 {
             ByteMatchTable::new([ #($res,)* ])
         });
@@ -221,7 +221,7 @@ impl SafeByteMatchTable {
 /// ```
 /// {
 ///   use crate::lexer::search::SafeByteMatchTable;
-///   #[allow(clippy::eq_op)]
+///   #[allow(clippy::eq_op, clippy::allow_attributes)]
 ///   const TABLE: SafeByteMatchTable = SafeByteMatchTable::new([
 ///     (!0u8.is_ascii()),
 ///     (!1u8.is_ascii()),
@@ -236,7 +236,7 @@ macro_rules! safe_byte_match_table {
         use crate::lexer::search::SafeByteMatchTable;
         // Clippy creates warnings because e.g. `safe_byte_match_table!(|b| b == 0)`
         // is expanded to `SafeByteMatchTable([0 == 0, ... ])`
-        #[allow(clippy::eq_op)]
+        #[allow(clippy::eq_op, clippy::allow_attributes)]
         const TABLE: SafeByteMatchTable = seq_macro::seq!($byte in 0u8..=255 {
             SafeByteMatchTable::new([#($res,)*])
         });
@@ -428,11 +428,12 @@ macro_rules! byte_search {
         // responsibility to uphold this invariant.
         // Therefore we can assume this is taken care of one way or another, and wrap the calls
         // to unsafe functions in this function with `unsafe {}`.
-        #[allow(clippy::unnecessary_safety_comment)]
+        #[allow(clippy::unnecessary_safety_comment, clippy::allow_attributes)]
         $table.use_table();
 
         let mut $pos = $start;
-        #[allow(unused_unsafe, clippy::unnecessary_safety_comment)] // Silence warnings if macro called in unsafe code
+        // Silence warnings if macro called in unsafe code
+        #[allow(unused_unsafe, clippy::unnecessary_safety_comment, clippy::allow_attributes)]
         'outer: loop {
             let $byte = if $pos.addr() <= $lexer.source.end_for_batch_search_addr() {
                 // Search a batch of `SEARCH_BATCH_SIZE` bytes.
@@ -486,7 +487,12 @@ macro_rules! byte_search {
                     $lexer.source.set_position($pos);
 
                     // Avoid lint errors if `$eof_handler` contains `return` statement
-                    #[allow(unused_variables, unreachable_code, clippy::diverging_sub_expression)]
+                    #[allow(
+                        unused_variables,
+                        unreachable_code,
+                        clippy::diverging_sub_expression,
+                        clippy::allow_attributes
+                    )]
                     {
                         let eof_ret = $eof_handler;
                         break 'outer eof_ret;

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -483,7 +483,7 @@ impl<'a> ParserImpl<'a> {
         Ok(expr)
     }
 
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn parse_program(&mut self) -> Result<Program<'a>> {
         // initialize cur_token and prev_token by moving onto the first token
         self.bump_any();

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1327,7 +1327,6 @@ impl<'a> ParserImpl<'a> {
                 break;
             }
 
-            #[allow(clippy::unnecessary_fallible_conversions)]
             if let Ok(kind) = ModifierKind::try_from(self.cur_kind()) {
                 let modifier = Modifier { kind, span: self.cur_token().span() };
                 flags.set(kind.into(), true);

--- a/crates/oxc_prettier/examples/prettier.rs
+++ b/crates/oxc_prettier/examples/prettier.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout)]
+#![expect(clippy::print_stdout)]
 use std::path::Path;
 
 use oxc_allocator::Allocator;

--- a/crates/oxc_prettier/src/format/print/array.rs
+++ b/crates/oxc_prettier/src/format/print/array.rs
@@ -290,7 +290,7 @@ fn is_line_after_element_empty(p: &Prettier<'_>, index: u32) -> bool {
         let current_idx = current_idx?;
         match p.source_text[current_idx as usize..].chars().next() {
             Some(',') => Some(current_idx),
-            #[allow(clippy::cast_possible_truncation)]
+            #[expect(clippy::cast_possible_truncation)]
             Some(c) => skip_to_comma(p, skip_comment(p, current_idx + c.len_utf8() as u32)),
             None => None,
         }

--- a/crates/oxc_prettier/src/format/print/call_arguments.rs
+++ b/crates/oxc_prettier/src/format/print/call_arguments.rs
@@ -24,7 +24,7 @@ pub fn print_call_arguments<'a>(
     let mut parts = Vec::new_in(p.allocator);
     parts.push(text!("("));
 
-    #[allow(clippy::cast_sign_loss)]
+    #[expect(clippy::cast_sign_loss)]
     let get_printed_arguments = |p: &mut Prettier<'a>, skip_index: isize| {
         let mut printed_arguments = Vec::new_in(p.allocator);
         let mut len = arguments.len();

--- a/crates/oxc_prettier/src/format/print/member.rs
+++ b/crates/oxc_prettier/src/format/print/member.rs
@@ -3,7 +3,7 @@ use oxc_ast::ast::*;
 
 use crate::{array, group, indent, ir::Doc, softline, text, Format, Prettier};
 
-#[allow(clippy::enum_variant_names)]
+#[expect(clippy::enum_variant_names)]
 pub enum MemberExpressionLike<'a, 'b> {
     ComputedMemberExpression(&'b ComputedMemberExpression<'a>),
     StaticMemberExpression(&'b StaticMemberExpression<'a>),

--- a/crates/oxc_prettier/src/format/print/module.rs
+++ b/crates/oxc_prettier/src/format/print/module.rs
@@ -50,7 +50,7 @@ pub fn print_import_declaration<'a>(p: &mut Prettier<'a>, decl: &ImportDeclarati
     array!(p, parts)
 }
 
-#[allow(clippy::enum_variant_names)]
+#[expect(clippy::enum_variant_names)]
 pub enum ExportDeclarationLike<'a, 'b> {
     ExportAllDeclaration(&'b ExportAllDeclaration<'a>),
     ExportNamedDeclaration(&'b ExportNamedDeclaration<'a>),

--- a/crates/oxc_prettier/src/format/print/template_literal.rs
+++ b/crates/oxc_prettier/src/format/print/template_literal.rs
@@ -5,7 +5,6 @@ use crate::{
     array, format::Format, group, ir::Doc, line_suffix_boundary, softline, text, Prettier,
 };
 
-#[allow(clippy::enum_variant_names)]
 pub enum TemplateLiteralLike<'a, 'b> {
     TemplateLiteral(&'b TemplateLiteral<'a>),
     TSTemplateLiteralType(&'b TSTemplateLiteralType<'a>),

--- a/crates/oxc_prettier/src/ir/doc.rs
+++ b/crates/oxc_prettier/src/ir/doc.rs
@@ -24,7 +24,7 @@ pub struct Group<'a> {
     pub contents: Vec<'a, Doc<'a>>,
     pub should_break: bool,
     pub expanded_states: Option<Vec<'a, Doc<'a>>>,
-    #[allow(clippy::struct_field_names)]
+    #[expect(clippy::struct_field_names)]
     pub group_id: Option<GroupId>,
 }
 

--- a/crates/oxc_prettier/src/lib.rs
+++ b/crates/oxc_prettier/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(unused, clippy::unused_self)]
+#![expect(unused, clippy::unused_self)]
 //! Prettier
 //!
 //! A port of <https://github.com/prettier/prettier>
@@ -56,7 +56,6 @@ pub struct Prettier<'a> {
 }
 
 impl<'a> Prettier<'a> {
-    #[allow(clippy::needless_pass_by_value)]
     pub fn new(allocator: &'a Allocator, options: PrettierOptions) -> Self {
         Self {
             allocator,
@@ -99,7 +98,7 @@ impl<'a> Prettier<'a> {
         (len >= 3).then(|| self.stack[len - 3])
     }
 
-    #[allow(unused)]
+    #[expect(unused)]
     fn nth_parent_kind(&self, n: usize) -> Option<AstKind<'a>> {
         let len = self.stack.len();
         (len > n).then(|| self.stack[len - n - 1])
@@ -111,7 +110,7 @@ impl<'a> Prettier<'a> {
     }
 
     /// A hack for erasing the lifetime requirement.
-    #[allow(clippy::unused_self)]
+    #[expect(clippy::unused_self)]
     fn alloc<T>(&self, t: &T) -> &'a T {
         // SAFETY:
         // This should be safe as long as `src` is an reference from the allocator.
@@ -169,7 +168,7 @@ impl<'a> Prettier<'a> {
         self.skip_everything_but_new_line(Some(start_index), /* backwards */ false)
     }
 
-    #[allow(clippy::unused_self)]
+    #[expect(clippy::unused_self)]
     fn skip_inline_comment(&self, start_index: Option<u32>) -> Option<u32> {
         let start_index = start_index?;
         Some(start_index)
@@ -215,7 +214,7 @@ impl<'a> Prettier<'a> {
         None
     }
 
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn skip_newline(&self, start_index: Option<u32>, backwards: bool) -> Option<u32> {
         let start_index = start_index?;
         let c = if backwards {

--- a/crates/oxc_prettier/src/printer/mod.rs
+++ b/crates/oxc_prettier/src/printer/mod.rs
@@ -93,7 +93,7 @@ impl<'a> Printer<'a> {
         }
     }
 
-    #[allow(clippy::cast_possible_wrap)]
+    #[expect(clippy::cast_possible_wrap)]
     fn remaining_width(&self) -> isize {
         (self.options.print_width as isize) - (self.pos as isize)
     }
@@ -128,7 +128,6 @@ impl<'a> Printer<'a> {
                 self.set_group_mode_from_last_cmd(group.group_id);
             }
             Mode::Break => {
-                #[allow(clippy::cast_possible_wrap)]
                 let remaining_width = self.remaining_width();
                 let Doc::Group(group) = &doc else {
                     unreachable!();
@@ -362,7 +361,7 @@ impl<'a> Printer<'a> {
         self.group_mode_map.insert(id, mode);
     }
 
-    #[allow(clippy::cast_possible_wrap)]
+    #[expect(clippy::cast_possible_wrap)]
     fn fits(&self, next: &Command<'a>, width: isize) -> bool {
         let mut remaining_width = width;
         let mut queue: VecDeque<(Mode, &Doc)> = VecDeque::new();

--- a/crates/oxc_regular_expression/examples/parse_literal.rs
+++ b/crates/oxc_regular_expression/examples/parse_literal.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout)]
+#![expect(clippy::print_stdout)]
 
 use oxc_allocator::Allocator;
 use oxc_regular_expression::{LiteralParser, Options};

--- a/crates/oxc_regular_expression/examples/regex_visitor.rs
+++ b/crates/oxc_regular_expression/examples/regex_visitor.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout)]
+#![expect(clippy::print_stdout)]
 
 use oxc_allocator::Allocator;
 use oxc_regular_expression::{

--- a/crates/oxc_regular_expression/src/generated/derive_get_address.rs
+++ b/crates/oxc_regular_expression/src/generated/derive_get_address.rs
@@ -1,7 +1,7 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/derives/get_address.rs`
 
-#![allow(clippy::match_same_arms)]
+#![expect(clippy::match_same_arms)]
 
 use oxc_allocator::{Address, GetAddress};
 

--- a/crates/oxc_regular_expression/src/lib.rs
+++ b/crates/oxc_regular_expression/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::missing_errors_doc)]
+#![expect(clippy::missing_errors_doc)]
 
 mod ast_impl;
 mod diagnostics;

--- a/crates/oxc_regular_expression/src/parser/parser_impl.rs
+++ b/crates/oxc_regular_expression/src/parser/parser_impl.rs
@@ -83,7 +83,7 @@ impl<'a> ConstructorParser<'a> {
             let reader =
                 Reader::initialize(flags_text, true, parse_string_literal).map_err(|_| {
                     let span_start = flags_span_offset;
-                    #[allow(clippy::cast_possible_truncation)]
+                    #[expect(clippy::cast_possible_truncation)]
                     let span_end = flags_span_offset + flags_text.len() as u32;
                     diagnostics::invalid_input(Span::new(span_start, span_end))
                 })?;
@@ -101,7 +101,7 @@ impl<'a> ConstructorParser<'a> {
         let reader =
             Reader::initialize(pattern_text, unicode_mode, parse_string_literal).map_err(|_| {
                 let span_start = pattern_span_offset;
-                #[allow(clippy::cast_possible_truncation)]
+                #[expect(clippy::cast_possible_truncation)]
                 let span_end = pattern_span_offset + pattern_text.len() as u32;
                 diagnostics::invalid_input(Span::new(span_start, span_end))
             })?;

--- a/crates/oxc_regular_expression/src/parser/pattern_parser/pattern_parser_impl.rs
+++ b/crates/oxc_regular_expression/src/parser/pattern_parser/pattern_parser_impl.rs
@@ -1677,7 +1677,7 @@ impl<'a> PatternParser<'a> {
     //   { DecimalDigits[~Sep] , DecimalDigits[~Sep] }
     // ```
     /// Returns: ((min, max), greedy)
-    #[allow(clippy::type_complexity)]
+    #[expect(clippy::type_complexity)]
     fn consume_quantifier(&mut self) -> Result<Option<((u64, Option<u64>), bool)>> {
         const MAX_QUANTIFIER: u64 = 9_007_199_254_740_991; // 2^53 - 1
         let is_greedy = |reader: &mut Reader| !reader.eat('?');
@@ -1754,7 +1754,7 @@ impl<'a> PatternParser<'a> {
         if let Some(index) = self.consume_decimal_digits()? {
             // \0 is CharacterEscape, not DecimalEscape
             if index != 0 {
-                #[allow(clippy::cast_possible_truncation)]
+                #[expect(clippy::cast_possible_truncation)]
                 return Ok(Some(index as u32));
             }
 
@@ -1778,7 +1778,7 @@ impl<'a> PatternParser<'a> {
         let mut value: u64 = 0;
         while let Some(cp) = self.reader.peek().filter(|&cp| character::is_decimal_digit(cp)) {
             // `- '0' as u32`: convert code point to digit
-            #[allow(clippy::cast_lossless)]
+            #[expect(clippy::cast_lossless)]
             let d = (cp - '0' as u32) as u64;
 
             // To prevent panic on overflow cases like `\999999999999999999999`, `a{999999999999999999999}`

--- a/crates/oxc_regular_expression/src/parser/reader/string_literal_parser/ast.rs
+++ b/crates/oxc_regular_expression/src/parser/reader/string_literal_parser/ast.rs
@@ -2,9 +2,9 @@ use oxc_span::Span;
 
 #[derive(Debug)]
 pub struct StringLiteral {
-    #[allow(dead_code)]
+    #[allow(unused, clippy::allow_attributes)]
     pub span: Span,
-    #[allow(dead_code)]
+    #[allow(unused, clippy::allow_attributes)]
     pub kind: StringLiteralKind,
     pub body: Vec<CodePoint>,
 }

--- a/crates/oxc_regular_expression/src/parser/reader/string_literal_parser/parser_impl.rs
+++ b/crates/oxc_regular_expression/src/parser/reader/string_literal_parser/parser_impl.rs
@@ -25,7 +25,7 @@ pub fn parse_regexp_literal(
     let mut offset = 0;
     for ch in source_text.chars() {
         let start = offset;
-        #[allow(clippy::cast_possible_truncation)]
+        #[expect(clippy::cast_possible_truncation)]
         let end = start + ch.len_utf8() as u32;
 
         let offsets_and_cp: OffsetsAndCp = ((start, end), ch as u32);
@@ -498,7 +498,7 @@ impl Parser {
 
     fn advance(&mut self) {
         if let Some(ch) = self.chars.get(self.index) {
-            #[allow(clippy::cast_possible_truncation)]
+            #[expect(clippy::cast_possible_truncation)]
             let len = ch.len_utf8() as u32;
             self.offset += len;
             self.index += 1;

--- a/crates/oxc_semantic/CHANGELOG.md
+++ b/crates/oxc_semantic/CHANGELOG.md
@@ -134,7 +134,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - 98d7946 semantic: Import flags and ID types from `oxc_syntax` (#7887) (overlookmotel)
 - 1cf8f8f semantic: `SymbolTable::set_name` return old name (#7869) (overlookmotel)
 - 5d42df8 semantic: Use `Expression::is_super` (#7851) (overlookmotel)
-- 8cf9766 semantic, syntax, wasm: Remove `#![allow(non_snake_case)]` (#7863) (overlookmotel)
+- 8cf9766 semantic, syntax, wasm: Remove `#![expect(non_snake_case)]` (#7863) (overlookmotel)
 
 ### Styling
 
@@ -415,7 +415,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Refactor
 
-- 4bdc202 rust: Remove some #[allow(unused)] (#5716) (Boshen)
+- 4bdc202 rust: Remove some #[expect(unused)] (#5716) (Boshen)
 - a35fb14 semantic: `Stats::assert_accurate` take `self` (#5758) (overlookmotel)
 - 4b896f1 semantic: Make `Stats` `Copy` (#5756) (overlookmotel)
 - b4b460f semantic: `Stats` store counts as `u32` (#5754) (overlookmotel)

--- a/crates/oxc_semantic/examples/cfg.rs
+++ b/crates/oxc_semantic/examples/cfg.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout)]
+#![expect(clippy::print_stdout)]
 use std::{env, path::Path, sync::Arc};
 
 use itertools::Itertools;

--- a/crates/oxc_semantic/examples/semantic.rs
+++ b/crates/oxc_semantic/examples/semantic.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout)]
+#![expect(clippy::print_stdout)]
 use std::{env, path::Path, sync::Arc};
 
 use itertools::Itertools;

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -13,7 +13,7 @@ use oxc_syntax::{
 use crate::SemanticBuilder;
 
 pub(crate) trait Binder<'a> {
-    #[allow(unused_variables)]
+    #[expect(unused_variables)]
     fn bind(&self, builder: &mut SemanticBuilder<'a>) {}
 }
 

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -262,7 +262,7 @@ impl<'a> SemanticBuilder<'a> {
             // Check that estimated counts accurately (unless in release mode)
             #[cfg(debug_assertions)]
             if let Some(stats) = check_stats {
-                #[allow(clippy::cast_possible_truncation)]
+                #[expect(clippy::cast_possible_truncation)]
                 let actual_stats = Stats::new(
                     self.nodes.len() as u32,
                     self.scope.len() as u32,
@@ -344,7 +344,6 @@ impl<'a> SemanticBuilder<'a> {
     }
 
     #[inline]
-    #[allow(clippy::unnecessary_wraps)]
     fn retrieve_recorded_ast_node(&mut self) -> Option<NodeId> {
         if self.cfg.is_some() {
             Some(self.ast_node_records.pop().expect("there is no ast node record to stop."))
@@ -2074,7 +2073,6 @@ impl<'a> SemanticBuilder<'a> {
         }
     }
 
-    #[allow(clippy::single_match)]
     fn leave_kind(&mut self, kind: AstKind<'a>) {
         match kind {
             AstKind::Class(_) => {

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -202,7 +202,7 @@ pub fn check_simple_assignment_target<'a>(
     ctx: &SemanticBuilder<'a>,
 ) {
     if let Some(expression) = target.get_expression() {
-        #[allow(clippy::match_same_arms)]
+        #[expect(clippy::match_same_arms)]
         match expression.get_inner_expression() {
             Expression::Identifier(_) => {}
             match_member_expression!(Expression) => {}
@@ -286,7 +286,7 @@ pub fn check_ts_enum_declaration<'a>(decl: &TSEnumDeclaration<'a>, ctx: &Semanti
     let mut need_initializer = false;
 
     decl.members.iter().for_each(|member| {
-        #[allow(clippy::unnested_or_patterns)]
+        #[expect(clippy::unnested_or_patterns)]
         if let Some(initializer) = &member.initializer {
             need_initializer = !matches!(
                 initializer,

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -186,7 +186,7 @@ impl<'a> Semantic<'a> {
 
     /// Get statistics about data held in `Semantic`.
     pub fn stats(&self) -> Stats {
-        #[allow(clippy::cast_possible_truncation)]
+        #[expect(clippy::cast_possible_truncation)]
         Stats::new(
             self.nodes.len() as u32,
             self.scopes.len() as u32,

--- a/crates/oxc_semantic/src/stats.rs
+++ b/crates/oxc_semantic/src/stats.rs
@@ -103,7 +103,7 @@ impl Stats {
     #[must_use]
     pub fn increase_by(mut self, excess: f64) -> Self {
         let factor = excess + 1.0;
-        #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_lossless)]
+        #[expect(clippy::cast_possible_truncation, clippy::cast_sign_loss, clippy::cast_lossless)]
         let increase = |n: u32| (n as f64 * factor) as u32;
 
         self.scopes = increase(self.scopes);

--- a/crates/oxc_semantic/tests/conformance/mod.rs
+++ b/crates/oxc_semantic/tests/conformance/mod.rs
@@ -23,19 +23,19 @@ pub trait ConformanceTest {
     fn name(&self) -> &'static str;
 
     #[must_use]
-    #[allow(dead_code, unused_variables)]
+    #[expect(unused_variables)]
     fn run_once(&self, semantic: &Semantic<'_>) -> TestResult {
         TestResult::Pass
     }
 
     #[must_use]
-    #[allow(unused_variables)]
+    #[expect(unused_variables)]
     fn run_on_node<'a>(&self, node: &AstNode<'a>, semantic: &Semantic<'a>) -> TestResult {
         TestResult::Pass
     }
 
     #[must_use]
-    #[allow(unused_variables)]
+    #[expect(unused_variables)]
     fn run_on_symbol(&self, symbol_id: SymbolId, semantic: &Semantic<'_>) -> TestResult {
         TestResult::Pass
     }
@@ -115,7 +115,7 @@ impl SemanticConformance {
         diagnostics
     }
 
-    #[allow(clippy::unused_self)]
+    #[expect(clippy::unused_self)]
     fn record_results(
         &self,
         diagnostics: &mut Vec<OxcDiagnostic>,

--- a/crates/oxc_semantic/tests/integration/main.rs
+++ b/crates/oxc_semantic/tests/integration/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::missing_panics_doc)]
+#![expect(clippy::missing_panics_doc)]
 
 pub mod cfg;
 pub mod classes;

--- a/crates/oxc_semantic/tests/integration/util/mod.rs
+++ b/crates/oxc_semantic/tests/integration/util/mod.rs
@@ -127,7 +127,7 @@ impl<'a> SemanticTester<'a> {
     /// # Panics
     /// - if parsing fails
     /// - if semantic analysis does/does not produce errors as expected
-    #[allow(unstable_name_collisions)]
+    #[expect(unstable_name_collisions)]
     pub fn build(&self) -> Semantic<'_> {
         let semantic_ret = self.build_with_errors();
         match (self.expect_errors, semantic_ret.errors.is_empty()) {
@@ -150,7 +150,7 @@ impl<'a> SemanticTester<'a> {
     /// semantic analysis
     /// # Panics
     ///
-    #[allow(unstable_name_collisions)]
+    #[expect(unstable_name_collisions)]
     pub fn build_with_errors(&self) -> SemanticBuilderReturn<'_> {
         let parse =
             oxc_parser::Parser::new(&self.allocator, self.source_text, self.source_type).parse();

--- a/crates/oxc_semantic/tests/integration/util/symbol_tester.rs
+++ b/crates/oxc_semantic/tests/integration/util/symbol_tester.rs
@@ -199,7 +199,6 @@ impl<'a> SymbolTester<'a> {
         self
     }
 
-    #[allow(clippy::wrong_self_convention)]
     pub fn is_in_scope(mut self, expected_flags: ScopeFlags) -> Self {
         let target_name: &str = self.target_symbol_name.as_ref();
         self.test_result = match self.test_result {
@@ -219,7 +218,6 @@ impl<'a> SymbolTester<'a> {
         self
     }
 
-    #[allow(clippy::wrong_self_convention)]
     pub fn is_not_in_scope(mut self, excluded_flags: ScopeFlags) -> Self {
         let target_name: &str = self.target_symbol_name.as_ref();
         self.test_result = match self.test_result {

--- a/crates/oxc_span/src/cmp.rs
+++ b/crates/oxc_span/src/cmp.rs
@@ -41,7 +41,7 @@ impl<T: ContentEq> ContentEq for Option<T> {
         // NOTE: based on the standard library
         // Spelling out the cases explicitly optimizes better than
         // `_ => false`
-        #[allow(clippy::match_same_arms)]
+        #[expect(clippy::match_same_arms)]
         match (self, other) {
             (Some(lhs), Some(rhs)) => lhs.content_eq(rhs),
             (Some(_), None) => false,

--- a/crates/oxc_span/src/source_type/mod.rs
+++ b/crates/oxc_span/src/source_type/mod.rs
@@ -478,7 +478,7 @@ impl SourceType {
             }
             "js" | "cjs" | "mjs" | "jsx" => Language::JavaScript,
             "tsx" => Language::TypeScript,
-            #[allow(clippy::case_sensitive_file_extension_comparisons)]
+            #[expect(clippy::case_sensitive_file_extension_comparisons)]
             "mts" | "cts" => {
                 if file_name[..file_name.len() - 4].ends_with(".d") {
                     Language::TypeScriptDefinition
@@ -505,7 +505,6 @@ mod tests {
     use super::SourceType;
 
     #[test]
-    #[allow(clippy::similar_names)]
     fn test_ts_from_path() {
         let ts = SourceType::from_path("foo.ts")
             .expect("foo.ts should be a valid TypeScript file path.");
@@ -546,7 +545,7 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::similar_names)]
+    #[expect(clippy::similar_names)]
     fn test_d_ts_from_path() {
         let dts = SourceType::from_path("foo.d.ts").unwrap();
         let dmts = SourceType::from_path("foo.d.mts").unwrap();
@@ -579,7 +578,6 @@ mod tests {
     }
 
     #[test]
-    #[allow(clippy::similar_names)]
     fn test_js_from_path() {
         let js = SourceType::from_path("foo.js")
             .expect("foo.js should be a valid JavaScript file path.");

--- a/crates/oxc_syntax/CHANGELOG.md
+++ b/crates/oxc_syntax/CHANGELOG.md
@@ -69,7 +69,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Refactor
 
 - 3858221 global: Sort imports (#7883) (overlookmotel)
-- 8cf9766 semantic, syntax, wasm: Remove `#![allow(non_snake_case)]` (#7863) (overlookmotel)
+- 8cf9766 semantic, syntax, wasm: Remove `#![expect(non_snake_case)]` (#7863) (overlookmotel)
 
 ### Styling
 

--- a/crates/oxc_syntax/src/class.rs
+++ b/crates/oxc_syntax/src/class.rs
@@ -1,5 +1,5 @@
 //! Class and class element syntax items
-#![allow(missing_docs)] // fixme
+#![expect(missing_docs)] // fixme
 use bitflags::bitflags;
 use oxc_index::define_index_type;
 

--- a/crates/oxc_syntax/src/es_target.rs
+++ b/crates/oxc_syntax/src/es_target.rs
@@ -5,7 +5,7 @@ use cow_utils::CowUtils;
 
 /// ECMAScript Target
 #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
-#[allow(missing_docs)]
+#[expect(missing_docs)]
 pub enum ESTarget {
     ES5,
     ES2015,

--- a/crates/oxc_syntax/src/identifier.rs
+++ b/crates/oxc_syntax/src/identifier.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs)] // fixme
+#![expect(missing_docs)] // fixme
 use assert_unchecked::assert_unchecked;
 use unicode_id_start::{is_id_continue_unicode, is_id_start_unicode};
 
@@ -168,7 +168,7 @@ pub fn is_identifier_part_unicode(c: char) -> bool {
 }
 
 /// Determine if a string is a valid JS identifier.
-#[allow(clippy::missing_panics_doc)]
+#[expect(clippy::missing_panics_doc)]
 pub fn is_identifier_name(name: &str) -> bool {
     // This function contains a fast path for ASCII (common case), iterating over bytes and using
     // the cheap `is_identifier_start_ascii` and `is_identifier_part_ascii` to test bytes.
@@ -194,7 +194,7 @@ pub fn is_identifier_name(name: &str) -> bool {
                 // Process block of 8 bytes.
                 // Check that next 8 bytes are all ASCII.
                 // SAFETY: We checked above that there are at least 8 bytes to read starting at `index`
-                #[allow(clippy::cast_ptr_alignment)]
+                #[expect(clippy::cast_ptr_alignment)]
                 let next8_as_u64 = unsafe {
                     let ptr = bytes.as_ptr().add(index).cast::<u64>();
                     ptr.read_unaligned()
@@ -219,7 +219,7 @@ pub fn is_identifier_name(name: &str) -> bool {
                 // Process block of 4 bytes.
                 // Check that next 4 bytes are all ASCII.
                 // SAFETY: We checked above that there are at least 4 bytes to read starting at `index`
-                #[allow(clippy::cast_ptr_alignment)]
+                #[expect(clippy::cast_ptr_alignment)]
                 let next4_as_u32 = unsafe {
                     let ptr = bytes.as_ptr().add(index).cast::<u32>();
                     ptr.read_unaligned()

--- a/crates/oxc_syntax/src/node.rs
+++ b/crates/oxc_syntax/src/node.rs
@@ -30,7 +30,7 @@ impl NodeId {
     ///
     /// # SAFETY
     /// `idx` must not be `u32::MAX`.
-    #[allow(clippy::missing_safety_doc, clippy::unnecessary_safety_comment)]
+    #[expect(clippy::missing_safety_doc, clippy::unnecessary_safety_comment)]
     pub const unsafe fn new_unchecked(idx: u32) -> Self {
         // SAFETY: Caller must ensure `idx` is not `u32::MAX`
         Self(NonMaxU32::new_unchecked(idx))
@@ -38,7 +38,7 @@ impl NodeId {
 }
 
 impl Idx for NodeId {
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn from_usize(idx: usize) -> Self {
         assert!(idx < u32::MAX as usize);
         // SAFETY: We just checked `idx` is a legal value for `NonMaxU32`

--- a/crates/oxc_syntax/src/number.rs
+++ b/crates/oxc_syntax/src/number.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs)] // fixme
+#![expect(missing_docs)] // fixme
 use oxc_allocator::CloneIn;
 use oxc_ast_macros::ast;
 use oxc_span::ContentEq;

--- a/crates/oxc_syntax/src/precedence.rs
+++ b/crates/oxc_syntax/src/precedence.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs)] // fixme
+#![expect(missing_docs)] // fixme
 pub trait GetPrecedence {
     fn precedence(&self) -> Precedence;
 }

--- a/crates/oxc_syntax/src/reference.rs
+++ b/crates/oxc_syntax/src/reference.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs)] // fixme
+#![expect(missing_docs)] // fixme
 use bitflags::bitflags;
 use nonmax::NonMaxU32;
 use oxc_index::Idx;
@@ -19,7 +19,7 @@ use oxc_ast_macros::ast;
 pub struct ReferenceId(NonMaxU32);
 
 impl Idx for ReferenceId {
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn from_usize(idx: usize) -> Self {
         assert!(idx < u32::MAX as usize);
         // SAFETY: We just checked `idx` is a legal value for `NonMaxU32`

--- a/crates/oxc_syntax/src/scope.rs
+++ b/crates/oxc_syntax/src/scope.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs)] // fixme
+#![expect(missing_docs)] // fixme
 use bitflags::bitflags;
 use nonmax::NonMaxU32;
 use oxc_index::Idx;
@@ -30,7 +30,7 @@ impl ScopeId {
     ///
     /// # SAFETY
     /// `idx` must not be `u32::MAX`.
-    #[allow(clippy::missing_safety_doc, clippy::unnecessary_safety_comment)]
+    #[expect(clippy::missing_safety_doc, clippy::unnecessary_safety_comment)]
     pub const unsafe fn new_unchecked(idx: u32) -> Self {
         // SAFETY: Caller must ensure `idx` is not `u32::MAX`
         Self(NonMaxU32::new_unchecked(idx))
@@ -38,7 +38,7 @@ impl ScopeId {
 }
 
 impl Idx for ScopeId {
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn from_usize(idx: usize) -> Self {
         assert!(idx < u32::MAX as usize);
         // SAFETY: We just checked `idx` is a legal value for `NonMaxU32`

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -1,4 +1,4 @@
-#![allow(missing_docs)] // fixme
+#![expect(missing_docs)] // fixme
 use bitflags::bitflags;
 use nonmax::NonMaxU32;
 use oxc_index::Idx;
@@ -30,7 +30,7 @@ impl SymbolId {
     ///
     /// # SAFETY
     /// `idx` must not be `u32::MAX`.
-    #[allow(clippy::missing_safety_doc, clippy::unnecessary_safety_comment)]
+    #[expect(clippy::missing_safety_doc, clippy::unnecessary_safety_comment)]
     pub const unsafe fn new_unchecked(idx: u32) -> Self {
         // SAFETY: Caller must ensure `idx` is not `u32::MAX`
         Self(NonMaxU32::new_unchecked(idx))
@@ -38,7 +38,7 @@ impl SymbolId {
 }
 
 impl Idx for SymbolId {
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn from_usize(idx: usize) -> Self {
         assert!(idx < u32::MAX as usize);
         // SAFETY: We just checked `idx` is a legal value for `NonMaxU32`
@@ -64,7 +64,7 @@ impl Serialize for SymbolId {
 pub struct RedeclarationId(NonMaxU32);
 
 impl Idx for RedeclarationId {
-    #[allow(clippy::cast_possible_truncation)]
+    #[expect(clippy::cast_possible_truncation)]
     fn from_usize(idx: usize) -> Self {
         assert!(idx < u32::MAX as usize);
         // SAFETY: We just checked `idx` is valid for `NonMaxU32`

--- a/crates/oxc_transformer/CHANGELOG.md
+++ b/crates/oxc_transformer/CHANGELOG.md
@@ -578,7 +578,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - 217d433 transformer/arrow-functions: Remove unused `&mut self` function param (#7165) (overlookmotel)
 - 426df71 transformer/arrow-functions: Use `scope_id` method (#7164) (overlookmotel)
 - 11c5e12 transformer/arrow-functions: Correct comments (#7163) (overlookmotel)
-- 1238506 transformer/async-generator-function: Remove inactive `#[allow(clippy::unused_self)]` attrs (#7167) (overlookmotel)
+- 1238506 transformer/async-generator-function: Remove inactive `#[expect(clippy::unused_self)]` attrs (#7167) (overlookmotel)
 - 84ee581 transformer/async-generator-functions: Simplify identifying whether within an async generator function (#7170) (overlookmotel)
 - 1b12328 transformer/async-generator-functions: Use `clone` not `clone_in` on `LabelIdentifier` (#7172) (overlookmotel)
 - cd1006f transformer/async-generator-functions: Do not transform yield expression where inside generator function (#7134) (Dunqing)
@@ -588,8 +588,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - b57d5a5 transformer/async-to-generator: Remove unused `&self` function param (#7166) (overlookmotel)
 - f80085c transformer/async-to-generator: Move handling of `MethodDefinition`'s value to `exit_function` (#7105) (Dunqing)
 - e2241e6 transformer/jsx-self: Remove unused `&self` function params (#7159) (overlookmotel)
-- 1dfd241 transformer/optional-catch-binding: Remove inactive `#[allow(clippy::unused_self)]` attr (#7158) (overlookmotel)
-- fd9b44c transformer/typescript: Remove inactive `#[allow(clippy::unused_self)]` attr (#7160) (overlookmotel)
+- 1dfd241 transformer/optional-catch-binding: Remove inactive `#[expect(clippy::unused_self)]` attr (#7158) (overlookmotel)
+- fd9b44c transformer/typescript: Remove inactive `#[expect(clippy::unused_self)]` attr (#7160) (overlookmotel)
 
 ### Styling
 
@@ -997,7 +997,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Refactor
 
-- 4bdc202 rust: Remove some #[allow(unused)] (#5716) (Boshen)
+- 4bdc202 rust: Remove some #[expect(unused)] (#5716) (Boshen)
 - cc0408b semantic: S/AstNodeId/NodeId (#5740) (Boshen)
 
 ## [0.28.0] - 2024-09-11

--- a/crates/oxc_transformer/examples/transformer.rs
+++ b/crates/oxc_transformer/examples/transformer.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout)]
+#![expect(clippy::print_stdout)]
 use std::path::Path;
 
 use oxc_allocator::Allocator;

--- a/crates/oxc_transformer/src/es2017/mod.rs
+++ b/crates/oxc_transformer/src/es2017/mod.rs
@@ -8,7 +8,6 @@ mod options;
 pub use async_to_generator::{AsyncGeneratorExecutor, AsyncToGenerator};
 pub use options::ES2017Options;
 
-#[allow(dead_code)]
 pub struct ES2017<'a, 'ctx> {
     options: ES2017Options,
 

--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -115,7 +115,7 @@ impl<'a> LogicalAssignmentOperators<'a, '_> {
                 self.convert_computed_member_expression(computed_expr, ctx)
             }
             // TODO
-            #[allow(clippy::match_same_arms)]
+            #[expect(clippy::match_same_arms)]
             AssignmentTarget::PrivateFieldExpression(_) => return,
             // All other are TypeScript syntax.
 

--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -2130,7 +2130,7 @@ impl<'a> ClassProperties<'a, '_> {
     /// * Setter: `_prop.call(_assertClassBrand(Class, object), value)`
     /// * Prop: `_privateFieldSet(_prop, object, value)`
     /// * Prop binding is `None`: `_writeOnlyError("#method")`
-    #[allow(clippy::too_many_arguments)]
+    #[expect(clippy::too_many_arguments)]
     fn create_private_setter(
         &self,
         private_name: &str,

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -427,7 +427,7 @@ impl<'a, 'ctx> JsxImpl<'a, 'ctx> {
                 }
 
                 let is_development = options.development;
-                #[allow(clippy::single_match_else, clippy::cast_possible_truncation)]
+                #[expect(clippy::single_match_else, clippy::cast_possible_truncation)]
                 let (jsx_runtime_importer, source_len) = match options.import_source.as_ref() {
                     Some(import_source) => {
                         let mut import_source = &**import_source;

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -134,7 +134,7 @@ impl<'a> Transformer<'a> {
 
         let (symbols, scopes) = traverse_mut(&mut transformer, allocator, program, symbols, scopes);
         let helpers_used = self.ctx.helper_loader.used_helpers.borrow_mut().drain().collect();
-        #[allow(deprecated)]
+        #[expect(deprecated)]
         TransformerReturn { errors: self.ctx.take_errors(), symbols, scopes, helpers_used }
     }
 }

--- a/crates/oxc_transformer/src/options/babel/mod.rs
+++ b/crates/oxc_transformer/src/options/babel/mod.rs
@@ -69,7 +69,7 @@ enum PluginPresetEntry {
     String(String),
     Vec1([String; 1]),
     Tuple(String, serde_json::Value),
-    Triple(String, serde_json::Value, #[allow(unused)] String),
+    Triple(String, serde_json::Value, #[expect(unused)] String),
 }
 
 impl PluginPresetEntry {

--- a/crates/oxc_transformer/src/options/env.rs
+++ b/crates/oxc_transformer/src/options/env.rs
@@ -147,8 +147,8 @@ impl From<BabelEnvOptions> for EnvOptions {
 }
 
 impl From<EngineTargets> for EnvOptions {
-    #[allow(clippy::enum_glob_use)]
     fn from(o: EngineTargets) -> Self {
+        #[allow(clippy::enum_glob_use, clippy::allow_attributes)]
         use ESFeature::*;
         Self {
             module: Module::default(),

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -409,7 +409,7 @@ impl<'a> TypeScriptEnum<'a> {
         }
     }
 
-    #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss, clippy::cast_sign_loss)]
+    #[expect(clippy::cast_sign_loss)]
     fn eval_binary_expression(
         &self,
         expr: &BinaryExpression<'a>,
@@ -474,7 +474,6 @@ impl<'a> TypeScriptEnum<'a> {
         }
     }
 
-    #[allow(clippy::cast_possible_truncation, clippy::cast_precision_loss)]
     fn eval_unary_expression(
         &self,
         expr: &UnaryExpression<'a>,

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -164,7 +164,7 @@ impl<'a> TypeScriptModule<'a, '_> {
         Some(ctx.ast.declaration_variable(SPAN, kind, decls, false))
     }
 
-    #[allow(clippy::only_used_in_recursion)]
+    #[expect(clippy::only_used_in_recursion)]
     fn transform_ts_type_name(
         &self,
         type_name: &mut TSTypeName<'a>,

--- a/crates/oxc_wasm/src/options.rs
+++ b/crates/oxc_wasm/src/options.rs
@@ -64,7 +64,7 @@ pub struct OxcParserOptions {
 #[tsify(from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 // allow empty object for future compatibility
-#[allow(clippy::empty_structs_with_brackets)]
+#[expect(clippy::empty_structs_with_brackets)]
 pub struct OxcLinterOptions {}
 
 #[derive(Debug, Default, Clone, Deserialize, Tsify)]

--- a/napi/minify/src/lib.rs
+++ b/napi/minify/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::needless_pass_by_value)]
+#![expect(clippy::needless_pass_by_value)]
 
 mod options;
 

--- a/napi/parser/src/magic_string.rs
+++ b/napi/parser/src/magic_string.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::cast_possible_truncation)]
+#![expect(clippy::cast_possible_truncation)]
 use std::sync::Arc;
 
 use napi::Either;
@@ -117,7 +117,7 @@ impl MagicString {
     }
 
     #[napi]
-    #[allow(clippy::inherent_to_string)]
+    #[allow(clippy::inherent_to_string, clippy::allow_attributes)]
     pub fn to_string(&self) -> String {
         self.cell.borrow_dependent().to_string()
     }

--- a/napi/transform/src/isolated_declaration.rs
+++ b/napi/transform/src/isolated_declaration.rs
@@ -40,7 +40,7 @@ impl From<IsolatedDeclarationsOptions> for oxc::isolated_declarations::IsolatedD
 }
 
 /// TypeScript Isolated Declarations for Standalone DTS Emit
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::allow_attributes)]
 #[napi]
 pub fn isolated_declaration(
     filename: String,

--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -1,5 +1,5 @@
 // NOTE: Types must be aligned with [@types/babel__core](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/b5dc32740d9b45d11cff9b025896dd333c795b39/types/babel__core/index.d.ts).
-#![allow(rustdoc::bare_urls)]
+#![expect(rustdoc::bare_urls)]
 
 use std::{
     ops::ControlFlow,
@@ -597,7 +597,7 @@ impl CompilerInterface for Compiler {
         self.declaration_map = ret.map.map(SourceMap::from);
     }
 
-    #[allow(deprecated)]
+    #[expect(deprecated)]
     fn after_transform(
         &mut self,
         _program: &mut oxc::ast::ast::Program<'_>,
@@ -622,7 +622,7 @@ impl CompilerInterface for Compiler {
 ///
 /// @returns an object containing the transformed code, source maps, and any
 /// errors that occurred during parsing or transformation.
-#[allow(clippy::needless_pass_by_value)]
+#[allow(clippy::needless_pass_by_value, clippy::allow_attributes)]
 #[napi]
 pub fn transform(
     filename: String,

--- a/tasks/ast_tools/src/derives/get_address.rs
+++ b/tasks/ast_tools/src/derives/get_address.rs
@@ -23,7 +23,7 @@ impl Derive for DeriveGetAddress {
 
     fn prelude(&self) -> TokenStream {
         quote! {
-            #![allow(clippy::match_same_arms)]
+            #![expect(clippy::match_same_arms)]
 
             ///@@line_break
             use oxc_allocator::{Address, GetAddress};

--- a/tasks/ast_tools/src/derives/get_span.rs
+++ b/tasks/ast_tools/src/derives/get_span.rs
@@ -47,7 +47,7 @@ impl Derive for DeriveGetSpan {
 
     fn prelude(&self) -> TokenStream {
         quote! {
-            #![allow(clippy::match_same_arms)]
+            #![expect(clippy::match_same_arms)]
 
             ///@@line_break
             use oxc_span::{Span, GetSpan};
@@ -91,7 +91,7 @@ impl Derive for DeriveGetSpanMut {
 
     fn prelude(&self) -> TokenStream {
         quote! {
-            #![allow(clippy::match_same_arms)]
+            #![expect(clippy::match_same_arms)]
 
             ///@@line_break
             use oxc_span::{Span, GetSpanMut};

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -48,7 +48,7 @@ impl Generator for AstBuilderGenerator {
             //! AST node factories
 
             //!@@line_break
-            #![allow(
+            #![expect(
                 clippy::default_trait_access,
                 clippy::too_many_arguments,
                 clippy::fn_params_excessive_bools,

--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -167,7 +167,7 @@ impl Generator for AstKindGenerator {
         }
 
         let output = quote! {
-            #![allow(missing_docs)] ///@ FIXME (in ast_tools/src/generators/ast_kind.rs)
+            #![expect(missing_docs)] ///@ FIXME (in ast_tools/src/generators/ast_kind.rs)
 
             ///@@line_break
             use std::ptr;

--- a/tasks/ast_tools/src/generators/visit.rs
+++ b/tasks/ast_tools/src/generators/visit.rs
@@ -231,7 +231,7 @@ fn generate_output(
         //! * [rustc visitor](https://github.com/rust-lang/rust/blob/1.82.0/compiler/rustc_ast/src/visit.rs)
 
         //!@@line_break
-        #![allow(unused_variables, clippy::semicolon_if_nothing_returned)]
+        #![expect(unused_variables, clippy::semicolon_if_nothing_returned)]
 
         ///@@line_break
         use std::cell::Cell;

--- a/tasks/ast_tools/src/output/rust.rs
+++ b/tasks/ast_tools/src/output/rust.rs
@@ -49,7 +49,7 @@ pub fn rust_fmt(source_text: &str) -> String {
 /// in generated code.
 ///
 /// `//!@` form can be used to insert a line break in a position where `///@ ...`
-/// is not valid syntax e.g. before an `#![allow(...)]`.
+/// is not valid syntax e.g. before an `#![expect(...)]`.
 ///
 /// To dynamically generate a comment:
 /// ```

--- a/tasks/benchmark/benches/lexer.rs
+++ b/tasks/benchmark/benches/lexer.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::disallowed_methods)]
+#![expect(clippy::disallowed_methods)]
 use oxc_allocator::Allocator;
 use oxc_ast::{ast::*, Visit};
 use oxc_benchmark::{criterion_group, criterion_main, BenchmarkId, Criterion};

--- a/tasks/common/src/lib.rs
+++ b/tasks/common/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout, clippy::disallowed_methods)]
+#![expect(clippy::print_stdout, clippy::disallowed_methods)]
 use std::path::{Path, PathBuf};
 
 mod diff;

--- a/tasks/compat_data/src/lib.rs
+++ b/tasks/compat_data/src/lib.rs
@@ -51,7 +51,7 @@ pub fn generate() {
     });
 
     let code = quote! {
-        #![allow(clippy::enum_glob_use, clippy::match_same_arms)]
+        #![expect(clippy::enum_glob_use, clippy::match_same_arms)]
 
         use std::sync::OnceLock;
 

--- a/tasks/compat_data/src/main.rs
+++ b/tasks/compat_data/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout)]
+#![expect(clippy::print_stdout)]
 use std::process::Command;
 
 use oxc_compat_data::generate;

--- a/tasks/coverage/src/lib.rs
+++ b/tasks/coverage/src/lib.rs
@@ -1,4 +1,5 @@
-#![allow(clippy::print_stdout, clippy::print_stderr, clippy::disallowed_methods)]
+#![expect(clippy::print_stdout, clippy::disallowed_methods)]
+
 // Core
 mod runtime;
 mod suite;

--- a/tasks/javascript_globals/src/main.rs
+++ b/tasks/javascript_globals/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout, clippy::print_stderr)]
+#![expect(clippy::print_stdout, clippy::print_stderr)]
 use lazy_static::lazy_static;
 use oxc_tasks_common::agent;
 use rustc_hash::FxHashMap;

--- a/tasks/minsize/src/lib.rs
+++ b/tasks/minsize/src/lib.rs
@@ -1,4 +1,5 @@
-#![allow(clippy::print_stdout, clippy::print_stderr)]
+#![expect(clippy::print_stdout)]
+
 use std::{
     fs::{self, File},
     io::{self, Write},

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout)]
+#![expect(clippy::print_stdout)]
 
 mod ignore_list;
 pub mod options;

--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout, clippy::print_stderr, clippy::disallowed_methods)]
+#![expect(clippy::print_stdout, clippy::print_stderr, clippy::disallowed_methods)]
 use std::{
     borrow::Cow,
     fmt::{self, Display, Formatter},

--- a/tasks/transform_conformance/src/lib.rs
+++ b/tasks/transform_conformance/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::print_stdout, clippy::print_stderr)]
+#![expect(clippy::print_stdout)]
 
 mod constants;
 mod driver;

--- a/tasks/website/src/lib.rs
+++ b/tasks/website/src/lib.rs
@@ -1,8 +1,3 @@
-#![allow(
-    clippy::print_stdout,
-    clippy::print_stderr,
-    clippy::missing_panics_doc,
-    clippy::disallowed_methods
-)]
+#![expect(clippy::print_stdout, clippy::missing_panics_doc, clippy::disallowed_methods)]
 
 pub mod linter;

--- a/tasks/website/src/linter/rules/html.rs
+++ b/tasks/website/src/linter/rules/html.rs
@@ -1,4 +1,4 @@
-#![allow(non_snake_case)]
+#![expect(non_snake_case)]
 
 use std::{
     cell::RefCell,

--- a/tasks/website/src/main.rs
+++ b/tasks/website/src/main.rs
@@ -1,4 +1,5 @@
-#![allow(clippy::print_stdout, clippy::print_stderr)]
+#![expect(clippy::print_stdout)]
+
 use pico_args::Arguments;
 use website::linter;
 

--- a/wasm/parser/CHANGELOG.md
+++ b/wasm/parser/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Refactor
 
-- 8cf9766 semantic, syntax, wasm: Remove `#![allow(non_snake_case)]` (#7863) (overlookmotel)
+- 8cf9766 semantic, syntax, wasm: Remove `#![expect(non_snake_case)]` (#7863) (overlookmotel)
 
 ## [0.35.0] - 2024-11-04
 

--- a/wasm/parser/src/lib.rs
+++ b/wasm/parser/src/lib.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::needless_pass_by_value)]
+#![expect(clippy::needless_pass_by_value)]
 
 use oxc::{allocator::Allocator, parser::Parser, span::SourceType};
 use serde::{Deserialize, Serialize};


### PR DESCRIPTION
Replace `#[allow]` with `#[expect]` through the whole codebase.

This also surfaced many places where the `#[allow]` attributes were outdated/pointless and could be removed entirely.

Only places `#[allow]` remains are:

1. In generated code and macros, where lint errors may or may not be triggered depending on the generated code.
2. A few places where clippy malfunctions. These use e.g. `#[allow(unused, clippy::allow_attributes)]`.
