### PR TITLE
refactor(ast_tools): remove `Def::file_id` method, add `StructDef::file` and `EnumDef::file` methods instead

### DIFF
--- a/tasks/ast_tools/src/schema/defs/box.rs
+++ b/tasks/ast_tools/src/schema/defs/box.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use super::{extensions::layout::Layout, Def, Derives, FileId, Schema, TypeDef, TypeId};
+use super::{extensions::layout::Layout, Def, Derives, Schema, TypeDef, TypeId};
 
 /// Type definition for a `Box`.
 #[derive(Debug)]
@@ -38,13 +38,6 @@ impl Def for BoxDef {
     /// Get type name.
     fn name(&self) -> &str {
         &self.name
-    }
-
-    /// Get [`FileId`] of file containing definition of this type.
-    ///
-    /// `Box`es are not defined in a file, so returns `None`.
-    fn file_id(&self) -> Option<FileId> {
-        None
     }
 
     /// Get all traits which have derives generated for this type.

--- a/tasks/ast_tools/src/schema/defs/cell.rs
+++ b/tasks/ast_tools/src/schema/defs/cell.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use super::{extensions::layout::Layout, Def, Derives, FileId, Schema, TypeDef, TypeId};
+use super::{extensions::layout::Layout, Def, Derives, Schema, TypeDef, TypeId};
 
 /// Type definition for a `Cell`.
 #[derive(Debug)]
@@ -38,13 +38,6 @@ impl Def for CellDef {
     /// Get type name.
     fn name(&self) -> &str {
         &self.name
-    }
-
-    /// Get [`FileId`] of file containing definition of this type.
-    ///
-    /// `Cell`s are not defined in a file, so returns `None`.
-    fn file_id(&self) -> Option<FileId> {
-        None
     }
 
     /// Get all traits which have derives generated for this type.

--- a/tasks/ast_tools/src/schema/defs/enum.rs
+++ b/tasks/ast_tools/src/schema/defs/enum.rs
@@ -16,7 +16,7 @@ use super::{
         layout::Layout,
         visit::{VisitEnum, VisitFieldOrVariant},
     },
-    Def, Derives, FileId, Schema, TypeDef, TypeId,
+    Def, Derives, File, FileId, Schema, TypeDef, TypeId,
 };
 
 pub type Discriminant = u8;
@@ -100,6 +100,12 @@ impl EnumDef {
         self.layout.layout_64.size == 1
     }
 
+    /// Get the [`File`] which this struct is defined in.
+    #[expect(dead_code)]
+    pub fn file<'s>(&self, schema: &'s Schema) -> &'s File {
+        &schema.files[self.file_id]
+    }
+
     /// Get iterator over variant indexes.
     ///
     /// Only includes own variant, not inherited.
