### PR TITLE
refactor(ast/estree): define custom ESTree serializers on struct fields via meta types

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -927,11 +927,7 @@ pub struct AssignmentTargetPropertyIdentifier<'a> {
     pub span: Span,
     #[estree(rename = "key")]
     pub binding: IdentifierReference<'a>,
-    #[estree(
-        rename = "value",
-        via = crate::serialize::AssignmentTargetPropertyIdentifierValue(self),
-        ts_type = "IdentifierReference | AssignmentTargetWithDefault",
-    )]
+    #[estree(rename = "value", via = AssignmentTargetPropertyIdentifierValue)]
     pub init: Option<Expression<'a>>,
 }
 
@@ -1818,7 +1814,7 @@ pub struct ArrowFunctionExpression<'a> {
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
     /// See `expression` for whether this arrow expression returns an expression.
     // ESTree: https://github.com/estree/estree/blob/master/es2015.md#arrowfunctionexpression
-    #[estree(via = crate::serialize::ArrowFunctionExpressionBody(self), ts_type = "FunctionBody | Expression")]
+    #[estree(via = ArrowFunctionExpressionBody)]
     pub body: Box<'a, FunctionBody<'a>>,
     pub scope_id: Cell<Option<ScopeId>>,
 }
@@ -2304,11 +2300,7 @@ pub struct AccessorProperty<'a> {
 pub struct ImportExpression<'a> {
     pub span: Span,
     pub source: Expression<'a>,
-    #[estree(
-        rename = "options",
-        via = crate::serialize::import_expression_options(&self.arguments),
-        ts_type = "Expression | null"
-    )]
+    #[estree(rename = "options", via = ImportExpressionArguments)]
     pub arguments: Vec<'a, Expression<'a>>,
     #[estree(skip)]
     pub phase: Option<ImportPhase>,
@@ -2320,13 +2312,13 @@ pub struct ImportExpression<'a> {
 pub struct ImportDeclaration<'a> {
     pub span: Span,
     /// `None` for `import 'foo'`, `Some([])` for `import {} from 'foo'`
-    #[estree(via = crate::serialize::OptionVecDefault(&self.specifiers), ts_type = "Array<ImportDeclarationSpecifier>")]
+    #[estree(via = ImportDeclarationSpecifiers)]
     pub specifiers: Option<Vec<'a, ImportDeclarationSpecifier<'a>>>,
     pub source: StringLiteral<'a>,
     pub phase: Option<ImportPhase>,
     /// Some(vec![]) for empty assertion
     #[ts]
-    #[estree(rename = "attributes", via = crate::serialize::ImportExportWithClause(&self.with_clause), ts_type = "Array<ImportAttribute>")]
+    #[estree(rename = "attributes", via = ImportDeclarationWithClause)]
     pub with_clause: Option<Box<'a, WithClause<'a>>>,
     /// `import type { foo } from 'bar'`
     #[ts]
@@ -2464,7 +2456,7 @@ pub struct ExportNamedDeclaration<'a> {
     pub export_kind: ImportOrExportKind,
     /// Some(vec![]) for empty assertion
     #[ts]
-    #[estree(rename = "attributes", via = crate::serialize::ImportExportWithClause(&self.with_clause), ts_type = "Array<ImportAttribute>")]
+    #[estree(rename = "attributes", via = ExportNamedDeclarationWithClause)]
     pub with_clause: Option<Box<'a, WithClause<'a>>>,
 }
 
@@ -2505,7 +2497,7 @@ pub struct ExportAllDeclaration<'a> {
     pub source: StringLiteral<'a>,
     /// Will be `Some(vec![])` for empty assertion
     #[ts]
-    #[estree(rename = "attributes", via = crate::serialize::ImportExportWithClause(&self.with_clause), ts_type = "Array<ImportAttribute>")]
+    #[estree(rename = "attributes", via = ExportAllDeclarationWithClause)]
     pub with_clause: Option<Box<'a, WithClause<'a>>>, // Some(vec![]) for empty assertion
     #[ts]
     pub export_kind: ImportOrExportKind, // `export type *`

--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -122,7 +122,7 @@ pub struct RegExpLiteral<'a> {
     pub span: Span,
     /// The parsed regular expression. See [`oxc_regular_expression`] for more
     /// details.
