### PR TITLE
fix(ecmascript): to_string for object with toString

### DIFF
--- a/crates/oxc_ecmascript/src/to_primitive.rs
+++ b/crates/oxc_ecmascript/src/to_primitive.rs
@@ -107,7 +107,7 @@ impl ToPrimitive<'_> for Expression<'_> {
     }
 }
 
-fn maybe_object_with_to_primitive_related_properties_overridden(
+pub(crate) fn maybe_object_with_to_primitive_related_properties_overridden(
     obj: &ObjectExpression<'_>,
 ) -> bool {
     obj.properties.iter().any(|prop| match prop {

--- a/crates/oxc_ecmascript/src/to_string.rs
+++ b/crates/oxc_ecmascript/src/to_string.rs
@@ -3,7 +3,10 @@ use std::borrow::Cow;
 use oxc_ast::ast::*;
 use oxc_syntax::operator::UnaryOperator;
 
-use crate::{array_join::ArrayJoin, is_global_reference::IsGlobalReference, ToBoolean};
+use crate::{
+    array_join::ArrayJoin, is_global_reference::IsGlobalReference,
+    to_primitive::maybe_object_with_to_primitive_related_properties_overridden, ToBoolean,
+};
 
 /// `ToString`
 ///
@@ -132,6 +135,10 @@ impl<'a> ToJsString<'a> for ArrayExpression<'a> {
 
 impl<'a> ToJsString<'a> for ObjectExpression<'a> {
     fn to_js_string(&self, _is_global_reference: &impl IsGlobalReference) -> Option<Cow<'a, str>> {
-        Some(Cow::Borrowed("[object Object]"))
+        if maybe_object_with_to_primitive_related_properties_overridden(self) {
+            None
+        } else {
+            Some(Cow::Borrowed("[object Object]"))
+        }
     }
 }

--- a/crates/oxc_minifier/tests/ecmascript/to_string.rs
+++ b/crates/oxc_minifier/tests/ecmascript/to_string.rs
@@ -1,6 +1,9 @@
 use oxc_allocator::Allocator;
 use oxc_ast::{ast::*, AstBuilder};
-use oxc_ecmascript::{is_global_reference::IsGlobalReference, ToJsString};
+use oxc_ecmascript::{
+    is_global_reference::{IsGlobalReference, WithoutGlobalReferenceInformation},
+    ToJsString,
+};
 use oxc_span::SPAN;
 
 struct GlobalReferenceInformation {
@@ -28,6 +31,26 @@ fn test() {
     let global_undefined_string =
         undefined.to_js_string(&GlobalReferenceInformation { is_undefined_shadowed: false });
 
+    let empty_object = ast.expression_object(SPAN, ast.vec(), None);
+    let object_with_to_string = ast.expression_object(
+        SPAN,
+        ast.vec1(ast.object_property_kind_object_property(
+            SPAN,
+            PropertyKind::Init,
+            ast.property_key_static_identifier(SPAN, "toString"),
+            ast.expression_string_literal(SPAN, "foo", None),
+            false,
+            false,
+            false,
+        )),
+        None,
+    );
+    let empty_object_string = empty_object.to_js_string(&WithoutGlobalReferenceInformation {});
+    let object_with_to_string_string =
+        object_with_to_string.to_js_string(&WithoutGlobalReferenceInformation {});
+
     assert_eq!(shadowed_undefined_string, None);
     assert_eq!(global_undefined_string, Some("undefined".into()));
+    assert_eq!(empty_object_string, Some("[object Object]".into()));
+    assert_eq!(object_with_to_string_string, None);
 }


### PR DESCRIPTION
`({} + "")` returns `"[object Object]"` but `({ toString() { return "foo" } } + "")` does not.