### PR TITLE
test(transformer/legacy-decorator): add an exec test that verifies it working with reflect-metadata well.

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,8 @@ importers:
 
   npm/runtime: {}
 
+  npm/wasm-web: {}
+
   tasks/benchmark/codspeed:
     devDependencies:
       axios:
@@ -210,6 +212,9 @@ importers:
       '@oxc-project/runtime':
         specifier: link:../../npm/runtime
         version: link:../../npm/runtime
+      reflect-metadata:
+        specifier: ^0.2.2
+        version: 0.2.2
 
   wasm/parser:
     dependencies:
@@ -3062,6 +3067,9 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  reflect-metadata@0.2.2:
+    resolution: {integrity: sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==}
 
   regenerator-runtime@0.14.1:
     resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
@@ -6646,6 +6654,8 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  reflect-metadata@0.2.2: {}
 
   regenerator-runtime@0.14.1: {}
 

--- a/tasks/transform_conformance/package.json
+++ b/tasks/transform_conformance/package.json
@@ -18,7 +18,8 @@
     "@babel/plugin-transform-optional-chaining": "^7.25.9",
     "@babel/plugin-transform-private-methods": "^7.25.9",
     "@babel/plugin-transform-private-property-in-object": "^7.25.9",
-    "@oxc-project/runtime": "link:../../npm/runtime"
+    "@oxc-project/runtime": "link:../../npm/runtime",
+    "reflect-metadata": "^0.2.2"
   },
   "dependencies": {
     "@babel/plugin-transform-typescript": "^7.26.3"

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: acbc09a8
 
-Passed: 135/219
+Passed: 136/220
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -319,7 +319,7 @@ x Output mismatch
 x Output mismatch
 
 
-# legacy-decorators (0/62)
+# legacy-decorators (1/63)
 * typescript/accessor/decoratorOnClassAccessor1/input.ts
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]

--- a/tasks/transform_conformance/snapshots/oxc_exec.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc_exec.snap.md
@@ -2,7 +2,7 @@ commit: acbc09a8
 
 node: v22.14.0
 
-Passed: 5 of 7 (71.43%)
+Passed: 6 of 8 (75.00%)
 
 Failures:
 

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/options.json
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    [
+      "transform-legacy-decorator",
+      {
+        "emitDecoratorMetadata": true
+      }
+    ]
+  ]
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/properties/exec.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/properties/exec.ts
@@ -1,0 +1,18 @@
+import "reflect-metadata";
+
+function dce() {
+}
+
+class Example {
+	@dce
+	count: number = 0;
+
+	@dce
+	message: string = "";
+}
+
+const example = new Example();
+
+expect(Reflect.getMetadata("design:type", example, "count")).toBe(Number);
+expect(Reflect.getMetadata("design:type", example, "message")).toBe(String);
+

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/properties/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/properties/input.ts
@@ -1,0 +1,18 @@
+import "reflect-metadata";
+
+function dce() {
+}
+
+class Example {
+	@dce
+	count: number = 0;
+
+	@dce
+	message: string = "";
+}
+
+const example = new Example();
+
+expect(Reflect.getMetadata("design:type", example, "count")).toBe(Number);
+expect(Reflect.getMetadata("design:type", example, "message")).toBe(String);
+

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/properties/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/properties/output.js
@@ -1,0 +1,16 @@
+import "reflect-metadata";
+
+function dce() {}
+
+class Example {
+  count = 0;
+  message = "";
+}
+
+babelHelpers.decorate([dce, babelHelpers.decorateMetadata("design:type", Number)], Example.prototype, "count", void 0);
+babelHelpers.decorate([dce, babelHelpers.decorateMetadata("design:type", String)], Example.prototype, "message", void 0);
+
+const example = new Example();
+
+expect(Reflect.getMetadata("design:type", example, "count")).toBe(Number);
+expect(Reflect.getMetadata("design:type", example, "message")).toBe(String);


### PR DESCRIPTION
close: https://github.com/oxc-project/oxc/pull/9190#pullrequestreview-2625134907
