### PR TITLE
docs(ast): docs for `AstBuilder` `*_with_*` methods list extra field names, not field types

### DIFF
--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -94,7 +94,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
-    /// Build a [`Program`] with `ScopeId`.
+    /// Build a [`Program`] with `scope_id`.
     ///
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_program_with_scope_id`] instead.
     ///
@@ -134,7 +134,7 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
-    /// Build a [`Program`] with `ScopeId`, and store it in the memory arena.
+    /// Build a [`Program`] with `scope_id`, and store it in the memory arena.
     ///
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::program_with_scope_id`] instead.
     ///
@@ -1071,7 +1071,7 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.identifier_reference(span, name), self.allocator)
     }
 
-    /// Build an [`IdentifierReference`] with `ReferenceId`.
+    /// Build an [`IdentifierReference`] with `reference_id`.
     ///
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_identifier_reference_with_reference_id`] instead.
     ///
@@ -1096,7 +1096,7 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
-    /// Build an [`IdentifierReference`] with `ReferenceId`, and store it in the memory arena.
+    /// Build an [`IdentifierReference`] with `reference_id`, and store it in the memory arena.
     ///
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::identifier_reference_with_reference_id`] instead.
     ///
@@ -1154,7 +1154,7 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.binding_identifier(span, name), self.allocator)
     }
 
-    /// Build a [`BindingIdentifier`] with `SymbolId`.
+    /// Build a [`BindingIdentifier`] with `symbol_id`.
     ///
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_binding_identifier_with_symbol_id`] instead.
     ///
@@ -1179,7 +1179,7 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
-    /// Build a [`BindingIdentifier`] with `SymbolId`, and store it in the memory arena.
+    /// Build a [`BindingIdentifier`] with `symbol_id`, and store it in the memory arena.
     ///
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::binding_identifier_with_symbol_id`] instead.
     ///
@@ -3322,7 +3322,7 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.block_statement(span, body), self.allocator)
     }
 
-    /// Build a [`BlockStatement`] with `ScopeId`.
+    /// Build a [`BlockStatement`] with `scope_id`.
     ///
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_block_statement_with_scope_id`] instead.
     ///
@@ -3340,7 +3340,7 @@ impl<'a> AstBuilder<'a> {
         BlockStatement { span, body, scope_id: Cell::new(Some(scope_id)) }
     }
 
-    /// Build a [`BlockStatement`] with `ScopeId`, and store it in the memory arena.
+    /// Build a [`BlockStatement`] with `scope_id`, and store it in the memory arena.
     ///
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::block_statement_with_scope_id`] instead.
     ///
@@ -3920,7 +3920,7 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.for_statement(span, init, test, update, body), self.allocator)
     }
 
-    /// Build a [`ForStatement`] with `ScopeId`.
+    /// Build a [`ForStatement`] with `scope_id`.
     ///
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_for_statement_with_scope_id`] instead.
     ///
@@ -3944,7 +3944,7 @@ impl<'a> AstBuilder<'a> {
         ForStatement { span, init, test, update, body, scope_id: Cell::new(Some(scope_id)) }
     }
 
-    /// Build a [`ForStatement`] with `ScopeId`, and store it in the memory arena.
+    /// Build a [`ForStatement`] with `scope_id`, and store it in the memory arena.
     ///
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::for_statement_with_scope_id`] instead.
     ///
@@ -4036,7 +4036,7 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.for_in_statement(span, left, right, body), self.allocator)
     }
 
-    /// Build a [`ForInStatement`] with `ScopeId`.
+    /// Build a [`ForInStatement`] with `scope_id`.
     ///
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_for_in_statement_with_scope_id`] instead.
     ///
@@ -4058,7 +4058,7 @@ impl<'a> AstBuilder<'a> {
         ForInStatement { span, left, right, body, scope_id: Cell::new(Some(scope_id)) }
     }
 
-    /// Build a [`ForInStatement`] with `ScopeId`, and store it in the memory arena.
+    /// Build a [`ForInStatement`] with `scope_id`, and store it in the memory arena.
     ///
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::for_in_statement_with_scope_id`] instead.
     ///
@@ -4152,7 +4152,7 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.for_of_statement(span, r#await, left, right, body), self.allocator)
     }
 
-    /// Build a [`ForOfStatement`] with `ScopeId`.
+    /// Build a [`ForOfStatement`] with `scope_id`.
     ///
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_for_of_statement_with_scope_id`] instead.
     ///
@@ -4176,7 +4176,7 @@ impl<'a> AstBuilder<'a> {
         ForOfStatement { span, r#await, left, right, body, scope_id: Cell::new(Some(scope_id)) }
     }
 
-    /// Build a [`ForOfStatement`] with `ScopeId`, and store it in the memory arena.
+    /// Build a [`ForOfStatement`] with `scope_id`, and store it in the memory arena.
     ///
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::for_of_statement_with_scope_id`] instead.
     ///
