### PR TITLE
feat(mangler): mangle private class names

### DIFF
--- a/crates/oxc/src/compiler.rs
+++ b/crates/oxc/src/compiler.rs
@@ -212,7 +212,8 @@ pub trait CompilerInterface {
 
         /* Mangler */
 
-        let mangler = self.mangle_options().map(|options| self.mangle(&mut program, options));
+        let mangler =
+            self.mangle_options().map(|options| self.mangle(&allocator, &mut program, options));
 
         /* Codegen */
 
@@ -285,8 +286,13 @@ pub trait CompilerInterface {
         Compressor::new(allocator, options).build(program);
     }
 
-    fn mangle(&self, program: &mut Program<'_>, options: MangleOptions) -> SymbolTable {
-        Mangler::new().with_options(options).build(program)
+    fn mangle<'a>(
+        &self,
+        allocator: &'a Allocator,
+        program: &mut Program<'a>,
+        options: MangleOptions,
+    ) -> SymbolTable {
+        Mangler::new().with_options(options).build(allocator, program)
     }
 
     fn codegen(

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -12,6 +12,8 @@ use oxc_semantic::{ScopeTree, Semantic, SemanticBuilder, SymbolId, SymbolTable};
 use oxc_span::Atom;
 
 pub(crate) mod base54;
+mod private_name;
+pub use private_name::PrivateClassNameMangler;
 
 #[derive(Default, Debug, Clone, Copy)]
 pub struct MangleOptions {

--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -178,12 +178,9 @@ impl Mangler {
         allocator: &'a Allocator,
         program: &mut Program<'a>,
     ) {
-        println!("Mangler::mangle_private_class_names");
-        dbg!(self.options);
         if !self.options.mangle_private_class_names {
             return;
         }
-        println!("Mangler::mangle_private_class_names");
         if self.options.debug {
             PrivateClassNameMangler::new(allocator, debug_name).build(program);
         } else {
@@ -199,7 +196,6 @@ impl Mangler {
     /// Panics if the child_ids does not exist in scope_tree.
     #[must_use]
     pub fn build<'a>(&self, allocator: &'a Allocator, program: &mut Program<'a>) -> SymbolTable {
-        dbg!(self.options);
         let semantic_builder = SemanticBuilder::new().with_scope_tree_child_ids(true);
         let semantic_builder = if let Some(stats) = self.stats {
             semantic_builder.with_stats(stats)

--- a/crates/oxc_mangler/src/private_name.rs
+++ b/crates/oxc_mangler/src/private_name.rs
@@ -1,0 +1,40 @@
+use oxc_allocator::{Allocator, FromIn};
+use oxc_ast::{VisitMut, ast::*};
+use rustc_hash::FxHashMap;
+
+use crate::{InlineString, base54};
+
+pub struct PrivateClassNameMangler<'a> {
+    allocator: &'a Allocator,
+    rename_map: FxHashMap<Atom<'a>, Atom<'a>>,
+    count: usize,
+}
+
+impl<'a> PrivateClassNameMangler<'a> {
+    pub fn new(allocator: &'a Allocator) -> Self {
+        Self { allocator, rename_map: FxHashMap::default(), count: 0 }
+    }
+
+    fn new_name(&mut self) -> InlineString<12> {
+        let new_name = base54(self.count);
+        self.count += 1;
+        new_name
+    }
+
+    pub fn build(&mut self, program: &mut Program<'a>) {
+        self.visit_program(program);
+    }
+}
+
+impl<'a> VisitMut<'a> for PrivateClassNameMangler<'a> {
+    fn visit_private_identifier(&mut self, node: &mut PrivateIdentifier<'a>) {
+        if let Some(new_name) = self.rename_map.get(&node.name) {
+            node.name = Atom::from(new_name.as_str());
+        } else {
+            let new_name = self.new_name();
+            let new_name = Atom::from_in(new_name.as_str(), self.allocator);
+            self.rename_map.insert(node.name, new_name);
+            node.name = new_name;
+        }
+    }
+}

--- a/crates/oxc_minifier/examples/mangler.rs
+++ b/crates/oxc_minifier/examples/mangler.rs
@@ -37,9 +37,13 @@ fn main() -> std::io::Result<()> {
 
 fn mangler(source_text: &str, source_type: SourceType, debug: bool) -> String {
     let allocator = Allocator::default();
-    let ret = Parser::new(&allocator, source_text, source_type).parse();
+    let mut ret = Parser::new(&allocator, source_text, source_type).parse();
     let symbol_table = Mangler::new()
-        .with_options(MangleOptions { debug, top_level: source_type.is_module() })
-        .build(&ret.program);
+        .with_options(MangleOptions {
+            debug,
+            top_level: source_type.is_module(),
+            mangle_private_class_names: true,
+        })
+        .build(&allocator, &mut ret.program);
     CodeGenerator::new().with_symbol_table(Some(symbol_table)).build(&ret.program).code
 }

--- a/crates/oxc_minifier/src/lib.rs
+++ b/crates/oxc_minifier/src/lib.rs
@@ -13,7 +13,7 @@ mod tester;
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::Program;
-use oxc_mangler::{Mangler, PrivateClassNameMangler};
+use oxc_mangler::Mangler;
 use oxc_semantic::{SemanticBuilder, Stats, SymbolTable};
 
 pub use oxc_mangler::MangleOptions;
@@ -57,14 +57,7 @@ impl Minifier {
             Stats::default()
         };
         let symbol_table = self.options.mangle.map(|options| {
-            PrivateClassNameMangler::new(allocator).build(program);
-
-            let semantic = SemanticBuilder::new()
-                .with_stats(stats)
-                .with_scope_tree_child_ids(true)
-                .build(program)
-                .semantic;
-            Mangler::default().with_options(options).build_with_semantic(semantic, program)
+            Mangler::new().with_options(options).with_stats(stats).build(allocator, program)
         });
         MinifierReturn { symbol_table }
     }

--- a/crates/oxc_minifier/src/lib.rs
+++ b/crates/oxc_minifier/src/lib.rs
@@ -13,7 +13,7 @@ mod tester;
 
 use oxc_allocator::Allocator;
 use oxc_ast::ast::Program;
-use oxc_mangler::Mangler;
+use oxc_mangler::{Mangler, PrivateClassNameMangler};
 use oxc_semantic::{SemanticBuilder, Stats, SymbolTable};
 
 pub use oxc_mangler::MangleOptions;
@@ -57,6 +57,8 @@ impl Minifier {
             Stats::default()
         };
         let symbol_table = self.options.mangle.map(|options| {
+            PrivateClassNameMangler::new(allocator).build(program);
+
             let semantic = SemanticBuilder::new()
                 .with_stats(stats)
                 .with_scope_tree_child_ids(true)

--- a/crates/oxc_minifier/tests/mangler/mod.rs
+++ b/crates/oxc_minifier/tests/mangler/mod.rs
@@ -10,9 +10,10 @@ fn mangle(source_text: &str, top_level: bool) -> String {
     let allocator = Allocator::default();
     let source_type = SourceType::mjs();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
-    let program = ret.program;
-    let symbol_table =
-        Mangler::new().with_options(MangleOptions { debug: false, top_level }).build(&program);
+    let mut program = ret.program;
+    let symbol_table = Mangler::new()
+        .with_options(MangleOptions { debug: false, top_level, mangle_private_class_names: true })
+        .build(&allocator, &mut program);
     CodeGenerator::new().with_symbol_table(Some(symbol_table)).build(&program).code
 }
 

--- a/napi/minify/index.d.ts
+++ b/napi/minify/index.d.ts
@@ -35,6 +35,8 @@ export interface MangleOptions {
   toplevel?: boolean
   /** Debug mangled names. */
   debug?: boolean
+  /** Pass true to mangle properties. */
+  manglePrivateClassNames?: boolean
 }
 
 /**

--- a/napi/minify/src/options.rs
+++ b/napi/minify/src/options.rs
@@ -54,11 +54,18 @@ pub struct MangleOptions {
 
     /// Debug mangled names.
     pub debug: Option<bool>,
+
+    /// Pass true to mangle properties.
+    pub mangle_private_class_names: Option<bool>,
 }
 
 impl From<&MangleOptions> for oxc_minifier::MangleOptions {
     fn from(o: &MangleOptions) -> Self {
-        Self { top_level: o.toplevel.unwrap_or(false), debug: o.debug.unwrap_or(false) }
+        Self {
+            top_level: o.toplevel.unwrap_or(false),
+            debug: o.debug.unwrap_or(false),
+            mangle_private_class_names: o.mangle_private_class_names.unwrap_or(false),
+        }
     }
 }
 

--- a/tasks/benchmark/benches/minifier.rs
+++ b/tasks/benchmark/benches/minifier.rs
@@ -1,6 +1,6 @@
 use oxc_allocator::Allocator;
 use oxc_benchmark::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use oxc_mangler::Mangler;
+use oxc_mangler::{MangleOptions, Mangler};
 use oxc_minifier::{CompressOptions, Compressor};
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
@@ -57,11 +57,15 @@ fn bench_mangler(criterion: &mut Criterion) {
         group.bench_function(id, |b| {
             b.iter_with_setup_wrapper(|runner| {
                 allocator.reset();
-                let program = Parser::new(&allocator, source_text, source_type).parse().program;
-                let semantic =
-                    SemanticBuilder::new().with_scope_tree_child_ids(true).build(&program).semantic;
+                let mut program = Parser::new(&allocator, source_text, source_type).parse().program;
                 runner.run(|| {
-                    let _ = Mangler::new().build_with_semantic(semantic, &program);
+                    let _ = Mangler::new()
+                        .with_options(MangleOptions {
+                            debug: false,
+                            top_level: true,
+                            mangle_private_class_names: true,
+                        })
+                        .build(&allocator, &mut program);
                 });
             });
         });


### PR DESCRIPTION
```
$ cat test.js
class Foo {
  constructor(k) {
    this.#kasd = k;
  }

  getK() {
    return this.#kasd;
  }
}
class Foo2 {
  constructor(k) {
    this.#kasd = k;
  }

  getK() {
    return this.#kasd;
  }
}

export { Foo, Foo2 };
$ cargo run -p oxc_minifier --example minifier -- --mangle
   Compiling oxc_mangler v0.51.0 (/Users/cameron/github/Boshen/oxc/crates/oxc_mangler)
   Compiling oxc_minifier v0.51.0 (/Users/cameron/github/Boshen/oxc/crates/oxc_minifier)
    Finished `dev` profile [unoptimized] target(s) in 0.96s
     Running `target/debug/examples/minifier --mangle`
class Foo {
        constructor(e) {
                this.#e = e;
        }
        getK() {
                return this.#e;
        }
}
class Foo2 {
        constructor(e) {
                this.#e = e;
        }
        getK() {
                return this.#e;
        }
}
export { Foo, Foo2 };
```

No diff on cargo misize. looks like non of the test suite has classes with private class members