### PR TITLE
feat(ast_tools): add `#[builder(default)]` attribute for struct fields

### DIFF
--- a/tasks/ast_tools/src/schema/defs/struct.rs
+++ b/tasks/ast_tools/src/schema/defs/struct.rs
@@ -8,7 +8,7 @@ use crate::utils::{create_ident_tokens, pluralize};
 
 use super::{
     extensions::{
-        ast_builder::AstBuilderType,
+        ast_builder::{AstBuilderStructField, AstBuilderType},
         clone_in::{CloneInStructField, CloneInType},
         content_eq::{ContentEqStructField, ContentEqType},
         estree::{ESTreeStruct, ESTreeStructField},
@@ -136,6 +136,7 @@ pub struct FieldDef {
     pub type_id: TypeId,
     pub visibility: Visibility,
     pub doc_comment: Option<String>,
+    pub builder: AstBuilderStructField,
     pub visit: VisitFieldOrVariant,
     pub offset: Offset,
     pub clone_in: CloneInStructField,
@@ -156,6 +157,7 @@ impl FieldDef {
             type_id,
             visibility,
             doc_comment,
+            builder: AstBuilderStructField::default(),
             visit: VisitFieldOrVariant::default(),
             offset: Offset::default(),
             clone_in: CloneInStructField::default(),

--- a/tasks/ast_tools/src/schema/extensions/ast_builder.rs
+++ b/tasks/ast_tools/src/schema/extensions/ast_builder.rs
@@ -4,3 +4,10 @@ pub struct AstBuilderType {
     /// `true` if should be replaced with default value in AST builder methods
     pub is_default: bool,
 }
+
+/// Details for `AstBuilder` generator on a struct field.
+#[derive(Default, Debug)]
+pub struct AstBuilderStructField {
+    /// `true` if should be replaced with default value in AST builder methods
+    pub is_default: bool,
+}


### PR DESCRIPTION
Extend `#[builder(default)]` attribute added in #9203 to also be usable on struct fields.

This will enable adding a `pure: bool` field to some structs, without altering the signature of AST builder methods.

Does not alter any generated code.