### PR TITLE
refactor(ast/estree): define types for `#[estree(add_fields)]` converters

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -493,7 +493,7 @@ pub use match_member_expression;
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "MemberExpression", add_fields(computed = true), add_ts = "computed: true")]
+#[estree(rename = "MemberExpression", add_fields(computed = True), add_ts = "computed: true")]
 pub struct ComputedMemberExpression<'a> {
     pub span: Span,
     pub object: Expression<'a>,
@@ -508,7 +508,7 @@ pub struct ComputedMemberExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "MemberExpression", add_fields(computed = false), add_ts = "computed: false")]
+#[estree(rename = "MemberExpression", add_fields(computed = False), add_ts = "computed: false")]
 pub struct StaticMemberExpression<'a> {
     pub span: Span,
     pub object: Expression<'a>,
@@ -522,7 +522,7 @@ pub struct StaticMemberExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "MemberExpression", add_fields(computed = false), add_ts = "computed: false")]
+#[estree(rename = "MemberExpression", add_fields(computed = False), add_ts = "computed: false")]
 pub struct PrivateFieldExpression<'a> {
     pub span: Span,
     pub object: Expression<'a>,
@@ -644,7 +644,7 @@ pub struct UpdateExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(add_fields(prefix = true), add_ts = "prefix: true")]
+#[estree(add_fields(prefix = True), add_ts = "prefix: true")]
 pub struct UnaryExpression<'a> {
     pub span: Span,
     pub operator: UnaryOperator,
@@ -668,7 +668,7 @@ pub struct BinaryExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "BinaryExpression", add_fields(operator = "\"in\""), add_ts = "operator: \"in\"")]
+#[estree(rename = "BinaryExpression", add_fields(operator = In), add_ts = "operator: \"in\"")]
 pub struct PrivateInExpression<'a> {
     pub span: Span,
     pub left: PrivateIdentifier<'a>,
@@ -897,7 +897,7 @@ pub enum AssignmentTargetProperty<'a> {
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(
     rename = "Property",
-    add_fields(kind = "\"init\"", method = false, shorthand = true, computed = false),
+    add_fields(kind = Init, method = False, shorthand = True, computed = False),
     add_ts = "kind: \"init\"; method: false; shorthand: true; computed: false"
 )]
 pub struct AssignmentTargetPropertyIdentifier<'a> {
@@ -920,7 +920,7 @@ pub struct AssignmentTargetPropertyIdentifier<'a> {
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(
     rename = "Property",
-    add_fields(kind = "\"init\"", method = false, shorthand = false),
+    add_fields(kind = Init, method = False, shorthand = False),
     add_ts = "kind: \"init\"; method: false; shorthand: false"
 )]
 pub struct AssignmentTargetPropertyProperty<'a> {
@@ -1527,7 +1527,7 @@ pub struct ObjectPattern<'a> {
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(
     rename = "Property",
-    add_fields(kind = "\"init\"", method = false),
+    add_fields(kind = Init, method = False),
     add_ts = "kind: \"init\"; method: false"
 )]
 pub struct BindingProperty<'a> {
@@ -1614,7 +1614,7 @@ pub struct BindingRestElement<'a> {
 // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/cd61c555bfc93e985b313263a42ed78074570d08/types/estree/index.d.ts#L411
 #[estree(
     add_ts_def = "type ParamPattern = FormalParameter | FormalParameterRest",
-    add_fields(expression = false),
+    add_fields(expression = False),
     add_ts = "expression: false"
 )]
 pub struct Function<'a> {
@@ -1768,10 +1768,7 @@ pub struct FunctionBody<'a> {
 )]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(
-    add_fields(generator = false, id = crate::serialize::NULL),
-    add_ts = "generator: false; id: null"
-)]
+#[estree(add_fields(generator = False, id = Null), add_ts = "generator: false; id: null")]
 pub struct ArrowFunctionExpression<'a> {
     pub span: Span,
     /// Is the function body an arrow expression? i.e. `() => expr` instead of `() => {}`

--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -20,11 +20,7 @@ use oxc_syntax::number::{BigintBase, NumberBase};
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(
-    rename = "Literal",
-    add_fields(raw = crate::serialize::boolean_literal_raw(self)),
-    add_ts = "raw: string | null",
-)]
+#[estree(rename = "Literal", add_fields(raw = BooleanLiteralRaw), add_ts = "raw: string | null")]
 pub struct BooleanLiteral {
     /// Node location in source code
     pub span: Span,
@@ -40,10 +36,7 @@ pub struct BooleanLiteral {
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(
     rename = "Literal",
-    add_fields(
-        value = crate::serialize::NULL,
-        raw = crate::serialize::null_literal_raw(self),
-    ),
+    add_fields(value = Null, raw = NullLiteralRaw),
     add_ts = "value: null, raw: \"null\" | null",
 )]
 pub struct NullLiteral {
@@ -102,10 +95,7 @@ pub struct StringLiteral<'a> {
 #[generate_derive(CloneIn, ContentEq, GetSpan, GetSpanMut, ESTree)]
 #[estree(
     rename = "Literal",
-    add_fields(
-        value = crate::serialize::NULL,
-        bigint = crate::serialize::bigint_literal_bigint(self),
-    ),
+    add_fields(value = Null, bigint = BigIntLiteralBigint),
     add_ts = "value: BigInt, bigint: string",
 )]
 pub struct BigIntLiteral<'a> {
