### PR TITLE
chore(linter): Improve the documentation of eslint/default-case

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/default_case.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_case.rs
@@ -48,41 +48,41 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// switch (foo) {
-    ///     case 1:
-    ///         break;
+    ///   case 1:
+    ///     break;
     /// }
     /// ```
     ///
     /// Examples of **correct** code for this rule:
     /// ```javascript
     /// switch (a) {
-    ///     case 1:
-    ///         /* code */
-    ///         break;
+    ///   case 1:
+    ///     /* code */
+    ///     break;
     ///
-    ///     default:
-    ///         /* code */
-    ///         break;
+    ///   default:
+    ///     /* code */
+    ///     break;
     /// }
     /// ```
     ///
     /// ```javascript
     /// switch (a) {
-    ///     case 1:
-    ///         /* code */
-    ///         break;
+    ///   case 1:
+    ///     /* code */
+    ///     break;
     ///
-    ///     // no default
+    ///   // no default
     /// }
     /// ```
     ///
     /// ```javascript
     /// switch (a) {
-    ///     case 1:
-    ///         /* code */
-    ///         break;
+    ///   case 1:
+    ///     /* code */
+    ///     break;
     ///
-    ///     // No Default
+    ///   // No Default
     /// }
     /// ```
     ///
@@ -100,11 +100,11 @@ declare_oxc_lint!(
     ///
     /// ```javascript
     /// switch(a) {
-    ///     case 1:
-    ///         /* code */
-    ///         break;
+    ///   case 1:
+    ///     /* code */
+    ///     break;
     ///
-    ///     // skip default
+    ///   // skip default
     /// }
     /// ```
     DefaultCase,

--- a/crates/oxc_linter/src/rules/eslint/default_case.rs
+++ b/crates/oxc_linter/src/rules/eslint/default_case.rs
@@ -35,14 +35,76 @@ declare_oxc_lint!(
     ///
     /// ### Why is this bad?
     ///
-    /// Some code conventions require that all switch statements have a default case, even if the
-    /// default case is empty.
+    /// Some code conventions require that all switch statements have a default case,
+    /// even if the default case is empty. The thinking is that it’s better to always
+    /// explicitly state what the default behavior should be so that it’s clear
+    /// whether or not the developer forgot to include the default behavior by mistake.
     ///
-    /// ### Example
+    /// You may optionally include a `// no default` after the last case if there is
+    /// no default case. The comment may be in any desired case, such as `// No Default`.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// switch (foo) {
-    ///   case 1:
-    ///     break;
+    ///     case 1:
+    ///         break;
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// switch (a) {
+    ///     case 1:
+    ///         /* code */
+    ///         break;
+    ///
+    ///     default:
+    ///         /* code */
+    ///         break;
+    /// }
+    /// ```
+    ///
+    /// ```javascript
+    /// switch (a) {
+    ///     case 1:
+    ///         /* code */
+    ///         break;
+    ///
+    ///     // no default
+    /// }
+    /// ```
+    ///
+    /// ```javascript
+    /// switch (a) {
+    ///     case 1:
+    ///         /* code */
+    ///         break;
+    ///
+    ///     // No Default
+    /// }
+    /// ```
+    ///
+    ///  ### Options
+    ///
+    ///  ### commentPattern
+    ///
+    /// `{ "commentPattern": string }`
+    ///
+    ///  This option is for specifying an alternative regular expression which
+    ///  will override the default `/^no default$/i` comment test pattern.
+    ///
+    ///  For example if `{ "commentPattern": "^skip\\sdefault" }` were used
+    ///  then the following example would not violate the rule:
+    ///
+    /// ```javascript
+    /// switch(a) {
+    ///     case 1:
+    ///         /* code */
+    ///         break;
+    ///
+    ///     // skip default
     /// }
     /// ```
     DefaultCase,

--- a/crates/oxc_linter/src/rules/eslint/max_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_params.rs
@@ -82,9 +82,9 @@ declare_oxc_lint!(
     ///
     /// ### max
     ///
-    /// This option is for changing the maximum allowed number of function parameters.
-    ///
     /// `{ "max": number }`
+    ///
+    /// This option is for changing the maximum allowed number of function parameters.
     ///
     /// For example `{ "max": 4 }` would mean that having a function take four
     /// parameters is allowed which overrides the default of three.

--- a/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_bitwise.rs
@@ -71,10 +71,10 @@ declare_oxc_lint!(
     ///
     /// ### allow
     ///
+    /// `{ "allow": string[] }`
+    ///
     /// The`allow` option permits the given list of bitwise operators to be used
     /// as exceptions to this rule.
-    ///
-    /// `{ "allow": string[] }`
     ///
     /// For example `{ "allow": ["~"] }` would allow the use of the bitwise operator
     /// `~` without restriction. Such as in the following:


### PR DESCRIPTION
Add more documentation aligned with doc template for eslint rule default-case.

Relates to [#6050](https://github.com/oxc-project/oxc/issues/6050).

Inline with @shulaoda comment on this PR I have made the documented option type consistent in the other two rules I recently updated.
