### PR TITLE
refactor(ast): introduce `#[estree(ts_alias)]` attr and use it on `Elision`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -281,7 +281,6 @@ pub struct ThisExpression {
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ArrayExpression<'a> {
     pub span: Span,
-    #[estree(ts_type = "Array<SpreadElement | Expression | null>")]
     pub elements: Vec<'a, ArrayExpressionElement<'a>>,
     /// Array trailing comma
     /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#arrays>
@@ -298,7 +297,6 @@ inherit_variants! {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(no_ts_def)]
 pub enum ArrayExpressionElement<'a> {
     /// `...[3, 4]` in `const array = [1, 2, ...[3, 4], null];`
     SpreadElement(Box<'a, SpreadElement<'a>>) = 64,
@@ -318,7 +316,8 @@ pub enum ArrayExpressionElement<'a> {
 /// Serialized as `null` in JSON AST. See `serialize.rs`.
 #[ast(visit)]
 #[derive(Debug, Clone)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq)]
+#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[estree(custom_serialize, ts_alias = "null")]
 pub struct Elision {
     pub span: Span,
 }

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -77,8 +77,10 @@ export interface ThisExpression extends Span {
 
 export interface ArrayExpression extends Span {
   type: 'ArrayExpression';
-  elements: Array<SpreadElement | Expression | null>;
+  elements: Array<ArrayExpressionElement>;
 }
+
+export type ArrayExpressionElement = SpreadElement | null | Expression;
 
 export interface ObjectExpression extends Span {
   type: 'ObjectExpression';

--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -115,9 +115,8 @@ fn parse_estree_attr(location: AttrLocation, part: AttrPart) -> Result<()> {
             AttrPart::String("custom_ts_def", value) => {
                 struct_def.estree.custom_ts_def = Some(value);
             }
-            AttrPart::String("add_ts_def", value) => {
-                struct_def.estree.add_ts_def = Some(value);
-            }
+            AttrPart::String("ts_alias", value) => struct_def.estree.ts_alias = Some(value),
+            AttrPart::String("add_ts_def", value) => struct_def.estree.add_ts_def = Some(value),
             AttrPart::String("rename", value) => struct_def.estree.rename = Some(value),
             AttrPart::String("via", value) => struct_def.estree.via = Some(value),
             _ => return Err(()),

--- a/tasks/ast_tools/src/schema/extensions/estree.rs
+++ b/tasks/ast_tools/src/schema/extensions/estree.rs
@@ -16,6 +16,10 @@ pub struct ESTreeStruct {
     /// Custom TS type definition. Does not include `export`.
     /// Empty string if type should not have a TS type definition.
     pub custom_ts_def: Option<String>,
+    /// TS alias.
+    /// e.g. `#[estree(ts_alias = "null")]` means this type won't have a type def generated,
+    /// and any struct / enum referencing it will substitute `null` as the type.
+    pub ts_alias: Option<String>,
     /// Additional custom TS type definition to add along with the generated one.
     /// Does not include `export`.
     pub add_ts_def: Option<String>,


### PR DESCRIPTION
Introduce `#[estree(ts_alias = "...")]` attribute to tell Typescript generator to substitute another type in the place of this one.

Use it on `Elision`, to make its TS type `null`. This allows removing other customizing attributes from other types - the codegen does more of the work.