### PR TITLE
feat(transformer/statement-injector): add a series of `insert_*_before/after_current_statement` methods

### DIFF
--- a/crates/oxc_transformer/src/common/mod.rs
+++ b/crates/oxc_transformer/src/common/mod.rs
@@ -65,6 +65,16 @@ impl<'a> Traverse<'a> for Common<'a, '_> {
         self.statement_injector.exit_statements(stmts, ctx);
     }
 
+    #[inline]
+    fn enter_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
+        self.statement_injector.enter_statement(stmt, ctx);
+    }
+
+    #[inline]
+    fn exit_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
+        self.statement_injector.exit_statement(stmt, ctx);
+    }
+
     fn enter_function(&mut self, func: &mut Function<'a>, ctx: &mut TraverseCtx<'a>) {
         self.arrow_function_converter.enter_function(func, ctx);
     }

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -530,6 +530,7 @@ impl<'a> Traverse<'a> for TransformerImpl<'a, '_> {
     }
 
     fn exit_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
+        self.common.exit_statement(stmt, ctx);
         if let Some(typescript) = self.x0_typescript.as_mut() {
             typescript.exit_statement(stmt, ctx);
         }
@@ -549,6 +550,7 @@ impl<'a> Traverse<'a> for TransformerImpl<'a, '_> {
     }
 
     fn enter_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
+        self.common.enter_statement(stmt, ctx);
         if let Some(typescript) = self.x0_typescript.as_mut() {
             typescript.enter_statement(stmt, ctx);
         }


### PR DESCRIPTION
These methods allow inserting statements before or after the current statement without needing the statement address. And can reduce the address looking up logic like

https://github.com/oxc-project/oxc/blob/c35f52bac58ad618df5bcfce1301ded3c6da26ce/crates/oxc_transformer/src/es2022/class_properties/class.rs#L434-L440 

 This is also an alternative to https://github.com/oxc-project/backlog/issues/140.