### PR TITLE
refactor(span): manually derive `Deserialize` for `CompactStr`

### DIFF
--- a/crates/oxc_span/Cargo.toml
+++ b/crates/oxc_span/Cargo.toml
@@ -28,7 +28,7 @@ compact_str = { workspace = true }
 miette = { workspace = true }
 
 schemars = { workspace = true, optional = true }
-serde = { workspace = true, features = ["derive"], optional = true }
+serde = { workspace = true, optional = true }
 
 [features]
 default = []

--- a/crates/oxc_span/src/compact_str.rs
+++ b/crates/oxc_span/src/compact_str.rs
@@ -6,7 +6,7 @@ use std::{
 
 use compact_str::CompactString;
 #[cfg(feature = "serialize")]
-use serde::{Serialize, Serializer};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::Span;
 
@@ -21,7 +21,6 @@ pub const MAX_INLINE_LEN: usize = 16;
 /// Currently implemented as just a wrapper around [`compact_str::CompactString`],
 /// but will be reduced in size with a custom implementation later.
 #[derive(Clone, Eq, PartialOrd, Ord)]
-#[cfg_attr(feature = "serialize", derive(serde::Deserialize))]
 pub struct CompactStr(CompactString);
 
 impl CompactStr {
@@ -226,6 +225,14 @@ impl fmt::Display for CompactStr {
 impl Serialize for CompactStr {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         self.as_str().serialize(serializer)
+    }
+}
+
+#[cfg(feature = "serialize")]
+impl<'de> Deserialize<'de> for CompactStr {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let compact_string = CompactString::deserialize(deserializer)?;
+        Ok(Self(compact_string))
     }
 }
 


### PR DESCRIPTION
The `Deserialize` impl for `CompactStr` is trivial, so write it manually, rather than using `serde`'s heavy proc macro machinery.

This allows disabling the `derive` feature for `serde` in `oxc_span` crate. Many other crates  depend on `oxc_span`, so this chips away at compile times.
