### PR TITLE
feat(ast_tools): introduce meta types

### DIFF
--- a/crates/oxc_ast_macros/src/lib.rs
+++ b/crates/oxc_ast_macros/src/lib.rs
@@ -1,4 +1,5 @@
 use proc_macro::TokenStream;
+use quote::quote;
 use syn::{parse_macro_input, Item};
 
 mod ast;
@@ -39,6 +40,20 @@ pub fn ast(_args: TokenStream, input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as Item);
     let expanded = ast::ast(&input);
     TokenStream::from(expanded)
+}
+
+/// Dummy attribute macro `#[ast_meta]`.
+///
+/// This macro passes the input through unchanged, except that it applies
+/// `#[derive(::oxc_ast_macros::Ast)]` to the type, to allow the use of helper attributes.
+///
+/// This attribute should be used on types which are not part of the AST, but are used by `oxc_ast_tools`
+/// in processing the AST in some way. The purpose of this attribute is to pass data to `oxc_ast_tools`.
+#[proc_macro_attribute]
+pub fn ast_meta(_args: TokenStream, input: TokenStream) -> TokenStream {
+    let mut output = TokenStream::from(quote!( #[derive(::oxc_ast_macros::Ast)] ));
+    output.extend(input);
+    output
 }
 
 /// Dummy derive macro for a non-existent trait `Ast`.

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -41,7 +41,10 @@
 //! All the source files listed in [`SOURCE_PATHS`] are read, and parsed with [`syn`].
 //!
 //! At this stage, only type names and other basic information about types is obtained.
-//! Each type is assigned a [`TypeId`], and a mapping of type name to [`TypeId`] is built.
+//! Each type with an `#[ast]` attribute is assigned a [`TypeId`], and a mapping of type name
+//! to [`TypeId`] is built.
+//!
+//! Any "meta types" with an `#[ast_meta]` attribute are also identified.
 //!
 //! This is the bare minimum required to link types up to each other in the next phase.
 //!
@@ -69,7 +72,8 @@
 //! Container types e.g. [`VecDef`] contain the `TypeId` of the inner type (e.g. `T` in `Vec<T>`).
 //!
 //! Custom attributes on types (e.g. `#[visit]`) are also parsed at this stage, in conjunction with
-//! the [`Generator`]s and [`Derive`]s which define those attributes.
+//! the [`Generator`]s and [`Derive`]s which define those attributes. Meta types ([`MetaType`]s)
+//! and their custom attributes are also parsed.
 //!
 //! The end result of this phase is the [`Schema`], which is the single source of truth about the AST.
 //!
@@ -143,7 +147,7 @@
 //! * That file should define types for structs / enums / struct fields / enum variants, depending on
 //!   where the data needs to be stored. e.g. `PictureStruct`, `PictureEnumField`.
 //! * Those types must implement `Default` and `Debug`.
-//! * Add those types to [`StructDef`], [`EnumDef`], [`FieldDef`] and/or [`VariantDef`].
+//! * Add those types to [`StructDef`], [`EnumDef`], [`FieldDef`], [`VariantDef`] and/or [`MetaType`].
 //! * Implement [`Generator::attrs`] / [`Derive::attrs`] to declare the generator's custom attributes.
 //! * Implement [`Generator::parse_attr`] / [`Derive::parse_attr`] to parse those attributes
 //!   and mutate the "extension" types in [`Schema`] as required.
@@ -152,6 +156,13 @@
 //!
 //! `oxc_ast_tools` provides abstractions [`AttrLocation`] and [`AttrPart`] which assist with parsing
 //! custom attributes, and are much simpler than `syn`'s types.
+//!
+//! #### Meta types
+//!
+//! Meta types ([`MetaType`]) are types which are not part of the AST, but are used by `oxc_ast_tools`
+//! in some way, and may also be used in generated output. Tagging a type with `#[ast_meta]` attribute
+//! and then adding further custom attributes to that type is a way to pass ancillary information to a
+//! `Derive` / `Generator`.
 //!
 //! [`TypeId`]: schema::TypeId
 //! [`TypeDef`]: schema::TypeDef
@@ -164,6 +175,7 @@
 //! [`PrimitiveDef`]: schema::PrimitiveDef
 //! [`FieldDef`]: schema::FieldDef
 //! [`VariantDef`]: schema::VariantDef
+//! [`MetaType`]: schema::MetaType
 //! [`AssertLayouts`]: generators::AssertLayouts
 //! [`TokenStream`]: proc_macro2::TokenStream
 //! [`AttrLocation`]: parse::attr::AttrLocation

--- a/tasks/ast_tools/src/parse/attr.rs
+++ b/tasks/ast_tools/src/parse/attr.rs
@@ -4,7 +4,7 @@ use bitflags::bitflags;
 
 use crate::{
     codegen::{DeriveId, GeneratorId},
-    schema::{Def, EnumDef, StructDef},
+    schema::{Def, EnumDef, MetaType, StructDef},
     Result, DERIVES, GENERATORS,
 };
 
@@ -41,8 +41,10 @@ bitflags! {
         const StructField = 1 << 4;
         /// Attribute on an enum variant
         const EnumVariant = 1 << 5;
+        /// Attribute on a meta type
+        const Meta = 1 << 6;
         /// Part of `#[ast]` attr e.g. `visit` in `#[ast(visit)]`
-        const AstAttr = 1 << 6;
+        const AstAttr = 1 << 7;
 
         /// Attribute on a struct which may or may not derive the trait
         const StructMaybeDerived = Self::Struct.bits() | Self::StructNotDerived.bits();
@@ -79,6 +81,8 @@ pub enum AttrLocation<'d> {
     /// Attribute on an enum variant.
     /// Comprises [`EnumDef`]` and variant index.
     EnumVariant(&'d mut EnumDef, usize),
+    /// Attribute on a meta type
+    Meta(&'d mut MetaType),
     /// Part of `#[ast]` attr on a struct
     StructAstAttr(&'d mut StructDef),
     /// Part of `#[ast]` attr on an enum
@@ -97,6 +101,7 @@ impl AttrLocation<'_> {
             AttrLocation::EnumVariant(enum_def, variant_index) => {
                 AttrLocation::EnumVariant(enum_def, *variant_index)
             }
+            AttrLocation::Meta(meta) => AttrLocation::Meta(meta),
             AttrLocation::StructAstAttr(struct_def) => AttrLocation::StructAstAttr(struct_def),
             AttrLocation::EnumAstAttr(enum_def) => AttrLocation::EnumAstAttr(enum_def),
         }
@@ -118,6 +123,7 @@ impl Display for AttrLocation<'_> {
             AttrLocation::EnumVariant(enum_def, variant_index) => {
                 write!(f, "{}::{}", enum_def.name(), enum_def.variants[*variant_index].name())
             }
+            AttrLocation::Meta(meta) => f.write_str(meta.name()),
         }
     }
 }

--- a/tasks/ast_tools/src/parse/load.rs
+++ b/tasks/ast_tools/src/parse/load.rs
@@ -19,38 +19,44 @@ use super::{
     FxIndexMap,
 };
 
-/// Load file and extract structs and enums with `#[ast]` attr.
+/// Load file and extract structs and enums with `#[ast]` or `#[ast_meta]` attributes.
 ///
 /// Only parses enough to get:
 /// * Name of type.
 /// * Inherits of enums wrapped in `inherit_variants!` macro.
 ///
-/// Inserts [`Skeleton`]s into `skeletons` and adds mappings from type name to type ID.
+/// Inserts [`Skeleton`]s into `skeletons` and `meta_skeletons`.
 ///
 /// This is the bare minimum to be able to "link up" types to each other in next pass.
-pub fn load_file(file_id: FileId, file_path: &str, skeletons: &mut FxIndexMap<String, Skeleton>) {
+pub fn load_file(
+    file_id: FileId,
+    file_path: &str,
+    skeletons: &mut FxIndexMap<String, Skeleton>,
+    meta_skeletons: &mut FxIndexMap<String, Skeleton>,
+) {
     let content = fs::read_to_string(file_path).unwrap();
 
     let file = parse_file(content.as_str()).unwrap();
 
     for item in file.items {
-        let (name, skeleton) = match item {
+        let (name, skeleton, is_meta) = match item {
             Item::Struct(item) => {
-                let Some(skeleton) = parse_struct(item, file_id) else { continue };
-                (skeleton.name.clone(), Skeleton::Struct(skeleton))
+                let Some((skeleton, is_meta)) = parse_struct(item, file_id) else { continue };
+                (skeleton.name.clone(), Skeleton::Struct(skeleton), is_meta)
             }
             Item::Enum(item) => {
-                let Some(skeleton) = parse_enum(item, file_id) else { continue };
-                (skeleton.name.clone(), Skeleton::Enum(skeleton))
+                let Some((skeleton, is_meta)) = parse_enum(item, file_id) else { continue };
+                (skeleton.name.clone(), Skeleton::Enum(skeleton), is_meta)
             }
             Item::Macro(item) => {
                 let Some(skeleton) = parse_macro(&item, file_id) else { continue };
-                (skeleton.name.clone(), Skeleton::Enum(skeleton))
+                (skeleton.name.clone(), Skeleton::Enum(skeleton), false)
             }
             _ => continue,
         };
 
-        match skeletons.entry(name) {
+        let use_skeletons = if is_meta { &mut *meta_skeletons } else { &mut *skeletons };
+        match use_skeletons.entry(name) {
             Entry::Occupied(entry) => panic!("2 types with same name: {}", entry.key()),
             Entry::Vacant(entry) => {
                 entry.insert(skeleton);
@@ -59,14 +65,14 @@ pub fn load_file(file_id: FileId, file_path: &str, skeletons: &mut FxIndexMap<St
     }
 }
 
-fn parse_struct(item: ItemStruct, file_id: FileId) -> Option<StructSkeleton> {
-    let name = get_type_name(&item.attrs, &item.ident)?;
-    Some(StructSkeleton { name, file_id, item })
+fn parse_struct(item: ItemStruct, file_id: FileId) -> Option<(StructSkeleton, /* is_meta */ bool)> {
+    let (name, is_meta) = get_type_name(&item.attrs, &item.ident)?;
+    Some((StructSkeleton { name, file_id, item }, is_meta))
 }
 
-fn parse_enum(item: ItemEnum, file_id: FileId) -> Option<EnumSkeleton> {
-    let name = get_type_name(&item.attrs, &item.ident)?;
-    Some(EnumSkeleton { name, file_id, item, inherits: vec![] })
+fn parse_enum(item: ItemEnum, file_id: FileId) -> Option<(EnumSkeleton, /* is_meta */ bool)> {
+    let (name, is_meta) = get_type_name(&item.attrs, &item.ident)?;
+    Some((EnumSkeleton { name, file_id, item, inherits: vec![] }, is_meta))
 }
 
 fn parse_macro(item: &ItemMacro, file_id: FileId) -> Option<EnumSkeleton> {
@@ -92,8 +98,7 @@ fn parse_macro(item: &ItemMacro, file_id: FileId) -> Option<EnumSkeleton> {
             let where_clause = input.parse::<Option<WhereClause>>()?;
             assert!(where_clause.is_none(), "Types with `where` clauses are not supported");
 
-            let name = get_type_name(&attrs, &ident);
-            let Some(name) = name else {
+            let Some((name, false)) = get_type_name(&attrs, &ident) else {
                 panic!("Enum in `inherit_variants!` macro must have `#[ast]` attr: {ident}");
             };
 
@@ -124,22 +129,28 @@ fn parse_macro(item: &ItemMacro, file_id: FileId) -> Option<EnumSkeleton> {
     Some(skeleton)
 }
 
-/// Get name of type.
+/// Get name of type, and whether it has an `#[ast_meta]` attribute on it.
 ///
-/// Parse attributes and find `#[ast]` attr, or `#[ast(foreign = ForeignType)]`.
+/// Parse attributes and find `#[ast]`, `#[ast(foreign = ForeignType)]`, or `#[ast_meta]`.
 ///
-/// If no `#[ast]` attr is present, returns `None`.
+/// If no `#[ast]` or `#[ast_meta]` attr is present, returns `None`.
 ///
 /// Otherwise, returns foreign name if provided with `#[ast(foreign = ForeignType)]`,
 /// or otherwise name of the `ident`.
 ///
 /// # Panics
-/// Panics if cannot parse `#[ast]` attribute.
-fn get_type_name(attrs: &[Attribute], ident: &Ident) -> Option<String> {
+/// Panics if cannot parse attributes.
+fn get_type_name(
+    attrs: &[Attribute],
+    ident: &Ident,
+) -> Option<(/* type name */ String, /* is_meta */ bool)> {
     let mut has_ast_attr = false;
+    let mut has_meta_attr = false;
     let mut foreign_name = None;
     for attr in attrs {
-        if attr.path().is_ident("ast") {
+        let Some(attr_ident) = attr.path().get_ident() else { continue };
+
+        if attr_ident == "ast" {
             has_ast_attr = true;
             if let Some(this_foreign_name) = parse_ast_attr_foreign_name(attr, ident) {
                 assert!(
@@ -148,11 +159,24 @@ fn get_type_name(attrs: &[Attribute], ident: &Ident) -> Option<String> {
                 );
                 foreign_name = Some(this_foreign_name);
             }
+        } else if attr_ident == "ast_meta" {
+            assert!(
+                matches!(&attr.meta, Meta::Path(_)),
+                "Unable to parse `#[ast_meta]` attribute on type: `{ident}`"
+            );
+            assert!(!has_meta_attr, "Multiple `#[ast_meta]` attributes on type: `{ident}`");
+            has_meta_attr = true;
         }
     }
 
-    if has_ast_attr {
-        Some(foreign_name.unwrap_or_else(|| ident_name(ident)))
+    if has_meta_attr {
+        assert!(
+            !has_ast_attr,
+            "Type cannot be tagged with both `#[ast]` and `#[ast_meta]`: `{ident}`"
+        );
+        Some((ident_name(ident), true))
+    } else if has_ast_attr {
+        Some((foreign_name.unwrap_or_else(|| ident_name(ident)), false))
     } else {
         None
     }

--- a/tasks/ast_tools/src/schema/meta.rs
+++ b/tasks/ast_tools/src/schema/meta.rs
@@ -1,0 +1,68 @@
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{parse_str, Ident, Path};
+
+use crate::utils::create_ident;
+
+use super::{File, FileId, MetaId, Schema};
+
+/// Definition for a meta type.
+///
+/// Meta types are types which are not part of the AST, but are associated with the AST in some way,
+/// and used by `oxc_ast_tools` as "helpers", or used in generated code.
+#[derive(Debug)]
+pub struct MetaType {
+    #[expect(dead_code)]
+    pub id: MetaId,
+    pub name: String,
+    pub file_id: FileId,
+}
+
+impl MetaType {
+    /// Create new [`MetaType`].
+    pub fn new(id: MetaId, name: String, file_id: FileId) -> Self {
+        Self { id, name, file_id }
+    }
+
+    /// Get meta type name.
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Get meta type name as an [`Ident`].
+    ///
+    /// [`Ident`]: struct@Ident
+    pub fn ident(&self) -> Ident {
+        create_ident(self.name())
+    }
+
+    /// Get the [`File`] which this meta type is defined in.
+    pub fn file<'s>(&self, schema: &'s Schema) -> &'s File {
+        &schema.files[self.file_id]
+    }
+
+    /// Get the import path for this meta type from specified crate.
+    ///
+    /// e.g. `crate::serialize::Null` or `oxc_ast::serialize::Null`.
+    #[expect(dead_code)]
+    pub fn import_path_from_crate(&self, from_krate: &str, schema: &Schema) -> TokenStream {
+        let file = self.file(schema);
+
+        let mut path = if file.krate() == from_krate {
+            quote!(crate)
+        } else {
+            let crate_ident = create_ident(file.krate());
+            quote!(#crate_ident)
+        };
+
+        if !file.import_path().is_empty() {
+            let import_path: Path = parse_str(file.import_path()).unwrap();
+            path.extend(quote!( #import_path ));
+        }
+
+        let ident = self.ident();
+        path.extend(quote!( ::#ident ));
+
+        path
+    }
+}

--- a/tasks/ast_tools/src/schema/mod.rs
+++ b/tasks/ast_tools/src/schema/mod.rs
@@ -7,9 +7,11 @@ use serde::Serialize;
 mod defs;
 mod derives;
 mod file;
+mod meta;
 pub use defs::*;
 pub use derives::Derives;
 pub use file::File;
+pub use meta::MetaType;
 
 /// Extensions to schema for specific derives / generators
 pub mod extensions {
@@ -36,6 +38,11 @@ define_index_type! {
     pub struct FileId = u32;
 }
 
+define_index_type! {
+    /// ID of meta type
+    pub struct MetaId = u32;
+}
+
 /// Schema of all AST types.
 #[derive(Debug)]
 pub struct Schema {
@@ -43,6 +50,10 @@ pub struct Schema {
     pub types: IndexVec<TypeId, TypeDef>,
     /// Mapping from type name to [`TypeId`]
     pub type_names: FxHashMap<String, TypeId>,
+    /// Meta types
+    pub metas: IndexVec<MetaId, MetaType>,
+    /// Mapping from meta type name to [`MetaId`]
+    pub meta_names: FxHashMap<String, MetaId>,
     /// Source files
     pub files: IndexVec<FileId, File>,
 }
@@ -65,6 +76,16 @@ impl Schema {
     pub fn type_by_name_mut(&mut self, name: &str) -> &mut TypeDef {
         let type_id = self.type_names[name];
         &mut self.types[type_id]
+    }
+
+    /// Get reference to [`MetaType`] for a meta type name.
+    ///
+    /// # Panics
+    /// Panics if no type with supplied name.
+    #[expect(dead_code)]
+    pub fn meta_by_name(&self, name: &str) -> &MetaType {
+        let meta_id = self.meta_names[name];
+        &self.metas[meta_id]
     }
 }
 


### PR DESCRIPTION
All AST types are tagged `#[ast]` to communicate to `oxc_ast_tools` that they're part of the AST.

Introduce `#[ast_meta]` attribute to define "meta types". Meta types are not part of the AST, but are used by `oxc_ast_tools` in generating code for AST types. Information about meta types can be communicated to `oxc_ast_tools` via further attributes on the types, same as for types marked `#[ast]`.