### PR TITLE
feat(ecmascript): `ValueType::from` for bitwise not operator

### DIFF
--- a/crates/oxc_ecmascript/src/constant_evaluation/value_type.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/value_type.rs
@@ -76,7 +76,7 @@ impl<'a> From<&Expression<'a>> for ValueType {
             },
             Expression::UnaryExpression(unary_expr) => match unary_expr.operator {
                 UnaryOperator::Void => Self::Undefined,
-                UnaryOperator::UnaryNegation => {
+                UnaryOperator::UnaryNegation | UnaryOperator::BitwiseNot => {
                     let argument_ty = Self::from(&unary_expr.argument);
                     match argument_ty {
                         Self::BigInt => Self::BigInt,
@@ -92,7 +92,6 @@ impl<'a> From<&Expression<'a>> for ValueType {
                 UnaryOperator::UnaryPlus => Self::Number,
                 UnaryOperator::LogicalNot | UnaryOperator::Delete => Self::Boolean,
                 UnaryOperator::Typeof => Self::String,
-                UnaryOperator::BitwiseNot => Self::Undetermined,
             },
             Expression::BinaryExpression(e) => Self::from(&**e),
             Expression::SequenceExpression(e) => {

--- a/crates/oxc_minifier/tests/ecmascript/value_type.rs
+++ b/crates/oxc_minifier/tests/ecmascript/value_type.rs
@@ -57,6 +57,9 @@ fn unary_tests() {
     test("-undefined", ValueType::Number); // NaN
     test("-{ valueOf() { return 0n } }", ValueType::Undetermined);
     test("-foo", ValueType::Undetermined); // can be number or bigint
+    test("~0", ValueType::Number);
+    test("~0n", ValueType::BigInt);
+    test("~foo", ValueType::Undetermined); // can be number or bigint
 
     test("+0", ValueType::Number);
     test("+true", ValueType::Number);
@@ -71,10 +74,6 @@ fn unary_tests() {
 
     test("typeof 0", ValueType::String);
     test("typeof foo", ValueType::String);
-
-    // test("~0", ValueType::Number);
-    // test("~0n", ValueType::BigInt);
-    test("~foo", ValueType::Undetermined); // can be number or bigint
 }
 
 #[test]


### PR DESCRIPTION
**References**
- [Spec of `~`](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-bitwise-not-operator-runtime-semantics-evaluation)
- [Spec of unary `-`](https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-unary-minus-operator-runtime-semantics-evaluation)