### PR TITLE
test(ast): ESTree conformance tester skip cases where no Acorn JSON file

### DIFF
--- a/tasks/coverage/snapshots/estree_test262.snap
+++ b/tasks/coverage/snapshots/estree_test262.snap
@@ -1,5 +1,5 @@
 commit: bc5c1417
 
 estree_test262 Summary:
-AST Parsed     : 48762/48762 (100.00%)
-Positive Passed: 48762/48762 (100.00%)
+AST Parsed     : 44007/44007 (100.00%)
+Positive Passed: 44007/44007 (100.00%)


### PR DESCRIPTION
I made a mistake in #9277. I had run ESTree conformance and found all tests pass, but it turned out this was wrong! The `acorn-test262` submodule had got deleted somehow on my local machine. ESTree conformance tester marked any test with no Acorn JSON file as a pass. *All* the JSON files were missing, which meant *all* the tests passed.

Prevent this mistake happening again by instead skipping tests where no Acorn JSON file. Now if the submodule is not present, snapshot will show `Passed: 0/0` not `Passed: 48762/48762`.
