### PR TITLE
fix(lexer): fix decoding lone `\r` in template literals

### DIFF
--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -132,7 +132,7 @@ impl<'a> Lexer<'a> {
         source_text: &'a str,
         source_type: SourceType,
     ) -> Self {
-        let unique = UniquePromise::new_for_benchmarks();
+        let unique = UniquePromise::new_for_tests_and_benchmarks();
         Self::new(allocator, source_text, source_type, unique)
     }
 

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -266,8 +266,8 @@ mod parser_parse {
     ///
     /// `UniquePromise` is a zero-sized type and has no runtime cost. It's purely for the type-checker.
     ///
-    /// `UniquePromise::new_for_benchmarks` is a backdoor for benchmarks, so they can create a
-    /// `ParserImpl` or `Lexer`, and manipulate it directly, for testing/benchmarking purposes.
+    /// `UniquePromise::new_for_tests_and_benchmarks` is a backdoor for tests/benchmarks, so they can
+    /// create a `ParserImpl` or `Lexer`, and manipulate it directly, for testing/benchmarking purposes.
     pub(crate) struct UniquePromise(());
 
     impl UniquePromise {
@@ -279,8 +279,8 @@ mod parser_parse {
         /// Backdoor for tests/benchmarks to create a `UniquePromise` (see above).
         /// This function must NOT be exposed outside of tests and benchmarks,
         /// as it allows circumventing safety invariants of the parser.
-        #[cfg(feature = "benchmarking")]
-        pub fn new_for_benchmarks() -> Self {
+        #[cfg(any(test, feature = "benchmarking"))]
+        pub fn new_for_tests_and_benchmarks() -> Self {
             Self(())
         }
     }

--- a/tasks/coverage/snapshots/estree_test262.snap
+++ b/tasks/coverage/snapshots/estree_test262.snap
@@ -2,7 +2,7 @@ commit: bc5c1417
 
 estree_test262 Summary:
 AST Parsed     : 44293/44293 (100.00%)
-Positive Passed: 44243/44293 (99.89%)
+Positive Passed: 44244/44293 (99.89%)
 tasks/coverage/test262/test/annexB/built-ins/RegExp/prototype/compile/pattern-string-u.js
 serde_json error: unexpected end of hex escape at line 316 column 33
 
@@ -111,7 +111,6 @@ Mismatch: tasks/coverage/test262/test/language/expressions/postfix-decrement/tar
 Mismatch: tasks/coverage/test262/test/language/expressions/postfix-increment/target-cover-id.js
 Mismatch: tasks/coverage/test262/test/language/expressions/prefix-decrement/target-cover-id.js
 Mismatch: tasks/coverage/test262/test/language/expressions/prefix-increment/target-cover-id.js
-Mismatch: tasks/coverage/test262/test/language/expressions/template-literal/tv-line-terminator-sequence.js
 tasks/coverage/test262/test/language/literals/regexp/named-groups/invalid-lone-surrogate-groupname.js
 serde_json error: unexpected end of hex escape at line 64 column 40
 


### PR DESCRIPTION
Fix a bug in the lexer where a lone `\r` in a template literal was not converted to `\n` in the unescaped string (`TemplateElementValue::cooked`).

This fixes one of the ESTree compatibility tests.
