### PR TITLE
docs(ast): add missing docs and fix broken code for assignment targets

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -925,8 +925,18 @@ pub struct AssignmentTargetPropertyIdentifier<'a> {
 )]
 pub struct AssignmentTargetPropertyProperty<'a> {
     pub span: Span,
+    /// The property key
+    /// ```
+    /// ({ prop: renamed } = obj)
+    ///    ^^^^
+    /// ```
     #[estree(rename = "key")]
     pub name: PropertyKey<'a>,
+    /// The binding part of the property
+    /// ```
+    /// ({ prop: renamed } = obj)
+    ///          ^^^^^^^
+    /// ```
     #[estree(rename = "value")]
     pub binding: AssignmentTargetMaybeDefault<'a>,
     /// Property was declared with a computed key

--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -891,8 +891,8 @@ impl AssignmentTargetMaybeDefault<'_> {
     ///
     /// ## Example
     ///
-    /// - returns `b` when called on `a: b = 1` in `({a: b = 1} = obj)
-    /// - returns `b` when called on `a: b` in `({a: b} = obj)
+    /// - returns `b` when called on `a: b = 1` in `({a: b = 1} = obj)`
+    /// - returns `b` when called on `a: b` in `({a: b} = obj)`
     pub fn identifier(&self) -> Option<&IdentifierReference<'_>> {
         match self {
             AssignmentTargetMaybeDefault::AssignmentTargetIdentifier(id) => Some(id),

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -2641,8 +2641,8 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `name`
-    /// * `binding`
+    /// * `name`: The property key
+    /// * `binding`: The binding part of the property
     /// * `computed`: Property was declared with a computed key
     #[inline]
     pub fn assignment_target_property_assignment_target_property_property(
@@ -2699,8 +2699,8 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `name`
-    /// * `binding`
+    /// * `name`: The property key
+    /// * `binding`: The binding part of the property
     /// * `computed`: Property was declared with a computed key
     #[inline]
     pub fn assignment_target_property_property(
@@ -2719,8 +2719,8 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `name`
-    /// * `binding`
+    /// * `name`: The property key
+    /// * `binding`: The binding part of the property
     /// * `computed`: Property was declared with a computed key
     #[inline]
     pub fn alloc_assignment_target_property_property(


### PR DESCRIPTION
Adds some additional docs and examples for the `AssignmentTargetPropertyProperty` fields and the `identifer()` method on `AssignmentTargetMaybeDefault`.