@@ -126,11 +116,7 @@ pub struct BigIntLiteral<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, ContentEq, GetSpan, GetSpanMut, ESTree)]
-#[estree(
-    rename = "Literal",
-    add_fields(value = crate::serialize::NULL),
-    add_ts = "value: RegExp | null",
-)]
+#[estree(rename = "Literal", add_fields(value = Null), add_ts = "value: RegExp | null")]
 pub struct RegExpLiteral<'a> {
     /// Node location in source code
     pub span: Span,

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -355,7 +355,7 @@ impl Serialize for ComputedMemberExpression<'_> {
         map.serialize_entry("object", &self.object)?;
         map.serialize_entry("property", &self.expression)?;
         map.serialize_entry("optional", &self.optional)?;
-        map.serialize_entry("computed", &true)?;
+        map.serialize_entry("computed", &crate::serialize::True(self))?;
         map.end()
     }
 }
@@ -369,7 +369,7 @@ impl Serialize for StaticMemberExpression<'_> {
         map.serialize_entry("object", &self.object)?;
         map.serialize_entry("property", &self.property)?;
         map.serialize_entry("optional", &self.optional)?;
-        map.serialize_entry("computed", &false)?;
+        map.serialize_entry("computed", &crate::serialize::False(self))?;
         map.end()
     }
 }
@@ -383,7 +383,7 @@ impl Serialize for PrivateFieldExpression<'_> {
         map.serialize_entry("object", &self.object)?;
         map.serialize_entry("property", &self.field)?;
         map.serialize_entry("optional", &self.optional)?;
-        map.serialize_entry("computed", &false)?;
+        map.serialize_entry("computed", &crate::serialize::False(self))?;
         map.end()
     }
 }
@@ -509,7 +509,7 @@ impl Serialize for UnaryExpression<'_> {
         map.serialize_entry("end", &self.span.end)?;
         map.serialize_entry("operator", &self.operator)?;
         map.serialize_entry("argument", &self.argument)?;
-        map.serialize_entry("prefix", &true)?;
+        map.serialize_entry("prefix", &crate::serialize::True(self))?;
         map.end()
     }
 }
@@ -535,7 +535,7 @@ impl Serialize for PrivateInExpression<'_> {
         map.serialize_entry("end", &self.span.end)?;
         map.serialize_entry("left", &self.left)?;
         map.serialize_entry("right", &self.right)?;
-        map.serialize_entry("operator", &"in")?;
+        map.serialize_entry("operator", &crate::serialize::In(self))?;
         map.end()
     }
 }
@@ -717,10 +717,10 @@ impl Serialize for AssignmentTargetPropertyIdentifier<'_> {
             "value",
             &crate::serialize::AssignmentTargetPropertyIdentifierValue(self),
         )?;
-        map.serialize_entry("kind", &"init")?;
-        map.serialize_entry("method", &false)?;
-        map.serialize_entry("shorthand", &true)?;
-        map.serialize_entry("computed", &false)?;
+        map.serialize_entry("kind", &crate::serialize::Init(self))?;
+        map.serialize_entry("method", &crate::serialize::False(self))?;
+        map.serialize_entry("shorthand", &crate::serialize::True(self))?;
+        map.serialize_entry("computed", &crate::serialize::False(self))?;
         map.end()
     }
 }
@@ -734,9 +734,9 @@ impl Serialize for AssignmentTargetPropertyProperty<'_> {
         map.serialize_entry("key", &self.name)?;
         map.serialize_entry("value", &self.binding)?;
         map.serialize_entry("computed", &self.computed)?;
-        map.serialize_entry("kind", &"init")?;
-        map.serialize_entry("method", &false)?;
-        map.serialize_entry("shorthand", &false)?;
+        map.serialize_entry("kind", &crate::serialize::Init(self))?;
+        map.serialize_entry("method", &crate::serialize::False(self))?;
+        map.serialize_entry("shorthand", &crate::serialize::False(self))?;
         map.end()
     }
 }
@@ -1308,8 +1308,8 @@ impl Serialize for BindingProperty<'_> {
         map.serialize_entry("value", &self.value)?;
         map.serialize_entry("shorthand", &self.shorthand)?;
         map.serialize_entry("computed", &self.computed)?;
