### PR TITLE
feat(linter): add eslint/operator-assignment rule

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -146,6 +146,7 @@ mod eslint {
     pub mod no_var;
     pub mod no_void;
     pub mod no_with;
+    pub mod operator_assignment;
     pub mod prefer_exponentiation_operator;
     pub mod prefer_numeric_literals;
     pub mod prefer_object_has_own;
@@ -651,6 +652,7 @@ oxc_macros::declare_all_lint_rules! {
     eslint::no_var,
     eslint::no_void,
     eslint::no_with,
+    eslint::operator_assignment,
     eslint::prefer_promise_reject_errors,
     eslint::prefer_exponentiation_operator,
     eslint::prefer_numeric_literals,

--- a/crates/oxc_linter/src/rules/eslint/operator_assignment.rs
+++ b/crates/oxc_linter/src/rules/eslint/operator_assignment.rs
@@ -1,9 +1,10 @@
 use oxc_ast::{
+    AstKind,
     ast::{
         AssignmentExpression, AssignmentTarget, BinaryOperator, Expression, MemberExpression,
         SimpleAssignmentTarget, UnaryOperator, UpdateOperator,
     },
-    match_simple_assignment_target, AstKind,
+    match_simple_assignment_target,
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -11,7 +12,7 @@ use oxc_span::{GetSpan, Span};
 use oxc_syntax::precedence::GetPrecedence;
 use serde_json::Value;
 
-use crate::{context::LintContext, rule::Rule, utils::is_same_member_expression, AstNode};
+use crate::{AstNode, context::LintContext, rule::Rule, utils::is_same_member_expression};
 
 fn operator_assignment_diagnostic(mode: Mode, span: Span, operator: &str) -> OxcDiagnostic {
     let msg = if Mode::Never == mode {
@@ -31,11 +32,7 @@ enum Mode {
 
 impl Mode {
     pub fn from(raw: &str) -> Self {
-        if raw == "never" {
-            Self::Never
-        } else {
-            Self::Always
-        }
+        if raw == "never" { Self::Never } else { Self::Always }
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/operator_assignment.rs
+++ b/crates/oxc_linter/src/rules/eslint/operator_assignment.rs
@@ -1,0 +1,397 @@
+use oxc_ast::{ast::{AssignmentExpression, AssignmentOperator, AssignmentTarget, BinaryOperator, Expression}, match_simple_assignment_target, AstKind};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+use serde_json::Value;
+
+use crate::{
+    context::LintContext,
+    fixer::{RuleFix, RuleFixer},
+    rule::Rule,
+    AstNode,
+};
+
+fn operator_assignment_diagnostic(span: Span) -> OxcDiagnostic {
+    // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
+    OxcDiagnostic::warn("Should be an imperative statement about what is wrong")
+        .with_help("Should be a command-like statement that tells the user how to fix the issue")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, PartialEq, Clone)]
+enum Mode {
+    #[default]
+    Always,
+    Never,
+}
+
+impl Mode {
+    pub fn from(raw: &str) -> Self {
+        if raw == "never" {
+            Self::Never
+        } else {
+            Self::Always
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct OperatorAssignment {
+    mode: Mode,
+}
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    ///
+    /// ### Why is this bad?
+    ///
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
+    /// ```
+    OperatorAssignment,
+    eslint,
+    style,
+    fix
+);
+
+impl Rule for OperatorAssignment {
+    fn from_configuration(value: Value) -> Self {
+        Self {
+            mode: value.get(0).and_then(Value::as_str).map(Mode::from).unwrap_or_default(),
+        }
+    }
+
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::AssignmentExpression(assign_expr) = node.kind() else {
+            return;
+        };
+        if self.mode == Mode::Never {
+            return;
+        }
+
+    }
+}
+
+fn verfy(expr: &AssignmentExpression, ctx: &LintContext) {
+    if expr.operator != AssignmentOperator::Assign {
+        return;
+    }
+    let left= &expr.left;
+    if let Expression::BinaryExpression(binary_expr) = &expr.right {
+        let binary_operator = binary_expr.operator;
+        if is_commutative_operator_with_shorthand(binary_operator) || is_non_commutative_operator_with_shorthand(binary_operator) {
+            let replace_operator = format!("{}=", binary_operator.as_str());
+            if check_is_same_reference(&left, &binary_expr.left) {
+
+            }
+        }
+
+    }
+}
+
+fn check_is_same_reference(left: &AssignmentTarget, right: &Expression) -> bool {
+    match left {
+        match_simple_assignment_target!(AssignmentTarget) => {
+            let simple_assignment_target = left.to_simple_assignment_target();
+            return true;
+        }
+        _ => false,
+    }
+}
+
+fn is_commutative_operator_with_shorthand(operator: BinaryOperator) -> bool {
+    match operator {
+        BinaryOperator::Multiplication
+        | BinaryOperator::BitwiseAnd
+        | BinaryOperator::BitwiseXOR
+        | BinaryOperator::BitwiseOR => true,
+        _ => false,
+    }
+}
+
+fn is_non_commutative_operator_with_shorthand(operator: BinaryOperator) -> bool {
+    match operator {
+        BinaryOperator::Addition
+        | BinaryOperator::Subtraction
+        | BinaryOperator::Division
+        | BinaryOperator::Remainder
+        | BinaryOperator::ShiftLeft
+        | BinaryOperator::ShiftRight
+        | BinaryOperator::ShiftRightZeroFill
+        | BinaryOperator::Exponential => true,
+        _ => false,
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![];
+    let fail = vec![
+        ("x = x + y", None),
+    ];
+
+    // let pass = vec![
+    //     ("x = y", None),
+    //     ("x = y + x", None),
+    //     ("x += x + y", None),
+    //     ("x = (x + y) - z", None),
+    //     ("x -= y", None),
+    //     ("x = y - x", None),
+    //     ("x *= x", None),
+    //     ("x = y * z", None),
+    //     ("x = (x * y) * z", None),
+    //     ("x = y / x", None),
+    //     ("x /= y", None),
+    //     ("x %= y", None),
+    //     ("x <<= y", None),
+    //     ("x >>= x >> y", None),
+    //     ("x >>>= y", None),
+    //     ("x &= y", None),
+    //     ("x **= y", None),
+    //     ("x ^= y ^ z", None),
+    //     ("x |= x | y", None),
+    //     ("x = x && y", None),
+    //     ("x = x || y", None),
+    //     ("x = x < y", None),
+    //     ("x = x > y", None),
+    //     ("x = x <= y", None),
+    //     ("x = x >= y", None),
+    //     ("x = x instanceof y", None),
+    //     ("x = x in y", None),
+    //     ("x = x == y", None),
+    //     ("x = x != y", None),
+    //     ("x = x === y", None),
+    //     ("x = x !== y", None),
+    //     ("x[y] = x['y'] + z", None),
+    //     ("x.y = x['y'] / z", None),
+    //     ("x.y = z + x.y", None),
+    //     ("x[fn()] = x[fn()] + y", None),
+    //     ("x += x + y", Some(serde_json::json!(["always"]))),
+    //     ("x = x + y", Some(serde_json::json!(["never"]))),
+    //     ("x = x ** y", Some(serde_json::json!(["never"]))),
+    //     ("x = y ** x", None),
+    //     ("x = x * y + z", None),
+    //     ("this.x = this.y + z", Some(serde_json::json!(["always"]))),
+    //     ("this.x = foo.x + y", Some(serde_json::json!(["always"]))),
+    //     ("this.x = foo.this.x + y", Some(serde_json::json!(["always"]))),
+    //     ("const foo = 0; class C { foo = foo + 1; }", None),
+    //     ("x = x && y", Some(serde_json::json!(["always"]))),
+    //     ("x = x || y", Some(serde_json::json!(["always"]))),
+    //     ("x = x ?? y", Some(serde_json::json!(["always"]))),
+    //     ("x &&= y", Some(serde_json::json!(["never"]))),
+    //     ("x ||= y", Some(serde_json::json!(["never"]))),
+    //     ("x ??= y", Some(serde_json::json!(["never"]))),
+    // ];
+
+    // let fail = vec![
+    //     ("x = x + y", None),
+    //     ("x = x - y", None),
+    //     ("x = x * y", None),
+    //     ("x = y * x", None),
+    //     ("x = (y * z) * x", None),
+    //     ("x = x / y", None),
+    //     ("x = x % y", None),
+    //     ("x = x << y", None),
+    //     ("x = x >> y", None),
+    //     ("x = x >>> y", None),
+    //     ("x = x & y", None),
+    //     ("x = x ^ y", None),
+    //     ("x = x | y", None),
+    //     ("x[0] = x[0] - y", None),
+    //     ("x.y[z['a']][0].b = x.y[z['a']][0].b * 2", None),
+    //     ("x = x + y", Some(serde_json::json!(["always"]))),
+    //     ("x = (x + y)", Some(serde_json::json!(["always"]))),
+    //     ("x = x + (y)", Some(serde_json::json!(["always"]))),
+    //     ("x += (y)", Some(serde_json::json!(["never"]))),
+    //     ("x += y", Some(serde_json::json!(["never"]))),
+    //     ("foo.bar = foo.bar + baz", None),
+    //     ("foo.bar += baz", Some(serde_json::json!(["never"]))),
+    //     ("this.foo = this.foo + bar", None),
+    //     ("this.foo += bar", Some(serde_json::json!(["never"]))),
+    //     ("foo.bar.baz = foo.bar.baz + qux", None),
+    //     ("foo.bar.baz += qux", Some(serde_json::json!(["never"]))),
+    //     ("this.foo.bar = this.foo.bar + baz", None),
+    //     ("this.foo.bar += baz", Some(serde_json::json!(["never"]))),
+    //     ("foo[bar] = foo[bar] + baz", None),
+    //     ("this[foo] = this[foo] + bar", None),
+    //     ("foo[bar] >>>= baz", Some(serde_json::json!(["never"]))),
+    //     ("this[foo] >>>= bar", Some(serde_json::json!(["never"]))),
+    //     ("foo[5] = foo[5] / baz", None),
+    //     ("this[5] = this[5] / foo", None),
+    //     (
+    //         "/*1*/x/*2*/./*3*/y/*4*/= x.y +/*5*/z/*6*/./*7*/w/*8*/;",
+    //         Some(serde_json::json!(["always"])),
+    //     ),
+    //     (
+    //         "x // 1
+	// 		 . // 2
+	// 		 y // 3
+	// 		 = x.y + //4
+	// 		 z //5
+	// 		 . //6
+	// 		 w;",
+    //         Some(serde_json::json!(["always"])),
+    //     ),
+    //     ("x = /*1*/ x + y", Some(serde_json::json!(["always"]))),
+    //     (
+    //         "x = //1
+	// 		 x + y",
+    //         Some(serde_json::json!(["always"])),
+    //     ),
+    //     ("x.y = x/*1*/.y + z", Some(serde_json::json!(["always"]))),
+    //     (
+    //         "x.y = x. //1
+	// 		 y + z",
+    //         Some(serde_json::json!(["always"])),
+    //     ),
+    //     ("x = x /*1*/ + y", Some(serde_json::json!(["always"]))),
+    //     (
+    //         "x = x //1
+	// 		 + y",
+    //         Some(serde_json::json!(["always"])),
+    //     ),
+    //     ("/*1*/x +=/*2*/y/*3*/;", Some(serde_json::json!(["never"]))),
+    //     (
+    //         "x +=//1
+	// 		 y",
+    //         Some(serde_json::json!(["never"])),
+    //     ),
+    //     ("(/*1*/x += y)", Some(serde_json::json!(["never"]))),
+    //     ("x/*1*/+=  y", Some(serde_json::json!(["never"]))),
+    //     (
+    //         "x //1
+	// 		 +=  y",
+    //         Some(serde_json::json!(["never"])),
+    //     ),
+    //     ("(/*1*/x) +=  y", Some(serde_json::json!(["never"]))),
+    //     ("x/*1*/.y +=  z", Some(serde_json::json!(["never"]))),
+    //     (
+    //         "x.//1
+	// 		 y +=  z",
+    //         Some(serde_json::json!(["never"])),
+    //     ),
+    //     ("(foo.bar) ^= ((((((((((((((((baz))))))))))))))))", Some(serde_json::json!(["never"]))),
+    //     ("foo = foo ** bar", None),
+    //     ("foo **= bar", Some(serde_json::json!(["never"]))),
+    //     ("foo *= bar + 1", Some(serde_json::json!(["never"]))),
+    //     ("foo -= bar - baz", Some(serde_json::json!(["never"]))),
+    //     ("foo += bar + baz", Some(serde_json::json!(["never"]))),
+    //     ("foo += bar = 1", Some(serde_json::json!(["never"]))),
+    //     ("foo *= (bar + 1)", Some(serde_json::json!(["never"]))),
+    //     ("foo+=-bar", Some(serde_json::json!(["never"]))),
+    //     ("foo/=bar", Some(serde_json::json!(["never"]))),
+    //     ("foo/=/**/bar", Some(serde_json::json!(["never"]))),
+    //     (
+    //         "foo/=//
+	// 		bar",
+    //         Some(serde_json::json!(["never"])),
+    //     ),
+    //     ("foo/=/^bar$/", Some(serde_json::json!(["never"]))),
+    //     ("foo+=+bar", Some(serde_json::json!(["never"]))),
+    //     ("foo+= +bar", Some(serde_json::json!(["never"]))),
+    //     ("foo+=/**/+bar", Some(serde_json::json!(["never"]))),
+    //     ("foo+=+bar===baz", Some(serde_json::json!(["never"]))),
+    //     ("(obj?.a).b = (obj?.a).b + y", None),
+    //     ("obj.a = obj?.a + b", None),
+    // ];
+
+    // let fix = vec![
+    //     ("x = x + y", "x += y", None),
+    //     ("x = x - y", "x -= y", None),
+    //     ("x = x * y", "x *= y", None),
+    //     ("x = x / y", "x /= y", None),
+    //     ("x = x % y", "x %= y", None),
+    //     ("x = x << y", "x <<= y", None),
+    //     ("x = x >> y", "x >>= y", None),
+    //     ("x = x >>> y", "x >>>= y", None),
+    //     ("x = x & y", "x &= y", None),
+    //     ("x = x ^ y", "x ^= y", None),
+    //     ("x = x | y", "x |= y", None),
+    //     ("x[0] = x[0] - y", "x[0] -= y", None),
+    //     ("x = x + y", "x += y", Some(serde_json::json!(["always"]))),
+    //     ("x = (x + y)", "x += y", Some(serde_json::json!(["always"]))),
+    //     ("x = x + (y)", "x += (y)", Some(serde_json::json!(["always"]))),
+    //     ("x += (y)", "x = x + (y)", Some(serde_json::json!(["never"]))),
+    //     ("x += y", "x = x + y", Some(serde_json::json!(["never"]))),
+    //     ("foo.bar = foo.bar + baz", "foo.bar += baz", None),
+    //     ("foo.bar += baz", "foo.bar = foo.bar + baz", Some(serde_json::json!(["never"]))),
+    //     ("this.foo = this.foo + bar", "this.foo += bar", None),
+    //     ("this.foo += bar", "this.foo = this.foo + bar", Some(serde_json::json!(["never"]))),
+    //     ("foo[5] = foo[5] / baz", "foo[5] /= baz", None),
+    //     ("this[5] = this[5] / foo", "this[5] /= foo", None),
+    //     (
+    //         "/*1*/x/*2*/./*3*/y/*4*/= x.y +/*5*/z/*6*/./*7*/w/*8*/;",
+    //         "/*1*/x/*2*/./*3*/y/*4*/+=/*5*/z/*6*/./*7*/w/*8*/;",
+    //         Some(serde_json::json!(["always"])),
+    //     ),
+    //     (
+    //         "x // 1
+	// 		 . // 2
+	// 		 y // 3
+	// 		 = x.y + //4
+	// 		 z //5
+	// 		 . //6
+	// 		 w;",
+    //         "x // 1
+	// 		 . // 2
+	// 		 y // 3
+	// 		 += //4
+	// 		 z //5
+	// 		 . //6
+	// 		 w;",
+    //         Some(serde_json::json!(["always"])),
+    //     ),
+    //     ("/*1*/x +=/*2*/y/*3*/;", "/*1*/x = x +/*2*/y/*3*/;", Some(serde_json::json!(["never"]))),
+    //     (
+    //         "x +=//1
+	// 		 y",
+    //         "x = x +//1
+	// 		 y",
+    //         Some(serde_json::json!(["never"])),
+    //     ),
+    //     ("(/*1*/x += y)", "(/*1*/x = x + y)", Some(serde_json::json!(["never"]))),
+    //     (
+    //         "(foo.bar) ^= ((((((((((((((((baz))))))))))))))))",
+    //         "(foo.bar) = (foo.bar) ^ ((((((((((((((((baz))))))))))))))))",
+    //         Some(serde_json::json!(["never"])),
+    //     ),
+    //     ("foo = foo ** bar", "foo **= bar", None),
+    //     ("foo **= bar", "foo = foo ** bar", Some(serde_json::json!(["never"]))),
+    //     ("foo *= bar + 1", "foo = foo * (bar + 1)", Some(serde_json::json!(["never"]))),
+    //     ("foo -= bar - baz", "foo = foo - (bar - baz)", Some(serde_json::json!(["never"]))),
+    //     ("foo += bar + baz", "foo = foo + (bar + baz)", Some(serde_json::json!(["never"]))),
+    //     ("foo += bar = 1", "foo = foo + (bar = 1)", Some(serde_json::json!(["never"]))),
+    //     ("foo *= (bar + 1)", "foo = foo * (bar + 1)", Some(serde_json::json!(["never"]))),
+    //     ("foo+=-bar", "foo= foo+-bar", Some(serde_json::json!(["never"]))),
+    //     ("foo/=bar", "foo= foo/bar", Some(serde_json::json!(["never"]))),
+    //     ("foo/=/**/bar", "foo= foo/ /**/bar", Some(serde_json::json!(["never"]))),
+    //     (
+    //         "foo/=//
+	// 		bar",
+    //         "foo= foo/ //
+	// 		bar",
+    //         Some(serde_json::json!(["never"])),
+    //     ),
+    //     ("foo/=/^bar$/", "foo= foo/ /^bar$/", Some(serde_json::json!(["never"]))),
+    //     ("foo+=+bar", "foo= foo+ +bar", Some(serde_json::json!(["never"]))),
+    //     ("foo+= +bar", "foo= foo+ +bar", Some(serde_json::json!(["never"]))),
+    //     ("foo+=/**/+bar", "foo= foo+/**/+bar", Some(serde_json::json!(["never"]))),
+    //     ("foo+=+bar===baz", "foo= foo+(+bar===baz)", Some(serde_json::json!(["never"]))),
+    // ];
+    // Tester::new(OperatorAssignment::NAME, OperatorAssignment::PLUGIN, pass, fail)
+    //     .expect_fix(fix)
+    //     .test_and_snapshot();
+    Tester::new(OperatorAssignment::NAME, OperatorAssignment::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/eslint/operator_assignment.rs
+++ b/crates/oxc_linter/src/rules/eslint/operator_assignment.rs
@@ -82,6 +82,22 @@ declare_oxc_lint!(
     /// x = x + y;
     /// x.y = x.y / a.b;
     /// ```
+    ///
+    /// ### Options
+    /// This rule has a single string option:
+    ///
+    /// `{ type: String, default: 'always' }`
+    ///
+    /// * `always` requires assignment operator shorthand where possible
+    /// * `never` disallows assignment operator shorthand
+    ///
+    /// Example:
+    ///
+    /// ```json
+    /// "eslint/max-nested-callbacks": ["error", "always"]
+    ///
+    /// "eslint/max-nested-callbacks": ["error", "never"]
+    /// ```
     OperatorAssignment,
     eslint,
     style,

--- a/crates/oxc_linter/src/rules/eslint/operator_assignment.rs
+++ b/crates/oxc_linter/src/rules/eslint/operator_assignment.rs
@@ -79,12 +79,12 @@ impl Rule for OperatorAssignment {
         if self.mode == Mode::Never {
             prohibit(assign_expr, self.mode, ctx);
         } else {
-            verfy(assign_expr, self.mode, ctx);
+            verify(assign_expr, self.mode, ctx);
         }
     }
 }
 
-fn verfy(expr: &AssignmentExpression, mode: Mode, ctx: &LintContext) {
+fn verify(expr: &AssignmentExpression, mode: Mode, ctx: &LintContext) {
     if expr.operator != AssignmentOperator::Assign {
         return;
     }

--- a/crates/oxc_linter/src/rules/eslint/operator_assignment.rs
+++ b/crates/oxc_linter/src/rules/eslint/operator_assignment.rs
@@ -1,9 +1,9 @@
 use oxc_ast::{
+    AstKind,
     ast::{
         AssignmentExpression, AssignmentTarget, BinaryOperator, Expression, MemberExpression,
         SimpleAssignmentTarget, UnaryOperator, UpdateOperator,
     },
-    AstKind,
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -11,7 +11,7 @@ use oxc_span::{GetSpan, Span};
 use oxc_syntax::precedence::GetPrecedence;
 use serde_json::Value;
 
-use crate::{context::LintContext, rule::Rule, utils::is_same_member_expression, AstNode};
+use crate::{AstNode, context::LintContext, rule::Rule, utils::is_same_member_expression};
 
 fn operator_assignment_diagnostic(mode: Mode, span: Span, operator: &str) -> OxcDiagnostic {
     let msg = if Mode::Never == mode {
@@ -31,11 +31,7 @@ enum Mode {
 
 impl Mode {
     pub fn from(raw: &str) -> Self {
-        if raw == "never" {
-            Self::Never
-        } else {
-            Self::Always
-        }
+        if raw == "never" { Self::Never } else { Self::Always }
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/operator_assignment.rs
+++ b/crates/oxc_linter/src/rules/eslint/operator_assignment.rs
@@ -1,24 +1,27 @@
-use oxc_ast::{ast::{AssignmentExpression, AssignmentOperator, AssignmentTarget, BinaryOperator, Expression}, match_simple_assignment_target, AstKind};
+use oxc_ast::{
+    ast::{
+        AssignmentExpression, AssignmentOperator, AssignmentTarget, BinaryOperator, Expression,
+        MemberExpression, SimpleAssignmentTarget,
+    },
+    match_simple_assignment_target, AstKind,
+};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use serde_json::Value;
 
-use crate::{
-    context::LintContext,
-    fixer::{RuleFix, RuleFixer},
-    rule::Rule,
-    AstNode,
-};
+use crate::{context::LintContext, rule::Rule, utils::is_same_member_expression, AstNode};
 
-fn operator_assignment_diagnostic(span: Span) -> OxcDiagnostic {
-    // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
-    OxcDiagnostic::warn("Should be an imperative statement about what is wrong")
-        .with_help("Should be a command-like statement that tells the user how to fix the issue")
-        .with_label(span)
+fn operator_assignment_diagnostic(mode: Mode, span: Span, operator: &str) -> OxcDiagnostic {
+    let msg = if Mode::Never == mode {
+        format!("Unexpected operator assignment ({operator}) shorthand.")
+    } else {
+        format!("Assignment (=) can be replaced with operator assignment ({operator}).")
+    };
+    OxcDiagnostic::warn(msg).with_label(span)
 }
 
-#[derive(Debug, Default, PartialEq, Clone)]
+#[derive(Debug, Default, PartialEq, Clone, Copy)]
 enum Mode {
     #[default]
     Always,
@@ -42,7 +45,7 @@ pub struct OperatorAssignment {
 
 declare_oxc_lint!(
     /// ### What it does
-    ///
+    /// This rule requires or disallows assignment operator shorthand where possible.
     ///
     /// ### Why is this bad?
     ///
@@ -61,14 +64,12 @@ declare_oxc_lint!(
     OperatorAssignment,
     eslint,
     style,
-    fix
+    pending
 );
 
 impl Rule for OperatorAssignment {
     fn from_configuration(value: Value) -> Self {
-        Self {
-            mode: value.get(0).and_then(Value::as_str).map(Mode::from).unwrap_or_default(),
-        }
+        Self { mode: value.get(0).and_then(Value::as_str).map(Mode::from).unwrap_or_default() }
     }
 
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
@@ -76,236 +77,324 @@ impl Rule for OperatorAssignment {
             return;
         };
         if self.mode == Mode::Never {
-            return;
+            prohibit(assign_expr, self.mode, ctx);
+        } else {
+            verfy(assign_expr, self.mode, ctx);
         }
-
     }
 }
 
-fn verfy(expr: &AssignmentExpression, ctx: &LintContext) {
+fn verfy(expr: &AssignmentExpression, mode: Mode, ctx: &LintContext) {
     if expr.operator != AssignmentOperator::Assign {
         return;
     }
-    let left= &expr.left;
-    if let Expression::BinaryExpression(binary_expr) = &expr.right {
-        let binary_operator = binary_expr.operator;
-        if is_commutative_operator_with_shorthand(binary_operator) || is_non_commutative_operator_with_shorthand(binary_operator) {
-            let replace_operator = format!("{}=", binary_operator.as_str());
-            if check_is_same_reference(&left, &binary_expr.left) {
+    let left = &expr.left;
 
+    if let Expression::BinaryExpression(binary_expr) = &expr.right.without_parentheses() {
+        let binary_operator = binary_expr.operator;
+        let is_commutative_operator = is_commutative_operator_with_shorthand(binary_operator);
+        let is_non_commutative_operator =
+            is_non_commutative_operator_with_shorthand(binary_operator);
+        // for always
+        if is_commutative_operator || is_non_commutative_operator {
+            let replace_operator = format!("{}=", binary_operator.as_str());
+            if check_is_same_reference(left, &binary_expr.left, ctx) {
+                ctx.diagnostic(operator_assignment_diagnostic(mode, expr.span, &replace_operator));
+            } else if check_is_same_reference(left, &binary_expr.right, ctx)
+                && is_commutative_operator
+            {
+                // todo fix
+                ctx.diagnostic(operator_assignment_diagnostic(mode, expr.span, &replace_operator));
             }
         }
-
     }
 }
 
-fn check_is_same_reference(left: &AssignmentTarget, right: &Expression) -> bool {
+fn prohibit(expr: &AssignmentExpression, mode: Mode, ctx: &LintContext) {
+    if expr.operator != AssignmentOperator::Assign
+        && !check_is_logical_assign_operator(expr.operator)
+    {
+        if can_be_fixed(&expr.left) {
+            // todo fix
+            ctx.diagnostic(operator_assignment_diagnostic(mode, expr.span, expr.operator.as_str()));
+        } else {
+            ctx.diagnostic(operator_assignment_diagnostic(mode, expr.span, expr.operator.as_str()));
+        }
+    }
+}
+
+fn can_be_fixed(target: &AssignmentTarget) -> bool {
+    match target {
+        match_simple_assignment_target!(AssignmentTarget) => {
+            let simple_assignment_target = target.to_simple_assignment_target();
+
+            if matches!(
+                simple_assignment_target,
+                SimpleAssignmentTarget::AssignmentTargetIdentifier(_)
+            ) {
+                return true;
+            }
+            let Some(expr) = simple_assignment_target.as_member_expression() else {
+                return false;
+            };
+            match expr {
+                MemberExpression::ComputedMemberExpression(computed_expr) => {
+                    matches!(
+                        computed_expr.object,
+                        Expression::Identifier(_) | Expression::ThisExpression(_)
+                    ) && computed_expr.expression.is_literal()
+                }
+                MemberExpression::StaticMemberExpression(static_expr) => {
+                    matches!(
+                        static_expr.object,
+                        Expression::Identifier(_) | Expression::ThisExpression(_)
+                    )
+                }
+                MemberExpression::PrivateFieldExpression(_) => false,
+            }
+        }
+        _ => false,
+    }
+}
+
+fn check_is_same_reference(left: &AssignmentTarget, right: &Expression, ctx: &LintContext) -> bool {
     match left {
         match_simple_assignment_target!(AssignmentTarget) => {
             let simple_assignment_target = left.to_simple_assignment_target();
-            return true;
+            if let SimpleAssignmentTarget::AssignmentTargetIdentifier(id1) =
+                simple_assignment_target
+            {
+                return matches!(right, Expression::Identifier(id2) if id2.name == id1.name);
+            }
+
+            if let Some(left_member_expr) = simple_assignment_target.as_member_expression() {
+                if let Some(right_member_expr) = right.without_parentheses().get_member_expr() {
+                    // x.y vs x['y']
+                    if (matches!(left_member_expr, MemberExpression::ComputedMemberExpression(_))
+                        && !matches!(
+                            right_member_expr,
+                            MemberExpression::ComputedMemberExpression(_)
+                        ))
+                        || (!matches!(
+                            left_member_expr,
+                            MemberExpression::ComputedMemberExpression(_)
+                        ) && matches!(
+                            right_member_expr,
+                            MemberExpression::ComputedMemberExpression(_)
+                        ))
+                    {
+                        return false;
+                    }
+                    return is_same_member_expression(left_member_expr, right_member_expr, ctx);
+                }
+            }
+            false
         }
         _ => false,
     }
 }
 
 fn is_commutative_operator_with_shorthand(operator: BinaryOperator) -> bool {
-    match operator {
+    matches!(
+        operator,
         BinaryOperator::Multiplication
-        | BinaryOperator::BitwiseAnd
-        | BinaryOperator::BitwiseXOR
-        | BinaryOperator::BitwiseOR => true,
-        _ => false,
-    }
+            | BinaryOperator::BitwiseAnd
+            | BinaryOperator::BitwiseXOR
+            | BinaryOperator::BitwiseOR
+    )
 }
 
 fn is_non_commutative_operator_with_shorthand(operator: BinaryOperator) -> bool {
-    match operator {
+    matches!(
+        operator,
         BinaryOperator::Addition
-        | BinaryOperator::Subtraction
-        | BinaryOperator::Division
-        | BinaryOperator::Remainder
-        | BinaryOperator::ShiftLeft
-        | BinaryOperator::ShiftRight
-        | BinaryOperator::ShiftRightZeroFill
-        | BinaryOperator::Exponential => true,
-        _ => false,
-    }
+            | BinaryOperator::Subtraction
+            | BinaryOperator::Division
+            | BinaryOperator::Remainder
+            | BinaryOperator::ShiftLeft
+            | BinaryOperator::ShiftRight
+            | BinaryOperator::ShiftRightZeroFill
+            | BinaryOperator::Exponential
+    )
+}
+
+fn check_is_logical_assign_operator(operator: AssignmentOperator) -> bool {
+    matches!(
+        operator,
+        AssignmentOperator::LogicalAnd
+            | AssignmentOperator::LogicalOr
+            | AssignmentOperator::LogicalNullish
+    )
 }
 
 #[test]
 fn test() {
     use crate::tester::Tester;
 
-    let pass = vec![];
-    let fail = vec![
-        ("x = x + y", None),
+    let pass = vec![
+        ("x = y", None),
+        ("x = y + x", None),
+        ("x += x + y", None),
+        ("x = (x + y) - z", None),
+        ("x -= y", None),
+        ("x = y - x", None),
+        ("x *= x", None),
+        ("x = y * z", None),
+        ("x = (x * y) * z", None),
+        ("x = y / x", None),
+        ("x /= y", None),
+        ("x %= y", None),
+        ("x <<= y", None),
+        ("x >>= x >> y", None),
+        ("x >>>= y", None),
+        ("x &= y", None),
+        ("x **= y", None),
+        ("x ^= y ^ z", None),
+        ("x |= x | y", None),
+        ("x = x && y", None),
+        ("x = x || y", None),
+        ("x = x < y", None),
+        ("x = x > y", None),
+        ("x = x <= y", None),
+        ("x = x >= y", None),
+        ("x = x instanceof y", None),
+        ("x = x in y", None),
+        ("x = x == y", None),
+        ("x = x != y", None),
+        ("x = x === y", None),
+        ("x = x !== y", None),
+        ("x[y] = x['y'] + z", None),
+        ("x.y = x['y'] / z", None),
+        ("x.y = z + x.y", None),
+        ("x[fn()] = x[fn()] + y", None),
+        ("x += x + y", Some(serde_json::json!(["always"]))),
+        ("x = x + y", Some(serde_json::json!(["never"]))),
+        ("x = x ** y", Some(serde_json::json!(["never"]))),
+        ("x = y ** x", None),
+        ("x = x * y + z", None),
+        ("this.x = this.y + z", Some(serde_json::json!(["always"]))),
+        ("this.x = foo.x + y", Some(serde_json::json!(["always"]))),
+        ("this.x = foo.this.x + y", Some(serde_json::json!(["always"]))),
+        ("const foo = 0; class C { foo = foo + 1; }", None),
+        ("x = x && y", Some(serde_json::json!(["always"]))),
+        ("x = x || y", Some(serde_json::json!(["always"]))),
+        ("x = x ?? y", Some(serde_json::json!(["always"]))),
+        ("x &&= y", Some(serde_json::json!(["never"]))),
+        ("x ||= y", Some(serde_json::json!(["never"]))),
+        ("x ??= y", Some(serde_json::json!(["never"]))),
     ];
 
-    // let pass = vec![
-    //     ("x = y", None),
-    //     ("x = y + x", None),
-    //     ("x += x + y", None),
-    //     ("x = (x + y) - z", None),
-    //     ("x -= y", None),
-    //     ("x = y - x", None),
-    //     ("x *= x", None),
-    //     ("x = y * z", None),
-    //     ("x = (x * y) * z", None),
-    //     ("x = y / x", None),
-    //     ("x /= y", None),
-    //     ("x %= y", None),
-    //     ("x <<= y", None),
-    //     ("x >>= x >> y", None),
-    //     ("x >>>= y", None),
-    //     ("x &= y", None),
-    //     ("x **= y", None),
-    //     ("x ^= y ^ z", None),
-    //     ("x |= x | y", None),
-    //     ("x = x && y", None),
-    //     ("x = x || y", None),
-    //     ("x = x < y", None),
-    //     ("x = x > y", None),
-    //     ("x = x <= y", None),
-    //     ("x = x >= y", None),
-    //     ("x = x instanceof y", None),
-    //     ("x = x in y", None),
-    //     ("x = x == y", None),
-    //     ("x = x != y", None),
-    //     ("x = x === y", None),
-    //     ("x = x !== y", None),
-    //     ("x[y] = x['y'] + z", None),
-    //     ("x.y = x['y'] / z", None),
-    //     ("x.y = z + x.y", None),
-    //     ("x[fn()] = x[fn()] + y", None),
-    //     ("x += x + y", Some(serde_json::json!(["always"]))),
-    //     ("x = x + y", Some(serde_json::json!(["never"]))),
-    //     ("x = x ** y", Some(serde_json::json!(["never"]))),
-    //     ("x = y ** x", None),
-    //     ("x = x * y + z", None),
-    //     ("this.x = this.y + z", Some(serde_json::json!(["always"]))),
-    //     ("this.x = foo.x + y", Some(serde_json::json!(["always"]))),
-    //     ("this.x = foo.this.x + y", Some(serde_json::json!(["always"]))),
-    //     ("const foo = 0; class C { foo = foo + 1; }", None),
-    //     ("x = x && y", Some(serde_json::json!(["always"]))),
-    //     ("x = x || y", Some(serde_json::json!(["always"]))),
-    //     ("x = x ?? y", Some(serde_json::json!(["always"]))),
-    //     ("x &&= y", Some(serde_json::json!(["never"]))),
-    //     ("x ||= y", Some(serde_json::json!(["never"]))),
-    //     ("x ??= y", Some(serde_json::json!(["never"]))),
-    // ];
-
-    // let fail = vec![
-    //     ("x = x + y", None),
-    //     ("x = x - y", None),
-    //     ("x = x * y", None),
-    //     ("x = y * x", None),
-    //     ("x = (y * z) * x", None),
-    //     ("x = x / y", None),
-    //     ("x = x % y", None),
-    //     ("x = x << y", None),
-    //     ("x = x >> y", None),
-    //     ("x = x >>> y", None),
-    //     ("x = x & y", None),
-    //     ("x = x ^ y", None),
-    //     ("x = x | y", None),
-    //     ("x[0] = x[0] - y", None),
-    //     ("x.y[z['a']][0].b = x.y[z['a']][0].b * 2", None),
-    //     ("x = x + y", Some(serde_json::json!(["always"]))),
-    //     ("x = (x + y)", Some(serde_json::json!(["always"]))),
-    //     ("x = x + (y)", Some(serde_json::json!(["always"]))),
-    //     ("x += (y)", Some(serde_json::json!(["never"]))),
-    //     ("x += y", Some(serde_json::json!(["never"]))),
-    //     ("foo.bar = foo.bar + baz", None),
-    //     ("foo.bar += baz", Some(serde_json::json!(["never"]))),
-    //     ("this.foo = this.foo + bar", None),
-    //     ("this.foo += bar", Some(serde_json::json!(["never"]))),
-    //     ("foo.bar.baz = foo.bar.baz + qux", None),
-    //     ("foo.bar.baz += qux", Some(serde_json::json!(["never"]))),
-    //     ("this.foo.bar = this.foo.bar + baz", None),
-    //     ("this.foo.bar += baz", Some(serde_json::json!(["never"]))),
-    //     ("foo[bar] = foo[bar] + baz", None),
-    //     ("this[foo] = this[foo] + bar", None),
-    //     ("foo[bar] >>>= baz", Some(serde_json::json!(["never"]))),
-    //     ("this[foo] >>>= bar", Some(serde_json::json!(["never"]))),
-    //     ("foo[5] = foo[5] / baz", None),
-    //     ("this[5] = this[5] / foo", None),
-    //     (
-    //         "/*1*/x/*2*/./*3*/y/*4*/= x.y +/*5*/z/*6*/./*7*/w/*8*/;",
-    //         Some(serde_json::json!(["always"])),
-    //     ),
-    //     (
-    //         "x // 1
-	// 		 . // 2
-	// 		 y // 3
-	// 		 = x.y + //4
-	// 		 z //5
-	// 		 . //6
-	// 		 w;",
-    //         Some(serde_json::json!(["always"])),
-    //     ),
-    //     ("x = /*1*/ x + y", Some(serde_json::json!(["always"]))),
-    //     (
-    //         "x = //1
-	// 		 x + y",
-    //         Some(serde_json::json!(["always"])),
-    //     ),
-    //     ("x.y = x/*1*/.y + z", Some(serde_json::json!(["always"]))),
-    //     (
-    //         "x.y = x. //1
-	// 		 y + z",
-    //         Some(serde_json::json!(["always"])),
-    //     ),
-    //     ("x = x /*1*/ + y", Some(serde_json::json!(["always"]))),
-    //     (
-    //         "x = x //1
-	// 		 + y",
-    //         Some(serde_json::json!(["always"])),
-    //     ),
-    //     ("/*1*/x +=/*2*/y/*3*/;", Some(serde_json::json!(["never"]))),
-    //     (
-    //         "x +=//1
-	// 		 y",
-    //         Some(serde_json::json!(["never"])),
-    //     ),
-    //     ("(/*1*/x += y)", Some(serde_json::json!(["never"]))),
-    //     ("x/*1*/+=  y", Some(serde_json::json!(["never"]))),
-    //     (
-    //         "x //1
-	// 		 +=  y",
-    //         Some(serde_json::json!(["never"])),
-    //     ),
-    //     ("(/*1*/x) +=  y", Some(serde_json::json!(["never"]))),
-    //     ("x/*1*/.y +=  z", Some(serde_json::json!(["never"]))),
-    //     (
-    //         "x.//1
-	// 		 y +=  z",
-    //         Some(serde_json::json!(["never"])),
-    //     ),
-    //     ("(foo.bar) ^= ((((((((((((((((baz))))))))))))))))", Some(serde_json::json!(["never"]))),
-    //     ("foo = foo ** bar", None),
-    //     ("foo **= bar", Some(serde_json::json!(["never"]))),
-    //     ("foo *= bar + 1", Some(serde_json::json!(["never"]))),
-    //     ("foo -= bar - baz", Some(serde_json::json!(["never"]))),
-    //     ("foo += bar + baz", Some(serde_json::json!(["never"]))),
-    //     ("foo += bar = 1", Some(serde_json::json!(["never"]))),
-    //     ("foo *= (bar + 1)", Some(serde_json::json!(["never"]))),
-    //     ("foo+=-bar", Some(serde_json::json!(["never"]))),
-    //     ("foo/=bar", Some(serde_json::json!(["never"]))),
-    //     ("foo/=/**/bar", Some(serde_json::json!(["never"]))),
-    //     (
-    //         "foo/=//
-	// 		bar",
-    //         Some(serde_json::json!(["never"])),
-    //     ),
-    //     ("foo/=/^bar$/", Some(serde_json::json!(["never"]))),
-    //     ("foo+=+bar", Some(serde_json::json!(["never"]))),
-    //     ("foo+= +bar", Some(serde_json::json!(["never"]))),
-    //     ("foo+=/**/+bar", Some(serde_json::json!(["never"]))),
-    //     ("foo+=+bar===baz", Some(serde_json::json!(["never"]))),
-    //     ("(obj?.a).b = (obj?.a).b + y", None),
-    //     ("obj.a = obj?.a + b", None),
-    // ];
+    let fail = vec![
+        ("x = x + y", None),
+        ("x = x - y", None),
+        ("x = x * y", None),
+        ("x = y * x", None),
+        ("x = (y * z) * x", None),
+        ("x = x / y", None),
+        ("x = x % y", None),
+        ("x = x << y", None),
+        ("x = x >> y", None),
+        ("x = x >>> y", None),
+        ("x = x & y", None),
+        ("x = x ^ y", None),
+        ("x = x | y", None),
+        ("x[0] = x[0] - y", None),
+        ("x.y[z['a']][0].b = x.y[z['a']][0].b * 2", None),
+        ("x = x + y", Some(serde_json::json!(["always"]))),
+        ("x = (x + y)", Some(serde_json::json!(["always"]))),
+        ("x = x + (y)", Some(serde_json::json!(["always"]))),
+        ("x += (y)", Some(serde_json::json!(["never"]))),
+        ("x += y", Some(serde_json::json!(["never"]))),
+        ("foo.bar = foo.bar + baz", None),
+        ("foo.bar += baz", Some(serde_json::json!(["never"]))),
+        ("this.foo = this.foo + bar", None),
+        ("this.foo += bar", Some(serde_json::json!(["never"]))),
+        ("foo.bar.baz = foo.bar.baz + qux", None),
+        ("foo.bar.baz += qux", Some(serde_json::json!(["never"]))),
+        ("this.foo.bar = this.foo.bar + baz", None),
+        ("this.foo.bar += baz", Some(serde_json::json!(["never"]))),
+        ("foo[bar] = foo[bar] + baz", None),
+        ("this[foo] = this[foo] + bar", None),
+        ("foo[bar] >>>= baz", Some(serde_json::json!(["never"]))),
+        ("this[foo] >>>= bar", Some(serde_json::json!(["never"]))),
+        ("foo[5] = foo[5] / baz", None),
+        ("this[5] = this[5] / foo", None),
+        (
+            "/*1*/x/*2*/./*3*/y/*4*/= x.y +/*5*/z/*6*/./*7*/w/*8*/;",
+            Some(serde_json::json!(["always"])),
+        ),
+        (
+            "x // 1
+			 . // 2
+			 y // 3
+			 = x.y + //4
+			 z //5
+			 . //6
+			 w;",
+            Some(serde_json::json!(["always"])),
+        ),
+        ("x = /*1*/ x + y", Some(serde_json::json!(["always"]))),
+        (
+            "x = //1
+			 x + y",
+            Some(serde_json::json!(["always"])),
+        ),
+        ("x.y = x/*1*/.y + z", Some(serde_json::json!(["always"]))),
+        (
+            "x.y = x. //1
+			 y + z",
+            Some(serde_json::json!(["always"])),
+        ),
+        ("x = x /*1*/ + y", Some(serde_json::json!(["always"]))),
+        (
+            "x = x //1
+			 + y",
+            Some(serde_json::json!(["always"])),
+        ),
+        ("/*1*/x +=/*2*/y/*3*/;", Some(serde_json::json!(["never"]))),
+        (
+            "x +=//1
+			 y",
+            Some(serde_json::json!(["never"])),
+        ),
+        ("(/*1*/x += y)", Some(serde_json::json!(["never"]))),
+        ("x/*1*/+=  y", Some(serde_json::json!(["never"]))),
+        (
+            "x //1
+			 +=  y",
+            Some(serde_json::json!(["never"])),
+        ),
+        ("(/*1*/x) +=  y", Some(serde_json::json!(["never"]))),
+        ("x/*1*/.y +=  z", Some(serde_json::json!(["never"]))),
+        (
+            "x.//1
+			 y +=  z",
+            Some(serde_json::json!(["never"])),
+        ),
+        ("(foo.bar) ^= ((((((((((((((((baz))))))))))))))))", Some(serde_json::json!(["never"]))),
+        ("foo = foo ** bar", None),
+        ("foo **= bar", Some(serde_json::json!(["never"]))),
+        ("foo *= bar + 1", Some(serde_json::json!(["never"]))),
+        ("foo -= bar - baz", Some(serde_json::json!(["never"]))),
+        ("foo += bar + baz", Some(serde_json::json!(["never"]))),
+        ("foo += bar = 1", Some(serde_json::json!(["never"]))),
+        ("foo *= (bar + 1)", Some(serde_json::json!(["never"]))),
+        ("foo+=-bar", Some(serde_json::json!(["never"]))),
+        ("foo/=bar", Some(serde_json::json!(["never"]))),
+        ("foo/=/**/bar", Some(serde_json::json!(["never"]))),
+        (
+            "foo/=//
+			bar",
+            Some(serde_json::json!(["never"])),
+        ),
+        ("foo/=/^bar$/", Some(serde_json::json!(["never"]))),
+        ("foo+=+bar", Some(serde_json::json!(["never"]))),
+        ("foo+= +bar", Some(serde_json::json!(["never"]))),
+        ("foo+=/**/+bar", Some(serde_json::json!(["never"]))),
+        ("foo+=+bar===baz", Some(serde_json::json!(["never"]))),
+        ("(obj?.a).b = (obj?.a).b + y", None),
+        ("obj.a = obj?.a + b", None),
+    ];
 
     // let fix = vec![
     //     ("x = x + y", "x += y", None),
@@ -338,27 +427,27 @@ fn test() {
     //     ),
     //     (
     //         "x // 1
-	// 		 . // 2
-	// 		 y // 3
-	// 		 = x.y + //4
-	// 		 z //5
-	// 		 . //6
-	// 		 w;",
+    // 		 . // 2
+    // 		 y // 3
+    // 		 = x.y + //4
+    // 		 z //5
+    // 		 . //6
+    // 		 w;",
     //         "x // 1
-	// 		 . // 2
-	// 		 y // 3
-	// 		 += //4
-	// 		 z //5
-	// 		 . //6
-	// 		 w;",
+    // 		 . // 2
+    // 		 y // 3
+    // 		 += //4
+    // 		 z //5
+    // 		 . //6
+    // 		 w;",
     //         Some(serde_json::json!(["always"])),
     //     ),
     //     ("/*1*/x +=/*2*/y/*3*/;", "/*1*/x = x +/*2*/y/*3*/;", Some(serde_json::json!(["never"]))),
     //     (
     //         "x +=//1
-	// 		 y",
+    // 		 y",
     //         "x = x +//1
-	// 		 y",
+    // 		 y",
     //         Some(serde_json::json!(["never"])),
     //     ),
     //     ("(/*1*/x += y)", "(/*1*/x = x + y)", Some(serde_json::json!(["never"]))),
@@ -379,9 +468,9 @@ fn test() {
     //     ("foo/=/**/bar", "foo= foo/ /**/bar", Some(serde_json::json!(["never"]))),
     //     (
     //         "foo/=//
-	// 		bar",
+    // 		bar",
     //         "foo= foo/ //
-	// 		bar",
+    // 		bar",
     //         Some(serde_json::json!(["never"])),
     //     ),
     //     ("foo/=/^bar$/", "foo= foo/ /^bar$/", Some(serde_json::json!(["never"]))),
@@ -393,5 +482,6 @@ fn test() {
     // Tester::new(OperatorAssignment::NAME, OperatorAssignment::PLUGIN, pass, fail)
     //     .expect_fix(fix)
     //     .test_and_snapshot();
-    Tester::new(OperatorAssignment::NAME, OperatorAssignment::PLUGIN, pass, fail).test_and_snapshot();
+    Tester::new(OperatorAssignment::NAME, OperatorAssignment::PLUGIN, pass, fail)
+        .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/eslint_operator_assignment.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_operator_assignment.snap
@@ -6,18 +6,21 @@ source: crates/oxc_linter/src/tester.rs
  1 │ x = x + y
    · ─────────
    ╰────
+  help: Replace `x = x + y` with `x += y`.
 
   ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (-=).
    ╭─[operator_assignment.tsx:1:1]
  1 │ x = x - y
    · ─────────
    ╰────
+  help: Replace `x = x - y` with `x -= y`.
 
   ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (*=).
    ╭─[operator_assignment.tsx:1:1]
  1 │ x = x * y
    · ─────────
    ╰────
+  help: Replace `x = x * y` with `x *= y`.
 
   ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (*=).
    ╭─[operator_assignment.tsx:1:1]
@@ -36,54 +39,63 @@ source: crates/oxc_linter/src/tester.rs
  1 │ x = x / y
    · ─────────
    ╰────
+  help: Replace `x = x / y` with `x /= y`.
 
   ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (%=).
    ╭─[operator_assignment.tsx:1:1]
  1 │ x = x % y
    · ─────────
    ╰────
+  help: Replace `x = x % y` with `x %= y`.
 
   ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (<<=).
    ╭─[operator_assignment.tsx:1:1]
  1 │ x = x << y
    · ──────────
    ╰────
+  help: Replace `x = x << y` with `x <<= y`.
 
   ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (>>=).
    ╭─[operator_assignment.tsx:1:1]
  1 │ x = x >> y
    · ──────────
    ╰────
+  help: Replace `x = x >> y` with `x >>= y`.
 
   ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (>>>=).
    ╭─[operator_assignment.tsx:1:1]
  1 │ x = x >>> y
    · ───────────
    ╰────
+  help: Replace `x = x >>> y` with `x >>>= y`.
 
   ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (&=).
    ╭─[operator_assignment.tsx:1:1]
  1 │ x = x & y
    · ─────────
    ╰────
+  help: Replace `x = x & y` with `x &= y`.
 
   ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (^=).
    ╭─[operator_assignment.tsx:1:1]
  1 │ x = x ^ y
    · ─────────
    ╰────
+  help: Replace `x = x ^ y` with `x ^= y`.
 
   ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (|=).
    ╭─[operator_assignment.tsx:1:1]
  1 │ x = x | y
    · ─────────
    ╰────
+  help: Replace `x = x | y` with `x |= y`.
 
   ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (-=).
    ╭─[operator_assignment.tsx:1:1]
  1 │ x[0] = x[0] - y
    · ───────────────
    ╰────
+  help: Replace `x[0] = x[0] - y` with `x[0] -= y`.
 
   ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (*=).
    ╭─[operator_assignment.tsx:1:1]
@@ -96,54 +108,63 @@ source: crates/oxc_linter/src/tester.rs
  1 │ x = x + y
    · ─────────
    ╰────
+  help: Replace `x = x + y` with `x += y`.
 
   ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
    ╭─[operator_assignment.tsx:1:1]
  1 │ x = (x + y)
    · ───────────
    ╰────
+  help: Replace `x = (x + y)` with `x += y`.
 
   ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
    ╭─[operator_assignment.tsx:1:1]
  1 │ x = x + (y)
    · ───────────
    ╰────
+  help: Replace `x = x + (y)` with `x += (y)`.
 
   ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
    ╭─[operator_assignment.tsx:1:1]
  1 │ x += (y)
    · ────────
    ╰────
+  help: Replace `x += (y)` with `x = x + (y)`.
 
   ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
    ╭─[operator_assignment.tsx:1:1]
  1 │ x += y
    · ──────
    ╰────
+  help: Replace `x += y` with `x = x + y`.
 
   ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
    ╭─[operator_assignment.tsx:1:1]
  1 │ foo.bar = foo.bar + baz
    · ───────────────────────
    ╰────
+  help: Replace `foo.bar = foo.bar + baz` with `foo.bar += baz`.
 
   ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
    ╭─[operator_assignment.tsx:1:1]
  1 │ foo.bar += baz
    · ──────────────
    ╰────
+  help: Replace `foo.bar += baz` with `foo.bar = foo.bar + baz`.
 
   ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
    ╭─[operator_assignment.tsx:1:1]
  1 │ this.foo = this.foo + bar
    · ─────────────────────────
    ╰────
+  help: Replace `this.foo = this.foo + bar` with `this.foo += bar`.
 
   ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
    ╭─[operator_assignment.tsx:1:1]
  1 │ this.foo += bar
    · ───────────────
    ╰────
+  help: Replace `this.foo += bar` with `this.foo = this.foo + bar`.
 
   ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
    ╭─[operator_assignment.tsx:1:1]
@@ -198,18 +219,21 @@ source: crates/oxc_linter/src/tester.rs
  1 │ foo[5] = foo[5] / baz
    · ─────────────────────
    ╰────
+  help: Replace `foo[5] = foo[5] / baz` with `foo[5] /= baz`.
 
   ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (/=).
    ╭─[operator_assignment.tsx:1:1]
  1 │ this[5] = this[5] / foo
    · ───────────────────────
    ╰────
+  help: Replace `this[5] = this[5] / foo` with `this[5] /= foo`.
 
   ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
    ╭─[operator_assignment.tsx:1:6]
  1 │ /*1*/x/*2*/./*3*/y/*4*/= x.y +/*5*/z/*6*/./*7*/w/*8*/;
    ·      ───────────────────────────────────────────
    ╰────
+  help: Replace `x/*2*/./*3*/y/*4*/= x.y +/*5*/z/*6*/./*7*/w` with `x/*2*/./*3*/y/*4*/+=/*5*/z/*6*/./*7*/w`.
 
   ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
    ╭─[operator_assignment.tsx:1:1]
@@ -221,6 +245,19 @@ source: crates/oxc_linter/src/tester.rs
  6 │ │                . //6
  7 │ ╰─▶              w;
    ╰────
+  help: Replace `x // 1
+        			 . // 2
+        			 y // 3
+        			 = x.y + //4
+        			 z //5
+        			 . //6
+        			 w` with `x // 1
+        			 . // 2
+        			 y // 3
+        			 += //4
+        			 z //5
+        			 . //6
+        			 w`.
 
   ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
    ╭─[operator_assignment.tsx:1:1]
@@ -263,18 +300,23 @@ source: crates/oxc_linter/src/tester.rs
  1 │ /*1*/x +=/*2*/y/*3*/;
    ·      ──────────
    ╰────
+  help: Replace `x +=/*2*/y` with `x = x +/*2*/y`.
 
   ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
    ╭─[operator_assignment.tsx:1:1]
  1 │ ╭─▶ x +=//1
  2 │ ╰─▶              y
    ╰────
+  help: Replace `x +=//1
+        			 y` with `x = x +//1
+        			 y`.
 
   ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
    ╭─[operator_assignment.tsx:1:7]
  1 │ (/*1*/x += y)
    ·       ──────
    ╰────
+  help: Replace `x += y` with `x = x + y`.
 
   ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
    ╭─[operator_assignment.tsx:1:1]
@@ -311,102 +353,121 @@ source: crates/oxc_linter/src/tester.rs
  1 │ (foo.bar) ^= ((((((((((((((((baz))))))))))))))))
    · ────────────────────────────────────────────────
    ╰────
+  help: Replace `(foo.bar) ^= ((((((((((((((((baz))))))))))))))))` with `(foo.bar) = (foo.bar) ^ ((((((((((((((((baz))))))))))))))))`.
 
   ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (**=).
    ╭─[operator_assignment.tsx:1:1]
  1 │ foo = foo ** bar
    · ────────────────
    ╰────
+  help: Replace `foo = foo ** bar` with `foo **= bar`.
 
   ⚠ eslint(operator-assignment): Unexpected operator assignment (**=) shorthand.
    ╭─[operator_assignment.tsx:1:1]
  1 │ foo **= bar
    · ───────────
    ╰────
+  help: Replace `foo **= bar` with `foo = foo ** bar`.
 
   ⚠ eslint(operator-assignment): Unexpected operator assignment (*=) shorthand.
    ╭─[operator_assignment.tsx:1:1]
  1 │ foo *= bar + 1
    · ──────────────
    ╰────
+  help: Replace `foo *= bar + 1` with `foo = foo * (bar + 1)`.
 
   ⚠ eslint(operator-assignment): Unexpected operator assignment (-=) shorthand.
    ╭─[operator_assignment.tsx:1:1]
  1 │ foo -= bar - baz
    · ────────────────
    ╰────
+  help: Replace `foo -= bar - baz` with `foo = foo - (bar - baz)`.
 
   ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
    ╭─[operator_assignment.tsx:1:1]
  1 │ foo += bar + baz
    · ────────────────
    ╰────
+  help: Replace `foo += bar + baz` with `foo = foo + (bar + baz)`.
 
   ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
    ╭─[operator_assignment.tsx:1:1]
  1 │ foo += bar = 1
    · ──────────────
    ╰────
+  help: Replace `foo += bar = 1` with `foo = foo + (bar = 1)`.
 
   ⚠ eslint(operator-assignment): Unexpected operator assignment (*=) shorthand.
    ╭─[operator_assignment.tsx:1:1]
  1 │ foo *= (bar + 1)
    · ────────────────
    ╰────
+  help: Replace `foo *= (bar + 1)` with `foo = foo * (bar + 1)`.
 
   ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
    ╭─[operator_assignment.tsx:1:1]
  1 │ foo+=-bar
    · ─────────
    ╰────
+  help: Replace `foo+=-bar` with `foo= foo+-bar`.
 
   ⚠ eslint(operator-assignment): Unexpected operator assignment (/=) shorthand.
    ╭─[operator_assignment.tsx:1:1]
  1 │ foo/=bar
    · ────────
    ╰────
+  help: Replace `foo/=bar` with `foo= foo/bar`.
 
   ⚠ eslint(operator-assignment): Unexpected operator assignment (/=) shorthand.
    ╭─[operator_assignment.tsx:1:1]
  1 │ foo/=/**/bar
    · ────────────
    ╰────
+  help: Replace `foo/=/**/bar` with `foo= foo/ /**/bar`.
 
   ⚠ eslint(operator-assignment): Unexpected operator assignment (/=) shorthand.
    ╭─[operator_assignment.tsx:1:1]
  1 │ ╭─▶ foo/=//
  2 │ ╰─▶             bar
    ╰────
+  help: Replace `foo/=//
+        			bar` with `foo= foo/ //
+        			bar`.
 
   ⚠ eslint(operator-assignment): Unexpected operator assignment (/=) shorthand.
    ╭─[operator_assignment.tsx:1:1]
  1 │ foo/=/^bar$/
    · ────────────
    ╰────
+  help: Replace `foo/=/^bar$/` with `foo= foo/ /^bar$/`.
 
   ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
    ╭─[operator_assignment.tsx:1:1]
  1 │ foo+=+bar
    · ─────────
    ╰────
+  help: Replace `foo+=+bar` with `foo= foo+ +bar`.
 
   ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
    ╭─[operator_assignment.tsx:1:1]
  1 │ foo+= +bar
    · ──────────
    ╰────
+  help: Replace `foo+= +bar` with `foo= foo+ +bar`.
 
   ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
    ╭─[operator_assignment.tsx:1:1]
  1 │ foo+=/**/+bar
    · ─────────────
    ╰────
+  help: Replace `foo+=/**/+bar` with `foo= foo+/**/+bar`.
 
   ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
    ╭─[operator_assignment.tsx:1:1]
  1 │ foo+=+bar===baz
    · ───────────────
    ╰────
+  help: Replace `foo+=+bar===baz` with `foo= foo+(+bar===baz)`.
 
   ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
    ╭─[operator_assignment.tsx:1:1]
@@ -419,3 +480,18 @@ source: crates/oxc_linter/src/tester.rs
  1 │ obj.a = obj?.a + b
    · ──────────────────
    ╰────
+  help: Replace `obj.a = obj?.a + b` with `obj.a += b`.
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x += + (() => {})
+   · ─────────────────
+   ╰────
+  help: Replace `x += + (() => {})` with `x = x + + (() => {})`.
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x += + /** fooo */ (() => {})
+   · ─────────────────────────────
+   ╰────
+  help: Replace `x += + /** fooo */ (() => {})` with `x = x + + /** fooo */ (() => {})`.

--- a/crates/oxc_linter/src/snapshots/eslint_operator_assignment.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_operator_assignment.snap
@@ -1,0 +1,421 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x = x + y
+   · ─────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (-=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x = x - y
+   · ─────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (*=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x = x * y
+   · ─────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (*=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x = y * x
+   · ─────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (*=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x = (y * z) * x
+   · ───────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (/=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x = x / y
+   · ─────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (%=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x = x % y
+   · ─────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (<<=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x = x << y
+   · ──────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (>>=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x = x >> y
+   · ──────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (>>>=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x = x >>> y
+   · ───────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (&=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x = x & y
+   · ─────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (^=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x = x ^ y
+   · ─────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (|=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x = x | y
+   · ─────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (-=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x[0] = x[0] - y
+   · ───────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (*=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x.y[z['a']][0].b = x.y[z['a']][0].b * 2
+   · ───────────────────────────────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x = x + y
+   · ─────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x = (x + y)
+   · ───────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x = x + (y)
+   · ───────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x += (y)
+   · ────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x += y
+   · ──────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ foo.bar = foo.bar + baz
+   · ───────────────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ foo.bar += baz
+   · ──────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ this.foo = this.foo + bar
+   · ─────────────────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ this.foo += bar
+   · ───────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ foo.bar.baz = foo.bar.baz + qux
+   · ───────────────────────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ foo.bar.baz += qux
+   · ──────────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ this.foo.bar = this.foo.bar + baz
+   · ─────────────────────────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ this.foo.bar += baz
+   · ───────────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ foo[bar] = foo[bar] + baz
+   · ─────────────────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ this[foo] = this[foo] + bar
+   · ───────────────────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (>>>=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ foo[bar] >>>= baz
+   · ─────────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (>>>=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ this[foo] >>>= bar
+   · ──────────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (/=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ foo[5] = foo[5] / baz
+   · ─────────────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (/=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ this[5] = this[5] / foo
+   · ───────────────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
+   ╭─[operator_assignment.tsx:1:6]
+ 1 │ /*1*/x/*2*/./*3*/y/*4*/= x.y +/*5*/z/*6*/./*7*/w/*8*/;
+   ·      ───────────────────────────────────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ ╭─▶ x // 1
+ 2 │ │                . // 2
+ 3 │ │                y // 3
+ 4 │ │                = x.y + //4
+ 5 │ │                z //5
+ 6 │ │                . //6
+ 7 │ ╰─▶              w;
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x = /*1*/ x + y
+   · ───────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ ╭─▶ x = //1
+ 2 │ ╰─▶              x + y
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x.y = x/*1*/.y + z
+   · ──────────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ ╭─▶ x.y = x. //1
+ 2 │ ╰─▶              y + z
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x = x /*1*/ + y
+   · ───────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ ╭─▶ x = x //1
+ 2 │ ╰─▶              + y
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
+   ╭─[operator_assignment.tsx:1:6]
+ 1 │ /*1*/x +=/*2*/y/*3*/;
+   ·      ──────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ ╭─▶ x +=//1
+ 2 │ ╰─▶              y
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
+   ╭─[operator_assignment.tsx:1:7]
+ 1 │ (/*1*/x += y)
+   ·       ──────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x/*1*/+=  y
+   · ───────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ ╭─▶ x //1
+ 2 │ ╰─▶              +=  y
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ (/*1*/x) +=  y
+   · ──────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ x/*1*/.y +=  z
+   · ──────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ ╭─▶ x.//1
+ 2 │ ╰─▶              y +=  z
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (^=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ (foo.bar) ^= ((((((((((((((((baz))))))))))))))))
+   · ────────────────────────────────────────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (**=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ foo = foo ** bar
+   · ────────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (**=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ foo **= bar
+   · ───────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (*=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ foo *= bar + 1
+   · ──────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (-=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ foo -= bar - baz
+   · ────────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ foo += bar + baz
+   · ────────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ foo += bar = 1
+   · ──────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (*=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ foo *= (bar + 1)
+   · ────────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ foo+=-bar
+   · ─────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (/=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ foo/=bar
+   · ────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (/=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ foo/=/**/bar
+   · ────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (/=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ ╭─▶ foo/=//
+ 2 │ ╰─▶             bar
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (/=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ foo/=/^bar$/
+   · ────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ foo+=+bar
+   · ─────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ foo+= +bar
+   · ──────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ foo+=/**/+bar
+   · ─────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Unexpected operator assignment (+=) shorthand.
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ foo+=+bar===baz
+   · ───────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ (obj?.a).b = (obj?.a).b + y
+   · ───────────────────────────
+   ╰────
+
+  ⚠ eslint(operator-assignment): Assignment (=) can be replaced with operator assignment (+=).
+   ╭─[operator_assignment.tsx:1:1]
+ 1 │ obj.a = obj?.a + b
+   · ──────────────────
+   ╰────


### PR DESCRIPTION
There is currently no automatic fix implemented and I will request a review after I finish this work

Rule detail：[https://eslint.org/docs/latest/rules/operator-assignment
](https://eslint.org/docs/latest/rules/operator-assignment
)