### PR TITLE
feat(mangler): opt-out of direct eval

### DIFF
--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -192,6 +192,11 @@ impl Mangler {
 
         assert!(scope_tree.has_child_ids(), "child_id needs to be generated");
 
+        // TODO: implement opt-out of direct-eval in a branch of scopes.
+        if scope_tree.root_flags().contains_direct_eval() {
+            return symbol_table;
+        }
+
         let (exported_names, exported_symbols) = if self.options.top_level {
             Mangler::collect_exported_symbols(program)
         } else {

--- a/crates/oxc_minifier/tests/mangler/mod.rs
+++ b/crates/oxc_minifier/tests/mangler/mod.rs
@@ -17,6 +17,13 @@ fn mangle(source_text: &str, top_level: bool) -> String {
 }
 
 #[test]
+fn direct_eval() {
+    let source_text = "function foo() { let NO_MANGLE; eval('') }";
+    let mangled = mangle(source_text, false);
+    assert_eq!(mangled, "function foo() {\n\tlet NO_MANGLE;\n\teval(\"\");\n}\n");
+}
+
+#[test]
 fn mangler() {
     let cases = [
         "function foo(a) {a}",

--- a/crates/oxc_minifier/tests/peephole/mod.rs
+++ b/crates/oxc_minifier/tests/peephole/mod.rs
@@ -82,3 +82,24 @@ fn tagged_template() {
     test("foo(true && o.f)", "foo(o.f)");
     test("foo(true ? o.f : false)", "foo(o.f)");
 }
+
+#[test]
+fn eval() {
+    // Keep indirect-eval syntaxes
+    test_same("(!0 && eval)(x)");
+    test_same("(1 ? eval : 2)(x)");
+    test_same("(1 ? eval : 2)?.(x)");
+    test_same("(1, eval)(x)");
+    test_same("(1, eval)?.(x)");
+    test_same("(3, eval)(x)");
+    test_same("(4, eval)?.(x)");
+    test_same("(eval)(x)");
+    test_same("(eval)?.(x)");
+    test_same("eval(x)");
+    test_same("eval(x, y)");
+    test_same("eval(x,y)");
+    test_same("eval?.(x)");
+    test_same("eval?.(x)");
+    test_same("eval?.(x, y)");
+    test_same("eval?.(x,y)");
+}

--- a/crates/oxc_semantic/tests/integration/scopes.rs
+++ b/crates/oxc_semantic/tests/integration/scopes.rs
@@ -261,3 +261,25 @@ fn test_ts_conditional_types() {
         .has_number_of_references(0)
         .test();
 }
+
+#[test]
+fn test_eval() {
+    let direct_evals = ["eval('')", "function foo() { eval('') }"];
+    for code in direct_evals {
+        let tester = SemanticTester::js(code);
+        let semantic = tester.build();
+        assert!(semantic.scopes().root_flags().contains_direct_eval());
+    }
+
+    let indirect_evals = [
+        "eval?.('')",
+        "(0, eval)('')",
+        "const myEval = eval; myEval('')",
+        "const obj = { eval }; obj.eval('x + y')",
+    ];
+    for code in indirect_evals {
+        let tester = SemanticTester::js(code);
+        let semantic = tester.build();
+        assert!(!semantic.scopes().root_flags().contains_direct_eval());
+    }
+}

--- a/crates/oxc_syntax/src/scope.rs
+++ b/crates/oxc_syntax/src/scope.rs
@@ -79,6 +79,7 @@ bitflags! {
         const GetAccessor      = 1 << 7;
         const SetAccessor      = 1 << 8;
         const CatchClause      = 1 << 9;
+        const DirectEval       = 1 << 10; // <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval#direct_and_indirect_eval>
         const Var = Self::Top.bits() | Self::Function.bits() | Self::ClassStaticBlock.bits() | Self::TsModuleBlock.bits();
     }
 }
@@ -152,5 +153,10 @@ impl ScopeFlags {
     #[inline]
     pub fn is_catch_clause(&self) -> bool {
         self.contains(Self::CatchClause)
+    }
+
+    #[inline]
+    pub fn contains_direct_eval(&self) -> bool {
+        self.contains(Self::DirectEval)
     }
 }

--- a/tasks/coverage/snapshots/runtime.snap
+++ b/tasks/coverage/snapshots/runtime.snap
@@ -1,8 +1,101 @@
-commit: c4317b0c
+commit: bc5c1417
 
 runtime Summary:
-AST Parsed     : 17878/17878 (100.00%)
-Positive Passed: 17625/17878 (98.58%)
+AST Parsed     : 18253/18253 (100.00%)
+Positive Passed: 17317/18253 (94.87%)
+tasks/coverage/test262/test/language/eval-code/direct/var-env-func-init-global-update-configurable.js
+codegen error: Test262Error: descriptor should be enumerable; descriptor should be writable
+
+tasks/coverage/test262/test/language/eval-code/direct/var-env-var-init-global-exstng.js
+codegen error: Test262Error: descriptor should not be configurable
+
+tasks/coverage/test262/test/language/eval-code/indirect/var-env-func-init-global-update-configurable.js
+codegen error: Test262Error: descriptor should be enumerable; descriptor should be writable
+
+tasks/coverage/test262/test/language/eval-code/indirect/var-env-var-init-global-exstng.js
+codegen error: Test262Error: descriptor should not be configurable
+
+tasks/coverage/test262/test/language/expressions/arrow-function/dstr/ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/arrow-function/dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/arrow-function/dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/arrow-function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/arrow-function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/arrow-function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/arrow-function/dstr/dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/arrow-function/dstr/dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/arrow-function/dstr/dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/arrow-function/dstr/obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/arrow-function/dstr/obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/arrow-function/dstr/obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/assignment/dstr/array-elem-init-fn-name-class.js
+minify error: Test262Error: Expected true but got false
+
+tasks/coverage/test262/test/language/expressions/assignment/dstr/array-elem-init-fn-name-fn.js
+minify error: Test262Error: Expected true but got false
+
+tasks/coverage/test262/test/language/expressions/assignment/dstr/array-elem-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/assignment/dstr/obj-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/assignment/dstr/obj-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/assignment/dstr/obj-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/assignment/dstr/obj-prop-elem-init-evaluation.js
+minify error: Test262Error: value of `x` Expected SameValue(«undefined», «true») to be true
+
+tasks/coverage/test262/test/language/expressions/assignment/dstr/obj-prop-elem-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/assignment/dstr/obj-prop-elem-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/assignment/dstr/obj-prop-elem-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/assignment/dstr/obj-prop-elem-init-let.js
+minify error: Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
+
+tasks/coverage/test262/test/language/expressions/assignment/dstr/obj-prop-elem-init-yield-expr.js
+minify error: Test262Error: Expected SameValue(«true», «false») to be true
+
+tasks/coverage/test262/test/language/expressions/assignment/fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/assignment/fn-name-fn.js
+minify error: Test262Error: Expected true but got false
+
+tasks/coverage/test262/test/language/expressions/assignment/fn-name-gen.js
+minify error: Test262Error: Expected true but got false
+
 tasks/coverage/test262/test/language/expressions/assignment/fn-name-lhs-cover.js
 codegen error: Test262Error: descriptor value should be ; object value should be 
 
@@ -26,6 +119,9 @@ transform error: Test262Error: Expected SameValue(«true», «false») to be tru
 
 tasks/coverage/test262/test/language/expressions/async-function/forbidden-ext/b1/async-func-expr-nameless-forbidden-ext-direct-access-prop-caller.js
 transform error: Test262Error: Expected SameValue(«true», «false») to be true
+
+tasks/coverage/test262/test/language/expressions/async-function/name.js
+minify error: Test262Error: descriptor value should be func; object value should be func
 
 tasks/coverage/test262/test/language/expressions/async-function/named-reassign-fn-name-in-body-in-arrow.js
 transform error: Test262Error: Expected SameValue(«1», «function BindingIdentifier() {
@@ -54,6 +150,78 @@ transform error: Test262Error: Expected SameValue(«0», «1») to be true
 tasks/coverage/test262/test/language/expressions/async-generator/default-proto.js
 transform error: Test262Error: fn.prototype is undefined Expected SameValue(«[object Object]», «[object Object]») to be true
 
+tasks/coverage/test262/test/language/expressions/async-generator/dstr/ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/async-generator/dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/async-generator/dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/async-generator/dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/async-generator/dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/async-generator/dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/async-generator/dstr/dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/async-generator/dstr/dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/async-generator/dstr/dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/async-generator/dstr/named-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/async-generator/dstr/named-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/async-generator/dstr/named-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/async-generator/dstr/named-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/async-generator/dstr/named-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/async-generator/dstr/named-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/async-generator/dstr/named-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/async-generator/dstr/named-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/async-generator/dstr/named-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/async-generator/dstr/named-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/async-generator/dstr/named-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/async-generator/dstr/named-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/async-generator/dstr/obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/async-generator/dstr/obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/async-generator/dstr/obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
 tasks/coverage/test262/test/language/expressions/async-generator/forbidden-ext/b1/async-gen-func-expr-forbidden-ext-direct-access-prop-arguments.js
 transform error: Test262Error: Expected SameValue(«true», «false») to be true
 
@@ -65,6 +233,9 @@ transform error: Test262Error: Expected SameValue(«true», «false») to be tru
 
 tasks/coverage/test262/test/language/expressions/async-generator/forbidden-ext/b1/async-gen-named-func-expr-forbidden-ext-direct-access-prop-caller.js
 transform error: Test262Error: Expected SameValue(«true», «false») to be true
+
+tasks/coverage/test262/test/language/expressions/async-generator/name.js
+minify error: Test262Error: descriptor value should be func; object value should be func
 
 tasks/coverage/test262/test/language/expressions/async-generator/named-no-strict-reassign-fn-name-in-body-in-arrow.js
 transform error: Test262Error: Expected SameValue(«1», «function BindingIdentifier() {
@@ -213,6 +384,469 @@ transform error: Test262Error: reject reason Expected SameValue(«TypeError: The
 tasks/coverage/test262/test/language/expressions/class/async-gen-method-static/yield-star-sync-throw.js
 transform error: throw-arg-1
 
+tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-gen-meth-static-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/async-private-gen-meth-static-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-static-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-static-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-static-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-static-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/gen-meth-static-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/meth-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/meth-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/meth-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/meth-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/meth-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/meth-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/meth-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/meth-static-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/meth-static-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/meth-static-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/meth-static-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/meth-static-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/meth-static-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/meth-static-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-static-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-static-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-gen-meth-static-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-static-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-static-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-static-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-static-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/dstr/private-meth-static-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-derived-cls-direct-eval-err-contains-supercall-1.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-derived-cls-direct-eval-err-contains-supercall-2.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-derived-cls-direct-eval-err-contains-supercall.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-direct-eval-err-contains-arguments.js
+transform error: Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all
+
+tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-direct-eval-err-contains-newtarget.js
+transform error: Test262Error: Expected SameValue(«class {
+	constructor() {
+		babelHelpers.defineProperty(this, "x", eval("executed = true; () => new.target;"));
+	}
+}», «undefined») to be true
+
+tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-private-derived-cls-direct-eval-err-contains-supercall-1.js
+transform error: Test262Error: Expected a SyntaxError but got a TypeError
+
+tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-private-derived-cls-direct-eval-err-contains-supercall-2.js
+transform error: Test262Error: Expected a SyntaxError but got a TypeError
+
+tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-private-derived-cls-direct-eval-err-contains-supercall.js
+transform error: Test262Error: Expected a SyntaxError but got a TypeError
+
+tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-private-direct-eval-err-contains-arguments.js
+transform error: Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all
+
 tasks/coverage/test262/test/language/expressions/class/elements/async-gen-private-method/yield-star-async-next.js
 transform error: Test262Error: Expected SameValue(«"get next done (1)"», «"get next value (1)"») to be true
 
@@ -279,8 +913,30 @@ transform error: Test262Error: Expected SameValue(«"_Class"», «"C"») to be t
 tasks/coverage/test262/test/language/expressions/class/elements/class-name-static-initializer-default-export.js
 transform error: Test262Error: Expected SameValue(«"_Class"», «"default"») to be true
 
+tasks/coverage/test262/test/language/expressions/class/elements/class-name-static-initializer-expr.js
+minify error: Test262Error: Expected SameValue(«"expr"», «"C"») to be true
+
 tasks/coverage/test262/test/language/expressions/class/elements/computed-name-toprimitive-symbol.js
 transform error: TypeError: Cannot convert a Symbol value to a string
+
+tasks/coverage/test262/test/language/expressions/class/elements/derived-cls-direct-eval-err-contains-supercall-1.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/expressions/class/elements/derived-cls-direct-eval-err-contains-supercall-2.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/expressions/class/elements/derived-cls-direct-eval-err-contains-supercall.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/expressions/class/elements/direct-eval-err-contains-arguments.js
+transform error: Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all
+
+tasks/coverage/test262/test/language/expressions/class/elements/direct-eval-err-contains-newtarget.js
+transform error: Test262Error: Expected SameValue(«class {
+	constructor() {
+		babelHelpers.defineProperty(this, "x", eval("executed = true; new.target;"));
+	}
+}», «undefined») to be true
 
 tasks/coverage/test262/test/language/expressions/class/elements/evaluation-error/computed-name-toprimitive-err.js
 transform error: Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all
@@ -297,11 +953,54 @@ transform error: Test262Error: Expected a Test262Error to be thrown but no excep
 tasks/coverage/test262/test/language/expressions/class/elements/evaluation-error/computed-name-valueof-err.js
 transform error: Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all
 
+tasks/coverage/test262/test/language/expressions/class/elements/nested-derived-cls-direct-eval-err-contains-supercall-1.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/expressions/class/elements/nested-derived-cls-direct-eval-err-contains-supercall-2.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/expressions/class/elements/nested-derived-cls-direct-eval-err-contains-supercall.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/expressions/class/elements/nested-direct-eval-err-contains-arguments.js
+transform error: Test262Error: Expected a SyntaxError but got a TypeError
+
+tasks/coverage/test262/test/language/expressions/class/elements/nested-direct-eval-err-contains-newtarget.js
+transform error: Test262Error: Expected SameValue(«class {
+	constructor() {
+		babelHelpers.defineProperty(this, "x", eval("executed = true; new.target;"));
+	}
+}», «undefined») to be true
+
+tasks/coverage/test262/test/language/expressions/class/elements/nested-private-derived-cls-direct-eval-err-contains-supercall-1.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/expressions/class/elements/nested-private-derived-cls-direct-eval-err-contains-supercall-2.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/expressions/class/elements/nested-private-derived-cls-direct-eval-err-contains-supercall.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/expressions/class/elements/nested-private-direct-eval-err-contains-arguments.js
+transform error: Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all
+
 tasks/coverage/test262/test/language/expressions/class/elements/private-async-generator-method-name.js
 transform error: Test262Error: Expected SameValue(«"_method"», «"#method"») to be true
 
 tasks/coverage/test262/test/language/expressions/class/elements/private-async-method-name.js
 transform error: Test262Error: Expected SameValue(«"_method"», «"#method"») to be true
+
+tasks/coverage/test262/test/language/expressions/class/elements/private-derived-cls-direct-eval-err-contains-supercall-1.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/expressions/class/elements/private-derived-cls-direct-eval-err-contains-supercall-2.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/expressions/class/elements/private-derived-cls-direct-eval-err-contains-supercall.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/expressions/class/elements/private-direct-eval-err-contains-arguments.js
+transform error: Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all
 
 tasks/coverage/test262/test/language/expressions/class/elements/private-generator-method-name.js
 transform error: Test262Error: Expected SameValue(«"_method"», «"#method"») to be true
@@ -338,6 +1037,9 @@ transform error: Test262Error: Expected SameValue(«"undefinedtest"», «"test26
 
 tasks/coverage/test262/test/language/expressions/class/heritage-async-arrow-function.js
 transform error: Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
+
+tasks/coverage/test262/test/language/expressions/class/name.js
+minify error: Test262Error: descriptor value should be cls; object value should be cls
 
 tasks/coverage/test262/test/language/expressions/compound-assignment/left-hand-side-private-reference-accessor-property-add.js
 transform error: Test262Error: The expression should evaluate to the result Expected SameValue(«undefined», «3») to be true
@@ -378,11 +1080,95 @@ transform error: Test262Error: The expression should evaluate to the result Expe
 tasks/coverage/test262/test/language/expressions/does-not-equals/S11.9.2_A7.8.js
 minify error: Test262Error: #7: (1 != {valueOf: function() {throw "error"}, toString: function() {return 1}}) throw "error"
 
+tasks/coverage/test262/test/language/expressions/equals/coerce-symbol-to-prim-invocation.js
+minify error: Test262Error: method invoked exactly once Expected SameValue(«0», «1») to be true
+
 tasks/coverage/test262/test/language/expressions/exponentiation/bigint-negative-exponent-throws.js
 transform error: Test262Error: (-1n) ** -1n throws RangeError Expected a RangeError but got a TypeError
 
-tasks/coverage/test262/test/language/expressions/in/private-field-rhs-non-object.js
-transform error: Test262Error: Expected SameValue(«null», «null») to be false
+tasks/coverage/test262/test/language/expressions/function/dstr/ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/function/dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/function/dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/function/dstr/dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/function/dstr/dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/function/dstr/dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/function/dstr/obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/function/dstr/obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/function/dstr/obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/function/name.js
+minify error: Test262Error: descriptor value should be func; object value should be func
+
+tasks/coverage/test262/test/language/expressions/generators/dstr/ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/generators/dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/generators/dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/generators/dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/generators/dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/generators/dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/generators/dstr/dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/generators/dstr/dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/generators/dstr/dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/generators/dstr/obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/generators/dstr/obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/generators/dstr/obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/generators/name.js
+minify error: Test262Error: descriptor value should be func; object value should be func
+
+tasks/coverage/test262/test/language/expressions/greater-than/S11.8.2_A2.3_T1.js
+minify error: Test262Error: #1.3: Failed with: Test262Error: #1.1: Should have thrown
+
+tasks/coverage/test262/test/language/expressions/less-than-or-equal/S11.8.3_A2.3_T1.js
+minify error: Test262Error: #1.3: Failed with: Test262Error: #1.1: Should have thrown
 
 tasks/coverage/test262/test/language/expressions/logical-assignment/left-hand-side-private-reference-accessor-property-and.js
 transform error: Test262Error: The expression should evaluate to the result Expected SameValue(«undefined», «false») to be true
@@ -405,8 +1191,125 @@ transform error: Test262Error: The right-hand side should not be evaluated
 tasks/coverage/test262/test/language/expressions/object/__proto__-permitted-dup-shorthand.js
 codegen error: Test262Error: Expected SameValue(«[object Object]», «2») to be true
 
+tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/gen-meth-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/gen-meth-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/gen-meth-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/meth-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/meth-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/meth-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/meth-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/meth-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/meth-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/expressions/object/dstr/meth-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
 tasks/coverage/test262/test/language/expressions/object/dstr/object-rest-proxy-gopd-not-called-on-excluded-keys.js
 transform error: Test262Error: Actual [excludedString, 0, includedString, 1, Symbol(included_symbol)] and expected [Symbol(included_symbol), includedString, 1] should have the same contents. 
+
+tasks/coverage/test262/test/language/expressions/object/fn-name-class.js
+minify error: Test262Error: Expected true but got false
+
+tasks/coverage/test262/test/language/expressions/object/fn-name-fn.js
+minify error: Test262Error: Expected true but got false
+
+tasks/coverage/test262/test/language/expressions/object/fn-name-gen.js
+minify error: Test262Error: Expected true but got false
 
 tasks/coverage/test262/test/language/expressions/object/method-definition/async-gen-yield-star-async-next.js
 transform error: Test262Error: Expected SameValue(«"get next done (1)"», «"get next value (1)"») to be true
@@ -447,8 +1350,8 @@ transform error: TypeError: Cannot read properties of undefined (reading 'enumer
 tasks/coverage/test262/test/language/expressions/object/object-spread-proxy-ownkeys-returned-keys-order.js
 transform error: TypeError: Cannot read properties of undefined (reading 'enumerable')
 
-tasks/coverage/test262/test/language/expressions/unsigned-right-shift/S11.7.3_A2.2_T1.js
-minify error: Test262Error: #8.2: -4 >>> {valueOf: function() {return {}}, toString: function() {return {}}} throw TypeError. Actual: ReferenceError: e is not defined
+tasks/coverage/test262/test/language/expressions/optional-chaining/member-expression.js
+minify error: Test262Error: Expected SameValue(«"a"», «""») to be true
 
 tasks/coverage/test262/test/language/literals/regexp/u-surrogate-pairs-atom-escape-decimal.js
 codegen error: Test262Error: Expected SameValue(«true», «false») to be true
@@ -458,6 +1361,42 @@ transform error: Test262Error: Expected SameValue(«true», «false») to be tru
 
 tasks/coverage/test262/test/language/statements/async-function/forbidden-ext/b1/async-func-decl-forbidden-ext-direct-access-prop-caller.js
 transform error: Test262Error: Expected SameValue(«true», «false») to be true
+
+tasks/coverage/test262/test/language/statements/async-generator/dstr/ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/async-generator/dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/async-generator/dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/async-generator/dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/async-generator/dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/async-generator/dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/async-generator/dstr/dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/async-generator/dstr/dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/async-generator/dstr/dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/async-generator/dstr/obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/async-generator/dstr/obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/async-generator/dstr/obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
 
 tasks/coverage/test262/test/language/statements/async-generator/forbidden-ext/b1/async-gen-func-decl-forbidden-ext-direct-access-prop-arguments.js
 transform error: Test262Error: Expected SameValue(«true», «false») to be true
@@ -576,6 +1515,469 @@ transform error: Test262Error: reject reason Expected SameValue(«TypeError: The
 tasks/coverage/test262/test/language/statements/class/async-gen-method-static/yield-star-sync-throw.js
 transform error: throw-arg-1
 
+tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-gen-meth-static-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/async-private-gen-meth-static-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-static-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-static-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-static-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-static-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/gen-meth-static-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/meth-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/meth-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/meth-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/meth-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/meth-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/meth-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/meth-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/meth-static-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/meth-static-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/meth-static-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/meth-static-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/meth-static-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/meth-static-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/meth-static-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-static-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-static-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-static-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-gen-meth-static-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-meth-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-meth-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-meth-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-meth-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-meth-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-meth-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-meth-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-meth-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-meth-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-meth-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-meth-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-meth-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-meth-static-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-meth-static-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-meth-static-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-meth-static-dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-meth-static-dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-meth-static-dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-meth-static-dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-meth-static-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-meth-static-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/class/dstr/private-meth-static-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/class/elements/arrow-body-derived-cls-direct-eval-err-contains-supercall-1.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/statements/class/elements/arrow-body-derived-cls-direct-eval-err-contains-supercall-2.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/statements/class/elements/arrow-body-derived-cls-direct-eval-err-contains-supercall.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/statements/class/elements/arrow-body-direct-eval-err-contains-arguments.js
+transform error: Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all
+
+tasks/coverage/test262/test/language/statements/class/elements/arrow-body-direct-eval-err-contains-newtarget.js
+transform error: Test262Error: Expected SameValue(«class C {
+	constructor() {
+		babelHelpers.defineProperty(this, "x", eval("executed = true; () => new.target;"));
+	}
+}», «undefined») to be true
+
+tasks/coverage/test262/test/language/statements/class/elements/arrow-body-private-derived-cls-direct-eval-err-contains-supercall-1.js
+transform error: Test262Error: Expected a SyntaxError but got a TypeError
+
+tasks/coverage/test262/test/language/statements/class/elements/arrow-body-private-derived-cls-direct-eval-err-contains-supercall-2.js
+transform error: Test262Error: Expected a SyntaxError but got a TypeError
+
+tasks/coverage/test262/test/language/statements/class/elements/arrow-body-private-derived-cls-direct-eval-err-contains-supercall.js
+transform error: Test262Error: Expected a SyntaxError but got a TypeError
+
+tasks/coverage/test262/test/language/statements/class/elements/arrow-body-private-direct-eval-err-contains-arguments.js
+transform error: Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all
+
 tasks/coverage/test262/test/language/statements/class/elements/async-gen-private-method/yield-star-async-next.js
 transform error: Test262Error: Expected SameValue(«"get next done (1)"», «"get next value (1)"») to be true
 
@@ -642,6 +2044,25 @@ transform error: Test262Error: Frozen objects can't be changed Expected a TypeEr
 tasks/coverage/test262/test/language/statements/class/elements/computed-name-toprimitive-symbol.js
 transform error: TypeError: Cannot convert a Symbol value to a string
 
+tasks/coverage/test262/test/language/statements/class/elements/derived-cls-direct-eval-err-contains-supercall-1.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/statements/class/elements/derived-cls-direct-eval-err-contains-supercall-2.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/statements/class/elements/derived-cls-direct-eval-err-contains-supercall.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/statements/class/elements/direct-eval-err-contains-arguments.js
+transform error: Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all
+
+tasks/coverage/test262/test/language/statements/class/elements/direct-eval-err-contains-newtarget.js
+transform error: Test262Error: Expected SameValue(«class C {
+	constructor() {
+		babelHelpers.defineProperty(this, "x", eval("executed = true; new.target;"));
+	}
+}», «undefined») to be true
+
 tasks/coverage/test262/test/language/statements/class/elements/evaluation-error/computed-name-toprimitive-err.js
 transform error: Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all
 
@@ -657,11 +2078,54 @@ transform error: Test262Error: Expected a Test262Error to be thrown but no excep
 tasks/coverage/test262/test/language/statements/class/elements/evaluation-error/computed-name-valueof-err.js
 transform error: Test262Error: Expected a Test262Error to be thrown but no exception was thrown at all
 
+tasks/coverage/test262/test/language/statements/class/elements/nested-derived-cls-direct-eval-err-contains-supercall-1.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/statements/class/elements/nested-derived-cls-direct-eval-err-contains-supercall-2.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/statements/class/elements/nested-derived-cls-direct-eval-err-contains-supercall.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/statements/class/elements/nested-direct-eval-err-contains-arguments.js
+transform error: Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all
+
+tasks/coverage/test262/test/language/statements/class/elements/nested-direct-eval-err-contains-newtarget.js
+transform error: Test262Error: Expected SameValue(«class C {
+	constructor() {
+		babelHelpers.defineProperty(this, "x", eval("executed = true; new.target;"));
+	}
+}», «undefined») to be true
+
+tasks/coverage/test262/test/language/statements/class/elements/nested-private-derived-cls-direct-eval-err-contains-supercall-1.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/statements/class/elements/nested-private-derived-cls-direct-eval-err-contains-supercall-2.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/statements/class/elements/nested-private-derived-cls-direct-eval-err-contains-supercall.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/statements/class/elements/nested-private-direct-eval-err-contains-arguments.js
+transform error: Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all
+
 tasks/coverage/test262/test/language/statements/class/elements/private-async-generator-method-name.js
 transform error: Test262Error: Expected SameValue(«"_method"», «"#method"») to be true
 
 tasks/coverage/test262/test/language/statements/class/elements/private-async-method-name.js
 transform error: Test262Error: Expected SameValue(«"_method"», «"#method"») to be true
+
+tasks/coverage/test262/test/language/statements/class/elements/private-derived-cls-direct-eval-err-contains-supercall-1.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/statements/class/elements/private-derived-cls-direct-eval-err-contains-supercall-2.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/statements/class/elements/private-derived-cls-direct-eval-err-contains-supercall.js
+transform error: Test262Error: Expected a SyntaxError but got a ReferenceError
+
+tasks/coverage/test262/test/language/statements/class/elements/private-direct-eval-err-contains-arguments.js
+transform error: Test262Error: Expected a SyntaxError to be thrown but no exception was thrown at all
 
 tasks/coverage/test262/test/language/statements/class/elements/private-generator-method-name.js
 transform error: Test262Error: Expected SameValue(«"_method"», «"#method"») to be true
@@ -699,14 +2163,113 @@ transform error: Test262Error: Expected SameValue(«"undefinedtest"», «"test26
 tasks/coverage/test262/test/language/statements/class/static-init-expr-new-target.js
 transform error: SyntaxError: new.target expression is not allowed here
 
+tasks/coverage/test262/test/language/statements/class/subclass/class-definition-null-proto-this.js
+minify error: Test262Error: Expected a ReferenceError but got a Test262Error
+
 tasks/coverage/test262/test/language/statements/class/subclass/superclass-async-function.js
 transform error: TypeError: Cannot redefine property: prototype
 
 tasks/coverage/test262/test/language/statements/class/subclass/superclass-async-generator-function.js
 transform error: Test262Error: Expected a TypeError to be thrown but no exception was thrown at all
 
+tasks/coverage/test262/test/language/statements/const/block-local-use-before-initialization-in-prior-statement.js
+minify error: Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
+
+tasks/coverage/test262/test/language/statements/const/dstr/ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/const/dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/const/dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/const/dstr/obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/const/dstr/obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/const/dstr/obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/const/fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/const/fn-name-fn.js
+minify error: Test262Error: Expected true but got false
+
+tasks/coverage/test262/test/language/statements/const/fn-name-gen.js
+minify error: Test262Error: Expected true but got false
+
+tasks/coverage/test262/test/language/statements/const/function-local-use-before-initialization-in-prior-statement.js
+minify error: Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
+
+tasks/coverage/test262/test/language/statements/for/dstr/const-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for/dstr/const-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for/dstr/const-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for/dstr/const-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for/dstr/const-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for/dstr/const-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for/dstr/let-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for/dstr/let-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for/dstr/let-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for/dstr/let-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for/dstr/let-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for/dstr/let-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for/dstr/var-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for/dstr/var-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for/dstr/var-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for/dstr/var-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for/dstr/var-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for/dstr/var-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
 tasks/coverage/test262/test/language/statements/for-await-of/async-from-sync-iterator-continuation-abrupt-completion-get-constructor.js
 transform error: Test262Error: Actual [start, tick 1, catch, tick 2] and expected [start, tick 1, tick 2, catch] should have the same contents. 
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-init-fn-name-class.js
+minify error: Test262Error: Expected true but got false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-init-fn-name-fn.js
+minify error: Test262Error: Expected true but got false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
 
 tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-array-elem-init-yield-ident-valid.js
 transform error: Test262Error: Expected SameValue(«undefined», «4») to be true
@@ -729,8 +2292,29 @@ transform error: Test262Error: Expected SameValue(«undefined», «2») to be tr
 tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-array-rest-yield-ident-valid.js
 transform error: TypeError: Cannot read properties of undefined (reading 'length')
 
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-obj-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-obj-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFnexp"», «"xFnexp"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-obj-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
 tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-obj-id-init-yield-ident-valid.js
 transform error: Test262Error: Expected SameValue(«undefined», «3») to be true
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-obj-prop-elem-init-evaluation.js
+minify error: Test262Error: value of `x` Expected SameValue(«undefined», «true») to be true
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-obj-prop-elem-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-obj-prop-elem-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFnexp"», «"xFnexp"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-obj-prop-elem-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
 
 tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-obj-prop-elem-init-yield-ident-valid.js
 transform error: Test262Error: Expected SameValue(«undefined», «4») to be true
@@ -743,6 +2327,255 @@ transform error: Test262Error: Expected SameValue(«undefined», «22») to be t
 
 tasks/coverage/test262/test/language/statements/for-await-of/async-func-decl-dstr-obj-prop-nested-obj-yield-ident-valid.js
 transform error: Test262Error: Expected SameValue(«undefined», «2») to be true
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-const-async-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-const-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-let-async-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-let-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-var-async-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-func-dstr-var-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-decl-dstr-array-elem-init-fn-name-class.js
+minify error: Test262Error: Expected true but got false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-decl-dstr-array-elem-init-fn-name-fn.js
+minify error: Test262Error: Expected true but got false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-decl-dstr-array-elem-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-decl-dstr-obj-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-decl-dstr-obj-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFnexp"», «"xFnexp"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-decl-dstr-obj-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-decl-dstr-obj-prop-elem-init-evaluation.js
+minify error: Test262Error: value of `x` Expected SameValue(«undefined», «true») to be true
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-decl-dstr-obj-prop-elem-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-decl-dstr-obj-prop-elem-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFnexp"», «"xFnexp"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-decl-dstr-obj-prop-elem-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-decl-dstr-obj-prop-elem-init-yield-expr.js
+minify error: Timed out.
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-const-async-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-const-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-let-async-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-let-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-var-async-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-await-of/async-gen-dstr-var-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
 
 tasks/coverage/test262/test/language/statements/for-await-of/ticks-with-async-iter-resolved-promise-and-constructor-lookup-two.js
 transform error: Test262Error: Actual [pre, constructor, constructor, tick 1, loop, constructor, constructor, tick 2, post] and expected [pre, constructor, tick 1, loop, constructor, tick 2, post] should have the same contents. Ticks and constructor lookups
@@ -762,6 +2595,96 @@ minify error: Test262Error: Expected a ReferenceError to be thrown but no except
 tasks/coverage/test262/test/language/statements/for-in/scope-head-lex-open.js
 minify error: Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
 
+tasks/coverage/test262/test/language/statements/for-of/dstr/array-elem-init-fn-name-class.js
+minify error: Test262Error: Expected true but got false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/array-elem-init-fn-name-fn.js
+minify error: Test262Error: Expected true but got false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/array-elem-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/const-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/const-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/const-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/const-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/const-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/const-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/let-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/let-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/let-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/let-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/let-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/let-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/obj-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/obj-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/obj-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/obj-prop-elem-init-evaluation.js
+minify error: Test262Error: value of `x` Expected SameValue(«undefined», «true») to be true
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/obj-prop-elem-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/obj-prop-elem-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/obj-prop-elem-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/obj-prop-elem-init-let.js
+minify error: Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/obj-prop-elem-init-yield-expr.js
+minify error: Test262Error: Expected SameValue(«true», «false») to be true
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/var-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/var-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/var-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/var-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/var-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/for-of/dstr/var-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
 tasks/coverage/test262/test/language/statements/for-of/scope-body-lex-open.js
 minify error: Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
 
@@ -773,4 +2696,154 @@ minify error: Test262Error: Expected a ReferenceError to be thrown but no except
 
 tasks/coverage/test262/test/language/statements/for-of/string-astral-truncated.js
 codegen error: Test262Error: Expected SameValue(«"\\"», «"\\ud801"») to be true
+
+tasks/coverage/test262/test/language/statements/function/dstr/ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/function/dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/function/dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/function/dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/function/dstr/dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/function/dstr/dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/function/dstr/dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/function/dstr/obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/function/dstr/obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/function/dstr/obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/generators/dstr/ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/generators/dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/generators/dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/generators/dstr/dflt-ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/generators/dstr/dflt-ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/generators/dstr/dflt-ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/generators/dstr/dflt-obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/generators/dstr/dflt-obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/generators/dstr/dflt-obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/generators/dstr/obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/generators/dstr/obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/generators/dstr/obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/let/block-local-use-before-initialization-in-prior-statement.js
+minify error: Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
+
+tasks/coverage/test262/test/language/statements/let/dstr/ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/let/dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/let/dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/let/dstr/obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/let/dstr/obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/let/dstr/obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/let/fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/let/fn-name-fn.js
+minify error: Test262Error: Expected true but got false
+
+tasks/coverage/test262/test/language/statements/let/fn-name-gen.js
+minify error: Test262Error: Expected true but got false
+
+tasks/coverage/test262/test/language/statements/let/function-local-use-before-initialization-in-prior-statement.js
+minify error: Test262Error: Expected a ReferenceError to be thrown but no exception was thrown at all
+
+tasks/coverage/test262/test/language/statements/try/dstr/ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/try/dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/try/dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/try/dstr/obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/try/dstr/obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/try/dstr/obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/variable/dstr/ary-ptrn-elem-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/variable/dstr/ary-ptrn-elem-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/variable/dstr/ary-ptrn-elem-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/variable/dstr/obj-ptrn-id-init-fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/variable/dstr/obj-ptrn-id-init-fn-name-fn.js
+minify error: Test262Error: Expected SameValue(«"xFn"», «"xFn"») to be false
+
+tasks/coverage/test262/test/language/statements/variable/dstr/obj-ptrn-id-init-fn-name-gen.js
+minify error: Test262Error: Expected SameValue(«"xGen"», «"xGen"») to be false
+
+tasks/coverage/test262/test/language/statements/variable/fn-name-class.js
+minify error: Test262Error: Expected SameValue(«"xCls"», «"xCls"») to be false
+
+tasks/coverage/test262/test/language/statements/variable/fn-name-fn.js
+minify error: Test262Error: Expected true but got false
+
+tasks/coverage/test262/test/language/statements/variable/fn-name-gen.js
+minify error: Test262Error: Expected true but got false
 

--- a/tasks/coverage/snapshots/semantic_test262.snap
+++ b/tasks/coverage/snapshots/semantic_test262.snap
@@ -2,7 +2,7 @@ commit: bc5c1417
 
 semantic_test262 Summary:
 AST Parsed     : 44293/44293 (100.00%)
-Positive Passed: 42654/44293 (96.30%)
+Positive Passed: 42477/44293 (95.90%)
 tasks/coverage/test262/test/annexB/language/function-code/if-decl-else-decl-a-func-block-scoping.js
 semantic error: Symbol scope ID mismatch for "f":
 after transform: SymbolId(3): ScopeId(4294967294)
@@ -1264,6 +1264,416 @@ tasks/coverage/test262/test/language/arguments-object/cls-expr-async-private-gen
 semantic error: Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-expr-named-a-following-parameter-is-named-arguments-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-expr-named-a-preceding-parameter-is-named-arguments-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-func-decl-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-expr-named-fn-body-cntns-arguments-var-bind-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-expr-named-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-func-expr-nameless-a-preceding-parameter-is-named-arguments-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-func-decl-a-following-parameter-is-named-arguments-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-func-decl-a-preceding-parameter-is-named-arguments-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-func-decl-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-func-decl-fn-body-cntns-arguments-var-bind-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-func-decl-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-meth-a-following-parameter-is-named-arguments-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-named-func-expr-a-following-parameter-is-named-arguments-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-named-func-expr-a-preceding-parameter-is-named-arguments-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-func-decl-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-named-func-expr-fn-body-cntns-arguments-var-bind-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-gen-named-func-expr-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-meth-a-following-parameter-is-named-arguments-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-meth-a-following-parameter-is-named-arguments-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-meth-a-preceding-parameter-is-named-arguments-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-meth-a-preceding-parameter-is-named-arguments-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-func-decl-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-func-decl-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-lex-bind-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-lex-bind-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-var-bind-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-meth-fn-body-cntns-arguments-var-bind-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments-and-assign.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/eval-code/direct/async-meth-no-pre-existing-arguments-bindings-are-present-declare-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/async-function/named-eval-var-scope-syntax-err.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/async-function/named-reassign-fn-name-in-body-in-eval.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/async-function/named-strict-error-reassign-fn-name-in-body-in-eval.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/async-generator/named-eval-var-scope-syntax-err.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/async-generator/named-no-strict-reassign-fn-name-in-body-in-eval.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/async-generator/named-strict-error-reassign-fn-name-in-body-in-eval.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
 
 tasks/coverage/test262/test/language/expressions/class/cpn-class-expr-fields-computed-property-name-from-arrow-function-expression.js
 semantic error: Scope children mismatch:
@@ -5549,6 +5959,76 @@ Scope flags mismatch:
 after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(26): ScopeFlags(Function)
 
+tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-derived-cls-direct-eval-contains-superproperty-1.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-derived-cls-direct-eval-contains-superproperty-2.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-derived-cls-direct-eval-err-contains-supercall-1.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-derived-cls-direct-eval-err-contains-supercall-2.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-derived-cls-direct-eval-err-contains-supercall.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-direct-eval-err-contains-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-direct-eval-err-contains-newtarget.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-private-derived-cls-direct-eval-contains-superproperty-1.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-private-derived-cls-direct-eval-contains-superproperty-2.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-private-derived-cls-direct-eval-err-contains-supercall-1.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-private-derived-cls-direct-eval-err-contains-supercall-2.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-private-derived-cls-direct-eval-err-contains-supercall.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-private-direct-eval-err-contains-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/arrow-body-private-direct-eval-err-contains-newtarget.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
 tasks/coverage/test262/test/language/expressions/class/elements/async-gen-private-method/yield-promise-reject-next-catch.js
 semantic error: Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
@@ -6427,6 +6907,41 @@ Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 
+tasks/coverage/test262/test/language/expressions/class/elements/derived-cls-direct-eval-contains-superproperty-1.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/derived-cls-direct-eval-contains-superproperty-2.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/derived-cls-direct-eval-err-contains-supercall-1.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/derived-cls-direct-eval-err-contains-supercall-2.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/derived-cls-direct-eval-err-contains-supercall.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/direct-eval-err-contains-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/direct-eval-err-contains-newtarget.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
 tasks/coverage/test262/test/language/expressions/class/elements/multiple-definitions-rs-static-async-generator-method-privatename-identifier-alt.js
 semantic error: Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
@@ -6586,6 +7101,76 @@ rebuilt        : ScopeId(24): ScopeFlags(Function)
 Scope flags mismatch:
 after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(26): ScopeFlags(Function)
+
+tasks/coverage/test262/test/language/expressions/class/elements/nested-derived-cls-direct-eval-contains-superproperty-1.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/nested-derived-cls-direct-eval-contains-superproperty-2.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/nested-derived-cls-direct-eval-err-contains-supercall-1.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/nested-derived-cls-direct-eval-err-contains-supercall-2.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/nested-derived-cls-direct-eval-err-contains-supercall.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/nested-direct-eval-err-contains-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/nested-direct-eval-err-contains-newtarget.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/nested-private-derived-cls-direct-eval-contains-superproperty-1.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/nested-private-derived-cls-direct-eval-contains-superproperty-2.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/nested-private-derived-cls-direct-eval-err-contains-supercall-1.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/nested-private-derived-cls-direct-eval-err-contains-supercall-2.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/nested-private-derived-cls-direct-eval-err-contains-supercall.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/nested-private-direct-eval-err-contains-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/nested-private-direct-eval-err-contains-newtarget.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
 
 tasks/coverage/test262/test/language/expressions/class/elements/new-no-sc-line-method-rs-static-async-generator-method-privatename-identifier-alt.js
 semantic error: Scope flags mismatch:
@@ -6836,6 +7421,41 @@ tasks/coverage/test262/test/language/expressions/class/elements/private-async-me
 semantic error: Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
+
+tasks/coverage/test262/test/language/expressions/class/elements/private-derived-cls-direct-eval-contains-superproperty-1.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/private-derived-cls-direct-eval-contains-superproperty-2.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/private-derived-cls-direct-eval-err-contains-supercall-1.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/private-derived-cls-direct-eval-err-contains-supercall-2.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/private-derived-cls-direct-eval-err-contains-supercall.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/private-direct-eval-err-contains-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/class/elements/private-direct-eval-err-contains-newtarget.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
 
 tasks/coverage/test262/test/language/expressions/class/elements/private-methods/prod-private-async-generator.js
 semantic error: Scope flags mismatch:
@@ -7341,6 +7961,11 @@ Scope flags mismatch:
 after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(26): ScopeFlags(Function)
 
+tasks/coverage/test262/test/language/expressions/class/elements/static-field-init-with-this.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | DirectEval)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode)
+
 tasks/coverage/test262/test/language/expressions/class/elements/syntax/valid/grammar-static-private-async-gen-meth-prototype.js
 semantic error: Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
@@ -7669,6 +8294,16 @@ Symbol scope ID mismatch for "x":
 after transform: SymbolId(4): ScopeId(5)
 rebuilt        : SymbolId(5): ScopeId(3)
 
+tasks/coverage/test262/test/language/expressions/object/method-definition/async-gen-meth-eval-var-scope-syntax-err.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
+tasks/coverage/test262/test/language/expressions/object/method-definition/async-meth-eval-var-scope-syntax-err.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function | DirectEval)
+
 tasks/coverage/test262/test/language/module-code/top-level-await/syntax/for-await-await-expr-func-expression.js
 semantic error: Scope children mismatch:
 after transform: ScopeId(14): [ScopeId(1)]
@@ -7756,6 +8391,11 @@ Scope children mismatch:
 after transform: ScopeId(9): [ScopeId(10), ScopeId(11)]
 rebuilt        : ScopeId(30): [ScopeId(31)]
 
+tasks/coverage/test262/test/language/statements/async-function/eval-var-scope-syntax-err.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
+
 tasks/coverage/test262/test/language/statements/async-function/unscopables-with-in-nested-fn.js
 semantic error: Symbol flags mismatch for "ref":
 after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Function)
@@ -7765,6 +8405,11 @@ tasks/coverage/test262/test/language/statements/async-function/unscopables-with.
 semantic error: Symbol flags mismatch for "ref":
 after transform: SymbolId(3): SymbolFlags(BlockScopedVariable | Function)
 rebuilt        : SymbolId(4): SymbolFlags(FunctionScopedVariable)
+
+tasks/coverage/test262/test/language/statements/async-generator/eval-var-scope-syntax-err.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function | DirectEval)
 
 tasks/coverage/test262/test/language/statements/async-generator/unscopables-with-in-nested-fn.js
 semantic error: Symbol flags mismatch for "ref":
@@ -12134,6 +12779,76 @@ Scope flags mismatch:
 after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(26): ScopeFlags(Function)
 
+tasks/coverage/test262/test/language/statements/class/elements/arrow-body-derived-cls-direct-eval-contains-superproperty-1.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/arrow-body-derived-cls-direct-eval-contains-superproperty-2.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/arrow-body-derived-cls-direct-eval-err-contains-supercall-1.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/arrow-body-derived-cls-direct-eval-err-contains-supercall-2.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/arrow-body-derived-cls-direct-eval-err-contains-supercall.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/arrow-body-direct-eval-err-contains-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/arrow-body-direct-eval-err-contains-newtarget.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/arrow-body-private-derived-cls-direct-eval-contains-superproperty-1.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/arrow-body-private-derived-cls-direct-eval-contains-superproperty-2.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/arrow-body-private-derived-cls-direct-eval-err-contains-supercall-1.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/arrow-body-private-derived-cls-direct-eval-err-contains-supercall-2.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/arrow-body-private-derived-cls-direct-eval-err-contains-supercall.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/arrow-body-private-direct-eval-err-contains-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/arrow-body-private-direct-eval-err-contains-newtarget.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
 tasks/coverage/test262/test/language/statements/class/elements/async-gen-private-method/yield-promise-reject-next-catch.js
 semantic error: Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
@@ -13012,6 +13727,41 @@ Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 
+tasks/coverage/test262/test/language/statements/class/elements/derived-cls-direct-eval-contains-superproperty-1.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/derived-cls-direct-eval-contains-superproperty-2.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/derived-cls-direct-eval-err-contains-supercall-1.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/derived-cls-direct-eval-err-contains-supercall-2.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/derived-cls-direct-eval-err-contains-supercall.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/direct-eval-err-contains-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/direct-eval-err-contains-newtarget.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
 tasks/coverage/test262/test/language/statements/class/elements/multiple-definitions-rs-static-async-generator-method-privatename-identifier-alt.js
 semantic error: Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
@@ -13171,6 +13921,76 @@ rebuilt        : ScopeId(24): ScopeFlags(Function)
 Scope flags mismatch:
 after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(26): ScopeFlags(Function)
+
+tasks/coverage/test262/test/language/statements/class/elements/nested-derived-cls-direct-eval-contains-superproperty-1.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/nested-derived-cls-direct-eval-contains-superproperty-2.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/nested-derived-cls-direct-eval-err-contains-supercall-1.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/nested-derived-cls-direct-eval-err-contains-supercall-2.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/nested-derived-cls-direct-eval-err-contains-supercall.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/nested-direct-eval-err-contains-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/nested-direct-eval-err-contains-newtarget.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/nested-private-derived-cls-direct-eval-contains-superproperty-1.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/nested-private-derived-cls-direct-eval-contains-superproperty-2.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/nested-private-derived-cls-direct-eval-err-contains-supercall-1.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/nested-private-derived-cls-direct-eval-err-contains-supercall-2.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/nested-private-derived-cls-direct-eval-err-contains-supercall.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/nested-private-direct-eval-err-contains-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/nested-private-direct-eval-err-contains-newtarget.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
 
 tasks/coverage/test262/test/language/statements/class/elements/new-no-sc-line-method-rs-static-async-generator-method-privatename-identifier-alt.js
 semantic error: Scope flags mismatch:
@@ -13422,6 +14242,56 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
 
+tasks/coverage/test262/test/language/statements/class/elements/private-derived-cls-direct-eval-contains-superproperty-1.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/private-derived-cls-direct-eval-contains-superproperty-2.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/private-derived-cls-direct-eval-err-contains-supercall-1.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/private-derived-cls-direct-eval-err-contains-supercall-2.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/private-derived-cls-direct-eval-err-contains-supercall.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/private-direct-eval-err-contains-arguments.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/private-direct-eval-err-contains-newtarget.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/private-field-visible-to-direct-eval-on-initializer.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/private-getter-visible-to-direct-eval-on-initializer.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
+tasks/coverage/test262/test/language/statements/class/elements/private-method-visible-to-direct-eval-on-initializer.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
+
 tasks/coverage/test262/test/language/statements/class/elements/private-methods/prod-private-async-generator.js
 semantic error: Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
@@ -13431,6 +14301,11 @@ tasks/coverage/test262/test/language/statements/class/elements/private-methods/p
 semantic error: Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(8): ScopeFlags(Function)
+
+tasks/coverage/test262/test/language/statements/class/elements/private-setter-visible-to-direct-eval-on-initializer.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
 
 tasks/coverage/test262/test/language/statements/class/elements/private-static-async-generator-method-name.js
 semantic error: Scope flags mismatch:
@@ -13525,6 +14400,11 @@ rebuilt        : ScopeId(3): ScopeFlags(Function)
 Scope parent mismatch:
 after transform: ScopeId(5): Some(ScopeId(1))
 rebuilt        : ScopeId(3): Some(ScopeId(0))
+
+tasks/coverage/test262/test/language/statements/class/elements/privatename-not-valid-eval-earlyerr-3.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function | Constructor)
+rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function | Constructor | DirectEval)
 
 tasks/coverage/test262/test/language/statements/class/elements/regular-definitions-rs-static-async-generator-method-privatename-identifier-alt.js
 semantic error: Scope flags mismatch:
@@ -13925,6 +14805,11 @@ rebuilt        : ScopeId(24): ScopeFlags(Function)
 Scope flags mismatch:
 after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(26): ScopeFlags(Function)
+
+tasks/coverage/test262/test/language/statements/class/elements/static-field-init-with-this.js
+semantic error: Scope flags mismatch:
+after transform: ScopeId(1): ScopeFlags(StrictMode | DirectEval)
+rebuilt        : ScopeId(1): ScopeFlags(StrictMode)
 
 tasks/coverage/test262/test/language/statements/class/elements/syntax/valid/grammar-static-private-async-gen-meth-prototype.js
 semantic error: Scope flags mismatch:

--- a/tasks/coverage/src/runtime/mod.rs
+++ b/tasks/coverage/src/runtime/mod.rs
@@ -65,7 +65,6 @@ static SKIP_INCLUDES: &[&str] = &[
 
 static SKIP_TEST_CASES: &[&str] = &[
     // node.js runtime error
-    "language/eval-code",
     "language/expressions/dynamic-import",
     "language/global-code/decl-func.js",
     "language/module-code",
@@ -77,12 +76,7 @@ static SKIP_TEST_CASES: &[&str] = &[
     "language/expressions/prefix-decrement/operator-prefix-decrement-x-calls-putvalue-lhs-newvalue",
 ];
 
-static SKIP_ESID: &[&str] = &[
-    // Always fail because they need to perform `eval`
-    "sec-performeval-rules-in-initializer",
-    "sec-privatefieldget",
-    "sec-privatefieldset",
-];
+static SKIP_ESID: &[&str] = &["sec-privatefieldget", "sec-privatefieldset"];
 
 pub struct Test262RuntimeCase {
     base: Test262Case,
@@ -113,13 +107,7 @@ impl Case for Test262RuntimeCase {
         let features = &self.base.meta().features;
         self.base.should_fail()
             || self.base.skip_test_case()
-            || (self
-                .base
-                .meta()
-                .esid
-                .as_ref()
-                .is_some_and(|esid| SKIP_ESID.contains(&esid.as_ref()))
-                && test262_path.contains("direct-eval"))
+            || self.base.meta().esid.as_ref().is_some_and(|esid| SKIP_ESID.contains(&esid.as_ref()))
             || base_path.contains("built-ins")
             || base_path.contains("staging")
             || base_path.contains("intl402")


### PR DESCRIPTION
Context: 

* https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval
* https://esbuild.github.io/content-types/#direct-eval