### PR TITLE
feat(minifier): fold simple literals passed to unary `+`

### DIFF
--- a/crates/oxc_minifier/tests/peephole/esbuild.rs
+++ b/crates/oxc_minifier/tests/peephole/esbuild.rs
@@ -891,9 +891,9 @@ fn constant_evaluation_test() {
     test("x = !5", "x = !1;");
     test("x = typeof 5", "x = 'number';");
     test("x = +''", "x = 0;");
-    // test("x = +[]", "x = 0;");
+    test("x = +[]", "x = 0;");
     test("x = +{}", "x = NaN;");
-    // test("x = +/1/", "x = NaN;");
+    test("x = +/1/", "x = NaN;");
     test("x = +[1]", "x = +[1];");
     test("x = +'123'", "x = 123;");
     test("x = +'-123'", "x = -123;");


### PR DESCRIPTION
Added support for folding `+[]` and `+/any-regex/`.

`+` uses `ToNumber` and `ToNumber` uses `ToPrimitive` for objects. `ToPrimitive` for `[]` returns `""`, for `/any-regex/` it returns `"/any-regex/"`.

**References**
- [Spec of unary `+`](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-unary-plus-operator-runtime-semantics-evaluation)
- [Spec of `ToPrimitive`](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-toprimitive)

