### PR TITLE
test(ast/estree): ESTree conformance tester include tests with `Infinity`

### DIFF
--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ submodules:
   just clone-submodule tasks/coverage/babel https://github.com/babel/babel.git acbc09a87016778c1551ab5e7162fdd0e70b6663
   just clone-submodule tasks/coverage/typescript https://github.com/microsoft/TypeScript.git d85767abfd83880cea17cea70f9913e9c4496dcc
   just clone-submodule tasks/prettier_conformance/prettier https://github.com/prettier/prettier.git 7584432401a47a26943dd7a9ca9a8e032ead7285
-  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 3ab34526674f12701b98022fa1987a084ad3f356
+  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 ed8b455fd9775089444d53c09ea18fedf220da8b
   just update-transformer-fixtures
 
 # Install git pre-commit to format files

--- a/tasks/coverage/snapshots/estree_test262.snap
+++ b/tasks/coverage/snapshots/estree_test262.snap
@@ -1,5 +1,5 @@
 commit: bc5c1417
 
 estree_test262 Summary:
-AST Parsed     : 44001/44001 (100.00%)
-Positive Passed: 44001/44001 (100.00%)
+AST Parsed     : 44006/44006 (100.00%)
+Positive Passed: 44006/44006 (100.00%)

--- a/tasks/coverage/src/tools/estree.rs
+++ b/tasks/coverage/src/tools/estree.rs
@@ -110,16 +110,6 @@ impl Case for EstreeTest262Case {
             "test262/test/language/comments/hashbang/module.js",
             "test262/test/language/comments/hashbang/not-empty.js",
             "test262/test/language/comments/hashbang/use-strict.js",
-
-            // Infinite numbers.
-            // JSON we generate does correctly represent `Infinity` (as `1e+400`), but `serde` can't
-            // parse that, so these tests erroneously fail.
-            // NAPI binding contains a test case for `Infinity` instead.
-            "test262/test/built-ins/Array/prototype/indexOf/15.4.4.14-10-1.js",
-            "test262/test/built-ins/Array/prototype/lastIndexOf/15.4.4.15-9-1.js",
-            "test262/test/built-ins/Number/S9.3.1_A6_T1.js",
-            "test262/test/built-ins/Number/S9.3.1_A6_T2.js",
-            "test262/test/language/types/number/8.5.1.js",
         ];
 
         let path = &*self.path().to_string_lossy();


### PR DESCRIPTION
Now that we are comparing ASTs Oxc vs Acorn with a simple JSON string comparison (#9285), we can re-enable the tests for source files containing infinite numbers (e.g. `1e+9999`).

Our serializer outputs `f64::INFINITY` as `1e+400` in JSON, which `JSON.parse` interprets as JS value `Infinity`.

Bump `acorn-test262` to include commit https://github.com/oxc-project/acorn-test262/commit/ed8b455fd9775089444d53c09ea18fedf220da8b, which serializes `Infinity` in the same way.
