### PR TITLE
fix(ast/estree): fix serializing `BigInt`s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1585,8 +1585,6 @@ dependencies = [
  "bitflags 2.8.0",
  "cow-utils",
  "nonmax",
- "num-bigint",
- "num-traits",
  "oxc_allocator",
  "oxc_ast_macros",
  "oxc_estree",

--- a/crates/oxc_ast/Cargo.toml
+++ b/crates/oxc_ast/Cargo.toml
@@ -29,8 +29,6 @@ oxc_syntax = { workspace = true }
 bitflags = { workspace = true }
 cow-utils = { workspace = true }
 nonmax = { workspace = true }
-num-bigint = { workspace = true }
-num-traits = { workspace = true }
 
 serde = { workspace = true, features = ["derive"], optional = true }
 serde_json = { workspace = true, optional = true }

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -1,8 +1,6 @@
-use std::io::Write;
+use std::{borrow::Cow, io::Write};
 
 use cow_utils::CowUtils;
-use num_bigint::BigInt;
-use num_traits::Num;
 use serde::{
     ser::{SerializeMap, SerializeSeq, Serializer},
     Serialize,
@@ -10,7 +8,6 @@ use serde::{
 
 use oxc_allocator::{Box as ArenaBox, Vec as ArenaVec};
 use oxc_span::Span;
-use oxc_syntax::number::BigintBase;
 
 use crate::ast::*;
 
@@ -109,21 +106,8 @@ pub fn null_literal_raw(lit: &NullLiteral) -> Option<&str> {
 }
 
 /// Get `bigint` field of `BigIntLiteral`.
-pub fn bigint_literal_bigint(lit: &BigIntLiteral) -> String {
-    let src = &lit.raw.strip_suffix('n').unwrap().cow_replace('_', "");
-    let src = match lit.base {
-        BigintBase::Decimal => src,
-        BigintBase::Binary | BigintBase::Octal | BigintBase::Hex => &src[2..],
-    };
-
-    let radix = match lit.base {
-        BigintBase::Decimal => 10,
-        BigintBase::Binary => 2,
-        BigintBase::Octal => 8,
-        BigintBase::Hex => 16,
-    };
-
-    BigInt::from_str_radix(src, radix).unwrap().to_string()
+pub fn bigint_literal_bigint<'a>(lit: &'a BigIntLiteral<'a>) -> Cow<'a, str> {
+    lit.raw.strip_suffix('n').unwrap().cow_replace('_', "")
 }
 
 /// A placeholder for `RegExpLiteral`'s `value` field.

--- a/tasks/coverage/snapshots/estree_test262.snap
+++ b/tasks/coverage/snapshots/estree_test262.snap
@@ -2,7 +2,7 @@ commit: bc5c1417
 
 estree_test262 Summary:
 AST Parsed     : 44293/44293 (100.00%)
-Positive Passed: 40072/44293 (90.47%)
+Positive Passed: 40146/44293 (90.64%)
 Mismatch: tasks/coverage/test262/test/annexB/built-ins/RegExp/prototype/compile/flags-string-invalid.js
 Mismatch: tasks/coverage/test262/test/annexB/built-ins/RegExp/prototype/compile/flags-undefined.js
 Mismatch: tasks/coverage/test262/test/annexB/built-ins/RegExp/prototype/compile/pattern-regexp-props.js
@@ -18,27 +18,6 @@ serde_json error: lone leading surrogate in hex escape at line 154 column 28
 tasks/coverage/test262/test/built-ins/Array/prototype/concat/Array.prototype.concat_spreadable-string-wrapper.js
 serde_json error: unexpected end of hex escape at line 245 column 33
 
-Mismatch: tasks/coverage/test262/test/built-ins/Atomics/and/bigint/good-views.js
-Mismatch: tasks/coverage/test262/test/built-ins/Atomics/or/bigint/good-views.js
-Mismatch: tasks/coverage/test262/test/built-ins/Atomics/wait/bigint/no-spurious-wakeup-on-store.js
-Mismatch: tasks/coverage/test262/test/built-ins/Atomics/waitAsync/bigint/no-spurious-wakeup-on-store.js
-Mismatch: tasks/coverage/test262/test/built-ins/Atomics/xor/bigint/good-views.js
-Mismatch: tasks/coverage/test262/test/built-ins/BigInt/asIntN/arithmetic.js
-Mismatch: tasks/coverage/test262/test/built-ins/BigInt/asUintN/arithmetic.js
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigInt64/return-values-custom-offset.js
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigInt64/return-values.js
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigInt64/to-boolean-littleendian.js
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigInt64/toindex-byteoffset-toprimitive.js
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigInt64/toindex-byteoffset-wrapped-values.js
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigInt64/toindex-byteoffset.js
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigUint64/return-values-custom-offset.js
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigUint64/return-values.js
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigUint64/to-boolean-littleendian.js
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigUint64/toindex-byteoffset-toprimitive.js
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigUint64/toindex-byteoffset-wrapped-values.js
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/getBigUint64/toindex-byteoffset.js
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/setBigInt64/set-values-little-endian-order.js
-Mismatch: tasks/coverage/test262/test/built-ins/DataView/prototype/setBigInt64/to-boolean-littleendian.js
 Mismatch: tasks/coverage/test262/test/built-ins/Function/prototype/toString/private-method-class-expression.js
 Mismatch: tasks/coverage/test262/test/built-ins/Function/prototype/toString/private-method-class-statement.js
 Mismatch: tasks/coverage/test262/test/built-ins/Function/prototype/toString/private-static-method-class-expression.js
@@ -309,16 +288,8 @@ Mismatch: tasks/coverage/test262/test/language/arguments-object/cls-expr-private
 Mismatch: tasks/coverage/test262/test/language/arguments-object/cls-expr-private-meth-static-args-trailing-comma-single-args.js
 Mismatch: tasks/coverage/test262/test/language/arguments-object/cls-expr-private-meth-static-args-trailing-comma-spread-operator.js
 Mismatch: tasks/coverage/test262/test/language/arguments-object/cls-expr-private-meth-static-args-trailing-comma-undefined.js
-Mismatch: tasks/coverage/test262/test/language/expressions/addition/bigint-arithmetic.js
 Mismatch: tasks/coverage/test262/test/language/expressions/assignment/fn-name-lhs-cover.js
 Mismatch: tasks/coverage/test262/test/language/expressions/assignment/target-cover-id.js
-Mismatch: tasks/coverage/test262/test/language/expressions/bitwise-and/bigint-non-primitive.js
-Mismatch: tasks/coverage/test262/test/language/expressions/bitwise-and/bigint.js
-Mismatch: tasks/coverage/test262/test/language/expressions/bitwise-not/bigint.js
-Mismatch: tasks/coverage/test262/test/language/expressions/bitwise-or/bigint-non-primitive.js
-Mismatch: tasks/coverage/test262/test/language/expressions/bitwise-or/bigint.js
-Mismatch: tasks/coverage/test262/test/language/expressions/bitwise-xor/bigint-non-primitive.js
-Mismatch: tasks/coverage/test262/test/language/expressions/bitwise-xor/bigint.js
 Mismatch: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-ary-init-iter-close.js
 Mismatch: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-ary-init-iter-no-close.js
 Mismatch: tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-ary-name-iter-val.js
@@ -1929,9 +1900,6 @@ Mismatch: tasks/coverage/test262/test/language/expressions/compound-assignment/l
 Mismatch: tasks/coverage/test262/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-rshift.js
 Mismatch: tasks/coverage/test262/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-srshift.js
 Mismatch: tasks/coverage/test262/test/language/expressions/compound-assignment/left-hand-side-private-reference-readonly-accessor-property-sub.js
-Mismatch: tasks/coverage/test262/test/language/expressions/division/bigint-arithmetic.js
-Mismatch: tasks/coverage/test262/test/language/expressions/does-not-equals/bigint-and-bigint.js
-Mismatch: tasks/coverage/test262/test/language/expressions/does-not-equals/bigint-and-number-extremes.js
 Mismatch: tasks/coverage/test262/test/language/expressions/dynamic-import/always-create-new-promise.js
 Mismatch: tasks/coverage/test262/test/language/expressions/dynamic-import/assign-expr-get-value-abrupt-throws.js
 Mismatch: tasks/coverage/test262/test/language/expressions/dynamic-import/assignment-expression/additive-expr.js
@@ -2404,17 +2372,10 @@ Mismatch: tasks/coverage/test262/test/language/expressions/dynamic-import/usage/
 Mismatch: tasks/coverage/test262/test/language/expressions/dynamic-import/usage/top-level-import-then-is-call-expression-square-brackets.js
 Mismatch: tasks/coverage/test262/test/language/expressions/dynamic-import/usage/top-level-import-then-returns-thenable.js
 Mismatch: tasks/coverage/test262/test/language/expressions/dynamic-import/usage/top-level-import-then-specifier-tostring.js
-Mismatch: tasks/coverage/test262/test/language/expressions/equals/bigint-and-bigint.js
-Mismatch: tasks/coverage/test262/test/language/expressions/equals/bigint-and-number-extremes.js
-Mismatch: tasks/coverage/test262/test/language/expressions/exponentiation/bigint-arithmetic.js
 Mismatch: tasks/coverage/test262/test/language/expressions/function/scope-name-var-open-non-strict.js
 Mismatch: tasks/coverage/test262/test/language/expressions/function/scope-name-var-open-strict.js
 Mismatch: tasks/coverage/test262/test/language/expressions/generators/scope-name-var-open-non-strict.js
 Mismatch: tasks/coverage/test262/test/language/expressions/generators/scope-name-var-open-strict.js
-Mismatch: tasks/coverage/test262/test/language/expressions/greater-than/bigint-and-bigint.js
-Mismatch: tasks/coverage/test262/test/language/expressions/greater-than/bigint-and-number-extremes.js
-Mismatch: tasks/coverage/test262/test/language/expressions/greater-than-or-equal/bigint-and-bigint.js
-Mismatch: tasks/coverage/test262/test/language/expressions/greater-than-or-equal/bigint-and-number-extremes.js
 Mismatch: tasks/coverage/test262/test/language/expressions/import.meta/distinct-for-each-module.js
 Mismatch: tasks/coverage/test262/test/language/expressions/in/private-field-presence-accessor-shadowed.js
 Mismatch: tasks/coverage/test262/test/language/expressions/in/private-field-presence-accessor.js
@@ -2427,12 +2388,6 @@ Mismatch: tasks/coverage/test262/test/language/expressions/in/private-field-rhs-
 Mismatch: tasks/coverage/test262/test/language/expressions/in/private-field-rhs-non-object.js
 Mismatch: tasks/coverage/test262/test/language/expressions/in/private-field-rhs-unresolvable.js
 Mismatch: tasks/coverage/test262/test/language/expressions/in/private-field-rhs-yield-present.js
-Mismatch: tasks/coverage/test262/test/language/expressions/left-shift/bigint-non-primitive.js
-Mismatch: tasks/coverage/test262/test/language/expressions/left-shift/bigint.js
-Mismatch: tasks/coverage/test262/test/language/expressions/less-than/bigint-and-bigint.js
-Mismatch: tasks/coverage/test262/test/language/expressions/less-than/bigint-and-number-extremes.js
-Mismatch: tasks/coverage/test262/test/language/expressions/less-than-or-equal/bigint-and-bigint.js
-Mismatch: tasks/coverage/test262/test/language/expressions/less-than-or-equal/bigint-and-number-extremes.js
 Mismatch: tasks/coverage/test262/test/language/expressions/logical-assignment/left-hand-side-private-reference-accessor-property-and.js
 Mismatch: tasks/coverage/test262/test/language/expressions/logical-assignment/left-hand-side-private-reference-accessor-property-nullish.js
 Mismatch: tasks/coverage/test262/test/language/expressions/logical-assignment/left-hand-side-private-reference-accessor-property-or.js
@@ -2454,26 +2409,11 @@ Mismatch: tasks/coverage/test262/test/language/expressions/logical-assignment/le
 Mismatch: tasks/coverage/test262/test/language/expressions/logical-assignment/left-hand-side-private-reference-readonly-accessor-property-short-circuit-and.js
 Mismatch: tasks/coverage/test262/test/language/expressions/logical-assignment/left-hand-side-private-reference-readonly-accessor-property-short-circuit-nullish.js
 Mismatch: tasks/coverage/test262/test/language/expressions/logical-assignment/left-hand-side-private-reference-readonly-accessor-property-short-circuit-or.js
-Mismatch: tasks/coverage/test262/test/language/expressions/modulus/bigint-arithmetic.js
-Mismatch: tasks/coverage/test262/test/language/expressions/multiplication/bigint-arithmetic.js
-Mismatch: tasks/coverage/test262/test/language/expressions/postfix-decrement/bigint.js
 Mismatch: tasks/coverage/test262/test/language/expressions/postfix-decrement/target-cover-id.js
-Mismatch: tasks/coverage/test262/test/language/expressions/postfix-increment/bigint.js
 Mismatch: tasks/coverage/test262/test/language/expressions/postfix-increment/target-cover-id.js
-Mismatch: tasks/coverage/test262/test/language/expressions/prefix-decrement/bigint.js
 Mismatch: tasks/coverage/test262/test/language/expressions/prefix-decrement/target-cover-id.js
-Mismatch: tasks/coverage/test262/test/language/expressions/prefix-increment/bigint.js
 Mismatch: tasks/coverage/test262/test/language/expressions/prefix-increment/target-cover-id.js
-Mismatch: tasks/coverage/test262/test/language/expressions/right-shift/bigint-non-primitive.js
-Mismatch: tasks/coverage/test262/test/language/expressions/right-shift/bigint.js
-Mismatch: tasks/coverage/test262/test/language/expressions/strict-does-not-equals/bigint-and-bigint.js
-Mismatch: tasks/coverage/test262/test/language/expressions/strict-does-not-equals/bigint-and-number-extremes.js
-Mismatch: tasks/coverage/test262/test/language/expressions/strict-equals/bigint-and-bigint.js
-Mismatch: tasks/coverage/test262/test/language/expressions/strict-equals/bigint-and-number-extremes.js
-Mismatch: tasks/coverage/test262/test/language/expressions/subtraction/bigint-arithmetic.js
 Mismatch: tasks/coverage/test262/test/language/expressions/template-literal/tv-line-terminator-sequence.js
-Mismatch: tasks/coverage/test262/test/language/expressions/unary-minus/bigint.js
-Mismatch: tasks/coverage/test262/test/language/expressions/unsigned-right-shift/bigint-non-primitive.js
 Mismatch: tasks/coverage/test262/test/language/import/import-attributes/json-extensibility-array.js
 Mismatch: tasks/coverage/test262/test/language/import/import-attributes/json-extensibility-object.js
 Mismatch: tasks/coverage/test262/test/language/import/import-attributes/json-idempotency.js
@@ -2492,20 +2432,6 @@ Mismatch: tasks/coverage/test262/test/language/import/import-defer/errors/get-ot
 Mismatch: tasks/coverage/test262/test/language/import/import-defer/errors/get-other-while-evaluating-async/main.js
 Mismatch: tasks/coverage/test262/test/language/import/import-defer/errors/module-throws/defer-import-after-evaluation.js
 Mismatch: tasks/coverage/test262/test/language/import/import-defer/syntax/valid-default-binding-named-defer.js
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-bil-bd-nsl-bd.js
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-bil-bd-nsl-bds.js
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-bil-bds-nsl-bd.js
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-bil-bds-nsl-bds.js
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-hil-hd-nsl-hd.js
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-hil-hd-nsl-hds.js
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-hil-hds-nsl-hd.js
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-hil-hds-nsl-hds.js
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-hil-od-nsl-od-one-of.js
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-oil-od-nsl-od-one-of.js
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-oil-od-nsl-od.js
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-oil-od-nsl-ods.js
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-oil-ods-nsl-od.js
-Mismatch: tasks/coverage/test262/test/language/literals/bigint/numeric-separators/numeric-separator-literal-oil-ods-nsl-ods.js
 Mismatch: tasks/coverage/test262/test/language/literals/regexp/S7.8.5_A3.1_T5.js
 Mismatch: tasks/coverage/test262/test/language/literals/regexp/S7.8.5_A3.1_T6.js
 tasks/coverage/test262/test/language/literals/regexp/named-groups/invalid-lone-surrogate-groupname.js


### PR DESCRIPTION
Fix serialization of `BigIntLiteral`s. Turns out ESTree takes a much simpler approach than we were taking!