### PR TITLE
feat(linter): add unicorn/no-invalid-fetch-options rule

### DIFF
--- a/apps/oxlint/src/snapshots/_--ignore-path fixtures__linter__.customignore --no-ignore fixtures__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-path fixtures__linter__.customignore --no-ignore fixtures__linter__nan.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Use the isNaN function to compare with NaN.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 98 rules using 1 threads.
+Finished in <variable>ms on 1 file with 99 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--ignore-pattern _____.js --ignore-pattern _____.vue fixtures__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-pattern _____.js --ignore-pattern _____.vue fixtures__linter@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --ignore-pattern **/*.js --ignore-pattern **/*.vue fixtures/linter
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 98 rules using 1 threads.
+Finished in <variable>ms on 0 files with 99 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--import-plugin -A all -D no-cycle fixtures__flow__@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--import-plugin -A all -D no-cycle fixtures__flow__@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --import-plugin -A all -D no-cycle fixtures/flow/
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 2 files with 100 rules using 1 threads.
+Finished in <variable>ms on 2 files with 101 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--import-plugin fixtures__flow__index.mjs@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--import-plugin fixtures__flow__index.mjs@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --import-plugin fixtures/flow/index.mjs
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 100 rules using 1 threads.
+Finished in <variable>ms on 1 file with 101 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
@@ -23,7 +23,7 @@ working directory:
   help: Remove the appending `.skip`
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 110 rules using 1 threads.
+Finished in <variable>ms on 1 file with 111 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-D correctness fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-D correctness fixtures__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Delete this code.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 98 rules using 1 threads.
+Finished in <variable>ms on 1 file with 99 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-W correctness -A no-debugger fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W correctness -A no-debugger fixtures__linter__debugger.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -W correctness -A no-debugger fixtures/linter/debugger.js
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 97 rules using 1 threads.
+Finished in <variable>ms on 1 file with 98 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__eslintrc_env__eslintrc_no_env.json fixtures__eslintrc_env__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__eslintrc_env__eslintrc_no_env.json fixtures__eslintrc_env__test.js@oxlint.snap
@@ -13,7 +13,7 @@ working directory:
    `----
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__no_undef__eslintrc.json fixtures__no_undef__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__no_undef__eslintrc.json fixtures__no_undef__test.js@oxlint.snap
@@ -13,7 +13,7 @@ working directory:
    `----
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension@oxlint.snap
@@ -12,7 +12,7 @@ working directory:
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 98 rules using 1 threads.
+Finished in <variable>ms on 1 file with 99 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_env__eslintrc_env_browser.json fixtures__eslintrc_env__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_env__eslintrc_env_browser.json fixtures__eslintrc_env__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/eslintrc_env/eslintrc_env_browser.json fixtures/eslintrc_
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_off__eslintrc.json fixtures__eslintrc_off__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_off__eslintrc.json fixtures__eslintrc_off__test.js@oxlint.snap
@@ -12,7 +12,7 @@ working directory:
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 98 rules using 1 threads.
+Finished in <variable>ms on 1 file with 99 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/eslintrc_vitest_replace/eslintrc.json fixtures/eslintrc_v
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 98 rules using 1 threads.
+Finished in <variable>ms on 1 file with 99 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__linter__eslintrc.json fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__linter__eslintrc.json fixtures__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Delete this code.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 98 rules using 1 threads.
+Finished in <variable>ms on 1 file with 99 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__no_console_off__eslintrc.json fixtures__no_console_off__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__no_console_off__eslintrc.json fixtures__no_console_off__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/no_console_off/eslintrc.json fixtures/no_console_off/test
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 98 rules using 1 threads.
+Finished in <variable>ms on 1 file with 99 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__no_empty_allow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_allow_empty_catch__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__no_empty_allow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_allow_empty_catch__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/no_empty_allow_empty_catch/eslintrc.json -W no-empty fixt
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__no_empty_disallow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_disallow_empty_catch__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__no_empty_disallow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_disallow_empty_catch__test.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove this block or add a comment inside it
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.js -c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.ts -c fixtures__overrides__.oxlintrc.json fixtures__overrides__other.jsx@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.js -c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.ts -c fixtures__overrides__.oxlintrc.json fixtures__overrides__other.jsx@oxlint.snap
@@ -15,7 +15,7 @@ working directory:
   help: Replace var with let or const
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 100 rules using 1 threads.
+Finished in <variable>ms on 1 file with 101 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------
@@ -42,7 +42,7 @@ working directory:
   help: Delete this console statement.
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 100 rules using 1 threads.
+Finished in <variable>ms on 1 file with 101 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------
@@ -61,7 +61,7 @@ working directory:
   help: Replace var with let or const
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 100 rules using 1 threads.
+Finished in <variable>ms on 1 file with 101 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__overrides__directories-config.json fixtures__overrides@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__overrides__directories-config.json fixtures__overrides@oxlint.snap
@@ -35,7 +35,7 @@ working directory:
   help: Delete this code.
 
 Found 2 warnings and 2 errors.
