### PR TITLE
test(ast/estree): bump `acorn-test262` submodule

### DIFF
--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ submodules:
   just clone-submodule tasks/coverage/babel https://github.com/babel/babel.git acbc09a87016778c1551ab5e7162fdd0e70b6663
   just clone-submodule tasks/coverage/typescript https://github.com/microsoft/TypeScript.git d85767abfd83880cea17cea70f9913e9c4496dcc
   just clone-submodule tasks/prettier_conformance/prettier https://github.com/prettier/prettier.git 37fd1774d13ef68abcc03775ceef0a91f87a57d7
-  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 bd99d40ed634cc045aac70c6aa8f8b41af988331
+  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 dcb070006436b9f7783626c0741d5693953035c6
   just update-transformer-fixtures
 
 # Install git pre-commit to format files

--- a/tasks/coverage/snapshots/estree_test262.snap
+++ b/tasks/coverage/snapshots/estree_test262.snap
@@ -2,7 +2,7 @@ commit: bc5c1417
 
 estree_test262 Summary:
 AST Parsed     : 44293/44293 (100.00%)
-Positive Passed: 44242/44293 (99.88%)
+Positive Passed: 44243/44293 (99.89%)
 tasks/coverage/test262/test/annexB/built-ins/RegExp/prototype/compile/pattern-string-u.js
 serde_json error: unexpected end of hex escape at line 316 column 33
 
@@ -107,7 +107,6 @@ serde_json error: unexpected end of hex escape at line 184 column 33
 
 Mismatch: tasks/coverage/test262/test/language/expressions/assignment/fn-name-lhs-cover.js
 Mismatch: tasks/coverage/test262/test/language/expressions/assignment/target-cover-id.js
-Mismatch: tasks/coverage/test262/test/language/expressions/dynamic-import/import-attributes/2nd-param-await-ident.js
 Mismatch: tasks/coverage/test262/test/language/expressions/postfix-decrement/target-cover-id.js
 Mismatch: tasks/coverage/test262/test/language/expressions/postfix-increment/target-cover-id.js
 Mismatch: tasks/coverage/test262/test/language/expressions/prefix-decrement/target-cover-id.js


### PR DESCRIPTION
Bump `acorn-test262` submodule to integrate commit https://github.com/oxc-project/acorn-test262/commit/dcb070006436b9f7783626c0741d5693953035c6 which fixes Acorn's output for 1 of the ESTree conformance tests which was previously failing.

The problem on that test case wasn't Oxc, the problem was that we were running Acorn with the wrong options.