### PR TITLE
ci(benchmarks): fix and improve benchmarking commands

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,7 +4,7 @@ ck = "check --workspace --all-features --all-targets --locked"
 lint = "clippy --workspace --all-targets --all-features"
 codecov = "llvm-cov --workspace --ignore-filename-regex tasks"
 coverage = "run -p oxc_coverage --profile coverage --"
-benchmark = "run -p oxc_benchmark --release --"
+benchmark = "bench -p oxc_benchmark"
 minsize = "run -p oxc_minsize --profile coverage --"
 rule = "run -p rulegen"
 

--- a/justfile
+++ b/justfile
@@ -126,6 +126,12 @@ codecov:
 benchmark:
   cargo benchmark
 
+# Run the benchmarks for a single component.
+# e.g. `just benchmark-one parser`.
+# See `tasks/benchmark`.
+benchmark-one *args:
+  cargo benchmark --bench {{args}} --no-default-features --features {{args}}
+
 # Automatically DRY up Cargo.toml manifests in a workspace.
 autoinherit:
   cargo binstall cargo-autoinherit

--- a/tasks/benchmark/Cargo.toml
+++ b/tasks/benchmark/Cargo.toml
@@ -86,25 +86,21 @@ serde_json = { workspace = true, optional = true }
 
 [features]
 default = [
-  "dep:oxc_allocator",
-  "dep:oxc_ast",
-  "dep:oxc_codegen",
-  "dep:oxc_isolated_declarations",
-  "dep:oxc_linter",
-  "dep:oxc_minifier",
-  "dep:oxc_mangler",
-  "dep:oxc_parser",
-  "dep:oxc_prettier",
-  "dep:oxc_semantic",
-  "dep:oxc_span",
-  "dep:oxc_tasks_common",
-  "dep:oxc_transformer",
+  "lexer",
+  "parser",
+  "transformer",
+  "semantic",
+  "minifier",
+  "codegen",
+  "linter",
+  "prettier",
+  "isolated_declarations",
 ]
 codspeed = ["criterion2/codspeed"]
 codspeed_napi = ["criterion2/codspeed", "dep:serde", "dep:serde_json"]
 
 # Features for running each benchmark separately with minimum dependencies that benchmark needs.
-# e.g. `cargo build --release -p oxc_benchmark --bench parser --no-default-features --features parser`
+# e.g. `cargo bench -p oxc_benchmark --bench parser --no-default-features --features parser`
 lexer = ["dep:oxc_allocator", "dep:oxc_ast", "dep:oxc_parser", "dep:oxc_span", "dep:oxc_tasks_common"]
 parser = ["dep:oxc_allocator", "dep:oxc_ast", "dep:oxc_parser", "dep:oxc_span", "dep:oxc_tasks_common"]
 transformer = [

--- a/tasks/benchmark/benches/lexer.rs
+++ b/tasks/benchmark/benches/lexer.rs
@@ -9,8 +9,6 @@ use oxc_parser::{
 use oxc_span::SourceType;
 use oxc_tasks_common::{TestFile, TestFiles};
 
-// Dummy comment to force running benchmarks on CI. TODO: Remove this comment.
-
 fn bench_lexer(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("lexer");
 

--- a/tasks/benchmark/benches/lexer.rs
+++ b/tasks/benchmark/benches/lexer.rs
@@ -9,6 +9,8 @@ use oxc_parser::{
 use oxc_span::SourceType;
 use oxc_tasks_common::{TestFile, TestFiles};
 
+// Dummy comment to force running benchmarks on CI. TODO: Remove this comment.
+
 fn bench_lexer(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("lexer");
 


### PR DESCRIPTION
* Fix `cargo benchmark` - previous it failed with an error.
* Add `just benchmark-one` to run a single benchmark e.g. `just benchmark-one parser`.
* Simplify `default` feature in `tasks/benchmark/Cargo.toml`.
