### PR TITLE
fix(ast/estree): fix ESTree AST for imports and exports

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -2315,9 +2315,9 @@ pub struct ImportDeclaration<'a> {
     #[estree(via = ImportDeclarationSpecifiers)]
     pub specifiers: Option<Vec<'a, ImportDeclarationSpecifier<'a>>>,
     pub source: StringLiteral<'a>,
+    #[estree(skip)]
     pub phase: Option<ImportPhase>,
     /// Some(vec![]) for empty assertion
-    #[ts]
     #[estree(rename = "attributes", via = ImportDeclarationWithClause)]
     pub with_clause: Option<Box<'a, WithClause<'a>>>,
     /// `import type { foo } from 'bar'`
@@ -2446,6 +2446,7 @@ pub enum ImportAttributeKey<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[estree(custom_serialize)]
 pub struct ExportNamedDeclaration<'a> {
     pub span: Span,
     pub declaration: Option<Declaration<'a>>,
@@ -2455,7 +2456,6 @@ pub struct ExportNamedDeclaration<'a> {
     #[ts]
     pub export_kind: ImportOrExportKind,
     /// Some(vec![]) for empty assertion
-    #[ts]
     #[estree(rename = "attributes", via = ExportNamedDeclarationWithClause)]
     pub with_clause: Option<Box<'a, WithClause<'a>>>,
 }
@@ -2475,6 +2475,7 @@ pub struct ExportNamedDeclaration<'a> {
 pub struct ExportDefaultDeclaration<'a> {
     pub span: Span,
     pub declaration: ExportDefaultDeclarationKind<'a>,
+    #[estree(skip)]
     pub exported: ModuleExportName<'a>, // the `default` Keyword
 }
 
@@ -2496,7 +2497,6 @@ pub struct ExportAllDeclaration<'a> {
     pub exported: Option<ModuleExportName<'a>>,
     pub source: StringLiteral<'a>,
     /// Will be `Some(vec![])` for empty assertion
-    #[ts]
     #[estree(rename = "attributes", via = ExportAllDeclarationWithClause)]
     pub with_clause: Option<Box<'a, WithClause<'a>>>, // Some(vec![]) for empty assertion
     #[ts]

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1591,7 +1591,6 @@ impl ESTree for ImportDeclaration<'_> {
         state.serialize_field("end", &self.span.end);
         state.serialize_field("specifiers", &crate::serialize::ImportDeclarationSpecifiers(self));
         state.serialize_field("source", &self.source);
-        state.serialize_field("phase", &self.phase);
         state.serialize_field("attributes", &crate::serialize::ImportDeclarationWithClause(self));
         state.serialize_field("importKind", &self.import_kind);
         state.end();
@@ -1685,24 +1684,6 @@ impl ESTree for ImportAttributeKey<'_> {
     }
 }
 
-impl ESTree for ExportNamedDeclaration<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) {
-        let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ExportNamedDeclaration");
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
-        state.serialize_field("declaration", &self.declaration);
-        state.serialize_field("specifiers", &self.specifiers);
-        state.serialize_field("source", &self.source);
-        state.serialize_field("exportKind", &self.export_kind);
-        state.serialize_field(
-            "attributes",
-            &crate::serialize::ExportNamedDeclarationWithClause(self),
-        );
-        state.end();
-    }
-}
-
 impl ESTree for ExportDefaultDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
@@ -1710,7 +1691,6 @@ impl ESTree for ExportDefaultDeclaration<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("declaration", &self.declaration);
-        state.serialize_field("exported", &self.exported);
         state.end();
     }
 }

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -360,6 +360,30 @@ impl ESTree for ImportExpressionArguments<'_> {
     }
 }
 
+/// Serialize `ExportNamedDeclaration`.
+///
+/// Omit `with_clause` field (which is renamed to `attributes` in ESTree)
+/// unless `source` field is `Some`.
+impl ESTree for ExportNamedDeclaration<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", "ExportNamedDeclaration");
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("declaration", &self.declaration);
+        state.serialize_field("specifiers", &self.specifiers);
+        state.serialize_field("source", &self.source);
+        state.serialize_field("exportKind", &self.export_kind);
+        if self.source.is_some() {
+            state.serialize_field(
+                "attributes",
+                &crate::serialize::ExportNamedDeclarationWithClause(self),
+            );
+        }
+        state.end();
+    }
+}
+
 // Serializers for `with_clause` field of `ImportDeclaration`, `ExportNamedDeclaration`,
 // and `ExportAllDeclaration` (which are renamed to `attributes` in ESTree AST).
 //

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -701,7 +701,6 @@ export interface ImportDeclaration extends Span {
   type: 'ImportDeclaration';
   specifiers: Array<ImportDeclarationSpecifier>;
   source: StringLiteral;
-  phase: ImportPhase | null;
   attributes: Array<ImportAttribute>;
   importKind: ImportOrExportKind;
 }
@@ -747,7 +746,6 @@ export interface ExportNamedDeclaration extends Span {
 export interface ExportDefaultDeclaration extends Span {
   type: 'ExportDefaultDeclaration';
   declaration: ExportDefaultDeclarationKind;
-  exported: ModuleExportName;
 }
 
 export interface ExportAllDeclaration extends Span {


### PR DESCRIPTION
Fix ESTree AST for `ImportDeclaration`, `ExportNamedDeclaration`, `ExportDefaultDeclaration`, and `ExportAllDeclaration`.

Some had extraneous extra fields in ESTree AST, others had the `with_clause` field erroneously marked as TS-only (Acorn supports this field for plain JS).
