### PR TITLE
refactor(transformer/jsx): refactor and document `has_proto`

### DIFF
--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -1094,8 +1094,17 @@ fn create_static_member_expression<'a>(
     ctx.ast.member_expression_static(SPAN, object, property, false).into()
 }
 
+/// Check if an `ObjectExpression` has a property called `__proto__`.
+///
+/// Returns `true` for any of:
+/// * `{ __proto__: ... }`
+/// * `{ "__proto__": ... }`
+/// * `{ ["__proto__"]: ... }`
+///
+/// Also currently returns `true` for `{ [__proto__]: ... }`, but that's probably not correct.
+/// TODO: Fix that.
 fn has_proto(e: &ObjectExpression<'_>) -> bool {
-    e.properties.iter().any(|p| p.prop_name().is_some_and(|name| name.0 == "__proto__"))
+    e.properties.iter().any(|p| p.prop_name().is_some_and(|(name, _)| name == "__proto__"))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Make a tiny refactoring change to `has_proto` function, and document what it does.

Note: I've added a TODO comment because I think it doesn't handle one edge case correctly. But this wouldn't affect correctness of output, only would produce more verbose output than required. So not urgent to fix...
