### PR TITLE
fix(ast/estree): fix serializing `RegExpLiteral::value` field

### DIFF
--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -128,7 +128,7 @@ pub struct BigIntLiteral<'a> {
 #[generate_derive(CloneIn, ContentEq, GetSpan, GetSpanMut, ESTree)]
 #[estree(
     rename = "Literal",
-    add_fields(value = crate::serialize::EmptyObject),
+    add_fields(value = crate::serialize::RegExpLiteralValue(self)),
     add_ts = "value: {} | null",
 )]
 pub struct RegExpLiteral<'a> {

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1974,7 +1974,7 @@ impl Serialize for RegExpLiteral<'_> {
         map.serialize_entry("end", &self.span.end)?;
         map.serialize_entry("regex", &crate::serialize::RegExpLiteralRegex(self))?;
         map.serialize_entry("raw", &self.raw)?;
-        map.serialize_entry("value", &crate::serialize::EmptyObject)?;
+        map.serialize_entry("value", &crate::serialize::RegExpLiteralValue(self))?;
         map.end()
     }
 }

--- a/tasks/coverage/src/tools/estree.rs
+++ b/tasks/coverage/src/tools/estree.rs
@@ -2,7 +2,10 @@ use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use oxc::{
-    allocator::Allocator, ast::utf8_to_utf16::Utf8ToUtf16, parser::Parser, span::SourceType,
+    allocator::Allocator,
+    ast::utf8_to_utf16::Utf8ToUtf16,
+    parser::{ParseOptions, Parser},
+    span::SourceType,
 };
 
 use crate::{
@@ -57,7 +60,8 @@ impl Case for EstreeTest262Case {
         let is_module = self.base.is_module();
         let source_type = SourceType::default().with_module(is_module);
         let allocator = Allocator::new();
-        let ret = Parser::new(&allocator, source_text, source_type).parse();
+        let options = ParseOptions { parse_regular_expression: true, ..ParseOptions::default() };
+        let ret = Parser::new(&allocator, source_text, source_type).with_options(options).parse();
         // Ignore empty AST or parse errors.
         let mut program = ret.program;
         if program.is_empty() || ret.panicked || !ret.errors.is_empty() {


### PR DESCRIPTION
About half the remaining failing conformance tests relate to `RegExp`s. This should fix them, but it's not working, and I don't know why.

It looks like the `value` field should be `{}` for a valid regexp, and `null` for an invalid one. So this PR enables parsing regexps in Oxc's parser, and sets `value` field accordingly depending on whether the regexp parser says it's valid or not.

The weird thing is that some cases which should pass, still don't. e.g.:

https://github.com/tc39/test262/blob/bc5c14176e2b11a78859571eb693f028c8822458/test/built-ins/RegExp/regexp-modifiers/add-ignoreCase.js

This test contains `var re1 = /(?i:a)b/;`, which is a valid regexp.

Sure enough, AST Explorer shows `value: {}`. https://ast.sxzz.dev/#eNoliTsKhDAQhq8if7ULgn2avcSy1TSz4xSRmAlJFES8uwN23+NEQsDCOzepsXSMKB5YrGZncZ5enxj4/Z/czf2kPAwElZV/Wlu0TAgeEndtnTA+v9lWRb9H0WevNm/JmfKF6wZsLyU5

But when running Acorn locally (v8.14.0, same as AST Explorer uses), it shows `value: null`. Whaaaat?

```js
import { Parser } from "acorn";
const ast = Parser.parse('/(?i:a)b/', {ecmaVersion: "latest", sourceType: "module"});
console.log(ast.body[0].expression);
```

@sxzz As the author of AST Explorer, do you have any insight into this?