### PR TITLE
chore(linter): improve the documentation of eslint/no-ternary

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_ternary.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ternary.rs
@@ -77,7 +77,12 @@ impl Rule for NoTernary {
 fn test() {
     use crate::tester::Tester;
 
-    let pass = vec![r#""x ? y";"#, "if (true) { thing() } else { stuff() };"];
+    let pass = vec![
+        r#""x ? y";"#,
+        "if (true) { thing() } else { stuff() };",
+        "let foo; if (isBar) { foo = baz; } else { foo = qux; };",
+        "function quux() { if (foo) { return bar(); } else { return baz(); } }",
+    ];
 
     let fail = vec![
         "var foo = true ? thing : stuff;",

--- a/crates/oxc_linter/src/rules/eslint/no_ternary.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ternary.rs
@@ -49,8 +49,6 @@ declare_oxc_lint!(
     /// ```
     ///
     /// ```javascript
-    /// let foo;
-    ///
     /// function quux() {
     ///     if (foo) {
     ///         return bar();

--- a/crates/oxc_linter/src/rules/eslint/no_ternary.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ternary.rs
@@ -19,15 +19,45 @@ declare_oxc_lint!(
     /// Disallow ternary operators
     ///
     /// ### Why is this bad?
-    /// The ternary operator is used to conditionally assign a value to a variable. Some believe that the use of ternary operators leads to unclear code.
     ///
-    /// ### Example
+    /// The ternary operator is used to conditionally assign a value to a
+    /// variable. Some believe that the use of ternary operators leads to
+    /// unclear code.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// var foo = isBar ? baz : qux;
-    //
-    // function quux() {
-    //   return foo ? bar() : baz();
-    // }
+    /// ```
+    ///
+    /// ```javascript
+    /// function quux() {
+    ///   return foo ? bar() : baz();
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// let foo;
+    ///
+    /// if (isBar) {
+    ///     foo = baz;
+    /// } else {
+    ///     foo = qux;
+    /// }
+    /// ```
+    ///
+    /// ```javascript
+    /// let foo;
+    ///
+    /// function quux() {
+    ///     if (foo) {
+    ///         return bar();
+    ///     } else {
+    ///         return baz();
+    ///     }
+    /// }
     /// ```
     NoTernary,
     eslint,


### PR DESCRIPTION
Relates to  [#6050](https://github.com/oxc-project/oxc/issues/6050)

Adds correctness and incorrectness examples following rule documentation template.