### PR TITLE
chore(linter): improve the documentation of eslint/no-loss-of-precision

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
@@ -55,7 +55,6 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Examples of **correct** code for this rule:
-    ///
     /// ```javascript
     /// var x = 12345";
     /// ```

--- a/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
@@ -69,6 +69,10 @@ declare_oxc_lint!(
     /// ```
     ///
     /// ```javascript
+    /// var x = 123e34;
+    /// ```
+    ///
+    /// ```javascript
     /// var x = 0x1FFF_FFFF_FFF_FFF;
     /// ```
     NoLossOfPrecision,

--- a/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_loss_of_precision.rs
@@ -25,10 +25,51 @@ declare_oxc_lint!(
     /// It can lead to unexpected results in certain situations
     /// For example, when performing mathematical operations
     ///
-    /// ### Example
+    /// In JS, Numbers are stored as double-precision floating-point numbers
+    /// according to the IEEE 754 standard. Because of this, numbers can only
+    /// retain accuracy up to a certain amount of digits. If the programmer
+    /// enters additional digits, those digits will be lost in the conversion
+    /// to the Number type and will result in unexpected behavior.
     ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// var x = 2e999;
+    /// ```
+    ///
+    /// ```javascript
+    /// var x = 9007199254740993;
+    /// ```
+    ///
+    /// ```javascript
+    /// var x = 5123000000000000000000000000001;
+    /// ```
+    ///
+    /// ```javascript
+    /// var x = 1230000000000000000000000.0;
+    /// ```
+    ///
+    /// ```javascript
+    /// var x = 0X200000_0000000_1;
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    ///
+    /// ```javascript
+    /// var x = 12345";
+    /// ```
+    ///
+    /// ```javascript
+    /// var x = 123.456;
+    /// ```
+    ///
+    /// ```javascript
+    /// var x = 123.0000000000000000000000";
+    /// ```
+    ///
+    /// ```javascript
+    /// var x = 0x1FFF_FFFF_FFF_FFF;
     /// ```
     NoLossOfPrecision,
     eslint,


### PR DESCRIPTION
Relates to [#6050](https://github.com/oxc-project/oxc/issues/6050)

Adds correctness and incorrectness examples following rule documentation template.