### PR TITLE
fix(ast/estree): fix TS types for `BigIntLiteral` and `RegExpLiteral`

### DIFF
--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -106,7 +106,7 @@ pub struct StringLiteral<'a> {
         value = crate::serialize::NULL,
         bigint = crate::serialize::bigint_literal_bigint(self),
     ),
-    add_ts = "value: null, bigint: string",
+    add_ts = "value: BigInt, bigint: string",
 )]
 pub struct BigIntLiteral<'a> {
     /// Node location in source code
@@ -129,7 +129,7 @@ pub struct BigIntLiteral<'a> {
 #[estree(
     rename = "Literal",
     add_fields(value = crate::serialize::NULL),
-    add_ts = "value: null",
+    add_ts = "value: RegExp | null",
 )]
 pub struct RegExpLiteral<'a> {
     /// Node location in source code

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -810,7 +810,7 @@ export interface StringLiteral extends Span {
 export interface BigIntLiteral extends Span {
   type: 'Literal';
   raw: string | null;
-  value: null;
+  value: BigInt;
   bigint: string;
 }
 
@@ -818,7 +818,7 @@ export interface RegExpLiteral extends Span {
   type: 'Literal';
   regex: RegExp;
   raw: string | null;
-  value: null;
+  value: RegExp | null;
 }
 
 export interface RegExp {


### PR DESCRIPTION
The `value` fields of these 2 types are `null` in the JSON AST, but they're converted to `BigInt` or `RegExp`s on JS side. Adjust the TS type definitions accordingly.