### PR TITLE
fix(ast/estree): order fields same as Acorn

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -30,6 +30,7 @@ use super::{macros::inherit_variants, *};
 )]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[estree(field_order(span, directives, source_type, hashbang))]
 pub struct Program<'a> {
     pub span: Span,
     pub source_type: SourceType,
@@ -362,7 +363,11 @@ pub enum ObjectPropertyKind<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "Property")]
+#[estree(
+    rename = "Property",
+    field_order(span, method, shorthand, computed, key, kind, value),
+    custom_serialize
+)]
 pub struct ObjectProperty<'a> {
     pub span: Span,
     pub kind: PropertyKind,
@@ -411,6 +416,7 @@ pub enum PropertyKind {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[estree(field_order(span, expressions, quasis))]
 pub struct TemplateLiteral<'a> {
     pub span: Span,
     pub quasis: Vec<'a, TemplateElement<'a>>,
@@ -437,6 +443,7 @@ pub struct TaggedTemplateExpression<'a> {
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[estree(field_order(span, value, tail))]
 pub struct TemplateElement<'a> {
     pub span: Span,
     pub tail: bool,
@@ -493,7 +500,11 @@ pub use match_member_expression;
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "MemberExpression", add_fields(computed = True))]
+#[estree(
+    rename = "MemberExpression",
+    add_fields(computed = True),
+    field_order(span, object, expression, computed, optional),
+)]
 pub struct ComputedMemberExpression<'a> {
     pub span: Span,
     pub object: Expression<'a>,
@@ -508,7 +519,11 @@ pub struct ComputedMemberExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "MemberExpression", add_fields(computed = False))]
+#[estree(
+    rename = "MemberExpression",
+    add_fields(computed = False),
+    field_order(span, object, property, computed, optional),
+)]
 pub struct StaticMemberExpression<'a> {
     pub span: Span,
     pub object: Expression<'a>,
@@ -522,7 +537,11 @@ pub struct StaticMemberExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "MemberExpression", add_fields(computed = False))]
+#[estree(
+    rename = "MemberExpression",
+    add_fields(computed = False),
+    field_order(span, object, field, computed, optional),
+)]
 pub struct PrivateFieldExpression<'a> {
     pub span: Span,
     pub object: Expression<'a>,
@@ -644,7 +663,7 @@ pub struct UpdateExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(add_fields(prefix = True))]
+#[estree(add_fields(prefix = True), field_order(span, operator, prefix, argument))]
 pub struct UnaryExpression<'a> {
     pub span: Span,
     pub operator: UnaryOperator,
@@ -668,7 +687,11 @@ pub struct BinaryExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "BinaryExpression", add_fields(operator = In))]
+#[estree(
+    rename = "BinaryExpression",
+    add_fields(operator = In),
+    field_order(span, left, operator, right),
+)]
 pub struct PrivateInExpression<'a> {
     pub span: Span,
     pub left: PrivateIdentifier<'a>,
@@ -897,7 +920,8 @@ pub enum AssignmentTargetProperty<'a> {
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(
     rename = "Property",
-    add_fields(kind = Init, method = False, shorthand = True, computed = False),
+    add_fields(method = False, shorthand = True, computed = False, kind = Init),
+    field_order(span, method, shorthand, computed, binding, kind, init),
 )]
 pub struct AssignmentTargetPropertyIdentifier<'a> {
     pub span: Span,
@@ -917,7 +941,11 @@ pub struct AssignmentTargetPropertyIdentifier<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "Property", add_fields(kind = Init, method = False, shorthand = False))]
+#[estree(
+    rename = "Property",
+    add_fields(method = False, shorthand = False, kind = Init),
+    field_order(span, method, shorthand, computed, name, binding, kind),
+)]
 pub struct AssignmentTargetPropertyProperty<'a> {
     pub span: Span,
     /// The property key
@@ -1125,6 +1153,7 @@ pub use match_declaration;
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[estree(field_order(span, declarations, kind, declare))]
 pub struct VariableDeclaration<'a> {
     pub span: Span,
     pub kind: VariableDeclarationKind,
