### PR TITLE
test(ast/estree): ESTree conformance runner fail tests if parsing fails

### DIFF
--- a/tasks/coverage/snapshots/estree_test262.snap
+++ b/tasks/coverage/snapshots/estree_test262.snap
@@ -1,8 +1,8 @@
 commit: bc5c1417
 
 estree_test262 Summary:
-AST Parsed     : 44293/44293 (100.00%)
-Positive Passed: 44248/44293 (99.90%)
+AST Parsed     : 48812/48812 (100.00%)
+Positive Passed: 48767/48812 (99.91%)
 tasks/coverage/test262/test/annexB/built-ins/RegExp/prototype/compile/pattern-string-u.js
 serde_json error: unexpected end of hex escape at line 316 column 33
 


### PR DESCRIPTION
ESTree conformance test runner report parsing errors. Thankfully this does not reveal any problems.
