### PR TITLE
refactor(ast_tools): move parsing `#[ts]` attribute to ESTree derive

### DIFF
--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -10,10 +10,10 @@ use crate::{
     },
     output::Output,
     schema::{Def, EnumDef, FieldDef, Schema, StructDef, TypeDef},
-    Codegen, Generator, Result, TYPESCRIPT_DEFINITIONS_PATH,
+    Codegen, Generator, TYPESCRIPT_DEFINITIONS_PATH,
 };
 
-use super::{attr_positions, define_generator, AttrLocation, AttrPart, AttrPositions};
+use super::define_generator;
 
 /// Generator for TypeScript type definitions.
 pub struct TypescriptGenerator;
@@ -21,32 +21,6 @@ pub struct TypescriptGenerator;
 define_generator!(TypescriptGenerator);
 
 impl Generator for TypescriptGenerator {
-    /// Register that accept `#[ts]` attr on struct fields and enum variants.
-    fn attrs(&self) -> &[(&'static str, AttrPositions)] {
-        &[("ts", attr_positions!(StructField | EnumVariant))]
-    }
-
-    /// Parse `#[ts]` on struct field or enum variant.
-    fn parse_attr(&self, _attr_name: &str, location: AttrLocation, part: AttrPart) -> Result<()> {
-        // No need to check attr name is `ts`, because that's the only attribute this derive handles.
-        if !matches!(part, AttrPart::None) {
-            return Err(());
-        }
-
-        // Location can only be `StructField` or `EnumVariant`
-        match location {
-            AttrLocation::StructField(struct_def, field_index) => {
-                struct_def.fields[field_index].estree.is_ts = true;
-            }
-            AttrLocation::EnumVariant(enum_def, variant_index) => {
-                enum_def.variants[variant_index].estree.is_ts = true;
-            }
-            _ => unreachable!(),
-        }
-
-        Ok(())
-    }
-
     /// Generate Typescript type definitions for all AST types.
     fn generate(&self, schema: &Schema, codegen: &Codegen) -> Output {
         let estree_derive_id = codegen.get_derive_id_by_name("ESTree");


### PR DESCRIPTION
Pure refactor. `#[ts]` attribute is not actually used by either ESTree or Typescript generator at present. But when it *is* used, it'll be ESTree codegen which uses it. So move it to ESTree generator.

This change does not affect any generated code, just the internals of `oxc_ast_tools`.