### PR TITLE
ci(conformance): run ESTree conformance tests in CI

### DIFF
--- a/.github/actions/clone-submodules/action.yml
+++ b/.github/actions/clone-submodules/action.yml
@@ -32,3 +32,10 @@ runs:
         repository: prettier/prettier
         path: tasks/prettier_conformance/prettier
         ref: 7584432401a47a26943dd7a9ca9a8e032ead7285 # v3.5.0
+
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        show-progress: false
+        repository: oxc-project/acorn-test262
+        path: tasks/coverage/acorn-test262
+        ref: ed8b455fd9775089444d53c09ea18fedf220da8b # Latest main at 21/2/24

--- a/tasks/coverage/src/lib.rs
+++ b/tasks/coverage/src/lib.rs
@@ -71,6 +71,7 @@ impl AppArgs {
         self.run_transformer();
         self.run_transpiler();
         self.run_minifier();
+        self.run_estree();
     }
 
     pub fn run_parser(&self) {


### PR DESCRIPTION
After #9285, the ESTree conformance tests are fast enough to run in CI. Do that, so we notice if we break anything.

Time to run conformance on CI:

Before this PR: 3m 39s
After this PR: 3m 55s