### PR TITLE
refactor(ecmascript): allow IsGlobalReference to return None

### DIFF
--- a/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
@@ -21,9 +21,9 @@ pub trait ConstantEvaluation<'a>: MayHaveSideEffects + DetermineValueType {
 
     fn resolve_binding(&self, ident: &IdentifierReference<'a>) -> Option<ConstantValue<'a>> {
         match ident.name.as_str() {
-            "undefined" if self.is_global_reference(ident) => Some(ConstantValue::Undefined),
-            "NaN" if self.is_global_reference(ident) => Some(ConstantValue::Number(f64::NAN)),
-            "Infinity" if self.is_global_reference(ident) => {
+            "undefined" if self.is_global_reference(ident)? => Some(ConstantValue::Undefined),
+            "NaN" if self.is_global_reference(ident)? => Some(ConstantValue::Number(f64::NAN)),
+            "Infinity" if self.is_global_reference(ident)? => {
                 Some(ConstantValue::Number(f64::INFINITY))
             }
             _ => None,
@@ -71,8 +71,8 @@ pub trait ConstantEvaluation<'a>: MayHaveSideEffects + DetermineValueType {
     fn get_boolean_value(&self, expr: &Expression<'a>) -> Option<bool> {
         match expr {
             Expression::Identifier(ident) => match ident.name.as_str() {
-                "undefined" | "NaN" if self.is_global_reference(ident) => Some(false),
-                "Infinity" if self.is_global_reference(ident) => Some(true),
+                "undefined" | "NaN" if self.is_global_reference(ident)? => Some(false),
+                "Infinity" if self.is_global_reference(ident)? => Some(true),
                 _ => None,
             },
             Expression::LogicalExpression(logical_expr) => {
@@ -131,8 +131,8 @@ pub trait ConstantEvaluation<'a>: MayHaveSideEffects + DetermineValueType {
     fn eval_to_number(&self, expr: &Expression<'a>) -> Option<f64> {
         match expr {
             Expression::Identifier(ident) => match ident.name.as_str() {
-                "undefined" | "NaN" if self.is_global_reference(ident) => Some(f64::NAN),
-                "Infinity" if self.is_global_reference(ident) => Some(f64::INFINITY),
+                "undefined" | "NaN" if self.is_global_reference(ident)? => Some(f64::NAN),
+                "Infinity" if self.is_global_reference(ident)? => Some(f64::INFINITY),
                 _ => None,
             },
             Expression::UnaryExpression(unary_expr) => match unary_expr.operator {
@@ -367,7 +367,7 @@ pub trait ConstantEvaluation<'a>: MayHaveSideEffects + DetermineValueType {
                 if let Expression::Identifier(right_ident) = right {
                     let name = right_ident.name.as_str();
                     if matches!(name, "Object" | "Number" | "Boolean" | "String")
-                        && self.is_global_reference(right_ident)
+                        && self.is_global_reference(right_ident) == Some(true)
                     {
                         let left_ty = self.expression_value_type(left);
                         if left_ty.is_undetermined() {

--- a/crates/oxc_ecmascript/src/constant_evaluation/value_type.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/value_type.rs
@@ -84,7 +84,7 @@ pub trait DetermineValueType: IsGlobalReference {
                 }
             }
             Expression::Identifier(ident) => {
-                if self.is_global_reference(ident) {
+                if self.is_global_reference(ident) == Some(true) {
                     match ident.name.as_str() {
                         "undefined" => ValueType::Undefined,
                         "NaN" | "Infinity" => ValueType::Number,

--- a/crates/oxc_ecmascript/src/is_global_reference.rs
+++ b/crates/oxc_ecmascript/src/is_global_reference.rs
@@ -1,5 +1,18 @@
 use oxc_ast::ast::IdentifierReference;
 
 pub trait IsGlobalReference {
-    fn is_global_reference(&self, reference: &IdentifierReference<'_>) -> bool;
+    /// Whether the reference is a global reference.
+    ///
+    /// - None means it is unknown.
+    /// - Some(true) means it is a global reference.
+    /// - Some(false) means it is not a global reference.
+    fn is_global_reference(&self, reference: &IdentifierReference<'_>) -> Option<bool>;
+}
+
+pub struct WithoutGlobalReferenceInformation;
+
+impl IsGlobalReference for WithoutGlobalReferenceInformation {
+    fn is_global_reference(&self, _reference: &IdentifierReference<'_>) -> Option<bool> {
+        None
+    }
 }

--- a/crates/oxc_ecmascript/src/side_effects/may_have_side_effects.rs
+++ b/crates/oxc_ecmascript/src/side_effects/may_have_side_effects.rs
@@ -21,7 +21,7 @@ pub trait MayHaveSideEffects: Sized + IsGlobalReference {
                 // Reading global variables may have a side effect.
                 // NOTE: It should also return true when the reference might refer to a reference value created by a with statement
                 // NOTE: we ignore TDZ errors
-                _ => self.is_global_reference(ident),
+                _ => self.is_global_reference(ident) != Some(false),
             },
             Expression::NumericLiteral(_)
             | Expression::BooleanLiteral(_)
@@ -283,7 +283,7 @@ fn maybe_symbol_or_to_primitive_may_return_symbol(
     match expr {
         Expression::Identifier(ident) => {
             !(matches!(ident.name.as_str(), "Infinity" | "NaN" | "undefined")
-                && m.is_global_reference(ident))
+                && m.is_global_reference(ident) == Some(true))
         }
         Expression::StringLiteral(_)
         | Expression::TemplateLiteral(_)
@@ -310,7 +310,7 @@ fn maybe_symbol_or_bigint_or_to_primitive_may_return_symbol_or_bigint(
     match expr {
         Expression::Identifier(ident) => {
             !(matches!(ident.name.as_str(), "Infinity" | "NaN" | "undefined")
-                && m.is_global_reference(ident))
+                && m.is_global_reference(ident) == Some(true))
         }
         Expression::StringLiteral(_)
         | Expression::TemplateLiteral(_)

--- a/crates/oxc_minifier/src/ctx.rs
+++ b/crates/oxc_minifier/src/ctx.rs
@@ -20,8 +20,8 @@ impl<'a, 'b> Deref for Ctx<'a, 'b> {
 }
 
 impl oxc_ecmascript::is_global_reference::IsGlobalReference for Ctx<'_, '_> {
-    fn is_global_reference(&self, ident: &IdentifierReference<'_>) -> bool {
-        ident.is_global_reference(self.0.symbols())
+    fn is_global_reference(&self, ident: &IdentifierReference<'_>) -> Option<bool> {
+        Some(ident.is_global_reference(self.0.symbols()))
     }
 }
 

--- a/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
+++ b/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
@@ -8,8 +8,8 @@ struct SideEffectChecker {
     global_variable_names: Vec<String>,
 }
 impl IsGlobalReference for SideEffectChecker {
-    fn is_global_reference(&self, ident: &IdentifierReference<'_>) -> bool {
-        self.global_variable_names.iter().any(|name| name == ident.name.as_str())
+    fn is_global_reference(&self, ident: &IdentifierReference<'_>) -> Option<bool> {
+        Some(self.global_variable_names.iter().any(|name| name == ident.name.as_str()))
     }
 }
 impl MayHaveSideEffects for SideEffectChecker {}

--- a/crates/oxc_minifier/tests/ecmascript/value_type.rs
+++ b/crates/oxc_minifier/tests/ecmascript/value_type.rs
@@ -11,8 +11,8 @@ struct ValueTypeCalculator {
     global_variable_names: Vec<String>,
 }
 impl IsGlobalReference for ValueTypeCalculator {
-    fn is_global_reference(&self, ident: &IdentifierReference<'_>) -> bool {
-        self.global_variable_names.iter().any(|name| name == ident.name.as_str())
+    fn is_global_reference(&self, ident: &IdentifierReference<'_>) -> Option<bool> {
+        Some(self.global_variable_names.iter().any(|name| name == ident.name.as_str()))
     }
 }
 impl DetermineValueType for ValueTypeCalculator {}


### PR DESCRIPTION
so that the function can be used when the global reference information is not available