### PR TITLE
feat(transformer/statement-injector): add an assertion to check if it still contains statements that don't inject

### DIFF
--- a/crates/oxc_transformer/src/common/mod.rs
+++ b/crates/oxc_transformer/src/common/mod.rs
@@ -46,6 +46,7 @@ impl<'a> Traverse<'a> for Common<'a, '_> {
         self.var_declarations.exit_program(program, ctx);
         self.top_level_statements.exit_program(program, ctx);
         self.arrow_function_converter.exit_program(program, ctx);
+        self.statement_injector.exit_program(program, ctx);
     }
 
     fn enter_statements(

--- a/crates/oxc_transformer/src/common/statement_injector.rs
+++ b/crates/oxc_transformer/src/common/statement_injector.rs
@@ -41,6 +41,11 @@ impl<'a> Traverse<'a> for StatementInjector<'a, '_> {
     ) {
         self.ctx.statement_injector.insert_into_statements(statements, ctx);
     }
+
+    #[inline]
+    fn exit_program(&mut self, _program: &mut Program<'a>, _ctx: &mut TraverseCtx<'a>) {
+        self.ctx.statement_injector.assert_no_insertions_remaining();
+    }
 }
 
 #[derive(Debug)]
@@ -194,5 +199,13 @@ impl<'a> StatementInjectorStore<'a> {
         }
 
         *statements = new_statements;
+    }
+
+    // Assertion for checking if no remaining insertions are left.
+    // `#[inline(always)]` because this is a no-op in release mode
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
+    fn assert_no_insertions_remaining(&self) {
+        debug_assert!(self.insertions.borrow().is_empty());
     }
 }


### PR DESCRIPTION
When there are still statements that aren't inserted after the visitor ends, it means statements inserted with an incorrect address or outdated address (e.g., the original statement has mutated to a new statement). 

This PR adds an assertion to expose this potential bug as soon as possible on the development side.  