### PR TITLE
feat(minifier): fold typeof `{ foo }` when `foo` is declared

### DIFF
--- a/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
@@ -395,9 +395,10 @@ pub trait ConstantEvaluation<'a>: MayHaveSideEffects {
         match expr.operator {
             UnaryOperator::Typeof => {
                 let s = match &expr.argument {
-                    Expression::ObjectExpression(_) | Expression::ArrayExpression(_)
-                        if expr.argument.is_literal_value(true) =>
-                    {
+                    Expression::ObjectExpression(_) | Expression::ArrayExpression(_) => {
+                        if self.expression_may_have_side_effects(&expr.argument) {
+                            return None;
+                        }
                         "object"
                     }
                     Expression::FunctionExpression(_) => "function",

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -1158,7 +1158,9 @@ mod test {
         fold("x = typeof [1]", "x = \"object\"");
         fold("x = typeof [1,[]]", "x = \"object\"");
         fold("x = typeof {}", "x = \"object\"");
+        test("var foo; NOOP(x = typeof { foo })", "var foo; NOOP(x = \"object\")");
         fold("x = typeof function() {}", "x = 'function'");
+        fold_same("x = typeof foo"); // no sideeffect, but we don't know the result
 
         fold_same("x = typeof[1,[foo()]]");
         fold_same("x = typeof{bathwater:baby()}");


### PR DESCRIPTION
An access to declared `foo` is returns false for `is_literal_value`, but it's fine remove it as it doesn't have a sideeffect.