### PR TITLE
feat(linter): implement grouped-accessor-pairs

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -40,6 +40,7 @@ mod eslint {
     pub mod for_direction;
     pub mod func_names;
     pub mod getter_return;
+    pub mod grouped_accessor_pairs;
     pub mod guard_for_in;
     pub mod init_declarations;
     pub mod max_classes_per_file;
@@ -544,6 +545,7 @@ oxc_macros::declare_all_lint_rules! {
     eslint::for_direction,
     eslint::func_names,
     eslint::getter_return,
+    eslint::grouped_accessor_pairs,
     eslint::guard_for_in,
     eslint::init_declarations,
     eslint::max_classes_per_file,

--- a/crates/oxc_linter/src/rules/eslint/grouped_accessor_pairs.rs
+++ b/crates/oxc_linter/src/rules/eslint/grouped_accessor_pairs.rs
@@ -1,0 +1,278 @@
+use oxc_ast::{ast::{ObjectPropertyKind, PropertyKind}, AstKind};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::{GetSpan, Span};
+use serde_json::Value;
+
+use crate::{
+    context::LintContext,
+    rule::Rule,
+    AstNode,
+};
+
+fn grouped_accessor_pairs_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Should be an imperative statement about what is wrong")
+        .with_help("Should be a command-like statement that tells the user how to fix the issue")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, PartialEq, Clone)]
+enum OrderStyle {
+    #[default]
+    AnyOrder,
+    GetBeforeSet,
+    SetBeforeGet,
+}
+
+impl OrderStyle {
+    pub fn from(raw: &str) -> Self {
+        match raw {
+            "getBeforeSet" => Self::GetBeforeSet,
+            "setBeforeGet" => Self::SetBeforeGet,
+            _ => Self::AnyOrder,
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct GroupedAccessorPairs {
+    order_style: OrderStyle,
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    ///
+    /// ### Why is this bad?
+    ///
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
+    /// ```
+    GroupedAccessorPairs,
+    eslint,
+    style,
+);
+
+impl Rule for GroupedAccessorPairs {
+    fn from_configuration(value: Value) -> Self {
+        Self {
+            order_style: value.get(0).and_then(Value::as_str).map(OrderStyle::from).unwrap_or_default(),
+        }
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::ObjectExpression(obj_expr) => {
+                // let mut accessors = vec![];
+
+                for v in &obj_expr.properties {
+                    let ObjectPropertyKind::ObjectProperty(obj_prop) = v else {
+                        continue;
+                    };
+                    if obj_prop.kind == PropertyKind::Init {
+                        continue;
+                    }
+                    // let key_name = obj_prop.key.name().unwrap_or_else(|| {
+                    //     if let Some(expression) = obj_prop.key.as_expression() {
+                    //         return Cow::Borrowed(expression.span().source_text(ctx.source_text()));
+                    //     }
+                    //     Cow::Borrowed("")
+                    // });
+                    // let key_name = obj_prop.key.name().unwrap_or_else(|| obj_prop.key.as_expression().unwrap().span().source_text(ctx.source_text())).as_ref();
+
+                }
+            },
+            _ => {},
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (
+            "const boo = {
+                set [v](value) {
+                    
+                }
+            }",
+            None
+        ),
+    ];
+    let fail = vec![
+        (
+            "const o = {
+                set [a+b](value) {
+                    this.val = value;
+                },
+                get [a+b]() {
+                    return this.val;
+                },
+                set a(value) {
+                }
+            };",
+            None
+        )
+    ];
+
+//     let pass = vec![
+//         ("({})", None),
+// ("({ a })", None),
+// ("({ a(){}, b(){}, a(){} })", None),
+// ("({ a: 1, b: 2 })", None),
+// ("({ a, ...b, c: 1 })", None),
+// ("({ a, b, ...a })", None),
+// ("({ a: 1, [b]: 2, a: 3, [b]: 4 })", None),
+// ("({ a: function get(){}, b, a: function set(foo){} })", None),
+// ("({ get(){}, a, set(){} })", None),
+// ("class A {}", None),
+// ("(class { a(){} })", None),
+// ("class A { a(){} [b](){} a(){} [b](){} }", None),
+// ("(class { a(){} b(){} static a(){} static b(){} })", None),
+// ("class A { get(){} a(){} set(){} }", None),
+// ("({ get a(){} })", None),
+// ("({ set a(foo){} })", None),
+// ("({ a: 1, get b(){}, c, ...d })", None),
+// ("({ get a(){}, get b(){}, set c(foo){}, set d(foo){} })", None),
+// ("({ get a(){}, b: 1, set c(foo){} })", None),
+// ("({ set a(foo){}, b: 1, a: 2 })", None),
+// ("({ get a(){}, b: 1, a })", None),
+// ("({ set a(foo){}, b: 1, a(){} })", None),
+// ("({ get a(){}, b: 1, set [a](foo){} })", None),
+// ("({ set a(foo){}, b: 1, get 'a '(){} })", None),
+// ("({ get a(){}, b: 1, ...a })", None),
+// ("({ set a(foo){}, b: 1 }, { get a(){} })", None),
+// ("({ get a(){}, b: 1, ...{ set a(foo){} } })", None),
+// ("({ set a(foo){}, get b(){} })", Some(serde_json::json!(["getBeforeSet"]))),
+// ("({ get a(){}, set b(foo){} })", Some(serde_json::json!(["setBeforeGet"]))),
+// ("class A { get a(){} }", None),
+// ("(class { set a(foo){} })", None),
+// ("class A { static set a(foo){} }", None),
+// ("(class { static get a(){} })", None),
+// ("class A { a(){} set b(foo){} c(){} }", None),
+// ("(class { a(){} get b(){} c(){} })", None),
+// ("class A { get a(){} static get b(){} set c(foo){} static set d(bar){} }", None),
+// ("(class { get a(){} b(){} a(foo){} })", None),
+// ("class A { static set a(foo){} b(){} static a(){} }", None),
+// ("(class { get a(){} static b(){} set [a](foo){} })", None),
+// ("class A { static set a(foo){} b(){} static get ' a'(){} }", None),
+// ("(class { set a(foo){} b(){} static get a(){} })", None),
+// ("class A { static set a(foo){} b(){} get a(){} }", None),
+// ("(class { get a(){} }, class { b(){} set a(foo){} })", None),
+// ("({ get a(){}, set a(foo){} })", None),
+// ("({ a: 1, set b(foo){}, get b(){}, c: 2 })", None),
+// ("({ get a(){}, set a(foo){}, set b(bar){}, get b(){} })", None),
+// ("({ get [a](){}, set [a](foo){} })", None),
+// ("({ set a(foo){}, get 'a'(){} })", None),
+// ("({ a: 1, b: 2, get a(){}, set a(foo){}, c: 3, a: 4 })", None),
+// ("({ get a(){}, set a(foo){}, set b(bar){} })", None),
+// ("({ get a(){}, get b(){}, set b(bar){} })", None),
+// ("class A { get a(){} set a(foo){} }", None),
+// ("(class { set a(foo){} get a(){} })", None),
+// ("class A { static set a(foo){} static get a(){} }", None),
+// ("(class { static get a(){} static set a(foo){} })", None),
+// ("class A { a(){} set b(foo){} get b(){} c(){} get d(){} set d(bar){} }", None),
+// ("(class { set a(foo){} get a(){} get b(){} set b(bar){} })", None),
+// ("class A { static set [a](foo){} static get [a](){} }", None),
+// ("(class { get a(){} set [`a`](foo){} })", None),
+// ("class A { static get a(){} static set a(foo){} set a(bar){} static get a(){} }", None),
+// ("(class { static get a(){} get a(){} set a(foo){} })", None),
+// ("({ get a(){}, set a(foo){} })", Some(serde_json::json!(["anyOrder"]))),
+// ("({ set a(foo){}, get a(){} })", Some(serde_json::json!(["anyOrder"]))),
+// ("({ get a(){}, set a(foo){} })", Some(serde_json::json!(["getBeforeSet"]))),
+// ("({ set a(foo){}, get a(){} })", Some(serde_json::json!(["setBeforeGet"]))),
+// ("class A { get a(){} set a(foo){} }", Some(serde_json::json!(["anyOrder"]))),
+// ("(class { set a(foo){} get a(){} })", Some(serde_json::json!(["anyOrder"]))),
+// ("class A { get a(){} set a(foo){} }", Some(serde_json::json!(["getBeforeSet"]))),
+// ("(class { static set a(foo){} static get a(){} })", Some(serde_json::json!(["setBeforeGet"]))),
+// ("({ get a(){}, b: 1, get a(){} })", None),
+// ("({ set a(foo){}, b: 1, set a(foo){} })", None),
+// ("({ get a(){}, b: 1, set a(foo){}, c: 2, get a(){} })", None),
+// ("({ set a(foo){}, b: 1, set 'a'(bar){}, c: 2, get a(){} })", None),
+// ("class A { get [a](){} b(){} get [a](){} c(){} set [a](foo){} }", None),
+// ("(class { static set a(foo){} b(){} static get a(){} static c(){} static set a(bar){} })", None),
+// ("class A { get '#abc'(){} b(){} set #abc(foo){} }", None),
+// ("class A { get #abc(){} b(){} set '#abc'(foo){} }", None),
+// ("class A { set '#abc'(foo){} get #abc(){} }", Some(serde_json::json!(["getBeforeSet"]))),
+// ("class A { set #abc(foo){} get '#abc'(){} }", Some(serde_json::json!(["getBeforeSet"])))
+//     ];
+
+//     let fail = vec![
+//         ("({ get a(){}, b:1, set a(foo){} })", None),
+// ("({ set 'abc'(foo){}, b:1, get 'abc'(){} })", None),
+// ("({ get [a](){}, b:1, set [a](foo){} })", None),
+// ("class A { get abc(){} b(){} set abc(foo){} }", None),
+// ("(class { set abc(foo){} b(){} get abc(){} })", None),
+// ("class A { static set a(foo){} b(){} static get a(){} }", None),
+// ("(class { static get 123(){} b(){} static set 123(foo){} })", None),
+// ("class A { static get [a](){} b(){} static set [a](foo){} }", None),
+// ("class A { get '#abc'(){} b(){} set '#abc'(foo){} }", None),
+// ("class A { get #abc(){} b(){} set #abc(foo){} }", None),
+// ("({ set a(foo){}, get a(){} })", Some(serde_json::json!(["getBeforeSet"]))),
+// ("({ get 123(){}, set 123(foo){} })", Some(serde_json::json!(["setBeforeGet"]))),
+// ("({ get [a](){}, set [a](foo){} })", Some(serde_json::json!(["setBeforeGet"]))),
+// ("class A { set abc(foo){} get abc(){} }", Some(serde_json::json!(["getBeforeSet"]))),
+// ("(class { get [`abc`](){} set [`abc`](foo){} })", Some(serde_json::json!(["setBeforeGet"]))),
+// ("class A { static get a(){} static set a(foo){} }", Some(serde_json::json!(["setBeforeGet"]))),
+// ("(class { static set 'abc'(foo){} static get 'abc'(){} })", Some(serde_json::json!(["getBeforeSet"]))),
+// ("class A { static set [abc](foo){} static get [abc](){} }", Some(serde_json::json!(["getBeforeSet"]))),
+// ("class A { set '#abc'(foo){} get '#abc'(){} }", Some(serde_json::json!(["getBeforeSet"]))),
+// ("class A { set #abc(foo){} get #abc(){} }", Some(serde_json::json!(["getBeforeSet"]))),
+// ("({ get a(){}, b: 1, set a(foo){} })", Some(serde_json::json!(["anyOrder"]))),
+// ("({ get a(){}, b: 1, set a(foo){} })", Some(serde_json::json!(["setBeforeGet"]))),
+// ("({ get a(){}, b: 1, set a(foo){} })", Some(serde_json::json!(["getBeforeSet"]))),
+// ("class A { set a(foo){} b(){} get a(){} }", Some(serde_json::json!(["getBeforeSet"]))),
+// ("(class { static set a(foo){} b(){} static get a(){} })", Some(serde_json::json!(["setBeforeGet"]))),
+// ("({ get 'abc'(){}, d(){}, set 'abc'(foo){} })", None),
+// ("({ set ''(foo){}, get [''](){} })", Some(serde_json::json!(["getBeforeSet"]))),
+// ("class A { set abc(foo){} get 'abc'(){} }", Some(serde_json::json!(["getBeforeSet"]))),
+// ("(class { set [`abc`](foo){} get abc(){} })", Some(serde_json::json!(["getBeforeSet"]))),
+// ("({ set ['abc'](foo){}, get [`abc`](){} })", Some(serde_json::json!(["getBeforeSet"]))),
+// ("({ set 123(foo){}, get [123](){} })", Some(serde_json::json!(["getBeforeSet"]))),
+// ("class A { static set '123'(foo){} static get 123(){} }", Some(serde_json::json!(["getBeforeSet"]))),
+// ("(class { set [a+b](foo){} get [a+b](){} })", Some(serde_json::json!(["getBeforeSet"]))),
+// ("({ set [f(a)](foo){}, get [f(a)](){} })", Some(serde_json::json!(["getBeforeSet"]))),
+// ("({ get a(){}, b: 1, set a(foo){}, set c(foo){}, d(){}, get c(){} })", None),
+// ("({ get a(){}, set b(foo){}, set a(bar){}, get b(){} })", None),
+// ("({ get a(){}, set [a](foo){}, set a(bar){}, get [a](){} })", None),
+// ("({ a(){}, set b(foo){}, ...c, get b(){}, set c(bar){}, get c(){} })", Some(serde_json::json!(["getBeforeSet"]))),
+// ("({ set [a](foo){}, get [a](){}, set [-a](bar){}, get [-a](){} })", Some(serde_json::json!(["getBeforeSet"]))),
+// ("class A { get a(){} constructor (){} set a(foo){} get b(){} static c(){} set b(bar){} }", None),
+// ("(class { set a(foo){} static get a(){} get a(){} static set a(bar){} })", None),
+// ("class A { get a(){} set a(foo){} static get b(){} static set b(bar){} }", Some(serde_json::json!(["setBeforeGet"]))),
+// ("(class { set [a+b](foo){} get [a-b](){} get [a+b](){} set [a-b](bar){} })", None),
+// ("({ get a(){}, set a(foo){}, get b(){}, c: function(){}, set b(bar){} })", None),
+// ("({ get a(){}, get b(){}, set a(foo){} })", None),
+// ("({ set a(foo){}, get [a](){}, get a(){} })", None),
+// ("({ set [a](foo){}, set a(bar){}, get [a](){} })", None),
+// ("({ get a(){}, set a(foo){}, set b(bar){}, get b(){} })", Some(serde_json::json!(["getBeforeSet"]))),
+// ("class A { get a(){} static set b(foo){} static get b(){} set a(foo){} }", None),
+// ("(class { static get a(){} set a(foo){} static set a(bar){} })", None),
+// ("class A { set a(foo){} get a(){} static get a(){} static set a(bar){} }", Some(serde_json::json!(["setBeforeGet"]))),
+// ("({ get a(){}, a: 1, set a(foo){} })", None),
+// ("({ a(){}, set a(foo){}, get a(){} })", Some(serde_json::json!(["getBeforeSet"]))),
+// ("class A { get a(){} a(){} set a(foo){} }", None),
+// ("class A { get a(){} a; set a(foo){} }", None), // { "ecmaVersion": 2022 },
+// ("({ get a(){},
+// 			    b: 1,
+// 			    set a(foo){}
+// 			})", None),
+// ("class A { static set a(foo){} b(){} static get 
+// 			 a(){}
+// 			}", None)
+//     ];
+
+    Tester::new(GroupedAccessorPairs::NAME, GroupedAccessorPairs::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/eslint/grouped_accessor_pairs.rs
+++ b/crates/oxc_linter/src/rules/eslint/grouped_accessor_pairs.rs
@@ -1,30 +1,31 @@
-use oxc_ast::{ast::{ObjectPropertyKind, PropertyKind}, AstKind};
+use oxc_allocator::Box;
+use oxc_ast::{
+    ast::{ObjectProperty, ObjectPropertyKind, PropertyKind},
+    AstKind,
+};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
+use rustc_hash::FxHashMap;
 use serde_json::Value;
 
-use crate::{
-    context::LintContext,
-    rule::Rule,
-    AstNode,
-};
+use crate::{context::LintContext, rule::Rule, AstNode};
 
-fn grouped_accessor_pairs_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Should be an imperative statement about what is wrong")
-        .with_help("Should be a command-like statement that tells the user how to fix the issue")
+fn grouped_accessor_pairs_diagnostic(span: Span, msg: String) -> OxcDiagnostic {
+    OxcDiagnostic::warn(msg)
+        .with_help("Require grouped accessor pairs in object literals and classes")
         .with_label(span)
 }
 
 #[derive(Debug, Default, PartialEq, Clone)]
-enum OrderStyle {
+enum PairOrder {
     #[default]
     AnyOrder,
     GetBeforeSet,
     SetBeforeGet,
 }
 
-impl OrderStyle {
+impl PairOrder {
     pub fn from(raw: &str) -> Self {
         match raw {
             "getBeforeSet" => Self::GetBeforeSet,
@@ -36,7 +37,7 @@ impl OrderStyle {
 
 #[derive(Debug, Default, Clone)]
 pub struct GroupedAccessorPairs {
-    order_style: OrderStyle,
+    pair_order: PairOrder,
 }
 
 declare_oxc_lint!(
@@ -65,33 +66,76 @@ declare_oxc_lint!(
 impl Rule for GroupedAccessorPairs {
     fn from_configuration(value: Value) -> Self {
         Self {
-            order_style: value.get(0).and_then(Value::as_str).map(OrderStyle::from).unwrap_or_default(),
+            pair_order: value
+                .get(0)
+                .and_then(Value::as_str)
+                .map(PairOrder::from)
+                .unwrap_or_default(),
         }
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         match node.kind() {
             AstKind::ObjectExpression(obj_expr) => {
-                // let mut accessors = vec![];
+                let mut prop_map =
+                    FxHashMap::<String, Vec<(isize, &Box<ObjectProperty>)>>::default();
+                let properties = &obj_expr.properties;
 
-                for v in &obj_expr.properties {
+                for (idx, v) in properties.iter().enumerate() {
                     let ObjectPropertyKind::ObjectProperty(obj_prop) = v else {
                         continue;
                     };
                     if obj_prop.kind == PropertyKind::Init {
                         continue;
                     }
-                    // let key_name = obj_prop.key.name().unwrap_or_else(|| {
-                    //     if let Some(expression) = obj_prop.key.as_expression() {
-                    //         return Cow::Borrowed(expression.span().source_text(ctx.source_text()));
-                    //     }
-                    //     Cow::Borrowed("")
-                    // });
-                    // let key_name = obj_prop.key.name().unwrap_or_else(|| obj_prop.key.as_expression().unwrap().span().source_text(ctx.source_text())).as_ref();
+                    let temp_key_name = obj_prop.key.name();
+                    let key_name = if temp_key_name.is_none() {
+                        obj_prop
+                            .key
+                            .as_expression()
+                            .unwrap()
+                            .span()
+                            .source_text(ctx.source_text())
+                            .to_string()
+                    } else {
+                        temp_key_name.unwrap().to_string()
+                    };
 
+                    prop_map.entry(key_name).or_default().push((idx as isize, obj_prop));
                 }
-            },
-            _ => {},
+
+                for (key, val) in prop_map {
+                    if val.len() == 2 {
+                        let (first, first_node) = val[0];
+                        let (second, second_node) = val[1];
+                        let ((getter_prop, getter_idx), (setter_prop, setter_idx)) =
+                            if first_node.kind == PropertyKind::Get {
+                                ((first_node, first), (second_node, second))
+                            } else {
+                                ((second_node, second), (first_node, first))
+                            };
+                        let (former, latter) = if first < second {
+                            (first_node, second_node)
+                        } else {
+                            (second_node, first_node)
+                        };
+
+                        match self.pair_order {
+                            PairOrder::GetBeforeSet if getter_idx > setter_idx => {}
+                            PairOrder::SetBeforeGet if setter_idx > getter_idx => {}
+                            _ => {
+                                if (getter_idx - setter_idx).abs() > 1 {
+                                    ctx.diagnostic(grouped_accessor_pairs_diagnostic(
+                                        Span::new(latter.span.start, latter.key.span().end),
+                                        format!("Accessor pair {key} and {key} should be grouped."),
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            _ => {}
         }
     }
 }
@@ -100,19 +144,16 @@ impl Rule for GroupedAccessorPairs {
 fn test() {
     use crate::tester::Tester;
 
-    let pass = vec![
-        (
-            "const boo = {
+    let pass = vec![(
+        "const boo = {
                 set [v](value) {
                     
                 }
             }",
-            None
-        ),
-    ];
-    let fail = vec![
-        (
-            "const o = {
+        None,
+    )];
+    let fail = vec![(
+        "const o = {
                 set [a+b](value) {
                     this.val = value;
                 },
@@ -122,156 +163,155 @@ fn test() {
                 set a(value) {
                 }
             };",
-            None
-        )
-    ];
+        None,
+    )];
 
-//     let pass = vec![
-//         ("({})", None),
-// ("({ a })", None),
-// ("({ a(){}, b(){}, a(){} })", None),
-// ("({ a: 1, b: 2 })", None),
-// ("({ a, ...b, c: 1 })", None),
-// ("({ a, b, ...a })", None),
-// ("({ a: 1, [b]: 2, a: 3, [b]: 4 })", None),
-// ("({ a: function get(){}, b, a: function set(foo){} })", None),
-// ("({ get(){}, a, set(){} })", None),
-// ("class A {}", None),
-// ("(class { a(){} })", None),
-// ("class A { a(){} [b](){} a(){} [b](){} }", None),
-// ("(class { a(){} b(){} static a(){} static b(){} })", None),
-// ("class A { get(){} a(){} set(){} }", None),
-// ("({ get a(){} })", None),
-// ("({ set a(foo){} })", None),
-// ("({ a: 1, get b(){}, c, ...d })", None),
-// ("({ get a(){}, get b(){}, set c(foo){}, set d(foo){} })", None),
-// ("({ get a(){}, b: 1, set c(foo){} })", None),
-// ("({ set a(foo){}, b: 1, a: 2 })", None),
-// ("({ get a(){}, b: 1, a })", None),
-// ("({ set a(foo){}, b: 1, a(){} })", None),
-// ("({ get a(){}, b: 1, set [a](foo){} })", None),
-// ("({ set a(foo){}, b: 1, get 'a '(){} })", None),
-// ("({ get a(){}, b: 1, ...a })", None),
-// ("({ set a(foo){}, b: 1 }, { get a(){} })", None),
-// ("({ get a(){}, b: 1, ...{ set a(foo){} } })", None),
-// ("({ set a(foo){}, get b(){} })", Some(serde_json::json!(["getBeforeSet"]))),
-// ("({ get a(){}, set b(foo){} })", Some(serde_json::json!(["setBeforeGet"]))),
-// ("class A { get a(){} }", None),
-// ("(class { set a(foo){} })", None),
-// ("class A { static set a(foo){} }", None),
-// ("(class { static get a(){} })", None),
-// ("class A { a(){} set b(foo){} c(){} }", None),
-// ("(class { a(){} get b(){} c(){} })", None),
-// ("class A { get a(){} static get b(){} set c(foo){} static set d(bar){} }", None),
-// ("(class { get a(){} b(){} a(foo){} })", None),
-// ("class A { static set a(foo){} b(){} static a(){} }", None),
-// ("(class { get a(){} static b(){} set [a](foo){} })", None),
-// ("class A { static set a(foo){} b(){} static get ' a'(){} }", None),
-// ("(class { set a(foo){} b(){} static get a(){} })", None),
-// ("class A { static set a(foo){} b(){} get a(){} }", None),
-// ("(class { get a(){} }, class { b(){} set a(foo){} })", None),
-// ("({ get a(){}, set a(foo){} })", None),
-// ("({ a: 1, set b(foo){}, get b(){}, c: 2 })", None),
-// ("({ get a(){}, set a(foo){}, set b(bar){}, get b(){} })", None),
-// ("({ get [a](){}, set [a](foo){} })", None),
-// ("({ set a(foo){}, get 'a'(){} })", None),
-// ("({ a: 1, b: 2, get a(){}, set a(foo){}, c: 3, a: 4 })", None),
-// ("({ get a(){}, set a(foo){}, set b(bar){} })", None),
-// ("({ get a(){}, get b(){}, set b(bar){} })", None),
-// ("class A { get a(){} set a(foo){} }", None),
-// ("(class { set a(foo){} get a(){} })", None),
-// ("class A { static set a(foo){} static get a(){} }", None),
-// ("(class { static get a(){} static set a(foo){} })", None),
-// ("class A { a(){} set b(foo){} get b(){} c(){} get d(){} set d(bar){} }", None),
-// ("(class { set a(foo){} get a(){} get b(){} set b(bar){} })", None),
-// ("class A { static set [a](foo){} static get [a](){} }", None),
-// ("(class { get a(){} set [`a`](foo){} })", None),
-// ("class A { static get a(){} static set a(foo){} set a(bar){} static get a(){} }", None),
-// ("(class { static get a(){} get a(){} set a(foo){} })", None),
-// ("({ get a(){}, set a(foo){} })", Some(serde_json::json!(["anyOrder"]))),
-// ("({ set a(foo){}, get a(){} })", Some(serde_json::json!(["anyOrder"]))),
-// ("({ get a(){}, set a(foo){} })", Some(serde_json::json!(["getBeforeSet"]))),
-// ("({ set a(foo){}, get a(){} })", Some(serde_json::json!(["setBeforeGet"]))),
-// ("class A { get a(){} set a(foo){} }", Some(serde_json::json!(["anyOrder"]))),
-// ("(class { set a(foo){} get a(){} })", Some(serde_json::json!(["anyOrder"]))),
-// ("class A { get a(){} set a(foo){} }", Some(serde_json::json!(["getBeforeSet"]))),
-// ("(class { static set a(foo){} static get a(){} })", Some(serde_json::json!(["setBeforeGet"]))),
-// ("({ get a(){}, b: 1, get a(){} })", None),
-// ("({ set a(foo){}, b: 1, set a(foo){} })", None),
-// ("({ get a(){}, b: 1, set a(foo){}, c: 2, get a(){} })", None),
-// ("({ set a(foo){}, b: 1, set 'a'(bar){}, c: 2, get a(){} })", None),
-// ("class A { get [a](){} b(){} get [a](){} c(){} set [a](foo){} }", None),
-// ("(class { static set a(foo){} b(){} static get a(){} static c(){} static set a(bar){} })", None),
-// ("class A { get '#abc'(){} b(){} set #abc(foo){} }", None),
-// ("class A { get #abc(){} b(){} set '#abc'(foo){} }", None),
-// ("class A { set '#abc'(foo){} get #abc(){} }", Some(serde_json::json!(["getBeforeSet"]))),
-// ("class A { set #abc(foo){} get '#abc'(){} }", Some(serde_json::json!(["getBeforeSet"])))
-//     ];
+    //     let pass = vec![
+    //         ("({})", None),
+    // ("({ a })", None),
+    // ("({ a(){}, b(){}, a(){} })", None),
+    // ("({ a: 1, b: 2 })", None),
+    // ("({ a, ...b, c: 1 })", None),
+    // ("({ a, b, ...a })", None),
+    // ("({ a: 1, [b]: 2, a: 3, [b]: 4 })", None),
+    // ("({ a: function get(){}, b, a: function set(foo){} })", None),
+    // ("({ get(){}, a, set(){} })", None),
+    // ("class A {}", None),
+    // ("(class { a(){} })", None),
+    // ("class A { a(){} [b](){} a(){} [b](){} }", None),
+    // ("(class { a(){} b(){} static a(){} static b(){} })", None),
+    // ("class A { get(){} a(){} set(){} }", None),
+    // ("({ get a(){} })", None),
+    // ("({ set a(foo){} })", None),
+    // ("({ a: 1, get b(){}, c, ...d })", None),
+    // ("({ get a(){}, get b(){}, set c(foo){}, set d(foo){} })", None),
+    // ("({ get a(){}, b: 1, set c(foo){} })", None),
+    // ("({ set a(foo){}, b: 1, a: 2 })", None),
+    // ("({ get a(){}, b: 1, a })", None),
+    // ("({ set a(foo){}, b: 1, a(){} })", None),
+    // ("({ get a(){}, b: 1, set [a](foo){} })", None),
+    // ("({ set a(foo){}, b: 1, get 'a '(){} })", None),
+    // ("({ get a(){}, b: 1, ...a })", None),
+    // ("({ set a(foo){}, b: 1 }, { get a(){} })", None),
+    // ("({ get a(){}, b: 1, ...{ set a(foo){} } })", None),
+    // ("({ set a(foo){}, get b(){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    // ("({ get a(){}, set b(foo){} })", Some(serde_json::json!(["setBeforeGet"]))),
+    // ("class A { get a(){} }", None),
+    // ("(class { set a(foo){} })", None),
+    // ("class A { static set a(foo){} }", None),
+    // ("(class { static get a(){} })", None),
+    // ("class A { a(){} set b(foo){} c(){} }", None),
+    // ("(class { a(){} get b(){} c(){} })", None),
+    // ("class A { get a(){} static get b(){} set c(foo){} static set d(bar){} }", None),
+    // ("(class { get a(){} b(){} a(foo){} })", None),
+    // ("class A { static set a(foo){} b(){} static a(){} }", None),
+    // ("(class { get a(){} static b(){} set [a](foo){} })", None),
+    // ("class A { static set a(foo){} b(){} static get ' a'(){} }", None),
+    // ("(class { set a(foo){} b(){} static get a(){} })", None),
+    // ("class A { static set a(foo){} b(){} get a(){} }", None),
+    // ("(class { get a(){} }, class { b(){} set a(foo){} })", None),
+    // ("({ get a(){}, set a(foo){} })", None),
+    // ("({ a: 1, set b(foo){}, get b(){}, c: 2 })", None),
+    // ("({ get a(){}, set a(foo){}, set b(bar){}, get b(){} })", None),
+    // ("({ get [a](){}, set [a](foo){} })", None),
+    // ("({ set a(foo){}, get 'a'(){} })", None),
+    // ("({ a: 1, b: 2, get a(){}, set a(foo){}, c: 3, a: 4 })", None),
+    // ("({ get a(){}, set a(foo){}, set b(bar){} })", None),
+    // ("({ get a(){}, get b(){}, set b(bar){} })", None),
+    // ("class A { get a(){} set a(foo){} }", None),
+    // ("(class { set a(foo){} get a(){} })", None),
+    // ("class A { static set a(foo){} static get a(){} }", None),
+    // ("(class { static get a(){} static set a(foo){} })", None),
+    // ("class A { a(){} set b(foo){} get b(){} c(){} get d(){} set d(bar){} }", None),
+    // ("(class { set a(foo){} get a(){} get b(){} set b(bar){} })", None),
+    // ("class A { static set [a](foo){} static get [a](){} }", None),
+    // ("(class { get a(){} set [`a`](foo){} })", None),
+    // ("class A { static get a(){} static set a(foo){} set a(bar){} static get a(){} }", None),
+    // ("(class { static get a(){} get a(){} set a(foo){} })", None),
+    // ("({ get a(){}, set a(foo){} })", Some(serde_json::json!(["anyOrder"]))),
+    // ("({ set a(foo){}, get a(){} })", Some(serde_json::json!(["anyOrder"]))),
+    // ("({ get a(){}, set a(foo){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    // ("({ set a(foo){}, get a(){} })", Some(serde_json::json!(["setBeforeGet"]))),
+    // ("class A { get a(){} set a(foo){} }", Some(serde_json::json!(["anyOrder"]))),
+    // ("(class { set a(foo){} get a(){} })", Some(serde_json::json!(["anyOrder"]))),
+    // ("class A { get a(){} set a(foo){} }", Some(serde_json::json!(["getBeforeSet"]))),
+    // ("(class { static set a(foo){} static get a(){} })", Some(serde_json::json!(["setBeforeGet"]))),
+    // ("({ get a(){}, b: 1, get a(){} })", None),
+    // ("({ set a(foo){}, b: 1, set a(foo){} })", None),
+    // ("({ get a(){}, b: 1, set a(foo){}, c: 2, get a(){} })", None),
+    // ("({ set a(foo){}, b: 1, set 'a'(bar){}, c: 2, get a(){} })", None),
+    // ("class A { get [a](){} b(){} get [a](){} c(){} set [a](foo){} }", None),
+    // ("(class { static set a(foo){} b(){} static get a(){} static c(){} static set a(bar){} })", None),
+    // ("class A { get '#abc'(){} b(){} set #abc(foo){} }", None),
+    // ("class A { get #abc(){} b(){} set '#abc'(foo){} }", None),
+    // ("class A { set '#abc'(foo){} get #abc(){} }", Some(serde_json::json!(["getBeforeSet"]))),
+    // ("class A { set #abc(foo){} get '#abc'(){} }", Some(serde_json::json!(["getBeforeSet"])))
+    //     ];
 
-//     let fail = vec![
-//         ("({ get a(){}, b:1, set a(foo){} })", None),
-// ("({ set 'abc'(foo){}, b:1, get 'abc'(){} })", None),
-// ("({ get [a](){}, b:1, set [a](foo){} })", None),
-// ("class A { get abc(){} b(){} set abc(foo){} }", None),
-// ("(class { set abc(foo){} b(){} get abc(){} })", None),
-// ("class A { static set a(foo){} b(){} static get a(){} }", None),
-// ("(class { static get 123(){} b(){} static set 123(foo){} })", None),
-// ("class A { static get [a](){} b(){} static set [a](foo){} }", None),
-// ("class A { get '#abc'(){} b(){} set '#abc'(foo){} }", None),
-// ("class A { get #abc(){} b(){} set #abc(foo){} }", None),
-// ("({ set a(foo){}, get a(){} })", Some(serde_json::json!(["getBeforeSet"]))),
-// ("({ get 123(){}, set 123(foo){} })", Some(serde_json::json!(["setBeforeGet"]))),
-// ("({ get [a](){}, set [a](foo){} })", Some(serde_json::json!(["setBeforeGet"]))),
-// ("class A { set abc(foo){} get abc(){} }", Some(serde_json::json!(["getBeforeSet"]))),
-// ("(class { get [`abc`](){} set [`abc`](foo){} })", Some(serde_json::json!(["setBeforeGet"]))),
-// ("class A { static get a(){} static set a(foo){} }", Some(serde_json::json!(["setBeforeGet"]))),
-// ("(class { static set 'abc'(foo){} static get 'abc'(){} })", Some(serde_json::json!(["getBeforeSet"]))),
-// ("class A { static set [abc](foo){} static get [abc](){} }", Some(serde_json::json!(["getBeforeSet"]))),
-// ("class A { set '#abc'(foo){} get '#abc'(){} }", Some(serde_json::json!(["getBeforeSet"]))),
-// ("class A { set #abc(foo){} get #abc(){} }", Some(serde_json::json!(["getBeforeSet"]))),
-// ("({ get a(){}, b: 1, set a(foo){} })", Some(serde_json::json!(["anyOrder"]))),
-// ("({ get a(){}, b: 1, set a(foo){} })", Some(serde_json::json!(["setBeforeGet"]))),
-// ("({ get a(){}, b: 1, set a(foo){} })", Some(serde_json::json!(["getBeforeSet"]))),
-// ("class A { set a(foo){} b(){} get a(){} }", Some(serde_json::json!(["getBeforeSet"]))),
-// ("(class { static set a(foo){} b(){} static get a(){} })", Some(serde_json::json!(["setBeforeGet"]))),
-// ("({ get 'abc'(){}, d(){}, set 'abc'(foo){} })", None),
-// ("({ set ''(foo){}, get [''](){} })", Some(serde_json::json!(["getBeforeSet"]))),
-// ("class A { set abc(foo){} get 'abc'(){} }", Some(serde_json::json!(["getBeforeSet"]))),
-// ("(class { set [`abc`](foo){} get abc(){} })", Some(serde_json::json!(["getBeforeSet"]))),
-// ("({ set ['abc'](foo){}, get [`abc`](){} })", Some(serde_json::json!(["getBeforeSet"]))),
-// ("({ set 123(foo){}, get [123](){} })", Some(serde_json::json!(["getBeforeSet"]))),
-// ("class A { static set '123'(foo){} static get 123(){} }", Some(serde_json::json!(["getBeforeSet"]))),
-// ("(class { set [a+b](foo){} get [a+b](){} })", Some(serde_json::json!(["getBeforeSet"]))),
-// ("({ set [f(a)](foo){}, get [f(a)](){} })", Some(serde_json::json!(["getBeforeSet"]))),
-// ("({ get a(){}, b: 1, set a(foo){}, set c(foo){}, d(){}, get c(){} })", None),
-// ("({ get a(){}, set b(foo){}, set a(bar){}, get b(){} })", None),
-// ("({ get a(){}, set [a](foo){}, set a(bar){}, get [a](){} })", None),
-// ("({ a(){}, set b(foo){}, ...c, get b(){}, set c(bar){}, get c(){} })", Some(serde_json::json!(["getBeforeSet"]))),
-// ("({ set [a](foo){}, get [a](){}, set [-a](bar){}, get [-a](){} })", Some(serde_json::json!(["getBeforeSet"]))),
-// ("class A { get a(){} constructor (){} set a(foo){} get b(){} static c(){} set b(bar){} }", None),
-// ("(class { set a(foo){} static get a(){} get a(){} static set a(bar){} })", None),
-// ("class A { get a(){} set a(foo){} static get b(){} static set b(bar){} }", Some(serde_json::json!(["setBeforeGet"]))),
-// ("(class { set [a+b](foo){} get [a-b](){} get [a+b](){} set [a-b](bar){} })", None),
-// ("({ get a(){}, set a(foo){}, get b(){}, c: function(){}, set b(bar){} })", None),
-// ("({ get a(){}, get b(){}, set a(foo){} })", None),
-// ("({ set a(foo){}, get [a](){}, get a(){} })", None),
-// ("({ set [a](foo){}, set a(bar){}, get [a](){} })", None),
-// ("({ get a(){}, set a(foo){}, set b(bar){}, get b(){} })", Some(serde_json::json!(["getBeforeSet"]))),
-// ("class A { get a(){} static set b(foo){} static get b(){} set a(foo){} }", None),
-// ("(class { static get a(){} set a(foo){} static set a(bar){} })", None),
-// ("class A { set a(foo){} get a(){} static get a(){} static set a(bar){} }", Some(serde_json::json!(["setBeforeGet"]))),
-// ("({ get a(){}, a: 1, set a(foo){} })", None),
-// ("({ a(){}, set a(foo){}, get a(){} })", Some(serde_json::json!(["getBeforeSet"]))),
-// ("class A { get a(){} a(){} set a(foo){} }", None),
-// ("class A { get a(){} a; set a(foo){} }", None), // { "ecmaVersion": 2022 },
-// ("({ get a(){},
-// 			    b: 1,
-// 			    set a(foo){}
-// 			})", None),
-// ("class A { static set a(foo){} b(){} static get 
-// 			 a(){}
-// 			}", None)
-//     ];
+    //     let fail = vec![
+    //         ("({ get a(){}, b:1, set a(foo){} })", None),
+    // ("({ set 'abc'(foo){}, b:1, get 'abc'(){} })", None),
+    // ("({ get [a](){}, b:1, set [a](foo){} })", None),
+    // ("class A { get abc(){} b(){} set abc(foo){} }", None),
+    // ("(class { set abc(foo){} b(){} get abc(){} })", None),
+    // ("class A { static set a(foo){} b(){} static get a(){} }", None),
+    // ("(class { static get 123(){} b(){} static set 123(foo){} })", None),
+    // ("class A { static get [a](){} b(){} static set [a](foo){} }", None),
+    // ("class A { get '#abc'(){} b(){} set '#abc'(foo){} }", None),
+    // ("class A { get #abc(){} b(){} set #abc(foo){} }", None),
+    // ("({ set a(foo){}, get a(){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    // ("({ get 123(){}, set 123(foo){} })", Some(serde_json::json!(["setBeforeGet"]))),
+    // ("({ get [a](){}, set [a](foo){} })", Some(serde_json::json!(["setBeforeGet"]))),
+    // ("class A { set abc(foo){} get abc(){} }", Some(serde_json::json!(["getBeforeSet"]))),
+    // ("(class { get [`abc`](){} set [`abc`](foo){} })", Some(serde_json::json!(["setBeforeGet"]))),
+    // ("class A { static get a(){} static set a(foo){} }", Some(serde_json::json!(["setBeforeGet"]))),
+    // ("(class { static set 'abc'(foo){} static get 'abc'(){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    // ("class A { static set [abc](foo){} static get [abc](){} }", Some(serde_json::json!(["getBeforeSet"]))),
+    // ("class A { set '#abc'(foo){} get '#abc'(){} }", Some(serde_json::json!(["getBeforeSet"]))),
+    // ("class A { set #abc(foo){} get #abc(){} }", Some(serde_json::json!(["getBeforeSet"]))),
+    // ("({ get a(){}, b: 1, set a(foo){} })", Some(serde_json::json!(["anyOrder"]))),
+    // ("({ get a(){}, b: 1, set a(foo){} })", Some(serde_json::json!(["setBeforeGet"]))),
+    // ("({ get a(){}, b: 1, set a(foo){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    // ("class A { set a(foo){} b(){} get a(){} }", Some(serde_json::json!(["getBeforeSet"]))),
+    // ("(class { static set a(foo){} b(){} static get a(){} })", Some(serde_json::json!(["setBeforeGet"]))),
+    // ("({ get 'abc'(){}, d(){}, set 'abc'(foo){} })", None),
+    // ("({ set ''(foo){}, get [''](){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    // ("class A { set abc(foo){} get 'abc'(){} }", Some(serde_json::json!(["getBeforeSet"]))),
+    // ("(class { set [`abc`](foo){} get abc(){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    // ("({ set ['abc'](foo){}, get [`abc`](){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    // ("({ set 123(foo){}, get [123](){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    // ("class A { static set '123'(foo){} static get 123(){} }", Some(serde_json::json!(["getBeforeSet"]))),
+    // ("(class { set [a+b](foo){} get [a+b](){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    // ("({ set [f(a)](foo){}, get [f(a)](){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    // ("({ get a(){}, b: 1, set a(foo){}, set c(foo){}, d(){}, get c(){} })", None),
+    // ("({ get a(){}, set b(foo){}, set a(bar){}, get b(){} })", None),
+    // ("({ get a(){}, set [a](foo){}, set a(bar){}, get [a](){} })", None),
+    // ("({ a(){}, set b(foo){}, ...c, get b(){}, set c(bar){}, get c(){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    // ("({ set [a](foo){}, get [a](){}, set [-a](bar){}, get [-a](){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    // ("class A { get a(){} constructor (){} set a(foo){} get b(){} static c(){} set b(bar){} }", None),
+    // ("(class { set a(foo){} static get a(){} get a(){} static set a(bar){} })", None),
+    // ("class A { get a(){} set a(foo){} static get b(){} static set b(bar){} }", Some(serde_json::json!(["setBeforeGet"]))),
+    // ("(class { set [a+b](foo){} get [a-b](){} get [a+b](){} set [a-b](bar){} })", None),
+    // ("({ get a(){}, set a(foo){}, get b(){}, c: function(){}, set b(bar){} })", None),
+    // ("({ get a(){}, get b(){}, set a(foo){} })", None),
+    // ("({ set a(foo){}, get [a](){}, get a(){} })", None),
+    // ("({ set [a](foo){}, set a(bar){}, get [a](){} })", None),
+    // ("({ get a(){}, set a(foo){}, set b(bar){}, get b(){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    // ("class A { get a(){} static set b(foo){} static get b(){} set a(foo){} }", None),
+    // ("(class { static get a(){} set a(foo){} static set a(bar){} })", None),
+    // ("class A { set a(foo){} get a(){} static get a(){} static set a(bar){} }", Some(serde_json::json!(["setBeforeGet"]))),
+    // ("({ get a(){}, a: 1, set a(foo){} })", None),
+    // ("({ a(){}, set a(foo){}, get a(){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    // ("class A { get a(){} a(){} set a(foo){} }", None),
+    // ("class A { get a(){} a; set a(foo){} }", None), // { "ecmaVersion": 2022 },
+    // ("({ get a(){},
+    // 			    b: 1,
+    // 			    set a(foo){}
+    // 			})", None),
+    // ("class A { static set a(foo){} b(){} static get
+    // 			 a(){}
+    // 			}", None)
+    //     ];
 
     Tester::new(GroupedAccessorPairs::NAME, GroupedAccessorPairs::PLUGIN, pass, fail)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/eslint/grouped_accessor_pairs.rs
+++ b/crates/oxc_linter/src/rules/eslint/grouped_accessor_pairs.rs
@@ -1,6 +1,11 @@
+use std::borrow::Cow;
+
 use oxc_allocator::Box;
 use oxc_ast::{
-    ast::{ObjectProperty, ObjectPropertyKind, PropertyKind},
+    ast::{
+        ClassElement, Expression, MethodDefinition, MethodDefinitionKind, ObjectProperty,
+        ObjectPropertyKind, PropertyKey, PropertyKind,
+    },
     AstKind,
 };
 use oxc_diagnostics::OxcDiagnostic;
@@ -42,21 +47,97 @@ pub struct GroupedAccessorPairs {
 
 declare_oxc_lint!(
     /// ### What it does
-    ///
+    /// Require grouped accessor pairs in object literals and classes
     ///
     /// ### Why is this bad?
-    ///
+    /// While it is allowed to define the pair for a getter or a setter anywhere in an object or class definition,
+    /// it’s considered a best practice to group accessor functions for the same property.
     ///
     /// ### Examples
+    /// ```js
+    /// const o = {
+    ///     get a() {
+    ///         return this.val;
+    ///     },
+    ///     set a(value) {
+    ///         this.val = value;
+    ///     },
+    ///     b: 1
+    /// };
+    /// ```
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```js
-    /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
+    /// const foo = {
+    ///     get a() {
+    ///         return this.val;
+    ///     },
+    ///     b: 1,
+    ///     set a(value) {
+    ///         this.val = value;
+    ///     }
+    /// };
     /// ```
     ///
     /// Examples of **correct** code for this rule:
     /// ```js
-    /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
+    /// const foo = {
+    ///     get a() {
+    ///         return this.val;
+    ///     },
+    ///     set a(value) {
+    ///         this.val = value;
+    ///     },
+    ///     b: 1
+    /// };
+    /// ```
+    ///
+    /// Examples of incorrect code for this rule with the "getBeforeSet" option:
+    /// ```js
+    /// const foo = {
+    ///     set a(value) {
+    ///         this.val = value;
+    ///     },
+    ///     get a() {
+    ///         return this.val;
+    ///     }
+    /// };
+    /// ```
+    ///
+    /// Examples of correct code for this rule with the "getBeforeSet" option:
+    /// ```js
+    /// const foo = {
+    ///     get a() {
+    ///         return this.val;
+    ///     },
+    ///     set a(value) {
+    ///         this.val = value;
+    ///     }
+    /// };
+    /// ```
+    ///
+    /// Examples of incorrect code for this rule with the "setBeforeGet" option:
+    /// ```js
+    /// const foo = {
+    ///     get a() {
+    ///         return this.val;
+    ///     },
+    ///     set a(value) {
+    ///         this.val = value;
+    ///     }
+    /// };
+    /// ```
+    ///
+    /// Examples of correct code for this rule with the "setBeforeGet" option:
+    /// ```js
+    /// const foo = {
+    ///     set a(value) {
+    ///         this.val = value;
+    ///     },
+    ///     get a() {
+    ///         return this.val;
+    ///     }
+    /// };
     /// ```
     GroupedAccessorPairs,
     eslint,
@@ -78,7 +159,7 @@ impl Rule for GroupedAccessorPairs {
         match node.kind() {
             AstKind::ObjectExpression(obj_expr) => {
                 let mut prop_map =
-                    FxHashMap::<String, Vec<(isize, &Box<ObjectProperty>)>>::default();
+                    FxHashMap::<(String, bool), Vec<(usize, &Box<ObjectProperty>)>>::default();
                 let properties = &obj_expr.properties;
 
                 for (idx, v) in properties.iter().enumerate() {
@@ -88,43 +169,172 @@ impl Rule for GroupedAccessorPairs {
                     if obj_prop.kind == PropertyKind::Init {
                         continue;
                     }
-                    let temp_key_name = obj_prop.key.name();
-                    let key_name = if temp_key_name.is_none() {
-                        obj_prop
-                            .key
-                            .as_expression()
-                            .unwrap()
-                            .span()
-                            .source_text(ctx.source_text())
-                            .to_string()
+
+                    let key_name = obj_prop
+                        .key
+                        .name()
+                        .unwrap_or_else(|| {
+                            Cow::Borrowed(
+                                obj_prop
+                                    .key
+                                    .as_expression()
+                                    .unwrap()
+                                    .span()
+                                    .source_text(ctx.source_text()),
+                            )
+                        })
+                        .to_string();
+
+                    let is_literal = if matches!(
+                        obj_prop.key,
+                        PropertyKey::StaticIdentifier(_) | PropertyKey::PrivateIdentifier(_)
+                    ) {
+                        false
                     } else {
-                        temp_key_name.unwrap().to_string()
+                        matches!(
+                            obj_prop.key.as_expression().unwrap(),
+                            Expression::BooleanLiteral(_)
+                                | Expression::NullLiteral(_)
+                                | Expression::StringLiteral(_)
+                                | Expression::RegExpLiteral(_)
+                                | Expression::BigIntLiteral(_)
+                                | Expression::NumericLiteral(_)
+                                | Expression::TemplateLiteral(_)
+                        )
                     };
 
-                    prop_map.entry(key_name).or_default().push((idx as isize, obj_prop));
+                    let should_pre = if is_literal { false } else { obj_prop.computed };
+
+                    prop_map.entry((key_name, should_pre)).or_default().push((idx, obj_prop));
                 }
 
-                for (key, val) in prop_map {
+                for ((key, _), val) in prop_map {
                     if val.len() == 2 {
                         let (first, first_node) = val[0];
                         let (second, second_node) = val[1];
-                        let ((getter_prop, getter_idx), (setter_prop, setter_idx)) =
-                            if first_node.kind == PropertyKind::Get {
-                                ((first_node, first), (second_node, second))
-                            } else {
-                                ((second_node, second), (first_node, first))
-                            };
-                        let (former, latter) = if first < second {
-                            (first_node, second_node)
+                        if first_node.kind == second_node.kind {
+                            continue;
+                        }
+                        let (getter_idx, setter_idx) = if first_node.kind == PropertyKind::Get {
+                            (first, second)
                         } else {
-                            (second_node, first_node)
+                            (second, first)
                         };
+                        let latter = if first < second { second_node } else { first_node };
 
                         match self.pair_order {
-                            PairOrder::GetBeforeSet if getter_idx > setter_idx => {}
-                            PairOrder::SetBeforeGet if setter_idx > getter_idx => {}
+                            PairOrder::GetBeforeSet if getter_idx > setter_idx => {
+                                ctx.diagnostic(grouped_accessor_pairs_diagnostic(
+                                    Span::new(latter.span.start, latter.key.span().end),
+                                    format!("Expected {key} to be before {key}."),
+                                ));
+                            }
+                            PairOrder::SetBeforeGet if setter_idx > getter_idx => {
+                                ctx.diagnostic(grouped_accessor_pairs_diagnostic(
+                                    Span::new(latter.span.start, latter.key.span().end),
+                                    format!("Expected {key} to be before {key}."),
+                                ));
+                            }
                             _ => {
-                                if (getter_idx - setter_idx).abs() > 1 {
+                                if getter_idx.abs_diff(setter_idx) > 1 {
+                                    ctx.diagnostic(grouped_accessor_pairs_diagnostic(
+                                        Span::new(latter.span.start, latter.key.span().end),
+                                        format!("Accessor pair {key} and {key} should be grouped."),
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            AstKind::ClassBody(class_body) => {
+                let method_defines = &class_body.body;
+                let mut prop_map = FxHashMap::<
+                    (String, bool, bool),
+                    Vec<(usize, &Box<MethodDefinition>)>,
+                >::default();
+
+                for (idx, v) in method_defines.iter().enumerate() {
+                    let ClassElement::MethodDefinition(method_define) = v else {
+                        continue;
+                    };
+                    if !matches!(
+                        method_define.kind,
+                        MethodDefinitionKind::Get | MethodDefinitionKind::Set
+                    ) {
+                        continue;
+                    }
+
+                    let key_name = method_define
+                        .key
+                        .name()
+                        .unwrap_or_else(|| {
+                            Cow::Borrowed(
+                                method_define
+                                    .key
+                                    .as_expression()
+                                    .unwrap()
+                                    .span()
+                                    .source_text(ctx.source_text()),
+                            )
+                        })
+                        .to_string();
+                    let is_literal = if matches!(
+                        method_define.key,
+                        PropertyKey::StaticIdentifier(_) | PropertyKey::PrivateIdentifier(_)
+                    ) {
+                        false
+                    } else {
+                        matches!(
+                            method_define.key.as_expression().unwrap(),
+                            Expression::BooleanLiteral(_)
+                                | Expression::NullLiteral(_)
+                                | Expression::StringLiteral(_)
+                                | Expression::RegExpLiteral(_)
+                                | Expression::BigIntLiteral(_)
+                                | Expression::NumericLiteral(_)
+                                | Expression::TemplateLiteral(_)
+                        )
+                    };
+
+                    let should_pre = if is_literal { false } else { method_define.computed };
+
+                    prop_map
+                        .entry((key_name, should_pre, method_define.r#static))
+                        .or_default()
+                        .push((idx, method_define));
+                }
+
+                for ((key, ..), val) in prop_map {
+                    if val.len() == 2 {
+                        let (first, first_node) = val[0];
+                        let (second, second_node) = val[1];
+                        if first_node.kind == second_node.kind {
+                            continue;
+                        }
+                        let (getter_idx, setter_idx) =
+                            if first_node.kind == MethodDefinitionKind::Get {
+                                (first, second)
+                            } else {
+                                (second, first)
+                            };
+                        let latter = if first < second { second_node } else { first_node };
+
+                        match self.pair_order {
+                            PairOrder::GetBeforeSet if getter_idx > setter_idx => {
+                                ctx.diagnostic(grouped_accessor_pairs_diagnostic(
+                                    Span::new(latter.span.start, latter.key.span().end),
+                                    format!("Expected {key} to be before {key}."),
+                                ));
+                            }
+                            PairOrder::SetBeforeGet if setter_idx > getter_idx => {
+                                ctx.diagnostic(grouped_accessor_pairs_diagnostic(
+                                    Span::new(latter.span.start, latter.key.span().end),
+                                    format!("Expected {key} to be before {key}."),
+                                ));
+                            }
+                            _ => {
+                                if getter_idx.abs_diff(setter_idx) > 1 {
                                     ctx.diagnostic(grouped_accessor_pairs_diagnostic(
                                         Span::new(latter.span.start, latter.key.span().end),
                                         format!("Accessor pair {key} and {key} should be grouped."),
@@ -143,175 +353,152 @@ impl Rule for GroupedAccessorPairs {
 #[test]
 fn test() {
     use crate::tester::Tester;
+    let pass = vec![
+            ("({})", None),
+    ("({ a })", None),
+    ("({ a(){}, b(){}, a(){} })", None),
+    ("({ a: 1, b: 2 })", None),
+    ("({ a, ...b, c: 1 })", None),
+    ("({ a, b, ...a })", None),
+    ("({ a: 1, [b]: 2, a: 3, [b]: 4 })", None),
+    ("({ a: function get(){}, b, a: function set(foo){} })", None),
+    ("({ get(){}, a, set(){} })", None),
+    ("class A {}", None),
+    ("(class { a(){} })", None),
+    ("class A { a(){} [b](){} a(){} [b](){} }", None),
+    ("(class { a(){} b(){} static a(){} static b(){} })", None),
+    ("class A { get(){} a(){} set(){} }", None),
+    ("({ get a(){} })", None),
+    ("({ set a(foo){} })", None),
+    ("({ a: 1, get b(){}, c, ...d })", None),
+    ("({ get a(){}, get b(){}, set c(foo){}, set d(foo){} })", None),
+    ("({ get a(){}, b: 1, set c(foo){} })", None),
+    ("({ set a(foo){}, b: 1, a: 2 })", None),
+    ("({ get a(){}, b: 1, a })", None),
+    ("({ set a(foo){}, b: 1, a(){} })", None),
+    ("({ get a(){}, b: 1, set [a](foo){} })", None),
+    ("({ set a(foo){}, b: 1, get 'a '(){} })", None),
+    ("({ get a(){}, b: 1, ...a })", None),
+    ("({ set a(foo){}, b: 1 }, { get a(){} })", None),
+    ("({ get a(){}, b: 1, ...{ set a(foo){} } })", None),
+    ("({ set a(foo){}, get b(){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    ("({ get a(){}, set b(foo){} })", Some(serde_json::json!(["setBeforeGet"]))),
+    ("class A { get a(){} }", None),
+    ("(class { set a(foo){} })", None),
+    ("class A { static set a(foo){} }", None),
+    ("(class { static get a(){} })", None),
+    ("class A { a(){} set b(foo){} c(){} }", None),
+    ("(class { a(){} get b(){} c(){} })", None),
+    ("class A { get a(){} static get b(){} set c(foo){} static set d(bar){} }", None),
+    ("(class { get a(){} b(){} a(foo){} })", None),
+    ("class A { static set a(foo){} b(){} static a(){} }", None),
+    ("(class { get a(){} static b(){} set [a](foo){} })", None),
+    ("class A { static set a(foo){} b(){} static get ' a'(){} }", None),
+    ("(class { set a(foo){} b(){} static get a(){} })", None),
+    ("class A { static set a(foo){} b(){} get a(){} }", None),
+    ("(class { get a(){} }, class { b(){} set a(foo){} })", None),
+    ("({ get a(){}, set a(foo){} })", None),
+    ("({ a: 1, set b(foo){}, get b(){}, c: 2 })", None),
+    ("({ get a(){}, set a(foo){}, set b(bar){}, get b(){} })", None),
+    ("({ get [a](){}, set [a](foo){} })", None),
+    ("({ set a(foo){}, get 'a'(){} })", None),
+    ("({ a: 1, b: 2, get a(){}, set a(foo){}, c: 3, a: 4 })", None),
+    ("({ get a(){}, set a(foo){}, set b(bar){} })", None),
+    ("({ get a(){}, get b(){}, set b(bar){} })", None),
+    ("class A { get a(){} set a(foo){} }", None),
+    ("(class { set a(foo){} get a(){} })", None),
+    ("class A { static set a(foo){} static get a(){} }", None),
+    ("(class { static get a(){} static set a(foo){} })", None),
+    ("class A { a(){} set b(foo){} get b(){} c(){} get d(){} set d(bar){} }", None),
+    ("(class { set a(foo){} get a(){} get b(){} set b(bar){} })", None),
+    ("class A { static set [a](foo){} static get [a](){} }", None),
+    ("(class { get a(){} set [`a`](foo){} })", None),
+    ("class A { static get a(){} static set a(foo){} set a(bar){} static get a(){} }", None),
+    ("(class { static get a(){} get a(){} set a(foo){} })", None),
+    ("({ get a(){}, set a(foo){} })", Some(serde_json::json!(["anyOrder"]))),
+    ("({ set a(foo){}, get a(){} })", Some(serde_json::json!(["anyOrder"]))),
+    ("({ get a(){}, set a(foo){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    ("({ set a(foo){}, get a(){} })", Some(serde_json::json!(["setBeforeGet"]))),
+    ("class A { get a(){} set a(foo){} }", Some(serde_json::json!(["anyOrder"]))),
+    ("(class { set a(foo){} get a(){} })", Some(serde_json::json!(["anyOrder"]))),
+    ("class A { get a(){} set a(foo){} }", Some(serde_json::json!(["getBeforeSet"]))),
+    ("(class { static set a(foo){} static get a(){} })", Some(serde_json::json!(["setBeforeGet"]))),
+    ("({ get a(){}, b: 1, get a(){} })", None),
+    ("({ set a(foo){}, b: 1, set a(foo){} })", None),
+    ("({ get a(){}, b: 1, set a(foo){}, c: 2, get a(){} })", None),
+    ("({ set a(foo){}, b: 1, set 'a'(bar){}, c: 2, get a(){} })", None),
+    ("class A { get [a](){} b(){} get [a](){} c(){} set [a](foo){} }", None),
+    ("(class { static set a(foo){} b(){} static get a(){} static c(){} static set a(bar){} })", None),
+    ("class A { get '#abc'(){} b(){} set #abc(foo){} }", None),
+    ("class A { get #abc(){} b(){} set '#abc'(foo){} }", None),
+    ("class A { set '#abc'(foo){} get #abc(){} }", Some(serde_json::json!(["getBeforeSet"]))),
+    ("class A { set #abc(foo){} get '#abc'(){} }", Some(serde_json::json!(["getBeforeSet"])))
+        ];
 
-    let pass = vec![(
-        "const boo = {
-                set [v](value) {
-                    
-                }
-            }",
-        None,
-    )];
-    let fail = vec![(
-        "const o = {
-                set [a+b](value) {
-                    this.val = value;
-                },
-                get [a+b]() {
-                    return this.val;
-                },
-                set a(value) {
-                }
-            };",
-        None,
-    )];
-
-    //     let pass = vec![
-    //         ("({})", None),
-    // ("({ a })", None),
-    // ("({ a(){}, b(){}, a(){} })", None),
-    // ("({ a: 1, b: 2 })", None),
-    // ("({ a, ...b, c: 1 })", None),
-    // ("({ a, b, ...a })", None),
-    // ("({ a: 1, [b]: 2, a: 3, [b]: 4 })", None),
-    // ("({ a: function get(){}, b, a: function set(foo){} })", None),
-    // ("({ get(){}, a, set(){} })", None),
-    // ("class A {}", None),
-    // ("(class { a(){} })", None),
-    // ("class A { a(){} [b](){} a(){} [b](){} }", None),
-    // ("(class { a(){} b(){} static a(){} static b(){} })", None),
-    // ("class A { get(){} a(){} set(){} }", None),
-    // ("({ get a(){} })", None),
-    // ("({ set a(foo){} })", None),
-    // ("({ a: 1, get b(){}, c, ...d })", None),
-    // ("({ get a(){}, get b(){}, set c(foo){}, set d(foo){} })", None),
-    // ("({ get a(){}, b: 1, set c(foo){} })", None),
-    // ("({ set a(foo){}, b: 1, a: 2 })", None),
-    // ("({ get a(){}, b: 1, a })", None),
-    // ("({ set a(foo){}, b: 1, a(){} })", None),
-    // ("({ get a(){}, b: 1, set [a](foo){} })", None),
-    // ("({ set a(foo){}, b: 1, get 'a '(){} })", None),
-    // ("({ get a(){}, b: 1, ...a })", None),
-    // ("({ set a(foo){}, b: 1 }, { get a(){} })", None),
-    // ("({ get a(){}, b: 1, ...{ set a(foo){} } })", None),
-    // ("({ set a(foo){}, get b(){} })", Some(serde_json::json!(["getBeforeSet"]))),
-    // ("({ get a(){}, set b(foo){} })", Some(serde_json::json!(["setBeforeGet"]))),
-    // ("class A { get a(){} }", None),
-    // ("(class { set a(foo){} })", None),
-    // ("class A { static set a(foo){} }", None),
-    // ("(class { static get a(){} })", None),
-    // ("class A { a(){} set b(foo){} c(){} }", None),
-    // ("(class { a(){} get b(){} c(){} })", None),
-    // ("class A { get a(){} static get b(){} set c(foo){} static set d(bar){} }", None),
-    // ("(class { get a(){} b(){} a(foo){} })", None),
-    // ("class A { static set a(foo){} b(){} static a(){} }", None),
-    // ("(class { get a(){} static b(){} set [a](foo){} })", None),
-    // ("class A { static set a(foo){} b(){} static get ' a'(){} }", None),
-    // ("(class { set a(foo){} b(){} static get a(){} })", None),
-    // ("class A { static set a(foo){} b(){} get a(){} }", None),
-    // ("(class { get a(){} }, class { b(){} set a(foo){} })", None),
-    // ("({ get a(){}, set a(foo){} })", None),
-    // ("({ a: 1, set b(foo){}, get b(){}, c: 2 })", None),
-    // ("({ get a(){}, set a(foo){}, set b(bar){}, get b(){} })", None),
-    // ("({ get [a](){}, set [a](foo){} })", None),
-    // ("({ set a(foo){}, get 'a'(){} })", None),
-    // ("({ a: 1, b: 2, get a(){}, set a(foo){}, c: 3, a: 4 })", None),
-    // ("({ get a(){}, set a(foo){}, set b(bar){} })", None),
-    // ("({ get a(){}, get b(){}, set b(bar){} })", None),
-    // ("class A { get a(){} set a(foo){} }", None),
-    // ("(class { set a(foo){} get a(){} })", None),
-    // ("class A { static set a(foo){} static get a(){} }", None),
-    // ("(class { static get a(){} static set a(foo){} })", None),
-    // ("class A { a(){} set b(foo){} get b(){} c(){} get d(){} set d(bar){} }", None),
-    // ("(class { set a(foo){} get a(){} get b(){} set b(bar){} })", None),
-    // ("class A { static set [a](foo){} static get [a](){} }", None),
-    // ("(class { get a(){} set [`a`](foo){} })", None),
-    // ("class A { static get a(){} static set a(foo){} set a(bar){} static get a(){} }", None),
-    // ("(class { static get a(){} get a(){} set a(foo){} })", None),
-    // ("({ get a(){}, set a(foo){} })", Some(serde_json::json!(["anyOrder"]))),
-    // ("({ set a(foo){}, get a(){} })", Some(serde_json::json!(["anyOrder"]))),
-    // ("({ get a(){}, set a(foo){} })", Some(serde_json::json!(["getBeforeSet"]))),
-    // ("({ set a(foo){}, get a(){} })", Some(serde_json::json!(["setBeforeGet"]))),
-    // ("class A { get a(){} set a(foo){} }", Some(serde_json::json!(["anyOrder"]))),
-    // ("(class { set a(foo){} get a(){} })", Some(serde_json::json!(["anyOrder"]))),
-    // ("class A { get a(){} set a(foo){} }", Some(serde_json::json!(["getBeforeSet"]))),
-    // ("(class { static set a(foo){} static get a(){} })", Some(serde_json::json!(["setBeforeGet"]))),
-    // ("({ get a(){}, b: 1, get a(){} })", None),
-    // ("({ set a(foo){}, b: 1, set a(foo){} })", None),
-    // ("({ get a(){}, b: 1, set a(foo){}, c: 2, get a(){} })", None),
-    // ("({ set a(foo){}, b: 1, set 'a'(bar){}, c: 2, get a(){} })", None),
-    // ("class A { get [a](){} b(){} get [a](){} c(){} set [a](foo){} }", None),
-    // ("(class { static set a(foo){} b(){} static get a(){} static c(){} static set a(bar){} })", None),
-    // ("class A { get '#abc'(){} b(){} set #abc(foo){} }", None),
-    // ("class A { get #abc(){} b(){} set '#abc'(foo){} }", None),
-    // ("class A { set '#abc'(foo){} get #abc(){} }", Some(serde_json::json!(["getBeforeSet"]))),
-    // ("class A { set #abc(foo){} get '#abc'(){} }", Some(serde_json::json!(["getBeforeSet"])))
-    //     ];
-
-    //     let fail = vec![
-    //         ("({ get a(){}, b:1, set a(foo){} })", None),
-    // ("({ set 'abc'(foo){}, b:1, get 'abc'(){} })", None),
-    // ("({ get [a](){}, b:1, set [a](foo){} })", None),
-    // ("class A { get abc(){} b(){} set abc(foo){} }", None),
-    // ("(class { set abc(foo){} b(){} get abc(){} })", None),
-    // ("class A { static set a(foo){} b(){} static get a(){} }", None),
-    // ("(class { static get 123(){} b(){} static set 123(foo){} })", None),
-    // ("class A { static get [a](){} b(){} static set [a](foo){} }", None),
-    // ("class A { get '#abc'(){} b(){} set '#abc'(foo){} }", None),
-    // ("class A { get #abc(){} b(){} set #abc(foo){} }", None),
-    // ("({ set a(foo){}, get a(){} })", Some(serde_json::json!(["getBeforeSet"]))),
-    // ("({ get 123(){}, set 123(foo){} })", Some(serde_json::json!(["setBeforeGet"]))),
-    // ("({ get [a](){}, set [a](foo){} })", Some(serde_json::json!(["setBeforeGet"]))),
-    // ("class A { set abc(foo){} get abc(){} }", Some(serde_json::json!(["getBeforeSet"]))),
-    // ("(class { get [`abc`](){} set [`abc`](foo){} })", Some(serde_json::json!(["setBeforeGet"]))),
-    // ("class A { static get a(){} static set a(foo){} }", Some(serde_json::json!(["setBeforeGet"]))),
-    // ("(class { static set 'abc'(foo){} static get 'abc'(){} })", Some(serde_json::json!(["getBeforeSet"]))),
-    // ("class A { static set [abc](foo){} static get [abc](){} }", Some(serde_json::json!(["getBeforeSet"]))),
-    // ("class A { set '#abc'(foo){} get '#abc'(){} }", Some(serde_json::json!(["getBeforeSet"]))),
-    // ("class A { set #abc(foo){} get #abc(){} }", Some(serde_json::json!(["getBeforeSet"]))),
-    // ("({ get a(){}, b: 1, set a(foo){} })", Some(serde_json::json!(["anyOrder"]))),
-    // ("({ get a(){}, b: 1, set a(foo){} })", Some(serde_json::json!(["setBeforeGet"]))),
-    // ("({ get a(){}, b: 1, set a(foo){} })", Some(serde_json::json!(["getBeforeSet"]))),
-    // ("class A { set a(foo){} b(){} get a(){} }", Some(serde_json::json!(["getBeforeSet"]))),
-    // ("(class { static set a(foo){} b(){} static get a(){} })", Some(serde_json::json!(["setBeforeGet"]))),
-    // ("({ get 'abc'(){}, d(){}, set 'abc'(foo){} })", None),
-    // ("({ set ''(foo){}, get [''](){} })", Some(serde_json::json!(["getBeforeSet"]))),
-    // ("class A { set abc(foo){} get 'abc'(){} }", Some(serde_json::json!(["getBeforeSet"]))),
-    // ("(class { set [`abc`](foo){} get abc(){} })", Some(serde_json::json!(["getBeforeSet"]))),
-    // ("({ set ['abc'](foo){}, get [`abc`](){} })", Some(serde_json::json!(["getBeforeSet"]))),
-    // ("({ set 123(foo){}, get [123](){} })", Some(serde_json::json!(["getBeforeSet"]))),
-    // ("class A { static set '123'(foo){} static get 123(){} }", Some(serde_json::json!(["getBeforeSet"]))),
-    // ("(class { set [a+b](foo){} get [a+b](){} })", Some(serde_json::json!(["getBeforeSet"]))),
-    // ("({ set [f(a)](foo){}, get [f(a)](){} })", Some(serde_json::json!(["getBeforeSet"]))),
-    // ("({ get a(){}, b: 1, set a(foo){}, set c(foo){}, d(){}, get c(){} })", None),
-    // ("({ get a(){}, set b(foo){}, set a(bar){}, get b(){} })", None),
-    // ("({ get a(){}, set [a](foo){}, set a(bar){}, get [a](){} })", None),
-    // ("({ a(){}, set b(foo){}, ...c, get b(){}, set c(bar){}, get c(){} })", Some(serde_json::json!(["getBeforeSet"]))),
-    // ("({ set [a](foo){}, get [a](){}, set [-a](bar){}, get [-a](){} })", Some(serde_json::json!(["getBeforeSet"]))),
-    // ("class A { get a(){} constructor (){} set a(foo){} get b(){} static c(){} set b(bar){} }", None),
-    // ("(class { set a(foo){} static get a(){} get a(){} static set a(bar){} })", None),
-    // ("class A { get a(){} set a(foo){} static get b(){} static set b(bar){} }", Some(serde_json::json!(["setBeforeGet"]))),
-    // ("(class { set [a+b](foo){} get [a-b](){} get [a+b](){} set [a-b](bar){} })", None),
-    // ("({ get a(){}, set a(foo){}, get b(){}, c: function(){}, set b(bar){} })", None),
-    // ("({ get a(){}, get b(){}, set a(foo){} })", None),
-    // ("({ set a(foo){}, get [a](){}, get a(){} })", None),
-    // ("({ set [a](foo){}, set a(bar){}, get [a](){} })", None),
-    // ("({ get a(){}, set a(foo){}, set b(bar){}, get b(){} })", Some(serde_json::json!(["getBeforeSet"]))),
-    // ("class A { get a(){} static set b(foo){} static get b(){} set a(foo){} }", None),
-    // ("(class { static get a(){} set a(foo){} static set a(bar){} })", None),
-    // ("class A { set a(foo){} get a(){} static get a(){} static set a(bar){} }", Some(serde_json::json!(["setBeforeGet"]))),
-    // ("({ get a(){}, a: 1, set a(foo){} })", None),
-    // ("({ a(){}, set a(foo){}, get a(){} })", Some(serde_json::json!(["getBeforeSet"]))),
-    // ("class A { get a(){} a(){} set a(foo){} }", None),
-    // ("class A { get a(){} a; set a(foo){} }", None), // { "ecmaVersion": 2022 },
-    // ("({ get a(){},
-    // 			    b: 1,
-    // 			    set a(foo){}
-    // 			})", None),
-    // ("class A { static set a(foo){} b(){} static get
-    // 			 a(){}
-    // 			}", None)
-    //     ];
+    let fail = vec![
+            ("({ get a(){}, b:1, set a(foo){} })", None),
+    ("({ set 'abc'(foo){}, b:1, get 'abc'(){} })", None),
+    ("({ get [a](){}, b:1, set [a](foo){} })", None),
+    ("class A { get abc(){} b(){} set abc(foo){} }", None),
+    ("(class { set abc(foo){} b(){} get abc(){} })", None),
+    ("class A { static set a(foo){} b(){} static get a(){} }", None),
+    ("(class { static get 123(){} b(){} static set 123(foo){} })", None),
+    ("class A { static get [a](){} b(){} static set [a](foo){} }", None),
+    ("class A { get '#abc'(){} b(){} set '#abc'(foo){} }", None),
+    ("class A { get #abc(){} b(){} set #abc(foo){} }", None),
+    ("({ set a(foo){}, get a(){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    ("({ get 123(){}, set 123(foo){} })", Some(serde_json::json!(["setBeforeGet"]))),
+    ("({ get [a](){}, set [a](foo){} })", Some(serde_json::json!(["setBeforeGet"]))),
+    ("class A { set abc(foo){} get abc(){} }", Some(serde_json::json!(["getBeforeSet"]))),
+    ("(class { get [`abc`](){} set [`abc`](foo){} })", Some(serde_json::json!(["setBeforeGet"]))),
+    ("class A { static get a(){} static set a(foo){} }", Some(serde_json::json!(["setBeforeGet"]))),
+    ("(class { static set 'abc'(foo){} static get 'abc'(){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    ("class A { static set [abc](foo){} static get [abc](){} }", Some(serde_json::json!(["getBeforeSet"]))),
+    ("class A { set '#abc'(foo){} get '#abc'(){} }", Some(serde_json::json!(["getBeforeSet"]))),
+    ("class A { set #abc(foo){} get #abc(){} }", Some(serde_json::json!(["getBeforeSet"]))),
+    ("({ get a(){}, b: 1, set a(foo){} })", Some(serde_json::json!(["anyOrder"]))),
+    ("({ get a(){}, b: 1, set a(foo){} })", Some(serde_json::json!(["setBeforeGet"]))),
+    ("({ get a(){}, b: 1, set a(foo){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    ("class A { set a(foo){} b(){} get a(){} }", Some(serde_json::json!(["getBeforeSet"]))),
+    ("(class { static set a(foo){} b(){} static get a(){} })", Some(serde_json::json!(["setBeforeGet"]))),
+    ("({ get 'abc'(){}, d(){}, set 'abc'(foo){} })", None),
+    ("({ set ''(foo){}, get [''](){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    ("class A { set abc(foo){} get 'abc'(){} }", Some(serde_json::json!(["getBeforeSet"]))),
+    ("(class { set [`abc`](foo){} get abc(){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    ("({ set ['abc'](foo){}, get [`abc`](){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    ("({ set 123(foo){}, get [123](){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    ("class A { static set '123'(foo){} static get 123(){} }", Some(serde_json::json!(["getBeforeSet"]))),
+    ("(class { set [a+b](foo){} get [a+b](){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    ("({ set [f(a)](foo){}, get [f(a)](){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    ("({ get a(){}, b: 1, set a(foo){}, set c(foo){}, d(){}, get c(){} })", None),
+    ("({ get a(){}, set b(foo){}, set a(bar){}, get b(){} })", None),
+    ("({ get a(){}, set [a](foo){}, set a(bar){}, get [a](){} })", None),
+    ("({ a(){}, set b(foo){}, ...c, get b(){}, set c(bar){}, get c(){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    ("({ set [a](foo){}, get [a](){}, set [-a](bar){}, get [-a](){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    ("class A { get a(){} constructor (){} set a(foo){} get b(){} static c(){} set b(bar){} }", None),
+    ("(class { set a(foo){} static get a(){} get a(){} static set a(bar){} })", None),
+    ("class A { get a(){} set a(foo){} static get b(){} static set b(bar){} }", Some(serde_json::json!(["setBeforeGet"]))),
+    ("(class { set [a+b](foo){} get [a-b](){} get [a+b](){} set [a-b](bar){} })", None),
+    ("({ get a(){}, set a(foo){}, get b(){}, c: function(){}, set b(bar){} })", None),
+    ("({ get a(){}, get b(){}, set a(foo){} })", None),
+    ("({ set a(foo){}, get [a](){}, get a(){} })", None),
+    ("({ set [a](foo){}, set a(bar){}, get [a](){} })", None),
+    ("({ get a(){}, set a(foo){}, set b(bar){}, get b(){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    ("class A { get a(){} static set b(foo){} static get b(){} set a(foo){} }", None),
+    ("(class { static get a(){} set a(foo){} static set a(bar){} })", None),
+    ("class A { set a(foo){} get a(){} static get a(){} static set a(bar){} }", Some(serde_json::json!(["setBeforeGet"]))),
+    ("({ get a(){}, a: 1, set a(foo){} })", None),
+    ("({ a(){}, set a(foo){}, get a(){} })", Some(serde_json::json!(["getBeforeSet"]))),
+    ("class A { get a(){} a(){} set a(foo){} }", None),
+    ("class A { get a(){} a; set a(foo){} }", None), // { "ecmaVersion": 2022 },
+    ("({ get a(){},
+    			    b: 1,
+    			    set a(foo){}
+    			})", None),
+    ("class A { static set a(foo){} b(){} static get
+    			 a(){}
+    			}", None)
+        ];
 
     Tester::new(GroupedAccessorPairs::NAME, GroupedAccessorPairs::PLUGIN, pass, fail)
         .test_and_snapshot();

--- a/crates/oxc_linter/src/rules/eslint/grouped_accessor_pairs.rs
+++ b/crates/oxc_linter/src/rules/eslint/grouped_accessor_pairs.rs
@@ -483,6 +483,18 @@ fn test() {
             }
         }",
         Some(serde_json::json!(["getBeforeSet"])),
+    ),
+    (
+        "class foo {
+            get aa() {
+
+            }
+            get aa() {}
+            set aa(val) {
+
+            }
+        }",
+        Some(serde_json::json!(["setBeforeGet"])),
     )
         ];
 

--- a/crates/oxc_linter/src/snapshots/eslint_grouped_accessor_pairs.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_grouped_accessor_pairs.snap
@@ -1,14 +1,14 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:20]
  1 │ ({ get a(){}, b:1, set a(foo){} })
    ·                    ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair abc and abc should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'abc' and setter 'abc' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:27]
  1 │ ({ set 'abc'(foo){}, b:1, get 'abc'(){} })
    ·                           ─────────
@@ -22,63 +22,63 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair abc and abc should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'abc' and getter 'abc' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:29]
  1 │ class A { get abc(){} b(){} set abc(foo){} }
    ·                             ───────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair abc and abc should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'abc' and setter 'abc' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:31]
  1 │ (class { set abc(foo){} b(){} get abc(){} })
    ·                               ───────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair static getter 'a' and static setter 'a' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:37]
  1 │ class A { static set a(foo){} b(){} static get a(){} }
    ·                                     ────────────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair 123 and 123 should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair static setter '123' and static getter '123' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:35]
  1 │ (class { static get 123(){} b(){} static set 123(foo){} })
    ·                                   ──────────────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter and getter should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair static setter and static getter should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:36]
  1 │ class A { static get [a](){} b(){} static set [a](foo){} }
    ·                                    ─────────────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair #abc and #abc should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter '#abc' and getter '#abc' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:32]
  1 │ class A { get '#abc'(){} b(){} set '#abc'(foo){} }
    ·                                ──────────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair abc and abc should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair private setter #abc and private getter #abc should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:30]
  1 │ class A { get #abc(){} b(){} set #abc(foo){} }
    ·                              ────────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected a to be before a.
+  ⚠ eslint(grouped-accessor-pairs): Expected getter 'a' to be before setter 'a'.
    ╭─[grouped_accessor_pairs.tsx:1:18]
  1 │ ({ set a(foo){}, get a(){} })
    ·                  ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected 123 to be before 123.
+  ⚠ eslint(grouped-accessor-pairs): Expected setter '123' to be before getter '123'.
    ╭─[grouped_accessor_pairs.tsx:1:17]
  1 │ ({ get 123(){}, set 123(foo){} })
    ·                 ───────
@@ -92,147 +92,147 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected abc to be before abc.
+  ⚠ eslint(grouped-accessor-pairs): Expected getter 'abc' to be before setter 'abc'.
    ╭─[grouped_accessor_pairs.tsx:1:26]
  1 │ class A { set abc(foo){} get abc(){} }
    ·                          ───────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected abc to be before abc.
+  ⚠ eslint(grouped-accessor-pairs): Expected setter 'abc' to be before getter 'abc'.
    ╭─[grouped_accessor_pairs.tsx:1:26]
  1 │ (class { get [`abc`](){} set [`abc`](foo){} })
    ·                          ──────────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected a to be before a.
+  ⚠ eslint(grouped-accessor-pairs): Expected static setter 'a' to be before static getter 'a'.
    ╭─[grouped_accessor_pairs.tsx:1:28]
  1 │ class A { static get a(){} static set a(foo){} }
    ·                            ────────────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected abc to be before abc.
+  ⚠ eslint(grouped-accessor-pairs): Expected static getter 'abc' to be before static setter 'abc'.
    ╭─[grouped_accessor_pairs.tsx:1:34]
  1 │ (class { static set 'abc'(foo){} static get 'abc'(){} })
    ·                                  ────────────────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected getter to be before setter.
+  ⚠ eslint(grouped-accessor-pairs): Expected static getter to be before static setter.
    ╭─[grouped_accessor_pairs.tsx:1:35]
  1 │ class A { static set [abc](foo){} static get [abc](){} }
    ·                                   ───────────────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected #abc to be before #abc.
+  ⚠ eslint(grouped-accessor-pairs): Expected getter '#abc' to be before setter '#abc'.
    ╭─[grouped_accessor_pairs.tsx:1:29]
  1 │ class A { set '#abc'(foo){} get '#abc'(){} }
    ·                             ──────────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected abc to be before abc.
+  ⚠ eslint(grouped-accessor-pairs): Expected private getter #abc to be before private setter #abc.
    ╭─[grouped_accessor_pairs.tsx:1:27]
  1 │ class A { set #abc(foo){} get #abc(){} }
    ·                           ────────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:21]
  1 │ ({ get a(){}, b: 1, set a(foo){} })
    ·                     ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:21]
  1 │ ({ get a(){}, b: 1, set a(foo){} })
    ·                     ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected a to be before a.
+  ⚠ eslint(grouped-accessor-pairs): Expected setter 'a' to be before getter 'a'.
    ╭─[grouped_accessor_pairs.tsx:1:21]
  1 │ ({ get a(){}, b: 1, set a(foo){} })
    ·                     ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:21]
  1 │ ({ get a(){}, b: 1, set a(foo){} })
    ·                     ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'a' and setter 'a' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:30]
  1 │ class A { set a(foo){} b(){} get a(){} }
    ·                              ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected a to be before a.
+  ⚠ eslint(grouped-accessor-pairs): Expected getter 'a' to be before setter 'a'.
    ╭─[grouped_accessor_pairs.tsx:1:30]
  1 │ class A { set a(foo){} b(){} get a(){} }
    ·                              ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair static getter 'a' and static setter 'a' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:36]
  1 │ (class { static set a(foo){} b(){} static get a(){} })
    ·                                    ────────────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair abc and abc should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'abc' and getter 'abc' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:26]
  1 │ ({ get 'abc'(){}, d(){}, set 'abc'(foo){} })
    ·                          ─────────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected  to be before .
+  ⚠ eslint(grouped-accessor-pairs): Expected getter '' to be before setter ''.
    ╭─[grouped_accessor_pairs.tsx:1:19]
  1 │ ({ set ''(foo){}, get [''](){} })
    ·                   ───────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected abc to be before abc.
+  ⚠ eslint(grouped-accessor-pairs): Expected getter 'abc' to be before setter 'abc'.
    ╭─[grouped_accessor_pairs.tsx:1:26]
  1 │ class A { set abc(foo){} get 'abc'(){} }
    ·                          ─────────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected abc to be before abc.
+  ⚠ eslint(grouped-accessor-pairs): Expected getter 'abc' to be before setter 'abc'.
    ╭─[grouped_accessor_pairs.tsx:1:29]
  1 │ (class { set [`abc`](foo){} get abc(){} })
    ·                             ───────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected abc to be before abc.
+  ⚠ eslint(grouped-accessor-pairs): Expected getter 'abc' to be before setter 'abc'.
    ╭─[grouped_accessor_pairs.tsx:1:24]
  1 │ ({ set ['abc'](foo){}, get [`abc`](){} })
    ·                        ──────────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected 123 to be before 123.
+  ⚠ eslint(grouped-accessor-pairs): Expected getter '123' to be before setter '123'.
    ╭─[grouped_accessor_pairs.tsx:1:20]
  1 │ ({ set 123(foo){}, get [123](){} })
    ·                    ────────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected 123 to be before 123.
+  ⚠ eslint(grouped-accessor-pairs): Expected static getter '123' to be before static setter '123'.
    ╭─[grouped_accessor_pairs.tsx:1:35]
  1 │ class A { static set '123'(foo){} static get 123(){} }
    ·                                   ──────────────
@@ -253,35 +253,35 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:21]
  1 │ ({ get a(){}, b: 1, set a(foo){}, set c(foo){}, d(){}, get c(){} })
    ·                     ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair c and c should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'c' and setter 'c' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:56]
  1 │ ({ get a(){}, b: 1, set a(foo){}, set c(foo){}, d(){}, get c(){} })
    ·                                                        ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:29]
  1 │ ({ get a(){}, set b(foo){}, set a(bar){}, get b(){} })
    ·                             ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair b and b should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'b' and setter 'b' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:43]
  1 │ ({ get a(){}, set b(foo){}, set a(bar){}, get b(){} })
    ·                                           ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:31]
  1 │ ({ get a(){}, set [a](foo){}, set a(bar){}, get [a](){} })
    ·                               ─────
@@ -295,21 +295,21 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected c to be before c.
+  ⚠ eslint(grouped-accessor-pairs): Expected getter 'c' to be before setter 'c'.
    ╭─[grouped_accessor_pairs.tsx:1:56]
  1 │ ({ a(){}, set b(foo){}, ...c, get b(){}, set c(bar){}, get c(){} })
    ·                                                        ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair b and b should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'b' and setter 'b' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:31]
  1 │ ({ a(){}, set b(foo){}, ...c, get b(){}, set c(bar){}, get c(){} })
    ·                               ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected b to be before b.
+  ⚠ eslint(grouped-accessor-pairs): Expected getter 'b' to be before setter 'b'.
    ╭─[grouped_accessor_pairs.tsx:1:31]
  1 │ ({ a(){}, set b(foo){}, ...c, get b(){}, set c(bar){}, get c(){} })
    ·                               ─────
@@ -330,52 +330,45 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair b and b should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:74]
- 1 │ class A { get a(){} constructor (){} set a(foo){} get b(){} static c(){} set b(bar){} }
-   ·                                                                          ─────
-   ╰────
-  help: Require grouped accessor pairs in object literals and classes
-
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:38]
  1 │ class A { get a(){} constructor (){} set a(foo){} get b(){} static c(){} set b(bar){} }
    ·                                      ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:50]
- 1 │ (class { set a(foo){} static get a(){} get a(){} static set a(bar){} })
-   ·                                                  ────────────
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'b' and getter 'b' should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:74]
+ 1 │ class A { get a(){} constructor (){} set a(foo){} get b(){} static c(){} set b(bar){} }
+   ·                                                                          ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'a' and setter 'a' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:40]
  1 │ (class { set a(foo){} static get a(){} get a(){} static set a(bar){} })
    ·                                        ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected b to be before b.
-   ╭─[grouped_accessor_pairs.tsx:1:51]
- 1 │ class A { get a(){} set a(foo){} static get b(){} static set b(bar){} }
-   ·                                                   ────────────
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair static setter 'a' and static getter 'a' should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:50]
+ 1 │ (class { set a(foo){} static get a(){} get a(){} static set a(bar){} })
+   ·                                                  ────────────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected a to be before a.
+  ⚠ eslint(grouped-accessor-pairs): Expected setter 'a' to be before getter 'a'.
    ╭─[grouped_accessor_pairs.tsx:1:21]
  1 │ class A { get a(){} set a(foo){} static get b(){} static set b(bar){} }
    ·                     ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter and getter should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:55]
- 1 │ (class { set [a+b](foo){} get [a-b](){} get [a+b](){} set [a-b](bar){} })
-   ·                                                       ────────
+  ⚠ eslint(grouped-accessor-pairs): Expected static setter 'b' to be before static getter 'b'.
+   ╭─[grouped_accessor_pairs.tsx:1:51]
+ 1 │ class A { get a(){} set a(foo){} static get b(){} static set b(bar){} }
+   ·                                                   ────────────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
@@ -386,21 +379,28 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair b and b should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter and getter should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:55]
+ 1 │ (class { set [a+b](foo){} get [a-b](){} get [a+b](){} set [a-b](bar){} })
+   ·                                                       ────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'b' and getter 'b' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:57]
  1 │ ({ get a(){}, set a(foo){}, get b(){}, c: function(){}, set b(bar){} })
    ·                                                         ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:26]
  1 │ ({ get a(){}, get b(){}, set a(foo){} })
    ·                          ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'a' and setter 'a' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:31]
  1 │ ({ set a(foo){}, get [a](){}, get a(){} })
    ·                               ─────
@@ -414,63 +414,70 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected b to be before b.
+  ⚠ eslint(grouped-accessor-pairs): Expected getter 'b' to be before setter 'b'.
    ╭─[grouped_accessor_pairs.tsx:1:43]
  1 │ ({ get a(){}, set a(foo){}, set b(bar){}, get b(){} })
    ·                                           ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:58]
  1 │ class A { get a(){} static set b(foo){} static get b(){} set a(foo){} }
    ·                                                          ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair static setter 'a' and static getter 'a' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:40]
  1 │ (class { static get a(){} set a(foo){} static set a(bar){} })
    ·                                        ────────────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected a to be before a.
+  ⚠ eslint(grouped-accessor-pairs): Expected static setter 'a' to be before static getter 'a'.
    ╭─[grouped_accessor_pairs.tsx:1:51]
  1 │ class A { set a(foo){} get a(){} static get a(){} static set a(bar){} }
    ·                                                   ────────────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:21]
  1 │ ({ get a(){}, a: 1, set a(foo){} })
    ·                     ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected a to be before a.
+  ⚠ eslint(grouped-accessor-pairs): Expected getter 'a' to be before setter 'a'.
    ╭─[grouped_accessor_pairs.tsx:1:25]
  1 │ ({ a(){}, set a(foo){}, get a(){} })
    ·                         ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:27]
  1 │ class A { get a(){} a(){} set a(foo){} }
    ·                           ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:24]
  1 │ class A { get a(){} a; set a(foo){} }
    ·                        ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Expected static private getter #abc to be before static private setter #abc.
+   ╭─[grouped_accessor_pairs.tsx:1:37]
+ 1 │ class faoo { static set #abc(foo){} static get #abc(){} }
+   ·                                     ───────────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:3:12]
  2 │                     b: 1,
  3 │                     set a(foo){}
@@ -479,7 +486,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair static getter 'a' and static setter 'a' should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:37]
  1 │ ╭─▶ class A { static set a(foo){} b(){} static get
  2 │ ╰─▶                  a(){}
@@ -487,11 +494,72 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected false to be before false.
+  ⚠ eslint(grouped-accessor-pairs): Expected getter 'false' to be before setter 'false'.
    ╭─[grouped_accessor_pairs.tsx:5:13]
  4 │             },
  5 │             get 'false'() {
    ·             ───────────
  6 │                 return this.val;
    ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected setter '/a/g' to be before getter '/a/g'.
+   ╭─[grouped_accessor_pairs.tsx:5:13]
+ 4 │             },
+ 5 │             set [/a/g](value) {
+   ·             ─────────
+ 6 │                 this.val = value;
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected static private getter #abc to be before static private setter #abc.
+   ╭─[grouped_accessor_pairs.tsx:1:36]
+ 1 │ class foo { static set #abc(foo){} static get #abc(){} }
+   ·                                    ───────────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected static getter '#a+b' to be before static setter '#a+b'.
+   ╭─[grouped_accessor_pairs.tsx:5:13]
+ 4 │             }
+ 5 │             static get ['#a+b']() {
+   ·             ──────────────────
+ 6 │ 
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected getter to be before setter.
+   ╭─[grouped_accessor_pairs.tsx:5:13]
+ 4 │             }
+ 5 │             get [() => {}]() {
+   ·             ─────────────
+ 6 │ 
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected static getter '23' to be before static setter '23'.
+   ╭─[grouped_accessor_pairs.tsx:5:13]
+ 4 │             }
+ 5 │             static get 23() {
+   ·             ─────────────
+ 6 │ 
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected static getter '23' to be before static setter '23'.
+   ╭─[grouped_accessor_pairs.tsx:5:13]
+ 4 │             }
+ 5 │             static get 23() {
+   ·             ─────────────
+ 6 │ 
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected getter '23' to be before setter '23'.
+    ╭─[grouped_accessor_pairs.tsx:11:13]
+ 10 │             }
+ 11 │             get 23() {
+    ·             ──────
+ 12 │ 
+    ╰────
   help: Require grouped accessor pairs in object literals and classes

--- a/crates/oxc_linter/src/snapshots/eslint_grouped_accessor_pairs.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_grouped_accessor_pairs.snap
@@ -15,7 +15,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter and getter should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:22]
  1 │ ({ get [a](){}, b:1, set [a](foo){} })
    ·                      ──────
@@ -50,7 +50,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter and getter should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:36]
  1 │ class A { static get [a](){} b(){} static set [a](foo){} }
    ·                                    ─────────────
@@ -85,7 +85,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected a to be before a.
+  ⚠ eslint(grouped-accessor-pairs): Expected setter to be before getter.
    ╭─[grouped_accessor_pairs.tsx:1:17]
  1 │ ({ get [a](){}, set [a](foo){} })
    ·                 ──────
@@ -120,7 +120,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected abc to be before abc.
+  ⚠ eslint(grouped-accessor-pairs): Expected getter to be before setter.
    ╭─[grouped_accessor_pairs.tsx:1:35]
  1 │ class A { static set [abc](foo){} static get [abc](){} }
    ·                                   ───────────────
@@ -148,6 +148,13 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:21]
+ 1 │ ({ get a(){}, b: 1, set a(foo){} })
+   ·                     ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
   ⚠ eslint(grouped-accessor-pairs): Expected a to be before a.
    ╭─[grouped_accessor_pairs.tsx:1:21]
  1 │ ({ get a(){}, b: 1, set a(foo){} })
@@ -159,6 +166,13 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[grouped_accessor_pairs.tsx:1:21]
  1 │ ({ get a(){}, b: 1, set a(foo){} })
    ·                     ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:30]
+ 1 │ class A { set a(foo){} b(){} get a(){} }
+   ·                              ─────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
@@ -225,14 +239,14 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected a+b to be before a+b.
+  ⚠ eslint(grouped-accessor-pairs): Expected getter to be before setter.
    ╭─[grouped_accessor_pairs.tsx:1:27]
  1 │ (class { set [a+b](foo){} get [a+b](){} })
    ·                           ────────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected f(a) to be before f(a).
+  ⚠ eslint(grouped-accessor-pairs): Expected getter to be before setter.
    ╭─[grouped_accessor_pairs.tsx:1:23]
  1 │ ({ set [f(a)](foo){}, get [f(a)](){} })
    ·                       ─────────
@@ -274,7 +288,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter and setter should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:45]
  1 │ ({ get a(){}, set [a](foo){}, set a(bar){}, get [a](){} })
    ·                                             ──────
@@ -288,6 +302,13 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair b and b should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:31]
+ 1 │ ({ a(){}, set b(foo){}, ...c, get b(){}, set c(bar){}, get c(){} })
+   ·                               ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
   ⚠ eslint(grouped-accessor-pairs): Expected b to be before b.
    ╭─[grouped_accessor_pairs.tsx:1:31]
  1 │ ({ a(){}, set b(foo){}, ...c, get b(){}, set c(bar){}, get c(){} })
@@ -295,14 +316,14 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected a to be before a.
+  ⚠ eslint(grouped-accessor-pairs): Expected getter to be before setter.
    ╭─[grouped_accessor_pairs.tsx:1:20]
  1 │ ({ set [a](foo){}, get [a](){}, set [-a](bar){}, get [-a](){} })
    ·                    ──────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Expected -a to be before -a.
+  ⚠ eslint(grouped-accessor-pairs): Expected getter to be before setter.
    ╭─[grouped_accessor_pairs.tsx:1:50]
  1 │ ({ set [a](foo){}, get [a](){}, set [-a](bar){}, get [-a](){} })
    ·                                                  ───────
@@ -351,14 +372,14 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a-b and a-b should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter and getter should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:55]
  1 │ (class { set [a+b](foo){} get [a-b](){} get [a+b](){} set [a-b](bar){} })
    ·                                                       ────────
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a+b and a+b should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter and setter should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:41]
  1 │ (class { set [a+b](foo){} get [a-b](){} get [a+b](){} set [a-b](bar){} })
    ·                                         ────────
@@ -386,7 +407,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter and setter should be grouped.
    ╭─[grouped_accessor_pairs.tsx:1:34]
  1 │ ({ set [a](foo){}, set a(bar){}, get [a](){} })
    ·                                  ──────

--- a/crates/oxc_linter/src/snapshots/eslint_grouped_accessor_pairs.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_grouped_accessor_pairs.snap
@@ -1,565 +1,752 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:20]
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'a' and setter 'a' should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:4]
  1 │ ({ get a(){}, b:1, set a(foo){} })
-   ·                    ─────
+   ·    ──┬──           ──┬──
+   ·      │               ╰── setter 'a' is here
+   ·      ╰── getter 'a' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'abc' and setter 'abc' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:27]
+   ╭─[grouped_accessor_pairs.tsx:1:4]
  1 │ ({ set 'abc'(foo){}, b:1, get 'abc'(){} })
-   ·                           ─────────
+   ·    ────┬────              ────┬────
+   ·        │                      ╰── getter 'abc' is here
+   ·        ╰── setter 'abc' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter and getter should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:22]
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter and setter should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:4]
  1 │ ({ get [a](){}, b:1, set [a](foo){} })
-   ·                      ──────
-   ╰────
-  help: Require grouped accessor pairs in object literals and classes
-
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'abc' and getter 'abc' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:29]
- 1 │ class A { get abc(){} b(){} set abc(foo){} }
-   ·                             ───────
+   ·    ───┬──            ───┬──
+   ·       │                 ╰── setter is here
+   ·       ╰── getter is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'abc' and setter 'abc' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:31]
+   ╭─[grouped_accessor_pairs.tsx:1:11]
+ 1 │ class A { get abc(){} b(){} set abc(foo){} }
+   ·           ───┬───           ───┬───
+   ·              │                 ╰── setter 'abc' is here
+   ·              ╰── getter 'abc' is here
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'abc' and setter 'abc' should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:10]
  1 │ (class { set abc(foo){} b(){} get abc(){} })
-   ·                               ───────
+   ·          ───┬───              ───┬───
+   ·             │                    ╰── getter 'abc' is here
+   ·             ╰── setter 'abc' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Accessor pair static getter 'a' and static setter 'a' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:37]
+   ╭─[grouped_accessor_pairs.tsx:1:11]
  1 │ class A { static set a(foo){} b(){} static get a(){} }
-   ·                                     ────────────
+   ·           ──────┬─────              ──────┬─────
+   ·                 │                         ╰── static getter 'a' is here
+   ·                 ╰── static setter 'a' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair static setter '123' and static getter '123' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:35]
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair static getter '123' and static setter '123' should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:10]
  1 │ (class { static get 123(){} b(){} static set 123(foo){} })
-   ·                                   ──────────────
+   ·          ───────┬──────           ───────┬──────
+   ·                 │                        ╰── static setter '123' is here
+   ·                 ╰── static getter '123' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair static setter and static getter should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:36]
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair static getter and static setter should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:11]
  1 │ class A { static get [a](){} b(){} static set [a](foo){} }
-   ·                                    ─────────────
+   ·           ──────┬──────            ──────┬──────
+   ·                 │                        ╰── static setter is here
+   ·                 ╰── static getter is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter '#abc' and getter '#abc' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:32]
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter '#abc' and setter '#abc' should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:11]
  1 │ class A { get '#abc'(){} b(){} set '#abc'(foo){} }
-   ·                                ──────────
+   ·           ─────┬────           ─────┬────
+   ·                │                    ╰── setter '#abc' is here
+   ·                ╰── getter '#abc' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair private setter #abc and private getter #abc should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:30]
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair private getter #abc and private setter #abc should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:11]
  1 │ class A { get #abc(){} b(){} set #abc(foo){} }
-   ·                              ────────
+   ·           ────┬───           ────┬───
+   ·               │                  ╰── private setter #abc is here
+   ·               ╰── private getter #abc is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected getter 'a' to be before setter 'a'.
-   ╭─[grouped_accessor_pairs.tsx:1:18]
+   ╭─[grouped_accessor_pairs.tsx:1:4]
  1 │ ({ set a(foo){}, get a(){} })
-   ·                  ─────
+   ·    ──┬──         ──┬──
+   ·      │             ╰── getter 'a' is here
+   ·      ╰── setter 'a' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected setter '123' to be before getter '123'.
-   ╭─[grouped_accessor_pairs.tsx:1:17]
+   ╭─[grouped_accessor_pairs.tsx:1:4]
  1 │ ({ get 123(){}, set 123(foo){} })
-   ·                 ───────
+   ·    ───┬───      ───┬───
+   ·       │            ╰── setter '123' is here
+   ·       ╰── getter '123' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected setter to be before getter.
-   ╭─[grouped_accessor_pairs.tsx:1:17]
+   ╭─[grouped_accessor_pairs.tsx:1:4]
  1 │ ({ get [a](){}, set [a](foo){} })
-   ·                 ──────
+   ·    ───┬──       ───┬──
+   ·       │            ╰── setter is here
+   ·       ╰── getter is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected getter 'abc' to be before setter 'abc'.
-   ╭─[grouped_accessor_pairs.tsx:1:26]
+   ╭─[grouped_accessor_pairs.tsx:1:11]
  1 │ class A { set abc(foo){} get abc(){} }
-   ·                          ───────
+   ·           ───┬───        ───┬───
+   ·              │              ╰── getter 'abc' is here
+   ·              ╰── setter 'abc' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected setter 'abc' to be before getter 'abc'.
-   ╭─[grouped_accessor_pairs.tsx:1:26]
+   ╭─[grouped_accessor_pairs.tsx:1:10]
  1 │ (class { get [`abc`](){} set [`abc`](foo){} })
-   ·                          ──────────
+   ·          ─────┬────      ─────┬────
+   ·               │               ╰── setter 'abc' is here
+   ·               ╰── getter 'abc' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected static setter 'a' to be before static getter 'a'.
-   ╭─[grouped_accessor_pairs.tsx:1:28]
+   ╭─[grouped_accessor_pairs.tsx:1:11]
  1 │ class A { static get a(){} static set a(foo){} }
-   ·                            ────────────
+   ·           ──────┬─────     ──────┬─────
+   ·                 │                ╰── static setter 'a' is here
+   ·                 ╰── static getter 'a' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected static getter 'abc' to be before static setter 'abc'.
-   ╭─[grouped_accessor_pairs.tsx:1:34]
+   ╭─[grouped_accessor_pairs.tsx:1:10]
  1 │ (class { static set 'abc'(foo){} static get 'abc'(){} })
-   ·                                  ────────────────
+   ·          ────────┬───────        ────────┬───────
+   ·                  │                       ╰── static getter 'abc' is here
+   ·                  ╰── static setter 'abc' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected static getter to be before static setter.
-   ╭─[grouped_accessor_pairs.tsx:1:35]
+   ╭─[grouped_accessor_pairs.tsx:1:11]
  1 │ class A { static set [abc](foo){} static get [abc](){} }
-   ·                                   ───────────────
+   ·           ───────┬───────         ───────┬───────
+   ·                  │                       ╰── static getter is here
+   ·                  ╰── static setter is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected getter '#abc' to be before setter '#abc'.
-   ╭─[grouped_accessor_pairs.tsx:1:29]
+   ╭─[grouped_accessor_pairs.tsx:1:11]
  1 │ class A { set '#abc'(foo){} get '#abc'(){} }
-   ·                             ──────────
+   ·           ─────┬────        ─────┬────
+   ·                │                 ╰── getter '#abc' is here
+   ·                ╰── setter '#abc' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected private getter #abc to be before private setter #abc.
-   ╭─[grouped_accessor_pairs.tsx:1:27]
+   ╭─[grouped_accessor_pairs.tsx:1:11]
  1 │ class A { set #abc(foo){} get #abc(){} }
-   ·                           ────────
-   ╰────
-  help: Require grouped accessor pairs in object literals and classes
-
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:21]
- 1 │ ({ get a(){}, b: 1, set a(foo){} })
-   ·                     ─────
-   ╰────
-  help: Require grouped accessor pairs in object literals and classes
-
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:21]
- 1 │ ({ get a(){}, b: 1, set a(foo){} })
-   ·                     ─────
-   ╰────
-  help: Require grouped accessor pairs in object literals and classes
-
-  ⚠ eslint(grouped-accessor-pairs): Expected setter 'a' to be before getter 'a'.
-   ╭─[grouped_accessor_pairs.tsx:1:21]
- 1 │ ({ get a(){}, b: 1, set a(foo){} })
-   ·                     ─────
-   ╰────
-  help: Require grouped accessor pairs in object literals and classes
-
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:21]
- 1 │ ({ get a(){}, b: 1, set a(foo){} })
-   ·                     ─────
+   ·           ────┬───        ────┬───
+   ·               │               ╰── private getter #abc is here
+   ·               ╰── private setter #abc is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'a' and setter 'a' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:30]
+   ╭─[grouped_accessor_pairs.tsx:1:4]
+ 1 │ ({ get a(){}, b: 1, set a(foo){} })
+   ·    ──┬──            ──┬──
+   ·      │                ╰── setter 'a' is here
+   ·      ╰── getter 'a' is here
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'a' and setter 'a' should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:4]
+ 1 │ ({ get a(){}, b: 1, set a(foo){} })
+   ·    ──┬──            ──┬──
+   ·      │                ╰── setter 'a' is here
+   ·      ╰── getter 'a' is here
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected setter 'a' to be before getter 'a'.
+   ╭─[grouped_accessor_pairs.tsx:1:4]
+ 1 │ ({ get a(){}, b: 1, set a(foo){} })
+   ·    ──┬──            ──┬──
+   ·      │                ╰── setter 'a' is here
+   ·      ╰── getter 'a' is here
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'a' and setter 'a' should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:4]
+ 1 │ ({ get a(){}, b: 1, set a(foo){} })
+   ·    ──┬──            ──┬──
+   ·      │                ╰── setter 'a' is here
+   ·      ╰── getter 'a' is here
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'a' and setter 'a' should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:11]
  1 │ class A { set a(foo){} b(){} get a(){} }
-   ·                              ─────
+   ·           ──┬──              ──┬──
+   ·             │                  ╰── getter 'a' is here
+   ·             ╰── setter 'a' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected getter 'a' to be before setter 'a'.
-   ╭─[grouped_accessor_pairs.tsx:1:30]
+   ╭─[grouped_accessor_pairs.tsx:1:11]
  1 │ class A { set a(foo){} b(){} get a(){} }
-   ·                              ─────
+   ·           ──┬──              ──┬──
+   ·             │                  ╰── getter 'a' is here
+   ·             ╰── setter 'a' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Accessor pair static getter 'a' and static setter 'a' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:36]
+   ╭─[grouped_accessor_pairs.tsx:1:10]
  1 │ (class { static set a(foo){} b(){} static get a(){} })
-   ·                                    ────────────
+   ·          ──────┬─────              ──────┬─────
+   ·                │                         ╰── static getter 'a' is here
+   ·                ╰── static setter 'a' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'abc' and getter 'abc' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:26]
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'abc' and setter 'abc' should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:4]
  1 │ ({ get 'abc'(){}, d(){}, set 'abc'(foo){} })