@@ -4371,7 +4371,7 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.switch_statement(span, discriminant, cases), self.allocator)
     }
 
-    /// Build a [`SwitchStatement`] with `ScopeId`.
+    /// Build a [`SwitchStatement`] with `scope_id`.
     ///
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_switch_statement_with_scope_id`] instead.
     ///
@@ -4391,7 +4391,7 @@ impl<'a> AstBuilder<'a> {
         SwitchStatement { span, discriminant, cases, scope_id: Cell::new(Some(scope_id)) }
     }
 
-    /// Build a [`SwitchStatement`] with `ScopeId`, and store it in the memory arena.
+    /// Build a [`SwitchStatement`] with `scope_id`, and store it in the memory arena.
     ///
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::switch_statement_with_scope_id`] instead.
     ///
@@ -4616,7 +4616,7 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.catch_clause(span, param, body), self.allocator)
     }
 
-    /// Build a [`CatchClause`] with `ScopeId`.
+    /// Build a [`CatchClause`] with `scope_id`.
     ///
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_catch_clause_with_scope_id`] instead.
     ///
@@ -4644,7 +4644,7 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
-    /// Build a [`CatchClause`] with `ScopeId`, and store it in the memory arena.
+    /// Build a [`CatchClause`] with `scope_id`, and store it in the memory arena.
     ///
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::catch_clause_with_scope_id`] instead.
     ///
@@ -5144,7 +5144,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
-    /// Build a [`Function`] with `ScopeId`.
+    /// Build a [`Function`] with `scope_id`.
     ///
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_function_with_scope_id`] instead.
     ///
@@ -5200,7 +5200,7 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
-    /// Build a [`Function`] with `ScopeId`, and store it in the memory arena.
+    /// Build a [`Function`] with `scope_id`, and store it in the memory arena.
     ///
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::function_with_scope_id`] instead.
     ///
@@ -5476,7 +5476,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
-    /// Build an [`ArrowFunctionExpression`] with `ScopeId`.
+    /// Build an [`ArrowFunctionExpression`] with `scope_id`.
     ///
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_arrow_function_expression_with_scope_id`] instead.
     ///
@@ -5519,7 +5519,7 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
-    /// Build an [`ArrowFunctionExpression`] with `ScopeId`, and store it in the memory arena.
+    /// Build an [`ArrowFunctionExpression`] with `scope_id`, and store it in the memory arena.
     ///
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::arrow_function_expression_with_scope_id`] instead.
     ///
@@ -5707,7 +5707,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
-    /// Build a [`Class`] with `ScopeId`.
+    /// Build a [`Class`] with `scope_id`.
     ///
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_class_with_scope_id`] instead.
     ///
@@ -5761,7 +5761,7 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
-    /// Build a [`Class`] with `ScopeId`, and store it in the memory arena.
+    /// Build a [`Class`] with `scope_id`, and store it in the memory arena.
     ///
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::class_with_scope_id`] instead.
     ///
@@ -6324,7 +6324,7 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.static_block(span, body), self.allocator)
     }
 
-    /// Build a [`StaticBlock`] with `ScopeId`.
+    /// Build a [`StaticBlock`] with `scope_id`.
     ///
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_static_block_with_scope_id`] instead.
     ///
@@ -6342,7 +6342,7 @@ impl<'a> AstBuilder<'a> {
         StaticBlock { span, body, scope_id: Cell::new(Some(scope_id)) }
     }
 
-    /// Build a [`StaticBlock`] with `ScopeId`, and store it in the memory arena.
+    /// Build a [`StaticBlock`] with `scope_id`, and store it in the memory arena.
     ///
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::static_block_with_scope_id`] instead.
     ///
@@ -8526,7 +8526,7 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_enum_declaration(span, id, members, r#const, declare), self.allocator)
     }
 
-    /// Build a [`TSEnumDeclaration`] with `ScopeId`.
+    /// Build a [`TSEnumDeclaration`] with `scope_id`.
     ///
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_enum_declaration_with_scope_id`] instead.
     ///
@@ -8557,7 +8557,7 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
-    /// Build a [`TSEnumDeclaration`] with `ScopeId`, and store it in the memory arena.
+    /// Build a [`TSEnumDeclaration`] with `scope_id`, and store it in the memory arena.
     ///
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_enum_declaration_with_scope_id`] instead.
     ///
@@ -9505,7 +9505,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
-    /// Build a [`TSConditionalType`] with `ScopeId`.
+    /// Build a [`TSConditionalType`] with `scope_id`.
     ///
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_conditional_type_with_scope_id`] instead.
     ///
@@ -9536,7 +9536,7 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
-    /// Build a [`TSConditionalType`] with `ScopeId`, and store it in the memory arena.
+    /// Build a [`TSConditionalType`] with `scope_id`, and store it in the memory arena.
     ///
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_conditional_type_with_scope_id`] instead.
     ///