@@ -1339,6 +1368,7 @@ pub struct SwitchStatement<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[estree(field_order(span, consequent, test))]
 pub struct SwitchCase<'a> {
     pub span: Span,
     pub test: Option<Expression<'a>>,
@@ -1349,6 +1379,7 @@ pub struct SwitchCase<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[estree(field_order(span, body, label))]
 pub struct LabeledStatement<'a> {
     pub span: Span,
     pub label: LabelIdentifier<'a>,
@@ -1522,7 +1553,12 @@ pub struct ObjectPattern<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "Property", add_fields(kind = Init, method = False))]
+#[estree(
+    rename = "Property",
+    add_fields(method = False, kind = Init),
+    field_order(span, method, shorthand, computed, key, kind, value),
+    custom_serialize,
+)]
 pub struct BindingProperty<'a> {
     pub span: Span,
     pub key: PropertyKey<'a>,
@@ -1608,6 +1644,10 @@ pub struct BindingRestElement<'a> {
 #[estree(
     add_ts_def = "type ParamPattern = FormalParameter | FormalParameterRest",
     add_fields(expression = False),
+    field_order(
+        r#type, span, id, expression, generator, r#async, params, body,
+        declare, type_parameters, this_param, return_type,
+    ),
 )]
 pub struct Function<'a> {
     pub span: Span,
@@ -1709,7 +1749,7 @@ pub struct FormalParameters<'a> {
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 // Pluralize as `FormalParameterList` to avoid naming clash with `FormalParameters`.
 #[plural(FormalParameterList)]
-#[estree(no_type)]
+#[estree(no_type, field_order(pattern, decorators, accessibility, readonly, r#override))]
 pub struct FormalParameter<'a> {
     #[estree(skip)]
     pub span: Span,
@@ -1761,7 +1801,10 @@ pub struct FunctionBody<'a> {
 )]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(add_fields(generator = False, id = Null))]
+#[estree(
+    add_fields(id = Null, generator = False),
+    field_order(span, id, expression, generator, r#async, params, body, type_parameters, return_type),
+)]
 pub struct ArrowFunctionExpression<'a> {
     pub span: Span,
     /// Is the function body an arrow expression? i.e. `() => expr` instead of `() => {}`
@@ -1795,6 +1838,11 @@ pub struct YieldExpression<'a> {
 #[scope(flags = ScopeFlags::StrictMode)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[rustfmt::skip]
+#[estree(field_order(
+    r#type, span, id, super_class, body,
+    decorators, type_parameters, super_type_parameters, implements, r#abstract, declare,
+))]
 pub struct Class<'a> {
     pub span: Span,
     pub r#type: ClassType,
@@ -1934,6 +1982,11 @@ pub enum ClassElement<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[rustfmt::skip]
+#[estree(field_order(
+    r#type, span, r#static, computed, key, kind, value,
+    decorators, r#override, optional, accessibility
+))]
 pub struct MethodDefinition<'a> {
     pub span: Span,
     /// Method definition type
@@ -1973,6 +2026,11 @@ pub enum MethodDefinitionType {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[rustfmt::skip]
+#[estree(field_order(
+    r#type, span, r#static, computed, key, value,
+    decorators, declare, r#override, optional, definite, readonly, type_annotation, accessibility,
+))]
 pub struct PropertyDefinition<'a> {
     pub span: Span,
     pub r#type: PropertyDefinitionType,
@@ -2193,6 +2251,11 @@ pub enum AccessorPropertyType {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[rustfmt::skip]
+#[estree(field_order(
+    r#type, span, key, value, computed, r#static,
+    decorators, definite, type_annotation, accessibility,
+))]
 pub struct AccessorProperty<'a> {
     pub span: Span,
     pub r#type: AccessorPropertyType,

--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -89,7 +89,11 @@ pub struct StringLiteral<'a> {
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, ContentEq, GetSpan, GetSpanMut, ESTree)]
-#[estree(rename = "Literal", add_fields(value = BigIntLiteralValue, bigint = BigIntLiteralBigint))]
+#[estree(
+    rename = "Literal",
+    add_fields(value = BigIntLiteralValue, bigint = BigIntLiteralBigint),
+    field_order(span, value, raw, bigint),
+)]
 pub struct BigIntLiteral<'a> {
     /// Node location in source code
     pub span: Span,
