### PR TITLE
refactor(mangler): use `iter::repeat_n`

### DIFF
--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -206,9 +206,7 @@ impl Mangler {
         let allocator = Allocator::default();
 
         // All symbols with their assigned slots. Keyed by symbol id.
-        // TODO: Use `iter::repeat_n` once our MSRV reaches 1.82.0.
-        let mut slots: Vec<'_, Slot> =
-            Vec::from_iter_in(iter::repeat(0).take(symbol_table.len()), &allocator);
+        let mut slots = Vec::from_iter_in(iter::repeat_n(0, symbol_table.len()), &allocator);
 
         // Stores the lived scope ids for each slot. Keyed by slot number.
         let mut slot_liveness: std::vec::Vec<FixedBitSet> = vec![];


### PR DESCRIPTION
#9270 bumped MSRV to 1.82.0. So we can now use `iter::repeat_n`, which is slightly more performant than `iter::repeat(...).take(...)`.

This reverts part of #8929, which removed APIs incompatible with 1.81.0.