### PR TITLE
refactor(transformer): do not use `&mut` when `&` ref will do

### DIFF
--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -532,7 +532,7 @@ impl<'a> ArrowFunctionConverter<'a> {
 
     /// Traverses upward through ancestor nodes to find the `ScopeId` of the block
     /// that potential affects the `this` expression.
-    fn get_scope_id_from_this_affected_block(&self, ctx: &mut TraverseCtx<'a>) -> Option<ScopeId> {
+    fn get_scope_id_from_this_affected_block(&self, ctx: &TraverseCtx<'a>) -> Option<ScopeId> {
         // `this` inside a class resolves to `this` *outside* the class in:
         // * `extends` clause
         // * Computed method key
@@ -678,7 +678,7 @@ impl<'a> ArrowFunctionConverter<'a> {
 
     /// Check whether currently in a class property initializer.
     /// e.g. `x` in `class C { prop = [foo(x)]; }`
-    fn in_class_property_definition_value(ctx: &mut TraverseCtx<'a>) -> bool {
+    fn in_class_property_definition_value(ctx: &TraverseCtx<'a>) -> bool {
         for ancestor in ctx.ancestors() {
             if ancestor.is_parent_of_statement() {
                 return false;
@@ -1131,7 +1131,7 @@ impl<'a> ArrowFunctionConverter<'a> {
 
     /// Insert variable statement at the top of the statements.
     fn insert_variable_statement_at_the_top_of_statements(
-        &mut self,
+        &self,
         target_scope_id: ScopeId,
         statements: &mut ArenaVec<'a, Statement<'a>>,
         this_var: Option<BoundIdentifier<'a>>,

--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -307,7 +307,7 @@ impl<'a> HelperLoaderStore<'a> {
     }
 
     // Construct string directly in arena without an intermediate temp allocation
-    fn get_runtime_source(&self, helper: Helper, ctx: &mut TraverseCtx<'a>) -> Atom<'a> {
+    fn get_runtime_source(&self, helper: Helper, ctx: &TraverseCtx<'a>) -> Atom<'a> {
         let helper_name = helper.name();
         let len = self.module_name.len() + "/helpers/".len() + helper_name.len();
         let mut source = ArenaString::with_capacity_in(len, ctx.ast.allocator);

--- a/crates/oxc_transformer/src/common/module_imports.rs
+++ b/crates/oxc_transformer/src/common/module_imports.rs
@@ -163,11 +163,7 @@ impl<'a> ModuleImportsStore<'a> {
         }
     }
 
-    fn insert_import_statements(
-        &self,
-        transform_ctx: &TransformCtx<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
+    fn insert_import_statements(&self, transform_ctx: &TransformCtx<'a>, ctx: &TraverseCtx<'a>) {
         let mut imports = self.imports.borrow_mut();
         let stmts = imports.drain(..).map(|(source, names)| Self::get_import(source, names, ctx));
         transform_ctx.top_level_statements.insert_statements(stmts);

--- a/crates/oxc_transformer/src/common/statement_injector.rs
+++ b/crates/oxc_transformer/src/common/statement_injector.rs
@@ -161,7 +161,7 @@ impl<'a> StatementInjectorStore<'a> {
     fn insert_into_statements(
         &self,
         statements: &mut ArenaVec<'a, Statement<'a>>,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) {
         let mut insertions = self.insertions.borrow_mut();
         if insertions.is_empty() {

--- a/crates/oxc_transformer/src/common/var_declarations.rs
+++ b/crates/oxc_transformer/src/common/var_declarations.rs
@@ -207,7 +207,7 @@ impl<'a> VarDeclarationsStore<'a> {
     fn insert_into_statements(
         &self,
         stmts: &mut ArenaVec<'a, Statement<'a>>,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) {
         if matches!(ctx.parent(), Ancestor::ProgramBody(_)) {
             // Handle in `insert_into_program` instead
@@ -219,7 +219,7 @@ impl<'a> VarDeclarationsStore<'a> {
         }
     }
 
-    fn insert_into_program(&self, transform_ctx: &TransformCtx<'a>, ctx: &mut TraverseCtx<'a>) {
+    fn insert_into_program(&self, transform_ctx: &TransformCtx<'a>, ctx: &TraverseCtx<'a>) {
         if let Some(insert_stmts) = self.get_var_statement(ctx) {
             // Delegate to `TopLevelStatements`
             transform_ctx.top_level_statements.insert_statements(insert_stmts);
@@ -231,7 +231,7 @@ impl<'a> VarDeclarationsStore<'a> {
         debug_assert!(stack.last().is_none());
     }
 
-    fn get_var_statement(&self, ctx: &mut TraverseCtx<'a>) -> Option<Vec<Statement<'a>>> {
+    fn get_var_statement(&self, ctx: &TraverseCtx<'a>) -> Option<Vec<Statement<'a>>> {
         let mut stack = self.stack.borrow_mut();
         let Declarators { var_declarators, let_declarators } = stack.pop()?;
 
@@ -256,7 +256,7 @@ impl<'a> VarDeclarationsStore<'a> {
     fn create_declaration(
         kind: VariableDeclarationKind,
         declarators: ArenaVec<'a, VariableDeclarator<'a>>,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) -> Statement<'a> {
         Statement::VariableDeclaration(ctx.ast.alloc_variable_declaration(
             SPAN,

--- a/crates/oxc_transformer/src/decorator/legacy/metadata.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/metadata.rs
@@ -559,7 +559,7 @@ impl<'a> LegacyDecoratorMetadata<'a, '_> {
     fn create_checked_value(
         left: Expression<'a>,
         right: Expression<'a>,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) -> Expression<'a> {
         let operator = BinaryOperator::StrictEquality;
         let undefined = ctx.ast.expression_string_literal(SPAN, "undefined", None);
@@ -570,7 +570,7 @@ impl<'a> LegacyDecoratorMetadata<'a, '_> {
 
     // `_metadata(key, value)
     fn create_metadata_decorate(
-        &mut self,
+        &self,
         key: &str,
         value: Expression<'a>,
         ctx: &mut TraverseCtx<'a>,

--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -163,7 +163,7 @@ impl<'a> LegacyDecorator<'a, '_> {
     /// ```
     // `#[inline]` so that compiler sees that `stmt` is a `Statement::ClassDeclaration`.
     #[inline]
-    fn transform_class(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
+    fn transform_class(&self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
         let Statement::ClassDeclaration(class) = stmt else { unreachable!() };
 
         let stmt_address = class.address();
@@ -200,11 +200,7 @@ impl<'a> LegacyDecorator<'a, '_> {
     /// ```
     // `#[inline]` so that compiler sees that `stmt` is a `Statement::ExportDefaultDeclaration`.
     #[inline]
-    fn transform_export_default_class(
-        &mut self,
-        stmt: &mut Statement<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
+    fn transform_export_default_class(&self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
         let Statement::ExportDefaultDeclaration(export) = stmt else { unreachable!() };
         let stmt_address = export.address();
         let ExportDefaultDeclarationKind::ClassDeclaration(class) = &mut export.declaration else {
@@ -251,11 +247,7 @@ impl<'a> LegacyDecorator<'a, '_> {
     /// ```
     // `#[inline]` so that compiler sees that `stmt` is a `Statement::ExportNamedDeclaration`.
     #[inline]
-    fn transform_export_named_class(
-        &mut self,
-        stmt: &mut Statement<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
+    fn transform_export_named_class(&self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
         let Statement::ExportNamedDeclaration(export) = stmt else { unreachable!() };
         let stmt_address = export.address();
         let Some(Declaration::ClassDeclaration(class)) = &mut export.declaration else { return };
@@ -272,7 +264,7 @@ impl<'a> LegacyDecorator<'a, '_> {
     }
 
     fn transform_class_impl(
-        &mut self,
+        &self,
         class: &mut Class<'a>,
         stmt_address: Address,
         ctx: &mut TraverseCtx<'a>,
@@ -305,7 +297,7 @@ impl<'a> LegacyDecorator<'a, '_> {
     /// Transforms a decorated class declaration and appends the resulting statements. If
     /// the class requires an alias to avoid issues with double-binding, the alias is returned.
     fn transform_class_declaration_with_class_decorators(
-        &mut self,
+        &self,
         class: &mut Class<'a>,
         has_private_in_expression_in_decorator: bool,
         ctx: &mut TraverseCtx<'a>,
@@ -462,7 +454,7 @@ impl<'a> LegacyDecorator<'a, '_> {
 
     /// Transforms a non-decorated class declaration.
     fn transform_class_declaration_without_class_decorators(
-        &mut self,
+        &self,
         class: &mut Class<'a>,
         stmt_address: Address,
         has_private_in_expression_in_decorator: bool,
@@ -490,7 +482,7 @@ impl<'a> LegacyDecorator<'a, '_> {
     /// Transform decorators of [`ClassElement::MethodDefinition`],
     /// [`ClassElement::PropertyDefinition`] and [`ClassElement::AccessorProperty`].
     fn transform_decorators_of_class_elements(
-        &mut self,
+        &self,
         class: &mut Class<'a>,
         class_binding: &BoundIdentifier<'a>,
         ctx: &mut TraverseCtx<'a>,
@@ -680,7 +672,7 @@ impl<'a> LegacyDecorator<'a, '_> {
     /// Converts a vec of [`Decorator`] to [`Expression::ArrayExpression`].
     fn convert_decorators_to_array_expression(
         decorators_iter: impl Iterator<Item = Decorator<'a>>,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) -> Expression<'a> {
         let decorations = ctx.ast.vec_from_iter(
             decorators_iter.map(|decorator| ArrayExpressionElement::from(decorator.expression)),
@@ -841,7 +833,7 @@ impl<'a> LegacyDecorator<'a, '_> {
     ///  * Non-copiable key:
     ///    * `[a()] = 0;` mutates the key to `[_a = a()] = 0;` and returns `_a`
     fn get_name_of_property_key(
-        &mut self,
+        &self,
         key: &mut PropertyKey<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -125,11 +125,7 @@ impl<'a> ExponentiationOperator<'a, '_> {
     //
     // `#[inline]` so compiler knows `expr` is an `AssignmentExpression` with `IdentifierReference` on left
     #[inline]
-    fn convert_identifier_assignment(
-        &mut self,
-        expr: &mut Expression<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
+    fn convert_identifier_assignment(&self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         let Expression::AssignmentExpression(assign_expr) = expr else { unreachable!() };
         let AssignmentTarget::AssignmentTargetIdentifier(ident) = &mut assign_expr.left else {
             unreachable!()
@@ -142,8 +138,8 @@ impl<'a> ExponentiationOperator<'a, '_> {
 
     /// Get left side of `Math.pow(pow_left, ...)` for identifier
     fn get_pow_left_identifier(
-        &mut self,
-        ident: &mut IdentifierReference<'a>,
+        &self,
+        ident: &IdentifierReference<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> (
         // Left side of `Math.pow(pow_left, ...)`
@@ -196,7 +192,7 @@ impl<'a> ExponentiationOperator<'a, '_> {
     // `#[inline]` so compiler knows `expr` is an `AssignmentExpression` with `StaticMemberExpression` on left
     #[inline]
     fn convert_static_member_expression_assignment(
-        &mut self,
+        &self,
         expr: &mut Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
@@ -215,7 +211,7 @@ impl<'a> ExponentiationOperator<'a, '_> {
     /// Get left side of `Math.pow(pow_left, ...)` for static member expression
     /// and replacement for left side of assignment.
     fn get_pow_left_static_member(
-        &mut self,
+        &self,
         member_expr: &mut StaticMemberExpression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> (
@@ -295,7 +291,7 @@ impl<'a> ExponentiationOperator<'a, '_> {
     // `#[inline]` so compiler knows `expr` is an `AssignmentExpression` with `ComputedMemberExpression` on left
     #[inline]
     fn convert_computed_member_expression_assignment(
-        &mut self,
+        &self,
         expr: &mut Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
@@ -311,7 +307,7 @@ impl<'a> ExponentiationOperator<'a, '_> {
 
     /// Get left side of `Math.pow(pow_left, ...)` for computed member expression
     fn get_pow_left_computed_member(
-        &mut self,
+        &self,
         member_expr: &mut ComputedMemberExpression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> (
@@ -376,7 +372,7 @@ impl<'a> ExponentiationOperator<'a, '_> {
     // `#[inline]` so compiler knows `expr` is an `AssignmentExpression` with `PrivateFieldExpression` on left
     #[inline]
     fn convert_private_field_assignment(
-        &mut self,
+        &self,
         expr: &mut Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
@@ -393,7 +389,7 @@ impl<'a> ExponentiationOperator<'a, '_> {
     /// Get left side of `Math.pow(pow_left, ...)` for static member expression
     /// and replacement for left side of assignment.
     fn get_pow_left_private_field(
-        &mut self,
+        &self,
         field_expr: &mut PrivateFieldExpression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> (
@@ -472,7 +468,7 @@ impl<'a> ExponentiationOperator<'a, '_> {
     /// ^^^^^^^^^^^^^^^^^^^^^^^^^^ added to `temp_var_inits`
     /// ```
     fn get_second_member_expression_object(
-        &mut self,
+        &self,
         obj: &mut Expression<'a>,
         temp_var_inits: &mut ArenaVec<'a, Expression<'a>>,
         ctx: &mut TraverseCtx<'a>,
@@ -522,7 +518,7 @@ impl<'a> ExponentiationOperator<'a, '_> {
     fn revise_expression(
         expr: &mut Expression<'a>,
         mut temp_var_inits: ArenaVec<'a, Expression<'a>>,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) {
         if !temp_var_inits.is_empty() {
             temp_var_inits.reserve_exact(1);
@@ -552,7 +548,7 @@ impl<'a> ExponentiationOperator<'a, '_> {
     /// Add initialization expression `_name = expr` to `temp_var_inits`.
     /// Return `BoundIdentifier` for the temp var.
     fn create_temp_var(
-        &mut self,
+        &self,
         expr: Expression<'a>,
         temp_var_inits: &mut ArenaVec<'a, Expression<'a>>,
         ctx: &mut TraverseCtx<'a>,

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -146,7 +146,7 @@ impl<'a> Traverse<'a> for AsyncToGenerator<'a, '_> {
 
 impl<'a> AsyncToGenerator<'a, '_> {
     /// Check whether the current node is inside an async function.
-    fn is_inside_async_function(ctx: &mut TraverseCtx<'a>) -> bool {
+    fn is_inside_async_function(ctx: &TraverseCtx<'a>) -> bool {
         // Early return if current scope is top because we don't need to transform top-level await expression.
         if ctx.current_scope_flags().is_top() {
             return false;
@@ -168,7 +168,7 @@ impl<'a> AsyncToGenerator<'a, '_> {
     /// Ignores top-level await expressions.
     fn transform_await_expression(
         expr: &mut AwaitExpression<'a>,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) -> Option<Expression<'a>> {
         // We don't need to handle top-level await.
         if Self::is_inside_async_function(ctx) {
@@ -556,7 +556,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
     }
 
     /// Infers the function name from the [`TraverseCtx::parent`].
-    fn infer_function_name_from_parent_node(ctx: &mut TraverseCtx<'a>) -> Option<Atom<'a>> {
+    fn infer_function_name_from_parent_node(ctx: &TraverseCtx<'a>) -> Option<Atom<'a>> {
         match ctx.parent() {
             // infer `foo` from `const foo = async function() {}`
             Ancestor::VariableDeclaratorInit(declarator) => {
@@ -628,7 +628,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
         params: ArenaBox<'a, FormalParameters<'a>>,
         body: ArenaBox<'a, FunctionBody<'a>>,
         scope_id: ScopeId,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) -> ArenaBox<'a, Function<'a>> {
         let r#type = if id.is_some() {
             FunctionType::FunctionDeclaration
@@ -794,7 +794,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
 
     /// Creates an empty [FormalParameters] with [FormalParameterKind::FormalParameter].
     #[inline]
-    fn create_empty_params(ctx: &mut TraverseCtx<'a>) -> ArenaBox<'a, FormalParameters<'a>> {
+    fn create_empty_params(ctx: &TraverseCtx<'a>) -> ArenaBox<'a, FormalParameters<'a>> {
         ctx.ast.alloc_formal_parameters(
             SPAN,
             FormalParameterKind::FormalParameter,

--- a/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
@@ -23,11 +23,7 @@ impl<'a> AsyncGeneratorFunctions<'a, '_> {
         )
     }
 
-    pub(crate) fn transform_statement(
-        &mut self,
-        stmt: &mut Statement<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
+    pub(crate) fn transform_statement(&self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
         let (for_of, label) = match stmt {
             Statement::LabeledStatement(labeled) => {
                 let LabeledStatement { label, body, .. } = labeled.as_mut();
@@ -93,7 +89,7 @@ impl<'a> AsyncGeneratorFunctions<'a, '_> {
     }
 
     pub(self) fn transform_for_of_statement(
-        &mut self,
+        &self,
         stmt: &mut ForOfStatement<'a>,
         parent_scope_id: ScopeId,
         ctx: &mut TraverseCtx<'a>,

--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -379,7 +379,7 @@ impl<'a> ObjectRestSpread<'a, '_> {
     }
 
     fn walk_and_replace_nested_object_target(
-        &mut self,
+        &self,
         expr: &mut Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {

--- a/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
+++ b/crates/oxc_transformer/src/es2020/nullish_coalescing_operator.rs
@@ -66,7 +66,7 @@ impl<'a> Traverse<'a> for NullishCoalescingOperator<'a, '_> {
 
 impl<'a> NullishCoalescingOperator<'a, '_> {
     fn transform_logical_expression(
-        &mut self,
+        &self,
         logical_expr: ArenaBox<'a, LogicalExpression<'a>>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
@@ -205,7 +205,7 @@ impl<'a> NullishCoalescingOperator<'a, '_> {
         reference2: Expression<'a>,
         default: Expression<'a>,
         span: Span,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) -> Expression<'a> {
         let op = BinaryOperator::StrictInequality;
         let null = ctx.ast.expression_null_literal(SPAN);

--- a/crates/oxc_transformer/src/es2020/optional_chaining.rs
+++ b/crates/oxc_transformer/src/es2020/optional_chaining.rs
@@ -135,7 +135,7 @@ impl<'a> OptionalChaining<'a, '_> {
     }
 
     /// Get the call context from [`Self::call_context`]
-    fn get_call_context(&mut self, ctx: &mut TraverseCtx<'a>) -> Argument<'a> {
+    fn get_call_context(&self, ctx: &mut TraverseCtx<'a>) -> Argument<'a> {
         debug_assert!(!matches!(self.call_context, CallContext::None));
         Argument::from(if let CallContext::Binding(binding) = &self.call_context {
             binding.create_read_expression(ctx)
@@ -148,7 +148,7 @@ impl<'a> OptionalChaining<'a, '_> {
     fn should_specify_context(
         &self,
         ident: &IdentifierReference<'a>,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) -> bool {
         match &self.call_context {
             CallContext::None => false,
@@ -254,7 +254,7 @@ impl<'a> OptionalChaining<'a, '_> {
     #[inline]
     fn convert_chain_expression_to_expression(
         expr: &mut Expression<'a>,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) -> Expression<'a> {
         let Expression::ChainExpression(chain_expr) = ctx.ast.move_expression(expr) else {
             unreachable!()
@@ -354,7 +354,7 @@ impl<'a> OptionalChaining<'a, '_> {
     ///
     /// `Foo.bar` -> `Foo.bar.bind(context)`
     fn transform_expression_to_bind_context(
-        &mut self,
+        &self,
         mut expr: Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {

--- a/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/oxc_transformer/src/es2021/logical_assignment_operators.rs
@@ -88,7 +88,7 @@ impl<'a> Traverse<'a> for LogicalAssignmentOperators<'a, '_> {
 
 impl<'a> LogicalAssignmentOperators<'a, '_> {
     fn transform_logical_assignment(
-        &mut self,
+        &self,
         expr: &mut Expression<'a>,
         operator: LogicalOperator,
         ctx: &mut TraverseCtx<'a>,
@@ -148,7 +148,7 @@ impl<'a> LogicalAssignmentOperators<'a, '_> {
     }
 
     fn convert_static_member_expression(
-        &mut self,
+        &self,
         static_expr: &mut StaticMemberExpression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> (Expression<'a>, AssignmentTarget<'a>) {
@@ -174,7 +174,7 @@ impl<'a> LogicalAssignmentOperators<'a, '_> {
     }
 
     fn convert_computed_member_expression(
-        &mut self,
+        &self,
         computed_expr: &mut ComputedMemberExpression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> (Expression<'a>, AssignmentTarget<'a>) {

--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -813,11 +813,7 @@ impl<'a> ClassProperties<'a, '_> {
     }
 
     /// Insert an expression after the class.
-    pub(super) fn insert_expr_after_class(
-        &mut self,
-        expr: Expression<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
+    pub(super) fn insert_expr_after_class(&mut self, expr: Expression<'a>, ctx: &TraverseCtx<'a>) {
         if self.current_class().is_declaration {
             self.insert_after_stmts.push(ctx.ast.statement_expression(SPAN, expr));
         } else {

--- a/crates/oxc_transformer/src/es2022/class_properties/computed_key.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/computed_key.rs
@@ -79,7 +79,7 @@ impl<'a> ClassProperties<'a, '_> {
     /// Create `let _x;` statement and insert it.
     /// Return `_x = x()` assignment, and `_x` identifier referencing same temp var.
     fn create_computed_key_temp_var(
-        &mut self,
+        &self,
         key: Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> (/* assignment */ Expression<'a>, /* identifier */ Expression<'a>) {

--- a/crates/oxc_transformer/src/es2022/class_properties/instance_prop_init.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/instance_prop_init.rs
@@ -23,7 +23,7 @@ impl<'a> ClassProperties<'a, '_> {
     /// or a `_super` function. Change parent scope of first-level scopes in initializer to reflect this.
     pub(super) fn transform_instance_initializer(
         &mut self,
-        value: &mut Expression<'a>,
+        value: &Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
         if let Some(constructor_scope_id) = self.instance_inits_constructor_scope_id {
@@ -153,10 +153,7 @@ struct FastInstanceInitializerVisitor<'a, 'v> {
 }
 
 impl<'a, 'v> FastInstanceInitializerVisitor<'a, 'v> {
-    fn new(
-        class_properties: &'v mut ClassProperties<'a, '_>,
-        ctx: &'v mut TraverseCtx<'a>,
-    ) -> Self {
+    fn new(class_properties: &'v ClassProperties<'a, '_>, ctx: &'v mut TraverseCtx<'a>) -> Self {
         Self { parent_scope_id: class_properties.instance_inits_scope_id, ctx }
     }
 }

--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -203,7 +203,7 @@ impl<'a> ClassProperties<'a, '_> {
         is_declaration: bool,
         class_symbol_id: Option<SymbolId>,
         object: &Expression<'a>,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) -> Option<(SymbolId, ReferenceId)> {
         if is_declaration {
             if let Some(class_symbol_id) = class_symbol_id {
@@ -288,7 +288,7 @@ impl<'a> ClassProperties<'a, '_> {
         call_expr: &mut CallExpression<'a>,
         callee: Expression<'a>,
         context: Expression<'a>,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) {
         // Substitute `<callee>.call` as callee of call expression
         call_expr.callee = Expression::from(ctx.ast.member_expression_static(
@@ -579,7 +579,7 @@ impl<'a> ClassProperties<'a, '_> {
     // `transform_assignment_expression` can be elided.
     #[inline]
     fn transform_static_assignment_expression(
-        &mut self,
+        &self,
         expr: &mut Expression<'a>,
         prop_binding: &BoundIdentifier<'a>,
         class_binding: &BoundIdentifier<'a>,
@@ -1463,7 +1463,7 @@ impl<'a> ClassProperties<'a, '_> {
     #[inline]
     fn convert_chain_expression_to_expression(
         expr: &mut Expression<'a>,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) -> Expression<'a> {
         let Expression::ChainExpression(chain_expr) = ctx.ast.move_expression(expr) else {
             unreachable!()
@@ -1484,7 +1484,7 @@ impl<'a> ClassProperties<'a, '_> {
     /// be handled by optional-chaining plugin correctly.
     fn ensure_optional_expression_wrapped_by_chain_expression(
         expr: Expression<'a>,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) -> Expression<'a> {
         if Self::has_optional_expression(&expr) {
             let chain_element = match expr {
@@ -2076,7 +2076,7 @@ impl<'a> ClassProperties<'a, '_> {
     fn create_underscore_member_expr_target(
         object: Expression<'a>,
         span: Span,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) -> AssignmentTarget<'a> {
         AssignmentTarget::from(Self::create_underscore_member_expr(object, span, ctx))
     }
@@ -2085,7 +2085,7 @@ impl<'a> ClassProperties<'a, '_> {
     fn create_underscore_member_expression(
         object: Expression<'a>,
         span: Span,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) -> Expression<'a> {
         Expression::from(Self::create_underscore_member_expr(object, span, ctx))
     }
@@ -2094,7 +2094,7 @@ impl<'a> ClassProperties<'a, '_> {
     fn create_underscore_member_expr(
         object: Expression<'a>,
         span: Span,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) -> MemberExpression<'a> {
         ctx.ast.member_expression_static(span, object, create_underscore_ident_name(ctx), false)
     }

--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -25,8 +25,8 @@ impl<'a> ClassProperties<'a, '_> {
     ) {
         // Get value
         let value = match prop.value.take() {
-            Some(mut value) => {
-                self.transform_instance_initializer(&mut value, ctx);
+            Some(value) => {
+                self.transform_instance_initializer(&value, ctx);
                 value
             }
             None => ctx.ast.void_0(SPAN),
@@ -47,7 +47,7 @@ impl<'a> ClassProperties<'a, '_> {
     /// Loose: `Object.defineProperty(this, _prop, {writable: true, value: value})`
     /// Not loose: `_classPrivateFieldInitSpec(this, _prop, value)`
     fn create_private_instance_init_assignment(
-        &mut self,
+        &self,
         ident: &PrivateIdentifier<'a>,
         value: Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
@@ -62,7 +62,7 @@ impl<'a> ClassProperties<'a, '_> {
 
     /// `_classPrivateFieldInitSpec(this, _prop, value)`
     fn create_private_instance_init_assignment_not_loose(
-        &mut self,
+        &self,
         ident: &PrivateIdentifier<'a>,
         value: Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
@@ -309,7 +309,7 @@ impl<'a> ClassProperties<'a, '_> {
 
     /// `Object.defineProperty(<assignee>, _prop, {writable: true, value: value})`
     fn create_private_init_assignment_loose(
-        &mut self,
+        &self,
         ident: &PrivateIdentifier<'a>,
         value: Expression<'a>,
         assignee: Expression<'a>,

--- a/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
@@ -55,7 +55,7 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_, '_> {
 
     fn transform_static_member_expression_impl(
         &mut self,
-        member: &mut StaticMemberExpression<'a>,
+        member: &StaticMemberExpression<'a>,
         is_callee: bool,
         ctx: &mut TraverseCtx<'a>,
     ) -> Expression<'a> {
@@ -141,7 +141,7 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_, '_> {
     /// [A, B, C] -> [[A, B, C]]
     fn transform_super_call_expression_arguments(
         arguments: &mut ArenaVec<'a, Argument<'a>>,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) {
         let elements = arguments.drain(..).map(ArrayExpressionElement::from);
         let elements = ctx.ast.vec_from_iter(elements);

--- a/crates/oxc_transformer/src/es2022/class_properties/utils.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/utils.rs
@@ -26,7 +26,7 @@ pub(super) fn create_assignment<'a>(
 pub(super) fn create_variable_declaration<'a>(
     binding: &BoundIdentifier<'a>,
     init: Expression<'a>,
-    ctx: &mut TraverseCtx<'a>,
+    ctx: &TraverseCtx<'a>,
 ) -> Statement<'a> {
     let kind = VariableDeclarationKind::Var;
     let declarator = ctx.ast.variable_declarator(
@@ -52,7 +52,7 @@ where
 }
 
 /// Create `IdentifierName` for `_`.
-pub(super) fn create_underscore_ident_name<'a>(ctx: &mut TraverseCtx<'a>) -> IdentifierName<'a> {
+pub(super) fn create_underscore_ident_name<'a>(ctx: &TraverseCtx<'a>) -> IdentifierName<'a> {
     ctx.ast.identifier_name(SPAN, Atom::from("_"))
 }
 

--- a/crates/oxc_transformer/src/es2022/class_static_block.rs
+++ b/crates/oxc_transformer/src/es2022/class_static_block.rs
@@ -224,7 +224,7 @@ impl<'a> Keys<'a> {
     ///
     /// Returned key will be either `_`, or `_<integer>` starting with `_2`.
     #[inline]
-    fn get_unique(&mut self, ctx: &mut TraverseCtx<'a>) -> Atom<'a> {
+    fn get_unique(&mut self, ctx: &TraverseCtx<'a>) -> Atom<'a> {
         #[expect(clippy::if_not_else)]
         if !self.underscore {
             self.underscore = true;
@@ -237,7 +237,7 @@ impl<'a> Keys<'a> {
     // `#[cold]` and `#[inline(never)]` as it should be very rare to need a key other than `#_`.
     #[cold]
     #[inline(never)]
-    fn get_unique_slow(&mut self, ctx: &mut TraverseCtx<'a>) -> Atom<'a> {
+    fn get_unique_slow(&mut self, ctx: &TraverseCtx<'a>) -> Atom<'a> {
         // Source text length is limited to `u32::MAX` so impossible to have more than `u32::MAX`
         // private keys. So `u32` is sufficient here.
         let mut i = 2u32;

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -194,7 +194,7 @@ impl<'a, 'ctx> AutomaticScriptBindings<'a, 'ctx> {
     }
 
     fn add_require_statement(
-        &mut self,
+        &self,
         variable_name: &str,
         source: Atom<'a>,
         front: bool,
@@ -286,7 +286,7 @@ impl<'a, 'ctx> AutomaticModuleBindings<'a, 'ctx> {
     }
 
     fn add_jsx_import_statement(
-        &mut self,
+        &self,
         name: &'static str,
         ctx: &mut TraverseCtx<'a>,
     ) -> BoundIdentifier<'a> {
@@ -294,7 +294,7 @@ impl<'a, 'ctx> AutomaticModuleBindings<'a, 'ctx> {
     }
 
     fn add_import_statement(
-        &mut self,
+        &self,
         name: &'static str,
         source: Atom<'a>,
         ctx: &mut TraverseCtx<'a>,
@@ -508,7 +508,7 @@ impl<'a> JsxImpl<'a, '_> {
         self.ctx.source_type.is_script()
     }
 
-    fn insert_filename_var_statement(&mut self, ctx: &mut TraverseCtx<'a>) {
+    fn insert_filename_var_statement(&self, ctx: &TraverseCtx<'a>) {
         let Some(declarator) = self.jsx_source.get_filename_var_declarator(ctx) else { return };
 
         // If is a module, add filename statements before `import`s. If script, then after `require`s.

--- a/crates/oxc_transformer/src/jsx/jsx_self.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_self.rs
@@ -84,7 +84,7 @@ impl<'a> JsxSelf<'a, '_> {
     }
 
     pub fn get_object_property_kind_for_jsx_plugin(
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) -> ObjectPropertyKind<'a> {
         let kind = PropertyKind::Init;
         let key = ctx.ast.property_key_static_identifier(SPAN, SELF);

--- a/crates/oxc_transformer/src/jsx/jsx_source.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_source.rs
@@ -177,7 +177,7 @@ impl<'a> JsxSource<'a, '_> {
         ctx.ast.expression_object(SPAN, properties, None)
     }
 
-    pub fn get_filename_var_statement(&self, ctx: &mut TraverseCtx<'a>) -> Option<Statement<'a>> {
+    pub fn get_filename_var_statement(&self, ctx: &TraverseCtx<'a>) -> Option<Statement<'a>> {
         let decl = self.get_filename_var_declarator(ctx)?;
 
         let var_decl = Statement::VariableDeclaration(ctx.ast.alloc_variable_declaration(

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -712,7 +712,7 @@ impl<'a> ReactRefresh<'a, '_> {
 
     fn handle_function_declaration(
         &mut self,
-        func: &mut Function<'a>,
+        func: &Function<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Option<Statement<'a>> {
         let Some(id) = &func.id else {
@@ -854,7 +854,7 @@ impl<'a> ReactRefresh<'a, '_> {
     /// ```
     fn transform_arrow_function_to_block(
         arrow: &mut ArrowFunctionExpression<'a>,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) {
         if !arrow.expression {
             return;

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -5,8 +5,6 @@
 //! * <https://babel.dev/docs/presets>
 //! * <https://github.com/microsoft/TypeScript/blob/v5.6.3/src/compiler/transformer.ts>
 
-#![allow(clippy::needless_pass_by_ref_mut)]
-
 use std::path::Path;
 
 use oxc_allocator::{Allocator, Vec as ArenaVec};

--- a/crates/oxc_transformer/src/plugins/replace_global_defines.rs
+++ b/crates/oxc_transformer/src/plugins/replace_global_defines.rs
@@ -302,11 +302,7 @@ impl<'a> ReplaceGlobalDefines<'a> {
         expr
     }
 
-    fn replace_identifier_defines(
-        &self,
-        expr: &mut Expression<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) -> bool {
+    fn replace_identifier_defines(&self, expr: &mut Expression<'a>, ctx: &TraverseCtx<'a>) -> bool {
         match expr {
             Expression::Identifier(ident) => {
                 if let Some(new_expr) = self.replace_identifier_define_impl(ident, ctx) {
@@ -334,8 +330,8 @@ impl<'a> ReplaceGlobalDefines<'a> {
 
     fn replace_identifier_define_impl(
         &self,
-        ident: &mut oxc_allocator::Box<'_, IdentifierReference<'_>>,
-        ctx: &mut TraverseCtx<'a>,
+        ident: &oxc_allocator::Box<'_, IdentifierReference<'_>>,
+        ctx: &TraverseCtx<'a>,
     ) -> Option<Expression<'a>> {
         if !ident.is_global_reference(ctx.symbols()) {
             return None;
@@ -351,7 +347,7 @@ impl<'a> ReplaceGlobalDefines<'a> {
     }
 
     fn replace_define_with_assignment_expr(
-        &mut self,
+        &self,
         node: &mut AssignmentExpression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> bool {
@@ -378,11 +374,7 @@ impl<'a> ReplaceGlobalDefines<'a> {
         false
     }
 
-    fn replace_dot_defines(
-        &mut self,
-        expr: &mut Expression<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) -> bool {
+    fn replace_dot_defines(&self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) -> bool {
         match expr {
             Expression::ChainExpression(chain) => {
                 let Some(new_expr) =
@@ -429,9 +421,9 @@ impl<'a> ReplaceGlobalDefines<'a> {
     }
 
     fn replace_dot_computed_member_expr(
-        &mut self,
+        &self,
         ctx: &mut TraverseCtx<'a>,
-        member: &mut ComputedMemberExpression<'a>,
+        member: &ComputedMemberExpression<'a>,
     ) -> Option<Expression<'a>> {
         for dot_define in &self.config.0.dot {
             if Self::is_dot_define(
@@ -448,9 +440,9 @@ impl<'a> ReplaceGlobalDefines<'a> {
     }
 
     fn replace_dot_static_member_expr(
-        &mut self,
+        &self,
         ctx: &mut TraverseCtx<'a>,
-        member: &mut StaticMemberExpression<'a>,
+        member: &StaticMemberExpression<'a>,
     ) -> Option<Expression<'a>> {
         for dot_define in &self.config.0.dot {
             if Self::is_dot_define(
@@ -640,7 +632,7 @@ fn static_property_name_of_computed_expr<'b, 'a: 'b>(
 
 fn destructing_dot_define_optimizer<'ast>(
     mut expr: Expression<'ast>,
-    ctx: &mut TraverseCtx<'ast>,
+    ctx: &TraverseCtx<'ast>,
 ) -> Expression<'ast> {
     let Expression::ObjectExpression(obj) = &mut expr else { return expr };
     let parent = ctx.parent();

--- a/crates/oxc_transformer/src/regexp/mod.rs
+++ b/crates/oxc_transformer/src/regexp/mod.rs
@@ -242,7 +242,7 @@ fn try_parse_pattern<'a>(
     pattern_span_offset: u32,
     flags_text: &'a str,
     flags_span_offset: u32,
-    ctx: &mut TraverseCtx<'a>,
+    ctx: &TraverseCtx<'a>,
 ) -> Result<Pattern<'a>> {
     use oxc_regular_expression::{LiteralParser, Options};
 

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -51,7 +51,7 @@ impl<'a> Traverse<'a> for TypeScriptModule<'a, '_> {
 impl<'a> TypeScriptModule<'a, '_> {
     /// Transform `export = expression` to `module.exports = expression`.
     fn transform_ts_export_assignment(
-        &mut self,
+        &self,
         export_assignment: &mut TSExportAssignment<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Statement<'a> {

--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -271,7 +271,7 @@ impl<'a> TypeScriptNamespace<'a, '_> {
     //                         ^^^^^^^
     fn create_variable_declaration(
         binding: &BoundIdentifier<'a>,
-        ctx: &mut TraverseCtx<'a>,
+        ctx: &TraverseCtx<'a>,
     ) -> Declaration<'a> {
         let kind = VariableDeclarationKind::Let;
         let declarations = {

--- a/crates/oxc_transformer/src/typescript/rewrite_extensions.rs
+++ b/crates/oxc_transformer/src/typescript/rewrite_extensions.rs
@@ -23,11 +23,7 @@ impl TypeScriptRewriteExtensions {
         options.rewrite_import_extensions.map(|mode| Self { mode })
     }
 
-    pub fn rewrite_extensions<'a>(
-        &self,
-        source: &mut StringLiteral<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
+    pub fn rewrite_extensions<'a>(&self, source: &mut StringLiteral<'a>, ctx: &TraverseCtx<'a>) {
         let value = source.value.as_str();
         if !value.contains(['/', '\\']) {
             return;

--- a/crates/oxc_transformer/src/utils/ast_builder.rs
+++ b/crates/oxc_transformer/src/utils/ast_builder.rs
@@ -8,7 +8,7 @@ use oxc_traverse::TraverseCtx;
 pub fn create_member_callee<'a>(
     object: Expression<'a>,
     property: &'static str,
-    ctx: &mut TraverseCtx<'a>,
+    ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
     let property = ctx.ast.identifier_name(SPAN, Atom::from(property));
     Expression::from(ctx.ast.member_expression_static(SPAN, object, property, false))
@@ -19,7 +19,7 @@ pub fn create_bind_call<'a>(
     callee: Expression<'a>,
     this: Expression<'a>,
     span: Span,
-    ctx: &mut TraverseCtx<'a>,
+    ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
     let callee = create_member_callee(callee, "bind", ctx);
     let arguments = ctx.ast.vec1(Argument::from(this));
@@ -31,7 +31,7 @@ pub fn create_call_call<'a>(
     callee: Expression<'a>,
     this: Expression<'a>,
     span: Span,
-    ctx: &mut TraverseCtx<'a>,
+    ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
     let callee = create_member_callee(callee, "call", ctx);
     let arguments = ctx.ast.vec1(Argument::from(this));
@@ -60,7 +60,7 @@ pub fn wrap_statements_in_arrow_function_iife<'a>(
     stmts: ArenaVec<'a, Statement<'a>>,
     scope_id: ScopeId,
     span: Span,
-    ctx: &mut TraverseCtx<'a>,
+    ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
     let kind = FormalParameterKind::ArrowFormalParameters;
     let params = ctx.ast.alloc_formal_parameters(SPAN, kind, ctx.ast.vec(), NONE);
@@ -75,7 +75,7 @@ pub fn wrap_statements_in_arrow_function_iife<'a>(
 /// `object` -> `object.prototype`.
 pub fn create_prototype_member<'a>(
     object: Expression<'a>,
-    ctx: &mut TraverseCtx<'a>,
+    ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
     let property = ctx.ast.identifier_name(SPAN, Atom::from("prototype"));
     let static_member = ctx.ast.member_expression_static(SPAN, object, property, false);
@@ -86,7 +86,7 @@ pub fn create_prototype_member<'a>(
 pub fn create_property_access<'a>(
     object: Expression<'a>,
     property: &str,
-    ctx: &mut TraverseCtx<'a>,
+    ctx: &TraverseCtx<'a>,
 ) -> Expression<'a> {
     let property = ctx.ast.identifier_name(SPAN, ctx.ast.atom(property));
     Expression::from(ctx.ast.member_expression_static(SPAN, object, property, false))


### PR DESCRIPTION
#9253 enabled clippy's `needless_pass_by_ref_mut` rule, but kept it disabled for the `oxc_transformer` crate.

This rule is really good as using `&` instead of `&mut` may allow the compiler to make more optimizations in some cases, as `&` guarantees that value is not changed during the function call which takes `&`.

Enable this lint and fix all the warnings it highlights.

The diff is large, but it's purely replacing `&mut` with `&` in lots of places.
