### PR TITLE
fix(ast/estree): `CatchParameter` do not include `type` and `Span` twice

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1440,7 +1440,9 @@ pub struct CatchClause<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[estree(no_type, ts_alias = "BindingPattern")]
 pub struct CatchParameter<'a> {
+    #[estree(skip)]
     pub span: Span,
     /// The bound error
     #[estree(flatten)]

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1231,9 +1231,6 @@ impl Serialize for CatchClause<'_> {
 impl Serialize for CatchParameter<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "CatchParameter")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
         self.pattern.kind.serialize(FlatMapSerializer(&mut map))?;
         map.serialize_entry("typeAnnotation", &self.pattern.type_annotation)?;
         map.serialize_entry("optional", &self.pattern.optional)?;

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -485,16 +485,9 @@ export interface TryStatement extends Span {
 
 export interface CatchClause extends Span {
   type: 'CatchClause';
-  param: CatchParameter | null;
+  param: BindingPattern | null;
   body: BlockStatement;
 }
-
-export type CatchParameter =
-  & ({
-    type: 'CatchParameter';
-  })
-  & Span
-  & BindingPattern;
 
 export interface DebuggerStatement extends Span {
   type: 'DebuggerStatement';


### PR DESCRIPTION
Fix ESTree JSON for `CatchParameter`. `BindingPattern` gets flattened into `CatchParameter` and contains its own `type` and `Span`, so we were producing JSON with multiple, `type`, `start` and `end` properties. Fix by skipping these.

Before:

```json
{
  "type": "CatchClause",
  "start": 7,
  "end": 19,
  "param": {
    "type": "CatchParameter",
    "start": 14,
    "end": 15,
    "type": "Identifier",
    "start": 14,
    "end": 15,
    "name": "x",
    "typeAnnotation": null,
    "optional": false
  },
  "body": {
    "type": "BlockStatement",
    "start": 17,
    "end": 19,
    "body": []
  }
}
```

After:

```json
{
  "type": "CatchClause",
  "start": 7,
  "end": 19,
  "param": {
    "type": "Identifier",
    "start": 14,
    "end": 15,
    "name": "x",
    "typeAnnotation": null,
    "optional": false
  },
  "body": {
    "type": "BlockStatement",
    "start": 17,
    "end": 19,
    "body": []
  }
}
```