### PR TITLE
refactor(minifier): `Math.pow(a,b)` -> `a ** (+b)` instead of `(+a) ** (+b)`

### DIFF
--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -392,6 +392,7 @@ impl<'a> PeepholeOptimizations {
 
         Some(ctx.ast.expression_binary(
             span,
+            // see [`PeepholeOptimizations::is_binary_operator_that_does_number_conversion`] why it does not require `wrap_with_unary_plus_if_needed` here
             ctx.ast.move_expression(first_arg),
             BinaryOperator::Exponential,
             wrap_with_unary_plus_if_needed(second_arg),

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -392,7 +392,7 @@ impl<'a> PeepholeOptimizations {
 
         Some(ctx.ast.expression_binary(
             span,
-            wrap_with_unary_plus_if_needed(first_arg),
+            ctx.ast.move_expression(first_arg),
             BinaryOperator::Exponential,
             wrap_with_unary_plus_if_needed(second_arg),
         ))


### PR DESCRIPTION
It's currently minifying twice through:

`Math.pow(a, b)` -> `(+a) ** (+b)` -> `a ** (+b)`

Correct me if this is wrong, i.e. we need to keep `(+a)` in the fold pass.