### PR TITLE
chore(linter): Improve the documentation of eslint/no-compare-neg-zero

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/max_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_params.rs
@@ -58,6 +58,12 @@ declare_oxc_lint!(
     /// }
     /// ```
     ///
+    /// ```javascript
+    /// let foo = (bar, baz, qux, qxx) => {
+    ///     doSomething();
+    /// };
+    /// ```
+    ///
     /// Examples of **correct** code for this rule:
     ///
     /// By default the maximum allowed number of function parameters is three.

--- a/crates/oxc_linter/src/rules/eslint/max_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_params.rs
@@ -38,17 +38,52 @@ impl Default for MaxParamsConfig {
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Enforce a maximum number of parameters in function definitions
     ///
     /// ### Why is this bad?
-    /// Functions that take numerous parameters can be difficult to read and write because it requires the memorization of what each parameter is, its type, and the order they should appear in. As a result, many coders adhere to a convention that caps the number of parameters a function can take.
     ///
-    /// ### Example
+    /// Functions that take numerous parameters can be difficult to read and
+    /// write because it requires the memorization of what each parameter is,
+    /// its type, and the order they should appear in. As a result, many coders
+    /// adhere to a convention that caps the number of parameters a function
+    /// can take.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// function foo (bar, baz, qux, qxx) {
     ///     doSomething();
     /// }
     /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    ///
+    /// By default the maximum allowed number of function parameters is three.
+    /// ```javascript
+    /// function foo (bar, baz, qux) {
+    ///     doSomething();
+    /// }
+    /// ```
+    ///
+    /// ```javascript
+    /// let foo = (bar, baz, qux) => {
+    ///     doSomething();
+    /// };
+    /// ```
+    ///
+    /// ### Options
+    ///
+    /// ### max
+    ///
+    /// This option is for changing the maximum number of function parameters
+    /// are allowed.
+    ///
+    /// `{ "max": number }`
+    ///
+    /// For example `{ "max": 4 }` would mean that having a function take four
+    /// parameters is allowed which overrides the default of three.
     MaxParams,
     eslint,
     style

--- a/crates/oxc_linter/src/rules/eslint/max_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_params.rs
@@ -39,7 +39,8 @@ impl Default for MaxParamsConfig {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// Enforce a maximum number of parameters in function definitions
+    /// Enforce a maximum number of parameters in function definitions which by
+    /// default is three.
     ///
     /// ### Why is this bad?
     ///
@@ -65,8 +66,6 @@ declare_oxc_lint!(
     /// ```
     ///
     /// Examples of **correct** code for this rule:
-    ///
-    /// By default the maximum allowed number of function parameters is three.
     /// ```javascript
     /// function foo (bar, baz, qux) {
     ///     doSomething();

--- a/crates/oxc_linter/src/rules/eslint/max_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_params.rs
@@ -38,56 +38,17 @@ impl Default for MaxParamsConfig {
 
 declare_oxc_lint!(
     /// ### What it does
-    ///
-    /// Enforce a maximum number of parameters in function definitions which by
-    /// default is three.
+    /// Enforce a maximum number of parameters in function definitions
     ///
     /// ### Why is this bad?
+    /// Functions that take numerous parameters can be difficult to read and write because it requires the memorization of what each parameter is, its type, and the order they should appear in. As a result, many coders adhere to a convention that caps the number of parameters a function can take.
     ///
-    /// Functions that take numerous parameters can be difficult to read and
-    /// write because it requires the memorization of what each parameter is,
-    /// its type, and the order they should appear in. As a result, many coders
-    /// adhere to a convention that caps the number of parameters a function
-    /// can take.
-    ///
-    /// ### Examples
-    ///
-    /// Examples of **incorrect** code for this rule:
+    /// ### Example
     /// ```javascript
     /// function foo (bar, baz, qux, qxx) {
     ///     doSomething();
     /// }
     /// ```
-    ///
-    /// ```javascript
-    /// let foo = (bar, baz, qux, qxx) => {
-    ///     doSomething();
-    /// };
-    /// ```
-    ///
-    /// Examples of **correct** code for this rule:
-    /// ```javascript
-    /// function foo (bar, baz, qux) {
-    ///     doSomething();
-    /// }
-    /// ```
-    ///
-    /// ```javascript
-    /// let foo = (bar, baz, qux) => {
-    ///     doSomething();
-    /// };
-    /// ```
-    ///
-    /// ### Options
-    ///
-    /// ### max
-    ///
-    /// This option is for changing the maximum allowed number of function parameters.
-    ///
-    /// `{ "max": number }`
-    ///
-    /// For example `{ "max": 4 }` would mean that having a function take four
-    /// parameters is allowed which overrides the default of three.
     MaxParams,
     eslint,
     style

--- a/crates/oxc_linter/src/rules/eslint/max_params.rs
+++ b/crates/oxc_linter/src/rules/eslint/max_params.rs
@@ -77,8 +77,7 @@ declare_oxc_lint!(
     ///
     /// ### max
     ///
-    /// This option is for changing the maximum number of function parameters
-    /// are allowed.
+    /// This option is for changing the maximum allowed number of function parameters.
     ///
     /// `{ "max": number }`
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_compare_neg_zero.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_compare_neg_zero.rs
@@ -17,16 +17,47 @@ pub struct NoCompareNegZero;
 
 declare_oxc_lint!(
     /// ### What it does
+    ///
     /// Disallow comparing against -0
     ///
     /// ### Why is this bad?
+    ///
     /// The rule should warn against code that tries to compare against -0,
     /// since that will not work as intended. That is, code like x === -0 will
     /// pass for both +0 and -0. The author probably intended Object.is(x, -0).
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
-    /// if (x === -0) {}
+    /// if (x === -0) {
+    ///     // doSomething()...
+    /// }
+    /// ```
+    ///
+    /// ```javascript
+    /// if (-0 > x) {
+    ///     // doSomething()...
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// if (x === 0) {
+    ///     // doSomething()...
+    /// }
+    /// ```
+    ///
+    /// ```javascript
+    /// if (Object.is(x, -0)) {
+    ///     // doSomething()...
+    /// }
+    /// ```
+    ///
+    /// ```javascript
+    /// if (0 > x) {
+    ///     // doSomething()...
+    /// }
     /// ```
     NoCompareNegZero,
     eslint,


### PR DESCRIPTION
Add more documentation aligned with doc template for eslint rule `no-compare-neg-zero`.

Relates to [#6050](https://github.com/oxc-project/oxc/issues/6050)