-   ·                          ─────────
+   ·    ────┬────             ────┬────
+   ·        │                     ╰── setter 'abc' is here
+   ·        ╰── getter 'abc' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected getter '' to be before setter ''.
-   ╭─[grouped_accessor_pairs.tsx:1:19]
+   ╭─[grouped_accessor_pairs.tsx:1:4]
  1 │ ({ set ''(foo){}, get [''](){} })
-   ·                   ───────
+   ·    ───┬──         ───┬───
+   ·       │              ╰── getter '' is here
+   ·       ╰── setter '' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected getter 'abc' to be before setter 'abc'.
-   ╭─[grouped_accessor_pairs.tsx:1:26]
+   ╭─[grouped_accessor_pairs.tsx:1:11]
  1 │ class A { set abc(foo){} get 'abc'(){} }
-   ·                          ─────────
+   ·           ───┬───        ────┬────
+   ·              │               ╰── getter 'abc' is here
+   ·              ╰── setter 'abc' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected getter 'abc' to be before setter 'abc'.
-   ╭─[grouped_accessor_pairs.tsx:1:29]
+   ╭─[grouped_accessor_pairs.tsx:1:10]
  1 │ (class { set [`abc`](foo){} get abc(){} })
-   ·                             ───────
+   ·          ─────┬────         ───┬───
+   ·               │                ╰── getter 'abc' is here
+   ·               ╰── setter 'abc' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected getter 'abc' to be before setter 'abc'.
-   ╭─[grouped_accessor_pairs.tsx:1:24]
+   ╭─[grouped_accessor_pairs.tsx:1:4]
  1 │ ({ set ['abc'](foo){}, get [`abc`](){} })
