### PR TITLE
fix(ecmascript): `ValueType::from` for unknown value should return Undetermined instead of Number

### DIFF
--- a/crates/oxc_ecmascript/src/constant_evaluation/value_type.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/value_type.rs
@@ -78,10 +78,16 @@ impl<'a> From<&Expression<'a>> for ValueType {
                 UnaryOperator::Void => Self::Undefined,
                 UnaryOperator::UnaryNegation => {
                     let argument_ty = Self::from(&unary_expr.argument);
-                    if argument_ty == Self::BigInt {
-                        return Self::BigInt;
+                    match argument_ty {
+                        Self::BigInt => Self::BigInt,
+                        // non-object values other than BigInt are converted to number by `ToNumber`
+                        Self::Number
+                        | Self::Boolean
+                        | Self::String
+                        | Self::Null
+                        | Self::Undefined => Self::Number,
+                        Self::Undetermined | Self::Object => Self::Undetermined,
                     }
-                    Self::Number
                 }
                 UnaryOperator::UnaryPlus => Self::Number,
                 UnaryOperator::LogicalNot | UnaryOperator::Delete => Self::Boolean,

--- a/crates/oxc_minifier/tests/ecmascript/value_type.rs
+++ b/crates/oxc_minifier/tests/ecmascript/value_type.rs
@@ -50,7 +50,13 @@ fn unary_tests() {
     test("-0", ValueType::Number);
     test("-Infinity", ValueType::Number);
     test("-0n", ValueType::BigInt);
-    // test("-foo", ValueType::Undetermined); // can be number or bigint
+    test("-true", ValueType::Number); // -1
+    test("-''", ValueType::Number); // -0
+    test("-'0n'", ValueType::Number); // NaN
+    test("-null", ValueType::Number); // -0
+    test("-undefined", ValueType::Number); // NaN
+    test("-{ valueOf() { return 0n } }", ValueType::Undetermined);
+    test("-foo", ValueType::Undetermined); // can be number or bigint
 
     test("+0", ValueType::Number);
     test("+true", ValueType::Number);

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -17,7 +17,7 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 
 1.25 MB    | 650.34 kB  | 646.76 kB  | 160.96 kB  | 163.73 kB  | three.js  
 
-2.14 MB    | 717.04 kB  | 724.14 kB  | 162.02 kB  | 181.07 kB  | victory.js
+2.14 MB    | 717.05 kB  | 724.14 kB  | 162.02 kB  | 181.07 kB  | victory.js
 
 3.20 MB    | 1.01 MB    | 1.01 MB    | 324.34 kB  | 331.56 kB  | echarts.js
 


### PR DESCRIPTION
**References**
- [Spec of unary `-`](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-unary-minus-operator-runtime-semantics-evaluation)