### PR TITLE
feat(linter): add eslint/id-denylist

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -43,6 +43,7 @@ mod eslint {
     pub mod getter_return;
     pub mod grouped_accessor_pairs;
     pub mod guard_for_in;
+    pub mod id_denylist;
     pub mod init_declarations;
     pub mod max_classes_per_file;
     pub mod max_lines;
@@ -553,6 +554,7 @@ oxc_macros::declare_all_lint_rules! {
     eslint::getter_return,
     eslint::grouped_accessor_pairs,
     eslint::guard_for_in,
+    eslint::id_denylist,
     eslint::init_declarations,
     eslint::max_nested_callbacks,
     eslint::max_lines_per_function,

--- a/crates/oxc_linter/src/rules/eslint/id_denylist.rs
+++ b/crates/oxc_linter/src/rules/eslint/id_denylist.rs
@@ -1,0 +1,292 @@
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{
+    context::LintContext,
+    fixer::{RuleFix, RuleFixer},
+    rule::Rule,
+    AstNode,
+};
+
+fn id_denylist_diagnostic(span: Span) -> OxcDiagnostic {
+    // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
+    OxcDiagnostic::warn("Should be an imperative statement about what is wrong")
+        .with_help("Should be a command-like statement that tells the user how to fix the issue")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct IdDenylist;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    ///
+    /// ### Why is this bad?
+    ///
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// FIXME: Tests will fail if examples are missing or syntactically incorrect.
+    /// ```
+    IdDenylist,
+    eslint,
+    nursery, // TODO: change category to `correctness`, `suspicious`, `pedantic`, `perf`, `restriction`, or `style`
+             // See <https://oxc.rs/docs/contribute/linter.html#rule-category> for details
+
+    pending  // TODO: describe fix capabilities. Remove if no fix can be done,
+             // keep at 'pending' if you think one could be added but don't know how.
+             // Options are 'fix', 'fix_dangerous', 'suggestion', and 'conditional_fix_suggestion'
+);
+
+impl Rule for IdDenylist {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {}
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        (r#"foo = "bar""#, Some(serde_json::json!(["bar"]))),
+        (r#"bar = "bar""#, Some(serde_json::json!(["foo"]))),
+        (r#"foo = "bar""#, Some(serde_json::json!(["f", "fo", "fooo", "bar"]))),
+        ("function foo(){}", Some(serde_json::json!(["bar"]))),
+        ("foo()", Some(serde_json::json!(["f", "fo", "fooo", "bar"]))),
+        ("import { foo as bar } from 'mod'", Some(serde_json::json!(["foo"]))), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("export { foo as bar } from 'mod'", Some(serde_json::json!(["foo"]))), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("foo.bar()", Some(serde_json::json!(["f", "fo", "fooo", "b", "ba", "baz"]))),
+        (
+            "var foo = bar.baz;",
+            Some(serde_json::json!(["f", "fo", "fooo", "b", "ba", "barr", "bazz"])),
+        ),
+        (
+            "var foo = bar.baz.bing;",
+            Some(serde_json::json!(["f", "fo", "fooo", "b", "ba", "barr", "bazz", "bingg"])),
+        ),
+        (
+            "foo.bar.baz = bing.bong.bash;",
+            Some(serde_json::json!(["f", "fo", "fooo", "b", "ba", "barr", "bazz", "bingg"])),
+        ),
+        (
+            "if (foo.bar) {}",
+            Some(serde_json::json!(["f", "fo", "fooo", "b", "ba", "barr", "bazz", "bingg"])),
+        ),
+        (
+            "var obj = { key: foo.bar };",
+            Some(serde_json::json!(["f", "fo", "fooo", "b", "ba", "barr", "bazz", "bingg"])),
+        ),
+        ("const {foo: bar} = baz", Some(serde_json::json!(["foo"]))), // { "ecmaVersion": 6 },
+        ("const {foo: {bar: baz}} = qux", Some(serde_json::json!(["foo", "bar"]))), // { "ecmaVersion": 6 },
+        ("function foo({ bar: baz }) {}", Some(serde_json::json!(["bar"]))), // { "ecmaVersion": 6 },
+        ("function foo({ bar: {baz: qux} }) {}", Some(serde_json::json!(["bar", "baz"]))), // { "ecmaVersion": 6 },
+        ("function foo({baz} = obj.qux) {}", Some(serde_json::json!(["qux"]))), // { "ecmaVersion": 6 },
+        ("function foo({ foo: {baz} = obj.qux }) {}", Some(serde_json::json!(["qux"]))), // { "ecmaVersion": 6 },
+        ("({a: bar = obj.baz});", Some(serde_json::json!(["baz"]))), // { "ecmaVersion": 6 },
+        ("({foo: {a: bar = obj.baz}} = qux);", Some(serde_json::json!(["baz"]))), // { "ecmaVersion": 6 },
+        (
+            "var arr = [foo.bar];",
+            Some(serde_json::json!(["f", "fo", "fooo", "b", "ba", "barr", "bazz", "bingg"])),
+        ),
+        (
+            "[foo.bar]",
+            Some(serde_json::json!(["f", "fo", "fooo", "b", "ba", "barr", "bazz", "bingg"])),
+        ),
+        (
+            "[foo.bar.nesting]",
+            Some(serde_json::json!(["f", "fo", "fooo", "b", "ba", "barr", "bazz", "bingg"])),
+        ),
+        (
+            "if (foo.bar === bar.baz) { [foo.bar] }",
+            Some(serde_json::json!(["f", "fo", "fooo", "b", "ba", "barr", "bazz", "bingg"])),
+        ),
+        (
+            "var myArray = new Array(); var myDate = new Date();",
+            Some(serde_json::json!(["array", "date", "mydate", "myarray", "new", "var"])),
+        ),
+        ("foo()", Some(serde_json::json!(["foo"]))),
+        ("foo.bar()", Some(serde_json::json!(["bar"]))),
+        ("foo.bar", Some(serde_json::json!(["bar"]))),
+        ("({foo: obj.bar.bar.bar.baz} = {});", Some(serde_json::json!(["foo", "bar"]))), // { "ecmaVersion": 6 },
+        ("({[obj.bar]: a = baz} = qux);", Some(serde_json::json!(["bar"]))), // { "ecmaVersion": 6 },
+        ("Number.parseInt()", Some(serde_json::json!(["Number"]))),
+        ("x = Number.NaN;", Some(serde_json::json!(["Number"]))),
+        ("var foo = undefined;", Some(serde_json::json!(["undefined"]))),
+        ("if (foo === undefined);", Some(serde_json::json!(["undefined"]))),
+        ("obj[undefined] = 5;", Some(serde_json::json!(["undefined"]))),
+        ("foo = { [myGlobal]: 1 };", Some(serde_json::json!(["myGlobal"]))), // {                "ecmaVersion": 6,                "globals": { "myGlobal": "readonly" }            },
+        ("({ myGlobal } = foo);", Some(serde_json::json!(["myGlobal"]))), // {                "ecmaVersion": 6,                "globals": { "myGlobal": "writable" }            },
+        ("/* global myGlobal: readonly */ myGlobal = 5;", Some(serde_json::json!(["myGlobal"]))),
+        ("var foo = [Map];", Some(serde_json::json!(["Map"]))), // {                "ecmaVersion": 6            },
+        ("var foo = { bar: window.baz };", Some(serde_json::json!(["window"]))), // {                "globals": {                    "window": "readonly"                }            },
+        ("class C { camelCase; #camelCase; #camelCase2() {} }", Some(serde_json::json!(["foo"]))), // { "ecmaVersion": 2022 },
+        (
+            "class C { snake_case; #snake_case; #snake_case2() {} }",
+            Some(serde_json::json!(["foo"])),
+        ), // { "ecmaVersion": 2022 },
+        ("import foo from 'foo.json' with { type: 'json' }", Some(serde_json::json!(["type"]))), // { "ecmaVersion": 2025, "sourceType": "module" },
+        ("export * from 'foo.json' with { type: 'json' }", Some(serde_json::json!(["type"]))), // { "ecmaVersion": 2025, "sourceType": "module" },
+        (
+            "export { default } from 'foo.json' with { type: 'json' }",
+            Some(serde_json::json!(["type"])),
+        ), // { "ecmaVersion": 2025, "sourceType": "module" },
+        (
+            "import('foo.json', { with: { type: 'json' } })",
+            Some(serde_json::json!(["with", "type"])),
+        ), // { "ecmaVersion": 2025 },
+        ("import('foo.json', { 'with': { type: 'json' } })", Some(serde_json::json!(["type"]))), // { "ecmaVersion": 2025 },
+        ("import('foo.json', { with: { type } })", Some(serde_json::json!(["type"]))), // { "ecmaVersion": 2025 }
+    ];
+
+    let fail = vec![
+        (r#"foo = "bar""#, Some(serde_json::json!(["foo"]))),
+        (r#"bar = "bar""#, Some(serde_json::json!(["bar"]))),
+        (r#"foo = "bar""#, Some(serde_json::json!(["f", "fo", "foo", "bar"]))),
+        ("function foo(){}", Some(serde_json::json!(["f", "fo", "foo", "bar"]))),
+        ("import foo from 'mod'", Some(serde_json::json!(["foo"]))), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("import * as foo from 'mod'", Some(serde_json::json!(["foo"]))), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("export * as foo from 'mod'", Some(serde_json::json!(["foo"]))), // { "ecmaVersion": 2020, "sourceType": "module" },
+        ("import { foo } from 'mod'", Some(serde_json::json!(["foo"]))), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("import { foo as bar } from 'mod'", Some(serde_json::json!(["bar"]))), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("import { foo as bar } from 'mod'", Some(serde_json::json!(["foo", "bar"]))), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("import { foo as foo } from 'mod'", Some(serde_json::json!(["foo"]))), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("import { foo, foo as bar } from 'mod'", Some(serde_json::json!(["foo"]))), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("import { foo as bar, foo } from 'mod'", Some(serde_json::json!(["foo"]))), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("import foo, { foo as bar } from 'mod'", Some(serde_json::json!(["foo"]))), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("var foo; export { foo as bar };", Some(serde_json::json!(["bar"]))), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("var foo; export { foo };", Some(serde_json::json!(["foo"]))), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("var foo; export { foo as bar };", Some(serde_json::json!(["foo"]))), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("var foo; export { foo as foo };", Some(serde_json::json!(["foo"]))), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("var foo; export { foo as bar };", Some(serde_json::json!(["foo", "bar"]))), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("export { foo } from 'mod'", Some(serde_json::json!(["foo"]))), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("export { foo as bar } from 'mod'", Some(serde_json::json!(["bar"]))), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("export { foo as bar } from 'mod'", Some(serde_json::json!(["foo", "bar"]))), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("export { foo as foo } from 'mod'", Some(serde_json::json!(["foo"]))), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("export { foo, foo as bar } from 'mod'", Some(serde_json::json!(["foo"]))), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("export { foo as bar, foo } from 'mod'", Some(serde_json::json!(["foo"]))), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("foo.bar()", Some(serde_json::json!(["f", "fo", "foo", "b", "ba", "baz"]))),
+        ("foo[bar] = baz;", Some(serde_json::json!(["bar"]))),
+        ("baz = foo[bar];", Some(serde_json::json!(["bar"]))),
+        (
+            "var foo = bar.baz;",
+            Some(serde_json::json!(["f", "fo", "foo", "b", "ba", "barr", "bazz"])),
+        ),
+        (
+            "var foo = bar.baz;",
+            Some(serde_json::json!(["f", "fo", "fooo", "b", "ba", "bar", "bazz"])),
+        ),
+        (
+            "if (foo.bar) {}",
+            Some(serde_json::json!(["f", "fo", "foo", "b", "ba", "barr", "bazz", "bingg"])),
+        ),
+        ("var obj = { key: foo.bar };", Some(serde_json::json!(["obj"]))),
+        ("var obj = { key: foo.bar };", Some(serde_json::json!(["key"]))),
+        ("var obj = { key: foo.bar };", Some(serde_json::json!(["foo"]))),
+        ("var arr = [foo.bar];", Some(serde_json::json!(["arr"]))),
+        ("var arr = [foo.bar];", Some(serde_json::json!(["foo"]))),
+        (
+            "[foo.bar]",
+            Some(serde_json::json!(["f", "fo", "foo", "b", "ba", "barr", "bazz", "bingg"])),
+        ),
+        (
+            "if (foo.bar === bar.baz) { [bing.baz] }",
+            Some(serde_json::json!(["f", "fo", "foo", "b", "ba", "barr", "bazz", "bingg"])),
+        ),
+        (
+            "if (foo.bar === bar.baz) { [foo.bar] }",
+            Some(serde_json::json!(["f", "fo", "fooo", "b", "ba", "bar", "bazz", "bingg"])),
+        ),
+        (
+            "var myArray = new Array(); var myDate = new Date();",
+            Some(serde_json::json!(["array", "date", "myDate", "myarray", "new", "var"])),
+        ),
+        (
+            "var myArray = new Array(); var myDate = new Date();",
+            Some(serde_json::json!(["array", "date", "mydate", "myArray", "new", "var"])),
+        ),
+        ("foo.bar = 1", Some(serde_json::json!(["bar"]))),
+        ("foo.bar.baz = 1", Some(serde_json::json!(["bar", "baz"]))),
+        ("const {foo} = baz", Some(serde_json::json!(["foo"]))), // { "ecmaVersion": 6 },
+        ("const {foo: bar} = baz", Some(serde_json::json!(["foo", "bar"]))), // { "ecmaVersion": 6 },
+        ("const {[foo]: bar} = baz", Some(serde_json::json!(["foo", "bar"]))), // { "ecmaVersion": 6 },
+        ("const {foo: {bar: baz}} = qux", Some(serde_json::json!(["foo", "bar", "baz"]))), // { "ecmaVersion": 6 },
+        ("const {foo: {[bar]: baz}} = qux", Some(serde_json::json!(["foo", "bar", "baz"]))), // { "ecmaVersion": 6 },
+        ("const {[foo]: {[bar]: baz}} = qux", Some(serde_json::json!(["foo", "bar", "baz"]))), // { "ecmaVersion": 6 },
+        ("function foo({ bar: baz }) {}", Some(serde_json::json!(["bar", "baz"]))), // { "ecmaVersion": 6 },
+        ("function foo({ bar: {baz: qux} }) {}", Some(serde_json::json!(["bar", "baz", "qux"]))), // { "ecmaVersion": 6 },
+        ("({foo: obj.bar} = baz);", Some(serde_json::json!(["foo", "bar"]))), // { "ecmaVersion": 6 },
+        ("({foo: obj.bar.bar.bar.baz} = {});", Some(serde_json::json!(["foo", "bar", "baz"]))), // { "ecmaVersion": 6 },
+        ("({[foo]: obj.bar} = baz);", Some(serde_json::json!(["foo", "bar"]))), // { "ecmaVersion": 6 },
+        ("({foo: { a: obj.bar }} = baz);", Some(serde_json::json!(["bar"]))), // { "ecmaVersion": 6 },
+        ("({a: obj.bar = baz} = qux);", Some(serde_json::json!(["bar"]))), // { "ecmaVersion": 6 },
+        (
+            "({a: obj.bar.bar.baz = obj.qux} = obj.qux);",
+            Some(serde_json::json!(["a", "bar", "baz", "qux"])),
+        ), // { "ecmaVersion": 6 },
+        (
+            "({a: obj[bar] = obj.qux} = obj.qux);",
+            Some(serde_json::json!(["a", "bar", "baz", "qux"])),
+        ), // { "ecmaVersion": 6 },
+        ("({a: [obj.bar] = baz} = qux);", Some(serde_json::json!(["bar"]))), // { "ecmaVersion": 6 },
+        ("({foo: { a: obj.bar = baz}} = qux);", Some(serde_json::json!(["bar"]))), // { "ecmaVersion": 6 },
+        ("({foo: { [a]: obj.bar }} = baz);", Some(serde_json::json!(["bar"]))), // { "ecmaVersion": 6 },
+        ("({...obj.bar} = baz);", Some(serde_json::json!(["bar"]))), // { "ecmaVersion": 9 },
+        ("([obj.bar] = baz);", Some(serde_json::json!(["bar"]))),    // { "ecmaVersion": 6 },
+        ("const [bar] = baz;", Some(serde_json::json!(["bar"]))),    // { "ecmaVersion": 6 },
+        ("foo.undefined = 1;", Some(serde_json::json!(["undefined"]))),
+        ("var foo = { undefined: 1 };", Some(serde_json::json!(["undefined"]))),
+        ("var foo = { undefined: undefined };", Some(serde_json::json!(["undefined"]))),
+        ("var foo = { Number() {} };", Some(serde_json::json!(["Number"]))), // { "ecmaVersion": 6 },
+        ("class Foo { Number() {} }", Some(serde_json::json!(["Number"]))), // { "ecmaVersion": 6 },
+        ("myGlobal: while(foo) { break myGlobal; } ", Some(serde_json::json!(["myGlobal"]))), // {                "globals": { "myGlobal": "readonly" }            },
+        ("const foo = 1; bar = foo;", Some(serde_json::json!(["foo"]))), // { "ecmaVersion": 6 },
+        ("let foo; foo = bar;", Some(serde_json::json!(["foo"]))),       // { "ecmaVersion": 6 },
+        ("bar = foo; var foo;", Some(serde_json::json!(["foo"]))),
+        ("function foo() {} var bar = foo;", Some(serde_json::json!(["foo"]))),
+        ("class Foo {} var bar = Foo;", Some(serde_json::json!(["Foo"]))), // { "ecmaVersion": 6 },
+        ("let undefined; undefined = 1;", Some(serde_json::json!(["undefined"]))), // { "ecmaVersion": 6 },
+        ("foo = undefined; var undefined;", Some(serde_json::json!(["undefined"]))),
+        ("function undefined(){} x = undefined;", Some(serde_json::json!(["undefined"]))),
+        ("class Number {} x = Number.NaN;", Some(serde_json::json!(["Number"]))), // { "ecmaVersion": 6 },
+        (
+            "/* globals myGlobal */ window.myGlobal = 5; foo = myGlobal;",
+            Some(serde_json::json!(["myGlobal"])),
+        ), // {                "globals": {                    "window": "readonly"                }            },
+        ("var foo = undefined;", Some(serde_json::json!(["undefined"]))), // {                "globals": { "undefined": "off" }            },
+        ("/* globals Number: off */ Number.parseInt()", Some(serde_json::json!(["Number"]))),
+        ("var foo = [Map];", Some(serde_json::json!(["Map"]))),
+        ("if (foo) { let undefined; bar = undefined; }", Some(serde_json::json!(["undefined"]))), // { "ecmaVersion": 6 },
+        ("function foo(Number) { var x = Number.NaN; }", Some(serde_json::json!(["Number"]))),
+        ("function foo() { var myGlobal; x = myGlobal; }", Some(serde_json::json!(["myGlobal"]))), // {                "globals": { "myGlobal": "readonly" }            },
+        (
+            "function foo(bar) { return Number.parseInt(bar); } const Number = 1;",
+            Some(serde_json::json!(["Number"])),
+        ), // { "ecmaVersion": 6, "sourceType": "module" },
+        (
+            "import Number from 'myNumber'; const foo = Number.parseInt(bar);",
+            Some(serde_json::json!(["Number"])),
+        ), // { "ecmaVersion": 6, "sourceType": "module" },
+        ("var foo = function undefined() {};", Some(serde_json::json!(["undefined"]))),
+        ("var foo = { undefined }", Some(serde_json::json!(["undefined"]))), // { "ecmaVersion": 6 },
+        (
+            "class C { camelCase; #camelCase; #camelCase2() {} }",
+            Some(serde_json::json!(["camelCase"])),
+        ), // { "ecmaVersion": 2022 },
+        (
+            "class C { snake_case; #snake_case() {}; #snake_case2() {} }",
+            Some(serde_json::json!(["snake_case"])),
+        ), // { "ecmaVersion": 2022 },
+        ("import('foo.json', { with: { [type]: 'json' } })", Some(serde_json::json!(["type"]))), // { "ecmaVersion": 2025 },
+        ("import('foo.json', { with: { type: json } })", Some(serde_json::json!(["json"]))), // { "ecmaVersion": 2025 }
+    ];
+
+    Tester::new(IdDenylist::NAME, IdDenylist::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/eslint/id_denylist.rs
+++ b/crates/oxc_linter/src/rules/eslint/id_denylist.rs
@@ -304,7 +304,9 @@ fn test() {
         ("obj[undefined] = 5;", Some(serde_json::json!(["undefined"]))),
         ("foo = { [myGlobal]: 1 };", Some(serde_json::json!(["myGlobal"]))), // {                "ecmaVersion": 6,                "globals": { "myGlobal": "readonly" }            },
         ("({ myGlobal } = foo);", Some(serde_json::json!(["myGlobal"]))), // {                "ecmaVersion": 6,                "globals": { "myGlobal": "writable" }            },
-        ("/* global myGlobal: readonly */ myGlobal = 5;", Some(serde_json::json!(["myGlobal"]))),
+        // Disabled as we don't seem to be supporting configuration comments for defining globals
+        // in any our our lint rules.
+        // ("/* global myGlobal: readonly */ myGlobal = 5;", Some(serde_json::json!(["myGlobal"]))),
         ("var foo = [Map];", Some(serde_json::json!(["Map"]))), // {                "ecmaVersion": 6            },
         ("var foo = { bar: window.baz };", Some(serde_json::json!(["window"]))), // {                "globals": {                    "window": "readonly"                }            },
         ("class C { camelCase; #camelCase; #camelCase2() {} }", Some(serde_json::json!(["foo"]))), // { "ecmaVersion": 2022 },


### PR DESCRIPTION
wip. Commented out these kinds of tests
```
// ("/* global myGlobal: readonly */ myGlobal = 5;", Some(serde_json::json!(["myGlobal"]))),
``` 
As not sure what do do with them. Seems as though all  the other rules comment out tests related to inline global conf comments.