### PR TITLE
refactor(ast): simplify serializing literal types

### DIFF
--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -20,7 +20,11 @@ use oxc_syntax::number::{BigintBase, NumberBase};
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "Literal", via = crate::serialize::ESTreeLiteral, add_ts = "raw: string | null")]
+#[estree(
+    rename = "Literal",
+    add_fields(raw = crate::serialize::boolean_literal_raw(self)),
+    add_ts = "raw: string | null",
+)]
 pub struct BooleanLiteral {
     /// Node location in source code
     pub span: Span,
@@ -34,7 +38,14 @@ pub struct BooleanLiteral {
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "Literal", via = crate::serialize::ESTreeLiteral, add_ts = "value: null, raw: \"null\" | null")]
+#[estree(
+    rename = "Literal",
+    add_fields(
+        value = (),
+        raw = crate::serialize::null_literal_raw(self),
+    ),
+    add_ts = "value: null, raw: \"null\" | null",
+)]
 pub struct NullLiteral {
     /// Node location in source code
     pub span: Span,
@@ -46,7 +57,7 @@ pub struct NullLiteral {
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, ContentEq, GetSpan, GetSpanMut, ESTree)]
-#[estree(rename = "Literal", via = crate::serialize::ESTreeLiteral)]
+#[estree(rename = "Literal")]
 pub struct NumericLiteral<'a> {
     /// Node location in source code
     pub span: Span,
@@ -69,7 +80,7 @@ pub struct NumericLiteral<'a> {
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, ContentEq, GetSpan, GetSpanMut, ESTree)]
-#[estree(rename = "Literal", via = crate::serialize::ESTreeLiteral)]
+#[estree(rename = "Literal")]
 pub struct StringLiteral<'a> {
     /// Node location in source code
     pub span: Span,
@@ -89,7 +100,14 @@ pub struct StringLiteral<'a> {
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, ContentEq, GetSpan, GetSpanMut, ESTree)]
-#[estree(rename = "Literal", via = crate::serialize::ESTreeLiteral, add_ts = "value: null, bigint: string")]
+#[estree(
+    rename = "Literal",
+    add_fields(
+        value = (),
+        bigint = crate::serialize::bigint_literal_bigint(self),
+    ),
+    add_ts = "value: null, bigint: string",
+)]
 pub struct BigIntLiteral<'a> {
     /// Node location in source code
     pub span: Span,
@@ -109,16 +127,15 @@ pub struct BigIntLiteral<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, ContentEq, GetSpan, GetSpanMut, ESTree)]
 #[estree(
-	rename = "Literal",
-	via = crate::serialize::ESTreeLiteral,
-	add_ts = "value: {} | null, regex: { pattern: string, flags: string }"
+    rename = "Literal",
+    add_fields(value = crate::serialize::EmptyObject),
+    add_ts = "value: {} | null",
 )]
 pub struct RegExpLiteral<'a> {
     /// Node location in source code
     pub span: Span,
     /// The parsed regular expression. See [`oxc_regular_expression`] for more
     /// details.
-    #[estree(skip)]
     pub regex: RegExp<'a>,
     /// The regular expression as it appears in source code
     ///
@@ -136,8 +153,10 @@ pub struct RegExpLiteral<'a> {
 #[estree(no_type)]
 pub struct RegExp<'a> {
     /// The regex pattern between the slashes
+    #[estree(ts_type = "string")]
     pub pattern: RegExpPattern<'a>,
     /// Regex flags after the closing slash
+    #[estree(ts_type = "string")]
     pub flags: RegExpFlags,
 }
 
@@ -147,6 +166,7 @@ pub struct RegExp<'a> {
 #[ast]
 #[derive(Debug)]
 #[generate_derive(CloneIn, ESTree)]
+#[estree(custom_serialize, no_ts_def)]
 pub enum RegExpPattern<'a> {
     /// Unparsed pattern. Contains string slice of the pattern.
     /// Pattern was not parsed, so may be valid or invalid.
