### PR TITLE
fix(ast/estree): fix serializing `RegExpLiteral`

### DIFF
--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -128,8 +128,8 @@ pub struct BigIntLiteral<'a> {
 #[generate_derive(CloneIn, ContentEq, GetSpan, GetSpanMut, ESTree)]
 #[estree(
     rename = "Literal",
-    add_fields(value = crate::serialize::EmptyObject),
-    add_ts = "value: {} | null",
+    add_fields(value = crate::serialize::NULL),
+    add_ts = "value: null",
 )]
 pub struct RegExpLiteral<'a> {
     /// Node location in source code

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1983,7 +1983,7 @@ impl Serialize for RegExpLiteral<'_> {
         map.serialize_entry("end", &self.span.end)?;
         map.serialize_entry("regex", &crate::serialize::RegExpLiteralRegex(self))?;
         map.serialize_entry("raw", &self.raw)?;
-        map.serialize_entry("value", &crate::serialize::EmptyObject)?;
+        map.serialize_entry("value", &crate::serialize::NULL)?;
         map.end()
     }
 }

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -133,16 +133,6 @@ impl Serialize for RegExpLiteralRegex<'_> {
     }
 }
 
-/// A placeholder for `RegExpLiteral`'s `value` field.
-pub struct EmptyObject;
-
-impl Serialize for EmptyObject {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let map = serializer.serialize_map(None)?;
-        map.end()
-    }
-}
-
 impl Serialize for RegExpFlags {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_str(&self.to_string())

--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ submodules:
   just clone-submodule tasks/coverage/babel https://github.com/babel/babel.git acbc09a87016778c1551ab5e7162fdd0e70b6663
   just clone-submodule tasks/coverage/typescript https://github.com/microsoft/TypeScript.git d85767abfd83880cea17cea70f9913e9c4496dcc
   just clone-submodule tasks/prettier_conformance/prettier https://github.com/prettier/prettier.git 37fd1774d13ef68abcc03775ceef0a91f87a57d7
-  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 4547a9eb14583f32371383348f736129ce59695f
+  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 bd99d40ed634cc045aac70c6aa8f8b41af988331
   just update-transformer-fixtures
 
 # Install git pre-commit to format files

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -818,7 +818,7 @@ export interface RegExpLiteral extends Span {
   type: 'Literal';
   regex: RegExp;
   raw: string | null;
-  value: {} | null;
+  value: null;
 }
 
 export interface RegExp {

--- a/tasks/coverage/snapshots/estree_test262.snap
+++ b/tasks/coverage/snapshots/estree_test262.snap
@@ -2,7 +2,7 @@ commit: bc5c1417
 
 estree_test262 Summary:
 AST Parsed     : 44293/44293 (100.00%)
-Positive Passed: 44163/44293 (99.71%)
+Positive Passed: 44242/44293 (99.88%)
 tasks/coverage/test262/test/annexB/built-ins/RegExp/prototype/compile/pattern-string-u.js
 serde_json error: unexpected end of hex escape at line 316 column 33
 
@@ -30,16 +30,6 @@ serde_json error: unexpected end of hex escape at line 839 column 39
 tasks/coverage/test262/test/built-ins/RegExp/escape/escaped-surrogates.js
 serde_json error: unexpected end of hex escape at line 62 column 33
 
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/named-groups/duplicate-names-exec.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/named-groups/duplicate-names-group-property-enumeration-order.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/named-groups/duplicate-names-match-indices.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/named-groups/duplicate-names-match.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/named-groups/duplicate-names-matchall.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/named-groups/duplicate-names-replace.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/named-groups/duplicate-names-replaceall.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/named-groups/duplicate-names-search.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/named-groups/duplicate-names-split.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/named-groups/duplicate-names-test.js
 tasks/coverage/test262/test/built-ins/RegExp/named-groups/non-unicode-property-names-invalid.js
 serde_json error: unexpected end of hex escape at line 473 column 44
 
@@ -58,91 +48,24 @@ serde_json error: recursion limit exceeded at line 509 column 263
 tasks/coverage/test262/test/built-ins/RegExp/prototype/exec/S15.10.6.2_A3_T4.js
 serde_json error: recursion limit exceeded at line 509 column 263
 
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/prototype/exec/duplicate-named-groups-properties.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/prototype/exec/duplicate-named-indices-groups-properties.js
 tasks/coverage/test262/test/built-ins/RegExp/prototype/exec/u-captured-value.js
 serde_json error: unexpected end of hex escape at line 298 column 29
 
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-dotAll-does-not-affect-alternatives-outside.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-dotAll-does-not-affect-dotAll-property.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-dotAll-does-not-affect-ignoreCase-flag.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-dotAll-does-not-affect-multiline-flag.js
 tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-dotAll.js
 serde_json error: unexpected end of hex escape at line 866 column 33
 
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-affects-backreferences.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-affects-characterClasses.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-affects-characterEscapes.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-affects-slash-lower-b.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-affects-slash-lower-p.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-affects-slash-lower-w.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-affects-slash-upper-b.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-affects-slash-upper-p.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-affects-slash-upper-w.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-does-not-affect-alternatives-outside.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-does-not-affect-dotAll-flag.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-does-not-affect-ignoreCase-property.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-ignoreCase-does-not-affect-multiline-flag.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-ignoreCase.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-multiline-does-not-affect-alternatives-outside.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-multiline-does-not-affect-dotAll-flag.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-multiline-does-not-affect-ignoreCase-flag.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-multiline-does-not-affect-multiline-property.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-multiline.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-remove-modifiers.js
 tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/changing-dotAll-flag-does-not-affect-dotAll-modifier.js
 serde_json error: unexpected end of hex escape at line 886 column 33
 
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/changing-ignoreCase-flag-does-not-affect-ignoreCase-modifier.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/changing-multiline-flag-does-not-affect-multiline-modifier.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/nested-add-remove-modifiers.js
 tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/nesting-add-dotAll-within-remove-dotAll.js
 serde_json error: unexpected end of hex escape at line 866 column 33
 
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/nesting-add-ignoreCase-within-remove-ignoreCase.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/nesting-add-multiline-within-remove-multiline.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/nesting-dotAll-does-not-affect-alternatives-outside.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/nesting-ignoreCase-does-not-affect-alternatives-outside.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/nesting-multiline-does-not-affect-alternatives-outside.js
 tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/nesting-remove-dotAll-within-add-dotAll.js
 serde_json error: unexpected end of hex escape at line 894 column 33
 
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/nesting-remove-ignoreCase-within-add-ignoreCase.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/nesting-remove-multiline-within-add-multiline.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-dotAll-does-not-affect-alternatives-outside.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-dotAll-does-not-affect-dotAll-property.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-dotAll-does-not-affect-ignoreCase-flag.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-dotAll-does-not-affect-multiline-flag.js
 tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-dotAll.js
 serde_json error: unexpected end of hex escape at line 894 column 33
 
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-affects-backreferences.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-affects-characterClasses.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-affects-characterEscapes.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-affects-slash-lower-b.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-affects-slash-lower-p.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-affects-slash-lower-w.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-affects-slash-upper-b.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-affects-slash-upper-p.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-affects-slash-upper-w.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-does-not-affect-alternatives-outside.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-does-not-affect-dotAll-flag.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-does-not-affect-ignoreCase-property.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase-does-not-affect-multiline-flag.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-ignoreCase.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-multiline-does-not-affect-alternatives-outside.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-multiline-does-not-affect-dotAll-flag.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-multiline-does-not-affect-ignoreCase-flag.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-multiline-does-not-affect-multiline-property.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-multiline.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/syntax/valid/add-and-remove-modifiers-can-have-empty-remove-modifiers.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/syntax/valid/add-and-remove-modifiers.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/syntax/valid/add-modifiers-when-nested.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/syntax/valid/add-modifiers-when-not-set-as-flags.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/syntax/valid/add-modifiers-when-set-as-flags.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/syntax/valid/remove-modifiers-when-nested.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/syntax/valid/remove-modifiers-when-not-set-as-flags.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/syntax/valid/remove-modifiers-when-set-as-flags.js
 tasks/coverage/test262/test/built-ins/String/prototype/at/returns-code-unit.js
 serde_json error: unexpected end of hex escape at line 103 column 31
 
@@ -155,8 +78,6 @@ serde_json error: lone leading surrogate in hex escape at line 416 column 32
 tasks/coverage/test262/test/built-ins/String/prototype/isWellFormed/returns-boolean.js
 serde_json error: unexpected end of hex escape at line 103 column 29
 
-Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/match/duplicate-named-groups-properties.js
-Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/match/duplicate-named-indices-groups-properties.js
 tasks/coverage/test262/test/built-ins/String/prototype/match/regexp-prototype-match-v-u-flag.js
 serde_json error: unexpected end of hex escape at line 638 column 33
 


### PR DESCRIPTION
Output `null` in JSON for `value` field of `RegExpLiteral`.

This PR also bumps the `acorn-estree` submodule, to include commit https://github.com/oxc-project/acorn-test262/commit/bd99d40ed634cc045aac70c6aa8f8b41af988331 which does the same in the JSON snapshots of Acorn's output.

This is first step as described in https://github.com/oxc-project/oxc/pull/9028#issuecomment-2650652166.

A later PR will set the `value` field correctly on JS side.
