### PR TITLE
ci(benchmark): benchmark ESTree JS-only variant

### DIFF
--- a/justfile
+++ b/justfile
@@ -150,6 +150,9 @@ update-transformer-fixtures:
 test-estree *args='':
   cargo run -p oxc_coverage --profile coverage -- estree {{args}}
 
+tt *args:
+  cargo run -p oxc_coverage --profile coverage -- estree --diff --filter {{args}}
+
 # Install wasm-pack
 install-wasm:
   cargo binstall wasm-pack


### PR DESCRIPTION
Test, not for merging. Just an experiment to see what difference to performance omitting TS fields gets us.

Skipping TS fields makes serialization to JSON 2% faster. Not spectacular! But not nothing...

Of course `JSON.parse` will also be faster on JS side, as the JSON is smaller.