### PR TITLE
style(syntax): name trait method param without underscore

### DIFF
--- a/crates/oxc_syntax/src/module_record.rs
+++ b/crates/oxc_syntax/src/module_record.rs
@@ -465,7 +465,9 @@ pub trait VisitMutModuleRecord {
         self.visit_span(&mut name_span.span);
     }
 
-    fn visit_span(&mut self, _span: &mut Span) {}
+    #[expect(unused_variables)]
+    #[inline(always)]
+    fn visit_span(&mut self, span: &mut Span) {}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Follow-on after #9093. Style nit. Name unused param of `VisitMutModuleRecord::visit_span` without an underscore. This makes no difference to code's behavior, but produces nicer naming hints in IDE.

Also `#[inline(always)]` the method, as it's a no-op.