@@ -10524,7 +10524,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
-    /// Build a [`TSTypeAliasDeclaration`] with `ScopeId`.
+    /// Build a [`TSTypeAliasDeclaration`] with `scope_id`.
     ///
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_type_alias_declaration_with_scope_id`] instead.
     ///
@@ -10558,7 +10558,7 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
-    /// Build a [`TSTypeAliasDeclaration`] with `ScopeId`, and store it in the memory arena.
+    /// Build a [`TSTypeAliasDeclaration`] with `scope_id`, and store it in the memory arena.
     ///
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_type_alias_declaration_with_scope_id`] instead.
     ///
@@ -10708,7 +10708,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
-    /// Build a [`TSInterfaceDeclaration`] with `ScopeId`.
+    /// Build a [`TSInterfaceDeclaration`] with `scope_id`.
     ///
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_interface_declaration_with_scope_id`] instead.
     ///
@@ -10746,7 +10746,7 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
-    /// Build a [`TSInterfaceDeclaration`] with `ScopeId`, and store it in the memory arena.
+    /// Build a [`TSInterfaceDeclaration`] with `scope_id`, and store it in the memory arena.
     ///
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_interface_declaration_with_scope_id`] instead.
     ///
@@ -11281,7 +11281,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
-    /// Build a [`TSMethodSignature`] with `ScopeId`.
+    /// Build a [`TSMethodSignature`] with `scope_id`.
     ///
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_method_signature_with_scope_id`] instead.
     ///
@@ -11330,7 +11330,7 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
-    /// Build a [`TSMethodSignature`] with `ScopeId`, and store it in the memory arena.
+    /// Build a [`TSMethodSignature`] with `scope_id`, and store it in the memory arena.
     ///
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_method_signature_with_scope_id`] instead.
     ///
@@ -11441,7 +11441,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
-    /// Build a [`TSConstructSignatureDeclaration`] with `ScopeId`.
+    /// Build a [`TSConstructSignatureDeclaration`] with `scope_id`.
     ///
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_construct_signature_declaration_with_scope_id`] instead.
     ///
@@ -11474,7 +11474,7 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
-    /// Build a [`TSConstructSignatureDeclaration`] with `ScopeId`, and store it in the memory arena.
+    /// Build a [`TSConstructSignatureDeclaration`] with `scope_id`, and store it in the memory arena.
     ///
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_construct_signature_declaration_with_scope_id`] instead.
     ///
@@ -11730,7 +11730,7 @@ impl<'a> AstBuilder<'a> {
         Box::new_in(self.ts_module_declaration(span, id, body, kind, declare), self.allocator)
     }
 
-    /// Build a [`TSModuleDeclaration`] with `ScopeId`.
+    /// Build a [`TSModuleDeclaration`] with `scope_id`.
     ///
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_module_declaration_with_scope_id`] instead.
     ///
@@ -11754,7 +11754,7 @@ impl<'a> AstBuilder<'a> {
         TSModuleDeclaration { span, id, body, kind, declare, scope_id: Cell::new(Some(scope_id)) }
     }
 
-    /// Build a [`TSModuleDeclaration`] with `ScopeId`, and store it in the memory arena.
+    /// Build a [`TSModuleDeclaration`] with `scope_id`, and store it in the memory arena.
     ///
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_module_declaration_with_scope_id`] instead.
     ///
@@ -12415,7 +12415,7 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
-    /// Build a [`TSMappedType`] with `ScopeId`.
+    /// Build a [`TSMappedType`] with `scope_id`.
     ///
     /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_mapped_type_with_scope_id`] instead.
     ///
@@ -12452,7 +12452,7 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
-    /// Build a [`TSMappedType`] with `ScopeId`, and store it in the memory arena.
+    /// Build a [`TSMappedType`] with `scope_id`, and store it in the memory arena.
     ///
     /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_mapped_type_with_scope_id`] instead.
     ///

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -145,12 +145,8 @@ fn generate_builder_methods_for_struct(struct_def: &StructDef, schema: &Schema) 
             "_with_{}",
             default_params.clone().map(|param| param.field.name()).join("_and_")
         );
-        let doc_postfix = format!(
-            " with `{}`",
-            default_params
-                .map(|param| { param.field.type_def(schema).innermost_type(schema).name() })
-                .join("` and `")
-        );
+        let doc_postfix =
+            format!(" with `{}`", default_params.map(|param| param.field.name()).join("` and `"));
         (fn_name_postfix, doc_postfix)
     } else {
         (String::new(), String::new())


### PR DESCRIPTION
In docs for `AstBuilder` methods, list the extra field names, not the *type* of the fields. When we add default fields which are `bool` e.g. `no_side_effects: bool`, this will produce comments that make more sense.

Before:

```rs
/// Build a [`Program`] with `ScopeId`.
/// Build a [`Function`] with `bool`.
```

After:

```rs
/// Build a [`Program`] with `scope_id`.
/// Build a [`Function`] with `no_side_effects`.
```
