### PR TITLE
test(napi): add NAPI parser benchmark

### DIFF
--- a/napi/parser/bench.mjs
+++ b/napi/parser/bench.mjs
@@ -1,0 +1,48 @@
+import { writeFile } from 'fs/promises';
+import { join as pathJoin } from 'path';
+import { Bench } from 'tinybench';
+import { parseSync } from './index.js';
+
+// Same fixtures as used in Rust parser benchmarks
+const fixtureUrls = [
+  'https://raw.githubusercontent.com/microsoft/TypeScript/v5.3.3/src/compiler/checker.ts',
+  'https://raw.githubusercontent.com/oxc-project/benchmark-files/main/cal.com.tsx',
+  'https://raw.githubusercontent.com/oxc-project/benchmark-files/main/RadixUIAdoptionSection.jsx',
+  'https://cdn.jsdelivr.net/npm/pdfjs-dist@4.0.269/build/pdf.mjs',
+  'https://cdn.jsdelivr.net/npm/antd@5.12.5/dist/antd.js',
+];
+
+// Same directory as Rust benchmarks use for downloaded files
+// to avoid re-downloading if Rust benchmarks already downloaded
+const cacheDirPath = pathJoin(import.meta.dirname, '../../target');
+
+// Load fixtures
+const fixtures = await Promise.all(fixtureUrls.map(async (url) => {
+  const filename = url.split('/').at(-1),
+    path = pathJoin(cacheDirPath, filename);
+
+  let code;
+  try {
+    code = await readFile(path, 'utf8');
+  } catch {
+    const res = await fetch(url);
+    code = await res.text();
+    await writeFile(path, code);
+  }
+
+  return { filename, code };
+}));
+
+// Run benchmarks
+const bench = new Bench();
+for (const { filename, code } of fixtures) {
+  bench.add(
+    `parser_napi[${filename}]`,
+    () => {
+      parseSync(filename, code);
+    },
+  );
+}
+
+await bench.run();
+console.table(bench.table());

--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -4,7 +4,8 @@
   "scripts": {
     "build-dev": "napi build --no-dts-cache --platform --js bindings.js",
     "build": "napi build --no-dts-cache --platform --js bindings.js --release",
-    "test": "vitest --typecheck run ./test"
+    "test": "vitest --typecheck run ./test",
+    "bench": "node bench.mjs"
   },
   "napi": {
     "binaryName": "parser",
@@ -22,5 +23,8 @@
   },
   "dependencies": {
     "@oxc-project/types": "workspace:^"
+  },
+  "devDependencies": {
+    "tinybench": "^3.1.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,10 @@ importers:
       '@oxc-project/types':
         specifier: workspace:^
         version: link:../../npm/oxc-types
+    devDependencies:
+      tinybench:
+        specifier: ^3.1.1
+        version: 3.1.1
 
   napi/transform: {}
 
@@ -3283,6 +3287,10 @@ packages:
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinybench@3.1.1:
+    resolution: {integrity: sha512-74pmf47HY/bHqamcCMGris+1AtGGsqTZ3Hc/UK4QvSmRuf/9PIF9753+c8XBh7JfX2r9KeZtVjOYjd6vFpc0qQ==}
+    engines: {node: '>=18.0.0'}
 
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
@@ -6905,6 +6913,8 @@ snapshots:
   throttle-debounce@5.0.2: {}
 
   tinybench@2.9.0: {}
+
+  tinybench@3.1.1: {}
 
   tinyexec@0.3.2: {}
 


### PR DESCRIPTION
Add a quick benchmark for NAPI parser. It's included in our CI benchmarks, because likely will produce too much variance, but it's useful for local runs.