### PR TITLE
refactor(span): implement `Serialize` manually for `Atom`

### DIFF
--- a/crates/oxc_span/src/atom.rs
+++ b/crates/oxc_span/src/atom.rs
@@ -6,7 +6,7 @@ use std::{
 
 use oxc_allocator::{Allocator, CloneIn, FromIn};
 #[cfg(feature = "serialize")]
-use serde::Serialize;
+use serde::{Serialize, Serializer};
 
 use crate::{CompactStr, ContentEq};
 
@@ -15,8 +15,6 @@ use crate::{CompactStr, ContentEq};
 /// Use [CompactStr] with [Atom::to_compact_str] or [Atom::into_compact_str] for
 /// the lifetimeless form.
 #[derive(Clone, Copy, Eq)]
-#[cfg_attr(feature = "serialize", derive(Serialize))]
-#[cfg_attr(feature = "serialize", serde(transparent))]
 pub struct Atom<'a>(&'a str);
 
 impl Atom<'static> {
@@ -205,5 +203,12 @@ impl fmt::Debug for Atom<'_> {
 impl fmt::Display for Atom<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(self.as_str(), f)
+    }
+}
+
+#[cfg(feature = "serialize")]
+impl Serialize for Atom<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.0.serialize(serializer)
     }
 }

--- a/crates/oxc_span/src/compact_str.rs
+++ b/crates/oxc_span/src/compact_str.rs
@@ -224,11 +224,8 @@ impl fmt::Display for CompactStr {
 
 #[cfg(feature = "serialize")]
 impl Serialize for CompactStr {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(self.as_str())
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        self.as_str().serialize(serializer)
     }
 }
 


### PR DESCRIPTION
The `Serialize` impl for `Atom` is trivial, so there's no need to use `#[derive(Serialize)]` on it - just implement it by hand.

This is another step towards removing `serde-derive` from `oxc_span` and `oxc_ast`, which when complete will greatly improve compile times.

Also shorten the code for `impl Serialize for CompactStr`. That change is pure style refactor.