### PR TITLE
fix(ast/estree): `FormalParameter` do not include `Span` twice

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1709,6 +1709,7 @@ pub struct FormalParameters<'a> {
 #[plural(FormalParameterList)]
 #[estree(no_type)]
 pub struct FormalParameter<'a> {
+    #[estree(skip)]
     pub span: Span,
     #[ts]
     pub decorators: Vec<'a, Decorator<'a>>,

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1380,8 +1380,6 @@ impl Serialize for FunctionType {
 impl Serialize for FormalParameter<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
         map.serialize_entry("decorators", &self.decorators)?;
         self.pattern.kind.serialize(FlatMapSerializer(&mut map))?;
         map.serialize_entry("typeAnnotation", &self.pattern.type_annotation)?;

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -582,7 +582,6 @@ export type FormalParameter =
     readonly: boolean;
     override: boolean;
   })
-  & Span
   & BindingPattern;
 
 export type FormalParameterKind = 'FormalParameter' | 'UniqueFormalParameters' | 'ArrowFormalParameters' | 'Signature';


### PR DESCRIPTION
Fix ESTree JSON for `FormalParameter`. `BindingPatternKind` gets flattened into `FormalParameter` and contains its own `Span`, so we were producing JSON with multiple `start` and `end` properties:

```json
{
  "type": "FunctionDeclaration",
  "params": [
    {
      "start": 13,
      "end": 18,
      "decorators": [],
      "type": "Identifier",
      "start": 13,
      "end": 18,
      "name": "value",
      "typeAnnotation": null,
      "optional": false,
      "accessibility": null,
      "readonly": false,
      "override": false
    }
  ]
}
```

This PR fixes that by ignoring `FormalParameter`'s own `Span`.
