### PR TITLE
docs(wasm): correct and update docs

### DIFF
--- a/npm/parser-wasm/README.md
+++ b/npm/parser-wasm/README.md
@@ -15,27 +15,42 @@ And exports the files as
 "types": "./node/oxc_parser_wasm.d.ts",
 ```
 
-Checkout [oxc-parser](https://www.npmjs.com/package/oxc-parser) for usage in node.js via napi bindings.
+Check out [oxc-parser](https://www.npmjs.com/package/oxc-parser) for an alternative in Node.js
+which performs the same function, but using native code via NAPI bindings (slightly faster).
 
 Source code: https://github.com/oxc-project/oxc/tree/main/wasm/parser
 
 ## Usage
 
+### Node.js
+
 ```js
-import initWasm, { parseSync } from '@oxc-parser/wasm';
+import { parseSync } from '@oxc-parser/wasm';
 
-async function main() {
-  await initWasm();
+const code = 'let foo';
+const result = parseSync(code, { sourceFilename: 'test.ts' });
+console.log(result.program);
+```
 
-  const code = 'let foo';
-  const result = parseSync(code, { sourceFilename: 'test.ts' });
-  console.log(result);
-}
+### Browser
 
-main();
+```js
+import { initSync, parseSync } from '@oxc-parser/wasm';
+
+initSync();
+
+const code = 'let foo';
+const result = parseSync(code, { sourceFilename: 'test.ts' });
+console.log(result.program);
 ```
 
 ## Notes
+
+The AST returned conforms to the [ESTree](https://github.com/estree/estree) spec for JS syntax.
+
+For TypeScript code, the AST is broadly aligned with
+[typescript-eslint](https://typescript-eslint.io/packages/parser/)'s format, though there may be some
+differences.
 
 ### UTF8 vs UTF16 byte offsets
 

--- a/wasm/parser/README.md
+++ b/wasm/parser/README.md
@@ -15,27 +15,42 @@ And exports the files as
 "types": "./node/oxc_parser_wasm.d.ts",
 ```
 
-Checkout [oxc-parser](https://www.npmjs.com/package/oxc-parser) for usage in node.js via napi bindings.
+Check out [oxc-parser](https://www.npmjs.com/package/oxc-parser) for an alternative in Node.js
+which performs the same function, but using native code via NAPI bindings (slightly faster).
 
 Source code: https://github.com/oxc-project/oxc/tree/main/wasm/parser
 
 ## Usage
 
+### Node.js
+
 ```js
-import initWasm, { parseSync } from '@oxc-parser/wasm';
+import { parseSync } from '@oxc-parser/wasm';
 
-async function main() {
-  await initWasm();
+const code = 'let foo';
+const result = parseSync(code, { sourceFilename: 'test.ts' });
+console.log(result.program);
+```
 
-  const code = 'let foo';
-  const result = parseSync(code, { sourceFilename: 'test.ts' });
-  console.log(result);
-}
+### Browser
 
-main();
+```js
+import { initSync, parseSync } from '@oxc-parser/wasm';
+
+initSync();
+
+const code = 'let foo';
+const result = parseSync(code, { sourceFilename: 'test.ts' });
+console.log(result.program);
 ```
 
 ## Notes
+
+The AST returned conforms to the [ESTree](https://github.com/estree/estree) spec for JS syntax.
+
+For TypeScript code, the AST is broadly aligned with
+[typescript-eslint](https://typescript-eslint.io/packages/parser/)'s format, though there may be some
+differences.
 
 ### UTF8 vs UTF16 byte offsets
 


### PR DESCRIPTION
Update the docs for [@oxc-parser/wasm](https://www.npmjs.com/package/@oxc-parser/wasm) NPM package.

* Fix the examples. `initWasm` no longer exists in Node.js bindings, and has been replaced by `initSync` in browser bindings.
* Add notes that AST is ESTree-compatible.
* Clarify the text about `oxc-parser` package.

I am not 100% sure that the web example is now correct, as I've not tested it, but from looking at the code for the bindings, it looks like it should be.
