### PR TITLE
chore(oxc_language_server): show oxlint version in LS logs

### DIFF
--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -102,7 +102,11 @@ impl LanguageServer for Backend {
 
         if let Some(value) = options {
             info!("initialize: {:?}", value);
-            info!("language server version: {:?}", env!("CARGO_PKG_VERSION"));
+            info!(
+                "language server version: {:?} (oxlint {:?})",
+                env!("CARGO_PKG_VERSION"),
+                oxc_linter::__private::VERSION
+            );
             *self.options.lock().await = value;
         }
 

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -183,6 +183,12 @@ impl Linter {
     }
 }
 
+#[doc(hidden)]
+pub mod __private {
+    #[doc(hidden)]
+    pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+}
+
 #[cfg(test)]
 mod test {
     use super::Oxlintrc;

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -186,7 +186,7 @@ impl Linter {
 #[doc(hidden)]
 pub mod __private {
     #[doc(hidden)]
-    pub const VERSION: &'static str = env!("CARGO_PKG_VERSION");
+    pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR should be tackling the #8603 issue - log the oxlint version together with the LS version. This way we can version the language server and oxlint separately.

Closes #8603 