### PR TITLE
feat(minifier): substitute redundant assignment target bindings

### DIFF
--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -230,6 +230,18 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         self.substitute_object_property(prop, ctx);
     }
 
+    fn exit_assignment_target_property(
+        &mut self,
+        node: &mut AssignmentTargetProperty<'a>,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+        if !self.is_prev_function_changed() {
+            return;
+        }
+        let ctx = Ctx(ctx);
+        self.substitute_assignment_target_property(node, ctx);
+    }
+
     fn exit_assignment_target_property_property(
         &mut self,
         prop: &mut AssignmentTargetPropertyProperty<'a>,

--- a/crates/oxc_minifier/tests/peephole/esbuild.rs
+++ b/crates/oxc_minifier/tests/peephole/esbuild.rs
@@ -43,8 +43,8 @@ fn js_parser_test() {
     test("x = { '-2147483648': y }", "x = { '-2147483648': y };");
     test("x = { '-2147483649': y }", "x = { '-2147483649': y };");
     test("x.x; y['y']", "x.x, y.y;");
-    // test("({y: y, 'z': z} = x)", "({ y, z } = x);");
-    // test("var {y: y, 'z': z} = x", "var { y, z } = x;");
+    test("({y: y, 'z': z} = x)", "({ y, z } = x);");
+    test("var {y: y, 'z': z} = x", "var { y, z } = x;");
     test("x = {y: 1, 'z': 2}", "x = { y: 1, z: 2 };");
     test("x = {y() {}, 'z'() {}}", "x = { y() {}, z() {} };");
     test("x = {get y() {}, set 'z'(z) {}}", "x = { get y() {}, set z(z) {} };");


### PR DESCRIPTION
For compatibility with esbuild, compresses assignment targets such as `var {'x': x} = y` down to just `var {x} = y`.