### PR TITLE
refactor(ecmascript): pass IsGlobalReference to DetermineValueType instead of extending it

### DIFF
--- a/crates/oxc_ecmascript/src/constant_evaluation/equality_comparison.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/equality_comparison.rs
@@ -1,6 +1,6 @@
 use oxc_ast::ast::{Expression, NumberBase};
 
-use super::{ConstantEvaluation, ValueType};
+use super::{ConstantEvaluation, DetermineValueType, ValueType};
 
 /// <https://tc39.es/ecma262/#sec-abstract-equality-comparison>
 pub(super) fn abstract_equality_comparison<'a>(
@@ -8,8 +8,8 @@ pub(super) fn abstract_equality_comparison<'a>(
     left_expr: &Expression<'a>,
     right_expr: &Expression<'a>,
 ) -> Option<bool> {
-    let left = c.expression_value_type(left_expr);
-    let right = c.expression_value_type(right_expr);
+    let left = left_expr.value_type(c);
+    let right = right_expr.value_type(c);
     if left != ValueType::Undetermined && right != ValueType::Undetermined {
         if left == right {
             return strict_equality_comparison(c, left_expr, right_expr);
@@ -83,8 +83,8 @@ pub(super) fn strict_equality_comparison<'a>(
     left_expr: &Expression<'a>,
     right_expr: &Expression<'a>,
 ) -> Option<bool> {
-    let left = c.expression_value_type(left_expr);
-    let right = c.expression_value_type(right_expr);
+    let left = left_expr.value_type(c);
+    let right = right_expr.value_type(c);
     if !left.is_undetermined() && !right.is_undetermined() {
         // Strict equality can only be true for values of the same type.
         if left != right {

--- a/crates/oxc_minifier/src/ctx.rs
+++ b/crates/oxc_minifier/src/ctx.rs
@@ -1,7 +1,7 @@
 use std::ops::Deref;
 
 use oxc_ast::{ast::*, AstBuilder};
-use oxc_ecmascript::constant_evaluation::{ConstantEvaluation, ConstantValue, DetermineValueType};
+use oxc_ecmascript::constant_evaluation::{ConstantEvaluation, ConstantValue};
 use oxc_semantic::{IsGlobalReference, SymbolTable};
 use oxc_traverse::TraverseCtx;
 
@@ -21,8 +21,6 @@ impl oxc_ecmascript::is_global_reference::IsGlobalReference for Ctx<'_, '_> {
         Some(ident.is_global_reference(self.0.symbols()))
     }
 }
-
-impl DetermineValueType for Ctx<'_, '_> {}
 
 impl<'a> ConstantEvaluation<'a> for Ctx<'a, '_> {
     fn ast(&self) -> AstBuilder<'a> {

--- a/crates/oxc_minifier/src/peephole/minimize_conditions.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditions.rs
@@ -113,8 +113,8 @@ impl<'a> PeepholeOptimizations {
         if !e.operator.is_equality() {
             return None;
         }
-        let left = ctx.expression_value_type(&e.left);
-        let right = ctx.expression_value_type(&e.right);
+        let left = e.left.value_type(&ctx);
+        let right = e.right.value_type(&ctx);
         if left.is_undetermined() || right.is_undetermined() {
             return None;
         }

--- a/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
@@ -53,7 +53,7 @@ impl<'a> PeepholeOptimizations {
             Expression::BinaryExpression(e)
                 if e.operator.is_equality()
                     && matches!(&e.right, Expression::NumericLiteral(lit) if lit.value == 0.0)
-                    && ctx.expression_value_type(&e.left).is_number() =>
+                    && e.left.value_type(&ctx).is_number() =>
             {
                 let argument = ctx.ast.move_expression(&mut e.left);
                 *expr = if matches!(

--- a/crates/oxc_minifier/src/peephole/minimize_not_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_not_expression.rs
@@ -32,7 +32,7 @@ impl<'a> PeepholeOptimizations {
             // `!!true` -> `true`
             // `!!false` -> `false`
             Expression::UnaryExpression(e)
-                if e.operator.is_not() && ctx.expression_value_type(&e.argument).is_boolean() =>
+                if e.operator.is_not() && e.argument.value_type(&ctx).is_boolean() =>
             {
                 Some(ctx.ast.move_expression(&mut e.argument))
             }

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -162,7 +162,7 @@ impl<'a> PeepholeOptimizations {
                 0 => true,
                 1 => {
                     let Some(arg) = e.arguments[0].as_expression() else { return false };
-                    let ty = ctx.expression_value_type(arg);
+                    let ty = arg.value_type(&ctx);
                     matches!(
                         ty,
                         ValueType::Null

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -379,7 +379,7 @@ impl<'a> PeepholeOptimizations {
         let first_arg = first_arg.to_expression_mut(); // checked above
 
         let wrap_with_unary_plus_if_needed = |expr: &mut Expression<'a>| {
-            if ctx.expression_value_type(&*expr).is_number() {
+            if expr.value_type(&ctx).is_number() {
                 ctx.ast.move_expression(expr)
             } else {
                 ctx.ast.expression_unary(

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -248,11 +248,11 @@ impl<'a> PeepholeOptimizations {
         let parent_expression_does_to_number_conversion = match parent_expression {
             Ancestor::BinaryExpressionLeft(e) => {
                 Self::is_binary_operator_that_does_number_conversion(*e.operator())
-                    && ctx.expression_value_type(e.right()).is_number()
+                    && e.right().value_type(&ctx).is_number()
             }
             Ancestor::BinaryExpressionRight(e) => {
                 Self::is_binary_operator_that_does_number_conversion(*e.operator())
-                    && ctx.expression_value_type(e.left()).is_number()
+                    && e.left().value_type(&ctx).is_number()
             }
             _ => false,
         };
@@ -772,7 +772,7 @@ impl<'a> PeepholeOptimizations {
                 arguments_len == 0
                     || (arguments_len >= 1
                         && e.arguments[0].as_expression().is_some_and(|first_argument| {
-                            let ty = ctx.expression_value_type(first_argument);
+                            let ty = first_argument.value_type(&ctx);
                             !ty.is_undetermined() && !ty.is_object()
                         }))
             }

--- a/crates/oxc_minifier/tests/ecmascript/value_type.rs
+++ b/crates/oxc_minifier/tests/ecmascript/value_type.rs
@@ -7,15 +7,14 @@ use oxc_ecmascript::{
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 
-struct ValueTypeCalculator {
+struct GlobalReferenceChecker {
     global_variable_names: Vec<String>,
 }
-impl IsGlobalReference for ValueTypeCalculator {
+impl IsGlobalReference for GlobalReferenceChecker {
     fn is_global_reference(&self, ident: &IdentifierReference<'_>) -> Option<bool> {
         Some(self.global_variable_names.iter().any(|name| name == ident.name.as_str()))
     }
 }
-impl DetermineValueType for ValueTypeCalculator {}
 
 fn test(source_text: &str, expected: ValueType) {
     test_with_global_variables(
@@ -35,12 +34,12 @@ fn test_with_global_variables(
     assert!(!ret.panicked, "{source_text}");
     assert!(ret.errors.is_empty(), "{source_text}");
 
-    let value_type_caclculator = ValueTypeCalculator { global_variable_names };
+    let global_reference_checker = GlobalReferenceChecker { global_variable_names };
 
     let Some(Statement::ExpressionStatement(stmt)) = &ret.program.body.first() else {
         panic!("should have a expression statement body: {source_text}");
     };
-    let result = value_type_caclculator.expression_value_type(&stmt.expression);
+    let result = stmt.expression.value_type(&global_reference_checker);
     assert_eq!(result, expected, "{source_text}");
 }
 


### PR DESCRIPTION
Similar to #9101 but for DetermineValueType.