### PR TITLE
docs(linter): improve the documentation of eslint/no-useless-concat

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_useless_concat.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_concat.rs
@@ -25,11 +25,27 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// It’s unnecessary to concatenate two strings together.
+    /// It’s unnecessary to concatenate two strings together when they could
+    /// be combined into a single literal.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// var foo = "a" + "b";
+    /// ```
+    ///
+    /// ```javascript
+    /// var c = `a` + 'b';
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// var a = 'foo' + bar;
+    /// ```
+    ///
+    /// ```javascript
+    /// var b = `a` + bar;
     /// ```
     NoUselessConcat,
     eslint,

--- a/crates/oxc_linter/src/rules/eslint/no_useless_concat.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_concat.rs
@@ -32,11 +32,11 @@ declare_oxc_lint!(
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
-    /// var foo = "a" + "b";
+    /// var a = "a" + "b";
     /// ```
     ///
     /// ```javascript
-    /// var c = `a` + 'b';
+    /// var a = `a` + 'b' + 'c';
     /// ```
     ///
     /// Examples of **correct** code for this rule:
@@ -44,8 +44,11 @@ declare_oxc_lint!(
     /// var a = 'foo' + bar;
     /// ```
     ///
+    /// // when the string concatenation is multiline
     /// ```javascript
-    /// var b = `a` + bar;
+    /// var a = 'a'
+    ///     + 'b'
+    ///     + 'c';
     /// ```
     NoUselessConcat,
     eslint,

--- a/crates/oxc_linter/src/rules/eslint/no_useless_concat.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_concat.rs
@@ -32,21 +32,21 @@ declare_oxc_lint!(
     ///
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
-    /// var a = "a" + "b";
+    /// var foo = "a" + "b";
     /// ```
     ///
     /// ```javascript
-    /// var a = `a` + 'b' + 'c';
+    /// var foo = 'a' + 'b' + 'c';
     /// ```
     ///
     /// Examples of **correct** code for this rule:
     /// ```javascript
-    /// var a = 'foo' + bar;
+    /// var foo = 'a' + bar;
     /// ```
     ///
     /// // when the string concatenation is multiline
     /// ```javascript
-    /// var a = 'a'
+    /// var foo = 'a'
     ///     + 'b'
     ///     + 'c';
     /// ```


### PR DESCRIPTION
Relates to [#6050](https://github.com/oxc-project/oxc/issues/6050)

Adds correctness and incorrectness examples following rule documentation template.