### PR TITLE
feat(linter): add support for `extends` property in oxlintrc

### DIFF
--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -93,6 +93,7 @@ impl ConfigStoreBuilder {
             overrides,
             path,
             ignore_patterns: _,
+            extends: _,
         } = oxlintrc;
 
         let config = LintConfig { plugins, settings, env, globals, path: Some(path) };

--- a/crates/oxc_linter/src/snapshots/schema_json.snap
+++ b/crates/oxc_linter/src/snapshots/schema_json.snap
@@ -27,6 +27,13 @@ expression: json
         }
       ]
     },
+    "extends": {
+      "description": "Paths of configuration files that this configuration file extends (inherits from). The files are resolved relative to the location of the configuration file that contains the `extends` property. The configuration files are merged from the first to the last, with the last file overriding the previous ones.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "globals": {
       "description": "Enabled or disabled specific global variables.",
       "default": {},

--- a/npm/oxlint/configuration_schema.json
+++ b/npm/oxlint/configuration_schema.json
@@ -23,6 +23,13 @@
         }
       ]
     },
+    "extends": {
+      "description": "Paths of configuration files that this configuration file extends (inherits from). The files are resolved relative to the location of the configuration file that contains the `extends` property. The configuration files are merged from the first to the last, with the last file overriding the previous ones.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "globals": {
       "description": "Enabled or disabled specific global variables.",
       "default": {},

--- a/tasks/website/src/linter/snapshots/schema_markdown.snap
+++ b/tasks/website/src/linter/snapshots/schema_markdown.snap
@@ -140,6 +140,14 @@ Predefine global variables.
 Environments specify what global variables are predefined. See [ESLint's list of environments](https://eslint.org/docs/v8.x/use/configure/language-options#specifying-environments) for what environments are available and what each one provides.
 
 
+## extends
+
+type: `string[]`
+
+
+Paths of configuration files that this configuration file extends (inherits from). The files are resolved relative to the location of the configuration file that contains the `extends` property. The configuration files are merged from the first to the last, with the last file overriding the previous ones.
+
+
 ## globals
 
 type: `Record<string, string>`


### PR DESCRIPTION
- part of https://github.com/oxc-project/oxc/issues/9307

Allows oxlint configuration files to include an `extends` key at the top level. For now (until we decide to change it), this is strictly treated as a list of file paths and we don't support string values like `eslint:recommended` or anything like that.