-   ·                        ──────────
+   ·    ─────┬────          ─────┬────
+   ·         │                   ╰── getter 'abc' is here
+   ·         ╰── setter 'abc' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected getter '123' to be before setter '123'.
-   ╭─[grouped_accessor_pairs.tsx:1:20]
+   ╭─[grouped_accessor_pairs.tsx:1:4]
  1 │ ({ set 123(foo){}, get [123](){} })
-   ·                    ────────
+   ·    ───┬───         ────┬───
+   ·       │                ╰── getter '123' is here
+   ·       ╰── setter '123' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected static getter '123' to be before static setter '123'.
-   ╭─[grouped_accessor_pairs.tsx:1:35]
+   ╭─[grouped_accessor_pairs.tsx:1:11]
  1 │ class A { static set '123'(foo){} static get 123(){} }
-   ·                                   ──────────────
+   ·           ────────┬───────        ───────┬──────
+   ·                   │                      ╰── static getter '123' is here
+   ·                   ╰── static setter '123' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected getter to be before setter.
-   ╭─[grouped_accessor_pairs.tsx:1:27]
+   ╭─[grouped_accessor_pairs.tsx:1:10]
  1 │ (class { set [a+b](foo){} get [a+b](){} })
-   ·                           ────────
+   ·          ────┬───         ────┬───
+   ·              │                ╰── getter is here
+   ·              ╰── setter is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected getter to be before setter.
-   ╭─[grouped_accessor_pairs.tsx:1:23]
+   ╭─[grouped_accessor_pairs.tsx:1:4]
  1 │ ({ set [f(a)](foo){}, get [f(a)](){} })
