### PR TITLE
docs(linter): add prettier-ignore where formatting ruins code

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_nonoctal_decimal_escape.rs
@@ -30,13 +30,23 @@ declare_oxc_lint!(
     /// ECMAScript specification treats \8 and \9 in string literals as a legacy feature
     ///
     /// ### Example
+    ///
+    /// Examples of **incorrect** code for this rule:
+    ///
+    /// <!-- prettier-ignore-start -->
+    ///
     /// ```javascript
-    /// incorrect:
-    /// "\8"
-    /// "\9"
-    /// correct:
-    /// "8"
-    /// "\\9"
+    /// let x = "\8"
+    /// let y = "\9"
+    /// ```
+    ///
+    /// <!-- prettier-ignore-end -->
+    ///
+    /// Examples of **correct** code for this rule:
+    ///
+    /// ```javascript
+    /// let x = "8"
+    /// let y = "\\9"
     /// ```
     NoNonoctalDecimalEscape,
     eslint,

--- a/crates/oxc_linter/src/rules/unicorn/escape_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/escape_case.rs
@@ -28,20 +28,25 @@ declare_oxc_lint!(
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
+    ///
+    /// <!-- prettier-ignore-start -->
+    ///
     /// ```javascript
-    /// const foo = '\xa9';
-    /// const foo = '\ud834';
-    /// const foo = '\u{1d306}';
-    /// const foo = '\ca';
+    /// const foo = "\xa9";
+    /// const foo = "\ud834";
+    /// const foo = "\u{1d306}";
+    /// const foo = "\ca";
     /// ```
     ///
     /// Examples of **correct** code for this rule:
     /// ```javascript
-    /// const foo = '\xA9';
-    /// const foo = '\uD834';
-    /// const foo = '\u{1D306}';
-    /// const foo = '\cA';
+    /// const foo = "\xA9";
+    /// const foo = "\uD834";
+    /// const foo = "\u{1D306}";
+    /// const foo = "\cA";
     /// ```
+    ///
+    /// <!-- prettier-ignore-end -->
     EscapeCase,
     unicorn,
     pedantic,


### PR DESCRIPTION
While running `just website`, I noticed that these docs were causing some issues when running `npm run fmt` subsequently, I think due to the usage of character escapes. Disabling prettier seems to stop this from occurring.

Also the code examples in `no-nonoctal-decimal-escape` had weird formatting due to the usage of text which gets parsed as a label, so I updated the example.