### PR TITLE
refactor(ast/estree): define TS types for extra fields on converters

### DIFF
--- a/.github/.generated_ast_watch_list.yml
+++ b/.github/.generated_ast_watch_list.yml
@@ -20,6 +20,7 @@ src:
   - 'crates/oxc_ast/src/generated/get_id.rs'
   - 'crates/oxc_ast/src/generated/visit.rs'
   - 'crates/oxc_ast/src/generated/visit_mut.rs'
+  - 'crates/oxc_ast/src/serialize.rs'
   - 'crates/oxc_ast_macros/src/generated/mod.rs'
   - 'crates/oxc_ast_macros/src/lib.rs'
   - 'crates/oxc_regular_expression/src/ast.rs'

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -493,7 +493,7 @@ pub use match_member_expression;
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "MemberExpression", add_fields(computed = True), add_ts = "computed: true")]
+#[estree(rename = "MemberExpression", add_fields(computed = True))]
 pub struct ComputedMemberExpression<'a> {
     pub span: Span,
     pub object: Expression<'a>,
@@ -508,7 +508,7 @@ pub struct ComputedMemberExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "MemberExpression", add_fields(computed = False), add_ts = "computed: false")]
+#[estree(rename = "MemberExpression", add_fields(computed = False))]
 pub struct StaticMemberExpression<'a> {
     pub span: Span,
     pub object: Expression<'a>,
@@ -522,7 +522,7 @@ pub struct StaticMemberExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "MemberExpression", add_fields(computed = False), add_ts = "computed: false")]
+#[estree(rename = "MemberExpression", add_fields(computed = False))]
 pub struct PrivateFieldExpression<'a> {
     pub span: Span,
     pub object: Expression<'a>,
@@ -644,7 +644,7 @@ pub struct UpdateExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(add_fields(prefix = True), add_ts = "prefix: true")]
+#[estree(add_fields(prefix = True))]
 pub struct UnaryExpression<'a> {
     pub span: Span,
     pub operator: UnaryOperator,
@@ -668,7 +668,7 @@ pub struct BinaryExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "BinaryExpression", add_fields(operator = In), add_ts = "operator: \"in\"")]
+#[estree(rename = "BinaryExpression", add_fields(operator = In))]
 pub struct PrivateInExpression<'a> {
     pub span: Span,
     pub left: PrivateIdentifier<'a>,
@@ -898,7 +898,6 @@ pub enum AssignmentTargetProperty<'a> {
 #[estree(
     rename = "Property",
     add_fields(kind = Init, method = False, shorthand = True, computed = False),
-    add_ts = "kind: \"init\"; method: false; shorthand: true; computed: false"
 )]
 pub struct AssignmentTargetPropertyIdentifier<'a> {
     pub span: Span,
@@ -918,11 +917,7 @@ pub struct AssignmentTargetPropertyIdentifier<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(
-    rename = "Property",
-    add_fields(kind = Init, method = False, shorthand = False),
-    add_ts = "kind: \"init\"; method: false; shorthand: false"
-)]
+#[estree(rename = "Property", add_fields(kind = Init, method = False, shorthand = False))]
 pub struct AssignmentTargetPropertyProperty<'a> {
     pub span: Span,
     /// The property key
@@ -1525,11 +1520,7 @@ pub struct ObjectPattern<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(
-    rename = "Property",
-    add_fields(kind = Init, method = False),
-    add_ts = "kind: \"init\"; method: false"
-)]
+#[estree(rename = "Property", add_fields(kind = Init, method = False))]
 pub struct BindingProperty<'a> {
     pub span: Span,
     pub key: PropertyKey<'a>,
@@ -1615,7 +1606,6 @@ pub struct BindingRestElement<'a> {
 #[estree(
     add_ts_def = "type ParamPattern = FormalParameter | FormalParameterRest",
     add_fields(expression = False),
-    add_ts = "expression: false"
 )]
 pub struct Function<'a> {
     pub span: Span,
