### PR TITLE
fix(ecmascript): handle shadowed global variables in `ValueType`

### DIFF
--- a/crates/oxc_ecmascript/src/constant_evaluation/equality_comparison.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/equality_comparison.rs
@@ -8,8 +8,8 @@ pub(super) fn abstract_equality_comparison<'a>(
     left_expr: &Expression<'a>,
     right_expr: &Expression<'a>,
 ) -> Option<bool> {
-    let left = ValueType::from(left_expr);
-    let right = ValueType::from(right_expr);
+    let left = c.expression_value_type(left_expr);
+    let right = c.expression_value_type(right_expr);
     if left != ValueType::Undetermined && right != ValueType::Undetermined {
         if left == right {
             return strict_equality_comparison(c, left_expr, right_expr);
@@ -83,8 +83,8 @@ pub(super) fn strict_equality_comparison<'a>(
     left_expr: &Expression<'a>,
     right_expr: &Expression<'a>,
 ) -> Option<bool> {
-    let left = ValueType::from(left_expr);
-    let right = ValueType::from(right_expr);
+    let left = c.expression_value_type(left_expr);
+    let right = c.expression_value_type(right_expr);
     if !left.is_undetermined() && !right.is_undetermined() {
         // Strict equality can only be true for values of the same type.
         if left != right {

--- a/crates/oxc_ecmascript/src/constant_evaluation/value_type.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/value_type.rs
@@ -4,6 +4,8 @@ use oxc_ast::ast::{
 };
 use oxc_syntax::operator::{BinaryOperator, UnaryOperator};
 
+use crate::is_global_reference::IsGlobalReference;
+
 /// JavaScript Language Type
 ///
 /// <https://tc39.es/ecma262/#sec-ecmascript-language-types>
@@ -53,90 +55,97 @@ impl ValueType {
     }
 }
 
-impl<'a> From<&Expression<'a>> for ValueType {
-    /// Based on `get_known_value_type` in closure compiler
-    /// <https://github.com/google/closure-compiler/blob/v20240609/src/com/google/javascript/jscomp/NodeUtil.java#L1517>
-    ///
-    /// Evaluate the expression and attempt to determine which ValueType it could resolve to.
-    /// This function ignores the cases that throws an error, e.g. `foo * 0` can throw an error when `foo` is a bigint.
-    /// To detect those cases, use [`crate::side_effects::MayHaveSideEffects::expression_may_have_side_effects`].
-    fn from(expr: &Expression<'a>) -> Self {
+/// Based on `get_known_value_type` in closure compiler
+/// <https://github.com/google/closure-compiler/blob/v20240609/src/com/google/javascript/jscomp/NodeUtil.java#L1517>
+///
+/// Evaluate the expression and attempt to determine which ValueType it could resolve to.
+/// This function ignores the cases that throws an error, e.g. `foo * 0` can throw an error when `foo` is a bigint.
+/// To detect those cases, use [`crate::side_effects::MayHaveSideEffects::expression_may_have_side_effects`].
+pub trait DetermineValueType: IsGlobalReference {
+    fn expression_value_type(&self, expr: &Expression<'_>) -> ValueType {
         match expr {
-            Expression::BigIntLiteral(_) => Self::BigInt,
-            Expression::BooleanLiteral(_) | Expression::PrivateInExpression(_) => Self::Boolean,
-            Expression::NullLiteral(_) => Self::Null,
-            Expression::NumericLiteral(_) => Self::Number,
-            Expression::StringLiteral(_) | Expression::TemplateLiteral(_) => Self::String,
+            Expression::BigIntLiteral(_) => ValueType::BigInt,
+            Expression::BooleanLiteral(_) | Expression::PrivateInExpression(_) => {
+                ValueType::Boolean
+            }
+            Expression::NullLiteral(_) => ValueType::Null,
+            Expression::NumericLiteral(_) => ValueType::Number,
+            Expression::StringLiteral(_) | Expression::TemplateLiteral(_) => ValueType::String,
             Expression::ObjectExpression(_)
             | Expression::ArrayExpression(_)
             | Expression::RegExpLiteral(_)
             | Expression::FunctionExpression(_)
             | Expression::ArrowFunctionExpression(_)
-            | Expression::ClassExpression(_) => Self::Object,
+            | Expression::ClassExpression(_) => ValueType::Object,
             Expression::MetaProperty(meta_prop) => {
                 match (meta_prop.meta.name.as_str(), meta_prop.property.name.as_str()) {
-                    ("import", "meta") => Self::Object,
-                    _ => Self::Undetermined,
+                    ("import", "meta") => ValueType::Object,
+                    _ => ValueType::Undetermined,
                 }
             }
-            Expression::Identifier(ident) => match ident.name.as_str() {
-                "undefined" => Self::Undefined,
-                "NaN" | "Infinity" => Self::Number,
-                _ => Self::Undetermined,
-            },
+            Expression::Identifier(ident) => {
+                if self.is_global_reference(ident) {
+                    match ident.name.as_str() {
+                        "undefined" => ValueType::Undefined,
+                        "NaN" | "Infinity" => ValueType::Number,
+                        _ => ValueType::Undetermined,
+                    }
+                } else {
+                    ValueType::Undetermined
+                }
+            }
             Expression::UnaryExpression(unary_expr) => match unary_expr.operator {
-                UnaryOperator::Void => Self::Undefined,
+                UnaryOperator::Void => ValueType::Undefined,
                 UnaryOperator::UnaryNegation | UnaryOperator::BitwiseNot => {
-                    let argument_ty = Self::from(&unary_expr.argument);
+                    let argument_ty = self.expression_value_type(&unary_expr.argument);
                     match argument_ty {
-                        Self::BigInt => Self::BigInt,
+                        ValueType::BigInt => ValueType::BigInt,
                         // non-object values other than BigInt are converted to number by `ToNumber`
-                        Self::Number
-                        | Self::Boolean
-                        | Self::String
-                        | Self::Null
-                        | Self::Undefined => Self::Number,
-                        Self::Undetermined | Self::Object => Self::Undetermined,
+                        ValueType::Number
+                        | ValueType::Boolean
+                        | ValueType::String
+                        | ValueType::Null
+                        | ValueType::Undefined => ValueType::Number,
+                        ValueType::Undetermined | ValueType::Object => ValueType::Undetermined,
                     }
                 }
-                UnaryOperator::UnaryPlus => Self::Number,
-                UnaryOperator::LogicalNot | UnaryOperator::Delete => Self::Boolean,
-                UnaryOperator::Typeof => Self::String,
+                UnaryOperator::UnaryPlus => ValueType::Number,
+                UnaryOperator::LogicalNot | UnaryOperator::Delete => ValueType::Boolean,
+                UnaryOperator::Typeof => ValueType::String,
             },
-            Expression::BinaryExpression(e) => Self::from(&**e),
-            Expression::SequenceExpression(e) => {
-                e.expressions.last().map_or(ValueType::Undetermined, Self::from)
-            }
-            Expression::AssignmentExpression(e) => Self::from(&**e),
-            Expression::ConditionalExpression(e) => Self::from(&**e),
-            Expression::LogicalExpression(e) => Self::from(&**e),
-            Expression::ParenthesizedExpression(e) => Self::from(&e.expression),
-            _ => Self::Undetermined,
+            Expression::BinaryExpression(e) => self.binary_expression_value_type(e),
+            Expression::SequenceExpression(e) => e
+                .expressions
+                .last()
+                .map_or(ValueType::Undetermined, |e| self.expression_value_type(e)),
+            Expression::AssignmentExpression(e) => self.assignment_expression_value_type(e),
+            Expression::ConditionalExpression(e) => self.conditional_expression_value_type(e),
+            Expression::LogicalExpression(e) => self.logical_expression_value_type(e),
+            Expression::ParenthesizedExpression(e) => self.expression_value_type(&e.expression),
+            _ => ValueType::Undetermined,
         }
     }
-}
 
-impl<'a> From<&BinaryExpression<'a>> for ValueType {
-    fn from(e: &BinaryExpression<'a>) -> Self {
+    fn binary_expression_value_type(&self, e: &BinaryExpression<'_>) -> ValueType {
         match e.operator {
             BinaryOperator::Addition => {
-                let left = Self::from(&e.left);
-                let right = Self::from(&e.right);
-                if left == Self::Boolean
-                    && matches!(right, Self::Undefined | Self::Null | Self::Number)
+                let left = self.expression_value_type(&e.left);
+                let right = self.expression_value_type(&e.right);
+                if left == ValueType::Boolean
+                    && matches!(right, ValueType::Undefined | ValueType::Null | ValueType::Number)
                 {
-                    return Self::Number;
+                    return ValueType::Number;
                 }
-                if left == Self::String || right == Self::String {
-                    return Self::String;
+                if left == ValueType::String || right == ValueType::String {
+                    return ValueType::String;
                 }
                 // There are some pretty weird cases for object types:
                 //   {} + [] === "0"
                 //   [] + {} === "[object Object]"
-                if left == Self::Object || right == Self::Object {
-                    return Self::Undetermined;
+                if left == ValueType::Object || right == ValueType::Object {
+                    return ValueType::Undetermined;
                 }
-                Self::Undetermined
+                ValueType::Undetermined
             }
             BinaryOperator::Subtraction
             | BinaryOperator::Multiplication
@@ -148,22 +157,22 @@ impl<'a> From<&BinaryExpression<'a>> for ValueType {
             | BinaryOperator::BitwiseXOR
             | BinaryOperator::BitwiseAnd
             | BinaryOperator::Exponential => {
-                let left = Self::from(&e.left);
-                let right = Self::from(&e.right);
+                let left = self.expression_value_type(&e.left);
+                let right = self.expression_value_type(&e.right);
                 if left.is_bigint() || right.is_bigint() {
-                    Self::BigInt
+                    ValueType::BigInt
                 } else if !(left.is_object() || left.is_undetermined())
                     || !(right.is_object() || right.is_undetermined())
                 {
                     // non-object values other than BigInt are converted to number by `ToNumber`
                     // if either operand is a number, the result is always a number
                     // because if the other operand is a bigint, an error is thrown
-                    Self::Number
+                    ValueType::Number
                 } else {
-                    Self::Undetermined
+                    ValueType::Undetermined
                 }
             }
-            BinaryOperator::ShiftRightZeroFill => Self::Number,
+            BinaryOperator::ShiftRightZeroFill => ValueType::Number,
             BinaryOperator::Instanceof
             | BinaryOperator::In
             | BinaryOperator::Equality
@@ -173,21 +182,19 @@ impl<'a> From<&BinaryExpression<'a>> for ValueType {
             | BinaryOperator::LessThan
             | BinaryOperator::LessEqualThan
             | BinaryOperator::GreaterThan
-            | BinaryOperator::GreaterEqualThan => Self::Boolean,
+            | BinaryOperator::GreaterEqualThan => ValueType::Boolean,
         }
     }
-}
 
-impl<'a> From<&AssignmentExpression<'a>> for ValueType {
-    fn from(e: &AssignmentExpression<'a>) -> Self {
+    fn assignment_expression_value_type(&self, e: &AssignmentExpression<'_>) -> ValueType {
         match e.operator {
-            AssignmentOperator::Assign => Self::from(&e.right),
+            AssignmentOperator::Assign => self.expression_value_type(&e.right),
             AssignmentOperator::Addition => {
-                let right = Self::from(&e.right);
+                let right = self.expression_value_type(&e.right);
                 if right.is_string() {
-                    Self::String
+                    ValueType::String
                 } else {
-                    Self::Undetermined
+                    ValueType::Undetermined
                 }
             }
             AssignmentOperator::Subtraction
@@ -200,47 +207,43 @@ impl<'a> From<&AssignmentExpression<'a>> for ValueType {
             | AssignmentOperator::BitwiseXOR
             | AssignmentOperator::BitwiseAnd
             | AssignmentOperator::Exponential => {
-                let right = Self::from(&e.right);
+                let right = self.expression_value_type(&e.right);
                 if right.is_bigint() {
-                    Self::BigInt
+                    ValueType::BigInt
                 } else if !(right.is_object() || right.is_undetermined()) {
-                    Self::Number
+                    ValueType::Number
                 } else {
-                    Self::Undetermined
+                    ValueType::Undetermined
                 }
             }
-            AssignmentOperator::ShiftRightZeroFill => Self::Number,
+            AssignmentOperator::ShiftRightZeroFill => ValueType::Number,
             AssignmentOperator::LogicalAnd
             | AssignmentOperator::LogicalOr
-            | AssignmentOperator::LogicalNullish => Self::Undetermined,
+            | AssignmentOperator::LogicalNullish => ValueType::Undetermined,
         }
     }
-}
 
-impl<'a> From<&ConditionalExpression<'a>> for ValueType {
-    fn from(e: &ConditionalExpression<'a>) -> Self {
-        let left = Self::from(&e.consequent);
+    fn conditional_expression_value_type(&self, e: &ConditionalExpression<'_>) -> ValueType {
+        let left = self.expression_value_type(&e.consequent);
         if left.is_undetermined() {
-            return Self::Undetermined;
+            return ValueType::Undetermined;
         }
-        let right = Self::from(&e.alternate);
+        let right = self.expression_value_type(&e.alternate);
         if left == right {
             return left;
         }
-        Self::Undetermined
+        ValueType::Undetermined
     }
-}
 
-impl<'a> From<&LogicalExpression<'a>> for ValueType {
-    fn from(e: &LogicalExpression<'a>) -> Self {
-        let left = Self::from(&e.left);
+    fn logical_expression_value_type(&self, e: &LogicalExpression<'_>) -> ValueType {
+        let left = self.expression_value_type(&e.left);
         if !left.is_boolean() {
-            return Self::Undetermined;
+            return ValueType::Undetermined;
         }
-        let right = Self::from(&e.right);
+        let right = self.expression_value_type(&e.right);
         if left == right {
             return left;
         }
-        Self::Undetermined
+        ValueType::Undetermined
     }
 }

--- a/crates/oxc_ecmascript/src/is_global_reference.rs
+++ b/crates/oxc_ecmascript/src/is_global_reference.rs
@@ -1,0 +1,5 @@
+use oxc_ast::ast::IdentifierReference;
+
+pub trait IsGlobalReference {
+    fn is_global_reference(&self, reference: &IdentifierReference<'_>) -> bool;
+}

--- a/crates/oxc_ecmascript/src/lib.rs
+++ b/crates/oxc_ecmascript/src/lib.rs
@@ -22,6 +22,8 @@ mod to_integer_or_infinity;
 mod to_number;
 mod to_string;
 
+pub mod is_global_reference;
+
 #[cfg(feature = "constant_evaluation")]
 pub mod constant_evaluation;
 

--- a/crates/oxc_ecmascript/src/side_effects/may_have_side_effects.rs
+++ b/crates/oxc_ecmascript/src/side_effects/may_have_side_effects.rs
@@ -1,5 +1,7 @@
 use oxc_ast::ast::*;
 
+use crate::is_global_reference::IsGlobalReference;
+
 /// Returns true if subtree changes application state.
 ///
 /// This trait assumes the following:
@@ -11,9 +13,7 @@ use oxc_ast::ast::*;
 /// - TDZ errors does not happen.
 ///
 /// Ported from [closure-compiler](https://github.com/google/closure-compiler/blob/f3ce5ed8b630428e311fe9aa2e20d36560d975e2/src/com/google/javascript/jscomp/AstAnalyzer.java#L94)
-pub trait MayHaveSideEffects: Sized {
-    fn is_global_reference(&self, ident: &IdentifierReference<'_>) -> bool;
-
+pub trait MayHaveSideEffects: Sized + IsGlobalReference {
     fn expression_may_have_side_effects(&self, e: &Expression<'_>) -> bool {
         match e {
             Expression::Identifier(ident) => match ident.name.as_str() {

--- a/crates/oxc_minifier/src/ctx.rs
+++ b/crates/oxc_minifier/src/ctx.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use oxc_ast::{ast::*, AstBuilder};
 use oxc_ecmascript::{
-    constant_evaluation::{ConstantEvaluation, ConstantValue},
+    constant_evaluation::{ConstantEvaluation, ConstantValue, DetermineValueType},
     side_effects::MayHaveSideEffects,
 };
 use oxc_semantic::{IsGlobalReference, SymbolTable};
@@ -19,15 +19,19 @@ impl<'a, 'b> Deref for Ctx<'a, 'b> {
     }
 }
 
-impl<'a> ConstantEvaluation<'a> for Ctx<'a, '_> {
-    fn ast(&self) -> AstBuilder<'a> {
-        self.ast
+impl oxc_ecmascript::is_global_reference::IsGlobalReference for Ctx<'_, '_> {
+    fn is_global_reference(&self, ident: &IdentifierReference<'_>) -> bool {
+        ident.is_global_reference(self.0.symbols())
     }
 }
 
-impl MayHaveSideEffects for Ctx<'_, '_> {
-    fn is_global_reference(&self, ident: &IdentifierReference<'_>) -> bool {
-        ident.is_global_reference(self.0.symbols())
+impl MayHaveSideEffects for Ctx<'_, '_> {}
+
+impl DetermineValueType for Ctx<'_, '_> {}
+
+impl<'a> ConstantEvaluation<'a> for Ctx<'a, '_> {
+    fn ast(&self) -> AstBuilder<'a> {
+        self.ast
     }
 }
 

--- a/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
@@ -1,5 +1,5 @@
 use oxc_ast::ast::*;
-use oxc_ecmascript::constant_evaluation::{ConstantEvaluation, ValueType};
+use oxc_ecmascript::constant_evaluation::{ConstantEvaluation, DetermineValueType};
 use oxc_span::GetSpan;
 use oxc_traverse::Ancestor;
 
@@ -53,7 +53,7 @@ impl<'a> PeepholeOptimizations {
             Expression::BinaryExpression(e)
                 if e.operator.is_equality()
                     && matches!(&e.right, Expression::NumericLiteral(lit) if lit.value == 0.0)
-                    && ValueType::from(&e.left).is_number() =>
+                    && ctx.expression_value_type(&e.left).is_number() =>
             {
                 let argument = ctx.ast.move_expression(&mut e.left);
                 *expr = if matches!(

--- a/crates/oxc_minifier/src/peephole/minimize_not_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_not_expression.rs
@@ -1,5 +1,5 @@
 use oxc_ast::ast::*;
-use oxc_ecmascript::constant_evaluation::ValueType;
+use oxc_ecmascript::constant_evaluation::DetermineValueType;
 use oxc_span::GetSpan;
 
 use crate::ctx::Ctx;
@@ -32,7 +32,7 @@ impl<'a> PeepholeOptimizations {
             // `!!true` -> `true`
             // `!!false` -> `false`
             Expression::UnaryExpression(e)
-                if e.operator.is_not() && ValueType::from(&e.argument).is_boolean() =>
+                if e.operator.is_not() && ctx.expression_value_type(&e.argument).is_boolean() =>
             {
                 Some(ctx.ast.move_expression(&mut e.argument))
             }

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -1,6 +1,6 @@
 use oxc_ast::ast::*;
 use oxc_ecmascript::{
-    constant_evaluation::{IsLiteralValue, ValueType},
+    constant_evaluation::{DetermineValueType, IsLiteralValue, ValueType},
     side_effects::MayHaveSideEffects,
 };
 use oxc_span::GetSpan;
@@ -162,7 +162,7 @@ impl<'a> PeepholeOptimizations {
                 0 => true,
                 1 => {
                     let Some(arg) = e.arguments[0].as_expression() else { return false };
-                    let ty = ValueType::from(arg);
+                    let ty = ctx.expression_value_type(arg);
                     matches!(
                         ty,
                         ValueType::Null

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -4,7 +4,7 @@ use std::borrow::Cow;
 use oxc_allocator::IntoIn;
 use oxc_ast::ast::*;
 use oxc_ecmascript::{
-    constant_evaluation::{ConstantEvaluation, ValueType},
+    constant_evaluation::{ConstantEvaluation, DetermineValueType},
     StringCharAt, StringCharAtResult, StringCharCodeAt, StringIndexOf, StringLastIndexOf,
     StringSubstring, ToInt32,
 };
@@ -379,7 +379,7 @@ impl<'a> PeepholeOptimizations {
         let first_arg = first_arg.to_expression_mut(); // checked above
 
         let wrap_with_unary_plus_if_needed = |expr: &mut Expression<'a>| {
-            if ValueType::from(&*expr).is_number() {
+            if ctx.expression_value_type(&*expr).is_number() {
                 ctx.ast.move_expression(expr)
             } else {
                 ctx.ast.expression_unary(

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1,8 +1,7 @@
 use oxc_allocator::{CloneIn, Vec};
 use oxc_ast::{ast::*, NONE};
-use oxc_ecmascript::{
-    constant_evaluation::ValueType, side_effects::MayHaveSideEffects, ToJsString, ToNumber,
-};
+use oxc_ecmascript::constant_evaluation::DetermineValueType;
+use oxc_ecmascript::{side_effects::MayHaveSideEffects, ToJsString, ToNumber};
 use oxc_span::GetSpan;
 use oxc_span::SPAN;
 use oxc_syntax::{
@@ -217,11 +216,11 @@ impl<'a> PeepholeOptimizations {
         let parent_expression_does_to_number_conversion = match parent_expression {
             Ancestor::BinaryExpressionLeft(e) => {
                 Self::is_binary_operator_that_does_number_conversion(*e.operator())
-                    && ValueType::from(e.right()).is_number()
+                    && ctx.expression_value_type(e.right()).is_number()
             }
             Ancestor::BinaryExpressionRight(e) => {
                 Self::is_binary_operator_that_does_number_conversion(*e.operator())
-                    && ValueType::from(e.left()).is_number()
+                    && ctx.expression_value_type(e.left()).is_number()
             }
             _ => false,
         };
@@ -741,7 +740,7 @@ impl<'a> PeepholeOptimizations {
                 arguments_len == 0
                     || (arguments_len >= 1
                         && e.arguments[0].as_expression().is_some_and(|first_argument| {
-                            let ty = ValueType::from(first_argument);
+                            let ty = ctx.expression_value_type(first_argument);
                             !ty.is_undetermined() && !ty.is_object()
                         }))
             }

--- a/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
+++ b/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
@@ -1,17 +1,18 @@
 use oxc_allocator::Allocator;
 use oxc_ast::ast::{IdentifierReference, Statement};
-use oxc_ecmascript::side_effects::MayHaveSideEffects;
+use oxc_ecmascript::{is_global_reference::IsGlobalReference, side_effects::MayHaveSideEffects};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 
 struct SideEffectChecker {
     global_variable_names: Vec<String>,
 }
-impl MayHaveSideEffects for SideEffectChecker {
+impl IsGlobalReference for SideEffectChecker {
     fn is_global_reference(&self, ident: &IdentifierReference<'_>) -> bool {
         self.global_variable_names.iter().any(|name| name == ident.name.as_str())
     }
 }
+impl MayHaveSideEffects for SideEffectChecker {}
 
 fn test(source_text: &str, expected: bool) {
     test_with_global_variables(source_text, vec![], expected);


### PR DESCRIPTION
To fix the following case:
```js
function foo(undefined) {
  undefined // this should not be ValueType::Undefined
}
```