### PR TITLE
test(ast): ESTree conformance tester skip cases including infinite numbers

### DIFF
--- a/tasks/coverage/snapshots/estree_test262.snap
+++ b/tasks/coverage/snapshots/estree_test262.snap
@@ -1,5 +1,5 @@
 commit: bc5c1417
 
 estree_test262 Summary:
-AST Parsed     : 48767/48767 (100.00%)
-Positive Passed: 48767/48767 (100.00%)
+AST Parsed     : 48762/48762 (100.00%)
+Positive Passed: 48762/48762 (100.00%)

--- a/tasks/coverage/src/tools/estree.rs
+++ b/tasks/coverage/src/tools/estree.rs
@@ -91,6 +91,16 @@ impl Case for EstreeTest262Case {
             "test262/test/language/literals/regexp/u-surrogate-pairs-atom-char-class.js",
             "test262/test/language/literals/regexp/u-surrogate-pairs-atom-escape-decimal.js",
             "test262/test/language/statements/for-of/string-astral-truncated.js",
+
+            // Infinite numbers.
+            // JSON we generate does correctly represent `Infinity` (as `1e+400`), but `serde` can't
+            // parse that, so these tests erroneously fail.
+            // NAPI binding contains a test case for `Infinity` instead.
+            "test262/test/built-ins/Array/prototype/indexOf/15.4.4.14-10-1.js",
+            "test262/test/built-ins/Array/prototype/lastIndexOf/15.4.4.15-9-1.js",
+            "test262/test/built-ins/Number/S9.3.1_A6_T1.js",
+            "test262/test/built-ins/Number/S9.3.1_A6_T2.js",
+            "test262/test/language/types/number/8.5.1.js",
         ];
 
         let path = &*self.path().to_string_lossy();


### PR DESCRIPTION
Skip test cases where source code contains a number too large to fit in an `f64`, which is treated as `Infinity`.

The JSON that `ESTree` serializer produces is fine - `Infinity` is serialized as `1e+400`, which `JSON.parse` interprets correctly as `Infinity`. But `serde`, as used in ESTree conformance tester, can't deal with this which makes these tests erroneously fail. So skip them.
