### PR TITLE
chore(rust): enable doctests

### DIFF
--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -16,13 +16,11 @@ description.workspace = true
 workspace = true
 
 [lib]
-doctest = false
 
 [[bin]]
 name = "oxlint"
 path = "src/main.rs"
 test = false
-doctest = false
 
 [target.'cfg(all(not(target_env = "msvc"), not(target_os = "windows")))'.dependencies]
 jemallocator = { workspace = true, optional = true }

--- a/crates/oxc/Cargo.toml
+++ b/crates/oxc/Cargo.toml
@@ -18,7 +18,6 @@ workspace = true
 
 [lib]
 test = false
-doctest = false
 
 [[example]]
 name = "compiler"

--- a/crates/oxc_allocator/Cargo.toml
+++ b/crates/oxc_allocator/Cargo.toml
@@ -16,7 +16,6 @@ description.workspace = true
 workspace = true
 
 [lib]
-doctest = false
 
 [dependencies]
 oxc_estree = { workspace = true, optional = true }

--- a/crates/oxc_ast/Cargo.toml
+++ b/crates/oxc_ast/Cargo.toml
@@ -16,7 +16,6 @@ description.workspace = true
 workspace = true
 
 [lib]
-doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }

--- a/crates/oxc_ast/src/ast/comment.rs
+++ b/crates/oxc_ast/src/ast/comment.rs
@@ -24,7 +24,7 @@ pub enum CommentPosition {
     ///
     /// e.g.
     ///
-    /// ```
+    /// ```ignore
     /// /* leading */ token;
     /// /* leading */
     /// // leading

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -945,14 +945,14 @@ pub struct AssignmentTargetPropertyIdentifier<'a> {
 pub struct AssignmentTargetPropertyProperty<'a> {
     pub span: Span,
     /// The property key
-    /// ```
+    /// ```js
     /// ({ prop: renamed } = obj)
     ///    ^^^^
     /// ```
     #[estree(rename = "key")]
     pub name: PropertyKey<'a>,
     /// The binding part of the property
-    /// ```
+    /// ```js
     /// ({ prop: renamed } = obj)
     ///          ^^^^^^^
     /// ```

--- a/crates/oxc_ast/src/ast/macros.rs
+++ b/crates/oxc_ast/src/ast/macros.rs
@@ -18,7 +18,7 @@
 ///
 /// # Expansion
 ///
-/// ```
+/// ```ignore
 /// inherit_variants! {
 ///     #[ast]
 ///     enum Statement<'a> {
@@ -34,7 +34,7 @@
 ///
 /// expands to:
 ///
-/// ```
+/// ```ignore
 /// #[ast]
 /// enum Statement<'a> {
 ///     pub enum Statement<'a> {
@@ -744,7 +744,7 @@ pub(crate) use inherit_variants;
 ///
 /// NB: For illustration only - `Statement` and `Declaration` in reality share 9 variants, not 2.
 ///
-/// ```
+/// ```ignore
 /// shared_enum_variants!(
 ///     Statement, Declaration,
 ///     is_declaration,
@@ -757,7 +757,7 @@ pub(crate) use inherit_variants;
 ///
 /// expands to:
 ///
-/// ```
+/// ```ignore
 /// const _: () = {
 ///     assert!(discriminant!(Statement::VariableDeclaration) == discriminant!(Declaration::VariableDeclaration));
 ///     assert!(discriminant!(Statement::FunctionDeclaration) == discriminant!(Declaration::FunctionDeclaration));

--- a/crates/oxc_ast/src/ast/mod.rs
+++ b/crates/oxc_ast/src/ast/mod.rs
@@ -14,7 +14,7 @@
 //!
 //! Instead of nested enums:
 //!
-//! ```
+//! ```ignore
 //! pub enum Expression<'a> {
 //!     BooleanLiteral(Box<'a, BooleanLiteral>),
 //!     NullLiteral(Box<'a, NullLiteral>),
@@ -31,7 +31,7 @@
 //!
 //! We define the types using `inherit_variants!` macro:
 //!
-//! ```
+//! ```ignore
 //! inherit_variants! {
 //! #[repr(C, u8)]
 //! pub enum Expression<'a> {
@@ -52,7 +52,7 @@
 //!
 //! `inherit_variants!` macro expands `Expression` to:
 //!
-//! ```
+//! ```ignore
 //! #[repr(C, u8)]
 //! pub enum Expression<'a> {
 //!     BooleanLiteral(Box<'a, BooleanLiteral>) = 0,
@@ -82,7 +82,7 @@
 //!
 //! #### Creation
 //!
-//! ```
+//! ```ignore
 //! // Old
 //! let expr = Expression::MemberExpression(
 //!   MemberExpression::ComputedMemberExpression(computed_member_expr)
@@ -94,7 +94,7 @@
 //!
 //! #### Conversion
 //!
-//! ```
+//! ```ignore
 //! // Old
 //! let expr = Expression::MemberExpression(member_expr);
 //!
@@ -102,7 +102,7 @@
 //! let expr = Expression::from(member_expr);
 //! ```
 //!
-//! ```
+//! ```ignore
 //! // Old
 //! let maybe_member_expr = match expr {
 //!     Expression::MemberExpression(member_expr) => Some(member_expr),
@@ -115,7 +115,7 @@
 //!
 //! #### Testing
 //!
-//! ```
+//! ```ignore
 //! // Old
 //! if matches!(expr, Expression::MemberExpression(_)) { }
 //!
@@ -127,7 +127,7 @@
 //!
 //! #### Branching
 //!
-//! ```
+//! ```ignore
 //! // Old
 //! if let Expression::MemberExpression(member_expr) = &expr { }
 //!
@@ -137,7 +137,7 @@
 //!
 //! #### Matching
 //!
-//! ```
+//! ```ignore
 //! // Old
 //! match get_expression() {
 //!     Expression::MemberExpression(member_expr) => visitor.visit(member_expr),

--- a/crates/oxc_ast_macros/Cargo.toml
+++ b/crates/oxc_ast_macros/Cargo.toml
@@ -18,7 +18,6 @@ workspace = true
 
 [lib]
 proc-macro = true
-doctest = false
 
 [dependencies]
 proc-macro2 = { workspace = true }

--- a/crates/oxc_cfg/Cargo.toml
+++ b/crates/oxc_cfg/Cargo.toml
@@ -18,7 +18,6 @@ workspace = true
 
 [lib]
 test = false
-doctest = false
 
 [dependencies]
 oxc_index = { workspace = true }

--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -17,7 +17,6 @@ description.workspace = true
 workspace = true
 
 [lib]
-doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }

