### PR TITLE
refactor(tasks): use `Option::is_none_or`

### DIFF
--- a/tasks/ast_tools/src/generators/assert_layouts.rs
+++ b/tasks/ast_tools/src/generators/assert_layouts.rs
@@ -164,10 +164,7 @@ fn calculate_layout_for_struct(type_id: TypeId, schema: &mut Schema) -> Layout {
             // Update niche.
             // Take the largest niche. Preference for earlier niche if 2 fields have niches of same size.
             if let Some(field_niche) = &field_layout.niche {
-                // TODO: Use `Option::is_none_or` once our MSRV reaches 1.82.0
-                if layout.niche.is_none()
-                    || field_niche.count > layout.niche.as_ref().unwrap().count
-                {
+                if layout.niche.as_ref().is_none_or(|niche| field_niche.count > niche.count) {
                     let mut niche = field_niche.clone();
                     niche.offset += offset;
                     layout.niche = Some(niche);

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -172,13 +172,7 @@ fn collect_test_files(dir: &Path, filter: Option<&String>) -> Vec<PathBuf> {
         .into_iter()
         .filter_map(Result::ok)
         .filter(|e| !e.file_type().is_dir())
-        .filter(|e| {
-            // TODO: Use `Option::is_none_or` once our MSRV reaches 1.82.0
-            match e.path().file_name() {
-                Some(name) => name != FORMAT_TEST_SPEC_NAME,
-                None => true,
-            }
-        })
+        .filter(|e| e.path().file_name().is_none_or(|name| name != FORMAT_TEST_SPEC_NAME))
         .filter(|e| !IGNORE_TESTS.iter().any(|s| e.path().to_string_lossy().contains(s)))
         .filter(|e| filter.is_none_or(|name| e.path().to_string_lossy().contains(name)))
         .map(|e| e.path().to_path_buf())


### PR DESCRIPTION
#9270 bumped MSRV to 1.82.0. So we can now use `Option::is_none_or`.

This reverts part of #8929, which removed APIs incompatible with 1.81.0.
