### PR TITLE
refactor(ast)!: remove `PrivateInExpression::operator` field

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -668,11 +668,10 @@ pub struct BinaryExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "BinaryExpression")]
+#[estree(rename = "BinaryExpression", add_fields(operator = "\"in\""), add_ts = "operator: \"in\"")]
 pub struct PrivateInExpression<'a> {
     pub span: Span,
     pub left: PrivateIdentifier<'a>,
-    pub operator: BinaryOperator, // BinaryOperator::In
     pub right: Expression<'a>,
 }
 

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -187,12 +187,11 @@ const _: () = {
     assert!(offset_of!(BinaryExpression, operator) == 24);
     assert!(offset_of!(BinaryExpression, right) == 32);
 
-    assert!(size_of::<PrivateInExpression>() == 56);
+    assert!(size_of::<PrivateInExpression>() == 48);
     assert!(align_of::<PrivateInExpression>() == 8);
     assert!(offset_of!(PrivateInExpression, span) == 0);
     assert!(offset_of!(PrivateInExpression, left) == 8);
-    assert!(offset_of!(PrivateInExpression, operator) == 32);
-    assert!(offset_of!(PrivateInExpression, right) == 40);
+    assert!(offset_of!(PrivateInExpression, right) == 32);
 
     assert!(size_of::<LogicalExpression>() == 48);
     assert!(align_of::<LogicalExpression>() == 8);
@@ -1765,12 +1764,11 @@ const _: () = {
     assert!(offset_of!(BinaryExpression, operator) == 16);
     assert!(offset_of!(BinaryExpression, right) == 20);
 
-    assert!(size_of::<PrivateInExpression>() == 36);
+    assert!(size_of::<PrivateInExpression>() == 32);
     assert!(align_of::<PrivateInExpression>() == 4);
     assert!(offset_of!(PrivateInExpression, span) == 0);
     assert!(offset_of!(PrivateInExpression, left) == 8);
-    assert!(offset_of!(PrivateInExpression, operator) == 24);
-    assert!(offset_of!(PrivateInExpression, right) == 28);
+    assert!(offset_of!(PrivateInExpression, right) == 24);
 
     assert!(size_of::<LogicalExpression>() == 28);
     assert!(align_of::<LogicalExpression>() == 4);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -843,19 +843,15 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `left`
-    /// * `operator`
     /// * `right`
     #[inline]
     pub fn expression_private_in(
         self,
         span: Span,
         left: PrivateIdentifier<'a>,
-        operator: BinaryOperator,
         right: Expression<'a>,
     ) -> Expression<'a> {
-        Expression::PrivateInExpression(
-            self.alloc_private_in_expression(span, left, operator, right),
-        )
+        Expression::PrivateInExpression(self.alloc_private_in_expression(span, left, right))
     }
 
     /// Build an [`Expression::JSXElement`].
@@ -2128,17 +2124,15 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `left`
-    /// * `operator`
     /// * `right`
     #[inline]
     pub fn private_in_expression(
         self,
         span: Span,
         left: PrivateIdentifier<'a>,
-        operator: BinaryOperator,
         right: Expression<'a>,
     ) -> PrivateInExpression<'a> {
-        PrivateInExpression { span, left, operator, right }
+        PrivateInExpression { span, left, right }
     }
 
     /// Build a [`PrivateInExpression`], and store it in the memory arena.
@@ -2148,17 +2142,15 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `left`
-    /// * `operator`
     /// * `right`
     #[inline]
     pub fn alloc_private_in_expression(
         self,
         span: Span,
         left: PrivateIdentifier<'a>,
-        operator: BinaryOperator,
         right: Expression<'a>,
     ) -> Box<'a, PrivateInExpression<'a>> {
-        Box::new_in(self.private_in_expression(span, left, operator, right), self.allocator)
+        Box::new_in(self.private_in_expression(span, left, right), self.allocator)
     }
 
     /// Build a [`LogicalExpression`].

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -804,7 +804,6 @@ impl<'new_alloc> CloneIn<'new_alloc> for PrivateInExpression<'_> {
         PrivateInExpression {
             span: CloneIn::clone_in(&self.span, allocator),
             left: CloneIn::clone_in(&self.left, allocator),
-            operator: CloneIn::clone_in(&self.operator, allocator),
             right: CloneIn::clone_in(&self.right, allocator),
         }
     }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -448,7 +448,6 @@ impl ContentEq for BinaryExpression<'_> {
 impl ContentEq for PrivateInExpression<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.left, &other.left)
