### PR TITLE
feat(ast_tools): allow reordering fields in ESTree AST

### DIFF
--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -100,8 +100,34 @@ fn generate_ts_type_def_for_struct(struct_def: &StructDef, schema: &Schema) -> O
     }
 
     let mut output_as_type = false;
-    for field in &struct_def.fields {
-        if !should_skip_field(field, schema) {
+
+    if let Some(field_indices) = &struct_def.estree.field_indices {
+        // Specified field order - output in this order
+        for &field_index in field_indices {
+            let field_index = field_index as usize;
+            if let Some(field) = struct_def.fields.get(field_index) {
+                generate_ts_type_def_for_struct_field(
+                    struct_def,
+                    field,
+                    &mut fields_str,
+                    &mut extends,
+                    &mut output_as_type,
+                    schema,
+                );
+            } else {
+                let (field_name, converter_name) =
+                    &struct_def.estree.add_fields[field_index - struct_def.fields.len()];
+                generate_ts_type_def_for_added_struct_field(
+                    field_name,
+                    converter_name,
+                    &mut fields_str,
+                    schema,
+                );
+            }
+        }
+    } else {
+        // No specified field order - output in original order
+        for field in &struct_def.fields {
             generate_ts_type_def_for_struct_field(
                 struct_def,
                 field,
@@ -111,14 +137,15 @@ fn generate_ts_type_def_for_struct(struct_def: &StructDef, schema: &Schema) -> O
                 schema,
             );
         }
-    }
 
-    for (add_field_name, converter_name) in &struct_def.estree.add_fields {
-        let converter = schema.meta_by_name(converter_name);
-        let Some(add_field_ts_type) = &converter.estree.ts_type else {
-            panic!("No `ts_type` provided for ESTree converter `{}`", converter.name());
-        };
-        fields_str.push_str(&format!("\n\t{add_field_name}: {add_field_ts_type};"));
+        for (field_name, converter_name) in &struct_def.estree.add_fields {
+            generate_ts_type_def_for_added_struct_field(
+                field_name,
+                converter_name,
+                &mut fields_str,
+                schema,
+            );
+        }
     }
 
     let ts_def = if extends.is_empty() {
@@ -135,6 +162,28 @@ fn generate_ts_type_def_for_struct(struct_def: &StructDef, schema: &Schema) -> O
 ///
 /// Field definition is appended to `fields_str` or `extends`.
 fn generate_ts_type_def_for_struct_field<'s>(
+    struct_def: &StructDef,
+    field: &'s FieldDef,
+    fields_str: &mut String,
+    extends: &mut Vec<Cow<'s, str>>,
+    output_as_type: &mut bool,
+    schema: &'s Schema,
+) {
+    if should_skip_field(field, schema) {
+        return;
+    }
+
+    generate_ts_type_def_for_struct_field_impl(
+        struct_def,
+        field,
+        fields_str,
+        extends,
+        output_as_type,
+        schema,
+    );
+}
+
+fn generate_ts_type_def_for_struct_field_impl<'s>(
     struct_def: &StructDef,
     field: &'s FieldDef,
     fields_str: &mut String,
@@ -195,7 +244,7 @@ fn generate_ts_type_def_for_struct_field<'s>(
         if let TypeDef::Struct(field_type) = field.type_def(schema) {
             if let Some(flatten_field) = get_single_field(field_type, schema) {
                 // Only one field to flatten. Add it as a field on the parent type, instead of extending.
-                generate_ts_type_def_for_struct_field(
+                generate_ts_type_def_for_struct_field_impl(
                     field_type,
                     flatten_field,
                     fields_str,
@@ -217,6 +266,21 @@ fn generate_ts_type_def_for_struct_field<'s>(
 
     let field_camel_name = get_struct_field_name(field);
     fields_str.push_str(&format!("\n\t{field_camel_name}: {field_type_name};"));
+}
+
+/// Generate Typescript type definition for an extra struct field
+/// specified with `#[estree(add_fields(...))]`.
+fn generate_ts_type_def_for_added_struct_field(
+    field_name: &str,
+    converter_name: &str,
+    fields_str: &mut String,
+    schema: &Schema,
+) {
+    let converter = schema.meta_by_name(converter_name);
+    let Some(add_field_ts_type) = &converter.estree.ts_type else {
+        panic!("No `ts_type` provided for ESTree converter `{}`", converter.name());
+    };
+    fields_str.push_str(&format!("\n\t{field_name}: {add_field_ts_type};"));
 }
 
 /// Generate Typescript type definition for an enum.

--- a/tasks/ast_tools/src/parse/attr.rs
+++ b/tasks/ast_tools/src/parse/attr.rs
@@ -171,7 +171,6 @@ pub enum AttrPartListElement {
 
 impl AttrPartListElement {
     /// Unwrap this [`AttrPartListElement`] if it is an [`AttrPartListElement::Tag`].
-    #[expect(dead_code)]
     pub fn try_into_tag(self) -> Result<String> {
         if let Self::Tag(name) = self {
             Ok(name)

--- a/tasks/ast_tools/src/schema/extensions/estree.rs
+++ b/tasks/ast_tools/src/schema/extensions/estree.rs
@@ -12,6 +12,12 @@ pub struct ESTreeStruct {
     /// `(name, converter)` where `name` is the name of the field, and `converter` is name of
     /// a converter meta type.
     pub add_fields: Vec<(String, String)>,
+    /// Custom field order.
+    /// Contains field indices. Entries are:
+    /// * Actual struct field: index of the field.
+    /// * Added field: `struct_def.fields.len() + added_field_index`.
+    /// Does not include `type` field, if it's automatically added.
+    pub field_indices: Option<Vec<u8>>,
     /// TS alias.
     /// e.g. `#[estree(ts_alias = "null")]` means this type won't have a type def generated,
     /// and any struct / enum referencing it will substitute `null` as the type.


### PR DESCRIPTION
Add an attribute `#[estree(field_order(...))]` to alter the order of fields in ESTree AST.