### PR TITLE
fix(linter): do not use nested configs with `--config` option

### DIFF
--- a/apps/oxlint/fixtures/nested_config/oxlint-no-console.json
+++ b/apps/oxlint/fixtures/nested_config/oxlint-no-console.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "no-console": "error",
+    "no-debugger": "off"
+  }
+}

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_--experimental-nested-config --config oxlint-no-console.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_--experimental-nested-config --config oxlint-no-console.json@oxlint.snap
@@ -1,0 +1,43 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --experimental-nested-config --config oxlint-no-console.json
+working directory: fixtures/nested_config
+----------
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: eslint(no-console): Unexpected console statement.
+   ,-[console.ts:1:1]
+ 1 | console.log("test");
+   : ^^^^^^^^^^^
+   `----
+  help: Delete this console statement.
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: eslint(no-console): Unexpected console statement.
+   ,-[package1-empty-config/console.ts:1:1]
+ 1 | console.log("test");
+   : ^^^^^^^^^^^
+   `----
+  help: Delete this console statement.
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: eslint(no-console): Unexpected console statement.
+   ,-[package2-no-config/console.ts:1:1]
+ 1 | console.log("test");
+   : ^^^^^^^^^^^
+   `----
+  help: Delete this console statement.
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: eslint(no-console): Unexpected console statement.
+   ,-[package3-deep-config/src/components/component.js:2:3]
+ 1 | export function Component() {
+ 2 |   console.log("hello");
+   :   ^^^^^^^^^^^
+ 3 | }
+   `----
+  help: Delete this console statement.
+
+Found 0 warnings and 4 errors.
+Finished in <variable>ms on 7 files with 99 rules using 1 threads.
+----------
+CLI result: LintFoundErrors
+----------


### PR DESCRIPTION
- part of https://github.com/oxc-project/oxc/issues/7408

Ensures that when a config file is explicitly passed via `-c` or `--config`, that file will take precedence over all nested config files, and we will not search for config files within any directories.