### PR TITLE
fix(napi/parser): utf16 span for module record

### DIFF
--- a/crates/oxc_ast/src/utf8_to_utf16.rs
+++ b/crates/oxc_ast/src/utf8_to_utf16.rs
@@ -1,6 +1,7 @@
 //! Convert UTF-8 span offsets to UTF-16.
 
 use oxc_span::Span;
+use oxc_syntax::module_record::{ModuleRecord, VisitMutModuleRecord};
 
 use crate::{ast::Program, visit::VisitMut};
 
@@ -39,6 +40,11 @@ impl Utf8ToUtf16 {
         for comment in &mut program.comments {
             self.convert_span(&mut comment.span);
         }
+    }
+
+    /// Convert spans in ModuleRecord to UTF-16
+    pub fn convert_module_record(&mut self, module_record: &mut ModuleRecord<'_>) {
+        self.visit_module_record(module_record);
     }
 
     #[expect(clippy::cast_possible_truncation)]
@@ -97,6 +103,12 @@ impl Utf8ToUtf16 {
 }
 
 impl VisitMut<'_> for Utf8ToUtf16 {
+    fn visit_span(&mut self, span: &mut Span) {
+        self.convert_span(span);
+    }
+}
+
+impl VisitMutModuleRecord for Utf8ToUtf16 {
     fn visit_span(&mut self, span: &mut Span) {
         self.convert_span(span);
     }

--- a/napi/parser/src/lib.rs
+++ b/napi/parser/src/lib.rs
@@ -86,16 +86,15 @@ fn parse_with_return(filename: &str, source_text: String, options: &ParserOption
         })
         .collect::<Vec<Comment>>();
 
-    let module = EcmaScriptModule::from(&ret.module_record);
-
     if options.convert_span_utf16.unwrap_or(false) {
-        // TODO: fix spans in `module_record` and `errors`
+        // TODO: fix spans in `errors`
 
         // Empty `comments` so comment spans don't get converted twice
         ret.program.comments.clear();
 
         let mut converter = Utf8ToUtf16::new();
         converter.convert(&mut ret.program);
+        converter.convert_module_record(&mut ret.module_record);
 
         for comment in &mut comments {
             comment.start = converter.convert_offset(comment.start);
@@ -103,7 +102,7 @@ fn parse_with_return(filename: &str, source_text: String, options: &ParserOption
         }
     }
     let program = serde_json::to_string(&ret.program).unwrap();
-
+    let module = EcmaScriptModule::from(&ret.module_record);
     ParseResult { source_text, program, module, comments, errors }
 }
 

--- a/napi/parser/test/parse.test.ts
+++ b/napi/parser/test/parse.test.ts
@@ -121,6 +121,90 @@ it('utf16 span', async () => {
       ]
     `);
   }
+  {
+    const ret = await parseAsync('test.js', `"🤨";import x from "x"; export { x };import("y");import.meta.z`, {
+      convertSpanUtf16: true,
+    });
+    expect(ret.module).toMatchInlineSnapshot(`
+      {
+        "dynamicImports": [
+          {
+            "end": 48,
+            "moduleRequest": {
+              "end": 47,
+              "start": 44,
+            },
+            "start": 37,
+          },
+        ],
+        "hasModuleSyntax": true,
+        "importMetas": [
+          {
+            "end": 60,
+            "start": 49,
+          },
+        ],
+        "staticExports": [
+          {
+            "end": 23,
+            "entries": [
+              {
+                "end": 34,
+                "exportName": {
+                  "end": 34,
+                  "kind": "Name",
+                  "name": "x",
+                  "start": 33,
+                },
+                "importName": {
+                  "end": 13,
+                  "kind": "Name",
+                  "name": "x",
+                  "start": 12,
+                },
+                "localName": {
+                  "kind": "None",
+                },
+                "moduleRequest": {
+                  "end": 22,
+                  "start": 19,
+                  "value": "x",
+                },
+                "start": 33,
+              },
+            ],
+            "start": 5,
+          },
+        ],
+        "staticImports": [
+          {
+            "end": 23,
+            "entries": [
+              {
+                "importName": {
+                  "end": 13,
+                  "kind": "Default",
+                  "start": 12,
+                },
+                "isType": false,
+                "localName": {
+                  "end": 13,
+                  "start": 12,
+                  "value": "x",
+                },
+              },
+            ],
+            "moduleRequest": {
+              "end": 22,
+              "start": 19,
+              "value": "x",
+            },
+            "start": 5,
+          },
+        ],
+      }
+    `);
+  }
 });
 
 describe('error', () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,8 +112,6 @@ importers:
 
   npm/runtime: {}
 
-  npm/wasm-web: {}
-
   tasks/benchmark/codspeed:
     devDependencies:
       axios:


### PR DESCRIPTION
I (and mostly copilot) wrote `VisitMutModuleRecord` to visit all spans as I wasn't sure how `VisitMut` is generated. I'm looking into visit generator now if it's something I can do. Please let me know if manually writing it down is fine for now or I should try macro (or maybe a completely different approach).