-   ·                       ─────────
+   ·    ────┬────          ────┬────
+   ·        │                  ╰── getter is here
+   ·        ╰── setter is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:21]
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'a' and setter 'a' should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:4]
  1 │ ({ get a(){}, b: 1, set a(foo){}, set c(foo){}, d(){}, get c(){} })
-   ·                     ─────
+   ·    ──┬──            ──┬──
+   ·      │                ╰── setter 'a' is here
+   ·      ╰── getter 'a' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'c' and setter 'c' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:56]
+   ╭─[grouped_accessor_pairs.tsx:1:35]
  1 │ ({ get a(){}, b: 1, set a(foo){}, set c(foo){}, d(){}, get c(){} })
-   ·                                                        ─────
+   ·                                   ──┬──                ──┬──
+   ·                                     │                    ╰── getter 'c' is here
+   ·                                     ╰── setter 'c' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:29]
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'a' and setter 'a' should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:4]
  1 │ ({ get a(){}, set b(foo){}, set a(bar){}, get b(){} })
-   ·                             ─────
+   ·    ──┬──                    ──┬──
+   ·      │                        ╰── setter 'a' is here
+   ·      ╰── getter 'a' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'b' and setter 'b' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:43]
+   ╭─[grouped_accessor_pairs.tsx:1:15]
  1 │ ({ get a(){}, set b(foo){}, set a(bar){}, get b(){} })
