### PR TITLE
feat(napi/parser): add `convert_span_utf16` option

### DIFF
--- a/napi/parser/index.d.ts
+++ b/napi/parser/index.d.ts
@@ -198,6 +198,11 @@ export interface ParserOptions {
    * Default: true
    */
   preserveParens?: boolean
+  /**
+   * Default: false
+   * @experimental Only for internal usage on Rolldown and Vite.
+   */
+  convertSpanUtf16?: boolean
 }
 
 /** Parse synchronously. */

--- a/napi/parser/src/types.rs
+++ b/napi/parser/src/types.rs
@@ -24,6 +24,10 @@ pub struct ParserOptions {
     ///
     /// Default: true
     pub preserve_parens: Option<bool>,
+
+    /// Default: false
+    /// @experimental Only for internal usage on Rolldown and Vite.
+    pub convert_span_utf16: Option<bool>,
 }
 
 #[napi]

--- a/napi/parser/test/parse.test.ts
+++ b/napi/parser/test/parse.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { assert, describe, expect, it } from 'vitest';
 
 import { parseAsync, parseSync } from '../index.js';
 
@@ -26,6 +26,20 @@ describe('parse', () => {
     });
     expect(code.substring(comment.start, comment.end)).toBe('/*' + comment.value + '*/');
   });
+});
+
+it('utf16 span', async () => {
+  const code = "'🤨'";
+  {
+    const ret = await parseAsync('test.js', code);
+    expect(ret.program.end).toMatchInlineSnapshot(`6`);
+  }
+  {
+    const ret = await parseAsync('test.js', code, {
+      convertSpanUtf16: true,
+    });
+    expect(ret.program.end).toMatchInlineSnapshot(`4`);
+  }
 });
 
 describe('error', () => {


### PR DESCRIPTION
For starter, I added opt-in `convert_span_utf16` for `napi/parser` level option, so rolldown-vite can start to battle test estree output.