@@ -122,11 +128,6 @@ impl Def for EnumDef {
     /// Get type name.
     fn name(&self) -> &str {
         &self.name
-    }
-
-    /// Get [`FileId`] of file containing definition of this type.
-    fn file_id(&self) -> Option<FileId> {
-        Some(self.file_id)
     }
 
     /// Get all traits which have derives generated for this type.

--- a/tasks/ast_tools/src/schema/defs/mod.rs
+++ b/tasks/ast_tools/src/schema/defs/mod.rs
@@ -3,7 +3,11 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::Ident;
 
-use crate::{codegen::DeriveId, utils::create_ident, Schema};
+use crate::{
+    codegen::DeriveId,
+    schema::{File, Schema},
+    utils::create_ident,
+};
 
 use super::{extensions, Derives, FileId, TypeId};
 
@@ -31,9 +35,6 @@ pub trait Def {
 
     /// Get type name.
     fn name(&self) -> &str;
-
-    /// Get [`FileId`] of file containing definition of this type.
-    fn file_id(&self) -> Option<FileId>;
 
     /// Get all traits which have derives generated for this type.
     fn generated_derives(&self) -> Derives;

--- a/tasks/ast_tools/src/schema/defs/option.rs
+++ b/tasks/ast_tools/src/schema/defs/option.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use super::{extensions::layout::Layout, Def, Derives, FileId, Schema, TypeDef, TypeId};
+use super::{extensions::layout::Layout, Def, Derives, Schema, TypeDef, TypeId};
 
 /// Type definition for an `Option`.
 #[derive(Debug)]
@@ -38,13 +38,6 @@ impl Def for OptionDef {
     /// Get type name.
     fn name(&self) -> &str {
         &self.name
-    }
-
-    /// Get [`FileId`] of file containing definition of this type.
-    ///
-    /// `Options`s are not defined in a file, so returns `None`.
-    fn file_id(&self) -> Option<FileId> {
-        None
     }
 
     /// Get all traits which have derives generated for this type.

--- a/tasks/ast_tools/src/schema/defs/primitive.rs
+++ b/tasks/ast_tools/src/schema/defs/primitive.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use super::{extensions::layout::Layout, Def, Derives, FileId, Schema, TypeDef, TypeId};
+use super::{extensions::layout::Layout, Def, Derives, Schema, TypeDef, TypeId};
 
 /// Type definition for a primitive type.
 ///
@@ -31,13 +31,6 @@ impl Def for PrimitiveDef {
     /// Get type name.
     fn name(&self) -> &str {
         self.name
-    }
-
-    /// Get [`FileId`] of file containing definition of this type.
-    ///
-    /// Primitives are not defined in a file, so returns `None`.
-    fn file_id(&self) -> Option<FileId> {
-        None
     }
 
     /// Get all traits which have derives generated for this type.

--- a/tasks/ast_tools/src/schema/defs/struct.rs
+++ b/tasks/ast_tools/src/schema/defs/struct.rs
@@ -16,7 +16,7 @@ use super::{
         span::SpanStruct,
         visit::{VisitFieldOrVariant, VisitStruct},
     },
-    Def, Derives, FileId, Schema, TypeDef, TypeId,
+    Def, Derives, File, FileId, Schema, TypeDef, TypeId,
 };
 
 /// Type definition for a struct.
@@ -77,6 +77,12 @@ impl StructDef {
         self.plural_name().to_case(Case::Snake)
     }
 
+    /// Get the [`File`] which this struct is defined in.
+    #[expect(dead_code)]
+    pub fn file<'s>(&self, schema: &'s Schema) -> &'s File {
+        &schema.files[self.file_id]
+    }
+
     /// Get iterator over field indexes.
     pub fn field_indices(&self) -> Range<usize> {
         0..self.fields.len()
@@ -92,11 +98,6 @@ impl Def for StructDef {
     /// Get type name.
     fn name(&self) -> &str {
         &self.name
-    }
-
-    /// Get [`FileId`] of file containing definition of this type.
-    fn file_id(&self) -> Option<FileId> {
-        Some(self.file_id)
     }
 
     /// Get all traits which have derives generated for this type.

--- a/tasks/ast_tools/src/schema/defs/type.rs
+++ b/tasks/ast_tools/src/schema/defs/type.rs
@@ -1,8 +1,8 @@
 use proc_macro2::TokenStream;
 
 use super::{
-    BoxDef, CellDef, Def, Derives, EnumDef, FileId, OptionDef, PrimitiveDef, Schema, StructDef,
-    TypeId, VecDef,
+    BoxDef, CellDef, Def, Derives, EnumDef, OptionDef, PrimitiveDef, Schema, StructDef, TypeId,
+    VecDef,
 };
 
 /// Type definition for a type.
@@ -41,21 +41,6 @@ impl Def for TypeDef {
             TypeDef::Box(def) => def.name(),
             TypeDef::Vec(def) => def.name(),
             TypeDef::Cell(def) => def.name(),
-        }
-    }
-
-    /// Get [`FileId`] of file containing definition of this type.
-    ///
-    /// Returns `None` if type is not defined in a file (e.g. primitives).
-    fn file_id(&self) -> Option<FileId> {
-        match self {
-            TypeDef::Struct(def) => def.file_id(),
-            TypeDef::Enum(def) => def.file_id(),
-            TypeDef::Primitive(def) => def.file_id(),
-            TypeDef::Option(def) => def.file_id(),
-            TypeDef::Box(def) => def.file_id(),
-            TypeDef::Vec(def) => def.file_id(),
-            TypeDef::Cell(def) => def.file_id(),
         }
     }
 

--- a/tasks/ast_tools/src/schema/defs/vec.rs
+++ b/tasks/ast_tools/src/schema/defs/vec.rs
@@ -3,7 +3,7 @@ use quote::quote;
 
 use super::{
     extensions::{layout::Layout, visit::VisitVec},
-    Def, Derives, FileId, Schema, TypeDef, TypeId,
+    Def, Derives, Schema, TypeDef, TypeId,
 };
 
 /// Type definition for a `Vec`.
@@ -48,13 +48,6 @@ impl Def for VecDef {
     /// Get type name.
     fn name(&self) -> &str {
         &self.name
-    }
-
-    /// Get [`FileId`] of file containing definition of this type.
-    ///
-    /// `Vec`s are not defined in a file, so returns `None`.
-    fn file_id(&self) -> Option<FileId> {
-        None
     }
 
     /// Get all traits which have derives generated for this type.


### PR DESCRIPTION
Refactor. Remove methods that weren't useful, and replace them with ones which are!