-   ·                                           ─────
+   ·               ──┬──                       ──┬──
+   ·                 │                           ╰── getter 'b' is here
+   ·                 ╰── setter 'b' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:31]
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'a' and setter 'a' should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:4]
  1 │ ({ get a(){}, set [a](foo){}, set a(bar){}, get [a](){} })
-   ·                               ─────
+   ·    ──┬──                      ──┬──
+   ·      │                          ╰── setter 'a' is here
+   ·      ╰── getter 'a' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Accessor pair getter and setter should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:45]
+   ╭─[grouped_accessor_pairs.tsx:1:15]
  1 │ ({ get a(){}, set [a](foo){}, set a(bar){}, get [a](){} })
-   ·                                             ──────
+   ·               ───┬──                        ───┬──
+   ·                  │                             ╰── getter is here
+   ·                  ╰── setter is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected getter 'c' to be before setter 'c'.
-   ╭─[grouped_accessor_pairs.tsx:1:56]
+   ╭─[grouped_accessor_pairs.tsx:1:42]
  1 │ ({ a(){}, set b(foo){}, ...c, get b(){}, set c(bar){}, get c(){} })
-   ·                                                        ─────
+   ·                                          ──┬──         ──┬──
+   ·                                            │             ╰── getter 'c' is here
+   ·                                            ╰── setter 'c' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'b' and setter 'b' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:31]
+   ╭─[grouped_accessor_pairs.tsx:1:11]
  1 │ ({ a(){}, set b(foo){}, ...c, get b(){}, set c(bar){}, get c(){} })
