### PR TITLE
refactor(ast): add `NULL` value for serializing null types

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1724,7 +1724,7 @@ pub struct FunctionBody<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(
-    add_fields(generator = false, id = ()),
+    add_fields(generator = false, id = crate::serialize::NULL),
     add_ts = "generator: false; id: null"
 )]
 pub struct ArrowFunctionExpression<'a> {

--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -41,7 +41,7 @@ pub struct BooleanLiteral {
 #[estree(
     rename = "Literal",
     add_fields(
-        value = (),
+        value = crate::serialize::NULL,
         raw = crate::serialize::null_literal_raw(self),
     ),
     add_ts = "value: null, raw: \"null\" | null",
@@ -103,7 +103,7 @@ pub struct StringLiteral<'a> {
 #[estree(
     rename = "Literal",
     add_fields(
-        value = (),
+        value = crate::serialize::NULL,
         bigint = crate::serialize::bigint_literal_bigint(self),
     ),
     add_ts = "value: null, bigint: string",

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1427,7 +1427,7 @@ impl Serialize for ArrowFunctionExpression<'_> {
         map.serialize_entry("returnType", &self.return_type)?;
         map.serialize_entry("body", &self.body)?;
         map.serialize_entry("generator", &false)?;
-        map.serialize_entry("id", &())?;
+        map.serialize_entry("id", &crate::serialize::NULL)?;
         map.end()
     }
 }
@@ -1910,7 +1910,7 @@ impl Serialize for NullLiteral {
         map.serialize_entry("type", "Literal")?;
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("value", &())?;
+        map.serialize_entry("value", &crate::serialize::NULL)?;
         map.serialize_entry("raw", &crate::serialize::null_literal_raw(self))?;
         map.end()
     }
@@ -1947,7 +1947,7 @@ impl Serialize for BigIntLiteral<'_> {
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
         map.serialize_entry("raw", &self.raw)?;
-        map.serialize_entry("value", &())?;
+        map.serialize_entry("value", &crate::serialize::NULL)?;
         map.serialize_entry("bigint", &crate::serialize::bigint_literal_bigint(self))?;
         map.end()
     }

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -14,6 +14,9 @@ use oxc_syntax::number::BigintBase;
 
 use crate::ast::*;
 
+/// Constant value that will be serialized as `null` in JSON.
+pub(crate) const NULL: () = ();
+
 // --------------------
 // Literals
 // --------------------


### PR DESCRIPTION
from https://github.com/oxc-project/oxc/pull/8980#discussion_r1948222912, added a special value that just represents a unit type, which should always be serialized to `null`