@@ -1768,7 +1758,7 @@ pub struct FunctionBody<'a> {
 )]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(add_fields(generator = False, id = Null), add_ts = "generator: false; id: null")]
+#[estree(add_fields(generator = False, id = Null))]
 pub struct ArrowFunctionExpression<'a> {
     pub span: Span,
     /// Is the function body an arrow expression? i.e. `() => expr` instead of `() => {}`

--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -20,7 +20,7 @@ use oxc_syntax::number::{BigintBase, NumberBase};
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "Literal", add_fields(raw = BooleanLiteralRaw), add_ts = "raw: string | null")]
+#[estree(rename = "Literal", add_fields(raw = BooleanLiteralRaw))]
 pub struct BooleanLiteral {
     /// Node location in source code
     pub span: Span,
@@ -34,11 +34,7 @@ pub struct BooleanLiteral {
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(
-    rename = "Literal",
-    add_fields(value = Null, raw = NullLiteralRaw),
-    add_ts = "value: null, raw: \"null\" | null",
-)]
+#[estree(rename = "Literal", add_fields(value = Null, raw = NullLiteralRaw))]
 pub struct NullLiteral {
     /// Node location in source code
     pub span: Span,
@@ -93,11 +89,7 @@ pub struct StringLiteral<'a> {
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, ContentEq, GetSpan, GetSpanMut, ESTree)]
-#[estree(
-    rename = "Literal",
-    add_fields(value = Null, bigint = BigIntLiteralBigint),
-    add_ts = "value: BigInt, bigint: string",
-)]
+#[estree(rename = "Literal", add_fields(value = BigIntLiteralValue, bigint = BigIntLiteralBigint))]
 pub struct BigIntLiteral<'a> {
     /// Node location in source code
     pub span: Span,
@@ -116,7 +108,7 @@ pub struct BigIntLiteral<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, ContentEq, GetSpan, GetSpanMut, ESTree)]
-#[estree(rename = "Literal", add_fields(value = Null), add_ts = "value: RegExp | null")]
+#[estree(rename = "Literal", add_fields(value = RegExpLiteralValue))]
 pub struct RegExpLiteral<'a> {
     /// Node location in source code
     pub span: Span,

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1969,7 +1969,7 @@ impl Serialize for BigIntLiteral<'_> {
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
         map.serialize_entry("raw", &self.raw)?;
-        map.serialize_entry("value", &crate::serialize::Null(self))?;
+        map.serialize_entry("value", &crate::serialize::BigIntLiteralValue(self))?;
         map.serialize_entry("bigint", &crate::serialize::BigIntLiteralBigint(self))?;
         map.end()
     }
@@ -1983,7 +1983,7 @@ impl Serialize for RegExpLiteral<'_> {
         map.serialize_entry("end", &self.span.end)?;
         map.serialize_entry("regex", &crate::serialize::RegExpLiteralRegex(self))?;
         map.serialize_entry("raw", &self.raw)?;
-        map.serialize_entry("value", &crate::serialize::Null(self))?;
+        map.serialize_entry("value", &crate::serialize::RegExpLiteralValue(self))?;
         map.end()
     }
 }

--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -113,8 +113,12 @@ fn generate_ts_type_def_for_struct(struct_def: &StructDef, schema: &Schema) -> O
         }
     }
 
