### PR TITLE
chore(coverage): Bump prettier@3.5.0

### DIFF
--- a/.github/actions/clone-submodules/action.yml
+++ b/.github/actions/clone-submodules/action.yml
@@ -31,4 +31,4 @@ runs:
         show-progress: false
         repository: prettier/prettier
         path: tasks/prettier_conformance/prettier
-        ref: 37fd1774d13ef68abcc03775ceef0a91f87a57d7 # v3.4.1
+        ref: 7584432401a47a26943dd7a9ca9a8e032ead7285 # v3.5.0

--- a/justfile
+++ b/justfile
@@ -39,7 +39,7 @@ submodules:
   just clone-submodule tasks/coverage/test262 https://github.com/tc39/test262.git bc5c14176e2b11a78859571eb693f028c8822458
   just clone-submodule tasks/coverage/babel https://github.com/babel/babel.git acbc09a87016778c1551ab5e7162fdd0e70b6663
   just clone-submodule tasks/coverage/typescript https://github.com/microsoft/TypeScript.git d85767abfd83880cea17cea70f9913e9c4496dcc
-  just clone-submodule tasks/prettier_conformance/prettier https://github.com/prettier/prettier.git 37fd1774d13ef68abcc03775ceef0a91f87a57d7
+  just clone-submodule tasks/prettier_conformance/prettier https://github.com/prettier/prettier.git 7584432401a47a26943dd7a9ca9a8e032ead7285
   just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 dcb070006436b9f7783626c0741d5693953035c6
   just update-transformer-fixtures
 

--- a/tasks/prettier_conformance/snapshots/prettier.js.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.js.snap.md
@@ -1,4 +1,4 @@
-js compatibility: 252/641 (39.31%)
+js compatibility: 251/643 (39.04%)
 
 # Failed
 
@@ -51,17 +51,18 @@ js compatibility: 252/641 (39.31%)
 | js/assignment-comments/string.js | 💥 | 52.11% |
 | js/async/inline-await.js | 💥 | 25.00% |
 | js/async/nested.js | 💥 | 0.00% |
-| js/binary-expressions/arrow.js | 💥 | 55.32% |
-| js/binary-expressions/call.js | 💥 | 76.79% |
-| js/binary-expressions/comment.js | 💥 | 34.48% |
-| js/binary-expressions/if.js | 💥 | 92.31% |
-| js/binary-expressions/in_instanceof.js | 💥 | 98.63% |
-| js/binary-expressions/inline-jsx.js | 💥 | 33.33% |
-| js/binary-expressions/inline-object-array.js | 💥 | 48.24% |
-| js/binary-expressions/jsx_parent.js | 💥 | 33.33% |
-| js/binary-expressions/short-right.js | 💥 | 68.75% |
-| js/binary-expressions/test.js | 💥 | 82.46% |
-| js/binary-expressions/unary.js | 💥 | 75.00% |
+| js/binary-expressions/arrow.js | 💥💥 | 53.19% |
+| js/binary-expressions/call.js | 💥💥 | 54.46% |
+| js/binary-expressions/comment.js | 💥💥 | 29.63% |
+| js/binary-expressions/if.js | 💥💥 | 82.05% |
+| js/binary-expressions/in_instanceof.js | 💥💥 | 98.63% |
+| js/binary-expressions/inline-jsx.js | 💥💥 | 33.33% |
+| js/binary-expressions/inline-object-array.js | 💥💥 | 46.73% |
+| js/binary-expressions/jsx_parent.js | 💥💥 | 31.82% |
+| js/binary-expressions/return.js | 💥✨ | 35.00% |
+| js/binary-expressions/short-right.js | 💥💥 | 50.50% |
+| js/binary-expressions/test.js | 💥💥 | 63.16% |
+| js/binary-expressions/unary.js | 💥💥 | 62.50% |
 | js/break-calls/break.js | 💥 | 71.74% |
 | js/break-calls/parent.js | 💥 | 0.00% |
 | js/break-calls/react.js | 💥 | 52.92% |
@@ -267,6 +268,7 @@ js compatibility: 252/641 (39.31%)
 | js/non-strict/keywords.js | 💥 | 76.92% |
 | js/nullish-coalescing/nullish_coalesing_operator.js | 💥 | 80.00% |
 | js/numeric-separators/number.js | 💥 | 66.67% |
