### PR TITLE
fix(ast/estree): use `#[estree(append_to)]` for `TSModuleBlock`

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1205,11 +1205,11 @@ pub enum TSModuleDeclarationBody<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(custom_serialize)]
 pub struct TSModuleBlock<'a> {
     pub span: Span,
-    #[estree(skip)]
+    #[estree(rename = "body")]
     pub directives: Vec<'a, Directive<'a>>,
+    #[estree(append_to = "directives")]
     pub body: Vec<'a, Statement<'a>>,
 }
 

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -3043,6 +3043,20 @@ impl Serialize for TSModuleDeclarationBody<'_> {
     }
 }
 
+impl Serialize for TSModuleBlock<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "TSModuleBlock")?;
+        map.serialize_entry("start", &self.span.start)?;
+        map.serialize_entry("end", &self.span.end)?;
+        map.serialize_entry(
+            "body",
+            &AppendToConcat { array: &self.directives, after: &self.body },
+        )?;
+        map.end()
+    }
+}
+
 impl Serialize for TSTypeLiteral<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(None)?;

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -1280,7 +1280,7 @@ export type TSModuleDeclarationBody = TSModuleDeclaration | TSModuleBlock;
 
 export interface TSModuleBlock extends Span {
   type: 'TSModuleBlock';
-  body: Array<Statement>;
+  body: Array<Directive | Statement>;
 }
 
 export interface TSTypeLiteral extends Span {


### PR DESCRIPTION
Replace custom `Serialize` impl for `TSModuleBlock` by using `#[estree(append_to)]` instead. This also fixes the TS type def for `TSModuleBlock`.