-Finished in <variable>ms on 7 files with 97 rules using 1 threads.
+Finished in <variable>ms on 7 files with 98 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__astro__debugger.astro@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__astro__debugger.astro@oxlint.snap
@@ -39,7 +39,7 @@ working directory:
   help: Delete this code.
 
 Found 4 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 98 rules using 1 threads.
+Finished in <variable>ms on 1 file with 99 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter@oxlint.snap
@@ -28,7 +28,7 @@ working directory:
   help: Use the isNaN function to compare with NaN.
 
 Found 3 warnings and 0 errors.
-Finished in <variable>ms on 3 files with 98 rules using 1 threads.
+Finished in <variable>ms on 3 files with 99 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js fixtures__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js fixtures__linter__nan.js@oxlint.snap
@@ -21,7 +21,7 @@ working directory:
   help: Use the isNaN function to compare with NaN.
 
 Found 2 warnings and 0 errors.
-Finished in <variable>ms on 2 files with 98 rules using 1 threads.
+Finished in <variable>ms on 2 files with 99 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Delete this code.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 98 rules using 1 threads.
+Finished in <variable>ms on 1 file with 99 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__svelte__debugger.svelte@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__svelte__debugger.svelte@oxlint.snap
@@ -16,7 +16,7 @@ working directory:
   help: Delete this code.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 98 rules using 1 threads.
+Finished in <variable>ms on 1 file with 99 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__vue__debugger.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__vue__debugger.vue@oxlint.snap
@@ -23,7 +23,7 @@ working directory:
   help: Delete this code.
 
 Found 2 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 98 rules using 1 threads.
+Finished in <variable>ms on 1 file with 99 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__vue__empty.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__vue__empty.vue@oxlint.snap
@@ -6,7 +6,7 @@ arguments: fixtures/vue/empty.vue
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 98 rules using 1 threads.
+Finished in <variable>ms on 1 file with 99 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_foo.asdf@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_foo.asdf@oxlint.snap
@@ -6,7 +6,7 @@ arguments: foo.asdf
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 98 rules using 1 threads.
+Finished in <variable>ms on 0 files with 99 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__auto_config_detection_debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__auto_config_detection_debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/auto_config_detection
   help: Delete this code.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 98 rules using 1 threads.
