### PR TITLE
fix(minifier): compress computed string literals in method/property definitions

### DIFF
--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -864,8 +864,8 @@ impl<'a> PeepholeOptimizations {
                     NumberBase::Decimal,
                 ));
                 self.mark_current_function_as_changed();
+                return;
             }
-            return;
         }
         if *computed {
             *computed = false;
@@ -1662,7 +1662,7 @@ mod test {
             "class F { accessor  0 = _;  accessor  a = _;    accessor 1 = _;accessor     1 = _; accessor     b = _; accessor   'c.c' = _; accessor '1.1' = _; accessor '😊' = _; accessor 'd.d' = _ }"
         );
 
-        test_same("class C { ['-1']() {} }");
+        test("class C { ['-1']() {} }", "class C { '-1'() {} }");
         test_same("class C { ['prototype']() {} }");
         test_same("class C { ['__proto__']() {} }");
         test_same("class C { ['constructor']() {} }");

--- a/crates/oxc_minifier/tests/peephole/esbuild.rs
+++ b/crates/oxc_minifier/tests/peephole/esbuild.rs
@@ -122,7 +122,7 @@ fn js_parser_test() {
     // );
     test("class x { '0' = y }", "class x { 0 = y;}");
     test("class x { '123' = y }", "class x { 123 = y;}");
-    // test("class x { ['-123'] = y }", "class x { '-123' = y;}");
+    test("class x { ['-123'] = y }", "class x { '-123' = y;}");
     test("class x { '-0' = y }", "class x { '-0' = y;}");
     test("class x { '01' = y }", "class x { '01' = y;}");
     test("class x { '-01' = y }", "class x { '-01' = y;}");
@@ -130,7 +130,7 @@ fn js_parser_test() {
     test("class x { '-0x1' = y }", "class x { '-0x1' = y;}");
     test("class x { '2147483647' = y }", "class x { 2147483647 = y;}");
     test("class x { '2147483648' = y }", "class x { '2147483648' = y;}");
-    // test("class x { ['-2147483648'] = y }", "class x { '-2147483648' = y;}");
+    test("class x { ['-2147483648'] = y }", "class x { '-2147483648' = y;}");
     test("class x { ['-2147483649'] = y }", "class x { '-2147483649' = y;}");
     test("class Foo { static {} }", "class Foo {}");
     test("class Foo { static { 123 } }", "class Foo {}");


### PR DESCRIPTION
we were incorrectly returning early if the number value inside of the string was less than zero. but any string literal is valid to be part of a `PropertyDefinition`, or `MethodDefinition`, as part of `PropertyName`: https://tc39.es/ecma262/#prod-PropertyName