### PR TITLE
fix(napi/parser): fix unicode comment panic

### DIFF
--- a/crates/oxc_ast/src/utf8_to_utf16.rs
+++ b/crates/oxc_ast/src/utf8_to_utf16.rs
@@ -29,7 +29,7 @@ impl Utf8ToUtf16 {
     }
 
     /// Convert all spans in the AST to UTF-16.
-    pub fn convert(mut self, program: &mut Program<'_>) {
+    pub fn convert(&mut self, program: &mut Program<'_>) {
         self.build_table(program.source_text);
         // Skip if source is entirely ASCII
         if self.translations.len() == 1 {
@@ -81,7 +81,8 @@ impl Utf8ToUtf16 {
         span.end = self.convert_offset(span.end);
     }
 
-    fn convert_offset(&self, utf8_offset: u32) -> u32 {
+    /// Convert UTF-8 offset to UTF-16.
+    pub fn convert_offset(&self, utf8_offset: u32) -> u32 {
         // Find the first entry in table *after* the UTF-8 offset.
         // The difference we need to subtract is recorded in the entry prior to it.
         let index =

--- a/napi/parser/test/parse.test.ts
+++ b/napi/parser/test/parse.test.ts
@@ -105,6 +105,22 @@ it('utf16 span', async () => {
     });
     expect(ret.program.end).toMatchInlineSnapshot(`4`);
   }
+  {
+    const code = `// ∞`;
+    const ret = await parseAsync('test.js', code, {
+      convertSpanUtf16: true,
+    });
+    expect(ret.comments).toMatchInlineSnapshot(`
+      [
+        {
+          "end": 4,
+          "start": 0,
+          "type": "Line",
+          "value": " ∞",
+        },
+      ]
+    `);
+  }
 });
 
 describe('error', () => {


### PR DESCRIPTION
- closes https://github.com/oxc-project/oxc/issues/9079

I'm still leaving an existing TODO for `module_record` and `errors` span not being converted as they won't cause an immediate issue, but I'll work on that shortly.