### PR TITLE
feat(ast/estree)!: replace `serde` with custom `ESTree` serializer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,6 +1565,7 @@ dependencies = [
  "allocator-api2",
  "bumpalo",
  "hashbrown 0.15.2",
+ "oxc_estree",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -1584,8 +1585,6 @@ dependencies = [
  "oxc_regular_expression",
  "oxc_span",
  "oxc_syntax",
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1751,7 +1750,8 @@ dependencies = [
 name = "oxc_estree"
 version = "0.51.0"
 dependencies = [
- "serde",
+ "itoa",
+ "ryu-js",
 ]
 
 [[package]]
@@ -1964,7 +1964,6 @@ dependencies = [
  "pico-args",
  "rustc-hash",
  "seq-macro",
- "serde_json",
 ]
 
 [[package]]
@@ -1982,7 +1981,6 @@ dependencies = [
  "oxc_sourcemap",
  "rustc-hash",
  "self_cell",
- "serde_json",
  "string_wizard",
 ]
 
@@ -2040,7 +2038,6 @@ dependencies = [
  "oxc_span",
  "phf",
  "rustc-hash",
- "serde",
  "unicode-id-start",
 ]
 
@@ -2249,6 +2246,7 @@ dependencies = [
  "oxc_prettier",
  "serde",
  "serde-wasm-bindgen",
+ "serde_json",
  "tsify",
  "wasm-bindgen",
 ]

--- a/crates/oxc_allocator/Cargo.toml
+++ b/crates/oxc_allocator/Cargo.toml
@@ -19,6 +19,8 @@ workspace = true
 doctest = false
 
 [dependencies]
+oxc_estree = { workspace = true, optional = true }
+
 allocator-api2 = { workspace = true }
 bumpalo = { workspace = true, features = ["allocator-api2", "collections"] }
 hashbrown = { workspace = true, default-features = false, features = ["inline-more", "allocator-api2"] }
@@ -32,4 +34,4 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 [features]
-serialize = ["dep:serde"]
+serialize = ["dep:serde", "oxc_estree/serialize"]

--- a/crates/oxc_ast/Cargo.toml
+++ b/crates/oxc_ast/Cargo.toml
@@ -30,18 +30,12 @@ bitflags = { workspace = true }
 cow-utils = { workspace = true }
 nonmax = { workspace = true }
 
-serde = { workspace = true, optional = true }
-serde_json = { workspace = true, optional = true }
-
 [features]
 default = []
 serialize = [
-  "dep:serde",
-  "dep:serde_json",
   "oxc_allocator/serialize",
   "oxc_regular_expression/serialize",
   "oxc_span/serialize",
   "oxc_syntax/serialize",
-  "oxc_syntax/to_js_string",
   "oxc_estree/serialize",
 ]

--- a/crates/oxc_ast/src/ast_impl/literal.rs
+++ b/crates/oxc_ast/src/ast_impl/literal.rs
@@ -45,7 +45,7 @@ impl NumericLiteral<'_> {
             return int32_value;
         }
 
-        // NaN, Infinity if not included in our NumericLiteral, so we just serde(skip) step 2.
+        // NaN, Infinity if not included in our NumericLiteral, so we just skip step 2.
 
         // step 3
         let pos_int = num.signum() * num.abs().floor();

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1,35 +1,36 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/derives/estree.rs`
 
-#![allow(unused_imports, clippy::match_same_arms)]
+#![allow(unused_imports, clippy::match_same_arms, clippy::semicolon_if_nothing_returned)]
 
-use serde::{__private::ser::FlatMapSerializer, ser::SerializeMap, Serialize, Serializer};
-
-use oxc_estree::ser::{AppendTo, AppendToConcat};
+use oxc_estree::{
+    ser::{AppendTo, AppendToConcat},
+    ESTree, FlatStructSerializer, Serializer, StructSerializer,
+};
 
 use crate::ast::js::*;
 use crate::ast::jsx::*;
 use crate::ast::literal::*;
 use crate::ast::ts::*;
 
-impl Serialize for Program<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Program")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry(
+impl ESTree for Program<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "Program");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field(
             "body",
             &AppendToConcat { array: &self.directives, after: &self.body },
-        )?;
-        self.source_type.serialize(FlatMapSerializer(&mut map))?;
-        map.serialize_entry("hashbang", &self.hashbang)?;
-        map.end()
+        );
+        self.source_type.serialize(FlatStructSerializer(&mut state));
+        state.serialize_field("hashbang", &self.hashbang);
+        state.end();
     }
 }
 
-impl Serialize for Expression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for Expression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             Expression::BooleanLiteral(it) => it.serialize(serializer),
             Expression::NullLiteral(it) => it.serialize(serializer),
@@ -77,73 +78,73 @@ impl Serialize for Expression<'_> {
     }
 }
 
-impl Serialize for IdentifierName<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Identifier")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("name", &self.name)?;
-        map.end()
+impl ESTree for IdentifierName<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "Identifier");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("name", &self.name);
+        state.end();
     }
 }
 
-impl Serialize for IdentifierReference<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Identifier")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("name", &self.name)?;
-        map.end()
+impl ESTree for IdentifierReference<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "Identifier");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("name", &self.name);
+        state.end();
     }
 }
 
-impl Serialize for BindingIdentifier<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Identifier")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("name", &self.name)?;
-        map.end()
+impl ESTree for BindingIdentifier<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "Identifier");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("name", &self.name);
+        state.end();
     }
 }
 
-impl Serialize for LabelIdentifier<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Identifier")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("name", &self.name)?;
-        map.end()
+impl ESTree for LabelIdentifier<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "Identifier");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("name", &self.name);
+        state.end();
     }
 }
 
-impl Serialize for ThisExpression {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ThisExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.end()
+impl ESTree for ThisExpression {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ThisExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.end();
     }
 }
 
-impl Serialize for ArrayExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ArrayExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("elements", &self.elements)?;
-        map.end()
+impl ESTree for ArrayExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ArrayExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("elements", &self.elements);
+        state.end();
     }
 }
 
-impl Serialize for ArrayExpressionElement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for ArrayExpressionElement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             ArrayExpressionElement::SpreadElement(it) => it.serialize(serializer),
             ArrayExpressionElement::Elision(it) => it.serialize(serializer),
@@ -193,19 +194,19 @@ impl Serialize for ArrayExpressionElement<'_> {
     }
 }
 
-impl Serialize for ObjectExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ObjectExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("properties", &self.properties)?;
-        map.end()
+impl ESTree for ObjectExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ObjectExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("properties", &self.properties);
+        state.end();
     }
 }
 
-impl Serialize for ObjectPropertyKind<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for ObjectPropertyKind<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             ObjectPropertyKind::ObjectProperty(it) => it.serialize(serializer),
             ObjectPropertyKind::SpreadProperty(it) => it.serialize(serializer),
@@ -213,8 +214,8 @@ impl Serialize for ObjectPropertyKind<'_> {
     }
 }
 
-impl Serialize for PropertyKey<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for PropertyKey<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             PropertyKey::StaticIdentifier(it) => it.serialize(serializer),
             PropertyKey::PrivateIdentifier(it) => it.serialize(serializer),
@@ -264,64 +265,64 @@ impl Serialize for PropertyKey<'_> {
     }
 }
 
-impl Serialize for PropertyKind {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for PropertyKind {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            PropertyKind::Init => serializer.serialize_unit_variant("PropertyKind", 0, "init"),
-            PropertyKind::Get => serializer.serialize_unit_variant("PropertyKind", 1, "get"),
-            PropertyKind::Set => serializer.serialize_unit_variant("PropertyKind", 2, "set"),
+            PropertyKind::Init => "init".serialize(serializer),
+            PropertyKind::Get => "get".serialize(serializer),
+            PropertyKind::Set => "set".serialize(serializer),
         }
     }
 }
 
-impl Serialize for TemplateLiteral<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TemplateLiteral")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("expressions", &self.expressions)?;
-        map.serialize_entry("quasis", &self.quasis)?;
-        map.end()
+impl ESTree for TemplateLiteral<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TemplateLiteral");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("expressions", &self.expressions);
+        state.serialize_field("quasis", &self.quasis);
+        state.end();
     }
 }
 
-impl Serialize for TaggedTemplateExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TaggedTemplateExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("tag", &self.tag)?;
-        map.serialize_entry("quasi", &self.quasi)?;
-        map.serialize_entry("typeParameters", &self.type_parameters)?;
-        map.end()
+impl ESTree for TaggedTemplateExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TaggedTemplateExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("tag", &self.tag);
+        state.serialize_field("quasi", &self.quasi);
+        state.serialize_field("typeParameters", &self.type_parameters);
+        state.end();
     }
 }
 
-impl Serialize for TemplateElement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TemplateElement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("value", &self.value)?;
-        map.serialize_entry("tail", &self.tail)?;
-        map.end()
+impl ESTree for TemplateElement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TemplateElement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("value", &self.value);
+        state.serialize_field("tail", &self.tail);
+        state.end();
     }
 }
 
-impl Serialize for TemplateElementValue<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("raw", &self.raw)?;
-        map.serialize_entry("cooked", &self.cooked)?;
-        map.end()
+impl ESTree for TemplateElementValue<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("raw", &self.raw);
+        state.serialize_field("cooked", &self.cooked);
+        state.end();
     }
 }
 
-impl Serialize for MemberExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for MemberExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             MemberExpression::ComputedMemberExpression(it) => it.serialize(serializer),
             MemberExpression::StaticMemberExpression(it) => it.serialize(serializer),
@@ -330,100 +331,100 @@ impl Serialize for MemberExpression<'_> {
     }
 }
 
-impl Serialize for ComputedMemberExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "MemberExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("object", &self.object)?;
-        map.serialize_entry("property", &self.expression)?;
-        map.serialize_entry("computed", &crate::serialize::True(self))?;
-        map.serialize_entry("optional", &self.optional)?;
-        map.end()
+impl ESTree for ComputedMemberExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "MemberExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("object", &self.object);
+        state.serialize_field("property", &self.expression);
+        state.serialize_field("computed", &crate::serialize::True(self));
+        state.serialize_field("optional", &self.optional);
+        state.end();
     }
 }
 
-impl Serialize for StaticMemberExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "MemberExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("object", &self.object)?;
-        map.serialize_entry("property", &self.property)?;
-        map.serialize_entry("computed", &crate::serialize::False(self))?;
-        map.serialize_entry("optional", &self.optional)?;
-        map.end()
+impl ESTree for StaticMemberExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "MemberExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("object", &self.object);
+        state.serialize_field("property", &self.property);
+        state.serialize_field("computed", &crate::serialize::False(self));
+        state.serialize_field("optional", &self.optional);
+        state.end();
     }
 }
 
-impl Serialize for PrivateFieldExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "MemberExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("object", &self.object)?;
-        map.serialize_entry("property", &self.field)?;
-        map.serialize_entry("computed", &crate::serialize::False(self))?;
-        map.serialize_entry("optional", &self.optional)?;
-        map.end()
+impl ESTree for PrivateFieldExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "MemberExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("object", &self.object);
+        state.serialize_field("property", &self.field);
+        state.serialize_field("computed", &crate::serialize::False(self));
+        state.serialize_field("optional", &self.optional);
+        state.end();
     }
 }
 
-impl Serialize for CallExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "CallExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("callee", &self.callee)?;
-        map.serialize_entry("typeParameters", &self.type_parameters)?;
-        map.serialize_entry("arguments", &self.arguments)?;
-        map.serialize_entry("optional", &self.optional)?;
-        map.end()
+impl ESTree for CallExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "CallExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("callee", &self.callee);
+        state.serialize_field("typeParameters", &self.type_parameters);
+        state.serialize_field("arguments", &self.arguments);
+        state.serialize_field("optional", &self.optional);
+        state.end();
     }
 }
 
-impl Serialize for NewExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "NewExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("callee", &self.callee)?;
-        map.serialize_entry("arguments", &self.arguments)?;
-        map.serialize_entry("typeParameters", &self.type_parameters)?;
-        map.end()
+impl ESTree for NewExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "NewExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("callee", &self.callee);
+        state.serialize_field("arguments", &self.arguments);
+        state.serialize_field("typeParameters", &self.type_parameters);
+        state.end();
     }
 }
 
-impl Serialize for MetaProperty<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "MetaProperty")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("meta", &self.meta)?;
-        map.serialize_entry("property", &self.property)?;
-        map.end()
+impl ESTree for MetaProperty<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "MetaProperty");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("meta", &self.meta);
+        state.serialize_field("property", &self.property);
+        state.end();
     }
 }
 
-impl Serialize for SpreadElement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "SpreadElement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("argument", &self.argument)?;
-        map.end()
+impl ESTree for SpreadElement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "SpreadElement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("argument", &self.argument);
+        state.end();
     }
 }
 
-impl Serialize for Argument<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for Argument<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             Argument::SpreadElement(it) => it.serialize(serializer),
             Argument::BooleanLiteral(it) => it.serialize(serializer),
@@ -472,99 +473,99 @@ impl Serialize for Argument<'_> {
     }
 }
 
-impl Serialize for UpdateExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "UpdateExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("operator", &self.operator)?;
-        map.serialize_entry("prefix", &self.prefix)?;
-        map.serialize_entry("argument", &self.argument)?;
-        map.end()
+impl ESTree for UpdateExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "UpdateExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("operator", &self.operator);
+        state.serialize_field("prefix", &self.prefix);
+        state.serialize_field("argument", &self.argument);
+        state.end();
     }
 }
 
-impl Serialize for UnaryExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "UnaryExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("operator", &self.operator)?;
-        map.serialize_entry("prefix", &crate::serialize::True(self))?;
-        map.serialize_entry("argument", &self.argument)?;
-        map.end()
+impl ESTree for UnaryExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "UnaryExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("operator", &self.operator);
+        state.serialize_field("prefix", &crate::serialize::True(self));
+        state.serialize_field("argument", &self.argument);
+        state.end();
     }
 }
 
-impl Serialize for BinaryExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "BinaryExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("left", &self.left)?;
-        map.serialize_entry("operator", &self.operator)?;
-        map.serialize_entry("right", &self.right)?;
-        map.end()
+impl ESTree for BinaryExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "BinaryExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("left", &self.left);
+        state.serialize_field("operator", &self.operator);
+        state.serialize_field("right", &self.right);
+        state.end();
     }
 }
 
-impl Serialize for PrivateInExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "BinaryExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("left", &self.left)?;
-        map.serialize_entry("operator", &crate::serialize::In(self))?;
-        map.serialize_entry("right", &self.right)?;
-        map.end()
+impl ESTree for PrivateInExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "BinaryExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("left", &self.left);
+        state.serialize_field("operator", &crate::serialize::In(self));
+        state.serialize_field("right", &self.right);
+        state.end();
     }
 }
 
-impl Serialize for LogicalExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "LogicalExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("left", &self.left)?;
-        map.serialize_entry("operator", &self.operator)?;
-        map.serialize_entry("right", &self.right)?;
-        map.end()
+impl ESTree for LogicalExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "LogicalExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("left", &self.left);
+        state.serialize_field("operator", &self.operator);
+        state.serialize_field("right", &self.right);
+        state.end();
     }
 }
 
-impl Serialize for ConditionalExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ConditionalExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("test", &self.test)?;
-        map.serialize_entry("consequent", &self.consequent)?;
-        map.serialize_entry("alternate", &self.alternate)?;
-        map.end()
+impl ESTree for ConditionalExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ConditionalExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("test", &self.test);
+        state.serialize_field("consequent", &self.consequent);
+        state.serialize_field("alternate", &self.alternate);
+        state.end();
     }
 }
 
-impl Serialize for AssignmentExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "AssignmentExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("operator", &self.operator)?;
-        map.serialize_entry("left", &self.left)?;
-        map.serialize_entry("right", &self.right)?;
-        map.end()
+impl ESTree for AssignmentExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "AssignmentExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("operator", &self.operator);
+        state.serialize_field("left", &self.left);
+        state.serialize_field("right", &self.right);
+        state.end();
     }
 }
 
-impl Serialize for AssignmentTarget<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for AssignmentTarget<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             AssignmentTarget::AssignmentTargetIdentifier(it) => it.serialize(serializer),
             AssignmentTarget::TSAsExpression(it) => it.serialize(serializer),
@@ -581,8 +582,8 @@ impl Serialize for AssignmentTarget<'_> {
     }
 }
 
-impl Serialize for SimpleAssignmentTarget<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for SimpleAssignmentTarget<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             SimpleAssignmentTarget::AssignmentTargetIdentifier(it) => it.serialize(serializer),
             SimpleAssignmentTarget::TSAsExpression(it) => it.serialize(serializer),
@@ -597,8 +598,8 @@ impl Serialize for SimpleAssignmentTarget<'_> {
     }
 }
 
-impl Serialize for AssignmentTargetPattern<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for AssignmentTargetPattern<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             AssignmentTargetPattern::ArrayAssignmentTarget(it) => it.serialize(serializer),
             AssignmentTargetPattern::ObjectAssignmentTarget(it) => it.serialize(serializer),
@@ -606,44 +607,44 @@ impl Serialize for AssignmentTargetPattern<'_> {
     }
 }
 
-impl Serialize for ArrayAssignmentTarget<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ArrayPattern")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("elements", &AppendTo { array: &self.elements, after: &self.rest })?;
-        map.end()
+impl ESTree for ArrayAssignmentTarget<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ArrayPattern");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("elements", &AppendTo { array: &self.elements, after: &self.rest });
+        state.end();
     }
 }
 
-impl Serialize for ObjectAssignmentTarget<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ObjectPattern")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry(
+impl ESTree for ObjectAssignmentTarget<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ObjectPattern");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field(
             "properties",
             &AppendTo { array: &self.properties, after: &self.rest },
-        )?;
-        map.end()
+        );
+        state.end();
     }
 }
 
-impl Serialize for AssignmentTargetRest<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "RestElement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("argument", &self.target)?;
-        map.end()
+impl ESTree for AssignmentTargetRest<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "RestElement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("argument", &self.target);
+        state.end();
     }
 }
 
-impl Serialize for AssignmentTargetMaybeDefault<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for AssignmentTargetMaybeDefault<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(it) => {
                 it.serialize(serializer)
@@ -665,20 +666,20 @@ impl Serialize for AssignmentTargetMaybeDefault<'_> {
     }
 }
 
-impl Serialize for AssignmentTargetWithDefault<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "AssignmentPattern")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("left", &self.binding)?;
-        map.serialize_entry("right", &self.init)?;
-        map.end()
+impl ESTree for AssignmentTargetWithDefault<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "AssignmentPattern");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("left", &self.binding);
+        state.serialize_field("right", &self.init);
+        state.end();
     }
 }
 
-impl Serialize for AssignmentTargetProperty<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for AssignmentTargetProperty<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             AssignmentTargetProperty::AssignmentTargetPropertyIdentifier(it) => {
                 it.serialize(serializer)
@@ -690,86 +691,86 @@ impl Serialize for AssignmentTargetProperty<'_> {
     }
 }
 
-impl Serialize for AssignmentTargetPropertyIdentifier<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Property")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("method", &crate::serialize::False(self))?;
-        map.serialize_entry("shorthand", &crate::serialize::True(self))?;
-        map.serialize_entry("computed", &crate::serialize::False(self))?;
-        map.serialize_entry("key", &self.binding)?;
-        map.serialize_entry("kind", &crate::serialize::Init(self))?;
-        map.serialize_entry(
+impl ESTree for AssignmentTargetPropertyIdentifier<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "Property");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("method", &crate::serialize::False(self));
+        state.serialize_field("shorthand", &crate::serialize::True(self));
+        state.serialize_field("computed", &crate::serialize::False(self));
+        state.serialize_field("key", &self.binding);
+        state.serialize_field("kind", &crate::serialize::Init(self));
+        state.serialize_field(
             "value",
             &crate::serialize::AssignmentTargetPropertyIdentifierValue(self),
-        )?;
-        map.end()
+        );
+        state.end();
     }
 }
 
-impl Serialize for AssignmentTargetPropertyProperty<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Property")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("method", &crate::serialize::False(self))?;
-        map.serialize_entry("shorthand", &crate::serialize::False(self))?;
-        map.serialize_entry("computed", &self.computed)?;
-        map.serialize_entry("key", &self.name)?;
-        map.serialize_entry("value", &self.binding)?;
-        map.serialize_entry("kind", &crate::serialize::Init(self))?;
-        map.end()
+impl ESTree for AssignmentTargetPropertyProperty<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "Property");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("method", &crate::serialize::False(self));
+        state.serialize_field("shorthand", &crate::serialize::False(self));
+        state.serialize_field("computed", &self.computed);
+        state.serialize_field("key", &self.name);
+        state.serialize_field("value", &self.binding);
+        state.serialize_field("kind", &crate::serialize::Init(self));
+        state.end();
     }
 }
 
-impl Serialize for SequenceExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "SequenceExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("expressions", &self.expressions)?;
-        map.end()
+impl ESTree for SequenceExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "SequenceExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("expressions", &self.expressions);
+        state.end();
     }
 }
 
-impl Serialize for Super {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Super")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.end()
+impl ESTree for Super {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "Super");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.end();
     }
 }
 
-impl Serialize for AwaitExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "AwaitExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("argument", &self.argument)?;
-        map.end()
+impl ESTree for AwaitExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "AwaitExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("argument", &self.argument);
+        state.end();
     }
 }
 
-impl Serialize for ChainExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ChainExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("expression", &self.expression)?;
-        map.end()
+impl ESTree for ChainExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ChainExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("expression", &self.expression);
+        state.end();
     }
 }
 
-impl Serialize for ChainElement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for ChainElement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             ChainElement::CallExpression(it) => it.serialize(serializer),
             ChainElement::TSNonNullExpression(it) => it.serialize(serializer),
@@ -780,19 +781,19 @@ impl Serialize for ChainElement<'_> {
     }
 }
 
-impl Serialize for ParenthesizedExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ParenthesizedExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("expression", &self.expression)?;
-        map.end()
+impl ESTree for ParenthesizedExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ParenthesizedExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("expression", &self.expression);
+        state.end();
     }
 }
 
-impl Serialize for Statement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for Statement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             Statement::BlockStatement(it) => it.serialize(serializer),
             Statement::BreakStatement(it) => it.serialize(serializer),
@@ -830,42 +831,42 @@ impl Serialize for Statement<'_> {
     }
 }
 
-impl Serialize for Directive<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ExpressionStatement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("expression", &self.expression)?;
-        map.serialize_entry("directive", &self.directive)?;
-        map.end()
+impl ESTree for Directive<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ExpressionStatement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("expression", &self.expression);
+        state.serialize_field("directive", &self.directive);
+        state.end();
     }
 }
 
-impl Serialize for Hashbang<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Hashbang")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("value", &self.value)?;
-        map.end()
+impl ESTree for Hashbang<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "Hashbang");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("value", &self.value);
+        state.end();
     }
 }
 
-impl Serialize for BlockStatement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "BlockStatement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("body", &self.body)?;
-        map.end()
+impl ESTree for BlockStatement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "BlockStatement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("body", &self.body);
+        state.end();
     }
 }
 
-impl Serialize for Declaration<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for Declaration<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             Declaration::VariableDeclaration(it) => it.serialize(serializer),
             Declaration::FunctionDeclaration(it) => it.serialize(serializer),
@@ -879,128 +880,118 @@ impl Serialize for Declaration<'_> {
     }
 }
 
-impl Serialize for VariableDeclaration<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "VariableDeclaration")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("declarations", &self.declarations)?;
-        map.serialize_entry("kind", &self.kind)?;
-        map.serialize_entry("declare", &self.declare)?;
-        map.end()
+impl ESTree for VariableDeclaration<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "VariableDeclaration");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("declarations", &self.declarations);
+        state.serialize_field("kind", &self.kind);
+        state.serialize_field("declare", &self.declare);
+        state.end();
     }
 }
 
-impl Serialize for VariableDeclarationKind {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for VariableDeclarationKind {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            VariableDeclarationKind::Var => {
-                serializer.serialize_unit_variant("VariableDeclarationKind", 0, "var")
-            }
-            VariableDeclarationKind::Const => {
-                serializer.serialize_unit_variant("VariableDeclarationKind", 1, "const")
-            }
-            VariableDeclarationKind::Let => {
-                serializer.serialize_unit_variant("VariableDeclarationKind", 2, "let")
-            }
-            VariableDeclarationKind::Using => {
-                serializer.serialize_unit_variant("VariableDeclarationKind", 3, "using")
-            }
-            VariableDeclarationKind::AwaitUsing => {
-                serializer.serialize_unit_variant("VariableDeclarationKind", 4, "await using")
-            }
+            VariableDeclarationKind::Var => "var".serialize(serializer),
+            VariableDeclarationKind::Const => "const".serialize(serializer),
+            VariableDeclarationKind::Let => "let".serialize(serializer),
+            VariableDeclarationKind::Using => "using".serialize(serializer),
+            VariableDeclarationKind::AwaitUsing => "await using".serialize(serializer),
         }
     }
 }
 
-impl Serialize for VariableDeclarator<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "VariableDeclarator")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("id", &self.id)?;
-        map.serialize_entry("init", &self.init)?;
-        map.serialize_entry("definite", &self.definite)?;
-        map.end()
+impl ESTree for VariableDeclarator<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "VariableDeclarator");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("id", &self.id);
+        state.serialize_field("init", &self.init);
+        state.serialize_field("definite", &self.definite);
+        state.end();
     }
 }
 
-impl Serialize for EmptyStatement {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "EmptyStatement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.end()
+impl ESTree for EmptyStatement {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "EmptyStatement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.end();
     }
 }
 
-impl Serialize for ExpressionStatement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ExpressionStatement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("expression", &self.expression)?;
-        map.end()
+impl ESTree for ExpressionStatement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ExpressionStatement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("expression", &self.expression);
+        state.end();
     }
 }
 
-impl Serialize for IfStatement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "IfStatement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("test", &self.test)?;
-        map.serialize_entry("consequent", &self.consequent)?;
-        map.serialize_entry("alternate", &self.alternate)?;
-        map.end()
+impl ESTree for IfStatement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "IfStatement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("test", &self.test);
+        state.serialize_field("consequent", &self.consequent);
+        state.serialize_field("alternate", &self.alternate);
+        state.end();
     }
 }
 
-impl Serialize for DoWhileStatement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "DoWhileStatement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("body", &self.body)?;
-        map.serialize_entry("test", &self.test)?;
-        map.end()
+impl ESTree for DoWhileStatement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "DoWhileStatement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("body", &self.body);
+        state.serialize_field("test", &self.test);
+        state.end();
     }
 }
 
-impl Serialize for WhileStatement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "WhileStatement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("test", &self.test)?;
-        map.serialize_entry("body", &self.body)?;
-        map.end()
+impl ESTree for WhileStatement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "WhileStatement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("test", &self.test);
+        state.serialize_field("body", &self.body);
+        state.end();
     }
 }
 
-impl Serialize for ForStatement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ForStatement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("init", &self.init)?;
-        map.serialize_entry("test", &self.test)?;
-        map.serialize_entry("update", &self.update)?;
-        map.serialize_entry("body", &self.body)?;
-        map.end()
+impl ESTree for ForStatement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ForStatement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("init", &self.init);
+        state.serialize_field("test", &self.test);
+        state.serialize_field("update", &self.update);
+        state.serialize_field("body", &self.body);
+        state.end();
     }
 }
 
-impl Serialize for ForStatementInit<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for ForStatementInit<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             ForStatementInit::VariableDeclaration(it) => it.serialize(serializer),
             ForStatementInit::BooleanLiteral(it) => it.serialize(serializer),
@@ -1049,21 +1040,21 @@ impl Serialize for ForStatementInit<'_> {
     }
 }
 
-impl Serialize for ForInStatement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ForInStatement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("left", &self.left)?;
-        map.serialize_entry("right", &self.right)?;
-        map.serialize_entry("body", &self.body)?;
-        map.end()
+impl ESTree for ForInStatement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ForInStatement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("left", &self.left);
+        state.serialize_field("right", &self.right);
+        state.serialize_field("body", &self.body);
+        state.end();
     }
 }
 
-impl Serialize for ForStatementLeft<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for ForStatementLeft<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             ForStatementLeft::VariableDeclaration(it) => it.serialize(serializer),
             ForStatementLeft::AssignmentTargetIdentifier(it) => it.serialize(serializer),
@@ -1081,169 +1072,169 @@ impl Serialize for ForStatementLeft<'_> {
     }
 }
 
-impl Serialize for ForOfStatement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ForOfStatement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("await", &self.r#await)?;
-        map.serialize_entry("left", &self.left)?;
-        map.serialize_entry("right", &self.right)?;
-        map.serialize_entry("body", &self.body)?;
-        map.end()
+impl ESTree for ForOfStatement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ForOfStatement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("await", &self.r#await);
+        state.serialize_field("left", &self.left);
+        state.serialize_field("right", &self.right);
+        state.serialize_field("body", &self.body);
+        state.end();
     }
 }
 
-impl Serialize for ContinueStatement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ContinueStatement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("label", &self.label)?;
-        map.end()
+impl ESTree for ContinueStatement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ContinueStatement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("label", &self.label);
+        state.end();
     }
 }
 
-impl Serialize for BreakStatement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "BreakStatement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("label", &self.label)?;
-        map.end()
+impl ESTree for BreakStatement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "BreakStatement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("label", &self.label);
+        state.end();
     }
 }
 
-impl Serialize for ReturnStatement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ReturnStatement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("argument", &self.argument)?;
-        map.end()
+impl ESTree for ReturnStatement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ReturnStatement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("argument", &self.argument);
+        state.end();
     }
 }
 
-impl Serialize for WithStatement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "WithStatement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("object", &self.object)?;
-        map.serialize_entry("body", &self.body)?;
-        map.end()
+impl ESTree for WithStatement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "WithStatement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("object", &self.object);
+        state.serialize_field("body", &self.body);
+        state.end();
     }
 }
 
-impl Serialize for SwitchStatement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "SwitchStatement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("discriminant", &self.discriminant)?;
-        map.serialize_entry("cases", &self.cases)?;
-        map.end()
+impl ESTree for SwitchStatement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "SwitchStatement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("discriminant", &self.discriminant);
+        state.serialize_field("cases", &self.cases);
+        state.end();
     }
 }
 
-impl Serialize for SwitchCase<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "SwitchCase")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("consequent", &self.consequent)?;
-        map.serialize_entry("test", &self.test)?;
-        map.end()
+impl ESTree for SwitchCase<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "SwitchCase");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("consequent", &self.consequent);
+        state.serialize_field("test", &self.test);
+        state.end();
     }
 }
 
-impl Serialize for LabeledStatement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "LabeledStatement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("body", &self.body)?;
-        map.serialize_entry("label", &self.label)?;
-        map.end()
+impl ESTree for LabeledStatement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "LabeledStatement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("body", &self.body);
+        state.serialize_field("label", &self.label);
+        state.end();
     }
 }
 
-impl Serialize for ThrowStatement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ThrowStatement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("argument", &self.argument)?;
-        map.end()
+impl ESTree for ThrowStatement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ThrowStatement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("argument", &self.argument);
+        state.end();
     }
 }
 
-impl Serialize for TryStatement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TryStatement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("block", &self.block)?;
-        map.serialize_entry("handler", &self.handler)?;
-        map.serialize_entry("finalizer", &self.finalizer)?;
-        map.end()
+impl ESTree for TryStatement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TryStatement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("block", &self.block);
+        state.serialize_field("handler", &self.handler);
+        state.serialize_field("finalizer", &self.finalizer);
+        state.end();
     }
 }
 
-impl Serialize for CatchClause<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "CatchClause")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("param", &self.param)?;
-        map.serialize_entry("body", &self.body)?;
-        map.end()
+impl ESTree for CatchClause<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "CatchClause");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("param", &self.param);
+        state.serialize_field("body", &self.body);
+        state.end();
     }
 }
 
-impl Serialize for CatchParameter<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        self.pattern.kind.serialize(FlatMapSerializer(&mut map))?;
-        map.serialize_entry("typeAnnotation", &self.pattern.type_annotation)?;
-        map.serialize_entry("optional", &self.pattern.optional)?;
-        map.end()
+impl ESTree for CatchParameter<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        self.pattern.kind.serialize(FlatStructSerializer(&mut state));
+        state.serialize_field("typeAnnotation", &self.pattern.type_annotation);
+        state.serialize_field("optional", &self.pattern.optional);
+        state.end();
     }
 }
 
-impl Serialize for DebuggerStatement {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "DebuggerStatement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.end()
+impl ESTree for DebuggerStatement {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "DebuggerStatement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.end();
     }
 }
 
-impl Serialize for BindingPattern<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        self.kind.serialize(FlatMapSerializer(&mut map))?;
-        map.serialize_entry("typeAnnotation", &self.type_annotation)?;
-        map.serialize_entry("optional", &self.optional)?;
-        map.end()
+impl ESTree for BindingPattern<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        self.kind.serialize(FlatStructSerializer(&mut state));
+        state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.serialize_field("optional", &self.optional);
+        state.end();
     }
 }
 
-impl Serialize for BindingPatternKind<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for BindingPatternKind<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             BindingPatternKind::BindingIdentifier(it) => it.serialize(serializer),
             BindingPatternKind::ObjectPattern(it) => it.serialize(serializer),
@@ -1253,219 +1244,201 @@ impl Serialize for BindingPatternKind<'_> {
     }
 }
 
-impl Serialize for AssignmentPattern<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "AssignmentPattern")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("left", &self.left)?;
-        map.serialize_entry("right", &self.right)?;
-        map.end()
+impl ESTree for AssignmentPattern<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "AssignmentPattern");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("left", &self.left);
+        state.serialize_field("right", &self.right);
+        state.end();
     }
 }
 
-impl Serialize for ObjectPattern<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ObjectPattern")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry(
+impl ESTree for ObjectPattern<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ObjectPattern");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field(
             "properties",
             &AppendTo { array: &self.properties, after: &self.rest },
-        )?;
-        map.end()
+        );
+        state.end();
     }
 }
 
-impl Serialize for ArrayPattern<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ArrayPattern")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("elements", &AppendTo { array: &self.elements, after: &self.rest })?;
-        map.end()
+impl ESTree for ArrayPattern<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ArrayPattern");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("elements", &AppendTo { array: &self.elements, after: &self.rest });
+        state.end();
     }
 }
 
-impl Serialize for BindingRestElement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "RestElement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("argument", &self.argument)?;
-        map.end()
+impl ESTree for BindingRestElement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "RestElement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("argument", &self.argument);
+        state.end();
     }
 }
 
-impl Serialize for Function<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", &self.r#type)?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("id", &self.id)?;
-        map.serialize_entry("expression", &crate::serialize::False(self))?;
-        map.serialize_entry("generator", &self.generator)?;
-        map.serialize_entry("async", &self.r#async)?;
-        map.serialize_entry("params", &self.params)?;
-        map.serialize_entry("body", &self.body)?;
-        map.serialize_entry("declare", &self.declare)?;
-        map.serialize_entry("typeParameters", &self.type_parameters)?;
-        map.serialize_entry("thisParam", &self.this_param)?;
-        map.serialize_entry("returnType", &self.return_type)?;
-        map.end()
+impl ESTree for Function<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", &self.r#type);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("id", &self.id);
+        state.serialize_field("expression", &crate::serialize::False(self));
+        state.serialize_field("generator", &self.generator);
+        state.serialize_field("async", &self.r#async);
+        state.serialize_field("params", &self.params);
+        state.serialize_field("body", &self.body);
+        state.serialize_field("declare", &self.declare);
+        state.serialize_field("typeParameters", &self.type_parameters);
+        state.serialize_field("thisParam", &self.this_param);
+        state.serialize_field("returnType", &self.return_type);
+        state.end();
     }
 }
 
-impl Serialize for FunctionType {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for FunctionType {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            FunctionType::FunctionDeclaration => {
-                serializer.serialize_unit_variant("FunctionType", 0, "FunctionDeclaration")
+            FunctionType::FunctionDeclaration => "FunctionDeclaration".serialize(serializer),
+            FunctionType::FunctionExpression => "FunctionExpression".serialize(serializer),
+            FunctionType::TSDeclareFunction => "TSDeclareFunction".serialize(serializer),
+            FunctionType::TSEmptyBodyFunctionExpression => {
+                "TSEmptyBodyFunctionExpression".serialize(serializer)
             }
-            FunctionType::FunctionExpression => {
-                serializer.serialize_unit_variant("FunctionType", 1, "FunctionExpression")
-            }
-            FunctionType::TSDeclareFunction => {
-                serializer.serialize_unit_variant("FunctionType", 2, "TSDeclareFunction")
-            }
-            FunctionType::TSEmptyBodyFunctionExpression => serializer.serialize_unit_variant(
-                "FunctionType",
-                3,
-                "TSEmptyBodyFunctionExpression",
-            ),
         }
     }
 }
 
-impl Serialize for FormalParameter<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        self.pattern.kind.serialize(FlatMapSerializer(&mut map))?;
-        map.serialize_entry("typeAnnotation", &self.pattern.type_annotation)?;
-        map.serialize_entry("optional", &self.pattern.optional)?;
-        map.serialize_entry("decorators", &self.decorators)?;
-        map.serialize_entry("accessibility", &self.accessibility)?;
-        map.serialize_entry("readonly", &self.readonly)?;
-        map.serialize_entry("override", &self.r#override)?;
-        map.end()
+impl ESTree for FormalParameter<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        self.pattern.kind.serialize(FlatStructSerializer(&mut state));
+        state.serialize_field("typeAnnotation", &self.pattern.type_annotation);
+        state.serialize_field("optional", &self.pattern.optional);
+        state.serialize_field("decorators", &self.decorators);
+        state.serialize_field("accessibility", &self.accessibility);
+        state.serialize_field("readonly", &self.readonly);
+        state.serialize_field("override", &self.r#override);
+        state.end();
     }
 }
 
-impl Serialize for FormalParameterKind {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for FormalParameterKind {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            FormalParameterKind::FormalParameter => {
-                serializer.serialize_unit_variant("FormalParameterKind", 0, "FormalParameter")
+            FormalParameterKind::FormalParameter => "FormalParameter".serialize(serializer),
+            FormalParameterKind::UniqueFormalParameters => {
+                "UniqueFormalParameters".serialize(serializer)
             }
-            FormalParameterKind::UniqueFormalParameters => serializer.serialize_unit_variant(
-                "FormalParameterKind",
-                1,
-                "UniqueFormalParameters",
-            ),
             FormalParameterKind::ArrowFormalParameters => {
-                serializer.serialize_unit_variant("FormalParameterKind", 2, "ArrowFormalParameters")
+                "ArrowFormalParameters".serialize(serializer)
             }
-            FormalParameterKind::Signature => {
-                serializer.serialize_unit_variant("FormalParameterKind", 3, "Signature")
-            }
+            FormalParameterKind::Signature => "Signature".serialize(serializer),
         }
     }
 }
 
-impl Serialize for FunctionBody<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "BlockStatement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry(
+impl ESTree for FunctionBody<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "BlockStatement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field(
             "body",
             &AppendToConcat { array: &self.directives, after: &self.statements },
-        )?;
-        map.end()
+        );
+        state.end();
     }
 }
 
-impl Serialize for ArrowFunctionExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ArrowFunctionExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("id", &crate::serialize::Null(self))?;
-        map.serialize_entry("expression", &self.expression)?;
-        map.serialize_entry("generator", &crate::serialize::False(self))?;
-        map.serialize_entry("async", &self.r#async)?;
-        map.serialize_entry("params", &self.params)?;
-        map.serialize_entry("body", &crate::serialize::ArrowFunctionExpressionBody(self))?;
-        map.serialize_entry("typeParameters", &self.type_parameters)?;
-        map.serialize_entry("returnType", &self.return_type)?;
-        map.end()
+impl ESTree for ArrowFunctionExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ArrowFunctionExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("id", &crate::serialize::Null(self));
+        state.serialize_field("expression", &self.expression);
+        state.serialize_field("generator", &crate::serialize::False(self));
+        state.serialize_field("async", &self.r#async);
+        state.serialize_field("params", &self.params);
+        state.serialize_field("body", &crate::serialize::ArrowFunctionExpressionBody(self));
+        state.serialize_field("typeParameters", &self.type_parameters);
+        state.serialize_field("returnType", &self.return_type);
+        state.end();
     }
 }
 
-impl Serialize for YieldExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "YieldExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("delegate", &self.delegate)?;
-        map.serialize_entry("argument", &self.argument)?;
-        map.end()
+impl ESTree for YieldExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "YieldExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("delegate", &self.delegate);
+        state.serialize_field("argument", &self.argument);
+        state.end();
     }
 }
 
-impl Serialize for Class<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", &self.r#type)?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("id", &self.id)?;
-        map.serialize_entry("superClass", &self.super_class)?;
-        map.serialize_entry("body", &self.body)?;
-        map.serialize_entry("decorators", &self.decorators)?;
-        map.serialize_entry("typeParameters", &self.type_parameters)?;
-        map.serialize_entry("superTypeParameters", &self.super_type_parameters)?;
-        map.serialize_entry("implements", &self.implements)?;
-        map.serialize_entry("abstract", &self.r#abstract)?;
-        map.serialize_entry("declare", &self.declare)?;
-        map.end()
+impl ESTree for Class<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", &self.r#type);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("id", &self.id);
+        state.serialize_field("superClass", &self.super_class);
+        state.serialize_field("body", &self.body);
+        state.serialize_field("decorators", &self.decorators);
+        state.serialize_field("typeParameters", &self.type_parameters);
+        state.serialize_field("superTypeParameters", &self.super_type_parameters);
+        state.serialize_field("implements", &self.implements);
+        state.serialize_field("abstract", &self.r#abstract);
+        state.serialize_field("declare", &self.declare);
+        state.end();
     }
 }
 
-impl Serialize for ClassType {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for ClassType {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            ClassType::ClassDeclaration => {
-                serializer.serialize_unit_variant("ClassType", 0, "ClassDeclaration")
-            }
-            ClassType::ClassExpression => {
-                serializer.serialize_unit_variant("ClassType", 1, "ClassExpression")
-            }
+            ClassType::ClassDeclaration => "ClassDeclaration".serialize(serializer),
+            ClassType::ClassExpression => "ClassExpression".serialize(serializer),
         }
     }
 }
 
-impl Serialize for ClassBody<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ClassBody")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("body", &self.body)?;
-        map.end()
+impl ESTree for ClassBody<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ClassBody");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("body", &self.body);
+        state.end();
     }
 }
 
-impl Serialize for ClassElement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for ClassElement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             ClassElement::StaticBlock(it) => it.serialize(serializer),
             ClassElement::MethodDefinition(it) => it.serialize(serializer),
@@ -1476,121 +1449,106 @@ impl Serialize for ClassElement<'_> {
     }
 }
 
-impl Serialize for MethodDefinition<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", &self.r#type)?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("static", &self.r#static)?;
-        map.serialize_entry("computed", &self.computed)?;
-        map.serialize_entry("key", &self.key)?;
-        map.serialize_entry("kind", &self.kind)?;
-        map.serialize_entry("value", &self.value)?;
-        map.serialize_entry("decorators", &self.decorators)?;
-        map.serialize_entry("override", &self.r#override)?;
-        map.serialize_entry("optional", &self.optional)?;
-        map.serialize_entry("accessibility", &self.accessibility)?;
-        map.end()
+impl ESTree for MethodDefinition<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", &self.r#type);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("static", &self.r#static);
+        state.serialize_field("computed", &self.computed);
+        state.serialize_field("key", &self.key);
+        state.serialize_field("kind", &self.kind);
+        state.serialize_field("value", &self.value);
+        state.serialize_field("decorators", &self.decorators);
+        state.serialize_field("override", &self.r#override);
+        state.serialize_field("optional", &self.optional);
+        state.serialize_field("accessibility", &self.accessibility);
+        state.end();
     }
 }
 
-impl Serialize for MethodDefinitionType {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for MethodDefinitionType {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            MethodDefinitionType::MethodDefinition => {
-                serializer.serialize_unit_variant("MethodDefinitionType", 0, "MethodDefinition")
+            MethodDefinitionType::MethodDefinition => "MethodDefinition".serialize(serializer),
+            MethodDefinitionType::TSAbstractMethodDefinition => {
+                "TSAbstractMethodDefinition".serialize(serializer)
             }
-            MethodDefinitionType::TSAbstractMethodDefinition => serializer.serialize_unit_variant(
-                "MethodDefinitionType",
-                1,
-                "TSAbstractMethodDefinition",
-            ),
         }
     }
 }
 
-impl Serialize for PropertyDefinition<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", &self.r#type)?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("static", &self.r#static)?;
-        map.serialize_entry("computed", &self.computed)?;
-        map.serialize_entry("key", &self.key)?;
-        map.serialize_entry("value", &self.value)?;
-        map.serialize_entry("decorators", &self.decorators)?;
-        map.serialize_entry("declare", &self.declare)?;
-        map.serialize_entry("override", &self.r#override)?;
-        map.serialize_entry("optional", &self.optional)?;
-        map.serialize_entry("definite", &self.definite)?;
-        map.serialize_entry("readonly", &self.readonly)?;
-        map.serialize_entry("typeAnnotation", &self.type_annotation)?;
-        map.serialize_entry("accessibility", &self.accessibility)?;
-        map.end()
+impl ESTree for PropertyDefinition<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", &self.r#type);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("static", &self.r#static);
+        state.serialize_field("computed", &self.computed);
+        state.serialize_field("key", &self.key);
+        state.serialize_field("value", &self.value);
+        state.serialize_field("decorators", &self.decorators);
+        state.serialize_field("declare", &self.declare);
+        state.serialize_field("override", &self.r#override);
+        state.serialize_field("optional", &self.optional);
+        state.serialize_field("definite", &self.definite);
+        state.serialize_field("readonly", &self.readonly);
+        state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.serialize_field("accessibility", &self.accessibility);
+        state.end();
     }
 }
 
-impl Serialize for PropertyDefinitionType {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for PropertyDefinitionType {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             PropertyDefinitionType::PropertyDefinition => {
-                serializer.serialize_unit_variant("PropertyDefinitionType", 0, "PropertyDefinition")
+                "PropertyDefinition".serialize(serializer)
             }
-            PropertyDefinitionType::TSAbstractPropertyDefinition => serializer
-                .serialize_unit_variant(
-                    "PropertyDefinitionType",
-                    1,
-                    "TSAbstractPropertyDefinition",
-                ),
+            PropertyDefinitionType::TSAbstractPropertyDefinition => {
+                "TSAbstractPropertyDefinition".serialize(serializer)
+            }
         }
     }
 }
 
-impl Serialize for MethodDefinitionKind {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for MethodDefinitionKind {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            MethodDefinitionKind::Constructor => {
-                serializer.serialize_unit_variant("MethodDefinitionKind", 0, "constructor")
-            }
-            MethodDefinitionKind::Method => {
-                serializer.serialize_unit_variant("MethodDefinitionKind", 1, "method")
-            }
-            MethodDefinitionKind::Get => {
-                serializer.serialize_unit_variant("MethodDefinitionKind", 2, "get")
-            }
-            MethodDefinitionKind::Set => {
-                serializer.serialize_unit_variant("MethodDefinitionKind", 3, "set")
-            }
+            MethodDefinitionKind::Constructor => "constructor".serialize(serializer),
+            MethodDefinitionKind::Method => "method".serialize(serializer),
+            MethodDefinitionKind::Get => "get".serialize(serializer),
+            MethodDefinitionKind::Set => "set".serialize(serializer),
         }
     }
 }
 
-impl Serialize for PrivateIdentifier<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "PrivateIdentifier")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("name", &self.name)?;
-        map.end()
+impl ESTree for PrivateIdentifier<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "PrivateIdentifier");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("name", &self.name);
+        state.end();
     }
 }
 
-impl Serialize for StaticBlock<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "StaticBlock")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("body", &self.body)?;
-        map.end()
+impl ESTree for StaticBlock<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "StaticBlock");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("body", &self.body);
+        state.end();
     }
 }
 
-impl Serialize for ModuleDeclaration<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for ModuleDeclaration<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             ModuleDeclaration::ImportDeclaration(it) => it.serialize(serializer),
             ModuleDeclaration::ExportAllDeclaration(it) => it.serialize(serializer),
@@ -1602,77 +1560,73 @@ impl Serialize for ModuleDeclaration<'_> {
     }
 }
 
-impl Serialize for AccessorPropertyType {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for AccessorPropertyType {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            AccessorPropertyType::AccessorProperty => {
-                serializer.serialize_unit_variant("AccessorPropertyType", 0, "AccessorProperty")
+            AccessorPropertyType::AccessorProperty => "AccessorProperty".serialize(serializer),
+            AccessorPropertyType::TSAbstractAccessorProperty => {
+                "TSAbstractAccessorProperty".serialize(serializer)
             }
-            AccessorPropertyType::TSAbstractAccessorProperty => serializer.serialize_unit_variant(
-                "AccessorPropertyType",
-                1,
-                "TSAbstractAccessorProperty",
-            ),
         }
     }
 }
 
-impl Serialize for AccessorProperty<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", &self.r#type)?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("key", &self.key)?;
-        map.serialize_entry("value", &self.value)?;
-        map.serialize_entry("computed", &self.computed)?;
-        map.serialize_entry("static", &self.r#static)?;
-        map.serialize_entry("decorators", &self.decorators)?;
-        map.serialize_entry("definite", &self.definite)?;
-        map.serialize_entry("typeAnnotation", &self.type_annotation)?;
-        map.serialize_entry("accessibility", &self.accessibility)?;
-        map.end()
+impl ESTree for AccessorProperty<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", &self.r#type);
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("key", &self.key);
+        state.serialize_field("value", &self.value);
+        state.serialize_field("computed", &self.computed);
+        state.serialize_field("static", &self.r#static);
+        state.serialize_field("decorators", &self.decorators);
+        state.serialize_field("definite", &self.definite);
+        state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.serialize_field("accessibility", &self.accessibility);
+        state.end();
     }
 }
 
-impl Serialize for ImportExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ImportExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("source", &self.source)?;
-        map.serialize_entry("options", &crate::serialize::ImportExpressionArguments(self))?;
-        map.end()
+impl ESTree for ImportExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ImportExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("source", &self.source);
+        state.serialize_field("options", &crate::serialize::ImportExpressionArguments(self));
+        state.end();
     }
 }
 
-impl Serialize for ImportDeclaration<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ImportDeclaration")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("specifiers", &crate::serialize::ImportDeclarationSpecifiers(self))?;
-        map.serialize_entry("source", &self.source)?;
-        map.serialize_entry("phase", &self.phase)?;
-        map.serialize_entry("attributes", &crate::serialize::ImportDeclarationWithClause(self))?;
-        map.serialize_entry("importKind", &self.import_kind)?;
-        map.end()
+impl ESTree for ImportDeclaration<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ImportDeclaration");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("specifiers", &crate::serialize::ImportDeclarationSpecifiers(self));
+        state.serialize_field("source", &self.source);
+        state.serialize_field("phase", &self.phase);
+        state.serialize_field("attributes", &crate::serialize::ImportDeclarationWithClause(self));
+        state.serialize_field("importKind", &self.import_kind);
+        state.end();
     }
 }
 
-impl Serialize for ImportPhase {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for ImportPhase {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            ImportPhase::Source => serializer.serialize_unit_variant("ImportPhase", 0, "source"),
-            ImportPhase::Defer => serializer.serialize_unit_variant("ImportPhase", 1, "defer"),
+            ImportPhase::Source => "source".serialize(serializer),
+            ImportPhase::Defer => "defer".serialize(serializer),
         }
     }
 }
 
-impl Serialize for ImportDeclarationSpecifier<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for ImportDeclarationSpecifier<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             ImportDeclarationSpecifier::ImportSpecifier(it) => it.serialize(serializer),
             ImportDeclarationSpecifier::ImportDefaultSpecifier(it) => it.serialize(serializer),
@@ -1681,67 +1635,67 @@ impl Serialize for ImportDeclarationSpecifier<'_> {
     }
 }
 
-impl Serialize for ImportSpecifier<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ImportSpecifier")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("imported", &self.imported)?;
-        map.serialize_entry("local", &self.local)?;
-        map.serialize_entry("importKind", &self.import_kind)?;
-        map.end()
+impl ESTree for ImportSpecifier<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ImportSpecifier");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("imported", &self.imported);
+        state.serialize_field("local", &self.local);
+        state.serialize_field("importKind", &self.import_kind);
+        state.end();
     }
 }
 
-impl Serialize for ImportDefaultSpecifier<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ImportDefaultSpecifier")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("local", &self.local)?;
-        map.end()
+impl ESTree for ImportDefaultSpecifier<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ImportDefaultSpecifier");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("local", &self.local);
+        state.end();
     }
 }
 
-impl Serialize for ImportNamespaceSpecifier<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ImportNamespaceSpecifier")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("local", &self.local)?;
-        map.end()
+impl ESTree for ImportNamespaceSpecifier<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ImportNamespaceSpecifier");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("local", &self.local);
+        state.end();
     }
 }
 
-impl Serialize for WithClause<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "WithClause")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("attributesKeyword", &self.attributes_keyword)?;
-        map.serialize_entry("withEntries", &self.with_entries)?;
-        map.end()
+impl ESTree for WithClause<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "WithClause");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("attributesKeyword", &self.attributes_keyword);
+        state.serialize_field("withEntries", &self.with_entries);
+        state.end();
     }
 }
 
-impl Serialize for ImportAttribute<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ImportAttribute")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("key", &self.key)?;
-        map.serialize_entry("value", &self.value)?;
-        map.end()
+impl ESTree for ImportAttribute<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ImportAttribute");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("key", &self.key);
+        state.serialize_field("value", &self.value);
+        state.end();
     }
 }
 
-impl Serialize for ImportAttributeKey<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for ImportAttributeKey<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             ImportAttributeKey::Identifier(it) => it.serialize(serializer),
             ImportAttributeKey::StringLiteral(it) => it.serialize(serializer),
@@ -1749,65 +1703,66 @@ impl Serialize for ImportAttributeKey<'_> {
     }
 }
 
-impl Serialize for ExportNamedDeclaration<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ExportNamedDeclaration")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("declaration", &self.declaration)?;
-        map.serialize_entry("specifiers", &self.specifiers)?;
-        map.serialize_entry("source", &self.source)?;
-        map.serialize_entry("exportKind", &self.export_kind)?;
-        map.serialize_entry(
+impl ESTree for ExportNamedDeclaration<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ExportNamedDeclaration");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("declaration", &self.declaration);
+        state.serialize_field("specifiers", &self.specifiers);
+        state.serialize_field("source", &self.source);
+        state.serialize_field("exportKind", &self.export_kind);
+        state.serialize_field(
             "attributes",
             &crate::serialize::ExportNamedDeclarationWithClause(self),
-        )?;
-        map.end()
+        );
+        state.end();
     }
 }
 
-impl Serialize for ExportDefaultDeclaration<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ExportDefaultDeclaration")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("declaration", &self.declaration)?;
-        map.serialize_entry("exported", &self.exported)?;
-        map.end()
+impl ESTree for ExportDefaultDeclaration<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ExportDefaultDeclaration");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("declaration", &self.declaration);
+        state.serialize_field("exported", &self.exported);
+        state.end();
     }
 }
 
-impl Serialize for ExportAllDeclaration<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ExportAllDeclaration")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("exported", &self.exported)?;
-        map.serialize_entry("source", &self.source)?;
-        map.serialize_entry("attributes", &crate::serialize::ExportAllDeclarationWithClause(self))?;
-        map.serialize_entry("exportKind", &self.export_kind)?;
-        map.end()
+impl ESTree for ExportAllDeclaration<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ExportAllDeclaration");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("exported", &self.exported);
+        state.serialize_field("source", &self.source);
+        state
+            .serialize_field("attributes", &crate::serialize::ExportAllDeclarationWithClause(self));
+        state.serialize_field("exportKind", &self.export_kind);
+        state.end();
     }
 }
 
-impl Serialize for ExportSpecifier<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ExportSpecifier")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("local", &self.local)?;
-        map.serialize_entry("exported", &self.exported)?;
-        map.serialize_entry("exportKind", &self.export_kind)?;
-        map.end()
+impl ESTree for ExportSpecifier<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ExportSpecifier");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("local", &self.local);
+        state.serialize_field("exported", &self.exported);
+        state.serialize_field("exportKind", &self.export_kind);
+        state.end();
     }
 }
 
-impl Serialize for ExportDefaultDeclarationKind<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for ExportDefaultDeclarationKind<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             ExportDefaultDeclarationKind::FunctionDeclaration(it) => it.serialize(serializer),
             ExportDefaultDeclarationKind::ClassDeclaration(it) => it.serialize(serializer),
@@ -1858,8 +1813,8 @@ impl Serialize for ExportDefaultDeclarationKind<'_> {
     }
 }
 
-impl Serialize for ModuleExportName<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for ModuleExportName<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             ModuleExportName::IdentifierName(it) => it.serialize(serializer),
             ModuleExportName::IdentifierReference(it) => it.serialize(serializer),
@@ -1868,197 +1823,197 @@ impl Serialize for ModuleExportName<'_> {
     }
 }
 
-impl Serialize for BooleanLiteral {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Literal")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("value", &self.value)?;
-        map.serialize_entry("raw", &crate::serialize::BooleanLiteralRaw(self))?;
-        map.end()
+impl ESTree for BooleanLiteral {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "Literal");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("value", &self.value);
+        state.serialize_field("raw", &crate::serialize::BooleanLiteralRaw(self));
+        state.end();
     }
 }
 
-impl Serialize for NullLiteral {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Literal")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("value", &crate::serialize::Null(self))?;
-        map.serialize_entry("raw", &crate::serialize::NullLiteralRaw(self))?;
-        map.end()
+impl ESTree for NullLiteral {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "Literal");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("value", &crate::serialize::Null(self));
+        state.serialize_field("raw", &crate::serialize::NullLiteralRaw(self));
+        state.end();
     }
 }
 
-impl Serialize for NumericLiteral<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Literal")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("value", &self.value)?;
-        map.serialize_entry("raw", &self.raw)?;
-        map.end()
+impl ESTree for NumericLiteral<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "Literal");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("value", &self.value);
+        state.serialize_field("raw", &self.raw);
+        state.end();
     }
 }
 
-impl Serialize for StringLiteral<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Literal")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("value", &self.value)?;
-        map.serialize_entry("raw", &self.raw)?;
-        map.end()
+impl ESTree for StringLiteral<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "Literal");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("value", &self.value);
+        state.serialize_field("raw", &self.raw);
+        state.end();
     }
 }
 
-impl Serialize for BigIntLiteral<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Literal")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("value", &crate::serialize::BigIntLiteralValue(self))?;
-        map.serialize_entry("raw", &self.raw)?;
-        map.serialize_entry("bigint", &crate::serialize::BigIntLiteralBigint(self))?;
-        map.end()
+impl ESTree for BigIntLiteral<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "Literal");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("value", &crate::serialize::BigIntLiteralValue(self));
+        state.serialize_field("raw", &self.raw);
+        state.serialize_field("bigint", &crate::serialize::BigIntLiteralBigint(self));
+        state.end();
     }
 }
 
-impl Serialize for RegExpLiteral<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Literal")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("value", &crate::serialize::RegExpLiteralValue(self))?;
-        map.serialize_entry("raw", &self.raw)?;
-        map.serialize_entry("regex", &crate::serialize::RegExpLiteralRegex(self))?;
-        map.end()
+impl ESTree for RegExpLiteral<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "Literal");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("value", &crate::serialize::RegExpLiteralValue(self));
+        state.serialize_field("raw", &self.raw);
+        state.serialize_field("regex", &crate::serialize::RegExpLiteralRegex(self));
+        state.end();
     }
 }
 
-impl Serialize for RegExp<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("pattern", &self.pattern)?;
-        map.serialize_entry("flags", &self.flags)?;
-        map.end()
+impl ESTree for RegExp<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("pattern", &self.pattern);
+        state.serialize_field("flags", &self.flags);
+        state.end();
     }
 }
 
-impl Serialize for JSXElement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXElement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("openingElement", &self.opening_element)?;
-        map.serialize_entry("closingElement", &self.closing_element)?;
-        map.serialize_entry("children", &self.children)?;
-        map.end()
+impl ESTree for JSXElement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "JSXElement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("openingElement", &self.opening_element);
+        state.serialize_field("closingElement", &self.closing_element);
+        state.serialize_field("children", &self.children);
+        state.end();
     }
 }
 
-impl Serialize for JSXOpeningElement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXOpeningElement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("selfClosing", &self.self_closing)?;
-        map.serialize_entry("name", &self.name)?;
-        map.serialize_entry("attributes", &self.attributes)?;
-        map.serialize_entry("typeParameters", &self.type_parameters)?;
-        map.end()
+impl ESTree for JSXOpeningElement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "JSXOpeningElement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("selfClosing", &self.self_closing);
+        state.serialize_field("name", &self.name);
+        state.serialize_field("attributes", &self.attributes);
+        state.serialize_field("typeParameters", &self.type_parameters);
+        state.end();
     }
 }
 
-impl Serialize for JSXClosingElement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXClosingElement")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("name", &self.name)?;
-        map.end()
+impl ESTree for JSXClosingElement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "JSXClosingElement");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("name", &self.name);
+        state.end();
     }
 }
 
-impl Serialize for JSXFragment<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXFragment")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("openingFragment", &self.opening_fragment)?;
-        map.serialize_entry("closingFragment", &self.closing_fragment)?;
-        map.serialize_entry("children", &self.children)?;
-        map.end()
+impl ESTree for JSXFragment<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "JSXFragment");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("openingFragment", &self.opening_fragment);
+        state.serialize_field("closingFragment", &self.closing_fragment);
+        state.serialize_field("children", &self.children);
+        state.end();
     }
 }
 
-impl Serialize for JSXOpeningFragment {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXOpeningFragment")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.end()
+impl ESTree for JSXOpeningFragment {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "JSXOpeningFragment");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.end();
     }
 }
 
-impl Serialize for JSXClosingFragment {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXClosingFragment")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.end()
+impl ESTree for JSXClosingFragment {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "JSXClosingFragment");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.end();
     }
 }
 
-impl Serialize for JSXNamespacedName<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXNamespacedName")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("namespace", &self.namespace)?;
-        map.serialize_entry("property", &self.property)?;
-        map.end()
+impl ESTree for JSXNamespacedName<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "JSXNamespacedName");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("namespace", &self.namespace);
+        state.serialize_field("property", &self.property);
+        state.end();
     }
 }
 
-impl Serialize for JSXMemberExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXMemberExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("object", &self.object)?;
-        map.serialize_entry("property", &self.property)?;
-        map.end()
+impl ESTree for JSXMemberExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "JSXMemberExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("object", &self.object);
+        state.serialize_field("property", &self.property);
+        state.end();
     }
 }
 
-impl Serialize for JSXExpressionContainer<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXExpressionContainer")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("expression", &self.expression)?;
-        map.end()
+impl ESTree for JSXExpressionContainer<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "JSXExpressionContainer");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("expression", &self.expression);
+        state.end();
     }
 }
 
-impl Serialize for JSXExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for JSXExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             JSXExpression::EmptyExpression(it) => it.serialize(serializer),
             JSXExpression::BooleanLiteral(it) => it.serialize(serializer),
@@ -2107,18 +2062,18 @@ impl Serialize for JSXExpression<'_> {
     }
 }
 
-impl Serialize for JSXEmptyExpression {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXEmptyExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.end()
+impl ESTree for JSXEmptyExpression {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "JSXEmptyExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.end();
     }
 }
 
-impl Serialize for JSXAttributeItem<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for JSXAttributeItem<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             JSXAttributeItem::Attribute(it) => it.serialize(serializer),
             JSXAttributeItem::SpreadAttribute(it) => it.serialize(serializer),
@@ -2126,31 +2081,31 @@ impl Serialize for JSXAttributeItem<'_> {
     }
 }
 
-impl Serialize for JSXAttribute<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXAttribute")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("name", &self.name)?;
-        map.serialize_entry("value", &self.value)?;
-        map.end()
+impl ESTree for JSXAttribute<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "JSXAttribute");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("name", &self.name);
+        state.serialize_field("value", &self.value);
+        state.end();
     }
 }
 
-impl Serialize for JSXSpreadAttribute<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXSpreadAttribute")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("argument", &self.argument)?;
-        map.end()
+impl ESTree for JSXSpreadAttribute<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "JSXSpreadAttribute");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("argument", &self.argument);
+        state.end();
     }
 }
 
-impl Serialize for JSXAttributeName<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for JSXAttributeName<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             JSXAttributeName::Identifier(it) => it.serialize(serializer),
             JSXAttributeName::NamespacedName(it) => it.serialize(serializer),
@@ -2158,8 +2113,8 @@ impl Serialize for JSXAttributeName<'_> {
     }
 }
 
-impl Serialize for JSXAttributeValue<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for JSXAttributeValue<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             JSXAttributeValue::StringLiteral(it) => it.serialize(serializer),
             JSXAttributeValue::ExpressionContainer(it) => it.serialize(serializer),
@@ -2169,19 +2124,19 @@ impl Serialize for JSXAttributeValue<'_> {
     }
 }
 
-impl Serialize for JSXIdentifier<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXIdentifier")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("name", &self.name)?;
-        map.end()
+impl ESTree for JSXIdentifier<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "JSXIdentifier");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("name", &self.name);
+        state.end();
     }
 }
 
-impl Serialize for JSXChild<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for JSXChild<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             JSXChild::Text(it) => it.serialize(serializer),
             JSXChild::Element(it) => it.serialize(serializer),
@@ -2192,67 +2147,67 @@ impl Serialize for JSXChild<'_> {
     }
 }
 
-impl Serialize for JSXSpreadChild<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXSpreadChild")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("expression", &self.expression)?;
-        map.end()
+impl ESTree for JSXSpreadChild<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "JSXSpreadChild");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("expression", &self.expression);
+        state.end();
     }
 }
 
-impl Serialize for JSXText<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSXText")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("value", &self.value)?;
-        map.end()
+impl ESTree for JSXText<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "JSXText");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("value", &self.value);
+        state.end();
     }
 }
 
-impl Serialize for TSThisParameter<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSThisParameter")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("typeAnnotation", &self.type_annotation)?;
-        map.end()
+impl ESTree for TSThisParameter<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSThisParameter");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.end();
     }
 }
 
-impl Serialize for TSEnumDeclaration<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSEnumDeclaration")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("id", &self.id)?;
-        map.serialize_entry("members", &self.members)?;
-        map.serialize_entry("const", &self.r#const)?;
-        map.serialize_entry("declare", &self.declare)?;
-        map.end()
+impl ESTree for TSEnumDeclaration<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSEnumDeclaration");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("id", &self.id);
+        state.serialize_field("members", &self.members);
+        state.serialize_field("const", &self.r#const);
+        state.serialize_field("declare", &self.declare);
+        state.end();
     }
 }
 
-impl Serialize for TSEnumMember<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSEnumMember")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("id", &self.id)?;
-        map.serialize_entry("initializer", &self.initializer)?;
-        map.end()
+impl ESTree for TSEnumMember<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSEnumMember");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("id", &self.id);
+        state.serialize_field("initializer", &self.initializer);
+        state.end();
     }
 }
 
-impl Serialize for TSEnumMemberName<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for TSEnumMemberName<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             TSEnumMemberName::Identifier(it) => it.serialize(serializer),
             TSEnumMemberName::String(it) => it.serialize(serializer),
@@ -2260,30 +2215,30 @@ impl Serialize for TSEnumMemberName<'_> {
     }
 }
 
-impl Serialize for TSTypeAnnotation<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSTypeAnnotation")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("typeAnnotation", &self.type_annotation)?;
-        map.end()
+impl ESTree for TSTypeAnnotation<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSTypeAnnotation");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.end();
     }
 }
 
-impl Serialize for TSLiteralType<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSLiteralType")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("literal", &self.literal)?;
-        map.end()
+impl ESTree for TSLiteralType<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSLiteralType");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("literal", &self.literal);
+        state.end();
     }
 }
 
-impl Serialize for TSLiteral<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for TSLiteral<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             TSLiteral::BooleanLiteral(it) => it.serialize(serializer),
             TSLiteral::NumericLiteral(it) => it.serialize(serializer),
@@ -2295,8 +2250,8 @@ impl Serialize for TSLiteral<'_> {
     }
 }
 
-impl Serialize for TSType<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for TSType<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             TSType::TSAnyKeyword(it) => it.serialize(serializer),
             TSType::TSBigIntKeyword(it) => it.serialize(serializer),
@@ -2339,152 +2294,146 @@ impl Serialize for TSType<'_> {
     }
 }
 
-impl Serialize for TSConditionalType<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSConditionalType")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("checkType", &self.check_type)?;
-        map.serialize_entry("extendsType", &self.extends_type)?;
-        map.serialize_entry("trueType", &self.true_type)?;
-        map.serialize_entry("falseType", &self.false_type)?;
-        map.end()
+impl ESTree for TSConditionalType<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSConditionalType");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("checkType", &self.check_type);
+        state.serialize_field("extendsType", &self.extends_type);
+        state.serialize_field("trueType", &self.true_type);
+        state.serialize_field("falseType", &self.false_type);
+        state.end();
     }
 }
 
-impl Serialize for TSUnionType<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSUnionType")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("types", &self.types)?;
-        map.end()
+impl ESTree for TSUnionType<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSUnionType");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("types", &self.types);
+        state.end();
     }
 }
 
-impl Serialize for TSIntersectionType<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSIntersectionType")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("types", &self.types)?;
-        map.end()
+impl ESTree for TSIntersectionType<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSIntersectionType");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("types", &self.types);
+        state.end();
     }
 }
 
-impl Serialize for TSParenthesizedType<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSParenthesizedType")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("typeAnnotation", &self.type_annotation)?;
-        map.end()
+impl ESTree for TSParenthesizedType<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSParenthesizedType");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.end();
     }
 }
 
-impl Serialize for TSTypeOperator<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSTypeOperator")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("operator", &self.operator)?;
-        map.serialize_entry("typeAnnotation", &self.type_annotation)?;
-        map.end()
+impl ESTree for TSTypeOperator<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSTypeOperator");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("operator", &self.operator);
+        state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.end();
     }
 }
 
-impl Serialize for TSTypeOperatorOperator {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for TSTypeOperatorOperator {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            TSTypeOperatorOperator::Keyof => {
-                serializer.serialize_unit_variant("TSTypeOperatorOperator", 0, "keyof")
-            }
-            TSTypeOperatorOperator::Unique => {
-                serializer.serialize_unit_variant("TSTypeOperatorOperator", 1, "unique")
-            }
-            TSTypeOperatorOperator::Readonly => {
-                serializer.serialize_unit_variant("TSTypeOperatorOperator", 2, "readonly")
-            }
+            TSTypeOperatorOperator::Keyof => "keyof".serialize(serializer),
+            TSTypeOperatorOperator::Unique => "unique".serialize(serializer),
+            TSTypeOperatorOperator::Readonly => "readonly".serialize(serializer),
         }
     }
 }
 
-impl Serialize for TSArrayType<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSArrayType")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("elementType", &self.element_type)?;
-        map.end()
+impl ESTree for TSArrayType<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSArrayType");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("elementType", &self.element_type);
+        state.end();
     }
 }
 
-impl Serialize for TSIndexedAccessType<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSIndexedAccessType")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("objectType", &self.object_type)?;
-        map.serialize_entry("indexType", &self.index_type)?;
-        map.end()
+impl ESTree for TSIndexedAccessType<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSIndexedAccessType");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("objectType", &self.object_type);
+        state.serialize_field("indexType", &self.index_type);
+        state.end();
     }
 }
 
-impl Serialize for TSTupleType<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSTupleType")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("elementTypes", &self.element_types)?;
-        map.end()
+impl ESTree for TSTupleType<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSTupleType");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("elementTypes", &self.element_types);
+        state.end();
     }
 }
 
-impl Serialize for TSNamedTupleMember<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSNamedTupleMember")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("elementType", &self.element_type)?;
-        map.serialize_entry("label", &self.label)?;
-        map.serialize_entry("optional", &self.optional)?;
-        map.end()
+impl ESTree for TSNamedTupleMember<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSNamedTupleMember");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("elementType", &self.element_type);
+        state.serialize_field("label", &self.label);
+        state.serialize_field("optional", &self.optional);
+        state.end();
     }
 }
 
-impl Serialize for TSOptionalType<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSOptionalType")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("typeAnnotation", &self.type_annotation)?;
-        map.end()
+impl ESTree for TSOptionalType<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSOptionalType");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.end();
     }
 }
 
-impl Serialize for TSRestType<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSRestType")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("typeAnnotation", &self.type_annotation)?;
-        map.end()
+impl ESTree for TSRestType<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSRestType");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.end();
     }
 }
 
-impl Serialize for TSTupleElement<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for TSTupleElement<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             TSTupleElement::TSOptionalType(it) => it.serialize(serializer),
             TSTupleElement::TSRestType(it) => it.serialize(serializer),
@@ -2529,160 +2478,160 @@ impl Serialize for TSTupleElement<'_> {
     }
 }
 
-impl Serialize for TSAnyKeyword {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSAnyKeyword")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.end()
+impl ESTree for TSAnyKeyword {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSAnyKeyword");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.end();
     }
 }
 
-impl Serialize for TSStringKeyword {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSStringKeyword")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.end()
+impl ESTree for TSStringKeyword {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSStringKeyword");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.end();
     }
 }
 
-impl Serialize for TSBooleanKeyword {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSBooleanKeyword")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.end()
+impl ESTree for TSBooleanKeyword {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSBooleanKeyword");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.end();
     }
 }
 
-impl Serialize for TSNumberKeyword {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSNumberKeyword")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.end()
+impl ESTree for TSNumberKeyword {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSNumberKeyword");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.end();
     }
 }
 
-impl Serialize for TSNeverKeyword {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSNeverKeyword")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.end()
+impl ESTree for TSNeverKeyword {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSNeverKeyword");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.end();
     }
 }
 
-impl Serialize for TSIntrinsicKeyword {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSIntrinsicKeyword")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.end()
+impl ESTree for TSIntrinsicKeyword {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSIntrinsicKeyword");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.end();
     }
 }
 
-impl Serialize for TSUnknownKeyword {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSUnknownKeyword")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.end()
+impl ESTree for TSUnknownKeyword {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSUnknownKeyword");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.end();
     }
 }
 
-impl Serialize for TSNullKeyword {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSNullKeyword")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.end()
+impl ESTree for TSNullKeyword {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSNullKeyword");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.end();
     }
 }
 
-impl Serialize for TSUndefinedKeyword {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSUndefinedKeyword")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.end()
+impl ESTree for TSUndefinedKeyword {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSUndefinedKeyword");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.end();
     }
 }
 
-impl Serialize for TSVoidKeyword {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSVoidKeyword")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.end()
+impl ESTree for TSVoidKeyword {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSVoidKeyword");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.end();
     }
 }
 
-impl Serialize for TSSymbolKeyword {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSSymbolKeyword")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.end()
+impl ESTree for TSSymbolKeyword {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSSymbolKeyword");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.end();
     }
 }
 
-impl Serialize for TSThisType {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSThisType")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.end()
+impl ESTree for TSThisType {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSThisType");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.end();
     }
 }
 
-impl Serialize for TSObjectKeyword {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSObjectKeyword")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.end()
+impl ESTree for TSObjectKeyword {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSObjectKeyword");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.end();
     }
 }
 
-impl Serialize for TSBigIntKeyword {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSBigIntKeyword")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.end()
+impl ESTree for TSBigIntKeyword {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSBigIntKeyword");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.end();
     }
 }
 
-impl Serialize for TSTypeReference<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSTypeReference")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("typeName", &self.type_name)?;
-        map.serialize_entry("typeParameters", &self.type_parameters)?;
-        map.end()
+impl ESTree for TSTypeReference<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSTypeReference");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("typeName", &self.type_name);
+        state.serialize_field("typeParameters", &self.type_parameters);
+        state.end();
     }
 }
 
-impl Serialize for TSTypeName<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for TSTypeName<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             TSTypeName::IdentifierReference(it) => it.serialize(serializer),
             TSTypeName::QualifiedName(it) => it.serialize(serializer),
@@ -2690,141 +2639,135 @@ impl Serialize for TSTypeName<'_> {
     }
 }
 
-impl Serialize for TSQualifiedName<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSQualifiedName")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("left", &self.left)?;
-        map.serialize_entry("right", &self.right)?;
-        map.end()
+impl ESTree for TSQualifiedName<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSQualifiedName");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("left", &self.left);
+        state.serialize_field("right", &self.right);
+        state.end();
     }
 }
 
-impl Serialize for TSTypeParameterInstantiation<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSTypeParameterInstantiation")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("params", &self.params)?;
-        map.end()
+impl ESTree for TSTypeParameterInstantiation<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSTypeParameterInstantiation");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("params", &self.params);
+        state.end();
     }
 }
 
-impl Serialize for TSTypeParameter<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSTypeParameter")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("name", &self.name)?;
-        map.serialize_entry("constraint", &self.constraint)?;
-        map.serialize_entry("default", &self.default)?;
-        map.serialize_entry("in", &self.r#in)?;
-        map.serialize_entry("out", &self.out)?;
-        map.serialize_entry("const", &self.r#const)?;
-        map.end()
+impl ESTree for TSTypeParameter<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSTypeParameter");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("name", &self.name);
+        state.serialize_field("constraint", &self.constraint);
+        state.serialize_field("default", &self.default);
+        state.serialize_field("in", &self.r#in);
+        state.serialize_field("out", &self.out);
+        state.serialize_field("const", &self.r#const);
+        state.end();
     }
 }
 
-impl Serialize for TSTypeParameterDeclaration<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSTypeParameterDeclaration")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("params", &self.params)?;
-        map.end()
+impl ESTree for TSTypeParameterDeclaration<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSTypeParameterDeclaration");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("params", &self.params);
+        state.end();
     }
 }
 
-impl Serialize for TSTypeAliasDeclaration<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSTypeAliasDeclaration")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("id", &self.id)?;
-        map.serialize_entry("typeParameters", &self.type_parameters)?;
-        map.serialize_entry("typeAnnotation", &self.type_annotation)?;
-        map.serialize_entry("declare", &self.declare)?;
-        map.end()
+impl ESTree for TSTypeAliasDeclaration<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSTypeAliasDeclaration");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("id", &self.id);
+        state.serialize_field("typeParameters", &self.type_parameters);
+        state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.serialize_field("declare", &self.declare);
+        state.end();
     }
 }
 
-impl Serialize for TSAccessibility {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for TSAccessibility {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            TSAccessibility::Private => {
-                serializer.serialize_unit_variant("TSAccessibility", 0, "private")
-            }
-            TSAccessibility::Protected => {
-                serializer.serialize_unit_variant("TSAccessibility", 1, "protected")
-            }
-            TSAccessibility::Public => {
-                serializer.serialize_unit_variant("TSAccessibility", 2, "public")
-            }
+            TSAccessibility::Private => "private".serialize(serializer),
+            TSAccessibility::Protected => "protected".serialize(serializer),
+            TSAccessibility::Public => "public".serialize(serializer),
         }
     }
 }
 
-impl Serialize for TSClassImplements<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSClassImplements")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("expression", &self.expression)?;
-        map.serialize_entry("typeParameters", &self.type_parameters)?;
-        map.end()
+impl ESTree for TSClassImplements<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSClassImplements");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("expression", &self.expression);
+        state.serialize_field("typeParameters", &self.type_parameters);
+        state.end();
     }
 }
 
-impl Serialize for TSInterfaceDeclaration<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSInterfaceDeclaration")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("id", &self.id)?;
-        map.serialize_entry("extends", &self.extends)?;
-        map.serialize_entry("typeParameters", &self.type_parameters)?;
-        map.serialize_entry("body", &self.body)?;
-        map.serialize_entry("declare", &self.declare)?;
-        map.end()
+impl ESTree for TSInterfaceDeclaration<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSInterfaceDeclaration");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("id", &self.id);
+        state.serialize_field("extends", &self.extends);
+        state.serialize_field("typeParameters", &self.type_parameters);
+        state.serialize_field("body", &self.body);
+        state.serialize_field("declare", &self.declare);
+        state.end();
     }
 }
 
-impl Serialize for TSInterfaceBody<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSInterfaceBody")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("body", &self.body)?;
-        map.end()
+impl ESTree for TSInterfaceBody<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSInterfaceBody");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("body", &self.body);
+        state.end();
     }
 }
 
-impl Serialize for TSPropertySignature<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSPropertySignature")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("computed", &self.computed)?;
-        map.serialize_entry("optional", &self.optional)?;
-        map.serialize_entry("readonly", &self.readonly)?;
-        map.serialize_entry("key", &self.key)?;
-        map.serialize_entry("typeAnnotation", &self.type_annotation)?;
-        map.end()
+impl ESTree for TSPropertySignature<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSPropertySignature");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("computed", &self.computed);
+        state.serialize_field("optional", &self.optional);
+        state.serialize_field("readonly", &self.readonly);
+        state.serialize_field("key", &self.key);
+        state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.end();
     }
 }
 
-impl Serialize for TSSignature<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for TSSignature<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             TSSignature::TSIndexSignature(it) => it.serialize(serializer),
             TSSignature::TSPropertySignature(it) => it.serialize(serializer),
@@ -2835,120 +2778,114 @@ impl Serialize for TSSignature<'_> {
     }
 }
 
-impl Serialize for TSIndexSignature<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSIndexSignature")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("parameters", &self.parameters)?;
-        map.serialize_entry("typeAnnotation", &self.type_annotation)?;
-        map.serialize_entry("readonly", &self.readonly)?;
-        map.serialize_entry("static", &self.r#static)?;
-        map.end()
+impl ESTree for TSIndexSignature<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSIndexSignature");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("parameters", &self.parameters);
+        state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.serialize_field("readonly", &self.readonly);
+        state.serialize_field("static", &self.r#static);
+        state.end();
     }
 }
 
-impl Serialize for TSCallSignatureDeclaration<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSCallSignatureDeclaration")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("typeParameters", &self.type_parameters)?;
-        map.serialize_entry("thisParam", &self.this_param)?;
-        map.serialize_entry("params", &self.params)?;
-        map.serialize_entry("returnType", &self.return_type)?;
-        map.end()
+impl ESTree for TSCallSignatureDeclaration<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSCallSignatureDeclaration");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("typeParameters", &self.type_parameters);
+        state.serialize_field("thisParam", &self.this_param);
+        state.serialize_field("params", &self.params);
+        state.serialize_field("returnType", &self.return_type);
+        state.end();
     }
 }
 
-impl Serialize for TSMethodSignatureKind {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for TSMethodSignatureKind {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            TSMethodSignatureKind::Method => {
-                serializer.serialize_unit_variant("TSMethodSignatureKind", 0, "method")
-            }
-            TSMethodSignatureKind::Get => {
-                serializer.serialize_unit_variant("TSMethodSignatureKind", 1, "get")
-            }
-            TSMethodSignatureKind::Set => {
-                serializer.serialize_unit_variant("TSMethodSignatureKind", 2, "set")
-            }
+            TSMethodSignatureKind::Method => "method".serialize(serializer),
+            TSMethodSignatureKind::Get => "get".serialize(serializer),
+            TSMethodSignatureKind::Set => "set".serialize(serializer),
         }
     }
 }
 
-impl Serialize for TSMethodSignature<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSMethodSignature")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("key", &self.key)?;
-        map.serialize_entry("computed", &self.computed)?;
-        map.serialize_entry("optional", &self.optional)?;
-        map.serialize_entry("kind", &self.kind)?;
-        map.serialize_entry("typeParameters", &self.type_parameters)?;
-        map.serialize_entry("thisParam", &self.this_param)?;
-        map.serialize_entry("params", &self.params)?;
-        map.serialize_entry("returnType", &self.return_type)?;
-        map.end()
+impl ESTree for TSMethodSignature<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSMethodSignature");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("key", &self.key);
+        state.serialize_field("computed", &self.computed);
+        state.serialize_field("optional", &self.optional);
+        state.serialize_field("kind", &self.kind);
+        state.serialize_field("typeParameters", &self.type_parameters);
+        state.serialize_field("thisParam", &self.this_param);
+        state.serialize_field("params", &self.params);
+        state.serialize_field("returnType", &self.return_type);
+        state.end();
     }
 }
 
-impl Serialize for TSConstructSignatureDeclaration<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSConstructSignatureDeclaration")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("typeParameters", &self.type_parameters)?;
-        map.serialize_entry("params", &self.params)?;
-        map.serialize_entry("returnType", &self.return_type)?;
-        map.end()
+impl ESTree for TSConstructSignatureDeclaration<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSConstructSignatureDeclaration");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("typeParameters", &self.type_parameters);
+        state.serialize_field("params", &self.params);
+        state.serialize_field("returnType", &self.return_type);
+        state.end();
     }
 }
 
-impl Serialize for TSIndexSignatureName<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Identifier")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("name", &self.name)?;
-        map.serialize_entry("typeAnnotation", &self.type_annotation)?;
-        map.end()
+impl ESTree for TSIndexSignatureName<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "Identifier");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("name", &self.name);
+        state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.end();
     }
 }
 
-impl Serialize for TSInterfaceHeritage<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSInterfaceHeritage")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("expression", &self.expression)?;
-        map.serialize_entry("typeParameters", &self.type_parameters)?;
-        map.end()
+impl ESTree for TSInterfaceHeritage<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSInterfaceHeritage");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("expression", &self.expression);
+        state.serialize_field("typeParameters", &self.type_parameters);
+        state.end();
     }
 }
 
-impl Serialize for TSTypePredicate<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSTypePredicate")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("parameterName", &self.parameter_name)?;
-        map.serialize_entry("asserts", &self.asserts)?;
-        map.serialize_entry("typeAnnotation", &self.type_annotation)?;
-        map.end()
+impl ESTree for TSTypePredicate<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSTypePredicate");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("parameterName", &self.parameter_name);
+        state.serialize_field("asserts", &self.asserts);
+        state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.end();
     }
 }
 
-impl Serialize for TSTypePredicateName<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for TSTypePredicateName<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             TSTypePredicateName::Identifier(it) => it.serialize(serializer),
             TSTypePredicateName::This(it) => it.serialize(serializer),
@@ -2956,38 +2893,32 @@ impl Serialize for TSTypePredicateName<'_> {
     }
 }
 
-impl Serialize for TSModuleDeclaration<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSModuleDeclaration")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("id", &self.id)?;
-        map.serialize_entry("body", &self.body)?;
-        map.serialize_entry("kind", &self.kind)?;
-        map.serialize_entry("declare", &self.declare)?;
-        map.end()
+impl ESTree for TSModuleDeclaration<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSModuleDeclaration");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("id", &self.id);
+        state.serialize_field("body", &self.body);
+        state.serialize_field("kind", &self.kind);
+        state.serialize_field("declare", &self.declare);
+        state.end();
     }
 }
 
-impl Serialize for TSModuleDeclarationKind {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for TSModuleDeclarationKind {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            TSModuleDeclarationKind::Global => {
-                serializer.serialize_unit_variant("TSModuleDeclarationKind", 0, "global")
-            }
-            TSModuleDeclarationKind::Module => {
-                serializer.serialize_unit_variant("TSModuleDeclarationKind", 1, "module")
-            }
-            TSModuleDeclarationKind::Namespace => {
-                serializer.serialize_unit_variant("TSModuleDeclarationKind", 2, "namespace")
-            }
+            TSModuleDeclarationKind::Global => "global".serialize(serializer),
+            TSModuleDeclarationKind::Module => "module".serialize(serializer),
+            TSModuleDeclarationKind::Namespace => "namespace".serialize(serializer),
         }
     }
 }
 
-impl Serialize for TSModuleDeclarationName<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for TSModuleDeclarationName<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             TSModuleDeclarationName::Identifier(it) => it.serialize(serializer),
             TSModuleDeclarationName::StringLiteral(it) => it.serialize(serializer),
@@ -2995,8 +2926,8 @@ impl Serialize for TSModuleDeclarationName<'_> {
     }
 }
 
-impl Serialize for TSModuleDeclarationBody<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for TSModuleDeclarationBody<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             TSModuleDeclarationBody::TSModuleDeclaration(it) => it.serialize(serializer),
             TSModuleDeclarationBody::TSModuleBlock(it) => it.serialize(serializer),
@@ -3004,56 +2935,56 @@ impl Serialize for TSModuleDeclarationBody<'_> {
     }
 }
 
-impl Serialize for TSModuleBlock<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSModuleBlock")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry(
+impl ESTree for TSModuleBlock<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSModuleBlock");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field(
             "body",
             &AppendToConcat { array: &self.directives, after: &self.body },
-        )?;
-        map.end()
+        );
+        state.end();
     }
 }
 
-impl Serialize for TSTypeLiteral<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSTypeLiteral")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("members", &self.members)?;
-        map.end()
+impl ESTree for TSTypeLiteral<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSTypeLiteral");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("members", &self.members);
+        state.end();
     }
 }
 
-impl Serialize for TSInferType<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSInferType")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("typeParameter", &self.type_parameter)?;
-        map.end()
+impl ESTree for TSInferType<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSInferType");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("typeParameter", &self.type_parameter);
+        state.end();
     }
 }
 
-impl Serialize for TSTypeQuery<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSTypeQuery")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("exprName", &self.expr_name)?;
-        map.serialize_entry("typeParameters", &self.type_parameters)?;
-        map.end()
+impl ESTree for TSTypeQuery<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSTypeQuery");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("exprName", &self.expr_name);
+        state.serialize_field("typeParameters", &self.type_parameters);
+        state.end();
     }
 }
 
-impl Serialize for TSTypeQueryExprName<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for TSTypeQueryExprName<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             TSTypeQueryExprName::TSImportType(it) => it.serialize(serializer),
             TSTypeQueryExprName::IdentifierReference(it) => it.serialize(serializer),
@@ -3062,47 +2993,47 @@ impl Serialize for TSTypeQueryExprName<'_> {
     }
 }
 
-impl Serialize for TSImportType<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSImportType")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("isTypeOf", &self.is_type_of)?;
-        map.serialize_entry("parameter", &self.parameter)?;
-        map.serialize_entry("qualifier", &self.qualifier)?;
-        map.serialize_entry("attributes", &self.attributes)?;
-        map.serialize_entry("typeParameters", &self.type_parameters)?;
-        map.end()
+impl ESTree for TSImportType<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSImportType");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("isTypeOf", &self.is_type_of);
+        state.serialize_field("parameter", &self.parameter);
+        state.serialize_field("qualifier", &self.qualifier);
+        state.serialize_field("attributes", &self.attributes);
+        state.serialize_field("typeParameters", &self.type_parameters);
+        state.end();
     }
 }
 
-impl Serialize for TSImportAttributes<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSImportAttributes")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("attributesKeyword", &self.attributes_keyword)?;
-        map.serialize_entry("elements", &self.elements)?;
-        map.end()
+impl ESTree for TSImportAttributes<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSImportAttributes");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("attributesKeyword", &self.attributes_keyword);
+        state.serialize_field("elements", &self.elements);
+        state.end();
     }
 }
 
-impl Serialize for TSImportAttribute<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSImportAttribute")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("name", &self.name)?;
-        map.serialize_entry("value", &self.value)?;
-        map.end()
+impl ESTree for TSImportAttribute<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSImportAttribute");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("name", &self.name);
+        state.serialize_field("value", &self.value);
+        state.end();
     }
 }
 
-impl Serialize for TSImportAttributeName<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for TSImportAttributeName<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             TSImportAttributeName::Identifier(it) => it.serialize(serializer),
             TSImportAttributeName::StringLiteral(it) => it.serialize(serializer),
@@ -3110,131 +3041,123 @@ impl Serialize for TSImportAttributeName<'_> {
     }
 }
 
-impl Serialize for TSFunctionType<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSFunctionType")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("typeParameters", &self.type_parameters)?;
-        map.serialize_entry("thisParam", &self.this_param)?;
-        map.serialize_entry("params", &self.params)?;
-        map.serialize_entry("returnType", &self.return_type)?;
-        map.end()
+impl ESTree for TSFunctionType<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSFunctionType");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("typeParameters", &self.type_parameters);
+        state.serialize_field("thisParam", &self.this_param);
+        state.serialize_field("params", &self.params);
+        state.serialize_field("returnType", &self.return_type);
+        state.end();
     }
 }
 
-impl Serialize for TSConstructorType<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSConstructorType")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("abstract", &self.r#abstract)?;
-        map.serialize_entry("typeParameters", &self.type_parameters)?;
-        map.serialize_entry("params", &self.params)?;
-        map.serialize_entry("returnType", &self.return_type)?;
-        map.end()
+impl ESTree for TSConstructorType<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSConstructorType");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("abstract", &self.r#abstract);
+        state.serialize_field("typeParameters", &self.type_parameters);
+        state.serialize_field("params", &self.params);
+        state.serialize_field("returnType", &self.return_type);
+        state.end();
     }
 }
 
-impl Serialize for TSMappedType<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSMappedType")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("typeParameter", &self.type_parameter)?;
-        map.serialize_entry("nameType", &self.name_type)?;
-        map.serialize_entry("typeAnnotation", &self.type_annotation)?;
-        map.serialize_entry("optional", &self.optional)?;
-        map.serialize_entry("readonly", &self.readonly)?;
-        map.end()
+impl ESTree for TSMappedType<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSMappedType");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("typeParameter", &self.type_parameter);
+        state.serialize_field("nameType", &self.name_type);
+        state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.serialize_field("optional", &self.optional);
+        state.serialize_field("readonly", &self.readonly);
+        state.end();
     }
 }
 
-impl Serialize for TSMappedTypeModifierOperator {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for TSMappedTypeModifierOperator {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            TSMappedTypeModifierOperator::True => {
-                serializer.serialize_unit_variant("TSMappedTypeModifierOperator", 0, "true")
-            }
-            TSMappedTypeModifierOperator::Plus => {
-                serializer.serialize_unit_variant("TSMappedTypeModifierOperator", 1, "+")
-            }
-            TSMappedTypeModifierOperator::Minus => {
-                serializer.serialize_unit_variant("TSMappedTypeModifierOperator", 2, "-")
-            }
-            TSMappedTypeModifierOperator::None => {
-                serializer.serialize_unit_variant("TSMappedTypeModifierOperator", 3, "none")
-            }
+            TSMappedTypeModifierOperator::True => "true".serialize(serializer),
+            TSMappedTypeModifierOperator::Plus => "+".serialize(serializer),
+            TSMappedTypeModifierOperator::Minus => "-".serialize(serializer),
+            TSMappedTypeModifierOperator::None => "none".serialize(serializer),
         }
     }
 }
 
-impl Serialize for TSTemplateLiteralType<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSTemplateLiteralType")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("quasis", &self.quasis)?;
-        map.serialize_entry("types", &self.types)?;
-        map.end()
+impl ESTree for TSTemplateLiteralType<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSTemplateLiteralType");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("quasis", &self.quasis);
+        state.serialize_field("types", &self.types);
+        state.end();
     }
 }
 
-impl Serialize for TSAsExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSAsExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("expression", &self.expression)?;
-        map.serialize_entry("typeAnnotation", &self.type_annotation)?;
-        map.end()
+impl ESTree for TSAsExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSAsExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("expression", &self.expression);
+        state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.end();
     }
 }
 
-impl Serialize for TSSatisfiesExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSSatisfiesExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("expression", &self.expression)?;
-        map.serialize_entry("typeAnnotation", &self.type_annotation)?;
-        map.end()
+impl ESTree for TSSatisfiesExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSSatisfiesExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("expression", &self.expression);
+        state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.end();
     }
 }
 
-impl Serialize for TSTypeAssertion<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSTypeAssertion")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("expression", &self.expression)?;
-        map.serialize_entry("typeAnnotation", &self.type_annotation)?;
-        map.end()
+impl ESTree for TSTypeAssertion<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSTypeAssertion");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("expression", &self.expression);
+        state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.end();
     }
 }
 
-impl Serialize for TSImportEqualsDeclaration<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSImportEqualsDeclaration")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("id", &self.id)?;
-        map.serialize_entry("moduleReference", &self.module_reference)?;
-        map.serialize_entry("importKind", &self.import_kind)?;
-        map.end()
+impl ESTree for TSImportEqualsDeclaration<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSImportEqualsDeclaration");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("id", &self.id);
+        state.serialize_field("moduleReference", &self.module_reference);
+        state.serialize_field("importKind", &self.import_kind);
+        state.end();
     }
 }
 
-impl Serialize for TSModuleReference<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for TSModuleReference<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             TSModuleReference::ExternalModuleReference(it) => it.serialize(serializer),
             TSModuleReference::IdentifierReference(it) => it.serialize(serializer),
@@ -3243,116 +3166,112 @@ impl Serialize for TSModuleReference<'_> {
     }
 }
 
-impl Serialize for TSExternalModuleReference<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSExternalModuleReference")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("expression", &self.expression)?;
-        map.end()
+impl ESTree for TSExternalModuleReference<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSExternalModuleReference");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("expression", &self.expression);
+        state.end();
     }
 }
 
-impl Serialize for TSNonNullExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSNonNullExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("expression", &self.expression)?;
-        map.end()
+impl ESTree for TSNonNullExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSNonNullExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("expression", &self.expression);
+        state.end();
     }
 }
 
-impl Serialize for Decorator<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Decorator")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("expression", &self.expression)?;
-        map.end()
+impl ESTree for Decorator<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "Decorator");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("expression", &self.expression);
+        state.end();
     }
 }
 
-impl Serialize for TSExportAssignment<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSExportAssignment")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("expression", &self.expression)?;
-        map.end()
+impl ESTree for TSExportAssignment<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSExportAssignment");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("expression", &self.expression);
+        state.end();
     }
 }
 
-impl Serialize for TSNamespaceExportDeclaration<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSNamespaceExportDeclaration")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("id", &self.id)?;
-        map.end()
+impl ESTree for TSNamespaceExportDeclaration<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSNamespaceExportDeclaration");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("id", &self.id);
+        state.end();
     }
 }
 
-impl Serialize for TSInstantiationExpression<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "TSInstantiationExpression")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("expression", &self.expression)?;
-        map.serialize_entry("typeParameters", &self.type_parameters)?;
-        map.end()
+impl ESTree for TSInstantiationExpression<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "TSInstantiationExpression");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("expression", &self.expression);
+        state.serialize_field("typeParameters", &self.type_parameters);
+        state.end();
     }
 }
 
-impl Serialize for ImportOrExportKind {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for ImportOrExportKind {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            ImportOrExportKind::Value => {
-                serializer.serialize_unit_variant("ImportOrExportKind", 0, "value")
-            }
-            ImportOrExportKind::Type => {
-                serializer.serialize_unit_variant("ImportOrExportKind", 1, "type")
-            }
+            ImportOrExportKind::Value => "value".serialize(serializer),
+            ImportOrExportKind::Type => "type".serialize(serializer),
         }
     }
 }
 
-impl Serialize for JSDocNullableType<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSDocNullableType")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("typeAnnotation", &self.type_annotation)?;
-        map.serialize_entry("postfix", &self.postfix)?;
-        map.end()
+impl ESTree for JSDocNullableType<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "JSDocNullableType");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.serialize_field("postfix", &self.postfix);
+        state.end();
     }
 }
 
-impl Serialize for JSDocNonNullableType<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSDocNonNullableType")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("typeAnnotation", &self.type_annotation)?;
-        map.serialize_entry("postfix", &self.postfix)?;
-        map.end()
+impl ESTree for JSDocNonNullableType<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "JSDocNonNullableType");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.serialize_field("postfix", &self.postfix);
+        state.end();
     }
 }
 
-impl Serialize for JSDocUnknownType {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "JSDocUnknownType")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.end()
+impl ESTree for JSDocUnknownType {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "JSDocUnknownType");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.end();
     }
 }

--- a/crates/oxc_ast/src/lib.rs
+++ b/crates/oxc_ast/src/lib.rs
@@ -22,7 +22,7 @@
 //! You can obtain an AST by parsing source code with a [`Parser`] from [`oxc_parser`].
 //!
 //! ## Cargo Features
-//! * `"serde"` enables support for serde serialization
+//! * `"serialize"` enables support for serialization to ESTree JSON
 //!
 //! [`BindingIdentifier`]: ast::BindingIdentifier
 //! [`IdentifierReference`]: ast::IdentifierReference

--- a/crates/oxc_estree/Cargo.toml
+++ b/crates/oxc_estree/Cargo.toml
@@ -12,12 +12,16 @@ repository.workspace = true
 rust-version.workspace = true
 description.workspace = true
 
-[dependencies]
-serde = { workspace = true, optional = true }
-
 [lints]
 workspace = true
 
+[lib]
+doctest = false
+
+[dependencies]
+itoa = { workspace = true }
+ryu-js = { workspace = true, optional = true }
+
 [features]
 default = []
-serialize = ["dep:serde"]
+serialize = ["dep:ryu-js"]

--- a/crates/oxc_estree/src/lib.rs
+++ b/crates/oxc_estree/src/lib.rs
@@ -1,6 +1,12 @@
 #[cfg(feature = "serialize")]
 pub mod ser;
+#[cfg(feature = "serialize")]
+mod serialize;
+#[cfg(feature = "serialize")]
+pub use serialize::*;
 
-/// Empty trait that will be used later for custom serialization and TypeScript
-/// generation for AST nodes.
+/// Placeholder for real `ESTree` trait when `serialize` feature not enabled.
+///
+/// Provided to support `#[generate_derive(ESTree)]`, without enabling the feature.
+#[cfg(not(feature = "serialize"))]
 pub trait ESTree {}

--- a/crates/oxc_estree/src/ser.rs
+++ b/crates/oxc_estree/src/ser.rs
@@ -1,4 +1,4 @@
-use serde::ser::{Serialize, SerializeSeq, Serializer};
+use crate::{ESTree, SequenceSerializer, Serializer};
 
 /// A helper struct for serializing a sequence followed by an optional element.
 /// This is only used by generated ESTree serialization code.
@@ -7,17 +7,17 @@ pub struct AppendTo<'a, TVec, TAfter> {
     pub after: &'a Option<TAfter>,
 }
 
-impl<TVec: Serialize, TAfter: Serialize> Serialize for AppendTo<'_, TVec, TAfter> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl<TVec: ESTree, TAfter: ESTree> ESTree for AppendTo<'_, TVec, TAfter> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         if let Some(after) = self.after {
-            let mut seq = serializer.serialize_seq(Some(self.array.len() + 1))?;
+            let mut seq = serializer.serialize_sequence();
             for element in self.array {
-                seq.serialize_element(element)?;
+                seq.serialize_element(element);
             }
-            seq.serialize_element(after)?;
-            seq.end()
+            seq.serialize_element(after);
+            seq.end();
         } else {
-            self.array.serialize(serializer)
+            self.array.serialize(serializer);
         }
     }
 }
