### PR TITLE
feat(minifier): fold complicated array literals passed to unary `+`

### DIFF
--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -1204,6 +1204,16 @@ mod test {
         fold("a=~0xffffffff", "a=0");
         fold("a=~~0xffffffff", "a=-1");
         fold("a=~.5", "a=-1");
+
+        fold("a=+[]", "a=0");
+        fold_same("a=+[...foo]");
+        fold("a=+[,]", "a=0");
+        fold("a=+[0]", "a=0");
+        fold("a=+['0x10']", "a=16");
+        fold("a=+[[]]", "a=0");
+        fold("a=+[0, 1]", "a=NaN");
+        test_same("var foo; NOOP(a=+[0, ...foo])"); // can be either `a=0` or `a=NaN` (also `...foo` may have a side effect)
+        test("var foo; NOOP(a=+[0, ...[foo ? 'foo': ''], 1])", "var foo; NOOP(a=NaN)");
     }
 
     #[test]

--- a/crates/oxc_minifier/tests/peephole/esbuild.rs
+++ b/crates/oxc_minifier/tests/peephole/esbuild.rs
@@ -894,7 +894,7 @@ fn constant_evaluation_test() {
     test("x = +[]", "x = 0;");
     test("x = +{}", "x = NaN;");
     test("x = +/1/", "x = NaN;");
-    test("x = +[1]", "x = +[1];");
+    test("x = +[1]", "x = 1;");
     test("x = +'123'", "x = 123;");
     test("x = +'-123'", "x = -123;");
     test("x = +'0x10'", "x = 16;");


### PR DESCRIPTION
Array literals never have `Symbol.toPrimitive` / `toString` / `valueOf` overriden (assuming the prototype is not modified).
So for array literals `Array::toString` is used for `ToPrimitive`. `Array::toString` calls `Array::join`.
If there's only one element, `Array::join` returns the stringified first element. If there's more than one element, the return value of it always contains `,` .

**References**
- [Spec of unary `+`](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-unary-plus-operator-runtime-semantics-evaluation)
- [Spec of `ToPrimitive`](https://tc39.es/ecma262/multipage/abstract-operations.html#sec-toprimitive)
- [Spec of `Array::toString`](https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.tostring)
- [Spec of `Array::join`](https://tc39.es/ecma262/multipage/indexed-collections.html#sec-array.prototype.join)