### PR TITLE
refactor(ast/estree): remove redundant `ts_type`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1713,10 +1713,7 @@ pub struct FormalParameter<'a> {
     pub span: Span,
     #[ts]
     pub decorators: Vec<'a, Decorator<'a>>,
-    #[estree(
-        flatten,
-        ts_type = "(BindingIdentifier | ObjectPattern | ArrayPattern | AssignmentPattern)"
-    )]
+    #[estree(flatten)]
     pub pattern: BindingPattern<'a>,
     #[ts]
     pub accessibility: Option<TSAccessibility>,

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -583,7 +583,7 @@ export type FormalParameter =
     override: boolean;
   })
   & Span
-  & (BindingIdentifier | ObjectPattern | ArrayPattern | AssignmentPattern);
+  & BindingPattern;
 
 export type FormalParameterKind = 'FormalParameter' | 'UniqueFormalParameters' | 'ArrowFormalParameters' | 'Signature';
 


### PR DESCRIPTION
We hard-coded `BindingPattern` for this, so it's now redundant.

https://github.com/oxc-project/oxc/blob/4748dd0447c865b6d7483b61c0f111bbf209f165/tasks/ast_tools/src/generators/typescript.rs#L232-L235