@@ -27,15 +27,15 @@ pub struct AppendToConcat<'a, TVec, TAfter> {
     pub after: &'a [TAfter],
 }
 
-impl<TVec: Serialize, TAfter: Serialize> Serialize for AppendToConcat<'_, TVec, TAfter> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut seq = serializer.serialize_seq(Some(self.array.len() + self.after.len()))?;
+impl<TVec: ESTree, TAfter: ESTree> ESTree for AppendToConcat<'_, TVec, TAfter> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut seq = serializer.serialize_sequence();
         for element in self.array {
-            seq.serialize_element(element)?;
+            seq.serialize_element(element);
         }
         for element in self.after {
-            seq.serialize_element(element)?;
+            seq.serialize_element(element);
         }
-        seq.end()
+        seq.end();
     }
 }

--- a/crates/oxc_estree/src/serialize/blanket.rs
+++ b/crates/oxc_estree/src/serialize/blanket.rs
@@ -1,0 +1,103 @@
+use std::borrow::Cow;
+
+use super::{ESTree, Serializer};
+
+/// [`ESTree`] implementation for a `&` reference to any type that implements `ESTree`.
+impl<T> ESTree for &T
+where
+    T: ESTree + ?Sized,
+{
+    #[inline(always)]
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        (**self).serialize(serializer);
+    }
+}
+
+/// [`ESTree`] implementation for a `&mut` reference to any type that implements `ESTree`.
+impl<T> ESTree for &mut T
+where
+    T: ESTree + ?Sized,
+{
+    #[inline(always)]
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        (**self).serialize(serializer);
+    }
+}
+
+/// [`ESTree`] implementation for `Option<T>`.
+impl<T: ESTree> ESTree for Option<T> {
+    fn serialize<S: Serializer>(&self, mut serializer: S) {
+        if let Some(value) = self {
+            value.serialize(serializer);
+        } else {
+            serializer.buffer_mut().push_str("null");
+        }
+    }
+}
+
+/// [`ESTree`] implementation for a `Cow` wrapping any type that implements `ESTree`.
+impl<T> ESTree for Cow<'_, T>
+where
+    T: ESTree + ToOwned + ?Sized,
+{
+    #[inline(always)]
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        (**self).serialize(serializer);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::CompactSerializer;
+    use super::*;
+
+    #[expect(clippy::needless_borrow)]
+    #[test]
+    fn serialize_ref() {
+        let cases = [(&"foo", r#""foo""#), (&&"bar", r#""bar""#)];
+
+        for (input, output) in cases {
+            let mut serializer = CompactSerializer::new();
+            input.serialize(&mut serializer);
+            let s = serializer.into_string();
+            assert_eq!(&s, output);
+        }
+    }
+
+    #[test]
+    fn serialize_mut_ref() {
+        let cases = [(&mut "foo", r#""foo""#), (&mut &mut "bar", r#""bar""#)];
+
+        for (input, output) in cases {
+            let mut serializer = CompactSerializer::new();
+            input.serialize(&mut serializer);
+            let s = serializer.into_string();
+            assert_eq!(&s, output);
+        }
+    }
+
+    #[test]
+    fn serialize_option() {
+        let cases = [(None, "null"), (Some(123.0f64), "123")];
+
+        for (input, output) in cases {
+            let mut serializer = CompactSerializer::new();
+            input.serialize(&mut serializer);
+            let s = serializer.into_string();
+            assert_eq!(&s, output);
+        }
+    }
+
+    #[test]
+    fn serialize_cow() {
+        let cases =
+            [(Cow::Borrowed("foo"), r#""foo""#), (Cow::Owned("bar".to_string()), r#""bar""#)];
+
+        for (input, output) in cases {
+            let mut serializer = CompactSerializer::new();
+            input.serialize(&mut serializer);
+            let s = serializer.into_string();
+            assert_eq!(&s, output);
+        }
+    }
+}

--- a/crates/oxc_estree/src/serialize/buffer.rs
+++ b/crates/oxc_estree/src/serialize/buffer.rs
@@ -1,0 +1,51 @@
+/// Buffer to store serialized JSON.
+pub struct Buffer {
+    bytes: Vec<u8>,
+}
+
+impl Buffer {
+    /// Create new [`Buffer`].
+    pub(super) fn new() -> Self {
+        Self { bytes: vec![] }
+    }
+
+    /// Push a single ASCII byte to the buffer.
+    ///
+    /// # Panics
+    /// Panics if `byte` is not ASCII.
+    #[inline(always)]
+    pub(super) fn push_ascii_byte(&mut self, byte: u8) {
+        assert!(byte.is_ascii());
+        // SAFETY: We just checked this byte is ASCII
+        unsafe { self.push_ascii_byte_unchecked(byte) };
+    }
+
+    /// Push a single ASCII byte to the buffer, without checking that it's ASCII.
+    ///
+    /// # SAFETY
+    /// `byte` must be ASCII.
+    #[inline(always)]
+    pub(super) unsafe fn push_ascii_byte_unchecked(&mut self, byte: u8) {
+        self.bytes.push(byte);
+    }
+
+    /// Push a raw string to the buffer.
+    pub(super) fn push_str(&mut self, s: &str) {
+        self.bytes.extend_from_slice(s.as_bytes());
+    }
+
+    /// Push a slice of bytes to the buffer.
+    ///
+    /// # SAFETY
+    /// `bytes` must comprise a valid UTF-8 string.
+    pub(super) unsafe fn push_bytes(&mut self, bytes: &[u8]) {
+        self.bytes.extend_from_slice(bytes);
+    }
+
+    /// Consume [`Buffer`] and convert buffer to string.
+    pub(super) fn into_string(self) -> String {
+        // SAFETY: None of `Serializer`'s safe methods allow
+        // adding invalid byte sequences to `self.bytes`
+        unsafe { String::from_utf8_unchecked(self.bytes) }
+    }
+}

--- a/crates/oxc_estree/src/serialize/formatter.rs
+++ b/crates/oxc_estree/src/serialize/formatter.rs
@@ -1,0 +1,104 @@
+use super::Buffer;
+
+/// Formatter trait.
+pub trait Formatter {
+    /// Create new [`Formatter`].
+    fn new() -> Self;
+
+    /// Called before the first field of a struct or element of a sequence.
+    /// If the struct/sequence has no fields/elements, this is not called.
+    fn before_first_element(&mut self, buffer: &mut Buffer);
+
+    /// Called before a later field of a struct or element of a sequence
+    /// (i.e. not the first field/element).
+    fn before_later_element(&mut self, buffer: &mut Buffer);
+
+    /// Called after the key of a struct field.
+    fn before_field_value(&mut self, buffer: &mut Buffer);
+
+    /// Called after the last element of a sequence / last element of a struct.
+    /// If the struct/sequence has no fields/elements, this is not called.
+    fn after_last_element(&mut self, buffer: &mut Buffer);
+}
+
+/// Compact formatter.
+///
+/// All methods are no-ops.
+/// This formatter does not insert line breaks, indentation, or whitespace.
+///
+/// e.g. `{"type":"Program","start":0,"end":0,"body":[]}`
+pub struct CompactFormatter;
+
+impl Formatter for CompactFormatter {
+    #[inline(always)]
+    fn new() -> Self {
+        Self
+    }
+
+    #[inline(always)]
+    fn before_first_element(&mut self, _buffer: &mut Buffer) {}
+
+    #[inline(always)]
+    fn before_later_element(&mut self, _buffer: &mut Buffer) {}
+
+    #[inline(always)]
+    fn before_field_value(&mut self, _buffer: &mut Buffer) {}
+
+    #[inline(always)]
+    fn after_last_element(&mut self, _buffer: &mut Buffer) {}
+}
+
+/// Pretty-print formatter.
+///
+/// Produces pretty-formatted JSON with line breaks, indentation, and whitespace.
+///
+/// e.g.:
+///
+/// ```json
+/// {
+///   "type": "Program",
+///   "start": 0,
+///   "end": 0,
+///   "body": []
+/// }
+/// ```
+///
+/// Note that empty structs/sequences do not contain line breaks (`[]` not `[\n  ]`, `{}` not `{\n  }`)
+/// because `before_first_element` and `after_last_element` are only called if the struct/sequence
+/// contains at least 1 element.
+pub struct PrettyFormatter {
+    indent: usize,
+}
+
+impl Formatter for PrettyFormatter {
+    #[inline(always)]
+    fn new() -> Self {
+        Self { indent: 0 }
+    }
+
+    fn before_first_element(&mut self, buffer: &mut Buffer) {
+        self.indent += 1;
+        self.push_new_line_and_indent(buffer);
+    }
+
+    fn before_later_element(&mut self, buffer: &mut Buffer) {
+        self.push_new_line_and_indent(buffer);
+    }
+
+    fn before_field_value(&mut self, buffer: &mut Buffer) {
+        buffer.push_ascii_byte(b' ');
+    }
+
+    fn after_last_element(&mut self, buffer: &mut Buffer) {
+        self.indent -= 1;
+        self.push_new_line_and_indent(buffer);
+    }
+}
+
+impl PrettyFormatter {
+    fn push_new_line_and_indent(&self, buffer: &mut Buffer) {
+        buffer.push_ascii_byte(b'\n');
+        // SAFETY: Spaces are ASCII
+        unsafe { buffer.push_bytes(&b"  ".repeat(self.indent)) };
+    }
+}

--- a/crates/oxc_estree/src/serialize/mod.rs
+++ b/crates/oxc_estree/src/serialize/mod.rs
@@ -1,0 +1,116 @@
+// Methods which are trivial or just delegate to other methods are marked `#[inline(always)]`
+#![expect(clippy::inline_always)]
+
+mod blanket;
+mod buffer;
+mod formatter;
+mod primitives;
+mod sequences;
+mod strings;
+mod structs;
+use buffer::Buffer;
+use formatter::{CompactFormatter, Formatter, PrettyFormatter};
+use sequences::ESTreeSequenceSerializer;
+use structs::ESTreeStructSerializer;
+
+pub use sequences::SequenceSerializer;
+pub use structs::{FlatStructSerializer, StructSerializer};
+
+/// Trait for types which can be serialized to ESTree.
+pub trait ESTree {
+    fn serialize<S: Serializer>(&self, serializer: S);
+}
+
+/// Trait for serializers.
+//
+// This trait contains public methods.
+// Internal methods we don't want to expose outside this crate are in [`SerializerPrivate`] trait.
+#[expect(private_bounds)]
+pub trait Serializer: SerializerPrivate {
+    /// Type of struct serializer this serializer uses.
+    type StructSerializer: StructSerializer;
+    /// Type of sequence serializer this serializer uses.
+    type SequenceSerializer: SequenceSerializer;
+
+    /// Serialize struct.
+    fn serialize_struct(self) -> Self::StructSerializer;
+
+    /// Serialize sequence.
+    fn serialize_sequence(self) -> Self::SequenceSerializer;
+}
+
+/// Trait containing internal methods of [`Serializer`]s that we don't want to expose outside this crate.
+trait SerializerPrivate: Sized {
+    /// Formatter type
+    type Formatter: Formatter;
+
+    /// Get mutable reference to buffer.
+    fn buffer_mut(&mut self) -> &mut Buffer;
+
+    /// Get mutable references to buffer and formatter.
+    fn buffer_and_formatter_mut(&mut self) -> (&mut Buffer, &mut Self::Formatter);
+}
+
+/// ESTree serializer which produces compact JSON.
+pub type CompactSerializer = ESTreeSerializer<CompactFormatter>;
+
+/// ESTree serializer which produces pretty JSON.
+pub type PrettySerializer = ESTreeSerializer<PrettyFormatter>;
+
+/// ESTree serializer.
+pub struct ESTreeSerializer<F: Formatter> {
+    buffer: Buffer,
+    formatter: F,
+}
+
+impl<F: Formatter> ESTreeSerializer<F> {
+    /// Create new [`ESTreeSerializer`].
+    pub fn new() -> Self {
+        Self { buffer: Buffer::new(), formatter: F::new() }
+    }
+
+    /// Consume this [`ESTreeSerializer`] and convert buffer to string.
+    pub fn into_string(self) -> String {
+        self.buffer.into_string()
+    }
+}
+
+impl<F: Formatter> Default for ESTreeSerializer<F> {
+    #[inline(always)]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<'s, F: Formatter> Serializer for &'s mut ESTreeSerializer<F> {
+    type StructSerializer = ESTreeStructSerializer<'s, F>;
+    type SequenceSerializer = ESTreeSequenceSerializer<'s, F>;
+
+    /// Serialize struct.
+    #[inline(always)]
+    fn serialize_struct(self) -> ESTreeStructSerializer<'s, F> {
+        ESTreeStructSerializer::new(self)
+    }
+
+    /// Serialize sequence.
+    #[inline(always)]
+    fn serialize_sequence(self) -> ESTreeSequenceSerializer<'s, F> {
+        ESTreeSequenceSerializer::new(self)
+    }
+}
+
+impl<F: Formatter> SerializerPrivate for &mut ESTreeSerializer<F> {
+    type Formatter = F;
+
+    /// Get mutable reference to buffer.
+    #[inline(always)]
+    fn buffer_mut(&mut self) -> &mut Buffer {
+        &mut self.buffer
+    }
+
+    /// Get mutable references to buffer and formatter.
+    #[inline(always)]
+    fn buffer_and_formatter_mut(&mut self) -> (&mut Buffer, &mut F) {
+        (&mut self.buffer, &mut self.formatter)
+    }
+}

--- a/crates/oxc_estree/src/serialize/primitives.rs
+++ b/crates/oxc_estree/src/serialize/primitives.rs
@@ -1,0 +1,234 @@
+use itoa::Buffer as ItoaBuffer;
+use ryu_js::Buffer as RyuBuffer;
+
+use super::{ESTree, Serializer};
+
+/// [`ESTree`] implementation for `bool`.
+impl ESTree for bool {
+    fn serialize<S: Serializer>(&self, mut serializer: S) {
+        serializer.buffer_mut().push_str(if *self { "true" } else { "false" });
+    }
+}
+
+/// [`ESTree`] implementations for `f32` and `f64`.
+macro_rules! impl_float {
+    ($ty:ident) => {
+        impl ESTree for $ty {
+            fn serialize<S: Serializer>(&self, mut serializer: S) {
+                if self.is_finite() {
+                    let mut buffer = RyuBuffer::new();
+                    let s = buffer.format_finite(*self);
+                    serializer.buffer_mut().push_str(s);
+                } else if self.is_nan() {
+                    // Serialize `NAN` as `null`
+                    // TODO: Throw an error? Use a sentinel value?
+                    serializer.buffer_mut().push_str("null");
+                } else if *self == $ty::INFINITY {
+                    // Serialize `INFINITY` as `1e+400. `JSON.parse` deserializes this as `Infinity`.
+                    serializer.buffer_mut().push_str("1e+400");
+                } else {
+                    // Serialize `-INFINITY` as `-1e+400`. `JSON.parse` deserializes this as `-Infinity`.
+                    serializer.buffer_mut().push_str("-1e+400");
+                }
+            }
+        }
+    };
+}
+
+impl_float!(f32);
+impl_float!(f64);
+
+/// [`ESTree`] implementations for integer types.
+macro_rules! impl_integer {
+    ($ty:ident) => {
+        impl ESTree for $ty {
+            fn serialize<S: Serializer>(&self, mut serializer: S) {
+                let mut buffer = ItoaBuffer::new();
+                let s = buffer.format(*self);
+                serializer.buffer_mut().push_str(s);
+            }
+        }
+    };
+}
+
+impl_integer!(u8);
+impl_integer!(u16);
+impl_integer!(u32);
+impl_integer!(u64);
+impl_integer!(u128);
+impl_integer!(usize);
+impl_integer!(i8);
+impl_integer!(i16);
+impl_integer!(i32);
+impl_integer!(i64);
+impl_integer!(i128);
+impl_integer!(isize);
+
+/// [`ESTree`] implementation for `()`.
+impl ESTree for () {
+    fn serialize<S: Serializer>(&self, mut serializer: S) {
+        serializer.buffer_mut().push_str("null");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::CompactSerializer;
+    use super::*;
+
+    fn run_test<T: ESTree>(cases: &[(T, &str)]) {
+        for (input, output) in cases {
+            let mut serializer = CompactSerializer::new();
+            input.serialize(&mut serializer);
+            let s = serializer.into_string();
+            assert_eq!(&s, output);
+        }
+    }
+
+    #[test]
+    fn serialize_bool() {
+        run_test(&[(true, "true"), (false, "false")]);
+    }
+
+    #[test]
+    fn serialize_f32() {
+        run_test(&[
+            (0.0, "0"),
+            (1.0, "1"),
+            (123_456.0, "123456"),
+            (0.12345, "0.12345"),
+            (123.45, "123.45"),
+            (f32::MIN, "-3.4028235e+38"),
+            (f32::MAX, "3.4028235e+38"),
+            (f32::INFINITY, "1e+400"),
+            (-f32::INFINITY, "-1e+400"),
+        ]);
+    }
+
+    #[test]
+    fn serialize_f64() {
+        run_test(&[
+            (0.0, "0"),
+            (1.0, "1"),
+            (123_456.0, "123456"),
+            (0.12345, "0.12345"),
+            (123.45, "123.45"),
+            (f64::MIN, "-1.7976931348623157e+308"),
+            (f64::MAX, "1.7976931348623157e+308"),
+            (f64::INFINITY, "1e+400"),
+            (-f64::INFINITY, "-1e+400"),
+        ]);
+    }
+
+    #[test]
+    fn serialize_u8() {
+        run_test(&[(0, "0"), (1, "1"), (123, "123"), (u8::MAX, "255")]);
+    }
+
+    #[test]
+    fn serialize_u16() {
+        run_test(&[(0, "0"), (1, "1"), (12_345, "12345"), (u16::MAX, "65535")]);
+    }
+
+    #[test]
+    fn serialize_u32() {
+        run_test(&[(0, "0"), (1, "1"), (123_456, "123456"), (u32::MAX, "4294967295")]);
+    }
+
+    #[test]
+    fn serialize_u64() {
+        run_test(&[(0, "0"), (1, "1"), (123_456, "123456"), (u64::MAX, "18446744073709551615")]);
+    }
+
+    #[test]
+    fn serialize_u128() {
+        run_test(&[
+            (0, "0"),
+            (1, "1"),
+            (123_456, "123456"),
+            (u128::MAX, "340282366920938463463374607431768211455"),
+        ]);
+    }
+
+    #[test]
+    fn serialize_usize() {
+        run_test(&[(0, "0"), (1, "1"), (123_456, "123456"), (u32::MAX as usize, "4294967295")]);
+    }
+
+    #[test]
+    fn serialize_i8() {
+        run_test(&[
+            (0, "0"),
+            (1, "1"),
+            (-1, "-1"),
+            (123, "123"),
+            (i8::MIN, "-128"),
+            (i8::MAX, "127"),
+        ]);
+    }
+
+    #[test]
+    fn serialize_i16() {
+        run_test(&[
+            (0, "0"),
+            (1, "1"),
+            (-1, "-1"),
+            (12_345, "12345"),
+            (i16::MIN, "-32768"),
+            (i16::MAX, "32767"),
+        ]);
+    }
+
+    #[test]
+    fn serialize_i32() {
+        run_test(&[
+            (0, "0"),
+            (1, "1"),
+            (-1, "-1"),
+            (123_456, "123456"),
+            (i32::MIN, "-2147483648"),
+            (i32::MAX, "2147483647"),
+        ]);
+    }
+
+    #[test]
+    fn serialize_i64() {
+        run_test(&[
+            (0, "0"),
+            (1, "1"),
+            (-1, "-1"),
+            (123_456, "123456"),
+            (i64::MIN, "-9223372036854775808"),
+            (i64::MAX, "9223372036854775807"),
+        ]);
+    }
+
+    #[test]
+    fn serialize_i128() {
+        run_test(&[
+            (0, "0"),
+            (1, "1"),
+            (-1, "-1"),
+            (123_456, "123456"),
+            (i128::MIN, "-170141183460469231731687303715884105728"),
+            (i128::MAX, "170141183460469231731687303715884105727"),
+        ]);
+    }
+
+    #[test]
+    fn serialize_isize() {
+        run_test(&[
+            (0, "0"),
+            (1, "1"),
+            (-1, "-1"),
+            (123_456, "123456"),
+            (i32::MIN as isize, "-2147483648"),
+            (i32::MAX as isize, "2147483647"),
+        ]);
+    }
+
+    #[test]
+    fn serialize_unit() {
+        run_test(&[((), "null")]);
+    }
+}

--- a/crates/oxc_estree/src/serialize/sequences.rs
+++ b/crates/oxc_estree/src/serialize/sequences.rs
@@ -1,0 +1,132 @@
+use super::{ESTree, ESTreeSerializer, Formatter, Serializer, SerializerPrivate};
+
+/// Trait for sequence serializers.
+pub trait SequenceSerializer {
+    /// Serialize sequence entry.
+    fn serialize_element<T: ESTree + ?Sized>(&mut self, value: &T);
+
+    /// Finish serializing sequence.
+    fn end(self);
+}
+
+/// Serializer for sequences.
+///
+/// This is returned by `ESTreeSerializer::serialize_sequence`.
+pub struct ESTreeSequenceSerializer<'s, F: Formatter> {
+    /// Serializer
+    serializer: &'s mut ESTreeSerializer<F>,
+    /// State of sequence.
+    /// Starts as `SequenceState::Empty`, transitions to `SequenceState::HasEntries` on first entry.
+    state: SequenceState,
+}
+
+impl<'s, F: Formatter> ESTreeSequenceSerializer<'s, F> {
+    /// Create new [`ESTreeSequenceSerializer`].
+    pub(super) fn new(mut serializer: &'s mut ESTreeSerializer<F>) -> Self {
+        serializer.buffer_mut().push_ascii_byte(b'[');
+        Self { serializer, state: SequenceState::Empty }
+    }
+}
+
+impl<F: Formatter> SequenceSerializer for ESTreeSequenceSerializer<'_, F> {
+    /// Serialize sequence entry.
+    fn serialize_element<T: ESTree + ?Sized>(&mut self, value: &T) {
+        let (buffer, formatter) = self.serializer.buffer_and_formatter_mut();
+        if self.state == SequenceState::Empty {
+            self.state = SequenceState::HasEntries;
+            formatter.before_first_element(buffer);
+        } else {
+            buffer.push_ascii_byte(b',');
+            formatter.before_later_element(buffer);
+        }
+
+        value.serialize(&mut *self.serializer);
+    }
+
+    /// Finish serializing sequence.
+    fn end(mut self) {
+        let (buffer, formatter) = self.serializer.buffer_and_formatter_mut();
+        if self.state == SequenceState::HasEntries {
+            formatter.after_last_element(buffer);
+        }
+        buffer.push_ascii_byte(b']');
+    }
+}
+
+/// State of [`ESTreeSequenceSerializer`].
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SequenceState {
+    Empty,
+    HasEntries,
+}
+
+/// [`ESTree`] implementation for slices.
+impl<T: ESTree> ESTree for &[T] {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut seq = serializer.serialize_sequence();
+        for element in *self {
+            seq.serialize_element(element);
+        }
+        seq.end();
+    }
+}
+
+/// [`ESTree`] implementation for arrays.
+impl<T: ESTree, const N: usize> ESTree for [T; N] {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut seq = serializer.serialize_sequence();
+        for element in self {
+            seq.serialize_element(element);
+        }
+        seq.end();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{CompactSerializer, PrettySerializer, StructSerializer};
+    use super::*;
+
+    #[test]
+    fn serialize_sequence() {
+        struct Foo<'a> {
+            none: &'a [&'a str],
+            one: &'a [&'a str],
+            two: [&'a str; 2],
+        }
+
+        impl ESTree for Foo<'_> {
+            fn serialize<S: Serializer>(&self, serializer: S) {
+                let mut state = serializer.serialize_struct();
+                state.serialize_field("none", &self.none);
+                state.serialize_field("one", &self.one);
+                state.serialize_field("two", &self.two);
+                state.end();
+            }
+        }
+
+        let foo = Foo { none: &[], one: &["one"], two: ["two one", "two two"] };
+
+        let mut serializer = CompactSerializer::new();
+        foo.serialize(&mut serializer);
+        let s = serializer.into_string();
+        assert_eq!(&s, r#"{"none":[],"one":["one"],"two":["two one","two two"]}"#);
+
+        let mut serializer = PrettySerializer::new();
+        foo.serialize(&mut serializer);
+        let s = serializer.into_string();
+        assert_eq!(
+            &s,
+            r#"{
+  "none": [],
+  "one": [
+    "one"
+  ],
+  "two": [
+    "two one",
+    "two two"
+  ]
+}"#
+        );
+    }
+}

