### PR TITLE
refactor(ast/estree): simplify serializing `FormalParameters`

### DIFF
--- a/crates/oxc_ast/Cargo.toml
+++ b/crates/oxc_ast/Cargo.toml
@@ -30,7 +30,7 @@ bitflags = { workspace = true }
 cow-utils = { workspace = true }
 nonmax = { workspace = true }
 
-serde = { workspace = true, features = ["derive"], optional = true }
+serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
 
 [features]


### PR DESCRIPTION
Simplify the custom `Serialize` impl for `FormalParameters`.

This removes the last `#[derive(Serialize)]` in `oxc_ast` crate, which means we can turn off `serde`'s `derive` feature for this crate.

Unfortunately, `oxc_ast` depends on `oxc_span`, and that crate still uses `#[derive(Deserialize)]`. Therefore `oxc_ast` still has a transitive dependency on `serde-derive`. But this is a step to removing it, which when we do will greatly improve compile times.