+Finished in <variable>ms on 1 file with 99 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__ignore_directory_-c eslintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__ignore_directory_-c eslintrc.json@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/config_ignore_patterns/ignore_directory
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 98 rules using 1 threads.
+Finished in <variable>ms on 1 file with 99 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__with_oxlintrc_-c .__test__eslintrc.json --ignore-pattern _.ts .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__with_oxlintrc_-c .__test__eslintrc.json --ignore-pattern _.ts .@oxlint.snap
@@ -12,7 +12,7 @@ working directory: fixtures/config_ignore_patterns/with_oxlintrc
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 98 rules using 1 threads.
+Finished in <variable>ms on 1 file with 99 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__disable_eslint_and_unicorn_alias_rules_-c .oxlintrc-eslint.json test.js -c .oxlintrc-unicorn.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__disable_eslint_and_unicorn_alias_rules_-c .oxlintrc-eslint.json test.js -c .oxlintrc-unicorn.json test.js@oxlint.snap
@@ -16,7 +16,7 @@ arguments: -c .oxlintrc-unicorn.json test.js
 working directory: fixtures/disable_eslint_and_unicorn_alias_rules
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 62 rules using 1 threads.
+Finished in <variable>ms on 1 file with 63 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__linter_debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__linter_debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/linter
   help: Delete this code.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 98 rules using 1 threads.
+Finished in <variable>ms on 1 file with 99 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=default test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=default test.js@oxlint.snap
@@ -33,7 +33,7 @@ working directory: fixtures/output_formatter_diagnostic
   help: Delete this code.
 
 Found 2 warnings and 1 error.