--- a/crates/oxc_estree/src/serialize/strings.rs
+++ b/crates/oxc_estree/src/serialize/strings.rs
@@ -1,0 +1,169 @@
+use super::{Buffer, ESTree, Serializer};
+
+/// [`ESTree`] implementation for string slice.
+impl ESTree for str {
+    fn serialize<S: Serializer>(&self, mut serializer: S) {
+        write_str(self, serializer.buffer_mut());
+    }
+}
+
+/// [`ESTree`] implementation for `String`.
+impl ESTree for String {
+    fn serialize<S: Serializer>(&self, mut serializer: S) {
+        write_str(self.as_str(), serializer.buffer_mut());
+    }
+}
+
+/// Escapes
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+enum Escape {
+    __ = 0,
+    BB = b'b',  // \x08
+    TT = b't',  // \x09
+    NN = b'n',  // \x0A
+    FF = b'f',  // \x0C
+    RR = b'r',  // \x0D
+    QU = b'"',  // \x22
+    BS = b'\\', // \x5C
+    UU = b'u',  // \x00...\x1F except the ones above
+}
+
+/// Lookup table of escape sequences. A value of `b'x'` at index `i` means that byte `i`
+/// is escaped as "\x" in JSON. A value of 0 means that byte `i` is not escaped.
+///
+/// A value of `UU` means that byte is escaped as `\u00xx`, where `xx` is the hex code of the byte.
+/// e.g. `0x1F` is output as `\u001F`.
+static ESCAPE: [Escape; 256] = {
+    #[allow(clippy::enum_glob_use, clippy::allow_attributes)]
+    use Escape::*;
+
+    [
+        //   1   2   3   4   5   6   7   8   9   A   B   C   D   E   F
+        UU, UU, UU, UU, UU, UU, UU, UU, BB, TT, NN, UU, FF, RR, UU, UU, // 0
+        UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, UU, // 1
+        __, __, QU, __, __, __, __, __, __, __, __, __, __, __, __, __, // 2
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 3
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 4
+        __, __, __, __, __, __, __, __, __, __, __, __, BS, __, __, __, // 5
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 6
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 7
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 8
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // 9
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // A
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // B
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // C
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // D
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // E
+        __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, __, // F
+    ]
+};
+
+/// Write string to buffer.
+/// String is wrapped in `"`s, and with any characters which are not valid in JSON escaped.
+#[inline(always)]
+fn write_str(s: &str, buffer: &mut Buffer) {
+    buffer.push_ascii_byte(b'"');
+
+    let bytes = s.as_bytes();
+
+    let mut start = 0;
+    for (index, &byte) in bytes.iter().enumerate() {
+        let escape = ESCAPE[byte as usize];
+        if escape == Escape::__ {
+            continue;
+        }
+
+        if start < index {
+            // SAFETY: `bytes` is derived from a `&str`.
+            // `escape` is only non-zero for ASCII bytes.
+            // Therefore current `index` must mark the end of a valid UTF8 character sequence.
+            // `start` is either the start of string, or after an ASCII character,
+            // therefore always the start of a valid UTF8 character sequence.
+            unsafe { buffer.push_bytes(&bytes[start..index]) };
+        }
+
+        write_char_escape(escape, byte, buffer);
+
+        start = index + 1;
+    }
+
+    if start < bytes.len() {
+        // SAFETY: `bytes` is derived from a `&str`.
+        // `start` is either the start of string, or after an ASCII character,
+        // therefore always the start of a valid UTF8 character sequence.
+        unsafe { buffer.push_bytes(&bytes[start..]) };
+    }
+
+    buffer.push_ascii_byte(b'"');
+}
+
+fn write_char_escape(escape: Escape, byte: u8, buffer: &mut Buffer) {
+    #[expect(clippy::if_not_else)]
+    if escape != Escape::UU {
+        buffer.push_ascii_byte(b'\\');
+        // SAFETY: All values of `Escape` are ASCII
+        unsafe { buffer.push_ascii_byte_unchecked(escape as u8) };
+    } else {
+        static HEX_DIGITS: [u8; 16] = *b"0123456789abcdef";
+        let bytes = [
+            b'\\',
+            b'u',
+            b'0',
+            b'0',
+            HEX_DIGITS[(byte >> 4) as usize],
+            HEX_DIGITS[(byte & 0xF) as usize],
+        ];
+        // SAFETY: `bytes` contains only ASCII bytes
+        unsafe { buffer.push_bytes(&bytes) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::CompactSerializer;
+    use super::*;
+
+    #[test]
+    fn serialize_string_slice() {
+        let cases = [
+            ("", r#""""#),
+            ("foobar", r#""foobar""#),
+            ("\n", r#""\n""#),
+            ("\nfoobar", r#""\nfoobar""#),
+            ("foo\nbar", r#""foo\nbar""#),
+            ("foobar\n", r#""foobar\n""#),
+            (
+                "\x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0A\x0B\x0C\x0D\x0E\x0F",
+                r#""\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\b\t\n\u000b\f\r\u000e\u000f""#,
+            ),
+            (
+                "\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1A\x1B\x1C\x1D\x1E\x1F",
+                r#""\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f""#,
+            ),
+            (
+                r#"They call me "Bob" but I prefer "Dennis", innit?"#,
+                r#""They call me \"Bob\" but I prefer \"Dennis\", innit?""#,
+            ),
+        ];
+
+        for (input, output) in cases {
+            let mut serializer = CompactSerializer::new();
+            input.serialize(&mut serializer);
+            let s = serializer.into_string();
+            assert_eq!(&s, output);
+        }
+    }
+
+    #[test]
+    fn serialize_string() {
+        let cases = [(String::new(), r#""""#), ("foobar".to_string(), r#""foobar""#)];
+
+        for (input, output) in cases {
+            let mut serializer = CompactSerializer::new();
+            input.serialize(&mut serializer);
+            let s = serializer.into_string();
+            assert_eq!(&s, output);
+        }
+    }
+}

--- a/crates/oxc_estree/src/serialize/structs.rs
+++ b/crates/oxc_estree/src/serialize/structs.rs
@@ -1,0 +1,342 @@
+use super::{
+    Buffer, ESTree, ESTreeSequenceSerializer, ESTreeSerializer, Formatter, Serializer,
+    SerializerPrivate,
+};
+
+/// Trait for struct serializers.
+pub trait StructSerializer {
+    type Formatter: Formatter;
+
+    /// Serialize struct field.
+    ///
+    /// `key` must not contain any characters which require escaping in JSON.
+    fn serialize_field<T: ESTree + ?Sized>(&mut self, key: &str, value: &T);
+
+    /// Finish serializing struct.
+    fn end(self);
+}
+
+/// Serializer for structs.
+///
+/// This is returned by `ESTreeSerializer::serialize_struct`.
+pub struct ESTreeStructSerializer<'s, F: Formatter> {
+    /// Serializer
+    serializer: &'s mut ESTreeSerializer<F>,
+    /// State of struct.
+    /// Starts as `StructState::Empty`, transitions to `StructState::HasFields` on first field.
+    state: StructState,
+}
+
+impl<'s, F: Formatter> ESTreeStructSerializer<'s, F> {
+    /// Create new [`ESTreeStructSerializer`].
+    pub(super) fn new(mut serializer: &'s mut ESTreeSerializer<F>) -> Self {
+        serializer.buffer_mut().push_ascii_byte(b'{');
+        Self { serializer, state: StructState::Empty }
+    }
+}
+
+impl<F: Formatter> StructSerializer for ESTreeStructSerializer<'_, F> {
+    type Formatter = F;
+
+    /// Serialize struct field.
+    ///
+    /// `key` must not contain any characters which require escaping in JSON.
+    fn serialize_field<T: ESTree + ?Sized>(&mut self, key: &str, value: &T) {
+        let (buffer, formatter) = self.serializer.buffer_and_formatter_mut();
+        if self.state == StructState::Empty {
+            self.state = StructState::HasFields;
+            formatter.before_first_element(buffer);
+        } else {
+            buffer.push_ascii_byte(b',');
+            formatter.before_later_element(buffer);
+        }
+
+        buffer.push_ascii_byte(b'"');
+        buffer.push_str(key);
+        buffer.push_str("\":");
+        formatter.before_field_value(buffer);
+        value.serialize(&mut *self.serializer);
+    }
+
+    /// Finish serializing struct.
+    fn end(self) {
+        let mut serializer = self.serializer;
+        let (buffer, formatter) = serializer.buffer_and_formatter_mut();
+        if self.state == StructState::HasFields {
+            formatter.after_last_element(buffer);
+        }
+        buffer.push_ascii_byte(b'}');
+    }
+}
+
+/// State of [`StructSerializer`].
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(super) enum StructState {
+    Empty,
+    HasFields,
+}
+
+/// Flattening struct serializer.
+///
+/// The only method it's legal to call on a `FlatStructSerializer` is `serialize_struct`.
+///
+/// # Example
+/// ```
+/// struct SomeNode {
+///     // We want to flatten `Span` as if its fields were on `SomeNode`
+///     span: Span,
+///     whatever: u32,
+/// }
+///
+/// struct Span {
+///     start: u32,
+///     end: u32,
+/// }
+///
+/// impl ESTree for SomeNode {
+///     fn serialize<S: Serializer>(&self, serializer: S) {
+///         let mut state = serializer.serialize_struct();
+///         self.inner.serialize(FlatStructSerializer(&mut state));
+///         state.serialize_field("whatever", &self.whatever);
+///         state.end();
+///     }
+/// }
+///
+/// impl ESTree for Span {
+///     fn serialize<S: Serializer>(&self, serializer: S) {
+///         let mut state = serializer.serialize_struct();
+///         state.serialize_field("start", &self.start);
+///         state.serialize_field("end", &self.end);
+///         state.end();
+///     }
+/// }
+/// ```
+pub struct FlatStructSerializer<'p, P: StructSerializer>(pub &'p mut P);
+
+impl<'p, P: StructSerializer> Serializer for FlatStructSerializer<'p, P> {
+    type StructSerializer = Self;
+    type SequenceSerializer = ESTreeSequenceSerializer<'p, P::Formatter>;
+
+    /// Serialize struct.
+    fn serialize_struct(self) -> Self {
+        self
+    }
+
+    fn serialize_sequence(self) -> ESTreeSequenceSerializer<'p, P::Formatter> {
+        const {
+            panic!("Cannot flatten a sequence into a struct");
+        }
+    }
+}
+
+impl<P: StructSerializer> SerializerPrivate for FlatStructSerializer<'_, P> {
+    type Formatter = P::Formatter;
+
+    fn buffer_mut(&mut self) -> &mut Buffer {
+        const {
+            panic!("Cannot flatten anything but a struct into another struct");
+        }
+    }
+
+    fn buffer_and_formatter_mut(&mut self) -> (&mut Buffer, &mut P::Formatter) {
+        const {
+            panic!("Cannot flatten anything but a struct into another struct");
+        }
+    }
+}
+
+impl<P: StructSerializer> StructSerializer for FlatStructSerializer<'_, P> {
+    type Formatter = P::Formatter;
+
+    /// Serialize struct field.
+    ///
+    /// `key` must not contain any characters which require escaping in JSON.
+    #[inline(always)]
+    fn serialize_field<T: ESTree + ?Sized>(&mut self, key: &str, value: &T) {
+        // Delegate to parent `StructSerializer`
+        self.0.serialize_field(key, value);
+    }
+
+    /// Finish serializing struct.
+    fn end(self) {
+        // No-op - there may be more fields to be added to the struct in the parent
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{CompactSerializer, FlatStructSerializer, PrettySerializer, Serializer};
+    use super::*;
+
+    #[test]
+    fn serialize_struct() {
+        struct Foo<'a> {
+            n: f64,
+            u: u32,
+            bar: Bar<'a>,
+            empty: Null,
+            hello: Option<&'a str>,
+            maybe_bar: Option<Bar<'a>>,
+            maybe_not_bar: Option<Bar<'a>>,
+        }
+
+        struct Bar<'a> {
+            yes: &'a str,
+            no: &'a str,
+        }
+
+        struct Null;
+
+        impl ESTree for Foo<'_> {
+            fn serialize<S: Serializer>(&self, serializer: S) {
+                let mut state = serializer.serialize_struct();
+                state.serialize_field("n", &self.n);
+                state.serialize_field("u", &self.u);
+                state.serialize_field("bar", &self.bar);
+                state.serialize_field("empty", &self.empty);
+                state.serialize_field("hello", &self.hello);
+                state.serialize_field("maybe_bar", &self.maybe_bar);
+                state.serialize_field("maybe_not_bar", &self.maybe_not_bar);
+                state.end();
+            }
+        }
+
+        impl ESTree for Bar<'_> {
+            fn serialize<S: Serializer>(&self, serializer: S) {
+                let mut state = serializer.serialize_struct();
+                state.serialize_field("yes", &self.yes);
+                state.serialize_field("no", &self.no);
+                state.end();
+            }
+        }
+
+        impl ESTree for Null {
+            fn serialize<S: Serializer>(&self, serializer: S) {
+                let state = serializer.serialize_struct();
+                state.end();
+            }
+        }
+
+        let foo = Foo {
+            n: 123.0,
+            u: 12345,
+            bar: Bar { yes: "yup", no: "nope" },
+            empty: Null,
+            hello: Some("hi!"),
+            maybe_bar: Some(Bar { yes: "hell yeah!", no: "not a chance in a million, mate" }),
+            maybe_not_bar: None,
+        };
+
+        let mut serializer = CompactSerializer::new();
+        foo.serialize(&mut serializer);
+        let s = serializer.into_string();
+        assert_eq!(
+            &s,
+            r#"{"n":123,"u":12345,"bar":{"yes":"yup","no":"nope"},"empty":{},"hello":"hi!","maybe_bar":{"yes":"hell yeah!","no":"not a chance in a million, mate"},"maybe_not_bar":null}"#
+        );
+
+        let mut serializer = PrettySerializer::new();
+        foo.serialize(&mut serializer);
+        let s = serializer.into_string();
+        assert_eq!(
+            &s,
+            r#"{
+  "n": 123,
+  "u": 12345,
+  "bar": {
+    "yes": "yup",
+    "no": "nope"
+  },
+  "empty": {},
+  "hello": "hi!",
+  "maybe_bar": {
+    "yes": "hell yeah!",
+    "no": "not a chance in a million, mate"
+  },
+  "maybe_not_bar": null
+}"#
+        );
+    }
+
+    #[test]
+    fn serialize_flattened_struct() {
+        struct Outer {
+            outer1: &'static str,
+            inner: Inner,
+            outer2: &'static str,
+        }
+
+        struct Inner {
+            inner1: &'static str,
+            innermost: Innermost,
+            inner2: &'static str,
+        }
+
+        struct Innermost {
+            innermost1: &'static str,
+            innermost2: &'static str,
+        }
+
+        impl ESTree for Outer {
+            fn serialize<S: Serializer>(&self, serializer: S) {
+                let mut state = serializer.serialize_struct();
+                state.serialize_field("outer1", &self.outer1);
+                self.inner.serialize(FlatStructSerializer(&mut state));
+                state.serialize_field("outer2", &self.outer2);
+                state.end();
+            }
+        }
+
+        impl ESTree for Inner {
+            fn serialize<S: Serializer>(&self, serializer: S) {
+                let mut state = serializer.serialize_struct();
+                state.serialize_field("inner1", &self.inner1);
+                self.innermost.serialize(FlatStructSerializer(&mut state));
+                state.serialize_field("inner2", &self.inner2);
+                state.end();
+            }
+        }
+
+        impl ESTree for Innermost {
+            fn serialize<S: Serializer>(&self, serializer: S) {
+                let mut state = serializer.serialize_struct();
+                state.serialize_field("innermost1", &self.innermost1);
+                state.serialize_field("innermost2", &self.innermost2);
+                state.end();
+            }
+        }
+
+        let outer = Outer {
+            outer1: "out1",
+            inner: Inner {
+                inner1: "in1",
+                innermost: Innermost { innermost1: "inin1", innermost2: "inin2" },
+                inner2: "in2",
+            },
+            outer2: "out2",
+        };
+
+        let mut serializer = CompactSerializer::new();
+        outer.serialize(&mut serializer);
+        let s = serializer.into_string();
+        assert_eq!(
+            &s,
+            r#"{"outer1":"out1","inner1":"in1","innermost1":"inin1","innermost2":"inin2","inner2":"in2","outer2":"out2"}"#
+        );
+
+        let mut serializer = PrettySerializer::new();
+        outer.serialize(&mut serializer);
+        let s = serializer.into_string();
+        assert_eq!(
+            &s,
+            r#"{
+  "outer1": "out1",
+  "inner1": "in1",
+  "innermost1": "inin1",
+  "innermost2": "inin2",
+  "inner2": "in2",
+  "outer2": "out2"
+}"#
+        );
+    }
+}

