### PR TITLE
chore(build): bump MSRV to 1.81.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ homepage = "https://oxc.rs"
 keywords = ["JavaScript", "TypeScript", "linter", "minifier", "parser"]
 license = "MIT"
 repository = "https://github.com/oxc-project/oxc"
-rust-version = "1.80" # Support last 5 minor versions.
+rust-version = "1.81.0" # Support last 4 minor versions.
 description = "A collection of JavaScript tools written in Rust."
 
 # <https://doc.rust-lang.org/rustc/lints/listing/allowed-by-default.html>


### PR DESCRIPTION
As noted in #8929, many Oxc crates won't compile at present with our MSRV of 1.80.0, due to the liberal use of `#[expect]` attribute, which wasn't stabilized until 1.81.0.

It becomes a lint error in 1.81.0 to use `#[allow]`, so it'd seem to me pretty pointless to convert all the `#[expect]` attrs to `#[allow]` to honour our MSRV now, when we'll have to change them back to `#[expect]` again shortly.

So I propose that we bump the MSRV to 1.81.0 early instead. Next minor version of Rust is out in 2 weeks anyway.
