### PR TITLE
feat(tasks): ESTree conformance runner print JSON diff

### DIFF
--- a/tasks/coverage/src/tools/estree.rs
+++ b/tasks/coverage/src/tools/estree.rs
@@ -90,7 +90,7 @@ impl Case for EstreeTest262Case {
                     .missing_newline_hint(false)
             )
             .unwrap();
-            self.base.set_result(TestResult::Mismatch("Mismatch", String::new(), String::new()));
+            self.base.set_result(TestResult::Mismatch("Mismatch", oxc_json, acorn_json));
         }
     }
 }


### PR DESCRIPTION
ESTree conformance runner print JSON diff when run with `--diff`.

```sh
just test-estree --diff --filter array-like-has-length-but-no-indexes-with-values.js
```

The diff is not as useful as it could be, because it doesn't contain line numbers, but sometimes it's enough, and avoids delving into the diff files folder.