--- a/crates/oxc_parser/Cargo.toml
+++ b/crates/oxc_parser/Cargo.toml
@@ -40,7 +40,6 @@ memchr = { workspace = true }
 [dev-dependencies]
 oxc_ast = { workspace = true, features = ["serialize"] }
 pico-args = { workspace = true }
-serde_json = { workspace = true }
 
 [features]
 # Expose Lexer for benchmarks

--- a/crates/oxc_parser/examples/parser.rs
+++ b/crates/oxc_parser/examples/parser.rs
@@ -43,7 +43,7 @@ fn main() -> Result<(), String> {
         if show_estree {
             Utf8ToUtf16::new().convert(&mut program);
         }
-        println!("{}", serde_json::to_string_pretty(&program).unwrap());
+        println!("{}", program.to_pretty_json());
     }
 
     if ret.errors.is_empty() {

--- a/crates/oxc_regular_expression/Cargo.toml
+++ b/crates/oxc_regular_expression/Cargo.toml
@@ -30,12 +30,9 @@ phf = { workspace = true, features = ["macros"] }
 rustc-hash = { workspace = true }
 unicode-id-start = { workspace = true }
 
-serde = { workspace = true, optional = true }
-
 [features]
 default = []
 serialize = [
-  "dep:serde",
   "oxc_allocator/serialize",
   "oxc_span/serialize",
   "oxc_estree/serialize",

--- a/crates/oxc_regular_expression/src/generated/derive_estree.rs
+++ b/crates/oxc_regular_expression/src/generated/derive_estree.rs
@@ -1,49 +1,50 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/derives/estree.rs`
 
-#![allow(unused_imports, clippy::match_same_arms)]
+#![allow(unused_imports, clippy::match_same_arms, clippy::semicolon_if_nothing_returned)]
 
-use serde::{__private::ser::FlatMapSerializer, ser::SerializeMap, Serialize, Serializer};
-
-use oxc_estree::ser::{AppendTo, AppendToConcat};
+use oxc_estree::{
+    ser::{AppendTo, AppendToConcat},
+    ESTree, FlatStructSerializer, Serializer, StructSerializer,
+};
 
 use crate::ast::*;
 
-impl Serialize for Pattern<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Pattern")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("body", &self.body)?;
-        map.end()
+impl ESTree for Pattern<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "Pattern");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("body", &self.body);
+        state.end();
     }
 }
 
-impl Serialize for Disjunction<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Disjunction")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("body", &self.body)?;
-        map.end()
+impl ESTree for Disjunction<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "Disjunction");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("body", &self.body);
+        state.end();
     }
 }
 
-impl Serialize for Alternative<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Alternative")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("body", &self.body)?;
-        map.end()
+impl ESTree for Alternative<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "Alternative");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("body", &self.body);
+        state.end();
     }
 }
 
-impl Serialize for Term<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for Term<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             Term::BoundaryAssertion(it) => it.serialize(serializer),
             Term::LookAroundAssertion(it) => it.serialize(serializer),
@@ -61,222 +62,170 @@ impl Serialize for Term<'_> {
     }
 }
 
-impl Serialize for BoundaryAssertion {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "BoundaryAssertion")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("kind", &self.kind)?;
-        map.end()
+impl ESTree for BoundaryAssertion {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "BoundaryAssertion");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("kind", &self.kind);
+        state.end();
     }
 }
 
-impl Serialize for BoundaryAssertionKind {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for BoundaryAssertionKind {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            BoundaryAssertionKind::Start => {
-                serializer.serialize_unit_variant("BoundaryAssertionKind", 0, "start")
-            }
-            BoundaryAssertionKind::End => {
-                serializer.serialize_unit_variant("BoundaryAssertionKind", 1, "end")
-            }
-            BoundaryAssertionKind::Boundary => {
-                serializer.serialize_unit_variant("BoundaryAssertionKind", 2, "boundary")
-            }
-            BoundaryAssertionKind::NegativeBoundary => {
-                serializer.serialize_unit_variant("BoundaryAssertionKind", 3, "negativeBoundary")
+            BoundaryAssertionKind::Start => "start".serialize(serializer),
+            BoundaryAssertionKind::End => "end".serialize(serializer),
+            BoundaryAssertionKind::Boundary => "boundary".serialize(serializer),
+            BoundaryAssertionKind::NegativeBoundary => "negativeBoundary".serialize(serializer),
+        }
+    }
+}
+
+impl ESTree for LookAroundAssertion<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "LookAroundAssertion");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("kind", &self.kind);
+        state.serialize_field("body", &self.body);
+        state.end();
+    }
+}
+
+impl ESTree for LookAroundAssertionKind {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        match self {
+            LookAroundAssertionKind::Lookahead => "lookahead".serialize(serializer),
+            LookAroundAssertionKind::NegativeLookahead => "negativeLookahead".serialize(serializer),
+            LookAroundAssertionKind::Lookbehind => "lookbehind".serialize(serializer),
+            LookAroundAssertionKind::NegativeLookbehind => {
+                "negativeLookbehind".serialize(serializer)
             }
         }
     }
 }
 
-impl Serialize for LookAroundAssertion<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "LookAroundAssertion")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("kind", &self.kind)?;
-        map.serialize_entry("body", &self.body)?;
-        map.end()
+impl ESTree for Quantifier<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "Quantifier");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("min", &self.min);
+        state.serialize_field("max", &self.max);
+        state.serialize_field("greedy", &self.greedy);
+        state.serialize_field("body", &self.body);
+        state.end();
     }
 }
 
-impl Serialize for LookAroundAssertionKind {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for Character {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "Character");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("kind", &self.kind);
+        state.serialize_field("value", &self.value);
+        state.end();
+    }
+}
+
+impl ESTree for CharacterKind {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            LookAroundAssertionKind::Lookahead => {
-                serializer.serialize_unit_variant("LookAroundAssertionKind", 0, "lookahead")
-            }
-            LookAroundAssertionKind::NegativeLookahead => {
-                serializer.serialize_unit_variant("LookAroundAssertionKind", 1, "negativeLookahead")
-            }
-            LookAroundAssertionKind::Lookbehind => {
-                serializer.serialize_unit_variant("LookAroundAssertionKind", 2, "lookbehind")
-            }
-            LookAroundAssertionKind::NegativeLookbehind => serializer.serialize_unit_variant(
-                "LookAroundAssertionKind",
-                3,
-                "negativeLookbehind",
-            ),
+            CharacterKind::ControlLetter => "controlLetter".serialize(serializer),
+            CharacterKind::HexadecimalEscape => "hexadecimalEscape".serialize(serializer),
+            CharacterKind::Identifier => "identifier".serialize(serializer),
+            CharacterKind::Null => "null".serialize(serializer),
+            CharacterKind::Octal1 => "octal1".serialize(serializer),
+            CharacterKind::Octal2 => "octal2".serialize(serializer),
+            CharacterKind::Octal3 => "octal3".serialize(serializer),
+            CharacterKind::SingleEscape => "singleEscape".serialize(serializer),
+            CharacterKind::Symbol => "symbol".serialize(serializer),
+            CharacterKind::UnicodeEscape => "unicodeEscape".serialize(serializer),
         }
     }
 }
 
-impl Serialize for Quantifier<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Quantifier")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("min", &self.min)?;
-        map.serialize_entry("max", &self.max)?;
-        map.serialize_entry("greedy", &self.greedy)?;
-        map.serialize_entry("body", &self.body)?;
-        map.end()
+impl ESTree for CharacterClassEscape {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "CharacterClassEscape");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("kind", &self.kind);
+        state.end();
     }
 }
 
-impl Serialize for Character {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Character")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("kind", &self.kind)?;
-        map.serialize_entry("value", &self.value)?;
-        map.end()
-    }
-}
-
-impl Serialize for CharacterKind {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for CharacterClassEscapeKind {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            CharacterKind::ControlLetter => {
-                serializer.serialize_unit_variant("CharacterKind", 0, "controlLetter")
-            }
-            CharacterKind::HexadecimalEscape => {
-                serializer.serialize_unit_variant("CharacterKind", 1, "hexadecimalEscape")
-            }
-            CharacterKind::Identifier => {
-                serializer.serialize_unit_variant("CharacterKind", 2, "identifier")
-            }
-            CharacterKind::Null => serializer.serialize_unit_variant("CharacterKind", 3, "null"),
-            CharacterKind::Octal1 => {
-                serializer.serialize_unit_variant("CharacterKind", 4, "octal1")
-            }
-            CharacterKind::Octal2 => {
-                serializer.serialize_unit_variant("CharacterKind", 5, "octal2")
-            }
-            CharacterKind::Octal3 => {
-                serializer.serialize_unit_variant("CharacterKind", 6, "octal3")
-            }
-            CharacterKind::SingleEscape => {
-                serializer.serialize_unit_variant("CharacterKind", 7, "singleEscape")
-            }
-            CharacterKind::Symbol => {
-                serializer.serialize_unit_variant("CharacterKind", 8, "symbol")
-            }
-            CharacterKind::UnicodeEscape => {
-                serializer.serialize_unit_variant("CharacterKind", 9, "unicodeEscape")
-            }
+            CharacterClassEscapeKind::D => "d".serialize(serializer),
+            CharacterClassEscapeKind::NegativeD => "negativeD".serialize(serializer),
+            CharacterClassEscapeKind::S => "s".serialize(serializer),
+            CharacterClassEscapeKind::NegativeS => "negativeS".serialize(serializer),
+            CharacterClassEscapeKind::W => "w".serialize(serializer),
+            CharacterClassEscapeKind::NegativeW => "negativeW".serialize(serializer),
         }
     }
 }
 
-impl Serialize for CharacterClassEscape {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "CharacterClassEscape")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("kind", &self.kind)?;
-        map.end()
+impl ESTree for UnicodePropertyEscape<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "UnicodePropertyEscape");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("negative", &self.negative);
+        state.serialize_field("strings", &self.strings);
+        state.serialize_field("name", &self.name);
+        state.serialize_field("value", &self.value);
+        state.end();
     }
 }
 
-impl Serialize for CharacterClassEscapeKind {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for Dot {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "Dot");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.end();
+    }
+}
+
+impl ESTree for CharacterClass<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "CharacterClass");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("negative", &self.negative);
+        state.serialize_field("strings", &self.strings);
+        state.serialize_field("kind", &self.kind);
+        state.serialize_field("body", &self.body);
+        state.end();
+    }
+}
+
+impl ESTree for CharacterClassContentsKind {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            CharacterClassEscapeKind::D => {
-                serializer.serialize_unit_variant("CharacterClassEscapeKind", 0, "d")
-            }
-            CharacterClassEscapeKind::NegativeD => {
-                serializer.serialize_unit_variant("CharacterClassEscapeKind", 1, "negativeD")
-            }
-            CharacterClassEscapeKind::S => {
-                serializer.serialize_unit_variant("CharacterClassEscapeKind", 2, "s")
-            }
-            CharacterClassEscapeKind::NegativeS => {
-                serializer.serialize_unit_variant("CharacterClassEscapeKind", 3, "negativeS")
-            }
-            CharacterClassEscapeKind::W => {
-                serializer.serialize_unit_variant("CharacterClassEscapeKind", 4, "w")
-            }
-            CharacterClassEscapeKind::NegativeW => {
-                serializer.serialize_unit_variant("CharacterClassEscapeKind", 5, "negativeW")
-            }
+            CharacterClassContentsKind::Union => "union".serialize(serializer),
+            CharacterClassContentsKind::Intersection => "intersection".serialize(serializer),
+            CharacterClassContentsKind::Subtraction => "subtraction".serialize(serializer),
         }
     }
 }
 
-impl Serialize for UnicodePropertyEscape<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "UnicodePropertyEscape")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("negative", &self.negative)?;
-        map.serialize_entry("strings", &self.strings)?;
-        map.serialize_entry("name", &self.name)?;
-        map.serialize_entry("value", &self.value)?;
-        map.end()
-    }
-}
-
-impl Serialize for Dot {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Dot")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.end()
-    }
-}
-
-impl Serialize for CharacterClass<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "CharacterClass")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("negative", &self.negative)?;
-        map.serialize_entry("strings", &self.strings)?;
-        map.serialize_entry("kind", &self.kind)?;
-        map.serialize_entry("body", &self.body)?;
-        map.end()
-    }
-}
-
-impl Serialize for CharacterClassContentsKind {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        match self {
-            CharacterClassContentsKind::Union => {
-                serializer.serialize_unit_variant("CharacterClassContentsKind", 0, "union")
-            }
-            CharacterClassContentsKind::Intersection => {
-                serializer.serialize_unit_variant("CharacterClassContentsKind", 1, "intersection")
-            }
-            CharacterClassContentsKind::Subtraction => {
-                serializer.serialize_unit_variant("CharacterClassContentsKind", 2, "subtraction")
-            }
-        }
-    }
-}
-
-impl Serialize for CharacterClassContents<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for CharacterClassContents<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             CharacterClassContents::CharacterClassRange(it) => it.serialize(serializer),
             CharacterClassContents::CharacterClassEscape(it) => it.serialize(serializer),
@@ -288,107 +237,107 @@ impl Serialize for CharacterClassContents<'_> {
     }
 }
 
-impl Serialize for CharacterClassRange {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "CharacterClassRange")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("min", &self.min)?;
-        map.serialize_entry("max", &self.max)?;
-        map.end()
+impl ESTree for CharacterClassRange {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "CharacterClassRange");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("min", &self.min);
+        state.serialize_field("max", &self.max);
+        state.end();
     }
 }
 
-impl Serialize for ClassStringDisjunction<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ClassStringDisjunction")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("strings", &self.strings)?;
-        map.serialize_entry("body", &self.body)?;
-        map.end()
+impl ESTree for ClassStringDisjunction<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ClassStringDisjunction");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("strings", &self.strings);
+        state.serialize_field("body", &self.body);
+        state.end();
     }
 }
 
-impl Serialize for ClassString<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "ClassString")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("strings", &self.strings)?;
-        map.serialize_entry("body", &self.body)?;
-        map.end()
+impl ESTree for ClassString<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ClassString");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("strings", &self.strings);
+        state.serialize_field("body", &self.body);
+        state.end();
     }
 }
 
-impl Serialize for CapturingGroup<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "CapturingGroup")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("name", &self.name)?;
-        map.serialize_entry("body", &self.body)?;
-        map.end()
+impl ESTree for CapturingGroup<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "CapturingGroup");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("name", &self.name);
+        state.serialize_field("body", &self.body);
+        state.end();
     }
 }
 
-impl Serialize for IgnoreGroup<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "IgnoreGroup")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("modifiers", &self.modifiers)?;
-        map.serialize_entry("body", &self.body)?;
-        map.end()
+impl ESTree for IgnoreGroup<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "IgnoreGroup");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("modifiers", &self.modifiers);
+        state.serialize_field("body", &self.body);
+        state.end();
     }
 }
 
-impl Serialize for Modifiers {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Modifiers")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("enabling", &self.enabling)?;
-        map.serialize_entry("disabling", &self.disabling)?;
-        map.end()
+impl ESTree for Modifiers {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "Modifiers");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("enabling", &self.enabling);
+        state.serialize_field("disabling", &self.disabling);
+        state.end();
     }
 }
 
-impl Serialize for Modifier {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "Modifier")?;
-        map.serialize_entry("ignoreCase", &self.ignore_case)?;
-        map.serialize_entry("multiline", &self.multiline)?;
-        map.serialize_entry("sticky", &self.sticky)?;
-        map.end()
+impl ESTree for Modifier {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "Modifier");
+        state.serialize_field("ignoreCase", &self.ignore_case);
+        state.serialize_field("multiline", &self.multiline);
+        state.serialize_field("sticky", &self.sticky);
+        state.end();
     }
 }
 
-impl Serialize for IndexedReference {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "IndexedReference")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("index", &self.index)?;
-        map.end()
+impl ESTree for IndexedReference {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "IndexedReference");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("index", &self.index);
+        state.end();
     }
 }
 
-impl Serialize for NamedReference<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("type", "NamedReference")?;
-        map.serialize_entry("start", &self.span.start)?;
-        map.serialize_entry("end", &self.span.end)?;
-        map.serialize_entry("name", &self.name)?;
-        map.end()
+impl ESTree for NamedReference<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "NamedReference");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("name", &self.name);
+        state.end();
     }
 }

--- a/crates/oxc_span/src/atom.rs
+++ b/crates/oxc_span/src/atom.rs
@@ -6,7 +6,9 @@ use std::{
 
 use oxc_allocator::{Allocator, CloneIn, FromIn};
 #[cfg(feature = "serialize")]
-use serde::{Serialize, Serializer};
+use oxc_estree::{ESTree, Serializer as ESTreeSerializer};
+#[cfg(feature = "serialize")]
+use serde::{Serialize, Serializer as SerdeSerializer};
 
 use crate::{CompactStr, ContentEq};
 
@@ -208,7 +210,14 @@ impl fmt::Display for Atom<'_> {
 
 #[cfg(feature = "serialize")]
 impl Serialize for Atom<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        self.0.serialize(serializer)
+    fn serialize<S: SerdeSerializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        Serialize::serialize(self.as_str(), serializer)
+    }
+}
+
+#[cfg(feature = "serialize")]
+impl ESTree for Atom<'_> {
+    fn serialize<S: ESTreeSerializer>(&self, serializer: S) {
+        ESTree::serialize(self.as_str(), serializer);
     }
 }

--- a/crates/oxc_span/src/generated/derive_estree.rs
+++ b/crates/oxc_span/src/generated/derive_estree.rs
@@ -1,40 +1,39 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/derives/estree.rs`
 
-#![allow(unused_imports, clippy::match_same_arms)]
+#![allow(unused_imports, clippy::match_same_arms, clippy::semicolon_if_nothing_returned)]
 
-use serde::{__private::ser::FlatMapSerializer, ser::SerializeMap, Serialize, Serializer};
-
-use oxc_estree::ser::{AppendTo, AppendToConcat};
+use oxc_estree::{
+    ser::{AppendTo, AppendToConcat},
+    ESTree, FlatStructSerializer, Serializer, StructSerializer,
+};
 
 use crate::source_type::*;
 use crate::span::*;
 
-impl Serialize for Span {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("start", &self.start)?;
-        map.serialize_entry("end", &self.end)?;
-        map.end()
+impl ESTree for Span {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("start", &self.start);
+        state.serialize_field("end", &self.end);
+        state.end();
     }
 }
 
-impl Serialize for SourceType {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        let mut map = serializer.serialize_map(None)?;
-        map.serialize_entry("sourceType", &self.module_kind)?;
-        map.end()
+impl ESTree for SourceType {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("sourceType", &self.module_kind);
+        state.end();
     }
 }
 
-impl Serialize for ModuleKind {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for ModuleKind {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            ModuleKind::Script => serializer.serialize_unit_variant("ModuleKind", 0, "script"),
-            ModuleKind::Module => serializer.serialize_unit_variant("ModuleKind", 1, "module"),
-            ModuleKind::Unambiguous => {
-                serializer.serialize_unit_variant("ModuleKind", 2, "unambiguous")
-            }
+            ModuleKind::Script => "script".serialize(serializer),
+            ModuleKind::Module => "module".serialize(serializer),
+            ModuleKind::Unambiguous => "unambiguous".serialize(serializer),
         }
     }
 }

--- a/crates/oxc_span/src/span.rs
+++ b/crates/oxc_span/src/span.rs
@@ -5,6 +5,8 @@ use std::{
 };
 
 use miette::{LabeledSpan, SourceOffset, SourceSpan};
+#[cfg(feature = "serialize")]
+use serde::{ser::SerializeMap, Serialize, Serializer as SerdeSerializer};
 
 use oxc_allocator::{Allocator, CloneIn};
 use oxc_ast_macros::ast;
@@ -540,6 +542,16 @@ impl<'a> CloneIn<'a> for Span {
     #[inline]
     fn clone_in(&self, _: &'a Allocator) -> Self {
         *self
+    }
+}
+
+#[cfg(feature = "serialize")]
+impl Serialize for Span {
+    fn serialize<S: SerdeSerializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("start", &self.start)?;
+        map.serialize_entry("end", &self.end)?;
+        map.end()
     }
 }
 

