### PR TITLE
fix(ast/estree): remove unused TS type def for `WithClause`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -2416,6 +2416,7 @@ pub struct ImportNamespaceSpecifier<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[estree(no_ts_def)]
 pub struct WithClause<'a> {
     pub span: Span,
     pub attributes_keyword: IdentifierName<'a>, // `with` or `assert`

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -727,12 +727,6 @@ export interface ImportNamespaceSpecifier extends Span {
   local: BindingIdentifier;
 }
 
-export interface WithClause extends Span {
-  type: 'WithClause';
-  attributesKeyword: IdentifierName;
-  withEntries: Array<ImportAttribute>;
-}
-
 export interface ImportAttribute extends Span {
   type: 'ImportAttribute';
   key: ImportAttributeKey;


### PR DESCRIPTION
`WithClause` is flattened to just its `with_entries` field in ESTree AST, so the `WithClause` type doesn't appear in the ESTree AST. Remove the TS type def for it.