-    #[estree(via = crate::serialize::RegExpLiteralRegex(self))]
+    #[estree(via = RegExpLiteralRegex)]
     pub regex: RegExp<'a>,
     /// The regular expression as it appears in source code
     ///

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1642,10 +1642,7 @@ impl Serialize for ImportExpression<'_> {
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
         map.serialize_entry("source", &self.source)?;
-        map.serialize_entry(
-            "options",
-            &crate::serialize::import_expression_options(&self.arguments),
-        )?;
+        map.serialize_entry("options", &crate::serialize::ImportExpressionArguments(self))?;
         map.end()
     }
 }
@@ -1656,13 +1653,10 @@ impl Serialize for ImportDeclaration<'_> {
         map.serialize_entry("type", "ImportDeclaration")?;
         map.serialize_entry("start", &self.span.start)?;
         map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("specifiers", &crate::serialize::OptionVecDefault(&self.specifiers))?;
+        map.serialize_entry("specifiers", &crate::serialize::ImportDeclarationSpecifiers(self))?;
         map.serialize_entry("source", &self.source)?;
         map.serialize_entry("phase", &self.phase)?;
-        map.serialize_entry(
-            "attributes",
-            &crate::serialize::ImportExportWithClause(&self.with_clause),
-        )?;
+        map.serialize_entry("attributes", &crate::serialize::ImportDeclarationWithClause(self))?;
         map.serialize_entry("importKind", &self.import_kind)?;
         map.end()
     }
@@ -1767,7 +1761,7 @@ impl Serialize for ExportNamedDeclaration<'_> {
         map.serialize_entry("exportKind", &self.export_kind)?;
         map.serialize_entry(
             "attributes",
-            &crate::serialize::ImportExportWithClause(&self.with_clause),
+            &crate::serialize::ExportNamedDeclarationWithClause(self),
         )?;
         map.end()
     }
@@ -1793,10 +1787,7 @@ impl Serialize for ExportAllDeclaration<'_> {
         map.serialize_entry("end", &self.span.end)?;
         map.serialize_entry("exported", &self.exported)?;
         map.serialize_entry("source", &self.source)?;
-        map.serialize_entry(
-            "attributes",
-            &crate::serialize::ImportExportWithClause(&self.with_clause),
-        )?;
+        map.serialize_entry("attributes", &crate::serialize::ExportAllDeclarationWithClause(self))?;
         map.serialize_entry("exportKind", &self.export_kind)?;
         map.end()
     }

--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -236,6 +236,8 @@ fn generate_ts_type_def_for_struct_field_impl<'s>(
         }
 
         Cow::Owned(field_type_name)
+    } else if let Some(converter_name) = &field.estree.via {
+        Cow::Borrowed(get_ts_type_for_converter(converter_name, schema))
     } else {
         get_field_type_name(field, schema)
     };
@@ -276,11 +278,20 @@ fn generate_ts_type_def_for_added_struct_field(
     fields_str: &mut String,
     schema: &Schema,
 ) {
+    let ts_type = get_ts_type_for_converter(converter_name, schema);
+    fields_str.push_str(&format!("\n\t{field_name}: {ts_type};"));
+}
+
+/// Get the TS type definition for a converter.
+///
+/// Converters are specified with `#[estree(add_fields(field_name = converter_name))]`
+/// and `#[estree(via = converter_name)]`.
+fn get_ts_type_for_converter<'s>(converter_name: &str, schema: &'s Schema) -> &'s str {
     let converter = schema.meta_by_name(converter_name);
-    let Some(add_field_ts_type) = &converter.estree.ts_type else {
+    let Some(ts_type) = &converter.estree.ts_type else {
         panic!("No `ts_type` provided for ESTree converter `{}`", converter.name());
     };
-    fields_str.push_str(&format!("\n\t{field_name}: {add_field_ts_type};"));
+    ts_type
 }
 
 /// Generate Typescript type definition for an enum.


### PR DESCRIPTION
Bring the syntax for defining custom serializers for struct fields into line with how extra fields are defined.

`#[estree(via = Converter)]` now matches `#[estree(add_fields(field_name = Converter))]`.

In both cases, `Converter` is a meta type defined with `#[ast_meta]`, and the TS type def for the converted value is defined on the meta type, rather than the struct field. All converters consistently now take `self`.

This unclutters the Rust AST type defs, shortening lengthy `#[estree]` attributes, and makes the interface consistent. This change will also come in useful later, allowing us to add more info to the meta types with further attributes.