@@ -108,7 +112,11 @@ pub struct BigIntLiteral<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, ContentEq, GetSpan, GetSpanMut, ESTree)]
-#[estree(rename = "Literal", add_fields(value = RegExpLiteralValue))]
+#[estree(
+    rename = "Literal",
+    add_fields(value = RegExpLiteralValue),
+    field_order(span, value, raw, regex),
+)]
 pub struct RegExpLiteral<'a> {
     /// Node location in source code
     pub span: Span,

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -18,12 +18,12 @@ impl Serialize for Program<'_> {
         map.serialize_entry("type", "Program")?;
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
-        self.source_type.serialize(FlatMapSerializer(&mut map))?;
-        map.serialize_entry("hashbang", &self.hashbang)?;
         map.serialize_entry(
             "body",
             &AppendToConcat { array: &self.directives, after: &self.body },
         )?;
+        self.source_type.serialize(FlatMapSerializer(&mut map))?;
+        map.serialize_entry("hashbang", &self.hashbang)?;
         map.end()
     }
 }
@@ -213,22 +213,6 @@ impl Serialize for ObjectPropertyKind<'_> {
     }
 }
 
-impl Serialize for ObjectProperty<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Property")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("kind", &self.kind)?;
-        map.serialize_entry("key", &self.key)?;
-        map.serialize_entry("value", &self.value)?;
-        map.serialize_entry("method", &self.method)?;
-        map.serialize_entry("shorthand", &self.shorthand)?;
-        map.serialize_entry("computed", &self.computed)?;
-        map.end()
-    }
-}
-
 impl Serialize for PropertyKey<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         match self {
@@ -296,8 +280,8 @@ impl Serialize for TemplateLiteral<'_> {
         map.serialize_entry("type", "TemplateLiteral")?;
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("quasis", &self.quasis)?;
         map.serialize_entry("expressions", &self.expressions)?;
+        map.serialize_entry("quasis", &self.quasis)?;
         map.end()
     }
 }
@@ -321,8 +305,8 @@ impl Serialize for TemplateElement<'_> {
         map.serialize_entry("type", "TemplateElement")?;
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("tail", &self.tail)?;
         map.serialize_entry("value", &self.value)?;
+        map.serialize_entry("tail", &self.tail)?;
         map.end()
     }
 }
@@ -354,8 +338,8 @@ impl Serialize for ComputedMemberExpression<'_> {
         map.serialize_entry("end", &self.span.end)?;
         map.serialize_entry("object", &self.object)?;
         map.serialize_entry("property", &self.expression)?;
-        map.serialize_entry("optional", &self.optional)?;
         map.serialize_entry("computed", &crate::serialize::True(self))?;
+        map.serialize_entry("optional", &self.optional)?;
         map.end()
     }
 }
@@ -368,8 +352,8 @@ impl Serialize for StaticMemberExpression<'_> {
         map.serialize_entry("end", &self.span.end)?;
         map.serialize_entry("object", &self.object)?;
         map.serialize_entry("property", &self.property)?;
-        map.serialize_entry("optional", &self.optional)?;
         map.serialize_entry("computed", &crate::serialize::False(self))?;
+        map.serialize_entry("optional", &self.optional)?;
         map.end()
     }
 }
@@ -382,8 +366,8 @@ impl Serialize for PrivateFieldExpression<'_> {
         map.serialize_entry("end", &self.span.end)?;
         map.serialize_entry("object", &self.object)?;
         map.serialize_entry("property", &self.field)?;
-        map.serialize_entry("optional", &self.optional)?;
         map.serialize_entry("computed", &crate::serialize::False(self))?;
+        map.serialize_entry("optional", &self.optional)?;
         map.end()
     }
 }
@@ -508,8 +492,8 @@ impl Serialize for UnaryExpression<'_> {
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
         map.serialize_entry("operator", &self.operator)?;
-        map.serialize_entry("argument", &self.argument)?;
         map.serialize_entry("prefix", &crate::serialize::True(self))?;
+        map.serialize_entry("argument", &self.argument)?;
         map.end()
     }
 }
@@ -534,8 +518,8 @@ impl Serialize for PrivateInExpression<'_> {
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
         map.serialize_entry("left", &self.left)?;
