### PR TITLE
fix(ast_tools): do not flatten struct fields inline if fields are inaccessible from crate where `Serialize` impl is generated

### DIFF
--- a/tasks/ast_tools/src/schema/defs/struct.rs
+++ b/tasks/ast_tools/src/schema/defs/struct.rs
@@ -78,7 +78,6 @@ impl StructDef {
     }
 
     /// Get the [`File`] which this struct is defined in.
-    #[expect(dead_code)]
     pub fn file<'s>(&self, schema: &'s Schema) -> &'s File {
         &schema.files[self.file_id]
     }

--- a/tasks/ast_tools/src/schema/defs/type.rs
+++ b/tasks/ast_tools/src/schema/defs/type.rs
@@ -106,7 +106,6 @@ impl Def for TypeDef {
 
 /// `is_*` / `as_*` / `as_*_mut` methods.
 impl TypeDef {
-    #[expect(dead_code)]
     pub fn is_struct(&self) -> bool {
         matches!(self, Self::Struct(_))
     }
@@ -125,7 +124,6 @@ impl TypeDef {
         }
     }
 
-    #[expect(dead_code)]
     pub fn is_enum(&self) -> bool {
         matches!(self, Self::Enum(_))
     }


### PR DESCRIPTION
Fix a bug where ESTree codegen would generate a `Serialize` impl in one crate which attempts to access a private field of a struct defined in another crate.