### PR TITLE
fix(ast/estree): set `value` for `BigIntLiteral`s and `RegExpLiteral`s on JS side

### DIFF
--- a/napi/parser/test/parse.test.ts
+++ b/napi/parser/test/parse.test.ts
@@ -26,6 +26,71 @@ describe('parse', () => {
     });
     expect(code.substring(comment.start, comment.end)).toBe('/*' + comment.value + '*/');
   });
+
+  it('`BigIntLiteral` has `value` as `BigInt`', () => {
+    const ret = parseSync('test.js', '123_456n');
+    expect(ret.errors.length).toBe(0);
+    expect(ret.program.body.length).toBe(1);
+    expect(ret.program.body[0]).toEqual({
+      type: 'ExpressionStatement',
+      start: 0,
+      end: 8,
+      expression: {
+        type: 'Literal',
+        start: 0,
+        end: 8,
+        value: 123456n,
+        raw: '123_456n',
+        bigint: '123456',
+      },
+    });
+  });
+
+  describe('`RegExpLiteral`', () => {
+    it('has `value` as `RegExp` when valid regexp', () => {
+      const ret = parseSync('test.js', '/abc/gu');
+      expect(ret.errors.length).toBe(0);
+      expect(ret.program.body.length).toBe(1);
+      expect(ret.program.body[0]).toEqual({
+        type: 'ExpressionStatement',
+        start: 0,
+        end: 7,
+        expression: {
+          type: 'Literal',
+          start: 0,
+          end: 7,
+          value: /abc/gu,
+          raw: '/abc/gu',
+          regex: {
+            pattern: 'abc',
+            flags: 'gu',
+          },
+        },
+      });
+    });
+
+    it('has `value` as `null` when invalid regexp', () => {
+      const ret = parseSync('test.js', '/+/');
+      expect(ret.errors.length).toBe(0);
+      expect(ret.program.body.length).toBe(1);
+      expect(ret.program.body[0]).toEqual({
+        type: 'ExpressionStatement',
+        start: 0,
+        end: 3,
+        expression: {
+          type: 'Literal',
+          start: 0,
+          end: 3,
+          value: null,
+          raw: '/+/',
+          regex: {
+            pattern: '+',
+            flags: '',
+          },
+        },
+      });
+    });
+  });
 });
 
 it('utf16 span', async () => {


### PR DESCRIPTION
Add a "reviver" function to `JSON.parse` in NAPI parser module, to correctly set `value` field of `Literal`s for `RegExp`s and `BigInt`s.

Surprisingly, judging by a local run of NAPI parser benchmarks (added in #9045), this does not seem to hurt performance. In fact the benchmarks were showing a ~2% speed-up. That's clearly nonsense - just noise - but it does suggest at least that this isn't hurting performance significantly.