@@ -204,28 +224,6 @@ bitflags! {
 /// Dummy type to communicate the content of `RegExpFlags` to `oxc_ast_tools`.
 #[ast(foreign = RegExpFlags)]
 #[generate_derive(ESTree)]
-#[estree(
-    custom_serialize,
-    custom_ts_def = "
-        type RegExpFlags = {
-            /** Global flag */
-            G: 1;
-            /** Ignore case flag */
-            I: 2;
-            /** Multiline flag */
-            M: 4;
-            /** DotAll flag */
-            S: 8;
-            /** Unicode flag */
-            U: 16;
-            /** Sticky flag */
-            Y: 32;
-            /** Indices flag */
-            D: 64;
-            /** Unicode sets flag */
-            V: 128;
-        }
-    "
-)]
+#[estree(custom_serialize, no_ts_def)]
 #[expect(dead_code)]
 struct RegExpFlagsAlias(u8);

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1886,37 +1886,75 @@ impl Serialize for ModuleExportName<'_> {
 
 impl Serialize for BooleanLiteral {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        crate::serialize::ESTreeLiteral::from(self).serialize(serializer)
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "Literal")?;
+        map.serialize_entry("start", &self.span.start)?;
+        map.serialize_entry("end", &self.span.end)?;
+        map.serialize_entry("value", &self.value)?;
+        map.serialize_entry("raw", &crate::serialize::boolean_literal_raw(self))?;
+        map.end()
     }
 }
 
 impl Serialize for NullLiteral {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        crate::serialize::ESTreeLiteral::from(self).serialize(serializer)
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "Literal")?;
+        map.serialize_entry("start", &self.span.start)?;
+        map.serialize_entry("end", &self.span.end)?;
+        map.serialize_entry("value", &())?;
+        map.serialize_entry("raw", &crate::serialize::null_literal_raw(self))?;
+        map.end()
     }
 }
 
 impl Serialize for NumericLiteral<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        crate::serialize::ESTreeLiteral::from(self).serialize(serializer)
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "Literal")?;
+        map.serialize_entry("start", &self.span.start)?;
+        map.serialize_entry("end", &self.span.end)?;
+        map.serialize_entry("value", &self.value)?;
+        map.serialize_entry("raw", &self.raw)?;
+        map.end()
     }
 }
 
 impl Serialize for StringLiteral<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        crate::serialize::ESTreeLiteral::from(self).serialize(serializer)
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "Literal")?;
+        map.serialize_entry("start", &self.span.start)?;
+        map.serialize_entry("end", &self.span.end)?;
+        map.serialize_entry("value", &self.value)?;
+        map.serialize_entry("raw", &self.raw)?;
+        map.end()
     }
 }
 
 impl Serialize for BigIntLiteral<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        crate::serialize::ESTreeLiteral::from(self).serialize(serializer)
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "Literal")?;
+        map.serialize_entry("start", &self.span.start)?;
+        map.serialize_entry("end", &self.span.end)?;
+        map.serialize_entry("raw", &self.raw)?;
+        map.serialize_entry("value", &())?;
+        map.serialize_entry("bigint", &crate::serialize::bigint_literal_bigint(self))?;
+        map.end()
     }
 }
 
 impl Serialize for RegExpLiteral<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        crate::serialize::ESTreeLiteral::from(self).serialize(serializer)
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "Literal")?;
+        map.serialize_entry("start", &self.span.start)?;
+        map.serialize_entry("end", &self.span.end)?;
+        map.serialize_entry("regex", &self.regex)?;
+        map.serialize_entry("raw", &self.raw)?;
+        map.serialize_entry("value", &crate::serialize::EmptyObject)?;
+        map.end()
     }
 }
 
@@ -1926,16 +1964,6 @@ impl Serialize for RegExp<'_> {
         map.serialize_entry("pattern", &self.pattern)?;
         map.serialize_entry("flags", &self.flags)?;
         map.end()
-    }
-}
-
-impl Serialize for RegExpPattern<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        match self {
-            RegExpPattern::Raw(it) => it.serialize(serializer),
-            RegExpPattern::Invalid(it) => it.serialize(serializer),
-            RegExpPattern::Pattern(it) => it.serialize(serializer),
-        }
     }
 }
 

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -1033,36 +1033,15 @@ export interface BigIntLiteral extends Span {
 
 export interface RegExpLiteral extends Span {
   type: 'Literal';
+  regex: RegExp;
   raw: string | null;
   value: {} | null;
-  regex: { pattern: string; flags: string };
 }
 
 export interface RegExp {
-  pattern: RegExpPattern;
-  flags: RegExpFlags;
+  pattern: string;
+  flags: string;
 }
-
-export type RegExpPattern = string | string | Pattern;
-
-export type RegExpFlags = {
-  /** Global flag */
-  G: 1;
-  /** Ignore case flag */
-  I: 2;
-  /** Multiline flag */
-  M: 4;
-  /** DotAll flag */
-  S: 8;
-  /** Unicode flag */
-  U: 16;
-  /** Sticky flag */
-  Y: 32;
-  /** Indices flag */
-  D: 64;
-  /** Unicode sets flag */
-  V: 128;
-};
 
 export interface JSXElement extends Span {
   type: 'JSXElement';


### PR DESCRIPTION
Minimize the amount of hand-written serialization code for literal types (`BooleanLiteral` etc), mostly by using `#[estree(add_fields(...))]`.

Also correct the TS type def for `RegExpLiteral`.