### PR TITLE
feat(ast_tools): add `#[builder(skip)]` attribute for structs and enums

### DIFF
--- a/crates/oxc_span/src/span.rs
+++ b/crates/oxc_span/src/span.rs
@@ -74,6 +74,7 @@ pub const SPAN: Span = Span::new(0, 0);
 #[ast(visit)]
 #[derive(Default, Clone, Copy, Eq, PartialOrd, Ord)]
 #[generate_derive(ESTree)]
+#[builder(skip)]
 #[content_eq(skip)]
 #[estree(no_type, flatten)]
 pub struct Span {

--- a/tasks/ast_tools/src/schema/extensions/ast_builder.rs
+++ b/tasks/ast_tools/src/schema/extensions/ast_builder.rs
@@ -1,6 +1,8 @@
 /// Details for `AstBuilder` generator on a struct or enum.
 #[derive(Default, Debug)]
 pub struct AstBuilderType {
+    /// `true` if no builder methods should be created for this struct/enum
+    pub skip: bool,
     /// `true` if should be replaced with default value in AST builder methods
     pub is_default: bool,
 }


### PR DESCRIPTION
Add a `#[builder(skip)]` attribute which can be used on structs or enums to indicate no `AstBuilder` methods should be generated for this type.

Use that attribute on `Span`, to replace the hard-coded black list in codegen for `AstBuilder`.

Does not affect generated code, only the mechanism by which it's generated.