--- a/crates/oxc_syntax/src/generated/derive_estree.rs
+++ b/crates/oxc_syntax/src/generated/derive_estree.rs
@@ -1,177 +1,96 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/derives/estree.rs`
 
-#![allow(unused_imports, clippy::match_same_arms)]
+#![allow(unused_imports, clippy::match_same_arms, clippy::semicolon_if_nothing_returned)]
 
-use serde::{__private::ser::FlatMapSerializer, ser::SerializeMap, Serialize, Serializer};
-
-use oxc_estree::ser::{AppendTo, AppendToConcat};
+use oxc_estree::{
+    ser::{AppendTo, AppendToConcat},
+    ESTree, FlatStructSerializer, Serializer, StructSerializer,
+};
 
 use crate::operator::*;
 
-impl Serialize for AssignmentOperator {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for AssignmentOperator {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            AssignmentOperator::Assign => {
-                serializer.serialize_unit_variant("AssignmentOperator", 0, "=")
-            }
-            AssignmentOperator::Addition => {
-                serializer.serialize_unit_variant("AssignmentOperator", 1, "+=")
-            }
-            AssignmentOperator::Subtraction => {
-                serializer.serialize_unit_variant("AssignmentOperator", 2, "-=")
-            }
-            AssignmentOperator::Multiplication => {
-                serializer.serialize_unit_variant("AssignmentOperator", 3, "*=")
-            }
-            AssignmentOperator::Division => {
-                serializer.serialize_unit_variant("AssignmentOperator", 4, "/=")
-            }
-            AssignmentOperator::Remainder => {
-                serializer.serialize_unit_variant("AssignmentOperator", 5, "%=")
-            }
-            AssignmentOperator::Exponential => {
-                serializer.serialize_unit_variant("AssignmentOperator", 6, "**=")
-            }
-            AssignmentOperator::ShiftLeft => {
-                serializer.serialize_unit_variant("AssignmentOperator", 7, "<<=")
-            }
-            AssignmentOperator::ShiftRight => {
-                serializer.serialize_unit_variant("AssignmentOperator", 8, ">>=")
-            }
-            AssignmentOperator::ShiftRightZeroFill => {
-                serializer.serialize_unit_variant("AssignmentOperator", 9, ">>>=")
-            }
-            AssignmentOperator::BitwiseOR => {
-                serializer.serialize_unit_variant("AssignmentOperator", 10, "|=")
-            }
-            AssignmentOperator::BitwiseXOR => {
-                serializer.serialize_unit_variant("AssignmentOperator", 11, "^=")
-            }
-            AssignmentOperator::BitwiseAnd => {
-                serializer.serialize_unit_variant("AssignmentOperator", 12, "&=")
-            }
-            AssignmentOperator::LogicalOr => {
-                serializer.serialize_unit_variant("AssignmentOperator", 13, "||=")
-            }
-            AssignmentOperator::LogicalAnd => {
-                serializer.serialize_unit_variant("AssignmentOperator", 14, "&&=")
-            }
-            AssignmentOperator::LogicalNullish => {
-                serializer.serialize_unit_variant("AssignmentOperator", 15, "??=")
-            }
+            AssignmentOperator::Assign => "=".serialize(serializer),
+            AssignmentOperator::Addition => "+=".serialize(serializer),
+            AssignmentOperator::Subtraction => "-=".serialize(serializer),
+            AssignmentOperator::Multiplication => "*=".serialize(serializer),
+            AssignmentOperator::Division => "/=".serialize(serializer),
+            AssignmentOperator::Remainder => "%=".serialize(serializer),
+            AssignmentOperator::Exponential => "**=".serialize(serializer),
+            AssignmentOperator::ShiftLeft => "<<=".serialize(serializer),
+            AssignmentOperator::ShiftRight => ">>=".serialize(serializer),
+            AssignmentOperator::ShiftRightZeroFill => ">>>=".serialize(serializer),
+            AssignmentOperator::BitwiseOR => "|=".serialize(serializer),
+            AssignmentOperator::BitwiseXOR => "^=".serialize(serializer),
+            AssignmentOperator::BitwiseAnd => "&=".serialize(serializer),
+            AssignmentOperator::LogicalOr => "||=".serialize(serializer),
+            AssignmentOperator::LogicalAnd => "&&=".serialize(serializer),
+            AssignmentOperator::LogicalNullish => "??=".serialize(serializer),
         }
     }
 }
 
-impl Serialize for BinaryOperator {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for BinaryOperator {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            BinaryOperator::Equality => {
-                serializer.serialize_unit_variant("BinaryOperator", 0, "==")
-            }
-            BinaryOperator::Inequality => {
-                serializer.serialize_unit_variant("BinaryOperator", 1, "!=")
-            }
-            BinaryOperator::StrictEquality => {
-                serializer.serialize_unit_variant("BinaryOperator", 2, "===")
-            }
-            BinaryOperator::StrictInequality => {
-                serializer.serialize_unit_variant("BinaryOperator", 3, "!==")
-            }
-            BinaryOperator::LessThan => serializer.serialize_unit_variant("BinaryOperator", 4, "<"),
-            BinaryOperator::LessEqualThan => {
-                serializer.serialize_unit_variant("BinaryOperator", 5, "<=")
-            }
-            BinaryOperator::GreaterThan => {
-                serializer.serialize_unit_variant("BinaryOperator", 6, ">")
-            }
-            BinaryOperator::GreaterEqualThan => {
-                serializer.serialize_unit_variant("BinaryOperator", 7, ">=")
-            }
-            BinaryOperator::Addition => serializer.serialize_unit_variant("BinaryOperator", 8, "+"),
-            BinaryOperator::Subtraction => {
-                serializer.serialize_unit_variant("BinaryOperator", 9, "-")
-            }
-            BinaryOperator::Multiplication => {
-                serializer.serialize_unit_variant("BinaryOperator", 10, "*")
-            }
-            BinaryOperator::Division => {
-                serializer.serialize_unit_variant("BinaryOperator", 11, "/")
-            }
-            BinaryOperator::Remainder => {
-                serializer.serialize_unit_variant("BinaryOperator", 12, "%")
-            }
-            BinaryOperator::Exponential => {
-                serializer.serialize_unit_variant("BinaryOperator", 13, "**")
-            }
-            BinaryOperator::ShiftLeft => {
-                serializer.serialize_unit_variant("BinaryOperator", 14, "<<")
-            }
-            BinaryOperator::ShiftRight => {
-                serializer.serialize_unit_variant("BinaryOperator", 15, ">>")
-            }
-            BinaryOperator::ShiftRightZeroFill => {
-                serializer.serialize_unit_variant("BinaryOperator", 16, ">>>")
-            }
-            BinaryOperator::BitwiseOR => {
-                serializer.serialize_unit_variant("BinaryOperator", 17, "|")
-            }
-            BinaryOperator::BitwiseXOR => {
-                serializer.serialize_unit_variant("BinaryOperator", 18, "^")
-            }
-            BinaryOperator::BitwiseAnd => {
-                serializer.serialize_unit_variant("BinaryOperator", 19, "&")
-            }
-            BinaryOperator::In => serializer.serialize_unit_variant("BinaryOperator", 20, "in"),
-            BinaryOperator::Instanceof => {
-                serializer.serialize_unit_variant("BinaryOperator", 21, "instanceof")
-            }
+            BinaryOperator::Equality => "==".serialize(serializer),
+            BinaryOperator::Inequality => "!=".serialize(serializer),
+            BinaryOperator::StrictEquality => "===".serialize(serializer),
+            BinaryOperator::StrictInequality => "!==".serialize(serializer),
+            BinaryOperator::LessThan => "<".serialize(serializer),
+            BinaryOperator::LessEqualThan => "<=".serialize(serializer),
+            BinaryOperator::GreaterThan => ">".serialize(serializer),
+            BinaryOperator::GreaterEqualThan => ">=".serialize(serializer),
+            BinaryOperator::Addition => "+".serialize(serializer),
+            BinaryOperator::Subtraction => "-".serialize(serializer),
+            BinaryOperator::Multiplication => "*".serialize(serializer),
+            BinaryOperator::Division => "/".serialize(serializer),
+            BinaryOperator::Remainder => "%".serialize(serializer),
+            BinaryOperator::Exponential => "**".serialize(serializer),
+            BinaryOperator::ShiftLeft => "<<".serialize(serializer),
+            BinaryOperator::ShiftRight => ">>".serialize(serializer),
+            BinaryOperator::ShiftRightZeroFill => ">>>".serialize(serializer),
+            BinaryOperator::BitwiseOR => "|".serialize(serializer),
+            BinaryOperator::BitwiseXOR => "^".serialize(serializer),
+            BinaryOperator::BitwiseAnd => "&".serialize(serializer),
+            BinaryOperator::In => "in".serialize(serializer),
+            BinaryOperator::Instanceof => "instanceof".serialize(serializer),
         }
     }
 }
 
-impl Serialize for LogicalOperator {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for LogicalOperator {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            LogicalOperator::Or => serializer.serialize_unit_variant("LogicalOperator", 0, "||"),
-            LogicalOperator::And => serializer.serialize_unit_variant("LogicalOperator", 1, "&&"),
-            LogicalOperator::Coalesce => {
-                serializer.serialize_unit_variant("LogicalOperator", 2, "??")
-            }
+            LogicalOperator::Or => "||".serialize(serializer),
+            LogicalOperator::And => "&&".serialize(serializer),
+            LogicalOperator::Coalesce => "??".serialize(serializer),
         }
     }
 }
 
-impl Serialize for UnaryOperator {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for UnaryOperator {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            UnaryOperator::UnaryPlus => serializer.serialize_unit_variant("UnaryOperator", 0, "+"),
-            UnaryOperator::UnaryNegation => {
-                serializer.serialize_unit_variant("UnaryOperator", 1, "-")
-            }
-            UnaryOperator::LogicalNot => serializer.serialize_unit_variant("UnaryOperator", 2, "!"),
-            UnaryOperator::BitwiseNot => serializer.serialize_unit_variant("UnaryOperator", 3, "~"),
-            UnaryOperator::Typeof => {
-                serializer.serialize_unit_variant("UnaryOperator", 4, "typeof")
-            }
-            UnaryOperator::Void => serializer.serialize_unit_variant("UnaryOperator", 5, "void"),
-            UnaryOperator::Delete => {
-                serializer.serialize_unit_variant("UnaryOperator", 6, "delete")
-            }
+            UnaryOperator::UnaryPlus => "+".serialize(serializer),
+            UnaryOperator::UnaryNegation => "-".serialize(serializer),
+            UnaryOperator::LogicalNot => "!".serialize(serializer),
+            UnaryOperator::BitwiseNot => "~".serialize(serializer),
+            UnaryOperator::Typeof => "typeof".serialize(serializer),
+            UnaryOperator::Void => "void".serialize(serializer),
+            UnaryOperator::Delete => "delete".serialize(serializer),
         }
     }
 }
 
-impl Serialize for UpdateOperator {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+impl ESTree for UpdateOperator {
+    fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            UpdateOperator::Increment => {
-                serializer.serialize_unit_variant("UpdateOperator", 0, "++")
-            }
-            UpdateOperator::Decrement => {
-                serializer.serialize_unit_variant("UpdateOperator", 1, "--")
-            }
+            UpdateOperator::Increment => "++".serialize(serializer),
+            UpdateOperator::Decrement => "--".serialize(serializer),
         }
     }
 }

--- a/crates/oxc_wasm/Cargo.toml
+++ b/crates/oxc_wasm/Cargo.toml
@@ -28,5 +28,6 @@ oxc_prettier = { workspace = true }
 console_error_panic_hook = { workspace = true }
 serde = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
+serde_json = { workspace = true }
 tsify = { workspace = true }
 wasm-bindgen = { workspace = true }

--- a/napi/parser/Cargo.toml
+++ b/napi/parser/Cargo.toml
@@ -29,7 +29,6 @@ oxc_sourcemap = { workspace = true, features = ["napi"] }
 
 rustc-hash = { workspace = true }
 self_cell = { workspace = true }
-serde_json = { workspace = true }
 string_wizard = { workspace = true, features = ["sourcemap", "serde"] }
 
 ctor = { workspace = true }

--- a/napi/parser/src/lib.rs
+++ b/napi/parser/src/lib.rs
@@ -106,7 +106,7 @@ fn parse_with_return(filename: &str, source_text: String, options: &ParserOption
             }
         }
     }
-    let program = serde_json::to_string(&ret.program).unwrap();
+    let program = ret.program.to_json();
     let module = EcmaScriptModule::from(&ret.module_record);
     ParseResult { source_text, program, module, comments, errors }
 }

--- a/napi/parser/test/parse.test.ts
+++ b/napi/parser/test/parse.test.ts
@@ -27,6 +27,24 @@ describe('parse', () => {
     expect(code.substring(comment.start, comment.end)).toBe('/*' + comment.value + '*/');
   });
 
+  it('`Infinity` is represented as `Infinity` number', () => {
+    const ret = parseSync('test.js', '1e+350');
+    expect(ret.errors.length).toBe(0);
+    expect(ret.program.body.length).toBe(1);
+    expect(ret.program.body[0]).toEqual({
+      type: 'ExpressionStatement',
+      start: 0,
+      end: 6,
+      expression: {
+        type: 'Literal',
+        start: 0,
+        end: 6,
+        value: Infinity,
+        raw: '1e+350',
+      },
+    });
+  });
+
   it('`BigIntLiteral` has `value` as `BigInt`', () => {
     const ret = parseSync('test.js', '123_456n');
     expect(ret.errors.length).toBe(0);

--- a/tasks/coverage/snapshots/estree_test262.snap
+++ b/tasks/coverage/snapshots/estree_test262.snap
@@ -2,4 +2,19 @@ commit: bc5c1417
 
 estree_test262 Summary:
 AST Parsed     : 48767/48767 (100.00%)
-Positive Passed: 48767/48767 (100.00%)
+Positive Passed: 48762/48767 (99.99%)
+tasks/coverage/test262/test/built-ins/Array/prototype/indexOf/15.4.4.14-10-1.js
+serde_json error: number out of range at line 1 column 3184
+
+tasks/coverage/test262/test/built-ins/Array/prototype/lastIndexOf/15.4.4.15-9-1.js
+serde_json error: number out of range at line 1 column 3184
+
+tasks/coverage/test262/test/built-ins/Number/S9.3.1_A6_T1.js
+serde_json error: number out of range at line 1 column 1792
+
+tasks/coverage/test262/test/built-ins/Number/S9.3.1_A6_T2.js
+serde_json error: number out of range at line 1 column 3552
+
+tasks/coverage/test262/test/language/types/number/8.5.1.js
+serde_json error: number out of range at line 1 column 9723
+

--- a/tasks/coverage/src/driver.rs
+++ b/tasks/coverage/src/driver.rs
@@ -76,7 +76,7 @@ impl CompilerInterface for Driver {
             self.errors.push(OxcDiagnostic::error("SourceType must not be unambiguous."));
         }
         // Make sure serialization doesn't crash; also for code coverage.
-        program.test_to_json().unwrap();
+        program.to_json();
         ControlFlow::Continue(())
     }
 

--- a/wasm/parser/test-node.mjs
+++ b/wasm/parser/test-node.mjs
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import { parseSync } from '../../npm/parser-wasm/node/oxc_parser_wasm.js';
 
-const code = '/abc/gu; 123n;';
+const code = '/abc/gu; 123n; 1e+350;';
 const result = parseSync(code, { sourceFilename: 'test.ts' });
 
 assert(result.errors.length === 0);
@@ -12,8 +12,11 @@ assert(result.program === program);
 
 // Check output is correct
 assert(program.type === 'Program');
-assert(program.body.length === 2);
+assert(program.body.length === 3);
 
-// Check `RegExp`s and `BigInt`s are deserialized correctly
+// Check `RegExp`s, `BigInt`s and `Infinity` are deserialized correctly
 assert(program.body[0].expression.value instanceof RegExp);
 assert(typeof program.body[1].expression.value === 'bigint');
+const inf = program.body[2].expression.value;
+assert(typeof inf === 'number');
+assert(inf === Infinity);


### PR DESCRIPTION
Replace `serde` with a custom serializer specialized for writing JSON.

`impl Serialize` -> `impl ESTree`. I've called it `ESTree` in case we want to add e.g. `impl Babel` later on.

The main motivation is that with control of the serializer, we can make it stateful, so we can extend it to, for example, omit TS fields based on a flag. This is pretty much impossible with `serde`'s interface.

But a side-effect of the simpler implementation is that it's also more performant.

The usage of `ESTree` trait is very similar to `serde::Serialize`. Main differences:

* `serialize` method is infallible. Does not return a `Result`.
* `state = serializer.serialize_struct();` instead of `map = serializer.serialize_map();`.
* `state.serialize_field(...)` instead of `map.serialize_entry(...)`.
* Struct keys must be strings, and JSON-safe (not including `"` or other characters that require escaping in JSON).

This is a breaking change, as it's possible downstream consumers are using `serde` to serialize our AST to other formats. I'd guess unlikely, but possible. We can always implement `serde::Serialize` as well as `ESTree` further down the line if there's a demand.