### PR TITLE
fix(minifier): fix comparison of strings with unicode characters

### DIFF
--- a/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
@@ -487,7 +487,9 @@ pub trait ConstantEvaluation<'a>: MayHaveSideEffects {
         if px.is_string() && py.is_string() {
             let left_string = self.get_side_free_string_value(x)?;
             let right_string = self.get_side_free_string_value(y)?;
-            return Some(ConstantValue::Boolean(left_string.cmp(&right_string) == Ordering::Less));
+            return Some(ConstantValue::Boolean(
+                left_string.encode_utf16().cmp(right_string.encode_utf16()) == Ordering::Less,
+            ));
         }
 
         let left_num = self.get_side_free_number_value(x)?;

--- a/crates/oxc_minifier/tests/peephole/esbuild.rs
+++ b/crates/oxc_minifier/tests/peephole/esbuild.rs
@@ -927,10 +927,10 @@ fn constant_evaluation_test() {
     test("x = 'ab' > 'abc'", "x = !1;");
     test("x = 'ab' <= 'abc'", "x = !0;");
     test("x = 'ab' >= 'abc'", "x = !1;");
-    // test("x = '𐙩' < 'ﬡ'", "x = !0;"); // FIXME
-    // test("x = '𐙩' > 'ﬡ'", "x = !1;"); // FIXME
-    // test("x = '𐙩' <= 'ﬡ'", "x = !0;"); // FIXME
-    // test("x = '𐙩' >= 'ﬡ'", "x = !1;"); // FIXME
+    test("x = '𐙩' < 'ﬡ'", "x = !0;");
+    test("x = '𐙩' > 'ﬡ'", "x = !1;");
+    test("x = '𐙩' <= 'ﬡ'", "x = !0;");
+    test("x = '𐙩' >= 'ﬡ'", "x = !1;");
     test("x = 3 in 6", "x = 3 in 6;");
     test("x = 3 instanceof 6", "x = 3 instanceof 6;");
     test("x = (3, 6)", "x = 6;");


### PR DESCRIPTION
In `IsLessThan`, strings are compared by the following step.

3. If px is a String and py is a String, then
   a. Let lx be the length of px.
   b. Let ly be the length of py.
   c. For each integer i such that 0 ≤ i < min(lx, ly), in ascending order, do
      i. Let cx be the numeric value of the code unit at index i within px.
      ii. Let cy be the numeric value of the code unit at index i within py.
      iii. If cx < cy, return true.
      iv. If cx > cy, return false.
   d. If lx < ly, return true. Otherwise, return false.

Quoting the note below the algorithm

> The comparison of Strings uses a simple lexicographic ordering on sequences of UTF-16 code unit values.

It compares the UTF-16 code unit. The previous code was using UTF-8 code unit.

**References**
- [Spec of `IsLessThan`](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-islessthan)

