### PR TITLE
fix(isolated-declarations): private accessors keep their types

### DIFF
--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -504,6 +504,11 @@ impl<'a> IsolatedDeclarations<'a> {
                         continue;
                     }
 
+                    let type_annotation = match property.accessibility {
+                        Some(TSAccessibility::Private) => None,
+                        _ => property.type_annotation.clone_in(self.ast.allocator),
+                    };
+
                     // FIXME: missing many fields
                     let new_element = self.ast.class_element_accessor_property(
                         property.span,
@@ -514,7 +519,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         property.computed,
                         property.r#static,
                         property.definite,
-                        property.type_annotation.clone_in(self.ast.allocator),
+                        type_annotation,
                         property.accessibility,
                     );
                     elements.push(new_element);

--- a/crates/oxc_isolated_declarations/tests/fixtures/set-get-accessor.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/set-get-accessor.ts
@@ -14,6 +14,10 @@ class Cls {
 
   private get c() {}
   private set c() {}
+
+  accessor d: string;
+  private accessor e: string;
+  private static accessor f: string;
 }
 
 // Incorrect

--- a/crates/oxc_isolated_declarations/tests/snapshots/set-get-accessor.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/set-get-accessor.snap
@@ -12,6 +12,9 @@ declare class Cls {
 	set b(v: string);
 	private get c();
 	private set c(value);
+	accessor d: string;
+	private accessor e;
+	private static accessor f;
 }
 declare class ClsBad {
 	get a();
@@ -23,11 +26,11 @@ declare class ClsBad {
 
   x TS9009: At least one accessor must have an explicit return type annotation
   | with --isolatedDeclarations.
-    ,-[21:7]
- 20 | class ClsBad {
- 21 |   get a() {
+    ,-[25:7]
+ 24 | class ClsBad {
+ 25 |   get a() {
     :       ^
- 22 |     return;
+ 26 |     return;
     `----
 
 


### PR DESCRIPTION
Input:
```ts
export class Cls {
  accessor d: string;
  private accessor e: string;
  private static accessor f: string;
}
```

Expected:
```ts
export declare class Cls {
    accessor d: string;
    private accessor e;
    private static accessor f;
}
```

Actual:
```ts
export declare class Cls {
    accessor d: string;
    private accessor e: string;
    private static accessor f: string;
}
```

ts playground: https://www.typescriptlang.org/play/?#code/MYGwhgzhAEDCIwN4ChrTMYBTKB7ATtACYBc0EALvgJYB2A5gNyrQAONAbmBVupjhALQsZSjQbM07alx7kK3asD7Y8hAGaiqdJsgC+yZEA