-   ·                               ─────
+   ·           ──┬──               ──┬──
+   ·             │                   ╰── getter 'b' is here
+   ·             ╰── setter 'b' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected getter 'b' to be before setter 'b'.
-   ╭─[grouped_accessor_pairs.tsx:1:31]
+   ╭─[grouped_accessor_pairs.tsx:1:11]
  1 │ ({ a(){}, set b(foo){}, ...c, get b(){}, set c(bar){}, get c(){} })
-   ·                               ─────
+   ·           ──┬──               ──┬──
+   ·             │                   ╰── getter 'b' is here
+   ·             ╰── setter 'b' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected getter to be before setter.
-   ╭─[grouped_accessor_pairs.tsx:1:20]
+   ╭─[grouped_accessor_pairs.tsx:1:4]
  1 │ ({ set [a](foo){}, get [a](){}, set [-a](bar){}, get [-a](){} })
-   ·                    ──────
+   ·    ───┬──          ───┬──
+   ·       │               ╰── getter is here
+   ·       ╰── setter is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected getter to be before setter.
-   ╭─[grouped_accessor_pairs.tsx:1:50]
+   ╭─[grouped_accessor_pairs.tsx:1:33]
  1 │ ({ set [a](foo){}, get [a](){}, set [-a](bar){}, get [-a](){} })
