### PR TITLE
fix(linter): output line/column for `--format=stylish` instead of offset + length

### DIFF
--- a/apps/oxlint/src/output_formatter/mod.rs
+++ b/apps/oxlint/src/output_formatter/mod.rs
@@ -158,10 +158,6 @@ mod test {
         Tester::new().with_cwd(TEST_CWD.into()).test_and_snapshot(args);
     }
 
-    /// disabled for windows
-    /// stylish will output the offset which will be different for windows
-    /// when there are multiple lines (`\r\n` vs `\n`)
-    #[cfg(all(test, not(target_os = "windows")))]
     #[test]
     fn test_output_formatter_diagnostic_stylish() {
         let args = &["--format=stylish", "test.js"];

--- a/apps/oxlint/src/output_formatter/stylish.rs
+++ b/apps/oxlint/src/output_formatter/stylish.rs
@@ -63,9 +63,10 @@ fn format_stylish(diagnostics: &[Error]) -> String {
         };
         let max_len_width = diagnostics
             .iter()
-            .filter_map(|diagnostic| diagnostic.labels())
-            .flat_map(std::iter::Iterator::collect::<Vec<_>>)
-            .map(|label| format!("{}:{}", label.offset(), label.len()).len())
+            .map(|diagnostic| {
+                let start = Info::new(diagnostic).start;
+                format!("{}:{}", start.line, start.column).len()
+            })
             .max()
             .unwrap_or(0);
 
@@ -83,13 +84,12 @@ fn format_stylish(diagnostics: &[Error]) -> String {
                 "\u{1b}[33mwarning\u{1b}[0m"
             };
 
-            if let Some(label) = diagnostic.labels().expect("should have labels").next() {
-                let rule = diagnostic.code().map_or_else(String::new, |code| code.to_string());
-                let position = format!("{}:{}", label.offset(), label.len());
-                output.push_str(
-                    &format!("  \u{1b}[2m{position:max_len_width$}\u{1b}[0m  {severity_str}  {diagnostic}  \u{1b}[2m{rule}\u{1b}[0m\n"),
-                );
-            }
+            let info = Info::new(diagnostic);
+            let rule = diagnostic.code().map_or_else(String::new, |code| code.to_string());
+            let position = format!("{}:{}", info.start.line, info.start.column);
+            output.push_str(
+                &format!("  \u{1b}[2m{position:max_len_width$}\u{1b}[0m  {severity_str}  {diagnostic}  \u{1b}[2m{rule}\u{1b}[0m\n"),
+            );
         }
     }
 

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=stylish test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=stylish test.js@oxlint.snap
@@ -7,9 +7,9 @@ working directory: fixtures/output_formatter_diagnostic
 ----------
 
 [4mtest.js[0m
-  [2m9:3 [0m  [33mwarning[0m  Function 'foo' is declared but never used.  [2meslint(no-unused-vars)[0m
-  [2m16:1[0m  [33mwarning[0m  Parameter 'b' is declared but never used. Unused parameters should start with a '_'.  [2meslint(no-unused-vars)[0m
-  [2m38:9[0m  [31merror[0m  `debugger` statement is not allowed  [2meslint(no-debugger)[0m
+  [2m1:10[0m  [33mwarning[0m  Function 'foo' is declared but never used.  [2meslint(no-unused-vars)[0m
+  [2m1:17[0m  [33mwarning[0m  Parameter 'b' is declared but never used. Unused parameters should start with a '_'.  [2meslint(no-unused-vars)[0m
+  [2m5:1 [0m  [31merror[0m  `debugger` statement is not allowed  [2meslint(no-debugger)[0m
 
 [31m✖ 3 problems (1 error, 2 warnings)[0m
 ----------


### PR DESCRIPTION
closes #9098