### PR TITLE
feat(prettier): Debug print Doc AST 

### DIFF
--- a/crates/oxc_prettier/examples/prettier.rs
+++ b/crates/oxc_prettier/examples/prettier.rs
@@ -18,6 +18,8 @@ fn main() -> std::io::Result<()> {
     let name = args.subcommand().ok().flatten().unwrap_or_else(|| String::from("test.js"));
     let semi = !args.contains("--no-semi");
 
+    let debug = args.contains("--debug");
+
     let path = Path::new(&name);
     let source_text = std::fs::read_to_string(path)?;
     let allocator = Allocator::default();
@@ -25,11 +27,13 @@ fn main() -> std::io::Result<()> {
     let ret = Parser::new(&allocator, &source_text, source_type)
         .with_options(ParseOptions { preserve_parens: false, ..ParseOptions::default() })
         .parse();
-    let output = Prettier::new(
+    let mut prettier = Prettier::new(
         &allocator,
         PrettierOptions { semi, trailing_comma: TrailingComma::All, ..PrettierOptions::default() },
-    )
-    .build(&ret.program);
+    );
+
+    let output =
+        if debug { prettier.doc(&ret.program).to_string() } else { prettier.build(&ret.program) };
     println!("{output}");
 
     Ok(())

--- a/crates/oxc_prettier/examples/prettier.rs
+++ b/crates/oxc_prettier/examples/prettier.rs
@@ -11,6 +11,16 @@ use pico_args::Arguments;
 // create a `test.js`,
 // run `cargo run -p oxc_prettier --example prettier`
 // or `just example prettier`
+//
+// Debug:
+// run `cargo run -p oxc_prettier --example prettier -- --debug`
+//
+// The output will be the Doc AST JSON(= most verbose form) of the Prettier,
+// now you can paste and inspect it in their playground.
+// https://prettier.io/playground
+// Be sure to:
+// - change global option `--parser: doc-explorer`
+// - enable debug option `show doc`
 
 fn main() -> std::io::Result<()> {
     let mut args = Arguments::from_env();

--- a/crates/oxc_prettier/src/ir/display.rs
+++ b/crates/oxc_prettier/src/ir/display.rs
@@ -1,126 +1,123 @@
-use crate::ir::{Doc, Line};
+use crate::ir::{Doc, Fill, Group, IfBreak, IndentIfBreak, Line};
 
 impl std::fmt::Display for Doc<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", print_doc_to_debug(self))
+        write!(f, "{}", print_doc_ast(self))
     }
 }
 
-// https://github.com/prettier/prettier/blob/3.3.3/src/document/debug.js
-fn print_doc_to_debug(doc: &Doc<'_>) -> std::string::String {
-    use std::string::String;
-    let mut string = String::new();
+/// Print as Prettier's Doc AST format.
+/// You can pass this to `Prettier.__debug.formatDoc(docAst)` to inspect them as Doc commands.
+fn print_doc_ast(doc: &Doc<'_>) -> String {
+    let mut json = String::new();
+
     match doc {
         Doc::Str(s) => {
-            string.push('"');
-            string.push_str(s);
-            string.push('"');
+            json.push_str(&format!("\"{s}\""));
         }
         Doc::Array(docs) => {
-            string.push_str("[\n");
-            for (idx, doc) in docs.iter().enumerate() {
-                string.push_str(&print_doc_to_debug(doc));
-                if idx != docs.len() - 1 {
-                    string.push_str(", ");
-                }
-            }
-            string.push_str("]\n");
+            json.push_str(&format!(
+                "[{}]",
+                docs.iter().map(|doc| print_doc_ast(doc)).collect::<Vec<_>>().join(",")
+            ));
         }
         Doc::Indent(contents) => {
-            string.push_str("indent([");
-            for (idx, doc) in contents.iter().enumerate() {
-                string.push_str(&print_doc_to_debug(doc));
-                if idx != contents.len() - 1 {
-                    string.push_str(", ");
-                }
-            }
-            string.push_str("])");
-        }
-        Doc::IndentIfBreak(indent_if_break) => {
-            string.push_str("indentIfBreak(");
-            string.push_str("[\n");
-            string.push_str(&print_doc_to_debug(&indent_if_break.contents));
-            string.push_str(&format!(", {{id: {}}}", indent_if_break.group_id));
-            string.push_str("])");
-        }
-        Doc::Group(group) => {
-            if group.expanded_states.is_some() {
-                string.push_str("conditionalGroup([\n");
-            }
-
-            string.push_str("group([\n");
-            for (idx, doc) in group.contents.iter().enumerate() {
-                string.push_str(&print_doc_to_debug(doc));
-                if idx != group.contents.len() - 1 {
-                    string.push_str(", ");
-                }
-            }
-            string.push_str("], { shouldBreak: ");
-            string.push_str(&group.should_break.to_string());
-            if let Some(id) = group.group_id {
-                string.push_str(&format!(", id: {id}"));
-            }
-            string.push_str(" })");
-
-            if let Some(expanded_states) = &group.expanded_states {
-                string.push_str(",\n");
-                for (idx, doc) in expanded_states.iter().enumerate() {
-                    string.push_str(&print_doc_to_debug(doc));
-                    if idx != expanded_states.len() - 1 {
-                        string.push_str(", ");
-                    }
-                }
-                string.push_str("])");
-            }
-        }
-        Doc::Line(Line { soft, hard, .. }) => {
-            if *soft {
-                string.push_str("softline");
-            } else if *hard {
-                string.push_str("hardline");
-            } else {
-                string.push_str("line");
-            }
-        }
-        Doc::IfBreak(if_break) => {
-            string.push_str(&format!(
-                "ifBreak({}, {}",
-                print_doc_to_debug(&if_break.break_contents),
-                print_doc_to_debug(&if_break.flat_contents)
+            json.push('{');
+            json.push_str(r#""type":"indent""#);
+            json.push(',');
+            json.push_str(&format!(
+                r#""contents":[{}]"#,
+                contents.iter().map(|doc| print_doc_ast(doc)).collect::<Vec<_>>().join(",")
             ));
-            if let Some(group_id) = if_break.group_id {
-                string.push_str(&format!(", {{ groupId: {group_id} }}"));
-            }
-            string.push(')');
+            json.push('}');
         }
-        Doc::Fill(fill) => {
-            string.push_str("fill([\n");
-            let parts = fill.parts();
-            for (idx, doc) in parts.iter().enumerate() {
-                string.push_str(&print_doc_to_debug(doc));
-                if idx != parts.len() - 1 {
-                    string.push_str(", ");
-                }
+        Doc::IndentIfBreak(IndentIfBreak { contents, group_id }) => {
+            json.push('{');
+            json.push_str(r#""type":"indent_if_break""#);
+            json.push(',');
+            json.push_str(&format!(r#""contents":{}"#, print_doc_ast(contents)));
+            json.push(',');
+            json.push_str(&format!(r#"group_id":"{group_id}""#));
+            json.push('}');
+        }
+        Doc::Group(Group { contents, should_break, expanded_states, group_id }) => {
+            json.push('{');
+            json.push_str(r#""type":"group""#);
+            if let Some(group_id) = group_id {
+                json.push(',');
+                json.push_str(&format!(r#""id":"{group_id}""#));
             }
-            string.push_str("])");
+            json.push(',');
+            json.push_str(&format!(
+                r#""contents":[{}]"#,
+                contents.iter().map(|doc| print_doc_ast(doc)).collect::<Vec<_>>().join(",")
+            ));
+            json.push(',');
+            json.push_str(&format!(r#""break":{should_break}"#));
+            if let Some(expanded_states) = expanded_states {
+                json.push(',');
+                json.push_str(&format!(
+                    r#""expandStates":[{}]"#,
+                    expanded_states
+                        .iter()
+                        .map(|doc| print_doc_ast(doc))
+                        .collect::<Vec<_>>()
+                        .join(",")
+                ));
+            }
+            json.push('}');
+        }
+        Doc::Line(Line { soft, hard, literal }) => {
+            if *literal {
+                json.push_str(r#"{"type":"line","literal":true,"hard":true}"#);
+            } else if *hard {
+                json.push_str(r#"{"type":"line","hard":true}"#);
+            } else if *soft {
+                json.push_str(r#"{"type":"line","soft":true}"#);
+            } else {
+                json.push_str(r#"{"type":"line"}"#);
+            }
+        }
+        Doc::IfBreak(IfBreak { break_contents, flat_contents, group_id }) => {
+            json.push('{');
+            json.push_str(r#""type":"if-break""#);
+            json.push(',');
+            json.push_str(&format!(r#""break_contents":{}"#, print_doc_ast(break_contents)));
+            json.push(',');
+            json.push_str(&format!(r#""flat_contents":{}"#, print_doc_ast(flat_contents)));
+            if let Some(group_id) = group_id {
+                json.push(',');
+                json.push_str(&format!(r#""group_id":"{group_id}""#));
+            }
+            json.push('}');
+        }
+        Doc::Fill(Fill { parts }) => {
+            json.push('{');
+            json.push_str(r#""type":"fill""#);
+            json.push(',');
+            json.push_str(&format!(
+                r#""parts":[{}]"#,
+                parts.iter().map(|doc| print_doc_ast(doc)).collect::<Vec<_>>().join(",")
+            ));
+            json.push('}');
         }
         Doc::LineSuffix(docs) => {
-            string.push_str("lineSuffix(");
-            for (idx, doc) in docs.iter().enumerate() {
-                string.push_str(&print_doc_to_debug(doc));
-                if idx != docs.len() - 1 {
-                    string.push_str(", ");
-                }
-            }
-            string.push(')');
+            json.push('{');
+            json.push_str(r#""type":"line-suffix""#);
+            json.push(',');
+            json.push_str(&format!(
+                r#""contents":[{}]"#,
+                docs.iter().map(|doc| print_doc_ast(doc)).collect::<Vec<_>>().join(",")
+            ));
+            json.push('}');
         }
         Doc::LineSuffixBoundary => {
-            string.push_str("lineSuffixBoundary");
+            json.push_str(r#"{"type":"line-suffix-boundary"}"#);
         }
         Doc::BreakParent => {
-            string.push_str("BreakParent");
+            json.push_str(r#"{"type":"break-parent"}"#);
         }
     }
 
-    string
+    json
 }

--- a/crates/oxc_prettier/src/ir/display.rs
+++ b/crates/oxc_prettier/src/ir/display.rs
@@ -33,11 +33,11 @@ fn print_doc_ast(doc: &Doc<'_>) -> String {
         }
         Doc::IndentIfBreak(IndentIfBreak { contents, group_id }) => {
             json.push('{');
-            json.push_str(r#""type":"indent_if_break""#);
+            json.push_str(r#""type":"indent-if-break""#);
             json.push(',');
             json.push_str(&format!(r#""contents":{}"#, print_doc_ast(contents)));
             json.push(',');
-            json.push_str(&format!(r#"group_id":"{group_id}""#));
+            json.push_str(&format!(r#"groupId":"{group_id}""#));
             json.push('}');
         }
         Doc::Group(Group { contents, should_break, expanded_states, group_id }) => {
@@ -82,12 +82,12 @@ fn print_doc_ast(doc: &Doc<'_>) -> String {
             json.push('{');
             json.push_str(r#""type":"if-break""#);
             json.push(',');
-            json.push_str(&format!(r#""break_contents":{}"#, print_doc_ast(break_contents)));
+            json.push_str(&format!(r#""breakContents":{}"#, print_doc_ast(break_contents)));
             json.push(',');
-            json.push_str(&format!(r#""flat_contents":{}"#, print_doc_ast(flat_contents)));
+            json.push_str(&format!(r#""flatContents":{}"#, print_doc_ast(flat_contents)));
             if let Some(group_id) = group_id {
                 json.push(',');
-                json.push_str(&format!(r#""group_id":"{group_id}""#));
+                json.push_str(&format!(r#""groupId":"{group_id}""#));
             }
             json.push('}');
         }

--- a/crates/oxc_prettier/src/ir/doc.rs
+++ b/crates/oxc_prettier/src/ir/doc.rs
@@ -30,7 +30,7 @@ pub struct Group<'a> {
 
 #[derive(Debug)]
 pub struct Fill<'a> {
-    pub contents: Vec<'a, Doc<'a>>,
+    pub parts: Vec<'a, Doc<'a>>,
 }
 
 #[derive(Debug)]
@@ -56,29 +56,29 @@ pub struct IndentIfBreak<'a> {
 // Printer utils
 impl<'a> Fill<'a> {
     pub fn drain_out_pair(&mut self) -> (Option<Doc<'a>>, Option<Doc<'a>>) {
-        let content = if self.contents.len() > 0 { Some(self.contents.remove(0)) } else { None };
-        let whitespace = if self.contents.len() > 0 { Some(self.contents.remove(0)) } else { None };
+        let content = if self.parts.len() > 0 { Some(self.parts.remove(0)) } else { None };
+        let whitespace = if self.parts.len() > 0 { Some(self.parts.remove(0)) } else { None };
         (content, whitespace)
     }
 
     pub fn dequeue(&mut self) -> Option<Doc<'a>> {
-        if self.contents.len() > 0 {
-            Some(self.contents.remove(0))
+        if self.parts.len() > 0 {
+            Some(self.parts.remove(0))
         } else {
             None
         }
     }
 
     pub fn enqueue(&mut self, doc: Doc<'a>) {
-        self.contents.insert(0, doc);
+        self.parts.insert(0, doc);
     }
 
     pub fn parts(&self) -> &[Doc<'a>] {
-        &self.contents
+        &self.parts
     }
 
     pub fn take_parts(self) -> Vec<'a, Doc<'a>> {
-        self.contents
+        self.parts
     }
 }
 

--- a/crates/oxc_prettier/src/lib.rs
+++ b/crates/oxc_prettier/src/lib.rs
@@ -74,6 +74,7 @@ impl<'a> Prettier<'a> {
     }
 
     pub fn doc(mut self, program: &Program<'a>) -> Doc<'a> {
+        self.source_text = program.source_text;
         program.format(&mut self)
     }
 

--- a/crates/oxc_prettier/src/macros.rs
+++ b/crates/oxc_prettier/src/macros.rs
@@ -150,7 +150,7 @@ macro_rules! fill {
         fill!($p, temp_vec)
     }};
     ($p:ident, $vec:expr) => {{
-        $crate::ir::Doc::Fill($crate::ir::Fill { contents: $vec })
+        $crate::ir::Doc::Fill($crate::ir::Fill { parts: $vec })
     }};
 }
 

--- a/crates/oxc_prettier/src/utils/document.rs
+++ b/crates/oxc_prettier/src/utils/document.rs
@@ -24,7 +24,7 @@ pub fn will_break(doc: &mut Doc<'_>) -> bool {
         Doc::IfBreak(d) => will_break(&mut d.break_contents),
         Doc::Array(arr) | Doc::Indent(arr) | Doc::LineSuffix(arr) => check_array(arr),
         Doc::IndentIfBreak(IndentIfBreak { contents, .. }) => will_break(contents),
-        Doc::Fill(doc) => check_array(&mut doc.contents),
+        Doc::Fill(doc) => check_array(&mut doc.parts),
         Doc::Line(doc) => doc.hard,
         Doc::Str(_) | Doc::LineSuffixBoundary => false,
     }


### PR DESCRIPTION
Part of #5068 

Update `doc.to_string()` output to `Prettier.__debug.formatDoc()` compatible Doc AST json format.

```sh
# Usecase
cargo run -p oxc_prettier --example prettier --quiet -- --debug | jq .

# Advanced
cargo run -p oxc_prettier --example prettier --quiet -- --debug | pbcopy
# Open Prettier playground, select doc-explorer as parser option, then paste as input!
```