-   ·                                                  ───────
-   ╰────
-  help: Require grouped accessor pairs in object literals and classes
-
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:38]
- 1 │ class A { get a(){} constructor (){} set a(foo){} get b(){} static c(){} set b(bar){} }
-   ·                                      ─────
-   ╰────
-  help: Require grouped accessor pairs in object literals and classes
-
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'b' and getter 'b' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:74]
- 1 │ class A { get a(){} constructor (){} set a(foo){} get b(){} static c(){} set b(bar){} }
-   ·                                                                          ─────
+   ·                                 ───┬───          ───┬───
+   ·                                    │                ╰── getter is here
+   ·                                    ╰── setter is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'a' and setter 'a' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:40]
- 1 │ (class { set a(foo){} static get a(){} get a(){} static set a(bar){} })
-   ·                                        ─────
+   ╭─[grouped_accessor_pairs.tsx:1:11]
+ 1 │ class A { get a(){} constructor (){} set a(foo){} get b(){} static c(){} set b(bar){} }
+   ·           ──┬──                      ──┬──
+   ·             │                          ╰── setter 'a' is here
+   ·             ╰── getter 'a' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair static setter 'a' and static getter 'a' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:50]
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'b' and setter 'b' should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:51]
+ 1 │ class A { get a(){} constructor (){} set a(foo){} get b(){} static c(){} set b(bar){} }
+   ·                                                   ──┬──                  ──┬──
+   ·                                                     │                      ╰── setter 'b' is here
+   ·                                                     ╰── getter 'b' is here
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'a' and setter 'a' should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:10]
  1 │ (class { set a(foo){} static get a(){} get a(){} static set a(bar){} })
-   ·                                                  ────────────
+   ·          ──┬──                         ──┬──
+   ·            │                             ╰── getter 'a' is here
+   ·            ╰── setter 'a' is here
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair static getter 'a' and static setter 'a' should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:23]
+ 1 │ (class { set a(foo){} static get a(){} get a(){} static set a(bar){} })
+   ·                       ──────┬─────               ──────┬─────
+   ·                             │                          ╰── static setter 'a' is here
+   ·                             ╰── static getter 'a' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected setter 'a' to be before getter 'a'.
-   ╭─[grouped_accessor_pairs.tsx:1:21]
+   ╭─[grouped_accessor_pairs.tsx:1:11]
  1 │ class A { get a(){} set a(foo){} static get b(){} static set b(bar){} }
-   ·                     ─────
+   ·           ──┬──     ──┬──
+   ·             │         ╰── setter 'a' is here
+   ·             ╰── getter 'a' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected static setter 'b' to be before static getter 'b'.
-   ╭─[grouped_accessor_pairs.tsx:1:51]
+   ╭─[grouped_accessor_pairs.tsx:1:34]
  1 │ class A { get a(){} set a(foo){} static get b(){} static set b(bar){} }
-   ·                                                   ────────────
+   ·                                  ──────┬─────     ──────┬─────
+   ·                                        │                ╰── static setter 'b' is here
+   ·                                        ╰── static getter 'b' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Accessor pair getter and setter should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:41]
+   ╭─[grouped_accessor_pairs.tsx:1:10]
  1 │ (class { set [a+b](foo){} get [a-b](){} get [a+b](){} set [a-b](bar){} })
-   ·                                         ────────
+   ·          ────┬───                       ────┬───
+   ·              │                              ╰── getter is here
+   ·              ╰── setter is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter and getter should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:55]
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter and setter should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:27]
  1 │ (class { set [a+b](foo){} get [a-b](){} get [a+b](){} set [a-b](bar){} })
-   ·                                                       ────────
+   ·                           ────┬───                    ────┬───
+   ·                               │                           ╰── setter is here
+   ·                               ╰── getter is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'b' and getter 'b' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:57]
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'b' and setter 'b' should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:29]
  1 │ ({ get a(){}, set a(foo){}, get b(){}, c: function(){}, set b(bar){} })
-   ·                                                         ─────
-   ╰────
-  help: Require grouped accessor pairs in object literals and classes
-
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:26]
- 1 │ ({ get a(){}, get b(){}, set a(foo){} })
-   ·                          ─────
+   ·                             ──┬──                       ──┬──
+   ·                               │                           ╰── setter 'b' is here
+   ·                               ╰── getter 'b' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'a' and setter 'a' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:31]
+   ╭─[grouped_accessor_pairs.tsx:1:4]
+ 1 │ ({ get a(){}, get b(){}, set a(foo){} })
+   ·    ──┬──                 ──┬──
+   ·      │                     ╰── setter 'a' is here
+   ·      ╰── getter 'a' is here
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'a' and setter 'a' should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:4]
  1 │ ({ set a(foo){}, get [a](){}, get a(){} })
-   ·                               ─────
+   ·    ──┬──                      ──┬──
+   ·      │                          ╰── getter 'a' is here
+   ·      ╰── setter 'a' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Accessor pair getter and setter should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:34]
+   ╭─[grouped_accessor_pairs.tsx:1:4]
  1 │ ({ set [a](foo){}, set a(bar){}, get [a](){} })
-   ·                                  ──────
+   ·    ───┬──                        ───┬──
+   ·       │                             ╰── getter is here
+   ·       ╰── setter is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected getter 'b' to be before setter 'b'.
-   ╭─[grouped_accessor_pairs.tsx:1:43]
+   ╭─[grouped_accessor_pairs.tsx:1:29]
  1 │ ({ get a(){}, set a(foo){}, set b(bar){}, get b(){} })
-   ·                                           ─────
+   ·                             ──┬──         ──┬──
+   ·                               │             ╰── getter 'b' is here
+   ·                               ╰── setter 'b' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:58]
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'a' and setter 'a' should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:11]
  1 │ class A { get a(){} static set b(foo){} static get b(){} set a(foo){} }
-   ·                                                          ─────
+   ·           ──┬──                                          ──┬──
+   ·             │                                              ╰── setter 'a' is here
+   ·             ╰── getter 'a' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair static setter 'a' and static getter 'a' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:40]
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair static getter 'a' and static setter 'a' should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:10]
  1 │ (class { static get a(){} set a(foo){} static set a(bar){} })
-   ·                                        ────────────
+   ·          ──────┬─────                  ──────┬─────
+   ·                │                             ╰── static setter 'a' is here
+   ·                ╰── static getter 'a' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected static setter 'a' to be before static getter 'a'.
-   ╭─[grouped_accessor_pairs.tsx:1:51]
+   ╭─[grouped_accessor_pairs.tsx:1:34]
  1 │ class A { set a(foo){} get a(){} static get a(){} static set a(bar){} }
-   ·                                                   ────────────
+   ·                                  ──────┬─────     ──────┬─────
+   ·                                        │                ╰── static setter 'a' is here
+   ·                                        ╰── static getter 'a' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:21]
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'a' and setter 'a' should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:4]
  1 │ ({ get a(){}, a: 1, set a(foo){} })
-   ·                     ─────
+   ·    ──┬──            ──┬──
+   ·      │                ╰── setter 'a' is here
+   ·      ╰── getter 'a' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected getter 'a' to be before setter 'a'.
-   ╭─[grouped_accessor_pairs.tsx:1:25]
+   ╭─[grouped_accessor_pairs.tsx:1:11]
  1 │ ({ a(){}, set a(foo){}, get a(){} })
-   ·                         ─────
+   ·           ──┬──         ──┬──
+   ·             │             ╰── getter 'a' is here
+   ·             ╰── setter 'a' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:27]
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'a' and setter 'a' should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:11]
  1 │ class A { get a(){} a(){} set a(foo){} }
-   ·                           ─────
+   ·           ──┬──           ──┬──
+   ·             │               ╰── setter 'a' is here
+   ·             ╰── getter 'a' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:24]
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'a' and setter 'a' should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:11]
  1 │ class A { get a(){} a; set a(foo){} }
