### PR TITLE
refactor(ecmascript): pass IsGlobalReference to MayHaveSideEffects instead of extending it

### DIFF
--- a/crates/oxc_ecmascript/src/constant_evaluation/value_type.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/value_type.rs
@@ -60,7 +60,7 @@ impl ValueType {
 ///
 /// Evaluate the expression and attempt to determine which ValueType it could resolve to.
 /// This function ignores the cases that throws an error, e.g. `foo * 0` can throw an error when `foo` is a bigint.
-/// To detect those cases, use [`crate::side_effects::MayHaveSideEffects::expression_may_have_side_effects`].
+/// To detect those cases, use [`crate::side_effects::MayHaveSideEffects`].
 pub trait DetermineValueType: IsGlobalReference {
     fn expression_value_type(&self, expr: &Expression<'_>) -> ValueType {
         match expr {

--- a/crates/oxc_ecmascript/src/is_global_reference.rs
+++ b/crates/oxc_ecmascript/src/is_global_reference.rs
@@ -1,6 +1,6 @@
 use oxc_ast::ast::IdentifierReference;
 
-pub trait IsGlobalReference {
+pub trait IsGlobalReference: Sized {
     /// Whether the reference is a global reference.
     ///
     /// - None means it is unknown.

--- a/crates/oxc_minifier/src/ctx.rs
+++ b/crates/oxc_minifier/src/ctx.rs
@@ -1,10 +1,7 @@
 use std::ops::Deref;
 
 use oxc_ast::{ast::*, AstBuilder};
-use oxc_ecmascript::{
-    constant_evaluation::{ConstantEvaluation, ConstantValue, DetermineValueType},
-    side_effects::MayHaveSideEffects,
-};
+use oxc_ecmascript::constant_evaluation::{ConstantEvaluation, ConstantValue, DetermineValueType};
 use oxc_semantic::{IsGlobalReference, SymbolTable};
 use oxc_traverse::TraverseCtx;
 
@@ -24,8 +21,6 @@ impl oxc_ecmascript::is_global_reference::IsGlobalReference for Ctx<'_, '_> {
         Some(ident.is_global_reference(self.0.symbols()))
     }
 }
-
-impl MayHaveSideEffects for Ctx<'_, '_> {}
 
 impl DetermineValueType for Ctx<'_, '_> {}
 

--- a/crates/oxc_minifier/src/peephole/minimize_conditional_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditional_expression.rs
@@ -247,8 +247,8 @@ impl<'a> PeepholeOptimizations {
                 // we can improve compression by allowing side effects on one side if the other side is
                 // an identifier that is not modified after it is declared.
                 // but for now, we only perform compression if neither side has side effects.
-                && !(ctx.expression_may_have_side_effects(&expr.test)
-                    || ctx.expression_may_have_side_effects(&consequent.callee))
+                && !(expr.test.may_have_side_effects(&ctx)
+                    || consequent.callee.may_have_side_effects(&ctx))
                 && ctx.expr_eq(&consequent.callee, &alternate.callee)
                 && consequent
                     .arguments

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -574,7 +574,7 @@ impl<'a> PeepholeOptimizations {
                                 && var_decl.declarations[0]
                                     .init
                                     .as_ref()
-                                    .is_some_and(|init| ctx.expression_may_have_side_effects(init))
+                                    .is_some_and(|init| init.may_have_side_effects(&ctx))
                         } else {
                             // the spec does not allow multiple declarations though
                             true

--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -340,7 +340,7 @@ impl<'a, 'b> PeepholeOptimizations {
         }
 
         ctx.get_boolean_value(&expr.test).map(|v| {
-            if ctx.expression_may_have_side_effects(&expr.test) {
+            if expr.test.may_have_side_effects(&ctx) {
                 // "(a, true) ? b : c" => "a, b"
                 let exprs = ctx.ast.vec_from_iter([
                     {
@@ -377,9 +377,7 @@ impl<'a, 'b> PeepholeOptimizations {
         let (should_fold, new_len) = sequence_expr.expressions.iter().enumerate().fold(
             (false, 0),
             |(mut should_fold, mut new_len), (i, expr)| {
-                if i == sequence_expr.expressions.len() - 1
-                    || ctx.expression_may_have_side_effects(expr)
-                {
+                if i == sequence_expr.expressions.len() - 1 || expr.may_have_side_effects(&ctx) {
                     new_len += 1;
                 } else {
                     should_fold = true;
@@ -396,7 +394,7 @@ impl<'a, 'b> PeepholeOptimizations {
             let mut new_exprs = ctx.ast.vec_with_capacity(new_len);
             let len = sequence_expr.expressions.len();
             for (i, expr) in sequence_expr.expressions.iter_mut().enumerate() {
-                if i == len - 1 || ctx.expression_may_have_side_effects(expr) {
+                if i == len - 1 || expr.may_have_side_effects(&ctx) {
                     new_exprs.push(ctx.ast.move_expression(expr));
                 }
             }

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -170,7 +170,7 @@ impl<'a> PeepholeOptimizations {
                             | ValueType::Boolean
                             | ValueType::Number
                             | ValueType::String
-                    ) && !ctx.expression_may_have_side_effects(arg)
+                    ) && !arg.may_have_side_effects(&ctx)
                 }
                 _ => false,
             },

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -536,7 +536,7 @@ impl<'a> PeepholeOptimizations {
         if !match argument {
             Expression::Identifier(ident) => ctx.is_identifier_undefined(ident),
             Expression::UnaryExpression(e) => {
-                e.operator.is_void() && !ctx.expression_may_have_side_effects(argument)
+                e.operator.is_void() && !argument.may_have_side_effects(&ctx)
             }
             _ => false,
         } {


### PR DESCRIPTION
so that it can be used without creating a struct that implements MayHaveSideEffects.