-        map.serialize_entry("kind", &"init")?;
-        map.serialize_entry("method", &false)?;
+        map.serialize_entry("kind", &crate::serialize::Init(self))?;
+        map.serialize_entry("method", &crate::serialize::False(self))?;
         map.end()
     }
 }
@@ -1351,7 +1351,7 @@ impl Serialize for Function<'_> {
         map.serialize_entry("params", &self.params)?;
         map.serialize_entry("returnType", &self.return_type)?;
         map.serialize_entry("body", &self.body)?;
-        map.serialize_entry("expression", &false)?;
+        map.serialize_entry("expression", &crate::serialize::False(self))?;
         map.end()
     }
 }
@@ -1440,8 +1440,8 @@ impl Serialize for ArrowFunctionExpression<'_> {
         map.serialize_entry("params", &self.params)?;
         map.serialize_entry("returnType", &self.return_type)?;
         map.serialize_entry("body", &crate::serialize::ArrowFunctionExpressionBody(self))?;
-        map.serialize_entry("generator", &false)?;
-        map.serialize_entry("id", &crate::serialize::NULL)?;
+        map.serialize_entry("generator", &crate::serialize::False(self))?;
+        map.serialize_entry("id", &crate::serialize::Null(self))?;
         map.end()
     }
 }
@@ -1921,7 +1921,7 @@ impl Serialize for BooleanLiteral {
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
         map.serialize_entry("value", &self.value)?;
-        map.serialize_entry("raw", &crate::serialize::boolean_literal_raw(self))?;
+        map.serialize_entry("raw", &crate::serialize::BooleanLiteralRaw(self))?;
         map.end()
     }
 }
@@ -1932,8 +1932,8 @@ impl Serialize for NullLiteral {
         map.serialize_entry("type", "Literal")?;
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("value", &crate::serialize::NULL)?;
-        map.serialize_entry("raw", &crate::serialize::null_literal_raw(self))?;
+        map.serialize_entry("value", &crate::serialize::Null(self))?;
+        map.serialize_entry("raw", &crate::serialize::NullLiteralRaw(self))?;
         map.end()
     }
 }
@@ -1969,8 +1969,8 @@ impl Serialize for BigIntLiteral<'_> {
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
         map.serialize_entry("raw", &self.raw)?;
-        map.serialize_entry("value", &crate::serialize::NULL)?;
-        map.serialize_entry("bigint", &crate::serialize::bigint_literal_bigint(self))?;
+        map.serialize_entry("value", &crate::serialize::Null(self))?;
+        map.serialize_entry("bigint", &crate::serialize::BigIntLiteralBigint(self))?;
         map.end()
     }
 }
@@ -1983,7 +1983,7 @@ impl Serialize for RegExpLiteral<'_> {
         map.serialize_entry("end", &self.span.end)?;
         map.serialize_entry("regex", &crate::serialize::RegExpLiteralRegex(self))?;
         map.serialize_entry("raw", &self.raw)?;
-        map.serialize_entry("value", &crate::serialize::NULL)?;
+        map.serialize_entry("value", &crate::serialize::Null(self))?;
         map.end()
     }
 }

--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -8,7 +8,7 @@ use syn::{parse_str, Expr};
 
 use crate::{
     schema::{Def, EnumDef, FieldDef, Schema, StructDef, TypeDef, VariantDef, Visibility},
-    utils::number_lit,
+    utils::{create_ident, number_lit},
     Result,
 };
 
@@ -233,9 +233,9 @@ fn generate_body_for_struct(struct_def: &StructDef, schema: &Schema) -> TokenStr
     };
 
     // Add any additional manually-defined fields
-    let add_fields = struct_def.estree.add_fields.iter().map(|(name, value)| {
-        let value = parse_str::<syn::Expr>(value).unwrap();
-        quote!( map.serialize_entry(#name, &#value)?; )
+    let add_fields = struct_def.estree.add_fields.iter().map(|(name, converter)| {
+        let converter = create_ident(converter);
+        quote!( map.serialize_entry(#name, &crate::serialize::#converter(self))?; )
     });
 
     let stmts = gen.stmts;

--- a/tasks/ast_tools/src/schema/extensions/estree.rs
+++ b/tasks/ast_tools/src/schema/extensions/estree.rs
@@ -9,7 +9,8 @@ pub struct ESTreeStruct {
     /// `true` if serializer is implemented manually and should not be generated
     pub custom_serialize: bool,
     /// Additional fields to add to struct in ESTree AST.
-    /// `(name, value)` where `value` is a string which should be parsed as a Rust expression.
+    /// `(name, converter)` where `name` is the name of the field, and `converter` is name of
+    /// a converter type in the same crate, accessible as `crate::serialize::<converter>`.
     pub add_fields: Vec<(String, String)>,
     /// Additional fields to add to TS type definition
     pub add_ts: Option<String>,


### PR DESCRIPTION
Refactor. Replace the mismash of types, functions and values used in `#[estree(add_fields(...))]` attributes with a single set of "converter" types.
