### PR TITLE
fix(codegen): parenthesis is lacking when a pure comment is placed before a function expression inside a call expression

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1429,6 +1429,7 @@ impl GenExpr for PrivateFieldExpression<'_> {
 
 impl GenExpr for CallExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
+        let is_statement = p.start_of_stmt == p.code_len();
         let is_export_default = p.start_of_default_export == p.code_len();
         let mut wrap = precedence >= Precedence::New || ctx.intersects(Context::FORBID_CALL);
         if precedence >= Precedence::Postfix && p.has_annotation_comment(self.span.start) {
@@ -1439,6 +1440,8 @@ impl GenExpr for CallExpression<'_> {
             p.print_annotation_comments(self.span.start);
             if is_export_default {
                 p.start_of_default_export = p.code_len();
+            } else if is_statement {
+                p.start_of_stmt = p.code_len();
             }
             p.add_source_mapping(self.span);
             self.callee.print_expr(p, Precedence::Postfix, Context::empty());

--- a/crates/oxc_codegen/tests/integration/pure_comments.rs
+++ b/crates/oxc_codegen/tests/integration/pure_comments.rs
@@ -195,6 +195,8 @@ const defineSSRCustomElement = () => {
         let exp_no = /* @__PURE__ */ foo() ** foo();
         let new_exp_no = /* @__PURE__ */ new foo() ** foo();
         ",
+        "{ /* @__PURE__ */ (function() {})(); }",
+        "{ /* @__PURE__ */ (() => {})(); }",
     ];
 
     snapshot("pure_comments", &cases);

--- a/crates/oxc_codegen/tests/integration/snapshots/pure_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/pure_comments.snap
@@ -397,3 +397,17 @@ let parens_no = foo(bar);
 let new_parens_no = new foo(bar);
 let exp_no = /* @__PURE__ */ foo() ** foo();
 let new_exp_no = /* @__PURE__ */ new foo() ** foo();
+
+########## 22
+{ /* @__PURE__ */ (function() {})(); }
+----------
+{
+	/* @__PURE__ */ (function() {})();
+}
+
+########## 23
+{ /* @__PURE__ */ (() => {})(); }
+----------
+{
+	/* @__PURE__ */ (() => {})();
+}


### PR DESCRIPTION
close: #8906