-            && ContentEq::content_eq(&self.operator, &other.operator)
             && ContentEq::content_eq(&self.right, &other.right)
     }
 }

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -534,8 +534,8 @@ impl Serialize for PrivateInExpression<'_> {
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
         map.serialize_entry("left", &self.left)?;
-        map.serialize_entry("operator", &self.operator)?;
         map.serialize_entry("right", &self.right)?;
+        map.serialize_entry("operator", &"in")?;
         map.end()
     }
 }

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -6,7 +6,6 @@ use oxc_regular_expression::ast::Pattern;
 use oxc_span::{Atom, GetSpan, Span};
 use oxc_syntax::{
     number::{BigintBase, NumberBase},
-    operator::BinaryOperator,
     precedence::Precedence,
 };
 
@@ -987,7 +986,7 @@ impl<'a> ParserImpl<'a> {
             if let Expression::PrivateInExpression(private_in_expr) = right {
                 return Err(diagnostics::private_in_private(private_in_expr.span));
             }
-            self.ast.expression_private_in(self.end_span(lhs_span), left, BinaryOperator::In, right)
+            self.ast.expression_private_in(self.end_span(lhs_span), left, right)
         } else {
             self.parse_unary_expression_or_higher(lhs_span)?
         };

--- a/crates/oxc_prettier/src/format/js.rs
+++ b/crates/oxc_prettier/src/format/js.rs
@@ -1087,7 +1087,7 @@ impl<'a> Format<'a> for PrivateInExpression<'a> {
         wrap!(p, self, PrivateInExpression, {
             let left_doc = self.left.format(p);
             let right_doc = self.right.format(p);
-            array!(p, [left_doc, text!(" "), text!(self.operator.as_str()), text!(" "), right_doc])
+            array!(p, [left_doc, text!(" "), text!("in"), text!(" "), right_doc])
         })
     }
 }

--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -1858,7 +1858,7 @@ impl<'a> ClassProperties<'a, '_> {
         private_field: ArenaBox<'a, PrivateInExpression<'a>>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
-        let PrivateInExpression { left, right, span, .. } = private_field.unbox();
+        let PrivateInExpression { left, right, span } = private_field.unbox();
 
         let ResolvedPrivateProp { class_bindings, prop_binding, is_method, is_static, .. } =
             self.classes_stack.find_private_prop(&left);

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -3772,8 +3772,6 @@ impl<'a, 't> GetAddress for BinaryExpressionWithoutRight<'a, 't> {
 
 pub(crate) const OFFSET_PRIVATE_IN_EXPRESSION_SPAN: usize = offset_of!(PrivateInExpression, span);
 pub(crate) const OFFSET_PRIVATE_IN_EXPRESSION_LEFT: usize = offset_of!(PrivateInExpression, left);
-pub(crate) const OFFSET_PRIVATE_IN_EXPRESSION_OPERATOR: usize =
-    offset_of!(PrivateInExpression, operator);
 pub(crate) const OFFSET_PRIVATE_IN_EXPRESSION_RIGHT: usize = offset_of!(PrivateInExpression, right);
 
 #[repr(transparent)]
@@ -3787,14 +3785,6 @@ impl<'a, 't> PrivateInExpressionWithoutLeft<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_PRIVATE_IN_EXPRESSION_SPAN) as *const Span) }
-    }
-
-    #[inline]
-    pub fn operator(self) -> &'t BinaryOperator {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_PRIVATE_IN_EXPRESSION_OPERATOR)
-                as *const BinaryOperator)
-        }
     }
 
     #[inline]
@@ -3831,14 +3821,6 @@ impl<'a, 't> PrivateInExpressionWithoutRight<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_PRIVATE_IN_EXPRESSION_LEFT)
                 as *const PrivateIdentifier<'a>)
-        }
-    }
-
-    #[inline]
-    pub fn operator(self) -> &'t BinaryOperator {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_PRIVATE_IN_EXPRESSION_OPERATOR)
-                as *const BinaryOperator)
         }
     }
 }

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -204,8 +204,8 @@ export interface BinaryExpression extends Span {
 export interface PrivateInExpression extends Span {
   type: 'BinaryExpression';
   left: PrivateIdentifier;
-  operator: BinaryOperator;
   right: Expression;
+  operator: 'in';
 }
 
 export interface LogicalExpression extends Span {


### PR DESCRIPTION
Remove `PrivateInExpression::operator` field.

This field had no purpose beyond getting correct serialization to ESTree - it was always `BinaryOperator::In`, and no other value for `operator` makes sense in this position. So remove the field from the Rust type, and produce the desired output in ESTree AST using `#[estree(add_fields)]` instead.

This follows on after changes made to serialization of `PrivateInExpression` in #9033.