-   ·                        ─────
+   ·           ──┬──        ──┬──
+   ·             │            ╰── setter 'a' is here
+   ·             ╰── getter 'a' is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected static private getter #abc to be before static private setter #abc.
-   ╭─[grouped_accessor_pairs.tsx:1:37]
+   ╭─[grouped_accessor_pairs.tsx:1:14]
  1 │ class faoo { static set #abc(foo){} static get #abc(){} }
-   ·                                     ───────────────
+   ·              ───────┬───────        ───────┬───────
+   ·                     │                      ╰── static private getter #abc is here
+   ·                     ╰── static private setter #abc is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
-  ⚠ eslint(grouped-accessor-pairs): Accessor pair setter 'a' and getter 'a' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:3:12]
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair getter 'a' and setter 'a' should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:4]
+ 1 │ ({ get a(){},
+   ·    ──┬──
+   ·      ╰── getter 'a' is here
  2 │                     b: 1,
  3 │                     set a(foo){}
-   ·                     ─────
+   ·                     ──┬──
+   ·                       ╰── setter 'a' is here
  4 │                 })
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Accessor pair static getter 'a' and static setter 'a' should be grouped.
-   ╭─[grouped_accessor_pairs.tsx:1:37]
+   ╭─[grouped_accessor_pairs.tsx:1:11]
  1 │ ╭─▶ class A { static set a(foo){} b(){} static get
- 2 │ ╰─▶                  a(){}
+   · │             ──────┬─────
+   · │                   ╰── static setter 'a' is here
+ 2 │ ├─▶                  a(){}
+   · ╰──── static getter 'a' is here
  3 │                     }
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected getter 'false' to be before setter 'false'.
-   ╭─[grouped_accessor_pairs.tsx:5:13]
+   ╭─[grouped_accessor_pairs.tsx:2:13]
+ 1 │ const foo = {
+ 2 │             set [false](value) {
+   ·             ─────┬────
+   ·                  ╰── setter 'false' is here
+ 3 │                 this.val = value;
  4 │             },
  5 │             get 'false'() {
-   ·             ───────────
+   ·             ─────┬─────
+   ·                  ╰── getter 'false' is here
  6 │                 return this.val;
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected setter '/a/g' to be before getter '/a/g'.
-   ╭─[grouped_accessor_pairs.tsx:5:13]
+   ╭─[grouped_accessor_pairs.tsx:2:13]
+ 1 │ const foo = {
+ 2 │             get '/a/g'() {
+   ·             ─────┬────
+   ·                  ╰── getter '/a/g' is here
+ 3 │                 return this.val;
  4 │             },
  5 │             set [/a/g](value) {
-   ·             ─────────
+   ·             ────┬────
+   ·                 ╰── setter '/a/g' is here
  6 │                 this.val = value;
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected static private getter #abc to be before static private setter #abc.
-   ╭─[grouped_accessor_pairs.tsx:1:36]
+   ╭─[grouped_accessor_pairs.tsx:1:13]
  1 │ class foo { static set #abc(foo){} static get #abc(){} }
-   ·                                    ───────────────
+   ·             ───────┬───────        ───────┬───────
+   ·                    │                      ╰── static private getter #abc is here
+   ·                    ╰── static private setter #abc is here
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected static getter '#a+b' to be before static setter '#a+b'.
-   ╭─[grouped_accessor_pairs.tsx:5:13]
+   ╭─[grouped_accessor_pairs.tsx:2:13]
+ 1 │ class foo {
+ 2 │             static set ['#a+b'](val) {
+   ·             ─────────┬────────
+   ·                      ╰── static setter '#a+b' is here
+ 3 │ 
  4 │             }
  5 │             static get ['#a+b']() {
-   ·             ──────────────────
+   ·             ─────────┬────────
+   ·                      ╰── static getter '#a+b' is here
  6 │ 
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected getter to be before setter.
-   ╭─[grouped_accessor_pairs.tsx:5:13]
+   ╭─[grouped_accessor_pairs.tsx:2:13]
+ 1 │ class foo {
+ 2 │             set [() => {}](val) {
+   ·             ──────┬──────
+   ·                   ╰── setter is here
+ 3 │ 
  4 │             }
  5 │             get [() => {}]() {
-   ·             ─────────────
+   ·             ──────┬──────
+   ·                   ╰── getter is here
  6 │ 
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected static getter '23' to be before static setter '23'.
-   ╭─[grouped_accessor_pairs.tsx:5:13]
+   ╭─[grouped_accessor_pairs.tsx:2:13]
+ 1 │ class foo {
+ 2 │             static set [23](val) {
+   ·             ───────┬──────
+   ·                    ╰── static setter '23' is here
+ 3 │ 
  4 │             }
  5 │             static get 23() {
-   ·             ─────────────
+   ·             ──────┬──────
+   ·                   ╰── static getter '23' is here
  6 │ 
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected static getter '23' to be before static setter '23'.
-   ╭─[grouped_accessor_pairs.tsx:5:13]
+   ╭─[grouped_accessor_pairs.tsx:2:13]
+ 1 │ class jj {
+ 2 │             static set [23](val) {
+   ·             ───────┬──────
+   ·                    ╰── static setter '23' is here
+ 3 │ 
  4 │             }
  5 │             static get 23() {
-   ·             ─────────────
+   ·             ──────┬──────
+   ·                   ╰── static getter '23' is here
  6 │ 
    ╰────
   help: Require grouped accessor pairs in object literals and classes
 
   ⚠ eslint(grouped-accessor-pairs): Expected getter '23' to be before setter '23'.
-    ╭─[grouped_accessor_pairs.tsx:11:13]
+    ╭─[grouped_accessor_pairs.tsx:8:13]
+  7 │             }
+  8 │             set 23(val) {
+    ·             ───┬──
+    ·                ╰── setter '23' is here
+  9 │                 
  10 │             }
  11 │             get 23() {
-    ·             ──────
+    ·             ───┬──
+    ·                ╰── getter '23' is here
  12 │ 
     ╰────
   help: Require grouped accessor pairs in object literals and classes

--- a/crates/oxc_linter/src/snapshots/eslint_grouped_accessor_pairs.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_grouped_accessor_pairs.snap
@@ -486,3 +486,12 @@ source: crates/oxc_linter/src/tester.rs
  3 │                     }
    ╰────
   help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected false to be before false.
+   ╭─[grouped_accessor_pairs.tsx:5:13]
+ 4 │             },
+ 5 │             get 'false'() {
+   ·             ───────────
+ 6 │                 return this.val;
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes

--- a/crates/oxc_linter/src/snapshots/eslint_grouped_accessor_pairs.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_grouped_accessor_pairs.snap
@@ -1,0 +1,467 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:20]
+ 1 │ ({ get a(){}, b:1, set a(foo){} })
+   ·                    ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair abc and abc should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:27]
+ 1 │ ({ set 'abc'(foo){}, b:1, get 'abc'(){} })
+   ·                           ─────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:22]
+ 1 │ ({ get [a](){}, b:1, set [a](foo){} })
+   ·                      ──────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair abc and abc should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:29]
+ 1 │ class A { get abc(){} b(){} set abc(foo){} }
+   ·                             ───────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair abc and abc should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:31]
+ 1 │ (class { set abc(foo){} b(){} get abc(){} })
+   ·                               ───────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:37]
+ 1 │ class A { static set a(foo){} b(){} static get a(){} }
+   ·                                     ────────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair 123 and 123 should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:35]
+ 1 │ (class { static get 123(){} b(){} static set 123(foo){} })
+   ·                                   ──────────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:36]
+ 1 │ class A { static get [a](){} b(){} static set [a](foo){} }
+   ·                                    ─────────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair #abc and #abc should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:32]
+ 1 │ class A { get '#abc'(){} b(){} set '#abc'(foo){} }
+   ·                                ──────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair abc and abc should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:30]
+ 1 │ class A { get #abc(){} b(){} set #abc(foo){} }
+   ·                              ────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected a to be before a.
+   ╭─[grouped_accessor_pairs.tsx:1:18]
+ 1 │ ({ set a(foo){}, get a(){} })
+   ·                  ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected 123 to be before 123.
+   ╭─[grouped_accessor_pairs.tsx:1:17]
+ 1 │ ({ get 123(){}, set 123(foo){} })
+   ·                 ───────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected a to be before a.
+   ╭─[grouped_accessor_pairs.tsx:1:17]
+ 1 │ ({ get [a](){}, set [a](foo){} })
+   ·                 ──────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected abc to be before abc.
+   ╭─[grouped_accessor_pairs.tsx:1:26]
+ 1 │ class A { set abc(foo){} get abc(){} }
+   ·                          ───────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected abc to be before abc.
+   ╭─[grouped_accessor_pairs.tsx:1:26]
+ 1 │ (class { get [`abc`](){} set [`abc`](foo){} })
+   ·                          ──────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected a to be before a.
+   ╭─[grouped_accessor_pairs.tsx:1:28]
+ 1 │ class A { static get a(){} static set a(foo){} }
+   ·                            ────────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected abc to be before abc.
+   ╭─[grouped_accessor_pairs.tsx:1:34]
+ 1 │ (class { static set 'abc'(foo){} static get 'abc'(){} })
+   ·                                  ────────────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected abc to be before abc.
+   ╭─[grouped_accessor_pairs.tsx:1:35]
+ 1 │ class A { static set [abc](foo){} static get [abc](){} }
+   ·                                   ───────────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected #abc to be before #abc.
+   ╭─[grouped_accessor_pairs.tsx:1:29]
+ 1 │ class A { set '#abc'(foo){} get '#abc'(){} }
+   ·                             ──────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected abc to be before abc.
+   ╭─[grouped_accessor_pairs.tsx:1:27]
+ 1 │ class A { set #abc(foo){} get #abc(){} }
+   ·                           ────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:21]
+ 1 │ ({ get a(){}, b: 1, set a(foo){} })
+   ·                     ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected a to be before a.
+   ╭─[grouped_accessor_pairs.tsx:1:21]
+ 1 │ ({ get a(){}, b: 1, set a(foo){} })
+   ·                     ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:21]
+ 1 │ ({ get a(){}, b: 1, set a(foo){} })
+   ·                     ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected a to be before a.
+   ╭─[grouped_accessor_pairs.tsx:1:30]
+ 1 │ class A { set a(foo){} b(){} get a(){} }
+   ·                              ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:36]
+ 1 │ (class { static set a(foo){} b(){} static get a(){} })
+   ·                                    ────────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair abc and abc should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:26]
+ 1 │ ({ get 'abc'(){}, d(){}, set 'abc'(foo){} })
+   ·                          ─────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected  to be before .
+   ╭─[grouped_accessor_pairs.tsx:1:19]
+ 1 │ ({ set ''(foo){}, get [''](){} })
+   ·                   ───────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected abc to be before abc.
+   ╭─[grouped_accessor_pairs.tsx:1:26]
+ 1 │ class A { set abc(foo){} get 'abc'(){} }
+   ·                          ─────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected abc to be before abc.
+   ╭─[grouped_accessor_pairs.tsx:1:29]
+ 1 │ (class { set [`abc`](foo){} get abc(){} })
+   ·                             ───────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected abc to be before abc.
+   ╭─[grouped_accessor_pairs.tsx:1:24]
+ 1 │ ({ set ['abc'](foo){}, get [`abc`](){} })
+   ·                        ──────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected 123 to be before 123.
+   ╭─[grouped_accessor_pairs.tsx:1:20]
+ 1 │ ({ set 123(foo){}, get [123](){} })
+   ·                    ────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected 123 to be before 123.
+   ╭─[grouped_accessor_pairs.tsx:1:35]
+ 1 │ class A { static set '123'(foo){} static get 123(){} }
+   ·                                   ──────────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected a+b to be before a+b.
+   ╭─[grouped_accessor_pairs.tsx:1:27]
+ 1 │ (class { set [a+b](foo){} get [a+b](){} })
+   ·                           ────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected f(a) to be before f(a).
+   ╭─[grouped_accessor_pairs.tsx:1:23]
+ 1 │ ({ set [f(a)](foo){}, get [f(a)](){} })
+   ·                       ─────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:21]
+ 1 │ ({ get a(){}, b: 1, set a(foo){}, set c(foo){}, d(){}, get c(){} })
+   ·                     ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair c and c should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:56]
+ 1 │ ({ get a(){}, b: 1, set a(foo){}, set c(foo){}, d(){}, get c(){} })
+   ·                                                        ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:29]
+ 1 │ ({ get a(){}, set b(foo){}, set a(bar){}, get b(){} })
+   ·                             ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair b and b should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:43]
+ 1 │ ({ get a(){}, set b(foo){}, set a(bar){}, get b(){} })
+   ·                                           ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:31]
+ 1 │ ({ get a(){}, set [a](foo){}, set a(bar){}, get [a](){} })
+   ·                               ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:45]
+ 1 │ ({ get a(){}, set [a](foo){}, set a(bar){}, get [a](){} })
+   ·                                             ──────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected c to be before c.
+   ╭─[grouped_accessor_pairs.tsx:1:56]
+ 1 │ ({ a(){}, set b(foo){}, ...c, get b(){}, set c(bar){}, get c(){} })
+   ·                                                        ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected b to be before b.
+   ╭─[grouped_accessor_pairs.tsx:1:31]
+ 1 │ ({ a(){}, set b(foo){}, ...c, get b(){}, set c(bar){}, get c(){} })
+   ·                               ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected a to be before a.
+   ╭─[grouped_accessor_pairs.tsx:1:20]
+ 1 │ ({ set [a](foo){}, get [a](){}, set [-a](bar){}, get [-a](){} })
+   ·                    ──────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected -a to be before -a.
+   ╭─[grouped_accessor_pairs.tsx:1:50]
+ 1 │ ({ set [a](foo){}, get [a](){}, set [-a](bar){}, get [-a](){} })
+   ·                                                  ───────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair b and b should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:74]
+ 1 │ class A { get a(){} constructor (){} set a(foo){} get b(){} static c(){} set b(bar){} }
+   ·                                                                          ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:38]
+ 1 │ class A { get a(){} constructor (){} set a(foo){} get b(){} static c(){} set b(bar){} }
+   ·                                      ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:50]
+ 1 │ (class { set a(foo){} static get a(){} get a(){} static set a(bar){} })
+   ·                                                  ────────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:40]
+ 1 │ (class { set a(foo){} static get a(){} get a(){} static set a(bar){} })
+   ·                                        ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected b to be before b.
+   ╭─[grouped_accessor_pairs.tsx:1:51]
+ 1 │ class A { get a(){} set a(foo){} static get b(){} static set b(bar){} }
+   ·                                                   ────────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected a to be before a.
+   ╭─[grouped_accessor_pairs.tsx:1:21]
+ 1 │ class A { get a(){} set a(foo){} static get b(){} static set b(bar){} }
+   ·                     ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a-b and a-b should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:55]
+ 1 │ (class { set [a+b](foo){} get [a-b](){} get [a+b](){} set [a-b](bar){} })
+   ·                                                       ────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a+b and a+b should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:41]
+ 1 │ (class { set [a+b](foo){} get [a-b](){} get [a+b](){} set [a-b](bar){} })
+   ·                                         ────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair b and b should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:57]
+ 1 │ ({ get a(){}, set a(foo){}, get b(){}, c: function(){}, set b(bar){} })
+   ·                                                         ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:26]
+ 1 │ ({ get a(){}, get b(){}, set a(foo){} })
+   ·                          ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:31]
+ 1 │ ({ set a(foo){}, get [a](){}, get a(){} })
+   ·                               ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:34]
+ 1 │ ({ set [a](foo){}, set a(bar){}, get [a](){} })
+   ·                                  ──────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected b to be before b.
+   ╭─[grouped_accessor_pairs.tsx:1:43]
+ 1 │ ({ get a(){}, set a(foo){}, set b(bar){}, get b(){} })
+   ·                                           ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:58]
+ 1 │ class A { get a(){} static set b(foo){} static get b(){} set a(foo){} }
+   ·                                                          ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:40]
+ 1 │ (class { static get a(){} set a(foo){} static set a(bar){} })
+   ·                                        ────────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected a to be before a.
+   ╭─[grouped_accessor_pairs.tsx:1:51]
+ 1 │ class A { set a(foo){} get a(){} static get a(){} static set a(bar){} }
+   ·                                                   ────────────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:21]
+ 1 │ ({ get a(){}, a: 1, set a(foo){} })
+   ·                     ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Expected a to be before a.
+   ╭─[grouped_accessor_pairs.tsx:1:25]
+ 1 │ ({ a(){}, set a(foo){}, get a(){} })
+   ·                         ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:27]
+ 1 │ class A { get a(){} a(){} set a(foo){} }
+   ·                           ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:24]
+ 1 │ class A { get a(){} a; set a(foo){} }
+   ·                        ─────
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:3:12]
+ 2 │                     b: 1,
+ 3 │                     set a(foo){}
+   ·                     ─────
+ 4 │                 })
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes
+
+  ⚠ eslint(grouped-accessor-pairs): Accessor pair a and a should be grouped.
+   ╭─[grouped_accessor_pairs.tsx:1:37]
+ 1 │ ╭─▶ class A { static set a(foo){} b(){} static get
+ 2 │ ╰─▶                  a(){}
+ 3 │                     }
+   ╰────
+  help: Require grouped accessor pairs in object literals and classes


### PR DESCRIPTION
This feature is primarily used to implement eslint grouped-accessor-pairs rule, all the test cases passed, and I still need to make some adjustments to the code implementation, Once that's done, I'll request a review 😊

- doc：[https://eslint.org/docs/latest/rules/grouped-accessor-pairs](https://eslint.org/docs/latest/rules/grouped-accessor-pairs)
- code：[https://github.com/eslint/eslint/blob/main/lib/rules/grouped-accessor-pairs.js](https://github.com/eslint/eslint/blob/main/lib/rules/grouped-accessor-pairs.js)
- test：[https://github.com/eslint/eslint/blob/main/tests/lib/rules/grouped-accessor-pairs.js](https://github.com/eslint/eslint/blob/main/tests/lib/rules/grouped-accessor-pairs.js)