-    if let Some(add_ts) = struct_def.estree.add_ts.as_deref() {
-        fields_str.push_str(&format!("\n\t{add_ts};"));
+    for (add_field_name, converter_name) in &struct_def.estree.add_fields {
+        let converter = schema.meta_by_name(converter_name);
+        let Some(add_field_ts_type) = &converter.estree.ts_type else {
+            panic!("No `ts_type` provided for ESTree converter `{}`", converter.name());
+        };
+        fields_str.push_str(&format!("\n\t{add_field_name}: {add_field_ts_type};"));
     }
 
     let ts_def = if extends.is_empty() {

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -212,6 +212,7 @@ static SOURCE_PATHS: &[&str] = &[
     "crates/oxc_ast/src/ast/jsx.rs",
     "crates/oxc_ast/src/ast/ts.rs",
     "crates/oxc_ast/src/ast/comment.rs",
+    "crates/oxc_ast/src/serialize.rs",
     "crates/oxc_syntax/src/lib.rs",
     "crates/oxc_syntax/src/number.rs",
     "crates/oxc_syntax/src/operator.rs",

--- a/tasks/ast_tools/src/schema/extensions/estree.rs
+++ b/tasks/ast_tools/src/schema/extensions/estree.rs
@@ -10,10 +10,8 @@ pub struct ESTreeStruct {
     pub custom_serialize: bool,
     /// Additional fields to add to struct in ESTree AST.
     /// `(name, converter)` where `name` is the name of the field, and `converter` is name of
-    /// a converter type in the same crate, accessible as `crate::serialize::<converter>`.
+    /// a converter meta type.
     pub add_fields: Vec<(String, String)>,
-    /// Additional fields to add to TS type definition
-    pub add_ts: Option<String>,
     /// TS alias.
     /// e.g. `#[estree(ts_alias = "null")]` means this type won't have a type def generated,
     /// and any struct / enum referencing it will substitute `null` as the type.
@@ -63,4 +61,10 @@ pub struct ESTreeStructField {
 pub struct ESTreeEnumVariant {
     pub rename: Option<String>,
     pub is_ts: bool,
+}
+
+/// Configuration for ESTree generator on a meta type.
+#[derive(Default, Debug)]
+pub struct ESTreeMeta {
+    pub ts_type: Option<String>,
 }

--- a/tasks/ast_tools/src/schema/meta.rs
+++ b/tasks/ast_tools/src/schema/meta.rs
@@ -4,7 +4,7 @@ use syn::{parse_str, Ident, Path};
 
 use crate::utils::create_ident;
 
-use super::{File, FileId, MetaId, Schema};
+use super::{extensions::estree::ESTreeMeta, File, FileId, MetaId, Schema};
 
 /// Definition for a meta type.
 ///
@@ -16,12 +16,13 @@ pub struct MetaType {
     pub id: MetaId,
     pub name: String,
     pub file_id: FileId,
+    pub estree: ESTreeMeta,
 }
 
 impl MetaType {
     /// Create new [`MetaType`].
     pub fn new(id: MetaId, name: String, file_id: FileId) -> Self {
-        Self { id, name, file_id }
+        Self { id, name, file_id, estree: ESTreeMeta::default() }
     }
 
     /// Get meta type name.
@@ -44,7 +45,6 @@ impl MetaType {
     /// Get the import path for this meta type from specified crate.
     ///
     /// e.g. `crate::serialize::Null` or `oxc_ast::serialize::Null`.
-    #[expect(dead_code)]
     pub fn import_path_from_crate(&self, from_krate: &str, schema: &Schema) -> TokenStream {
         let file = self.file(schema);
 

--- a/tasks/ast_tools/src/schema/mod.rs
+++ b/tasks/ast_tools/src/schema/mod.rs
@@ -82,7 +82,6 @@ impl Schema {
     ///
     /// # Panics
     /// Panics if no type with supplied name.
-    #[expect(dead_code)]
     pub fn meta_by_name(&self, name: &str) -> &MetaType {
         let meta_id = self.meta_names[name];
         &self.metas[meta_id]


### PR DESCRIPTION
Refactor. Remove `#[estree(add_ts = "...")]` and achieve the same function by making the ESTree converter types into "meta types" (introduced in #9116). The converter types have their TS type specified with `#[estree(ts_type = "...")]`.

This reduces repetition, and avoids TS type definitions getting out of sync with the actual ESTree AST shape. It also prepares the way for being able to specify field order in the ESTree AST.
