### PR TITLE
test(linter): ensure CLI filters take precedence over nested configs

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -954,10 +954,32 @@ mod test {
     }
 
     #[test]
-    fn test_nested_config_precedence() {
+    fn test_nested_config_explicit_config_precedence() {
         // `--config` takes absolute precedence over nested configs, and will be used for
         // linting all files rather than the nested configuration files.
         let args = &["--experimental-nested-config", "--config", "oxlint-no-console.json"];
+        Tester::new().with_cwd("fixtures/nested_config".into()).test_and_snapshot(args);
+    }
+
+    #[test]
+    fn test_nested_config_filter_precedence() {
+        // CLI arguments take precedence over nested configs, but apply over top of the nested
+        // config files, rather than replacing them.
+        let args = &["--experimental-nested-config", "-A", "no-console"];
+        Tester::new().with_cwd("fixtures/nested_config".into()).test_and_snapshot(args);
+    }
+
+    #[test]
+    fn test_nested_config_explicit_config_and_filter_precedence() {
+        // Combining `--config` and CLI filters should make the passed config file be
+        // used for all files, but still override any rules specified in the config file.
+        let args = &[
+            "--experimental-nested-config",
+            "-A",
+            "no-console",
+            "--config",
+            "oxlint-no-console.json",
+        ];
         Tester::new().with_cwd("fixtures/nested_config".into()).test_and_snapshot(args);
     }
 }

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_--experimental-nested-config --config oxlint-no-console.json --experimental-nested-config --config oxlint-no-console.json -A no-console fixtures__nested_config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_--experimental-nested-config --config oxlint-no-console.json --experimental-nested-config --config oxlint-no-console.json -A no-console fixtures__nested_config@oxlint.snap
@@ -1,0 +1,53 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --experimental-nested-config --config oxlint-no-console.json
+working directory: fixtures/nested_config
+----------
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: eslint(no-console): Unexpected console statement.
+   ,-[console.ts:1:1]
+ 1 | console.log("test");
+   : ^^^^^^^^^^^
+   `----
+  help: Delete this console statement.
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: eslint(no-console): Unexpected console statement.
+   ,-[package1-empty-config/console.ts:1:1]
+ 1 | console.log("test");
+   : ^^^^^^^^^^^
+   `----
+  help: Delete this console statement.
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: eslint(no-console): Unexpected console statement.
+   ,-[package2-no-config/console.ts:1:1]
+ 1 | console.log("test");
+   : ^^^^^^^^^^^
+   `----
+  help: Delete this console statement.
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: eslint(no-console): Unexpected console statement.
+   ,-[package3-deep-config/src/components/component.js:2:3]
+ 1 | export function Component() {
+ 2 |   console.log("hello");
+   :   ^^^^^^^^^^^
+ 3 | }
+   `----
+  help: Delete this console statement.
+
+Found 0 warnings and 4 errors.
+Finished in <variable>ms on 7 files with 97 rules using 1 threads.
+----------
+CLI result: LintFoundErrors
+----------
+
+########## 
+arguments: --experimental-nested-config --config oxlint-no-console.json -A no-console fixtures/nested_config
+working directory: fixtures/nested_config
+----------
+Found 0 warnings and 0 errors.
+Finished in <variable>ms on 0 files with 97 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_--experimental-nested-config -A no-console --config oxlint-no-console.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_--experimental-nested-config -A no-console --config oxlint-no-console.json@oxlint.snap
@@ -1,0 +1,12 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --experimental-nested-config -A no-console --config oxlint-no-console.json
+working directory: fixtures/nested_config
+----------
+Found 0 warnings and 0 errors.
+Finished in <variable>ms on 7 files with 98 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_--experimental-nested-config -A no-console@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_--experimental-nested-config -A no-console@oxlint.snap
@@ -1,0 +1,34 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --experimental-nested-config -A no-console
+working directory: fixtures/nested_config
+----------
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[debugger.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Delete this code.
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[package1-empty-config/debugger.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Delete this code.
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[package2-no-config/debugger.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Delete this code.
+
+Found 1 warning and 2 errors.
+Finished in <variable>ms on 7 files with 99 rules using 1 threads.
+----------
+CLI result: LintFoundErrors
+----------


### PR DESCRIPTION
- part of https://github.com/oxc-project/oxc/issues/7408

Adds some regression tests to ensure that filters like `-D <rule>` or `-A <rule>` will override whatever is loaded from a configuration file that is either automatically loaded as a nested config, or explicitly loaded from the `--config` option.