### PR TITLE
fix(ast/estree): fix TS type for `AssignmentTargetPropertyIdentifier`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -898,7 +898,7 @@ pub enum AssignmentTargetProperty<'a> {
 #[estree(
     rename = "Property",
     add_fields(kind = "\"init\"", method = false, shorthand = true, computed = false),
-    add_ts = "kind: \"init\"; method: false; shorthand: false; computed: false"
+    add_ts = "kind: \"init\"; method: false; shorthand: true; computed: false"
 )]
 pub struct AssignmentTargetPropertyIdentifier<'a> {
     pub span: Span,

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -273,7 +273,7 @@ export interface AssignmentTargetPropertyIdentifier extends Span {
   value: IdentifierReference | AssignmentTargetWithDefault;
   kind: 'init';
   method: false;
-  shorthand: false;
+  shorthand: true;
   computed: false;
 }
 


### PR DESCRIPTION
Due to a typo, the TS type def for `AssignmentTargetPropertyIdentifier` was incorrect.