### PR TITLE
feat(ast)!: remove `TSLiteral::RegExpLiteral`

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -162,7 +162,6 @@ pub enum TSLiteral<'a> {
     NullLiteral(Box<'a, NullLiteral>) = 1,
     NumericLiteral(Box<'a, NumericLiteral<'a>>) = 2,
     BigIntLiteral(Box<'a, BigIntLiteral<'a>>) = 3,
-    RegExpLiteral(Box<'a, RegExpLiteral<'a>>) = 4,
     StringLiteral(Box<'a, StringLiteral<'a>>) = 5,
     TemplateLiteral(Box<'a, TemplateLiteral<'a>>) = 6,
     UnaryExpression(Box<'a, UnaryExpression<'a>>) = 7,

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -8780,24 +8780,6 @@ impl<'a> AstBuilder<'a> {
         TSLiteral::BigIntLiteral(self.alloc_big_int_literal(span, raw, base))
     }
 
-    /// Build a [`TSLiteral::RegExpLiteral`].
-    ///
-    /// This node contains a [`RegExpLiteral`] that will be stored in the memory arena.
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `regex`: The parsed regular expression. See [`oxc_regular_expression`] for more
-    /// * `raw`: The regular expression as it appears in source code
-    #[inline]
-    pub fn ts_literal_reg_exp_literal(
-        self,
-        span: Span,
-        regex: RegExp<'a>,
-        raw: Option<Atom<'a>>,
-    ) -> TSLiteral<'a> {
-        TSLiteral::RegExpLiteral(self.alloc_reg_exp_literal(span, regex, raw))
-    }
-
     /// Build a [`TSLiteral::StringLiteral`].
     ///
     /// This node contains a [`StringLiteral`] that will be stored in the memory arena.

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -3006,7 +3006,6 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSLiteral<'_> {
             Self::NullLiteral(it) => TSLiteral::NullLiteral(CloneIn::clone_in(it, allocator)),
             Self::NumericLiteral(it) => TSLiteral::NumericLiteral(CloneIn::clone_in(it, allocator)),
             Self::BigIntLiteral(it) => TSLiteral::BigIntLiteral(CloneIn::clone_in(it, allocator)),