-Finished in <variable>ms on 1 file with 98 rules using 1 threads.
+Finished in <variable>ms on 1 file with 99 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__overrides_env_globals_-c .oxlintrc.json .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__overrides_env_globals_-c .oxlintrc.json .@oxlint.snap
@@ -51,7 +51,7 @@ working directory: fixtures/overrides_env_globals
    `----
 
 Found 5 warnings and 0 errors.
-Finished in <variable>ms on 3 files with 98 rules using 1 threads.
+Finished in <variable>ms on 3 files with 99 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__two_rules_with_same_rule_name_-c .oxlintrc.json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__two_rules_with_same_rule_name_-c .oxlintrc.json test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c .oxlintrc.json test.js
 working directory: fixtures/two_rules_with_same_rule_name
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 62 rules using 1 threads.
+Finished in <variable>ms on 1 file with 63 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -332,6 +332,7 @@ mod unicorn {
     pub mod no_empty_file;
     pub mod no_hex_escape;
     pub mod no_instanceof_array;
+    pub mod no_invalid_fetch_options;
     pub mod no_invalid_remove_event_listener;
     pub mod no_length_as_slice_end;
     pub mod no_lonely_if;
@@ -936,6 +937,7 @@ oxc_macros::declare_all_lint_rules! {
     unicorn::explicit_length_check,
     unicorn::filename_case,
     unicorn::new_for_builtins,
+    unicorn::no_invalid_fetch_options,
     unicorn::no_abusive_eslint_disable,
     unicorn::no_anonymous_default_export,
     unicorn::no_array_for_each,

--- a/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
@@ -11,7 +11,7 @@ use oxc_span::Span;
 use crate::{ast_util::is_new_expression, rule::Rule, LintContext};
 
 fn no_invalid_fetch_options_diagnostic(span: Span, method: Option<String>) -> OxcDiagnostic {
-    let method = method.unwrap_or("GET/HEAD".to_string());
+    let method = method.unwrap_or("GET/HEAD".to_string()).to_uppercase();
     let message = format!(r#""body" is not allowed when method is "{method}""#);
 
     OxcDiagnostic::warn(message).with_label(span)
@@ -141,9 +141,9 @@ fn is_invalid_fetch_options(
             match &obj_prop.value {
                 Expression::StringLiteral(value_ident) => {
                     let method = value_ident.value.as_str();
-                    method_name = method;
 
                     is_get_or_head = !is_not_get_and_head(method);
+                    method_name = method;
                 }
                 Expression::Identifier(value_ident) => {
                     let symbols = ctx.semantic().symbols();
@@ -168,6 +168,7 @@ fn is_invalid_fetch_options(
                     };
 
                     is_get_or_head = !is_not_get_and_head(&str_lit.value);
+                    method_name = &str_lit.value;
                 }
                 _ => continue,
             };

--- a/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
@@ -14,7 +14,7 @@ use oxc_span::Span;
 use crate::{ast_util::is_new_expression, rule::Rule, LintContext};
 
 fn no_invalid_fetch_options_diagnostic(span: Span, method: &str) -> OxcDiagnostic {
-    let message = format!("The `body` is not allowed when method is `{method}`");
+    let message = format!(r#""body" is not allowed when method is "{method}""#);
 
     OxcDiagnostic::warn(message).with_label(span)
 }

--- a/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
@@ -1,0 +1,245 @@
+use oxc_allocator::Box;
+use oxc_ast::{
+    ast::{Argument, Expression, ObjectExpression, ObjectPropertyKind, PropertyKey},
+    AstKind,
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_semantic::AstNode;
+use oxc_span::Span;
+
+use crate::{ast_util::is_new_expression, rule::Rule, LintContext};
+
+fn no_invalid_fetch_options_diagnostic(span: Span, method: Option<String>) -> OxcDiagnostic {
+    let method = method.unwrap_or("GET/HEAD".to_string());
+    let message = format!(r#""body" is not allowed when method is "{method}""#);
+
+    OxcDiagnostic::warn(message).with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoInvalidFetchOptions;
+
+declare_oxc_lint!(
+    /// ### What it does
+    /// Disallow invalid options in fetch() and new Request()
+    ///
+    /// ### Why is this bad?
+    /// fetch() throws a TypeError when the method is GET or HEAD and a body is provided.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```javascript
+    /// const response = await fetch('/', {method: 'GET', body: 'foo=bar'});
+    ///
+    /// const request = new Request('/', {method: 'GET', body: 'foo=bar'});
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// const response = await fetch('/', {method: 'POST', body: 'foo=bar'});
+    ///
+    /// const request = new Request('/', {method: 'POST', body: 'foo=bar'});
+    /// ```
+    NoInvalidFetchOptions,
+    unicorn,
+    correctness,
+);
+
+impl Rule for NoInvalidFetchOptions {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::CallExpression(call_expr) => {
+                let Expression::Identifier(ident) = &call_expr.callee else {
+                    return;
+                };
+
+                if ident.name != "fetch" {
+                    return;
+                }
+
+                if call_expr.arguments.len() < 2 {
+                    return;
+                }
+
+                let Some(Argument::ObjectExpression(obj_expr)) = call_expr.arguments.get(1) else {
+                    return;
+                };
+
+                let (is_invalid_options, method_name, body_span) =
+                    is_invalid_fetch_options(obj_expr, ctx);
+
+                if is_invalid_options {
+                    ctx.diagnostic(no_invalid_fetch_options_diagnostic(
+                        body_span.unwrap_or(call_expr.span),
+                        method_name,
+                    ));
+                }
+            }
+            AstKind::NewExpression(new_expr) => {
+                if !is_new_expression(new_expr, &["Request"], Some(2), None) {
+                    return;
+                }
+
+                let Some(Argument::ObjectExpression(obj_expr)) = new_expr.arguments.get(1) else {
+                    return;
+                };
+
+                let (is_invalid_options, method_name, body_span) =
+                    is_invalid_fetch_options(obj_expr, ctx);
+
+                if is_invalid_options {
+                    ctx.diagnostic(no_invalid_fetch_options_diagnostic(
+                        body_span.unwrap_or(new_expr.span),
+                        method_name,
+                    ));
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn is_invalid_fetch_options(
+    obj_expr: &Box<'_, ObjectExpression<'_>>,
+    ctx: &LintContext<'_>,
+) -> (bool, Option<String>, Option<Span>) {
+    // fetch and Request method defaults to "GET"
+    let mut is_get_or_head = true;
+    let mut method_name = "GET";
+
+    let mut has_body = false;
+    let mut body_span = None;
+
+    for property in &obj_expr.properties {
+        if ObjectPropertyKind::is_spread(property) {
+            return (false, None, None);
+        }
+
+        let ObjectPropertyKind::ObjectProperty(obj_prop) = property else {
+            continue;
+        };
+
+        let PropertyKey::StaticIdentifier(key_ident) = &obj_prop.key else {
+            continue;
+        };
+
+        let key_ident_name = key_ident.name.as_str();
+
+        if key_ident_name == "body" {
+            has_body = !obj_prop.value.is_null_or_undefined();
+
+            if has_body {
+                body_span = Some(key_ident.span);
+            } else {
+                body_span = None;
+            }
+        }
+
+        if key_ident_name == "method" {
+            match &obj_prop.value {
+                Expression::StringLiteral(value_ident) => {
+                    let method = value_ident.value.as_str();
+                    method_name = method;
+
+                    is_get_or_head = !is_not_get_and_head(method);
+                }
+                Expression::Identifier(value_ident) => {
+                    let symbols = ctx.semantic().symbols();
+                    let reference_id = value_ident.reference_id();
+
+                    let Some(symbol_id) = symbols.get_reference(reference_id).symbol_id() else {
+                        continue;
+                    };
+
+                    let decl = ctx.semantic().nodes().get_node(symbols.get_declaration(symbol_id));
+
+                    let AstKind::VariableDeclarator(declarator) = decl.kind() else {
+                        continue;
+                    };
+
+                    let Some(init) = &declarator.init else {
+                        continue;
+                    };
+
+                    let Expression::StringLiteral(str_lit) = init else {
+                        continue;
+                    };
+
+                    is_get_or_head = !is_not_get_and_head(&str_lit.value);
+                }
+                _ => continue,
+            };
+        }
+    }
+
+    let is_invalid_options = is_get_or_head && has_body;
+
+    (is_invalid_options, Some(method_name.to_string()), body_span)
+}
+
+fn is_not_get_and_head(method: &str) -> bool {
+    let method = method.to_uppercase();
+    method != "GET" && method != "HEAD"
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"fetch(url, {method: "POST", body})"#,
+        r#"new Request(url, {method: "POST", body})"#,
+        r"fetch(url, {})",
+        r"new Request(url, {})",
+        r"fetch(url)",
+        r"new Request(url)",
+        r#"fetch(url, {method: "UNKNOWN", body})"#,
+        r#"new Request(url, {method: "UNKNOWN", body})"#,
+        r"fetch(url, {body: undefined})",
+        r"new Request(url, {body: undefined})",
+        r"fetch(url, {body: null})",
+        r"new Request(url, {body: null})",
+        r"fetch(url, {...options, body})",
+        r"new Request(url, {...options, body})",
+        r"new fetch(url, {body})",
+        r"Request(url, {body})",
+        r"not_fetch(url, {body})",
+        r"new not_Request(url, {body})",
+        r"fetch({body}, url)",
+        r"new Request({body}, url)",
+        r#"fetch(url, {[body]: "foo=bar"})"#,
+        r#"new Request(url, {[body]: "foo=bar"})"#,
+        r#"fetch(url, {body: "foo=bar", body: undefined});"#,
+        r#"new Request(url, {body: "foo=bar", body: undefined});"#,
+        r#"fetch(url, {method: "HEAD", body: "foo=bar", method: "post"});"#,
+        r#"new Request(url, {method: "HEAD",body: "foo=bar", method: "POST"});"#,
+        r#"fetch('/', {body: new URLSearchParams({ data: "test" }), method: "POST"})"#,
+        r#"const method = "post"; new Request(url, {method, body: "foo=bar"})"#,
+        r#"const method = "post"; fetch(url, {method, body: "foo=bar"})"#,
+    ];
+
+    let fail = vec![
+        r"fetch(url, {body})",
+        r"new Request(url, {body})",
+        r#"fetch(url, {method: "GET", body})"#,
+        r#"new Request(url, {method: "GET", body})"#,
+        r#"fetch(url, {method: "HEAD", body})"#,
+        r#"new Request(url, {method: "HEAD", body})"#,
+        r#"fetch(url, {method: "head", body})"#,
+        r#"new Request(url, {method: "head", body})"#,
+        r#"const method = "head"; new Request(url, {method, body: "foo=bar"})"#,
+        r#"const method = "head"; fetch(url, {method, body: "foo=bar"})"#,
+        r"fetch(url, {body}, extraArgument)",
+        r"new Request(url, {body}, extraArgument)",
+        r#"fetch(url, {body: undefined, body: "foo=bar"});"#,
+        r#"new Request(url, {body: undefined, body: "foo=bar"});"#,
+        r#"fetch(url, {method: "post", body: "foo=bar", method: "HEAD"});"#,
+        r#"new Request(url, {method: "post", body: "foo=bar", method: "HEAD"});"#,
+        r#"fetch('/', {body: new URLSearchParams({ data: "test" })})"#,
+    ];
+
+    Tester::new(NoInvalidFetchOptions::NAME, NoInvalidFetchOptions::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/unicorn_no_invalid_fetch_options.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_invalid_fetch_options.snap
@@ -1,103 +1,103 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `GET`
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
    ╭─[no_invalid_fetch_options.tsx:1:13]
  1 │ fetch(url, {body})
    ·             ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `GET`
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
    ╭─[no_invalid_fetch_options.tsx:1:19]
  1 │ new Request(url, {body})
    ·                   ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `GET`
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
    ╭─[no_invalid_fetch_options.tsx:1:28]
  1 │ fetch(url, {method: "GET", body})
    ·                            ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `GET`
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
    ╭─[no_invalid_fetch_options.tsx:1:34]
  1 │ new Request(url, {method: "GET", body})
    ·                                  ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `HEAD`
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "HEAD"
    ╭─[no_invalid_fetch_options.tsx:1:29]
  1 │ fetch(url, {method: "HEAD", body})
    ·                             ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `HEAD`
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "HEAD"
    ╭─[no_invalid_fetch_options.tsx:1:35]
  1 │ new Request(url, {method: "HEAD", body})
    ·                                   ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `HEAD`
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "HEAD"
    ╭─[no_invalid_fetch_options.tsx:1:29]
  1 │ fetch(url, {method: "head", body})
    ·                             ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `HEAD`
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "HEAD"
    ╭─[no_invalid_fetch_options.tsx:1:35]
  1 │ new Request(url, {method: "head", body})
    ·                                   ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `HEAD`
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "HEAD"
    ╭─[no_invalid_fetch_options.tsx:1:50]
  1 │ const method = "head"; new Request(url, {method, body: "foo=bar"})
    ·                                                  ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `HEAD`
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "HEAD"
    ╭─[no_invalid_fetch_options.tsx:1:44]
  1 │ const method = "head"; fetch(url, {method, body: "foo=bar"})
    ·                                            ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `GET`
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
    ╭─[no_invalid_fetch_options.tsx:1:13]
  1 │ fetch(url, {body}, extraArgument)
    ·             ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `GET`
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
    ╭─[no_invalid_fetch_options.tsx:1:19]
  1 │ new Request(url, {body}, extraArgument)
    ·                   ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `GET`
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
    ╭─[no_invalid_fetch_options.tsx:1:30]
  1 │ fetch(url, {body: undefined, body: "foo=bar"});
    ·                              ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `GET`
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
    ╭─[no_invalid_fetch_options.tsx:1:36]
  1 │ new Request(url, {body: undefined, body: "foo=bar"});
    ·                                    ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `HEAD`
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "HEAD"
    ╭─[no_invalid_fetch_options.tsx:1:29]
  1 │ fetch(url, {method: "post", body: "foo=bar", method: "HEAD"});
    ·                             ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `HEAD`
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "HEAD"
    ╭─[no_invalid_fetch_options.tsx:1:35]
  1 │ new Request(url, {method: "post", body: "foo=bar", method: "HEAD"});
    ·                                   ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `GET`
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
    ╭─[no_invalid_fetch_options.tsx:1:13]
  1 │ fetch('/', {body: new URLSearchParams({ data: "test" })})
    ·             ────

--- a/crates/oxc_linter/src/snapshots/unicorn_no_invalid_fetch_options.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_invalid_fetch_options.snap
@@ -37,25 +37,25 @@ source: crates/oxc_linter/src/tester.rs
    ·                                   ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "head"
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "HEAD"
    ╭─[no_invalid_fetch_options.tsx:1:29]
  1 │ fetch(url, {method: "head", body})
    ·                             ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "head"
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "HEAD"
    ╭─[no_invalid_fetch_options.tsx:1:35]
  1 │ new Request(url, {method: "head", body})
    ·                                   ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "HEAD"
    ╭─[no_invalid_fetch_options.tsx:1:50]
  1 │ const method = "head"; new Request(url, {method, body: "foo=bar"})
    ·                                                  ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "HEAD"
    ╭─[no_invalid_fetch_options.tsx:1:44]
  1 │ const method = "head"; fetch(url, {method, body: "foo=bar"})
    ·                                            ────

--- a/crates/oxc_linter/src/snapshots/unicorn_no_invalid_fetch_options.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_invalid_fetch_options.snap
@@ -1,0 +1,104 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
+   ╭─[no_invalid_fetch_options.tsx:1:13]
+ 1 │ fetch(url, {body})
+   ·             ────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
+   ╭─[no_invalid_fetch_options.tsx:1:19]
+ 1 │ new Request(url, {body})
+   ·                   ────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
+   ╭─[no_invalid_fetch_options.tsx:1:28]
+ 1 │ fetch(url, {method: "GET", body})
+   ·                            ────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
+   ╭─[no_invalid_fetch_options.tsx:1:34]
+ 1 │ new Request(url, {method: "GET", body})
+   ·                                  ────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "HEAD"
+   ╭─[no_invalid_fetch_options.tsx:1:29]
+ 1 │ fetch(url, {method: "HEAD", body})
+   ·                             ────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "HEAD"
+   ╭─[no_invalid_fetch_options.tsx:1:35]
+ 1 │ new Request(url, {method: "HEAD", body})
+   ·                                   ────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "head"
+   ╭─[no_invalid_fetch_options.tsx:1:29]
+ 1 │ fetch(url, {method: "head", body})
+   ·                             ────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "head"
+   ╭─[no_invalid_fetch_options.tsx:1:35]
+ 1 │ new Request(url, {method: "head", body})
+   ·                                   ────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
+   ╭─[no_invalid_fetch_options.tsx:1:50]
+ 1 │ const method = "head"; new Request(url, {method, body: "foo=bar"})
+   ·                                                  ────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
+   ╭─[no_invalid_fetch_options.tsx:1:44]
+ 1 │ const method = "head"; fetch(url, {method, body: "foo=bar"})
+   ·                                            ────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
+   ╭─[no_invalid_fetch_options.tsx:1:13]
+ 1 │ fetch(url, {body}, extraArgument)
+   ·             ────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
+   ╭─[no_invalid_fetch_options.tsx:1:19]
+ 1 │ new Request(url, {body}, extraArgument)
+   ·                   ────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
+   ╭─[no_invalid_fetch_options.tsx:1:30]
+ 1 │ fetch(url, {body: undefined, body: "foo=bar"});
+   ·                              ────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
+   ╭─[no_invalid_fetch_options.tsx:1:36]
+ 1 │ new Request(url, {body: undefined, body: "foo=bar"});
+   ·                                    ────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "HEAD"
+   ╭─[no_invalid_fetch_options.tsx:1:29]
+ 1 │ fetch(url, {method: "post", body: "foo=bar", method: "HEAD"});
+   ·                             ────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "HEAD"
+   ╭─[no_invalid_fetch_options.tsx:1:35]
+ 1 │ new Request(url, {method: "post", body: "foo=bar", method: "HEAD"});
+   ·                                   ────
+   ╰────
+
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
+   ╭─[no_invalid_fetch_options.tsx:1:13]
+ 1 │ fetch('/', {body: new URLSearchParams({ data: "test" })})
+   ·             ────
+   ╰────

--- a/crates/oxc_linter/src/snapshots/unicorn_no_invalid_fetch_options.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_invalid_fetch_options.snap
@@ -1,103 +1,103 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `GET`
    ╭─[no_invalid_fetch_options.tsx:1:13]
  1 │ fetch(url, {body})
    ·             ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `GET`
    ╭─[no_invalid_fetch_options.tsx:1:19]
  1 │ new Request(url, {body})
    ·                   ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `GET`
    ╭─[no_invalid_fetch_options.tsx:1:28]
  1 │ fetch(url, {method: "GET", body})
    ·                            ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `GET`
    ╭─[no_invalid_fetch_options.tsx:1:34]
  1 │ new Request(url, {method: "GET", body})
    ·                                  ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "HEAD"
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `HEAD`
    ╭─[no_invalid_fetch_options.tsx:1:29]
  1 │ fetch(url, {method: "HEAD", body})
    ·                             ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "HEAD"
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `HEAD`
    ╭─[no_invalid_fetch_options.tsx:1:35]
  1 │ new Request(url, {method: "HEAD", body})
    ·                                   ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "HEAD"
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `HEAD`
    ╭─[no_invalid_fetch_options.tsx:1:29]
  1 │ fetch(url, {method: "head", body})
    ·                             ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "HEAD"
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `HEAD`
    ╭─[no_invalid_fetch_options.tsx:1:35]
  1 │ new Request(url, {method: "head", body})
    ·                                   ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "HEAD"
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `HEAD`
    ╭─[no_invalid_fetch_options.tsx:1:50]
  1 │ const method = "head"; new Request(url, {method, body: "foo=bar"})
    ·                                                  ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "HEAD"
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `HEAD`
    ╭─[no_invalid_fetch_options.tsx:1:44]
  1 │ const method = "head"; fetch(url, {method, body: "foo=bar"})
    ·                                            ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `GET`
    ╭─[no_invalid_fetch_options.tsx:1:13]
  1 │ fetch(url, {body}, extraArgument)
    ·             ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `GET`
    ╭─[no_invalid_fetch_options.tsx:1:19]
  1 │ new Request(url, {body}, extraArgument)
    ·                   ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `GET`
    ╭─[no_invalid_fetch_options.tsx:1:30]
  1 │ fetch(url, {body: undefined, body: "foo=bar"});
    ·                              ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `GET`
    ╭─[no_invalid_fetch_options.tsx:1:36]
  1 │ new Request(url, {body: undefined, body: "foo=bar"});
    ·                                    ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "HEAD"
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `HEAD`
    ╭─[no_invalid_fetch_options.tsx:1:29]
  1 │ fetch(url, {method: "post", body: "foo=bar", method: "HEAD"});
    ·                             ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "HEAD"
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `HEAD`
    ╭─[no_invalid_fetch_options.tsx:1:35]
  1 │ new Request(url, {method: "post", body: "foo=bar", method: "HEAD"});
    ·                                   ────
    ╰────
 
-  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): The `body` is not allowed when method is `GET`
    ╭─[no_invalid_fetch_options.tsx:1:13]
  1 │ fetch('/', {body: new URLSearchParams({ data: "test" })})
    ·             ────


### PR DESCRIPTION
This PR implements [unicorn/no-invalid-fetch-options](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/v56.0.1/docs/rules/no-invalid-fetch-options.md) rule

issue: https://github.com/oxc-project/oxc/issues/684