+| js/object-multiline/multiline.js | 💥💥 | 60.26% |
 | js/object-prop-break-in/comment.js | 💥 | 90.91% |
 | js/object-prop-break-in/short-keys.js | 💥 | 60.00% |
 | js/object-property-comment/after-key.js | 💥 | 71.43% |
@@ -392,4 +394,5 @@ js compatibility: 252/641 (39.31%)
 | jsx/spread/attribute.js | 💥 | 30.19% |
 | jsx/spread/child.js | 💥 | 26.67% |
 | jsx/stateless-arrow-fn/test.js | 💥 | 14.79% |
-| jsx/text-wrap/test.js | 💥 | 38.05% |
+| jsx/text-wrap/issue-16897.js | 💥 | 56.00% |
+| jsx/text-wrap/test.js | 💥 | 38.12% |

--- a/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
+++ b/tasks/prettier_conformance/snapshots/prettier.ts.snap.md
@@ -1,4 +1,4 @@
-ts compatibility: 201/568 (35.39%)
+ts compatibility: 201/573 (35.08%)
 
 # Failed
 
@@ -50,7 +50,8 @@ ts compatibility: 201/568 (35.39%)
 | jsx/spread/attribute.js | 💥 | 30.19% |
 | jsx/spread/child.js | 💥 | 26.67% |
 | jsx/stateless-arrow-fn/test.js | 💥 | 14.79% |
-| jsx/text-wrap/test.js | 💥 | 38.05% |
+| jsx/text-wrap/issue-16897.js | 💥 | 56.00% |
+| jsx/text-wrap/test.js | 💥 | 38.12% |
 | typescript/ambient/ambient.ts | 💥 | 88.24% |
 | typescript/angular-component-examples/15934-computed.component.ts | 💥💥 | 61.54% |
 | typescript/angular-component-examples/15934.component.ts | 💥💥 | 38.46% |
@@ -103,6 +104,8 @@ ts compatibility: 201/568 (35.39%)
 | typescript/comments/15707.ts | 💥 | 22.22% |
 | typescript/comments/16065-2.ts | 💥 | 46.51% |
 | typescript/comments/16065.ts | 💥 | 77.78% |
+| typescript/comments/16207.ts | 💥 | 40.00% |
+| typescript/comments/16889.ts | 💥 | 59.77% |
 | typescript/comments/abstract_class.ts | 💥 | 54.55% |
 | typescript/comments/abstract_methods.ts | 💥 | 25.00% |
 | typescript/comments/after_jsx_generic.tsx | 💥 | 10.81% |
@@ -262,7 +265,8 @@ ts compatibility: 201/568 (35.39%)
 | typescript/interface2/comments-declare.ts | 💥 | 50.00% |
 | typescript/interface2/comments.ts | 💥 | 59.02% |
 | typescript/interface2/break/break.ts | 💥💥💥 | 50.67% |
-| typescript/intersection/type-arguments.ts | 💥💥 | 16.00% |
+| typescript/intersection/intersection-parens.ts | 💥💥💥 | 43.01% |
+| typescript/intersection/type-arguments.ts | 💥💥💥 | 16.00% |
 | typescript/intersection/consistent-with-flow/comment.ts | 💥 | 0.00% |
 | typescript/intersection/consistent-with-flow/intersection-parens.ts | 💥 | 32.56% |
 | typescript/key-remapping-in-mapped-types/key-remapping.ts | 💥 | 25.00% |
@@ -293,6 +297,7 @@ ts compatibility: 201/568 (35.39%)
 | typescript/non-null/braces.ts | 💥 | 54.55% |
 | typescript/non-null/optional-chain.ts | 💥 | 72.22% |
 | typescript/non-null/parens.ts | 💥 | 61.22% |
+| typescript/object-multiline/multiline.ts | 💥💥 | 61.49% |
 | typescript/optional-method/optional-method.ts | 💥 | 84.21% |
 | typescript/optional-type/complex.ts | 💥 | 0.00% |
 | typescript/prettier-ignore/issue-14238.ts | 💥 | 0.00% |


### PR DESCRIPTION
> https://prettier.io/blog/2025/02/09/3.5.0

Test coverage has dropped slightly because they added more tests for the new `objectWrap` and `experimentalOperatorPosition` options.

I will try to support `objectWrap` in the near future.