--- a/crates/oxc_data_structures/Cargo.toml
+++ b/crates/oxc_data_structures/Cargo.toml
@@ -18,7 +18,6 @@ workspace = true
 
 [lib]
 test = true
-doctest = false
 
 [dependencies]
 assert-unchecked = { workspace = true }

--- a/crates/oxc_diagnostics/Cargo.toml
+++ b/crates/oxc_diagnostics/Cargo.toml
@@ -16,7 +16,6 @@ description.workspace = true
 workspace = true
 
 [lib]
-doctest = false
 
 [dependencies]
 cow-utils = { workspace = true }

--- a/crates/oxc_ecmascript/Cargo.toml
+++ b/crates/oxc_ecmascript/Cargo.toml
@@ -18,7 +18,6 @@ workspace = true
 
 [lib]
 test = true
-doctest = false
 
 [dependencies]
 oxc_ast = { workspace = true }

--- a/crates/oxc_estree/Cargo.toml
+++ b/crates/oxc_estree/Cargo.toml
@@ -16,7 +16,6 @@ description.workspace = true
 workspace = true
 
 [lib]
-doctest = false
 
 [dependencies]
 itoa = { workspace = true }

--- a/crates/oxc_isolated_declarations/Cargo.toml
+++ b/crates/oxc_isolated_declarations/Cargo.toml
@@ -20,7 +20,6 @@ description.workspace = true
 workspace = true
 
 [lib]
-doctest = false
 test = false
 
 [dependencies]

