### PR TITLE
refactor(ast): simplify serializing `SourceType`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -31,7 +31,6 @@ use super::{macros::inherit_variants, *};
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct Program<'a> {
     pub span: Span,
-    #[estree(via = crate::serialize::ESTreeSourceType, ts_type = "ModuleKind")]
     pub source_type: SourceType,
     #[estree(skip)]
     pub source_text: &'a str,

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -18,10 +18,7 @@ impl Serialize for Program<'_> {
         map.serialize_entry("type", "Program")?;
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry(
-            "sourceType",
-            &crate::serialize::ESTreeSourceType::from(&self.source_type),
-        )?;
+        self.source_type.serialize(FlatMapSerializer(&mut map))?;
         map.serialize_entry("hashbang", &self.hashbang)?;
         map.serialize_entry("directives", &self.directives)?;
         map.serialize_entry("body", &self.body)?;

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -7,7 +7,7 @@ use serde::{
 };
 
 use oxc_allocator::{Box as ArenaBox, Vec as ArenaVec};
-use oxc_span::{Atom, SourceType, Span};
+use oxc_span::{Atom, Span};
 use oxc_syntax::number::BigintBase;
 
 use crate::ast::{
@@ -321,19 +321,5 @@ impl Serialize for JSXMemberExpressionObject<'_> {
                 JSXIdentifier { span: expr.span, name: "this".into() }.serialize(serializer)
             }
         }
-    }
-}
-
-pub struct ESTreeSourceType<'a>(pub &'a SourceType);
-
-impl<'a> From<&'a SourceType> for ESTreeSourceType<'a> {
-    fn from(inner: &'a SourceType) -> Self {
-        Self(inner)
-    }
-}
-
-impl Serialize for ESTreeSourceType<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        self.0.module_kind().serialize(serializer)
     }
 }

--- a/crates/oxc_span/src/generated/derive_estree.rs
+++ b/crates/oxc_span/src/generated/derive_estree.rs
@@ -22,22 +22,8 @@ impl Serialize for Span {
 impl Serialize for SourceType {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("language", &self.language)?;
-        map.serialize_entry("moduleKind", &self.module_kind)?;
-        map.serialize_entry("variant", &self.variant)?;
+        map.serialize_entry("sourceType", &self.module_kind)?;
         map.end()
-    }
-}
-
-impl Serialize for Language {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        match self {
-            Language::JavaScript => serializer.serialize_unit_variant("Language", 0, "javascript"),
-            Language::TypeScript => serializer.serialize_unit_variant("Language", 1, "typescript"),
-            Language::TypeScriptDefinition => {
-                serializer.serialize_unit_variant("Language", 2, "typescriptDefinition")
-            }
-        }
     }
 }
 
@@ -49,17 +35,6 @@ impl Serialize for ModuleKind {
             ModuleKind::Unambiguous => {
                 serializer.serialize_unit_variant("ModuleKind", 2, "unambiguous")
             }
-        }
-    }
-}
-
-impl Serialize for LanguageVariant {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        match self {
-            LanguageVariant::Standard => {
-                serializer.serialize_unit_variant("LanguageVariant", 0, "standard")
-            }
-            LanguageVariant::Jsx => serializer.serialize_unit_variant("LanguageVariant", 1, "jsx"),
         }
     }
 }

--- a/crates/oxc_span/src/source_type/mod.rs
+++ b/crates/oxc_span/src/source_type/mod.rs
@@ -13,31 +13,30 @@ pub use error::UnknownExtension;
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[generate_derive(ESTree)]
-#[estree(no_type)]
+#[estree(no_type, flatten)]
 pub struct SourceType {
     /// JavaScript or TypeScript, default JavaScript
+    #[estree(skip)]
     pub(super) language: Language,
 
     /// Script or Module, default Module
+    #[estree(rename = "sourceType")]
     pub(super) module_kind: ModuleKind,
 
     /// Support JSX for JavaScript and TypeScript? default without JSX
+    #[estree(skip)]
     pub(super) variant: LanguageVariant,
 }
 
 /// JavaScript or TypeScript
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[generate_derive(ESTree)]
 pub enum Language {
     /// Indicates a JavaScript or JSX file
-    #[estree(rename = "javascript")]
     JavaScript = 0,
     /// Indicates a TypeScript file
-    #[estree(rename = "typescript")]
     TypeScript = 1,
     /// Indicates a TypeScript definition file (`*.d.ts`)
-    #[estree(rename = "typescriptDefinition")]
     TypeScriptDefinition = 2,
 }
 
@@ -64,7 +63,6 @@ pub enum ModuleKind {
 /// JSX for JavaScript and TypeScript
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-#[generate_derive(ESTree)]
 pub enum LanguageVariant {
     /// Standard JavaScript or TypeScript without any language extensions. Stage
     /// 3 proposals do not count as language extensions.

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -1806,17 +1806,7 @@ export interface Span {
   end: number;
 }
 
-export interface SourceType {
-  language: Language;
-  moduleKind: ModuleKind;
-  variant: LanguageVariant;
-}
-
-export type Language = 'javascript' | 'typescript' | 'typescriptDefinition';
-
 export type ModuleKind = 'script' | 'module' | 'unambiguous';
-
-export type LanguageVariant = 'standard' | 'jsx';
 
 export interface Pattern extends Span {
   type: 'Pattern';


### PR DESCRIPTION
#8919 fixed serialization of the `Program::source_type` field.

Remove the custom `Serialize` impl for this - use `#[estree(flatten)]` and `#[estree(skip)]` attributes to achieve the same thing. Also, remove extraneous TS type definitions for the parts of `SourceType` which aren't part of the ESTree AST.
