### PR TITLE
refactor(ecmascript): merge constant evaluation logics

### DIFF
--- a/crates/oxc_ecmascript/src/constant_evaluation/equality_comparison.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/equality_comparison.rs
@@ -1,18 +1,18 @@
 use oxc_ast::ast::{Expression, NumberBase};
 
-use super::{ConstantEvaluation, DetermineValueType, ValueType};
+use super::{ConstantEvaluation, ConstantEvaluationCtx, DetermineValueType, ValueType};
 
 /// <https://tc39.es/ecma262/#sec-abstract-equality-comparison>
 pub(super) fn abstract_equality_comparison<'a>(
-    c: &impl ConstantEvaluation<'a>,
+    ctx: &impl ConstantEvaluationCtx<'a>,
     left_expr: &Expression<'a>,
     right_expr: &Expression<'a>,
 ) -> Option<bool> {
-    let left = left_expr.value_type(c);
-    let right = right_expr.value_type(c);
+    let left = left_expr.value_type(ctx);
+    let right = right_expr.value_type(ctx);
     if left != ValueType::Undetermined && right != ValueType::Undetermined {
         if left == right {
-            return strict_equality_comparison(c, left_expr, right_expr);
+            return strict_equality_comparison(ctx, left_expr, right_expr);
         }
         if matches!(
             (left, right),
@@ -24,14 +24,14 @@ pub(super) fn abstract_equality_comparison<'a>(
         if matches!((left, right), (ValueType::Number, ValueType::String))
             || matches!(right, ValueType::Boolean)
         {
-            if let Some(num) = c.get_side_free_number_value(right_expr) {
-                let number_literal_expr = c.ast().expression_numeric_literal(
+            if let Some(num) = right_expr.get_side_free_number_value(ctx) {
+                let number_literal_expr = ctx.ast().expression_numeric_literal(
                     oxc_span::SPAN,
                     num,
                     None,
                     if num.fract() == 0.0 { NumberBase::Decimal } else { NumberBase::Float },
                 );
-                return abstract_equality_comparison(c, left_expr, &number_literal_expr);
+                return abstract_equality_comparison(ctx, left_expr, &number_literal_expr);
             }
             return None;
         }
@@ -39,21 +39,21 @@ pub(super) fn abstract_equality_comparison<'a>(
         if matches!((left, right), (ValueType::String, ValueType::Number))
             || matches!(left, ValueType::Boolean)
         {
-            if let Some(num) = c.get_side_free_number_value(left_expr) {
-                let number_literal_expr = c.ast().expression_numeric_literal(
+            if let Some(num) = left_expr.get_side_free_number_value(ctx) {
+                let number_literal_expr = ctx.ast().expression_numeric_literal(
                     oxc_span::SPAN,
                     num,
                     None,
                     if num.fract() == 0.0 { NumberBase::Decimal } else { NumberBase::Float },
                 );
-                return abstract_equality_comparison(c, &number_literal_expr, right_expr);
+                return abstract_equality_comparison(ctx, &number_literal_expr, right_expr);
             }
             return None;
         }
 
         if matches!(left, ValueType::BigInt) || matches!(right, ValueType::BigInt) {
-            let left_bigint = c.get_side_free_bigint_value(left_expr);
-            let right_bigint = c.get_side_free_bigint_value(right_expr);
+            let left_bigint = left_expr.get_side_free_bigint_value(ctx);
+            let right_bigint = right_expr.get_side_free_bigint_value(ctx);
             if let (Some(l_big), Some(r_big)) = (left_bigint, right_bigint) {
                 return Some(l_big.eq(&r_big));
             }
@@ -79,12 +79,12 @@ pub(super) fn abstract_equality_comparison<'a>(
 /// <https://tc39.es/ecma262/#sec-strict-equality-comparison>
 #[expect(clippy::float_cmp)]
 pub(super) fn strict_equality_comparison<'a>(
-    c: &impl ConstantEvaluation<'a>,
+    ctx: &impl ConstantEvaluationCtx<'a>,
     left_expr: &Expression<'a>,
     right_expr: &Expression<'a>,
 ) -> Option<bool> {
-    let left = left_expr.value_type(c);
-    let right = right_expr.value_type(c);
+    let left = left_expr.value_type(ctx);
+    let right = right_expr.value_type(ctx);
     if !left.is_undetermined() && !right.is_undetermined() {
         // Strict equality can only be true for values of the same type.
         if left != right {
@@ -92,27 +92,27 @@ pub(super) fn strict_equality_comparison<'a>(
         }
         return match left {
             ValueType::Number => {
-                let lnum = c.get_side_free_number_value(left_expr)?;
-                let rnum = c.get_side_free_number_value(right_expr)?;
+                let lnum = left_expr.get_side_free_number_value(ctx)?;
+                let rnum = right_expr.get_side_free_number_value(ctx)?;
                 if lnum.is_nan() || rnum.is_nan() {
                     return Some(false);
                 }
                 Some(lnum == rnum)
             }
             ValueType::String => {
-                let left = c.get_side_free_string_value(left_expr)?;
-                let right = c.get_side_free_string_value(right_expr)?;
+                let left = left_expr.get_side_free_string_value(ctx)?;
+                let right = right_expr.get_side_free_string_value(ctx)?;
                 Some(left == right)
             }
             ValueType::Undefined | ValueType::Null => Some(true),
             ValueType::Boolean => {
-                let left = c.get_boolean_value(left_expr)?;
-                let right = c.get_boolean_value(right_expr)?;
+                let left = left_expr.evaluate_value_to_boolean(ctx)?;
+                let right = right_expr.evaluate_value_to_boolean(ctx)?;
                 Some(left == right)
             }
             ValueType::BigInt => {
-                let left = c.get_side_free_bigint_value(left_expr)?;
-                let right = c.get_side_free_bigint_value(right_expr)?;
+                let left = left_expr.get_side_free_bigint_value(ctx)?;
+                let right = right_expr.get_side_free_bigint_value(ctx)?;
                 Some(left == right)
             }
             ValueType::Object => None,

--- a/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
@@ -19,422 +19,389 @@ pub use is_literal_value::IsLiteralValue;
 pub use value::ConstantValue;
 pub use value_type::{DetermineValueType, ValueType};
 
-pub trait ConstantEvaluation<'a>: IsGlobalReference {
+pub trait ConstantEvaluationCtx<'a>: IsGlobalReference {
     fn ast(&self) -> AstBuilder<'a>;
+}
 
-    fn resolve_binding(&self, ident: &IdentifierReference<'a>) -> Option<ConstantValue<'a>> {
-        match ident.name.as_str() {
-            "undefined" if self.is_global_reference(ident)? => Some(ConstantValue::Undefined),
-            "NaN" if self.is_global_reference(ident)? => Some(ConstantValue::Number(f64::NAN)),
-            "Infinity" if self.is_global_reference(ident)? => {
+pub trait ConstantEvaluation<'a>: MayHaveSideEffects {
+    /// Evaluate the expression to a constant value.
+    ///
+    /// Use the specific functions (e.g. [`ConstantEvaluation::evaluate_value_to_boolean`], [`ConstantEvaluation::evaluate_value`]).
+    ///
+    /// - target_ty: How the result will be used.
+    ///              For example, if the result will be converted to a boolean,
+    ///              passing `Some(ValueType::Boolean)` will allow to utilize that information.
+    fn evaluate_value_to(
+        &self,
+        ctx: &impl ConstantEvaluationCtx<'a>,
+        target_ty: Option<ValueType>,
+    ) -> Option<ConstantValue<'a>>;
+
+    /// Evaluate the expression to a constant value.
+    ///
+    /// If you know the result will be converted to a specific type, use other functions (e.g. [`ConstantEvaluation::evaluate_value_to_boolean`]).
+    fn evaluate_value(&self, ctx: &impl ConstantEvaluationCtx<'a>) -> Option<ConstantValue<'a>> {
+        self.evaluate_value_to(ctx, None)
+    }
+
+    /// Evaluate the expression to a constant value and convert it to a number.
+    fn evaluate_value_to_number(&self, ctx: &impl ConstantEvaluationCtx<'a>) -> Option<f64> {
+        self.evaluate_value_to(ctx, Some(ValueType::Number))?.to_number(ctx)
+    }
+
+    /// Evaluate the expression to a constant value and convert it to a bigint.
+    fn evaluate_value_to_bigint(&self, ctx: &impl ConstantEvaluationCtx<'a>) -> Option<BigInt> {
+        self.evaluate_value_to(ctx, Some(ValueType::BigInt))?.into_bigint()
+    }
+
+    /// Evaluate the expression to a constant value and convert it to a boolean.
+    fn evaluate_value_to_boolean(&self, ctx: &impl ConstantEvaluationCtx<'a>) -> Option<bool> {
+        self.evaluate_value_to(ctx, Some(ValueType::Boolean))?.to_boolean(ctx)
+    }
+
+    fn get_side_free_number_value(&self, ctx: &impl ConstantEvaluationCtx<'a>) -> Option<f64> {
+        let value = self.evaluate_value_to_number(ctx)?;
+        // Calculating the number value, if any, is likely to be faster than calculating side effects,
+        // and there are only a very few cases where we can compute a number value, but there could
+        // also be side effects. e.g. `void doSomething()` has value NaN, regardless of the behavior
+        // of `doSomething()`
+        (!self.may_have_side_effects(ctx)).then_some(value)
+    }
+
+    fn get_side_free_bigint_value(&self, ctx: &impl ConstantEvaluationCtx<'a>) -> Option<BigInt> {
+        let value = self.evaluate_value_to_bigint(ctx)?;
+        (!self.may_have_side_effects(ctx)).then_some(value)
+    }
+
+    fn get_side_free_boolean_value(&self, ctx: &impl ConstantEvaluationCtx<'a>) -> Option<bool> {
+        let value = self.evaluate_value_to_boolean(ctx)?;
+        (!self.may_have_side_effects(ctx)).then_some(value)
+    }
+
+    fn get_side_free_string_value(
+        &self,
+        ctx: &impl ConstantEvaluationCtx<'a>,
+    ) -> Option<Cow<'a, str>> {
+        let value = self.evaluate_value_to(ctx, Some(ValueType::String))?.to_js_string(ctx)?;
+        (!self.may_have_side_effects(ctx)).then_some(value)
+    }
+}
+
+impl<'a> ConstantEvaluation<'a> for IdentifierReference<'a> {
+    fn evaluate_value_to(
+        &self,
+        ctx: &impl ConstantEvaluationCtx<'a>,
+        _target_ty: Option<ValueType>,
+    ) -> Option<ConstantValue<'a>> {
+        match self.name.as_str() {
+            "undefined" if ctx.is_global_reference(self)? => Some(ConstantValue::Undefined),
+            "NaN" if ctx.is_global_reference(self)? => Some(ConstantValue::Number(f64::NAN)),
+            "Infinity" if ctx.is_global_reference(self)? => {
                 Some(ConstantValue::Number(f64::INFINITY))
             }
             _ => None,
         }
     }
+}
 
-    fn get_side_free_number_value(&self, expr: &Expression<'a>) -> Option<f64> {
-        let value = self.eval_to_number(expr);
-        // Calculating the number value, if any, is likely to be faster than calculating side effects,
-        // and there are only a very few cases where we can compute a number value, but there could
-        // also be side effects. e.g. `void doSomething()` has value NaN, regardless of the behavior
-        // of `doSomething()`
-        if value.is_some() && expr.may_have_side_effects(self) {
-            None
-        } else {
-            value
-        }
-    }
-
-    fn get_side_free_string_value(&self, expr: &Expression<'a>) -> Option<Cow<'a, str>> {
-        let value = expr.to_js_string(self);
-        if value.is_some() && !expr.may_have_side_effects(self) {
-            return value;
-        }
-        None
-    }
-
-    fn get_side_free_boolean_value(&self, expr: &Expression<'a>) -> Option<bool> {
-        let value = self.get_boolean_value(expr);
-        if value.is_some() && !expr.may_have_side_effects(self) {
-            return value;
-        }
-        None
-    }
-
-    fn get_side_free_bigint_value(&self, expr: &Expression<'a>) -> Option<BigInt> {
-        let value = expr.to_big_int(self);
-        if value.is_some() && expr.may_have_side_effects(self) {
-            None
-        } else {
-            value
-        }
-    }
-
-    fn get_boolean_value(&self, expr: &Expression<'a>) -> Option<bool> {
-        match expr {
-            Expression::Identifier(ident) => match ident.name.as_str() {
-                "undefined" | "NaN" if self.is_global_reference(ident)? => Some(false),
-                "Infinity" if self.is_global_reference(ident)? => Some(true),
-                _ => None,
-            },
-            Expression::LogicalExpression(logical_expr) => {
-                match logical_expr.operator {
-                    // true && true -> true
-                    // true && false -> false
-                    // a && true -> None
-                    LogicalOperator::And => {
-                        let left = self.get_boolean_value(&logical_expr.left);
-                        let right = self.get_boolean_value(&logical_expr.right);
-                        match (left, right) {
-                            (Some(true), Some(true)) => Some(true),
-                            (Some(false), _) | (_, Some(false)) => Some(false),
-                            (None, _) | (_, None) => None,
-                        }
-                    }
-                    // true || false -> true
-                    // false || false -> false
-                    // a || b -> None
-                    LogicalOperator::Or => {
-                        let left = self.get_boolean_value(&logical_expr.left);
-                        let right = self.get_boolean_value(&logical_expr.right);
-                        match (left, right) {
-                            (Some(true), _) | (_, Some(true)) => Some(true),
-                            (Some(false), Some(false)) => Some(false),
-                            (None, _) | (_, None) => None,
-                        }
-                    }
-                    LogicalOperator::Coalesce => None,
-                }
-            }
-            Expression::SequenceExpression(sequence_expr) => {
-                // For sequence expression, the value is the value of the RHS.
-                sequence_expr.expressions.last().and_then(|e| self.get_boolean_value(e))
-            }
-            Expression::UnaryExpression(unary_expr) => {
-                match unary_expr.operator {
-                    UnaryOperator::Void => Some(false),
-                    UnaryOperator::BitwiseNot
-                    | UnaryOperator::UnaryPlus
-                    | UnaryOperator::UnaryNegation => {
-                        // `~0 -> true` `+1 -> true` `+0 -> false` `-0 -> false`
-                        self.eval_to_number(expr).map(|value| !value.is_zero())
-                    }
-                    UnaryOperator::LogicalNot => {
-                        // !true -> false
-                        self.get_boolean_value(&unary_expr.argument).map(|b| !b)
-                    }
-                    _ => None,
-                }
-            }
-            expr => expr.to_boolean(self),
-        }
-    }
-
-    fn eval_to_number(&self, expr: &Expression<'a>) -> Option<f64> {
-        match expr {
-            Expression::Identifier(ident) => match ident.name.as_str() {
-                "undefined" | "NaN" if self.is_global_reference(ident)? => Some(f64::NAN),
-                "Infinity" if self.is_global_reference(ident)? => Some(f64::INFINITY),
-                _ => None,
-            },
-            Expression::UnaryExpression(unary_expr) => match unary_expr.operator {
-                UnaryOperator::UnaryPlus => self.eval_to_number(&unary_expr.argument),
-                UnaryOperator::UnaryNegation => {
-                    self.eval_to_number(&unary_expr.argument).map(|v| -v)
-                }
-                UnaryOperator::LogicalNot => {
-                    self.get_boolean_value(expr).map(|b| if b { 1_f64 } else { 0_f64 })
-                }
-                UnaryOperator::Void => Some(f64::NAN),
-                _ => None,
-            },
-            Expression::SequenceExpression(s) => {
-                s.expressions.last().and_then(|e| self.eval_to_number(e))
-            }
-            // If the object is empty, `toString` / `valueOf` / `Symbol.toPrimitive` is not overridden.
-            // (assuming that those methods in Object.prototype are not modified)
-            // In that case, `ToPrimitive` returns `"[object Object]"`
-            Expression::ObjectExpression(e) if e.properties.is_empty() => Some(f64::NAN),
-            // `ToPrimitive` for RegExp object returns `"/regexp/"`
-            Expression::RegExpLiteral(_) => Some(f64::NAN),
-            Expression::ArrayExpression(arr) => {
-                // If the array is empty, `ToPrimitive` returns `""`
-                if arr.elements.is_empty() {
-                    return Some(0.0);
-                }
-                if arr.elements.len() == 1 {
-                    let first_element = arr.elements.first().unwrap();
-                    return match first_element {
-                        ArrayExpressionElement::SpreadElement(_) => None,
-                        // `ToPrimitive` returns `""` for `[,]`
-                        ArrayExpressionElement::Elision(_) => Some(0.0),
-                        match_expression!(ArrayExpressionElement) => {
-                            self.eval_to_number(first_element.to_expression())
-                        }
-                    };
-                }
-
-                let non_spread_element_count = arr
-                    .elements
-                    .iter()
-                    .filter(|e| !matches!(e, ArrayExpressionElement::SpreadElement(_)))
-                    .count();
-                // If the array has at least 2 elements, `ToPrimitive` returns a string containing
-                // `,` which is not included in `StringNumericLiteral`
-                // So `ToNumber` returns `NaN`
-                if non_spread_element_count >= 2 {
-                    Some(f64::NAN)
-                } else {
-                    None
-                }
-            }
-            expr => {
-                use crate::ToNumber;
-                expr.to_number(self)
-            }
-        }
-    }
-
-    fn eval_to_big_int(&self, expr: &Expression<'a>) -> Option<BigInt> {
-        match expr {
-            Expression::UnaryExpression(unary_expr) => match unary_expr.operator {
-                UnaryOperator::UnaryPlus => self.eval_to_big_int(&unary_expr.argument),
-                UnaryOperator::UnaryNegation => {
-                    self.eval_to_big_int(&unary_expr.argument).map(|v| -v)
-                }
-                _ => None,
-            },
-            Expression::BigIntLiteral(_) => {
-                use crate::ToBigInt;
-                expr.to_big_int(self)
-            }
+impl<'a> ConstantEvaluation<'a> for Expression<'a> {
+    fn evaluate_value_to(
+        &self,
+        ctx: &impl ConstantEvaluationCtx<'a>,
+        target_ty: Option<ValueType>,
+    ) -> Option<ConstantValue<'a>> {
+        let result = match target_ty {
+            Some(ValueType::Boolean) => self.to_boolean(ctx).map(ConstantValue::Boolean),
+            Some(ValueType::Number) => self.to_number(ctx).map(ConstantValue::Number),
+            Some(ValueType::BigInt) => self.to_big_int(ctx).map(ConstantValue::BigInt),
+            Some(ValueType::String) => self.to_js_string(ctx).map(ConstantValue::String),
             _ => None,
+        };
+        if result.is_some() {
+            return result;
         }
-    }
 
-    fn eval_expression(&self, expr: &Expression<'a>) -> Option<ConstantValue<'a>> {
-        match expr {
-            Expression::BinaryExpression(e) => self.eval_binary_expression(e),
-            Expression::LogicalExpression(e) => self.eval_logical_expression(e),
-            Expression::UnaryExpression(e) => self.eval_unary_expression(e),
-            Expression::Identifier(ident) => self.resolve_binding(ident),
+        match self {
+            Expression::BinaryExpression(e) => e.evaluate_value_to(ctx, target_ty),
+            Expression::LogicalExpression(e) => e.evaluate_value_to(ctx, target_ty),
+            Expression::UnaryExpression(e) => e.evaluate_value_to(ctx, target_ty),
+            Expression::Identifier(ident) => ident.evaluate_value_to(ctx, target_ty),
             Expression::NumericLiteral(lit) => Some(ConstantValue::Number(lit.value)),
             Expression::NullLiteral(_) => Some(ConstantValue::Null),
             Expression::BooleanLiteral(lit) => Some(ConstantValue::Boolean(lit.value)),
-            Expression::BigIntLiteral(lit) => lit.to_big_int(self).map(ConstantValue::BigInt),
+            Expression::BigIntLiteral(lit) => lit.to_big_int(ctx).map(ConstantValue::BigInt),
             Expression::StringLiteral(lit) => {
                 Some(ConstantValue::String(Cow::Borrowed(lit.value.as_str())))
             }
-            Expression::StaticMemberExpression(e) => self.eval_static_member_expression(e),
-            Expression::ComputedMemberExpression(e) => self.eval_computed_member_expression(e),
+            Expression::StaticMemberExpression(e) => e.evaluate_value_to(ctx, target_ty),
+            Expression::ComputedMemberExpression(e) => e.evaluate_value_to(ctx, target_ty),
+            Expression::SequenceExpression(e) => {
+                // For sequence expression, the value is the value of the RHS.
+                e.expressions.last().and_then(|e| e.evaluate_value_to(ctx, target_ty))
+            }
             _ => None,
         }
     }
+}
 
-    fn eval_binary_expression(&self, e: &BinaryExpression<'a>) -> Option<ConstantValue<'a>> {
-        self.eval_binary_operation(e.operator, &e.left, &e.right)
-    }
-
-    fn eval_binary_operation(
+impl<'a> ConstantEvaluation<'a> for BinaryExpression<'a> {
+    fn evaluate_value_to(
         &self,
-        operator: BinaryOperator,
-        left: &Expression<'a>,
-        right: &Expression<'a>,
+        ctx: &impl ConstantEvaluationCtx<'a>,
+        target_ty: Option<ValueType>,
     ) -> Option<ConstantValue<'a>> {
-        match operator {
-            BinaryOperator::Addition => {
-                use crate::to_primitive::ToPrimitive;
-                if left.may_have_side_effects(self) || right.may_have_side_effects(self) {
-                    return None;
+        // FIXME: skipped for now to avoid performance regression, can be removed
+        if target_ty == Some(ValueType::Boolean) {
+            return None;
+        }
+
+        binary_operation_evaluate_value_to(self.operator, &self.left, &self.right, ctx, target_ty)
+    }
+}
+
+pub fn binary_operation_evaluate_value<'a, Ctx: ConstantEvaluationCtx<'a>>(
+    operator: BinaryOperator,
+    left: &Expression<'a>,
+    right: &Expression<'a>,
+    ctx: &Ctx,
+) -> Option<ConstantValue<'a>> {
+    binary_operation_evaluate_value_to(operator, left, right, ctx, None)
+}
+
+fn binary_operation_evaluate_value_to<'a>(
+    operator: BinaryOperator,
+    left: &Expression<'a>,
+    right: &Expression<'a>,
+    ctx: &impl ConstantEvaluationCtx<'a>,
+    _target_ty: Option<ValueType>,
+) -> Option<ConstantValue<'a>> {
+    match operator {
+        BinaryOperator::Addition => {
+            use crate::to_primitive::ToPrimitive;
+            if left.may_have_side_effects(ctx) || right.may_have_side_effects(ctx) {
+                return None;
+            }
+            let left_to_primitive = left.to_primitive(ctx);
+            let right_to_primitive = right.to_primitive(ctx);
+            if left_to_primitive.is_string() == Some(true)
+                || right_to_primitive.is_string() == Some(true)
+            {
+                let lval = left.evaluate_value(ctx)?;
+                let rval = right.evaluate_value(ctx)?;
+                let lstr = lval.to_js_string(ctx)?;
+                let rstr = rval.to_js_string(ctx)?;
+                return Some(ConstantValue::String(lstr + rstr));
+            }
+            let left_to_numeric_type = left_to_primitive.to_numeric(ctx);
+            let right_to_numeric_type = right_to_primitive.to_numeric(ctx);
+            if left_to_numeric_type.is_number() || right_to_numeric_type.is_number() {
+                let lval = left.evaluate_value_to_number(ctx)?;
+                let rval = right.evaluate_value_to_number(ctx)?;
+                return Some(ConstantValue::Number(lval + rval));
+            }
+            if left_to_numeric_type.is_bigint() && right_to_numeric_type.is_bigint() {
+                let lval = left.evaluate_value_to_bigint(ctx)?;
+                let rval = right.evaluate_value_to_bigint(ctx)?;
+                return Some(ConstantValue::BigInt(lval + rval));
+            }
+            None
+        }
+        BinaryOperator::Subtraction
+        | BinaryOperator::Division
+        | BinaryOperator::Remainder
+        | BinaryOperator::Multiplication
+        | BinaryOperator::Exponential => {
+            let lval = left.evaluate_value_to_number(ctx)?;
+            let rval = right.evaluate_value_to_number(ctx)?;
+            let val = match operator {
+                BinaryOperator::Subtraction => lval - rval,
+                BinaryOperator::Division => lval / rval,
+                BinaryOperator::Remainder => {
+                    if rval.is_zero() {
+                        f64::NAN
+                    } else {
+                        lval % rval
+                    }
                 }
-                let left_to_primitive = left.to_primitive(self);
-                let right_to_primitive = right.to_primitive(self);
-                if left_to_primitive.is_string() == Some(true)
-                    || right_to_primitive.is_string() == Some(true)
+                BinaryOperator::Multiplication => lval * rval,
+                BinaryOperator::Exponential => {
+                    let result = lval.powf(rval);
+                    // For now, ignore the result if it large or has a decimal part
+                    // so that the output does not become bigger than the input.
+                    if result.is_finite() && (result.fract() != 0.0 || result.log10() > 4.0) {
+                        return None;
+                    }
+                    result
+                }
+                _ => unreachable!(),
+            };
+            Some(ConstantValue::Number(val))
+        }
+        #[expect(clippy::cast_sign_loss)]
+        BinaryOperator::ShiftLeft
+        | BinaryOperator::ShiftRight
+        | BinaryOperator::ShiftRightZeroFill => {
+            let left = left.get_side_free_number_value(ctx)?;
+            let right = right.get_side_free_number_value(ctx)?;
+            let left = left.to_int_32();
+            let right = (right.to_int_32() as u32) & 31;
+            Some(ConstantValue::Number(match operator {
+                BinaryOperator::ShiftLeft => f64::from(left << right),
+                BinaryOperator::ShiftRight => f64::from(left >> right),
+                BinaryOperator::ShiftRightZeroFill => f64::from((left as u32) >> right),
+                _ => unreachable!(),
+            }))
+        }
+        BinaryOperator::LessThan => is_less_than(ctx, left, right).map(|value| match value {
+            ConstantValue::Undefined => ConstantValue::Boolean(false),
+            _ => value,
+        }),
+        BinaryOperator::GreaterThan => is_less_than(ctx, right, left).map(|value| match value {
+            ConstantValue::Undefined => ConstantValue::Boolean(false),
+            _ => value,
+        }),
+        BinaryOperator::LessEqualThan => is_less_than(ctx, right, left).map(|value| match value {
+            ConstantValue::Boolean(true) | ConstantValue::Undefined => {
+                ConstantValue::Boolean(false)
+            }
+            ConstantValue::Boolean(false) => ConstantValue::Boolean(true),
+            _ => unreachable!(),
+        }),
+        BinaryOperator::GreaterEqualThan => {
+            is_less_than(ctx, left, right).map(|value| match value {
+                ConstantValue::Boolean(true) | ConstantValue::Undefined => {
+                    ConstantValue::Boolean(false)
+                }
+                ConstantValue::Boolean(false) => ConstantValue::Boolean(true),
+                _ => unreachable!(),
+            })
+        }
+        BinaryOperator::BitwiseAnd | BinaryOperator::BitwiseOR | BinaryOperator::BitwiseXOR => {
+            if left.value_type(ctx).is_bigint() && right.value_type(ctx).is_bigint() {
+                let left_val = left.get_side_free_bigint_value(ctx)?;
+                let right_val = right.get_side_free_bigint_value(ctx)?;
+                let result_val: BigInt = match operator {
+                    BinaryOperator::BitwiseAnd => left_val & right_val,
+                    BinaryOperator::BitwiseOR => left_val | right_val,
+                    BinaryOperator::BitwiseXOR => left_val ^ right_val,
+                    _ => unreachable!(),
+                };
+                return Some(ConstantValue::BigInt(result_val));
+            }
+            let left_num = left.get_side_free_number_value(ctx);
+            let right_num = right.get_side_free_number_value(ctx);
+            if let (Some(left_val), Some(right_val)) = (left_num, right_num) {
+                let left_val_int = left_val.to_int_32();
+                let right_val_int = right_val.to_int_32();
+
+                let result_val: f64 = match operator {
+                    BinaryOperator::BitwiseAnd => f64::from(left_val_int & right_val_int),
+                    BinaryOperator::BitwiseOR => f64::from(left_val_int | right_val_int),
+                    BinaryOperator::BitwiseXOR => f64::from(left_val_int ^ right_val_int),
+                    _ => unreachable!(),
+                };
+                return Some(ConstantValue::Number(result_val));
+            }
+            None
+        }
+        BinaryOperator::Instanceof => {
+            if left.may_have_side_effects(ctx) {
+                return None;
+            }
+            if let Expression::Identifier(right_ident) = right {
+                let name = right_ident.name.as_str();
+                if matches!(name, "Object" | "Number" | "Boolean" | "String")
+                    && ctx.is_global_reference(right_ident) == Some(true)
                 {
-                    let lval = self.eval_expression(left)?;
-                    let rval = self.eval_expression(right)?;
-                    let lstr = lval.to_js_string(self)?;
-                    let rstr = rval.to_js_string(self)?;
-                    return Some(ConstantValue::String(lstr + rstr));
-                }
-                let left_to_numeric_type = left_to_primitive.to_numeric(self);
-                let right_to_numeric_type = right_to_primitive.to_numeric(self);
-                if left_to_numeric_type.is_number() || right_to_numeric_type.is_number() {
-                    let lval = self.eval_expression(left)?;
-                    let rval = self.eval_expression(right)?;
-                    let lnum = lval.to_number(self)?;
-                    let rnum = rval.to_number(self)?;
-                    return Some(ConstantValue::Number(lnum + rnum));
-                }
-                if left_to_numeric_type.is_bigint() && right_to_numeric_type.is_bigint() {
-                    let lval = self.eval_to_big_int(left)?;
-                    let rval = self.eval_to_big_int(right)?;
-                    return Some(ConstantValue::BigInt(lval + rval));
-                }
-                None
-            }
-            BinaryOperator::Subtraction
-            | BinaryOperator::Division
-            | BinaryOperator::Remainder
-            | BinaryOperator::Multiplication
-            | BinaryOperator::Exponential => {
-                let lval = self.eval_to_number(left)?;
-                let rval = self.eval_to_number(right)?;
-                let val = match operator {
-                    BinaryOperator::Subtraction => lval - rval,
-                    BinaryOperator::Division => lval / rval,
-                    BinaryOperator::Remainder => {
-                        if rval.is_zero() {
-                            f64::NAN
-                        } else {
-                            lval % rval
-                        }
+                    let left_ty = left.value_type(ctx);
+                    if left_ty.is_undetermined() {
+                        return None;
                     }
-                    BinaryOperator::Multiplication => lval * rval,
-                    BinaryOperator::Exponential => lval.powf(rval),
-                    _ => unreachable!(),
-                };
-                Some(ConstantValue::Number(val))
-            }
-            #[expect(clippy::cast_sign_loss)]
-            BinaryOperator::ShiftLeft
-            | BinaryOperator::ShiftRight
-            | BinaryOperator::ShiftRightZeroFill => {
-                let left = self.get_side_free_number_value(left)?;
-                let right = self.get_side_free_number_value(right)?;
-                let left = left.to_int_32();
-                let right = (right.to_int_32() as u32) & 31;
-                Some(ConstantValue::Number(match operator {
-                    BinaryOperator::ShiftLeft => f64::from(left << right),
-                    BinaryOperator::ShiftRight => f64::from(left >> right),
-                    BinaryOperator::ShiftRightZeroFill => f64::from((left as u32) >> right),
-                    _ => unreachable!(),
-                }))
-            }
-            BinaryOperator::LessThan => self.is_less_than(left, right).map(|value| match value {
-                ConstantValue::Undefined => ConstantValue::Boolean(false),
-                _ => value,
-            }),
-            BinaryOperator::GreaterThan => {
-                self.is_less_than(right, left).map(|value| match value {
-                    ConstantValue::Undefined => ConstantValue::Boolean(false),
-                    _ => value,
-                })
-            }
-            BinaryOperator::LessEqualThan => {
-                self.is_less_than(right, left).map(|value| match value {
-                    ConstantValue::Boolean(true) | ConstantValue::Undefined => {
-                        ConstantValue::Boolean(false)
-                    }
-                    ConstantValue::Boolean(false) => ConstantValue::Boolean(true),
-                    _ => unreachable!(),
-                })
-            }
-            BinaryOperator::GreaterEqualThan => {
-                self.is_less_than(left, right).map(|value| match value {
-                    ConstantValue::Boolean(true) | ConstantValue::Undefined => {
-                        ConstantValue::Boolean(false)
-                    }
-                    ConstantValue::Boolean(false) => ConstantValue::Boolean(true),
-                    _ => unreachable!(),
-                })
-            }
-            BinaryOperator::BitwiseAnd | BinaryOperator::BitwiseOR | BinaryOperator::BitwiseXOR => {
-                if left.value_type(self).is_bigint() && right.value_type(self).is_bigint() {
-                    let left_val = self.get_side_free_bigint_value(left)?;
-                    let right_val = self.get_side_free_bigint_value(right)?;
-                    let result_val: BigInt = match operator {
-                        BinaryOperator::BitwiseAnd => left_val & right_val,
-                        BinaryOperator::BitwiseOR => left_val | right_val,
-                        BinaryOperator::BitwiseXOR => left_val ^ right_val,
-                        _ => unreachable!(),
-                    };
-                    return Some(ConstantValue::BigInt(result_val));
+                    return Some(ConstantValue::Boolean(
+                        name == "Object" && left.value_type(ctx).is_object(),
+                    ));
                 }
-                let left_num = self.get_side_free_number_value(left);
-                let right_num = self.get_side_free_number_value(right);
-                if let (Some(left_val), Some(right_val)) = (left_num, right_num) {
-                    let left_val_int = left_val.to_int_32();
-                    let right_val_int = right_val.to_int_32();
+            }
+            None
+        }
+        BinaryOperator::StrictEquality
+        | BinaryOperator::StrictInequality
+        | BinaryOperator::Equality
+        | BinaryOperator::Inequality => {
+            if left.may_have_side_effects(ctx) || right.may_have_side_effects(ctx) {
+                return None;
+            }
+            let value = match operator {
+                BinaryOperator::StrictEquality | BinaryOperator::StrictInequality => {
+                    strict_equality_comparison(ctx, left, right)?
+                }
+                BinaryOperator::Equality | BinaryOperator::Inequality => {
+                    abstract_equality_comparison(ctx, left, right)?
+                }
+                _ => unreachable!(),
+            };
+            Some(ConstantValue::Boolean(match operator {
+                BinaryOperator::StrictEquality | BinaryOperator::Equality => value,
+                BinaryOperator::StrictInequality | BinaryOperator::Inequality => !value,
+                _ => unreachable!(),
+            }))
+        }
+        BinaryOperator::In => None,
+    }
+}
 
-                    let result_val: f64 = match operator {
-                        BinaryOperator::BitwiseAnd => f64::from(left_val_int & right_val_int),
-                        BinaryOperator::BitwiseOR => f64::from(left_val_int | right_val_int),
-                        BinaryOperator::BitwiseXOR => f64::from(left_val_int ^ right_val_int),
-                        _ => unreachable!(),
-                    };
-                    return Some(ConstantValue::Number(result_val));
-                }
-                None
-            }
-            BinaryOperator::Instanceof => {
-                if left.may_have_side_effects(self) {
-                    return None;
-                }
-                if let Expression::Identifier(right_ident) = right {
-                    let name = right_ident.name.as_str();
-                    if matches!(name, "Object" | "Number" | "Boolean" | "String")
-                        && self.is_global_reference(right_ident) == Some(true)
+impl<'a> ConstantEvaluation<'a> for LogicalExpression<'a> {
+    fn evaluate_value_to(
+        &self,
+        ctx: &impl ConstantEvaluationCtx<'a>,
+        target_ty: Option<ValueType>,
+    ) -> Option<ConstantValue<'a>> {
+        match self.operator {
+            LogicalOperator::And => match self.left.evaluate_value_to_boolean(ctx) {
+                Some(true) => self.right.evaluate_value(ctx),
+                Some(false) => self.left.evaluate_value(ctx),
+                None => {
+                    // ToBoolean(a && false) -> false
+                    if target_ty == Some(ValueType::Boolean)
+                        && self.right.evaluate_value_to_boolean(ctx) == Some(false)
                     {
-                        let left_ty = left.value_type(self);
-                        if left_ty.is_undetermined() {
-                            return None;
-                        }
-                        return Some(ConstantValue::Boolean(
-                            name == "Object" && left.value_type(self).is_object(),
-                        ));
+                        Some(ConstantValue::Boolean(false))
+                    } else {
+                        None
                     }
                 }
-                None
-            }
-            BinaryOperator::StrictEquality
-            | BinaryOperator::StrictInequality
-            | BinaryOperator::Equality
-            | BinaryOperator::Inequality => {
-                if left.may_have_side_effects(self) || right.may_have_side_effects(self) {
-                    return None;
+            },
+            LogicalOperator::Or => match self.left.evaluate_value_to_boolean(ctx) {
+                Some(true) => self.left.evaluate_value(ctx),
+                Some(false) => self.right.evaluate_value(ctx),
+                None => {
+                    // ToBoolean(a || true) -> true
+                    if target_ty == Some(ValueType::Boolean)
+                        && self.right.evaluate_value_to_boolean(ctx) == Some(true)
+                    {
+                        Some(ConstantValue::Boolean(true))
+                    } else {
+                        None
+                    }
                 }
-                let value = match operator {
-                    BinaryOperator::StrictEquality | BinaryOperator::StrictInequality => {
-                        strict_equality_comparison(self, left, right)?
-                    }
-                    BinaryOperator::Equality | BinaryOperator::Inequality => {
-                        abstract_equality_comparison(self, left, right)?
-                    }
-                    _ => unreachable!(),
-                };
-                Some(ConstantValue::Boolean(match operator {
-                    BinaryOperator::StrictEquality | BinaryOperator::Equality => value,
-                    BinaryOperator::StrictInequality | BinaryOperator::Inequality => !value,
-                    _ => unreachable!(),
-                }))
-            }
-            BinaryOperator::In => None,
+            },
+            LogicalOperator::Coalesce => None,
         }
     }
+}
 
-    fn eval_logical_expression(&self, expr: &LogicalExpression<'a>) -> Option<ConstantValue<'a>> {
-        match expr.operator {
-            LogicalOperator::And => {
-                if self.get_boolean_value(&expr.left) == Some(true) {
-                    self.eval_expression(&expr.right)
-                } else {
-                    self.eval_expression(&expr.left)
-                }
-            }
-            _ => None,
-        }
-    }
-
-    fn eval_unary_expression(&self, expr: &UnaryExpression<'a>) -> Option<ConstantValue<'a>> {
-        match expr.operator {
+impl<'a> ConstantEvaluation<'a> for UnaryExpression<'a> {
+    fn evaluate_value_to(
+        &self,
+        ctx: &impl ConstantEvaluationCtx<'a>,
+        _target_ty: Option<ValueType>,
+    ) -> Option<ConstantValue<'a>> {
+        match self.operator {
             UnaryOperator::Typeof => {
-                if expr.argument.may_have_side_effects(self) {
+                if self.argument.may_have_side_effects(ctx) {
                     return None;
                 }
-                let arg_ty = expr.argument.value_type(self);
+                let arg_ty = self.argument.value_type(ctx);
                 let s = match arg_ty {
                     ValueType::BigInt => "bigint",
                     ValueType::Number => "number",
@@ -442,7 +409,7 @@ pub trait ConstantEvaluation<'a>: IsGlobalReference {
                     ValueType::Boolean => "boolean",
                     ValueType::Undefined => "undefined",
                     ValueType::Null => "object",
-                    _ => match &expr.argument {
+                    _ => match &self.argument {
                         Expression::ObjectExpression(_) | Expression::ArrayExpression(_) => {
                             "object"
                         }
@@ -455,56 +422,64 @@ pub trait ConstantEvaluation<'a>: IsGlobalReference {
                 Some(ConstantValue::String(Cow::Borrowed(s)))
             }
             UnaryOperator::Void => {
-                (!expr.argument.may_have_side_effects(self)).then_some(ConstantValue::Undefined)
+                (!self.argument.may_have_side_effects(ctx)).then_some(ConstantValue::Undefined)
             }
             UnaryOperator::LogicalNot => self
-                .get_side_free_boolean_value(&expr.argument)
+                .argument
+                .get_side_free_boolean_value(ctx)
                 .map(|b| !b)
                 .map(ConstantValue::Boolean),
             UnaryOperator::UnaryPlus => {
-                self.get_side_free_number_value(&expr.argument).map(ConstantValue::Number)
+                self.argument.get_side_free_number_value(ctx).map(ConstantValue::Number)
             }
-            UnaryOperator::UnaryNegation => match expr.argument.value_type(self) {
+            UnaryOperator::UnaryNegation => match self.argument.value_type(ctx) {
                 ValueType::BigInt => self
-                    .get_side_free_bigint_value(&expr.argument)
+                    .argument
+                    .get_side_free_bigint_value(ctx)
                     .map(|v| -v)
                     .map(ConstantValue::BigInt),
                 ValueType::Number => self
-                    .get_side_free_number_value(&expr.argument)
+                    .argument
+                    .get_side_free_number_value(ctx)
                     .map(|v| if v.is_nan() { v } else { -v })
                     .map(ConstantValue::Number),
                 ValueType::Undefined => Some(ConstantValue::Number(f64::NAN)),
                 ValueType::Null => Some(ConstantValue::Number(-0.0)),
                 _ => None,
             },
-            UnaryOperator::BitwiseNot => match expr.argument.value_type(self) {
+            UnaryOperator::BitwiseNot => match self.argument.value_type(ctx) {
                 ValueType::BigInt => self
-                    .get_side_free_bigint_value(&expr.argument)
+                    .argument
+                    .get_side_free_bigint_value(ctx)
                     .map(|v| !v)
                     .map(ConstantValue::BigInt),
                 #[expect(clippy::cast_lossless)]
                 _ => self
-                    .get_side_free_number_value(&expr.argument)
+                    .argument
+                    .get_side_free_number_value(ctx)
                     .map(|v| (!v.to_int_32()) as f64)
                     .map(ConstantValue::Number),
             },
             UnaryOperator::Delete => None,
         }
     }
+}
 
-    fn eval_static_member_expression(
+impl<'a> ConstantEvaluation<'a> for StaticMemberExpression<'a> {
+    fn evaluate_value_to(
         &self,
-        expr: &StaticMemberExpression<'a>,
+        ctx: &impl ConstantEvaluationCtx<'a>,
+        _target_ty: Option<ValueType>,
     ) -> Option<ConstantValue<'a>> {
-        match expr.property.name.as_str() {
+        match self.property.name.as_str() {
             "length" => {
-                if let Some(ConstantValue::String(s)) = self.eval_expression(&expr.object) {
+                if let Some(ConstantValue::String(s)) = self.object.evaluate_value(ctx) {
                     Some(ConstantValue::Number(s.encode_utf16().count().to_f64().unwrap()))
                 } else {
-                    if expr.object.may_have_side_effects(self) {
+                    if self.object.may_have_side_effects(ctx) {
                         return None;
                     }
-                    if let Expression::ArrayExpression(arr) = &expr.object {
+                    if let Expression::ArrayExpression(arr) = &self.object {
                         Some(ConstantValue::Number(arr.elements.len().to_f64().unwrap()))
                     } else {
                         None
@@ -514,20 +489,23 @@ pub trait ConstantEvaluation<'a>: IsGlobalReference {
             _ => None,
         }
     }
+}
 
-    fn eval_computed_member_expression(
+impl<'a> ConstantEvaluation<'a> for ComputedMemberExpression<'a> {
+    fn evaluate_value_to(
         &self,
-        expr: &ComputedMemberExpression<'a>,
+        ctx: &impl ConstantEvaluationCtx<'a>,
+        _target_ty: Option<ValueType>,
     ) -> Option<ConstantValue<'a>> {
-        match &expr.expression {
+        match &self.expression {
             Expression::StringLiteral(s) if s.value == "length" => {
-                if let Some(ConstantValue::String(s)) = self.eval_expression(&expr.object) {
+                if let Some(ConstantValue::String(s)) = self.object.evaluate_value(ctx) {
                     Some(ConstantValue::Number(s.encode_utf16().count().to_f64().unwrap()))
                 } else {
-                    if expr.object.may_have_side_effects(self) {
+                    if self.object.may_have_side_effects(ctx) {
                         return None;
                     }
-                    if let Expression::ArrayExpression(arr) = &expr.object {
+                    if let Expression::ArrayExpression(arr) = &self.object {
                         Some(ConstantValue::Number(arr.elements.len().to_f64().unwrap()))
                     } else {
                         None
@@ -537,109 +515,111 @@ pub trait ConstantEvaluation<'a>: IsGlobalReference {
             _ => None,
         }
     }
+}
 
-    /// <https://tc39.es/ecma262/multipage/abstract-operations.html#sec-islessthan>
-    fn is_less_than(&self, x: &Expression<'a>, y: &Expression<'a>) -> Option<ConstantValue<'a>> {
-        if x.may_have_side_effects(self) || y.may_have_side_effects(self) {
-            return None;
-        }
+#[expect(clippy::similar_names)]
+fn is_less_than<'a>(
+    ctx: &impl ConstantEvaluationCtx<'a>,
+    x: &Expression<'a>,
+    y: &Expression<'a>,
+) -> Option<ConstantValue<'a>> {
+    if x.may_have_side_effects(ctx) || y.may_have_side_effects(ctx) {
+        return None;
+    }
 
-        // a. Let px be ? ToPrimitive(x, NUMBER).
-        // b. Let py be ? ToPrimitive(y, NUMBER).
-        let px = x.value_type(self);
-        let py = y.value_type(self);
+    // a. Let px be ? ToPrimitive(x, NUMBER).
+    // b. Let py be ? ToPrimitive(y, NUMBER).
+    let px = x.value_type(ctx);
+    let py = y.value_type(ctx);
 
-        // If the operands are not primitives, `ToPrimitive` is *not* a noop.
-        if px.is_undetermined() || px.is_object() || py.is_undetermined() || py.is_object() {
-            return None;
-        }
+    // If the operands are not primitives, `ToPrimitive` is *not* a noop.
+    if px.is_undetermined() || px.is_object() || py.is_undetermined() || py.is_object() {
+        return None;
+    }
 
-        // 3. If px is a String and py is a String, then
-        if px.is_string() && py.is_string() {
-            let left_string = x.to_js_string(self)?;
-            let right_string = y.to_js_string(self)?;
-            return Some(ConstantValue::Boolean(
-                left_string.encode_utf16().cmp(right_string.encode_utf16()) == Ordering::Less,
-            ));
-        }
+    // 3. If px is a String and py is a String, then
+    if px.is_string() && py.is_string() {
+        let left_string = x.to_js_string(ctx)?;
+        let right_string = y.to_js_string(ctx)?;
+        return Some(ConstantValue::Boolean(
+            left_string.encode_utf16().cmp(right_string.encode_utf16()) == Ordering::Less,
+        ));
+    }
 
-        // a. If px is a BigInt and py is a String, then
-        if px.is_bigint() && py.is_string() {
-            use crate::StringToBigInt;
-            let ny = y.to_js_string(self)?.as_ref().string_to_big_int();
-            let Some(ny) = ny else { return Some(ConstantValue::Undefined) };
-            return Some(ConstantValue::Boolean(x.to_big_int(self)? < ny));
-        }
-        // b. If px is a String and py is a BigInt, then
-        if px.is_string() && py.is_bigint() {
-            use crate::StringToBigInt;
-            let nx = x.to_js_string(self)?.as_ref().string_to_big_int();
-            let Some(nx) = nx else { return Some(ConstantValue::Undefined) };
-            return Some(ConstantValue::Boolean(nx < y.to_big_int(self)?));
-        }
+    // a. If px is a BigInt and py is a String, then
+    if px.is_bigint() && py.is_string() {
+        use crate::StringToBigInt;
+        let ny = y.to_js_string(ctx)?.as_ref().string_to_big_int();
+        let Some(ny) = ny else { return Some(ConstantValue::Undefined) };
+        return Some(ConstantValue::Boolean(x.to_big_int(ctx)? < ny));
+    }
+    // b. If px is a String and py is a BigInt, then
+    if px.is_string() && py.is_bigint() {
+        use crate::StringToBigInt;
+        let nx = x.to_js_string(ctx)?.as_ref().string_to_big_int();
+        let Some(nx) = nx else { return Some(ConstantValue::Undefined) };
+        return Some(ConstantValue::Boolean(nx < y.to_big_int(ctx)?));
+    }
 
-        // Both operands are primitives here.
-        // ToNumeric returns a BigInt if the operand is a BigInt. Otherwise, it returns a Number.
-        let nx_is_number = !px.is_bigint();
-        let ny_is_number = !py.is_bigint();
+    // Both operands are primitives here.
+    // ToNumeric returns a BigInt if the operand is a BigInt. Otherwise, it returns a Number.
+    let nx_is_number = !px.is_bigint();
+    let ny_is_number = !py.is_bigint();
 
-        // f. If SameType(nx, ny) is true, then
-        //   i. If nx is a Number, then
-        if nx_is_number && ny_is_number {
-            let left_num = self.eval_to_number(x)?;
-            if left_num.is_nan() {
-                return Some(ConstantValue::Undefined);
-            }
-            let right_num = self.eval_to_number(y)?;
-            if right_num.is_nan() {
-                return Some(ConstantValue::Undefined);
-            }
-            return Some(ConstantValue::Boolean(left_num < right_num));
-        }
-        //   ii. Else,
-        if px.is_bigint() && py.is_bigint() {
-            return Some(ConstantValue::Boolean(x.to_big_int(self)? < y.to_big_int(self)?));
-        }
-
-        let nx = self.eval_to_number(x);
-        let ny = self.eval_to_number(y);
-
-        // h. If nx or ny is NaN, return undefined.
-        if nx_is_number && nx.is_some_and(f64::is_nan)
-            || ny_is_number && ny.is_some_and(f64::is_nan)
-        {
+    // f. If SameType(nx, ny) is true, then
+    //   i. If nx is a Number, then
+    if nx_is_number && ny_is_number {
+        let left_num = x.evaluate_value_to_number(ctx)?;
+        if left_num.is_nan() {
             return Some(ConstantValue::Undefined);
         }
-
-        // i. If nx is -∞𝔽 or ny is +∞𝔽, return true.
-        if nx_is_number && nx.is_some_and(|n| n == f64::NEG_INFINITY)
-            || ny_is_number && ny.is_some_and(|n| n == f64::INFINITY)
-        {
-            return Some(ConstantValue::Boolean(true));
+        let right_num = y.evaluate_value_to_number(ctx)?;
+        if right_num.is_nan() {
+            return Some(ConstantValue::Undefined);
         }
-        // j. If nx is +∞𝔽 or ny is -∞𝔽, return false.
-        if nx_is_number && nx.is_some_and(|n| n == f64::INFINITY)
-            || ny_is_number && ny.is_some_and(|n| n == f64::NEG_INFINITY)
-        {
-            return Some(ConstantValue::Boolean(false));
-        }
-
-        // k. If ℝ(nx) < ℝ(ny), return true; otherwise return false.
-        if px.is_bigint() {
-            let nx = x.to_big_int(self)?;
-            let ny = self.eval_to_number(y)?;
-            return compare_bigint_and_f64(&nx, ny)
-                .map(|ord| ConstantValue::Boolean(ord == Ordering::Less));
-        }
-        if py.is_bigint() {
-            let ny = y.to_big_int(self)?;
-            let nx = self.eval_to_number(x)?;
-            return compare_bigint_and_f64(&ny, nx)
-                .map(|ord| ConstantValue::Boolean(ord.reverse() == Ordering::Less));
-        }
-
-        None
+        return Some(ConstantValue::Boolean(left_num < right_num));
     }
+    //   ii. Else,
+    if px.is_bigint() && py.is_bigint() {
+        return Some(ConstantValue::Boolean(x.to_big_int(ctx)? < y.to_big_int(ctx)?));
+    }
+
+    let nx = x.evaluate_value_to_number(ctx);
+    let ny = y.evaluate_value_to_number(ctx);
+
+    // h. If nx or ny is NaN, return undefined.
+    if nx_is_number && nx.is_some_and(f64::is_nan) || ny_is_number && ny.is_some_and(f64::is_nan) {
+        return Some(ConstantValue::Undefined);
+    }
+
+    // i. If nx is -∞𝔽 or ny is +∞𝔽, return true.
+    if nx_is_number && nx.is_some_and(|n| n == f64::NEG_INFINITY)
+        || ny_is_number && ny.is_some_and(|n| n == f64::INFINITY)
+    {
+        return Some(ConstantValue::Boolean(true));
+    }
+    // j. If nx is +∞𝔽 or ny is -∞𝔽, return false.
+    if nx_is_number && nx.is_some_and(|n| n == f64::INFINITY)
+        || ny_is_number && ny.is_some_and(|n| n == f64::NEG_INFINITY)
+    {
+        return Some(ConstantValue::Boolean(false));
+    }
+
+    // k. If ℝ(nx) < ℝ(ny), return true; otherwise return false.
+    if px.is_bigint() {
+        let nx = x.to_big_int(ctx)?;
+        let ny = y.evaluate_value_to_number(ctx)?;
+        return compare_bigint_and_f64(&nx, ny)
+            .map(|ord| ConstantValue::Boolean(ord == Ordering::Less));
+    }
+    if py.is_bigint() {
+        let ny = y.to_big_int(ctx)?;
+        let nx = x.evaluate_value_to_number(ctx)?;
+        return compare_bigint_and_f64(&ny, nx)
+            .map(|ord| ConstantValue::Boolean(ord.reverse() == Ordering::Less));
+    }
+
+    None
 }
 
 fn compare_bigint_and_f64(x: &BigInt, y: f64) -> Option<Ordering> {

--- a/crates/oxc_ecmascript/src/constant_evaluation/value.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/value.rs
@@ -2,8 +2,9 @@ use core::f64;
 use std::borrow::Cow;
 
 use num_bigint::BigInt;
+use num_traits::Zero;
 
-use crate::{is_global_reference::IsGlobalReference, ToJsString, ToNumber};
+use crate::{is_global_reference::IsGlobalReference, ToBoolean, ToJsString, ToNumber};
 
 #[derive(Debug, PartialEq)]
 pub enum ConstantValue<'a> {
@@ -50,6 +51,13 @@ impl<'a> ConstantValue<'a> {
         }
     }
 
+    pub fn into_bigint(self) -> Option<BigInt> {
+        match self {
+            Self::BigInt(s) => Some(s),
+            _ => None,
+        }
+    }
+
     pub fn into_boolean(self) -> Option<bool> {
         match self {
             Self::Boolean(s) => Some(s),
@@ -85,6 +93,18 @@ impl<'a> ToNumber<'a> for ConstantValue<'a> {
             Self::Boolean(true) => Some(1.0),
             Self::Boolean(false) | Self::Null => Some(0.0),
             Self::Undefined => Some(f64::NAN),
+        }
+    }
+}
+
+impl<'a> ToBoolean<'a> for ConstantValue<'a> {
+    fn to_boolean(&self, _is_global_reference: &impl IsGlobalReference) -> Option<bool> {
+        match self {
+            Self::Number(n) => Some(!n.is_nan() && *n != 0.0),
+            Self::BigInt(n) => Some(*n != BigInt::zero()),
+            Self::String(s) => Some(!s.as_ref().is_empty()),
+            Self::Boolean(b) => Some(*b),
+            Self::Null | Self::Undefined => Some(false),
         }
     }
 }

--- a/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
@@ -73,7 +73,7 @@ impl<'a> PeepholeOptimizations {
                 self.try_fold_expr_in_boolean_context(&mut e.left, ctx);
                 self.try_fold_expr_in_boolean_context(&mut e.right, ctx);
                 // "if (anything && truthyNoSideEffects)" => "if (anything)"
-                if ctx.get_side_free_boolean_value(&e.right) == Some(true) {
+                if e.right.get_side_free_boolean_value(&ctx) == Some(true) {
                     *expr = ctx.ast.move_expression(&mut e.left);
                     return true;
                 }
@@ -83,7 +83,7 @@ impl<'a> PeepholeOptimizations {
                 self.try_fold_expr_in_boolean_context(&mut e.left, ctx);
                 self.try_fold_expr_in_boolean_context(&mut e.right, ctx);
                 // "if (anything || falsyNoSideEffects)" => "if (anything)"
-                if ctx.get_side_free_boolean_value(&e.right) == Some(false) {
+                if e.right.get_side_free_boolean_value(&ctx) == Some(false) {
                     *expr = ctx.ast.move_expression(&mut e.left);
                     return true;
                 }
@@ -92,7 +92,7 @@ impl<'a> PeepholeOptimizations {
                 // "if (a ? !!b : !!c)" => "if (a ? b : c)"
                 self.try_fold_expr_in_boolean_context(&mut e.consequent, ctx);
                 self.try_fold_expr_in_boolean_context(&mut e.alternate, ctx);
-                if let Some(boolean) = ctx.get_side_free_boolean_value(&e.consequent) {
+                if let Some(boolean) = e.consequent.get_side_free_boolean_value(&ctx) {
                     let right = ctx.ast.move_expression(&mut e.alternate);
                     let left = ctx.ast.move_expression(&mut e.test);
                     let span = e.span;
@@ -106,7 +106,7 @@ impl<'a> PeepholeOptimizations {
                     *expr = self.join_with_left_associative_op(span, op, left, right, ctx);
                     return true;
                 }
-                if let Some(boolean) = ctx.get_side_free_boolean_value(&e.alternate) {
+                if let Some(boolean) = e.alternate.get_side_free_boolean_value(&ctx) {
                     let left = ctx.ast.move_expression(&mut e.test);
                     let right = ctx.ast.move_expression(&mut e.consequent);
                     let span = e.span;


### PR DESCRIPTION
- merged `eval_to_*` into `eval_expression` to dedupe logics
- moved some parts of `eval_expression` to `to_number`
- changed `ConstantEvaluation` to receive `ConstantEvaluationCtx` instead of extending `IsGlobalReference` to align with other traits