--- a/crates/oxc_language_server/Cargo.toml
+++ b/crates/oxc_language_server/Cargo.toml
@@ -19,7 +19,6 @@ workspace = true
 [[bin]]
 name = "oxc_language_server"
 test = true
-doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -17,7 +17,6 @@ description.workspace = true
 workspace = true
 
 [lib]
-doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }

--- a/crates/oxc_macros/Cargo.toml
+++ b/crates/oxc_macros/Cargo.toml
@@ -19,7 +19,6 @@ workspace = true
 [lib]
 proc-macro = true
 test = false
-doctest = false
 
 [dependencies]
 convert_case = { workspace = true }

--- a/crates/oxc_mangler/Cargo.toml
+++ b/crates/oxc_mangler/Cargo.toml
@@ -18,7 +18,6 @@ workspace = true
 
 [lib]
 test = false
-doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }

--- a/crates/oxc_minifier/Cargo.toml
+++ b/crates/oxc_minifier/Cargo.toml
@@ -18,7 +18,6 @@ workspace = true
 
 [lib]
 test = true
-doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }

--- a/crates/oxc_napi/Cargo.toml
+++ b/crates/oxc_napi/Cargo.toml
@@ -17,7 +17,6 @@ description.workspace = true
 workspace = true
 
 [lib]
-doctest = false
 crate-type = ["lib", "cdylib"]
 
 [dependencies]

--- a/crates/oxc_parser/Cargo.toml
+++ b/crates/oxc_parser/Cargo.toml
@@ -16,7 +16,6 @@ description.workspace = true
 workspace = true
 
 [lib]
-doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }

--- a/crates/oxc_prettier/Cargo.toml
+++ b/crates/oxc_prettier/Cargo.toml
@@ -17,7 +17,6 @@ description.workspace = true
 workspace = true
 
 [lib]
-doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }

--- a/crates/oxc_regular_expression/Cargo.toml
+++ b/crates/oxc_regular_expression/Cargo.toml
@@ -17,7 +17,6 @@ description.workspace = true
 workspace = true
 
 [lib]
-doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -16,7 +16,6 @@ description.workspace = true
 workspace = true
 
 [lib]
-doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }

--- a/crates/oxc_span/Cargo.toml
+++ b/crates/oxc_span/Cargo.toml
@@ -17,7 +17,6 @@ description.workspace = true
 workspace = true
 
 [lib]
-doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }

--- a/crates/oxc_syntax/Cargo.toml
+++ b/crates/oxc_syntax/Cargo.toml
@@ -17,7 +17,6 @@ description.workspace = true
 workspace = true
 
 [lib]
-doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }

--- a/crates/oxc_transformer/Cargo.toml
+++ b/crates/oxc_transformer/Cargo.toml
@@ -18,7 +18,6 @@ workspace = true
 
 [lib]
 test = true
-doctest = false
 
 [dependencies]
 oxc-browserslist = { workspace = true }

--- a/crates/oxc_wasm/Cargo.toml
+++ b/crates/oxc_wasm/Cargo.toml
@@ -16,7 +16,6 @@ workspace = true
 [lib]
 crate-type = ["cdylib", "rlib"]
 test = false
-doctest = false
 
 [dependencies]
 oxc = { workspace = true, features = ["codegen", "minifier", "semantic", "serialize", "transformer", "isolated_declarations", "wasm"] }

--- a/napi/minify/Cargo.toml
+++ b/napi/minify/Cargo.toml
@@ -19,7 +19,6 @@ workspace = true
 [lib]
 crate-type = ["cdylib", "lib"]
 test = false
-doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }

--- a/napi/parser/Cargo.toml
+++ b/napi/parser/Cargo.toml
@@ -19,7 +19,6 @@ workspace = true
 [lib]
 crate-type = ["cdylib", "lib"]
 test = false
-doctest = false
 
 [dependencies]
 oxc = { workspace = true }

--- a/napi/transform/Cargo.toml
+++ b/napi/transform/Cargo.toml
@@ -19,7 +19,6 @@ workspace = true
 [lib]
 crate-type = ["cdylib", "lib"]
 test = false
-doctest = false
 
 [dependencies]
 oxc = { workspace = true, features = ["full"] }

