### PR TITLE
chore(linter): Improve the documentation of eslint/max-params

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/max_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_params.rs
@@ -58,6 +58,12 @@ declare_oxc_lint!(
     /// }
     /// ```
     ///
+    /// ```javascript
+    /// let foo = (bar, baz, qux, qxx) => {
+    ///     doSomething();
+    /// };
+    /// ```
+    ///
     /// Examples of **correct** code for this rule:
     ///
     /// By default the maximum allowed number of function parameters is three.

--- a/crates/oxc_linter/src/rules/eslint/max_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_params.rs
@@ -38,17 +38,52 @@ impl Default for MaxParamsConfig {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Enforce a maximum number of parameters in function definitions
     ///
     /// ### Why is this bad?
-    /// Functions that take numerous parameters can be difficult to read and write because it requires the memorization of what each parameter is, its type, and the order they should appear in. As a result, many coders adhere to a convention that caps the number of parameters a function can take.
     ///
-    /// ### Example
+    /// Functions that take numerous parameters can be difficult to read and
+    /// write because it requires the memorization of what each parameter is,
+    /// its type, and the order they should appear in. As a result, many coders
+    /// adhere to a convention that caps the number of parameters a function
+    /// can take.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// function foo (bar, baz, qux, qxx) {
     ///     doSomething();
     /// }
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    ///
+    /// By default the maximum allowed number of function parameters is three.
+    /// ```javascript
+    /// function foo (bar, baz, qux) {
+    ///     doSomething();
+    /// }
+    /// ```
+    ///
+    /// ```javascript
+    /// let foo = (bar, baz, qux) => {
+    ///     doSomething();
+    /// };
+    /// ```
+    ///
+    /// ### Options
+    ///
+    /// ### max
+    ///
+    /// This option is for changing the maximum number of function parameters
+    /// are allowed.
+    ///
+    /// `{ "max": number }`
+    ///
+    /// For example `{ "max": 4 }` would mean that having a function take four
+    /// parameters is allowed which overrides the default of three.
     MaxParams,
     eslint,
     style

--- a/crates/oxc_linter/src/rules/eslint/max_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_params.rs
@@ -39,7 +39,8 @@ impl Default for MaxParamsConfig {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Enforce a maximum number of parameters in function definitions
+    /// Enforce a maximum number of parameters in function definitions which by
+    /// default is three.
     ///
     /// ### Why is this bad?
     ///
@@ -65,8 +66,6 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Examples of **correct** code for this rule:
-    ///
-    /// By default the maximum allowed number of function parameters is three.
     /// ```javascript
     /// function foo (bar, baz, qux) {
     ///     doSomething();

--- a/crates/oxc_linter/src/rules/eslint/max_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_params.rs
@@ -77,8 +77,7 @@ declare_oxc_lint!(
     ///
     /// ### max
     ///
-    /// This option is for changing the maximum number of function parameters
-    /// are allowed.
+    /// This option is for changing the maximum allowed number of function parameters.
     ///
     /// `{ "max": number }`
     ///


### PR DESCRIPTION
Add more documentation aligned with doc template for eslint rule max-params.

Relates to [#6050](https://github.com/oxc-project/oxc/issues/6050)