### PR TITLE
fix(transformer/typescript): typescript parameter properties disappear when there's two or more classes that uses that feature

### DIFF
--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -372,6 +372,7 @@ impl<'a> Traverse<'a> for TypeScriptAnnotations<'a, '_> {
                             .map(|assignment| assignment.create_this_property_assignment(ctx)),
                     );
             }
+            self.has_super_call = false;
         }
     }
 

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments/input.ts
@@ -9,3 +9,7 @@ class Bar extends Foo {
     super(foo, bar, zoo, bang, too);
   }
 }
+class Baz extends Bar {
+  constructor(public foo, private bar, protected zoo, readonly bang, override boom, too) {
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/class-constructor-arguments/output.js
@@ -8,9 +8,20 @@ class Foo {
     console.log(this.foo, this.bar, this.zoo, this.bang);
   }
 }
+
 class Bar extends Foo {
   constructor(foo, bar, zoo, bang, boom, too) {
     super(foo, bar, zoo, bang, too);
+    this.foo = foo;
+    this.bar = bar;
+    this.zoo = zoo;
+    this.bang = bang;
+    this.boom = boom;
+  }
+}
+
+class Baz extends Bar {
+  constructor(foo, bar, zoo, bang, boom, too) {
     this.foo = foo;
     this.bar = bar;
     this.zoo = zoo;


### PR DESCRIPTION
close: #8917

This problem is due to forgetting to reset the status.