-            Self::RegExpLiteral(it) => TSLiteral::RegExpLiteral(CloneIn::clone_in(it, allocator)),
             Self::StringLiteral(it) => TSLiteral::StringLiteral(CloneIn::clone_in(it, allocator)),
             Self::TemplateLiteral(it) => {
                 TSLiteral::TemplateLiteral(CloneIn::clone_in(it, allocator))

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -1765,7 +1765,6 @@ impl ContentEq for TSLiteral<'_> {
             (Self::NullLiteral(a), Self::NullLiteral(b)) => a.content_eq(b),
             (Self::NumericLiteral(a), Self::NumericLiteral(b)) => a.content_eq(b),
             (Self::BigIntLiteral(a), Self::BigIntLiteral(b)) => a.content_eq(b),
-            (Self::RegExpLiteral(a), Self::RegExpLiteral(b)) => a.content_eq(b),
             (Self::StringLiteral(a), Self::StringLiteral(b)) => a.content_eq(b),
             (Self::TemplateLiteral(a), Self::TemplateLiteral(b)) => a.content_eq(b),
             (Self::UnaryExpression(a), Self::UnaryExpression(b)) => a.content_eq(b),

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -2335,7 +2335,6 @@ impl Serialize for TSLiteral<'_> {
             TSLiteral::NullLiteral(it) => it.serialize(serializer),
             TSLiteral::NumericLiteral(it) => it.serialize(serializer),
             TSLiteral::BigIntLiteral(it) => it.serialize(serializer),
-            TSLiteral::RegExpLiteral(it) => it.serialize(serializer),
             TSLiteral::StringLiteral(it) => it.serialize(serializer),
             TSLiteral::TemplateLiteral(it) => it.serialize(serializer),
             TSLiteral::UnaryExpression(it) => it.serialize(serializer),

--- a/crates/oxc_ast/src/generated/derive_get_address.rs
+++ b/crates/oxc_ast/src/generated/derive_get_address.rs
@@ -617,7 +617,6 @@ impl GetAddress for TSLiteral<'_> {
             Self::NullLiteral(it) => GetAddress::address(it),
             Self::NumericLiteral(it) => GetAddress::address(it),
             Self::BigIntLiteral(it) => GetAddress::address(it),
-            Self::RegExpLiteral(it) => GetAddress::address(it),
             Self::StringLiteral(it) => GetAddress::address(it),
             Self::TemplateLiteral(it) => GetAddress::address(it),
             Self::UnaryExpression(it) => GetAddress::address(it),

--- a/crates/oxc_ast/src/generated/derive_get_span.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span.rs
@@ -1515,7 +1515,6 @@ impl GetSpan for TSLiteral<'_> {
             Self::NullLiteral(it) => GetSpan::span(&**it),
             Self::NumericLiteral(it) => GetSpan::span(&**it),
             Self::BigIntLiteral(it) => GetSpan::span(&**it),
-            Self::RegExpLiteral(it) => GetSpan::span(&**it),
             Self::StringLiteral(it) => GetSpan::span(&**it),
             Self::TemplateLiteral(it) => GetSpan::span(&**it),
             Self::UnaryExpression(it) => GetSpan::span(&**it),

--- a/crates/oxc_ast/src/generated/derive_get_span_mut.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span_mut.rs
@@ -1515,7 +1515,6 @@ impl GetSpanMut for TSLiteral<'_> {
             Self::NullLiteral(it) => GetSpanMut::span_mut(&mut **it),
             Self::NumericLiteral(it) => GetSpanMut::span_mut(&mut **it),
             Self::BigIntLiteral(it) => GetSpanMut::span_mut(&mut **it),
-            Self::RegExpLiteral(it) => GetSpanMut::span_mut(&mut **it),
             Self::StringLiteral(it) => GetSpanMut::span_mut(&mut **it),
             Self::TemplateLiteral(it) => GetSpanMut::span_mut(&mut **it),
             Self::UnaryExpression(it) => GetSpanMut::span_mut(&mut **it),

--- a/crates/oxc_ast/src/generated/visit.rs
+++ b/crates/oxc_ast/src/generated/visit.rs
@@ -3200,7 +3200,6 @@ pub mod walk {
             TSLiteral::NullLiteral(it) => visitor.visit_null_literal(it),
             TSLiteral::NumericLiteral(it) => visitor.visit_numeric_literal(it),
             TSLiteral::BigIntLiteral(it) => visitor.visit_big_int_literal(it),
-            TSLiteral::RegExpLiteral(it) => visitor.visit_reg_exp_literal(it),
             TSLiteral::StringLiteral(it) => visitor.visit_string_literal(it),
             TSLiteral::TemplateLiteral(it) => visitor.visit_template_literal(it),
             TSLiteral::UnaryExpression(it) => visitor.visit_unary_expression(it),

--- a/crates/oxc_ast/src/generated/visit_mut.rs
+++ b/crates/oxc_ast/src/generated/visit_mut.rs
@@ -3355,7 +3355,6 @@ pub mod walk_mut {
             TSLiteral::NullLiteral(it) => visitor.visit_null_literal(it),
             TSLiteral::NumericLiteral(it) => visitor.visit_numeric_literal(it),
             TSLiteral::BigIntLiteral(it) => visitor.visit_big_int_literal(it),
-            TSLiteral::RegExpLiteral(it) => visitor.visit_reg_exp_literal(it),
             TSLiteral::StringLiteral(it) => visitor.visit_string_literal(it),
             TSLiteral::TemplateLiteral(it) => visitor.visit_template_literal(it),
             TSLiteral::UnaryExpression(it) => visitor.visit_unary_expression(it),

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -3341,7 +3341,6 @@ impl Gen for TSLiteral<'_> {
             Self::NullLiteral(decl) => decl.print(p, ctx),
             Self::NumericLiteral(decl) => decl.print_expr(p, Precedence::Lowest, ctx),
             Self::BigIntLiteral(decl) => decl.print_expr(p, Precedence::Lowest, ctx),
-            Self::RegExpLiteral(decl) => decl.print(p, ctx),
             Self::StringLiteral(decl) => decl.print(p, ctx),
             Self::TemplateLiteral(decl) => decl.print(p, ctx),
             Self::UnaryExpression(decl) => decl.print_expr(p, Precedence::Comma, ctx),

--- a/crates/oxc_linter/src/rules/typescript/no_inferrable_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_inferrable_types.rs
@@ -145,7 +145,6 @@ fn is_inferrable_type(type_annotation: &TSTypeAnnotation, init: &Expression) -> 
             TSLiteral::NumericLiteral(_) => is_init_number(init),
             TSLiteral::BigIntLiteral(_) => is_init_bigint(init),
             TSLiteral::StringLiteral(_) => is_init_string(init),
-            TSLiteral::RegExpLiteral(_) => is_init_regexp(init),
             TSLiteral::TemplateLiteral(_) | TSLiteral::UnaryExpression(_) => false,
         },
         TSType::TSStringKeyword(_) => is_init_string(init),

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -966,7 +966,6 @@ impl<'a> ParserImpl<'a> {
                 Expression::NullLiteral(literal) => TSLiteral::NullLiteral(literal),
                 Expression::NumericLiteral(literal) => TSLiteral::NumericLiteral(literal),
                 Expression::BigIntLiteral(literal) => TSLiteral::BigIntLiteral(literal),
-                Expression::RegExpLiteral(literal) => TSLiteral::RegExpLiteral(literal),
                 Expression::StringLiteral(literal) => TSLiteral::StringLiteral(literal),
                 Expression::TemplateLiteral(literal) => TSLiteral::TemplateLiteral(literal),
                 _ => return Err(self.unexpected()),

--- a/crates/oxc_prettier/src/format/typescript.rs
+++ b/crates/oxc_prettier/src/format/typescript.rs
@@ -305,7 +305,6 @@ impl<'a> Format<'a> for TSLiteralType<'a> {
             TSLiteral::NullLiteral(v) => v.format(p),
             TSLiteral::NumericLiteral(v) => v.format(p),
             TSLiteral::BigIntLiteral(v) => v.format(p),
-            TSLiteral::RegExpLiteral(v) => v.format(p),
             TSLiteral::StringLiteral(v) => v.format(p),
             TSLiteral::TemplateLiteral(v) => v.format(p),
             TSLiteral::UnaryExpression(v) => v.format(p),

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -3783,9 +3783,6 @@ unsafe fn walk_ts_literal<'a, Tr: Traverse<'a>>(
         TSLiteral::BigIntLiteral(node) => {
             walk_big_int_literal(traverser, (&mut **node) as *mut _, ctx)
         }
-        TSLiteral::RegExpLiteral(node) => {
-            walk_reg_exp_literal(traverser, (&mut **node) as *mut _, ctx)
-        }
         TSLiteral::StringLiteral(node) => {
             walk_string_literal(traverser, (&mut **node) as *mut _, ctx)
         }

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -958,7 +958,6 @@ export type TSLiteral =
   | NullLiteral
   | NumericLiteral
   | BigIntLiteral
-  | RegExpLiteral
   | StringLiteral
   | TemplateLiteral
   | UnaryExpression;


### PR DESCRIPTION
`RegExp` cannot be a type, I have checked [typescript-eslint](https://github.com/typescript-eslint/typescript-eslint/blob/87d72ba76c055499ea233efb73cdaef1f0d2ac4a/packages/ast-spec/src/type/TSLiteralType/spec.ts), and don't see it as well

https://ast.sxzz.dev/#eNqrVspRslLKSixLLE4uyiwoUdJRKgAKlFQWpMIFkqECCo4KtgpBqemuFQUxeWABJ6CAvqM+UE0+UE11TJ6CQoxSTmJeemliempYalFxZn5ejJKVgqVlTF6tUi0Aa9IidA==