### PR TITLE
test(ast/estree): ESTree conformance tester ignore fixtures with hashbangs

### DIFF
--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ submodules:
   just clone-submodule tasks/coverage/babel https://github.com/babel/babel.git acbc09a87016778c1551ab5e7162fdd0e70b6663
   just clone-submodule tasks/coverage/typescript https://github.com/microsoft/TypeScript.git d85767abfd83880cea17cea70f9913e9c4496dcc
   just clone-submodule tasks/prettier_conformance/prettier https://github.com/prettier/prettier.git 7584432401a47a26943dd7a9ca9a8e032ead7285
-  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 dcb070006436b9f7783626c0741d5693953035c6
+  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 3ab34526674f12701b98022fa1987a084ad3f356
   just update-transformer-fixtures
 
 # Install git pre-commit to format files

--- a/tasks/coverage/snapshots/estree_test262.snap
+++ b/tasks/coverage/snapshots/estree_test262.snap
@@ -1,5 +1,5 @@
 commit: bc5c1417
 
 estree_test262 Summary:
-AST Parsed     : 44007/44007 (100.00%)
-Positive Passed: 44007/44007 (100.00%)
+AST Parsed     : 44001/44001 (100.00%)
+Positive Passed: 44001/44001 (100.00%)

--- a/tasks/coverage/src/tools/estree.rs
+++ b/tasks/coverage/src/tools/estree.rs
@@ -100,6 +100,19 @@ impl Case for EstreeTest262Case {
             "test262/test/language/literals/regexp/u-surrogate-pairs-atom-escape-decimal.js",
             "test262/test/language/statements/for-of/string-astral-truncated.js",
 
+            // Hashbangs.
+            // We intentionally diverge from Acorn, by including an extra `hashbang` field on `Program`.
+            // `acorn-test262` adapts Acorn's AST to add a `hashbang: null` field to `Program`,
+            // in order to match Oxc's output.
+            // But these fixtures *do* include hashbangs, so there's a mismatch, because `hashbang`
+            // field is (correctly) not `null` in these cases.
+            "test262/test/language/comments/hashbang/line-terminator-carriage-return.js",
+            "test262/test/language/comments/hashbang/line-terminator-line-separator.js",
+            "test262/test/language/comments/hashbang/line-terminator-paragraph-separator.js",
+            "test262/test/language/comments/hashbang/module.js",
+            "test262/test/language/comments/hashbang/not-empty.js",
+            "test262/test/language/comments/hashbang/use-strict.js",
+
             // Infinite numbers.
             // JSON we generate does correctly represent `Infinity` (as `1e+400`), but `serde` can't
             // parse that, so these tests erroneously fail.


### PR DESCRIPTION
ESTree conformance tester ignore 6 fixtures where there's a hashbang.

The `Program::hashbang` field is not part of ESTree (ESTree treats it as a comment). But in my opinion, this field is useful, and we should diverge from ESTree to include it on our JS-side AST. The addition of this field won't break anyone's code.

Bump `acorn-test262` to include commit https://github.com/oxc-project/acorn-test262/commit/3ab34526674f12701b98022fa1987a084ad3f356 which adds a `hashbang: null` field to `Program` in the Acorn JSON files.

This PR prepares for checking our AST aginst Acorn's with a direct JSON-to-JSON comparison, ensuring the addition of this extra field doesn't cause all the tests to fail.
