### PR TITLE
refactor(ast/estree): rename serializers and serialization methods

### DIFF
--- a/crates/oxc_allocator/src/boxed.rs
+++ b/crates/oxc_allocator/src/boxed.rs
@@ -253,12 +253,12 @@ mod test {
 
     #[test]
     fn box_serialize_estree() {
-        use oxc_estree::{CompactSerializer, ESTree};
+        use oxc_estree::{CompactTSSerializer, ESTree};
 
         let allocator = Allocator::default();
         let b = Box::new_in("x", &allocator);
 
-        let mut serializer = CompactSerializer::new();
+        let mut serializer = CompactTSSerializer::new();
         b.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(s, r#""x""#);

--- a/crates/oxc_allocator/src/vec.rs
+++ b/crates/oxc_allocator/src/vec.rs
@@ -334,13 +334,13 @@ mod test {
 
     #[test]
     fn vec_serialize_estree() {
-        use oxc_estree::{CompactSerializer, ESTree};
+        use oxc_estree::{CompactTSSerializer, ESTree};
 
         let allocator = Allocator::default();
         let mut v = Vec::new_in(&allocator);
         v.push("x");
 
-        let mut serializer = CompactSerializer::new();
+        let mut serializer = CompactTSSerializer::new();
         v.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(s, r#"["x"]"#);

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -2,22 +2,23 @@ use cow_utils::CowUtils;
 
 use oxc_ast_macros::ast_meta;
 use oxc_estree::{
-    CompactSerializer, ESTree, PrettySerializer, SequenceSerializer, Serializer, StructSerializer,
+    CompactTSSerializer, ESTree, PrettyTSSerializer, SequenceSerializer, Serializer,
+    StructSerializer,
 };
 
 use crate::ast::*;
 
 impl Program<'_> {
-    /// Serialize AST to ESTree JSON.
-    pub fn to_json(&self) -> String {
-        let mut serializer = CompactSerializer::new();
+    /// Serialize AST to ESTree JSON, including TypeScript fields.
+    pub fn to_estree_ts_json(&self) -> String {
+        let mut serializer = CompactTSSerializer::new();
         self.serialize(&mut serializer);
         serializer.into_string()
     }
 
-    /// Serialize AST to ESTree JSON.
-    pub fn to_pretty_json(&self) -> String {
-        let mut serializer = PrettySerializer::new();
+    /// Serialize AST to pretty-printed ESTree JSON, including TypeScript fields.
+    pub fn to_pretty_estree_ts_json(&self) -> String {
+        let mut serializer = PrettyTSSerializer::new();
         self.serialize(&mut serializer);
         serializer.into_string()
     }

--- a/crates/oxc_estree/src/serialize/blanket.rs
+++ b/crates/oxc_estree/src/serialize/blanket.rs
@@ -48,7 +48,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::super::CompactSerializer;
+    use super::super::CompactTSSerializer;
     use super::*;
 
     #[expect(clippy::needless_borrow)]
@@ -57,7 +57,7 @@ mod tests {
         let cases = [(&"foo", r#""foo""#), (&&"bar", r#""bar""#)];
 
         for (input, output) in cases {
-            let mut serializer = CompactSerializer::new();
+            let mut serializer = CompactTSSerializer::new();
             input.serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);
@@ -69,7 +69,7 @@ mod tests {
         let cases = [(&mut "foo", r#""foo""#), (&mut &mut "bar", r#""bar""#)];
 
         for (input, output) in cases {
-            let mut serializer = CompactSerializer::new();
+            let mut serializer = CompactTSSerializer::new();
             input.serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);
@@ -81,7 +81,7 @@ mod tests {
         let cases = [(None, "null"), (Some(123.0f64), "123")];
 
         for (input, output) in cases {
-            let mut serializer = CompactSerializer::new();
+            let mut serializer = CompactTSSerializer::new();
             input.serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);
@@ -94,7 +94,7 @@ mod tests {
             [(Cow::Borrowed("foo"), r#""foo""#), (Cow::Owned("bar".to_string()), r#""bar""#)];
 
         for (input, output) in cases {
-            let mut serializer = CompactSerializer::new();
+            let mut serializer = CompactTSSerializer::new();
             input.serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);

--- a/crates/oxc_estree/src/serialize/mod.rs
+++ b/crates/oxc_estree/src/serialize/mod.rs
@@ -51,11 +51,11 @@ trait SerializerPrivate: Sized {
     fn buffer_and_formatter_mut(&mut self) -> (&mut Buffer, &mut Self::Formatter);
 }
 
-/// ESTree serializer which produces compact JSON.
-pub type CompactSerializer = ESTreeSerializer<CompactFormatter>;
+/// ESTree serializer which produces compact JSON, including TypeScript fields.
+pub type CompactTSSerializer = ESTreeSerializer<CompactFormatter>;
 
-/// ESTree serializer which produces pretty JSON.
-pub type PrettySerializer = ESTreeSerializer<PrettyFormatter>;
+/// ESTree serializer which produces pretty JSON, including TypeScript fields.
+pub type PrettyTSSerializer = ESTreeSerializer<PrettyFormatter>;
 
 /// ESTree serializer.
 pub struct ESTreeSerializer<F: Formatter> {

--- a/crates/oxc_estree/src/serialize/primitives.rs
+++ b/crates/oxc_estree/src/serialize/primitives.rs
@@ -73,12 +73,12 @@ impl ESTree for () {
 
 #[cfg(test)]
 mod tests {
-    use super::super::CompactSerializer;
+    use super::super::CompactTSSerializer;
     use super::*;
 
     fn run_test<T: ESTree>(cases: &[(T, &str)]) {
         for (input, output) in cases {
-            let mut serializer = CompactSerializer::new();
+            let mut serializer = CompactTSSerializer::new();
             input.serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);

--- a/crates/oxc_estree/src/serialize/sequences.rs
+++ b/crates/oxc_estree/src/serialize/sequences.rs
@@ -84,7 +84,7 @@ impl<T: ESTree, const N: usize> ESTree for [T; N] {
 
 #[cfg(test)]
 mod tests {
-    use super::super::{CompactSerializer, PrettySerializer, StructSerializer};
+    use super::super::{CompactTSSerializer, PrettyTSSerializer, StructSerializer};
     use super::*;
 
     #[test]
@@ -107,12 +107,12 @@ mod tests {
 
         let foo = Foo { none: &[], one: &["one"], two: ["two one", "two two"] };
 
-        let mut serializer = CompactSerializer::new();
+        let mut serializer = CompactTSSerializer::new();
         foo.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(&s, r#"{"none":[],"one":["one"],"two":["two one","two two"]}"#);
 
-        let mut serializer = PrettySerializer::new();
+        let mut serializer = PrettyTSSerializer::new();
         foo.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(

--- a/crates/oxc_estree/src/serialize/strings.rs
+++ b/crates/oxc_estree/src/serialize/strings.rs
@@ -121,7 +121,7 @@ fn write_char_escape(escape: Escape, byte: u8, buffer: &mut Buffer) {
 
 #[cfg(test)]
 mod tests {
-    use super::super::CompactSerializer;
+    use super::super::CompactTSSerializer;
     use super::*;
 
     #[test]
@@ -148,7 +148,7 @@ mod tests {
         ];
 
         for (input, output) in cases {
-            let mut serializer = CompactSerializer::new();
+            let mut serializer = CompactTSSerializer::new();
             input.serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);
@@ -160,7 +160,7 @@ mod tests {
         let cases = [(String::new(), r#""""#), ("foobar".to_string(), r#""foobar""#)];
 
         for (input, output) in cases {
-            let mut serializer = CompactSerializer::new();
+            let mut serializer = CompactTSSerializer::new();
             input.serialize(&mut serializer);
             let s = serializer.into_string();
             assert_eq!(&s, output);

--- a/crates/oxc_estree/src/serialize/structs.rs
+++ b/crates/oxc_estree/src/serialize/structs.rs
@@ -165,7 +165,7 @@ impl<P: StructSerializer> StructSerializer for FlatStructSerializer<'_, P> {
 
 #[cfg(test)]
 mod tests {
-    use super::super::{CompactSerializer, FlatStructSerializer, PrettySerializer, Serializer};
+    use super::super::{CompactTSSerializer, FlatStructSerializer, PrettyTSSerializer, Serializer};
     use super::*;
 
     #[test]
@@ -227,7 +227,7 @@ mod tests {
             maybe_not_bar: None,
         };
 
-        let mut serializer = CompactSerializer::new();
+        let mut serializer = CompactTSSerializer::new();
         foo.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(
@@ -235,7 +235,7 @@ mod tests {
             r#"{"n":123,"u":12345,"bar":{"yes":"yup","no":"nope"},"empty":{},"hello":"hi!","maybe_bar":{"yes":"hell yeah!","no":"not a chance in a million, mate"},"maybe_not_bar":null}"#
         );
 
-        let mut serializer = PrettySerializer::new();
+        let mut serializer = PrettyTSSerializer::new();
         foo.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(
@@ -316,7 +316,7 @@ mod tests {
             outer2: "out2",
         };
 
-        let mut serializer = CompactSerializer::new();
+        let mut serializer = CompactTSSerializer::new();
         outer.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(
@@ -324,7 +324,7 @@ mod tests {
             r#"{"outer1":"out1","inner1":"in1","innermost1":"inin1","innermost2":"inin2","inner2":"in2","outer2":"out2"}"#
         );
 
-        let mut serializer = PrettySerializer::new();
+        let mut serializer = PrettyTSSerializer::new();
         outer.serialize(&mut serializer);
         let s = serializer.into_string();
         assert_eq!(

--- a/crates/oxc_parser/examples/parser.rs
+++ b/crates/oxc_parser/examples/parser.rs
@@ -43,7 +43,7 @@ fn main() -> Result<(), String> {
         if show_estree {
             Utf8ToUtf16::new().convert(&mut program);
         }
-        println!("{}", program.to_pretty_json());
+        println!("{}", program.to_pretty_estree_ts_json());
     }
 
     if ret.errors.is_empty() {

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -472,7 +472,7 @@ impl Oxc {
 
     fn convert_ast(&mut self, program: &mut Program) {
         Utf8ToUtf16::new().convert(program);
-        self.ast_json = program.to_pretty_json();
+        self.ast_json = program.to_pretty_estree_ts_json();
         self.comments = Self::map_comments(program.source_text, &program.comments);
     }
 

--- a/napi/parser/src/lib.rs
+++ b/napi/parser/src/lib.rs
@@ -106,7 +106,7 @@ fn parse_with_return(filename: &str, source_text: String, options: &ParserOption
             }
         }
     }
-    let program = ret.program.to_json();
+    let program = ret.program.to_estree_ts_json();
     let module = EcmaScriptModule::from(&ret.module_record);
     ParseResult { source_text, program, module, comments, errors }
 }

--- a/tasks/benchmark/benches/parser.rs
+++ b/tasks/benchmark/benches/parser.rs
@@ -49,7 +49,7 @@ fn bench_estree(criterion: &mut Criterion) {
                     .program;
                 runner.run(|| {
                     Utf8ToUtf16::new().convert(&mut program);
-                    program.to_json();
+                    program.to_estree_ts_json();
                     program
                 });
             });

--- a/tasks/coverage/src/driver.rs
+++ b/tasks/coverage/src/driver.rs
@@ -76,7 +76,7 @@ impl CompilerInterface for Driver {
             self.errors.push(OxcDiagnostic::error("SourceType must not be unambiguous."));
         }
         // Make sure serialization doesn't crash; also for code coverage.
-        program.to_json();
+        program.to_estree_ts_json();
         ControlFlow::Continue(())
     }
 

--- a/tasks/coverage/src/tools/estree.rs
+++ b/tasks/coverage/src/tools/estree.rs
@@ -171,7 +171,7 @@ impl Case for EstreeTest262Case {
                 return;
             }
         };
-        let mut oxc_json_value = match deserialize_json(&program.to_json()) {
+        let mut oxc_json_value = match deserialize_json(&program.to_estree_ts_json()) {
             Ok(oxc_json) => oxc_json,
             Err(e) => {
                 self.base.set_result(TestResult::GenericError("serde_json", e.to_string()));

--- a/wasm/parser/src/lib.rs
+++ b/wasm/parser/src/lib.rs
@@ -101,7 +101,7 @@ pub fn parse_sync(
 
     let serializer = serde_wasm_bindgen::Serializer::json_compatible();
 
-    let program_json = ret.program.to_json();
+    let program_json = ret.program.to_estree_ts_json();
 
     let comments: Vec<JsValue> = if ret.program.comments.is_empty() {
         vec![]


### PR DESCRIPTION
Pure refactor. Rename:

* `Program::to_json` to `to_estree_ts_json`.
* `Program::to_pretty_json` to `to_pretty_estree_ts_json`.

This is preparatory work for #9285, which adds `*_js_*` variants of these 2 methods, which omit TypeScript fields.

Also rename the serializers, to include `TS` in their names, for the same reason.