-        map.serialize_entry("right", &self.right)?;
         map.serialize_entry("operator", &crate::serialize::In(self))?;
+        map.serialize_entry("right", &self.right)?;
         map.end()
     }
 }
@@ -712,15 +696,15 @@ impl Serialize for AssignmentTargetPropertyIdentifier<'_> {
         map.serialize_entry("type", "Property")?;
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
+        map.serialize_entry("method", &crate::serialize::False(self))?;
+        map.serialize_entry("shorthand", &crate::serialize::True(self))?;
+        map.serialize_entry("computed", &crate::serialize::False(self))?;
         map.serialize_entry("key", &self.binding)?;
+        map.serialize_entry("kind", &crate::serialize::Init(self))?;
         map.serialize_entry(
             "value",
             &crate::serialize::AssignmentTargetPropertyIdentifierValue(self),
         )?;
-        map.serialize_entry("kind", &crate::serialize::Init(self))?;
-        map.serialize_entry("method", &crate::serialize::False(self))?;
-        map.serialize_entry("shorthand", &crate::serialize::True(self))?;
-        map.serialize_entry("computed", &crate::serialize::False(self))?;
         map.end()
     }
 }
@@ -731,12 +715,12 @@ impl Serialize for AssignmentTargetPropertyProperty<'_> {
         map.serialize_entry("type", "Property")?;
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("key", &self.name)?;
-        map.serialize_entry("value", &self.binding)?;
-        map.serialize_entry("computed", &self.computed)?;
-        map.serialize_entry("kind", &crate::serialize::Init(self))?;
         map.serialize_entry("method", &crate::serialize::False(self))?;
         map.serialize_entry("shorthand", &crate::serialize::False(self))?;
+        map.serialize_entry("computed", &self.computed)?;
+        map.serialize_entry("key", &self.name)?;
+        map.serialize_entry("value", &self.binding)?;
+        map.serialize_entry("kind", &crate::serialize::Init(self))?;
         map.end()
     }
 }
@@ -901,8 +885,8 @@ impl Serialize for VariableDeclaration<'_> {
         map.serialize_entry("type", "VariableDeclaration")?;
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("kind", &self.kind)?;
         map.serialize_entry("declarations", &self.declarations)?;
+        map.serialize_entry("kind", &self.kind)?;
         map.serialize_entry("declare", &self.declare)?;
         map.end()
     }
@@ -1174,8 +1158,8 @@ impl Serialize for SwitchCase<'_> {
         map.serialize_entry("type", "SwitchCase")?;
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("test", &self.test)?;
         map.serialize_entry("consequent", &self.consequent)?;
+        map.serialize_entry("test", &self.test)?;
         map.end()
     }
 }
@@ -1186,8 +1170,8 @@ impl Serialize for LabeledStatement<'_> {
         map.serialize_entry("type", "LabeledStatement")?;
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("label", &self.label)?;
         map.serialize_entry("body", &self.body)?;
+        map.serialize_entry("label", &self.label)?;
         map.end()
     }
 }
@@ -1295,22 +1279,6 @@ impl Serialize for ObjectPattern<'_> {
     }
 }
 
-impl Serialize for BindingProperty<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Property")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("key", &self.key)?;
-        map.serialize_entry("value", &self.value)?;
-        map.serialize_entry("shorthand", &self.shorthand)?;
-        map.serialize_entry("computed", &self.computed)?;
-        map.serialize_entry("kind", &crate::serialize::Init(self))?;
-        map.serialize_entry("method", &crate::serialize::False(self))?;
-        map.end()
-    }
-}
-
 impl Serialize for ArrayPattern<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(None)?;
@@ -1336,19 +1304,19 @@ impl Serialize for BindingRestElement<'_> {
 impl Serialize for Function<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", &self.r#type)?;
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("type", &self.r#type)?;
         map.serialize_entry("id", &self.id)?;
+        map.serialize_entry("expression", &crate::serialize::False(self))?;
         map.serialize_entry("generator", &self.generator)?;
         map.serialize_entry("async", &self.r#async)?;
+        map.serialize_entry("params", &self.params)?;
+        map.serialize_entry("body", &self.body)?;
         map.serialize_entry("declare", &self.declare)?;
         map.serialize_entry("typeParameters", &self.type_parameters)?;
         map.serialize_entry("thisParam", &self.this_param)?;
-        map.serialize_entry("params", &self.params)?;
         map.serialize_entry("returnType", &self.return_type)?;
-        map.serialize_entry("body", &self.body)?;
-        map.serialize_entry("expression", &crate::serialize::False(self))?;
         map.end()
     }
 }
