### PR TITLE
feat(ast_tools): add `#[builder(default)]` attribute for structs and enums

### DIFF
--- a/crates/oxc_ast_macros/src/lib.rs
+++ b/crates/oxc_ast_macros/src/lib.rs
@@ -64,7 +64,18 @@ pub fn ast_meta(_args: TokenStream, input: TokenStream) -> TokenStream {
 /// See [`macro@ast`] for further details.
 #[proc_macro_derive(
     Ast,
-    attributes(clone_in, content_eq, estree, generate_derive, plural, scope, span, ts, visit)
+    attributes(
+        builder,
+        clone_in,
+        content_eq,
+        estree,
+        generate_derive,
+        plural,
+        scope,
+        span,
+        ts,
+        visit
+    )
 )]
 pub fn ast_derive(_input: TokenStream) -> TokenStream {
     TokenStream::new()

--- a/crates/oxc_syntax/src/reference.rs
+++ b/crates/oxc_syntax/src/reference.rs
@@ -13,6 +13,7 @@ use oxc_ast_macros::ast;
 
 #[ast]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[builder(default)]
 #[clone_in(default)]
 #[content_eq(skip)]
 #[estree(skip)]

--- a/crates/oxc_syntax/src/scope.rs
+++ b/crates/oxc_syntax/src/scope.rs
@@ -9,6 +9,7 @@ use oxc_ast_macros::ast;
 
 #[ast]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[builder(default)]
 #[clone_in(default)]
 #[content_eq(skip)]
 #[estree(skip)]

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -9,6 +9,7 @@ use oxc_ast_macros::ast;
 
 #[ast]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[builder(default)]
 #[clone_in(default)]
 #[content_eq(skip)]
 #[estree(skip)]

--- a/tasks/ast_tools/src/schema/defs/enum.rs
+++ b/tasks/ast_tools/src/schema/defs/enum.rs
@@ -9,6 +9,7 @@ use crate::utils::{create_ident, pluralize};
 
 use super::{
     extensions::{
+        ast_builder::AstBuilderType,
         clone_in::CloneInType,
         content_eq::ContentEqType,
         estree::{ESTreeEnum, ESTreeEnumVariant},
@@ -33,6 +34,7 @@ pub struct EnumDef {
     pub variants: Vec<VariantDef>,
     /// For `@inherits` inherited enum variants
     pub inherits: Vec<TypeId>,
+    pub builder: AstBuilderType,
     pub visit: VisitEnum,
     pub kind: Kind,
     pub layout: Layout,
@@ -63,6 +65,7 @@ impl EnumDef {
             generated_derives,
             variants,
             inherits,
+            builder: AstBuilderType::default(),
             visit: VisitEnum::default(),
             kind: Kind::default(),
             layout: Layout::default(),

--- a/tasks/ast_tools/src/schema/defs/struct.rs
+++ b/tasks/ast_tools/src/schema/defs/struct.rs
@@ -8,6 +8,7 @@ use crate::utils::{create_ident_tokens, pluralize};
 
 use super::{
     extensions::{
+        ast_builder::AstBuilderType,
         clone_in::{CloneInStructField, CloneInType},
         content_eq::{ContentEqStructField, ContentEqType},
         estree::{ESTreeStruct, ESTreeStructField},
@@ -29,6 +30,7 @@ pub struct StructDef {
     pub file_id: FileId,
     pub generated_derives: Derives,
     pub fields: Vec<FieldDef>,
+    pub builder: AstBuilderType,
     pub visit: VisitStruct,
     pub kind: Kind,
     pub layout: Layout,
@@ -57,6 +59,7 @@ impl StructDef {
             file_id,
             generated_derives,
             fields,
+            builder: AstBuilderType::default(),
             visit: VisitStruct::default(),
             kind: Kind::default(),
             layout: Layout::default(),

--- a/tasks/ast_tools/src/schema/extensions/ast_builder.rs
+++ b/tasks/ast_tools/src/schema/extensions/ast_builder.rs
@@ -1,0 +1,6 @@
+/// Details for `AstBuilder` generator on a struct or enum.
+#[derive(Default, Debug)]
+pub struct AstBuilderType {
+    /// `true` if should be replaced with default value in AST builder methods
+    pub is_default: bool,
+}

--- a/tasks/ast_tools/src/schema/mod.rs
+++ b/tasks/ast_tools/src/schema/mod.rs
@@ -15,6 +15,7 @@ pub use meta::MetaType;
 
 /// Extensions to schema for specific derives / generators
 pub mod extensions {
+    pub mod ast_builder;
     pub mod clone_in;
     pub mod content_eq;
     pub mod estree;


### PR DESCRIPTION
Add a `#[builder(default)]` attribute which can be used on structs or enums to indicate that AST builder methods should not require this field.

Use that attribute on `ScopeId`, `SymbolId` and `ReferenceId`, to replace the hard-coded list of semantic ID types in codegen for `AstBuilder`.

Does not affect generated code, only the mechanisms by which it's generated.