### PR TITLE
feat(oxlint): add `--experimental-nested-config` option

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -41,6 +41,10 @@ pub struct LintCommand {
     #[bpaf(external)]
     pub misc_options: MiscOptions,
 
+    /// Enables automatic loading of nested configuration files (experimental feature)
+    #[bpaf(switch, hide_usage)]
+    pub experimental_nested_config: bool,
+
     /// Single file, single path or list of paths
     #[bpaf(positional("PATH"), many, guard(validate_paths, PATHS_ERROR_MESSAGE))]
     pub paths: Vec<PathBuf>,
@@ -512,5 +516,13 @@ mod lint_options {
     fn list_rules() {
         let options = get_lint_options("--rules");
         assert!(options.list_rules);
+    }
+
+    #[test]
+    fn experimental_nested_config() {
+        let options = get_lint_options("--experimental-nested-config");
+        assert!(options.experimental_nested_config);
+        let options = get_lint_options(".");
+        assert!(!options.experimental_nested_config);
     }
 }

--- a/tasks/website/src/linter/snapshots/cli.snap
+++ b/tasks/website/src/linter/snapshots/cli.snap
@@ -133,6 +133,8 @@ Arguments:
 ## Available options:
 - **`    --rules`** &mdash; 
   list all the rules that are currently registered
+- **`    --experimental-nested-config`** &mdash; 
+  Enables automatic loading of nested configuration files (experimental feature)
 - **`-h`**, **`--help`** &mdash; 
   Prints help information
 - **`-V`**, **`--version`** &mdash; 

--- a/tasks/website/src/linter/snapshots/cli_terminal.snap
+++ b/tasks/website/src/linter/snapshots/cli_terminal.snap
@@ -81,5 +81,7 @@ Available positional items:
 
 Available options:
         --rules               list all the rules that are currently registered
+        --experimental-nested-config  Enables automatic loading of nested configuration files
+                              (experimental feature)
     -h, --help                Prints help information
     -V, --version             Prints version information


### PR DESCRIPTION
- part of https://github.com/oxc-project/oxc/issues/7408

Since the nested configuration work is too big to fit in one PR or even a stack of PRs, I suggest that we make it temporarily an opt-in CLI flag. Once we feel confident in the implementation replacing the existing code, we can remove the flag and make it true by default.