### PR TITLE
fix(linter): `no-console` should only report when `console` is inside global

### DIFF
--- a/apps/oxlint/fixtures/overrides/.oxlintrc.json
+++ b/apps/oxlint/fixtures/overrides/.oxlintrc.json
@@ -1,4 +1,7 @@
 {
+  "env": {
+    "browser": true
+  },
   "rules": {
     "no-var": "error",
     "no-console": "error"


### PR DESCRIPTION
found when I worked on `ctx.get_global_variable_value`