--- a/tasks/ast_tools/Cargo.toml
+++ b/tasks/ast_tools/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 [[bin]]
 name = "oxc_ast_tools"
 test = true
-doctest = false
 
 [dependencies]
 bitflags = { workspace = true }

--- a/tasks/benchmark/Cargo.toml
+++ b/tasks/benchmark/Cargo.toml
@@ -16,7 +16,6 @@ workspace = true
 [lib]
 test = false
 bench = false
-doctest = false
 
 [[bench]]
 name = "lexer"

--- a/tasks/common/Cargo.toml
+++ b/tasks/common/Cargo.toml
@@ -10,7 +10,6 @@ workspace = true
 
 [lib]
 test = false
-doctest = false
 
 [dependencies]
 console = { workspace = true }

--- a/tasks/compat_data/Cargo.toml
+++ b/tasks/compat_data/Cargo.toml
@@ -10,7 +10,6 @@ workspace = true
 
 [lib]
 test = false
-doctest = false
 
 [dependencies]
 oxc_tasks_common = { workspace = true }

--- a/tasks/coverage/Cargo.toml
+++ b/tasks/coverage/Cargo.toml
@@ -14,12 +14,10 @@ description.workspace = true
 workspace = true
 
 [lib]
-doctest = false
 
 [[bin]]
 name = "oxc_coverage"
 test = false
-doctest = false
 
 [dependencies]
 oxc = { workspace = true, features = ["full", "isolated_declarations", "serialize"] }

--- a/tasks/javascript_globals/Cargo.toml
+++ b/tasks/javascript_globals/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 [[bin]]
 name = "javascript_globals"
 test = false
-doctest = false
 
 [dependencies]
 handlebars = { workspace = true }

--- a/tasks/minsize/Cargo.toml
+++ b/tasks/minsize/Cargo.toml
@@ -10,12 +10,10 @@ workspace = true
 
 [lib]
 test = false
-doctest = false
 
 [[bin]]
 name = "oxc_minsize"
 test = false
-doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }

--- a/tasks/prettier_conformance/Cargo.toml
+++ b/tasks/prettier_conformance/Cargo.toml
@@ -14,13 +14,11 @@ description.workspace = true
 workspace = true
 
 [lib]
-doctest = false
 
 [[bin]]
 name = "oxc_prettier_conformance"
 path = "src/main.rs"
 test = false
-doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }

--- a/tasks/rulegen/Cargo.toml
+++ b/tasks/rulegen/Cargo.toml
@@ -11,7 +11,6 @@ workspace = true
 [[bin]]
 name = "rulegen"
 test = false
-doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }

--- a/tasks/transform_checker/Cargo.toml
+++ b/tasks/transform_checker/Cargo.toml
@@ -10,7 +10,6 @@ workspace = true
 
 [lib]
 test = false
-doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }

--- a/tasks/transform_conformance/Cargo.toml
+++ b/tasks/transform_conformance/Cargo.toml
@@ -14,12 +14,10 @@ description.workspace = true
 workspace = true
 
 [lib]
-doctest = false
 
 [[bin]]
 name = "oxc_transform_conformance"
 test = false
-doctest = false
 
 [dependencies]
 oxc = { workspace = true, features = ["full"] }

--- a/tasks/website/Cargo.toml
+++ b/tasks/website/Cargo.toml
@@ -11,10 +11,8 @@ workspace = true
 [[bin]]
 name = "website"
 test = false
-doctest = false
 
 [lib]
-doctest = false
 
 [dependencies]
 bpaf = { workspace = true, features = ["docgen"] }

--- a/wasm/parser/Cargo.toml
+++ b/wasm/parser/Cargo.toml
@@ -18,7 +18,6 @@ workspace = true
 [lib]
 crate-type = ["cdylib", "rlib"]
 test = false
-doctest = false
 
 [dependencies]
 oxc = { workspace = true, features = ["serialize"] }


### PR DESCRIPTION
With Rust Edition 2024 [Rustdoc combined tests](https://doc.rust-lang.org/edition-guide/rust-2024/rustdoc-doctests.html#rustdoc-combined-tests), we can finally enable doctests!