@@ -1377,10 +1345,10 @@ impl Serialize for FunctionType {
 impl Serialize for FormalParameter<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("decorators", &self.decorators)?;
         self.pattern.kind.serialize(FlatMapSerializer(&mut map))?;
         map.serialize_entry("typeAnnotation", &self.pattern.type_annotation)?;
         map.serialize_entry("optional", &self.pattern.optional)?;
+        map.serialize_entry("decorators", &self.decorators)?;
         map.serialize_entry("accessibility", &self.accessibility)?;
         map.serialize_entry("readonly", &self.readonly)?;
         map.serialize_entry("override", &self.r#override)?;
@@ -1429,14 +1397,14 @@ impl Serialize for ArrowFunctionExpression<'_> {
         map.serialize_entry("type", "ArrowFunctionExpression")?;
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("expression", &self.expression)?;
-        map.serialize_entry("async", &self.r#async)?;
-        map.serialize_entry("typeParameters", &self.type_parameters)?;
-        map.serialize_entry("params", &self.params)?;
-        map.serialize_entry("returnType", &self.return_type)?;
-        map.serialize_entry("body", &crate::serialize::ArrowFunctionExpressionBody(self))?;
-        map.serialize_entry("generator", &crate::serialize::False(self))?;
         map.serialize_entry("id", &crate::serialize::Null(self))?;
+        map.serialize_entry("expression", &self.expression)?;
+        map.serialize_entry("generator", &crate::serialize::False(self))?;
+        map.serialize_entry("async", &self.r#async)?;
+        map.serialize_entry("params", &self.params)?;
+        map.serialize_entry("body", &crate::serialize::ArrowFunctionExpressionBody(self))?;
+        map.serialize_entry("typeParameters", &self.type_parameters)?;
+        map.serialize_entry("returnType", &self.return_type)?;
         map.end()
     }
 }
@@ -1456,16 +1424,16 @@ impl Serialize for YieldExpression<'_> {
 impl Serialize for Class<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", &self.r#type)?;
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("type", &self.r#type)?;
-        map.serialize_entry("decorators", &self.decorators)?;
         map.serialize_entry("id", &self.id)?;
-        map.serialize_entry("typeParameters", &self.type_parameters)?;
         map.serialize_entry("superClass", &self.super_class)?;
+        map.serialize_entry("body", &self.body)?;
+        map.serialize_entry("decorators", &self.decorators)?;
+        map.serialize_entry("typeParameters", &self.type_parameters)?;
         map.serialize_entry("superTypeParameters", &self.super_type_parameters)?;
         map.serialize_entry("implements", &self.implements)?;
-        map.serialize_entry("body", &self.body)?;
         map.serialize_entry("abstract", &self.r#abstract)?;
         map.serialize_entry("declare", &self.declare)?;
         map.end()
@@ -1511,15 +1479,15 @@ impl Serialize for ClassElement<'_> {
 impl Serialize for MethodDefinition<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", &self.r#type)?;
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("type", &self.r#type)?;
-        map.serialize_entry("decorators", &self.decorators)?;
-        map.serialize_entry("key", &self.key)?;
-        map.serialize_entry("value", &self.value)?;
-        map.serialize_entry("kind", &self.kind)?;
-        map.serialize_entry("computed", &self.computed)?;
         map.serialize_entry("static", &self.r#static)?;
+        map.serialize_entry("computed", &self.computed)?;
+        map.serialize_entry("key", &self.key)?;
+        map.serialize_entry("kind", &self.kind)?;
+        map.serialize_entry("value", &self.value)?;
+        map.serialize_entry("decorators", &self.decorators)?;
         map.serialize_entry("override", &self.r#override)?;
         map.serialize_entry("optional", &self.optional)?;
         map.serialize_entry("accessibility", &self.accessibility)?;
@@ -1545,14 +1513,14 @@ impl Serialize for MethodDefinitionType {
 impl Serialize for PropertyDefinition<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", &self.r#type)?;
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("type", &self.r#type)?;
-        map.serialize_entry("decorators", &self.decorators)?;
+        map.serialize_entry("static", &self.r#static)?;
+        map.serialize_entry("computed", &self.computed)?;
         map.serialize_entry("key", &self.key)?;
         map.serialize_entry("value", &self.value)?;
-        map.serialize_entry("computed", &self.computed)?;
-        map.serialize_entry("static", &self.r#static)?;
+        map.serialize_entry("decorators", &self.decorators)?;
         map.serialize_entry("declare", &self.declare)?;
         map.serialize_entry("override", &self.r#override)?;
         map.serialize_entry("optional", &self.optional)?;
@@ -1652,14 +1620,14 @@ impl Serialize for AccessorPropertyType {
 impl Serialize for AccessorProperty<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", &self.r#type)?;
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("type", &self.r#type)?;
-        map.serialize_entry("decorators", &self.decorators)?;
         map.serialize_entry("key", &self.key)?;
         map.serialize_entry("value", &self.value)?;
         map.serialize_entry("computed", &self.computed)?;
         map.serialize_entry("static", &self.r#static)?;
+        map.serialize_entry("decorators", &self.decorators)?;
         map.serialize_entry("definite", &self.definite)?;
         map.serialize_entry("typeAnnotation", &self.type_annotation)?;
         map.serialize_entry("accessibility", &self.accessibility)?;
@@ -1963,8 +1931,8 @@ impl Serialize for BigIntLiteral<'_> {
         map.serialize_entry("type", "Literal")?;
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("raw", &self.raw)?;
         map.serialize_entry("value", &crate::serialize::BigIntLiteralValue(self))?;
+        map.serialize_entry("raw", &self.raw)?;
         map.serialize_entry("bigint", &crate::serialize::BigIntLiteralBigint(self))?;
         map.end()
     }
@@ -1976,9 +1944,9 @@ impl Serialize for RegExpLiteral<'_> {
         map.serialize_entry("type", "Literal")?;
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("regex", &crate::serialize::RegExpLiteralRegex(self))?;
-        map.serialize_entry("raw", &self.raw)?;
         map.serialize_entry("value", &crate::serialize::RegExpLiteralValue(self))?;
+        map.serialize_entry("raw", &self.raw)?;
+        map.serialize_entry("regex", &crate::serialize::RegExpLiteralRegex(self))?;
         map.end()
     }
 }

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -3,9 +3,9 @@
 
 export interface Program extends Span {
   type: 'Program';
+  body: Array<Directive | Statement>;
   sourceType: ModuleKind;
   hashbang: Hashbang | null;
-  body: Array<Directive | Statement>;
 }
 
 export type Expression =
@@ -90,12 +90,12 @@ export type ObjectPropertyKind = ObjectProperty | SpreadElement;
 
 export interface ObjectProperty extends Span {
   type: 'Property';
-  kind: PropertyKind;
-  key: PropertyKey;
-  value: Expression;
   method: boolean;
   shorthand: boolean;
   computed: boolean;
+  key: PropertyKey;
+  kind: PropertyKind;
+  value: Expression;
 }
 
 export type PropertyKey = IdentifierName | PrivateIdentifier | Expression;
@@ -104,8 +104,8 @@ export type PropertyKind = 'init' | 'get' | 'set';
 
 export interface TemplateLiteral extends Span {
   type: 'TemplateLiteral';
-  quasis: Array<TemplateElement>;
   expressions: Array<Expression>;
+  quasis: Array<TemplateElement>;
 }
 
 export interface TaggedTemplateExpression extends Span {
@@ -117,8 +117,8 @@ export interface TaggedTemplateExpression extends Span {
 
 export interface TemplateElement extends Span {
   type: 'TemplateElement';
-  tail: boolean;
   value: TemplateElementValue;
+  tail: boolean;
 }
 
 export interface TemplateElementValue {
@@ -132,24 +132,24 @@ export interface ComputedMemberExpression extends Span {
   type: 'MemberExpression';
   object: Expression;
   property: Expression;
-  optional: boolean;
   computed: true;
+  optional: boolean;
 }
 
 export interface StaticMemberExpression extends Span {
   type: 'MemberExpression';
   object: Expression;
   property: IdentifierName;
-  optional: boolean;
   computed: false;
+  optional: boolean;
 }
 
 export interface PrivateFieldExpression extends Span {
   type: 'MemberExpression';
   object: Expression;
   property: PrivateIdentifier;
-  optional: boolean;
   computed: false;
+  optional: boolean;
 }
 
 export interface CallExpression extends Span {
@@ -190,8 +190,8 @@ export interface UpdateExpression extends Span {
 export interface UnaryExpression extends Span {
   type: 'UnaryExpression';
   operator: UnaryOperator;
-  argument: Expression;
   prefix: true;
+  argument: Expression;
 }
 
 export interface BinaryExpression extends Span {
@@ -204,8 +204,8 @@ export interface BinaryExpression extends Span {
 export interface PrivateInExpression extends Span {
   type: 'BinaryExpression';
   left: PrivateIdentifier;
-  right: Expression;
   operator: 'in';
+  right: Expression;
 }
 
 export interface LogicalExpression extends Span {
@@ -269,22 +269,22 @@ export type AssignmentTargetProperty = AssignmentTargetPropertyIdentifier | Assi
 
 export interface AssignmentTargetPropertyIdentifier extends Span {
   type: 'Property';
-  key: IdentifierReference;
-  value: IdentifierReference | AssignmentTargetWithDefault;
-  kind: 'init';
   method: false;
   shorthand: true;
   computed: false;
+  key: IdentifierReference;
+  kind: 'init';
+  value: IdentifierReference | AssignmentTargetWithDefault;
 }
 
 export interface AssignmentTargetPropertyProperty extends Span {
   type: 'Property';
-  key: PropertyKey;
-  value: AssignmentTargetMaybeDefault;
-  computed: boolean;
-  kind: 'init';
   method: false;
   shorthand: false;
+  computed: boolean;
+  key: PropertyKey;
+  value: AssignmentTargetMaybeDefault;
+  kind: 'init';
 }
 
 export interface SequenceExpression extends Span {
@@ -363,8 +363,8 @@ export type Declaration =
 
 export interface VariableDeclaration extends Span {
   type: 'VariableDeclaration';
-  kind: VariableDeclarationKind;
   declarations: Array<VariableDeclarator>;
+  kind: VariableDeclarationKind;
   declare: boolean;
 }
 
@@ -461,14 +461,14 @@ export interface SwitchStatement extends Span {
 
 export interface SwitchCase extends Span {
   type: 'SwitchCase';
-  test: Expression | null;
   consequent: Array<Statement>;
+  test: Expression | null;
 }
 
 export interface LabeledStatement extends Span {
   type: 'LabeledStatement';
-  label: LabelIdentifier;
   body: Statement;
+  label: LabelIdentifier;
 }
 
 export interface ThrowStatement extends Span {
@@ -515,12 +515,12 @@ export interface ObjectPattern extends Span {
 
 export interface BindingProperty extends Span {
   type: 'Property';
-  key: PropertyKey;
-  value: BindingPattern;
+  method: false;
   shorthand: boolean;
   computed: boolean;
+  key: PropertyKey;
   kind: 'init';
-  method: false;
+  value: BindingPattern;
 }
 
 export interface ArrayPattern extends Span {
@@ -536,15 +536,15 @@ export interface BindingRestElement extends Span {
 export interface Function extends Span {
   type: FunctionType;
   id: BindingIdentifier | null;
+  expression: false;
   generator: boolean;
   async: boolean;
+  params: ParamPattern[];
+  body: FunctionBody | null;
   declare: boolean;
   typeParameters: TSTypeParameterDeclaration | null;
   thisParam: TSThisParameter | null;
-  params: ParamPattern[];
   returnType: TSTypeAnnotation | null;
-  body: FunctionBody | null;
-  expression: false;
 }
 
 export type ParamPattern = FormalParameter | FormalParameterRest;
@@ -586,14 +586,14 @@ export interface FunctionBody extends Span {
 
 export interface ArrowFunctionExpression extends Span {
   type: 'ArrowFunctionExpression';
-  expression: boolean;
-  async: boolean;
-  typeParameters: TSTypeParameterDeclaration | null;
-  params: ParamPattern[];
-  returnType: TSTypeAnnotation | null;
-  body: FunctionBody | Expression;
-  generator: false;
   id: null;
+  expression: boolean;
+  generator: false;
+  async: boolean;
+  params: ParamPattern[];
+  body: FunctionBody | Expression;
+  typeParameters: TSTypeParameterDeclaration | null;
+  returnType: TSTypeAnnotation | null;
 }
 
 export interface YieldExpression extends Span {
@@ -604,13 +604,13 @@ export interface YieldExpression extends Span {
 
 export interface Class extends Span {
   type: ClassType;
-  decorators: Array<Decorator>;
   id: BindingIdentifier | null;
-  typeParameters: TSTypeParameterDeclaration | null;
   superClass: Expression | null;
+  body: ClassBody;
+  decorators: Array<Decorator>;
+  typeParameters: TSTypeParameterDeclaration | null;
   superTypeParameters: TSTypeParameterInstantiation | null;
   implements: Array<TSClassImplements> | null;
-  body: ClassBody;
   abstract: boolean;
   declare: boolean;
 }
@@ -626,12 +626,12 @@ export type ClassElement = StaticBlock | MethodDefinition | PropertyDefinition |
 
 export interface MethodDefinition extends Span {
   type: MethodDefinitionType;
-  decorators: Array<Decorator>;
-  key: PropertyKey;
-  value: Function;
-  kind: MethodDefinitionKind;
-  computed: boolean;
   static: boolean;
+  computed: boolean;
+  key: PropertyKey;
+  kind: MethodDefinitionKind;
+  value: Function;
+  decorators: Array<Decorator>;
   override: boolean;
   optional: boolean;
   accessibility: TSAccessibility | null;
@@ -641,11 +641,11 @@ export type MethodDefinitionType = 'MethodDefinition' | 'TSAbstractMethodDefinit
 
 export interface PropertyDefinition extends Span {
   type: PropertyDefinitionType;
-  decorators: Array<Decorator>;
+  static: boolean;
+  computed: boolean;
   key: PropertyKey;
   value: Expression | null;
-  computed: boolean;
-  static: boolean;
+  decorators: Array<Decorator>;
   declare: boolean;
   override: boolean;
   optional: boolean;
@@ -681,11 +681,11 @@ export type AccessorPropertyType = 'AccessorProperty' | 'TSAbstractAccessorPrope
 
 export interface AccessorProperty extends Span {
   type: AccessorPropertyType;
-  decorators: Array<Decorator>;
   key: PropertyKey;
   value: Expression | null;
   computed: boolean;
   static: boolean;
+  decorators: Array<Decorator>;
   definite: boolean;
   typeAnnotation: TSTypeAnnotation | null;
   accessibility: TSAccessibility | null;
@@ -801,16 +801,16 @@ export interface StringLiteral extends Span {
 
 export interface BigIntLiteral extends Span {
   type: 'Literal';
-  raw: string | null;
   value: BigInt;
+  raw: string | null;
   bigint: string;
 }
 
 export interface RegExpLiteral extends Span {
   type: 'Literal';
-  regex: RegExp;
-  raw: string | null;
   value: RegExp | null;
+  raw: string | null;
+  regex: RegExp;
 }
 
 export interface RegExp {

--- a/tasks/coverage/Cargo.toml
+++ b/tasks/coverage/Cargo.toml
@@ -39,7 +39,7 @@ regex = { workspace = true }
 rustc-hash = { workspace = true }
 saphyr = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true, features = ["unbounded_depth"] }
+serde_json = { workspace = true, features = ["unbounded_depth", "preserve_order"] }
 similar = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 walkdir = { workspace = true }


### PR DESCRIPTION
Use the `#[estree(field_order(...))]` attribute introduced in #9127 to re-order fields in the ESTree AST so they match Acorn exactly.

Make the ESTree conformance tester stricter - it now errors on incorrect field order.

All conformance tests still passing after this PR.
