### PR TITLE
feat(linter): add oxc/no-redundant-constructor-init

### DIFF
--- a/apps/oxlint/src/snapshots/_--ignore-path fixtures__linter__.customignore --no-ignore fixtures__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-path fixtures__linter__.customignore --no-ignore fixtures__linter__nan.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Use the isNaN function to compare with NaN.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--ignore-pattern _____.js --ignore-pattern _____.vue fixtures__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-pattern _____.js --ignore-pattern _____.vue fixtures__linter@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --ignore-pattern **/*.js --ignore-pattern **/*.vue fixtures/linter
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 99 rules using 1 threads.
+Finished in <variable>ms on 0 files with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--import-plugin -A all -D no-cycle fixtures__flow__@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--import-plugin -A all -D no-cycle fixtures__flow__@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --import-plugin -A all -D no-cycle fixtures/flow/
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 2 files with 101 rules using 1 threads.
+Finished in <variable>ms on 2 files with 102 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--import-plugin fixtures__flow__index.mjs@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--import-plugin fixtures__flow__index.mjs@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --import-plugin fixtures/flow/index.mjs
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 102 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
@@ -23,7 +23,7 @@ working directory:
   help: Remove the appending `.skip`
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 111 rules using 1 threads.
+Finished in <variable>ms on 1 file with 112 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-D correctness fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-D correctness fixtures__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Delete this code.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-W correctness -A no-debugger fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W correctness -A no-debugger fixtures__linter__debugger.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -W correctness -A no-debugger fixtures/linter/debugger.js
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 98 rules using 1 threads.
+Finished in <variable>ms on 1 file with 99 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__eslintrc_env__eslintrc_no_env.json fixtures__eslintrc_env__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__eslintrc_env__eslintrc_no_env.json fixtures__eslintrc_env__test.js@oxlint.snap
@@ -13,7 +13,7 @@ working directory:
    `----
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 100 rules using 1 threads.
+Finished in <variable>ms on 1 file with 101 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__no_undef__eslintrc.json fixtures__no_undef__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__no_undef__eslintrc.json fixtures__no_undef__test.js@oxlint.snap
@@ -13,7 +13,7 @@ working directory:
    `----
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 100 rules using 1 threads.
+Finished in <variable>ms on 1 file with 101 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension@oxlint.snap
@@ -12,7 +12,7 @@ working directory:
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_env__eslintrc_env_browser.json fixtures__eslintrc_env__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_env__eslintrc_env_browser.json fixtures__eslintrc_env__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/eslintrc_env/eslintrc_env_browser.json fixtures/eslintrc_
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 100 rules using 1 threads.
+Finished in <variable>ms on 1 file with 101 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_off__eslintrc.json fixtures__eslintrc_off__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_off__eslintrc.json fixtures__eslintrc_off__test.js@oxlint.snap
@@ -12,7 +12,7 @@ working directory:
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/eslintrc_vitest_replace/eslintrc.json fixtures/eslintrc_v
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__linter__eslintrc.json fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__linter__eslintrc.json fixtures__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Delete this code.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__no_console_off__eslintrc.json fixtures__no_console_off__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__no_console_off__eslintrc.json fixtures__no_console_off__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/no_console_off/eslintrc.json fixtures/no_console_off/test
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__no_empty_allow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_allow_empty_catch__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__no_empty_allow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_allow_empty_catch__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/no_empty_allow_empty_catch/eslintrc.json -W no-empty fixt
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 100 rules using 1 threads.
+Finished in <variable>ms on 1 file with 101 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__no_empty_disallow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_disallow_empty_catch__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__no_empty_disallow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_disallow_empty_catch__test.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove this block or add a comment inside it
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 100 rules using 1 threads.
+Finished in <variable>ms on 1 file with 101 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.js -c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.ts -c fixtures__overrides__.oxlintrc.json fixtures__overrides__other.jsx@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.js -c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.ts -c fixtures__overrides__.oxlintrc.json fixtures__overrides__other.jsx@oxlint.snap
@@ -15,7 +15,7 @@ working directory:
   help: Replace var with let or const
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 102 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------
@@ -42,7 +42,7 @@ working directory:
   help: Delete this console statement.
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 102 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------
@@ -61,7 +61,7 @@ working directory:
   help: Replace var with let or const
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 102 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__overrides__directories-config.json fixtures__overrides@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__overrides__directories-config.json fixtures__overrides@oxlint.snap
@@ -35,7 +35,7 @@ working directory:
   help: Delete this code.
 
 Found 2 warnings and 2 errors.
-Finished in <variable>ms on 7 files with 98 rules using 1 threads.
+Finished in <variable>ms on 7 files with 99 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__astro__debugger.astro@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__astro__debugger.astro@oxlint.snap
@@ -39,7 +39,7 @@ working directory:
   help: Delete this code.
 
 Found 4 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter@oxlint.snap
@@ -28,7 +28,7 @@ working directory:
   help: Use the isNaN function to compare with NaN.
 
 Found 3 warnings and 0 errors.
-Finished in <variable>ms on 3 files with 99 rules using 1 threads.
+Finished in <variable>ms on 3 files with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js fixtures__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js fixtures__linter__nan.js@oxlint.snap
@@ -21,7 +21,7 @@ working directory:
   help: Use the isNaN function to compare with NaN.
 
 Found 2 warnings and 0 errors.
-Finished in <variable>ms on 2 files with 99 rules using 1 threads.
+Finished in <variable>ms on 2 files with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Delete this code.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__svelte__debugger.svelte@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__svelte__debugger.svelte@oxlint.snap
@@ -16,7 +16,7 @@ working directory:
   help: Delete this code.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__vue__debugger.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__vue__debugger.vue@oxlint.snap
@@ -23,7 +23,7 @@ working directory:
   help: Delete this code.
 
 Found 2 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__vue__empty.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__vue__empty.vue@oxlint.snap
@@ -6,7 +6,7 @@ arguments: fixtures/vue/empty.vue
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_foo.asdf@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_foo.asdf@oxlint.snap
@@ -6,7 +6,7 @@ arguments: foo.asdf
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 99 rules using 1 threads.
+Finished in <variable>ms on 0 files with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__auto_config_detection_debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__auto_config_detection_debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/auto_config_detection
   help: Delete this code.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__ignore_directory_-c eslintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__ignore_directory_-c eslintrc.json@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/config_ignore_patterns/ignore_directory
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__with_oxlintrc_-c .__test__eslintrc.json --ignore-pattern _.ts .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__with_oxlintrc_-c .__test__eslintrc.json --ignore-pattern _.ts .@oxlint.snap
@@ -12,7 +12,7 @@ working directory: fixtures/config_ignore_patterns/with_oxlintrc
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__linter_debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__linter_debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/linter
   help: Delete this code.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_--experimental-nested-config --config oxlint-no-console.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_--experimental-nested-config --config oxlint-no-console.json@oxlint.snap
@@ -37,7 +37,7 @@ working directory: fixtures/nested_config
   help: Delete this console statement.
 
 Found 0 warnings and 4 errors.
-Finished in <variable>ms on 7 files with 99 rules using 1 threads.
+Finished in <variable>ms on 7 files with 100 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_--experimental-nested-config -A no-console --config oxlint-no-console.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_--experimental-nested-config -A no-console --config oxlint-no-console.json@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --experimental-nested-config -A no-console --config oxlint-no-console
 working directory: fixtures/nested_config
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 7 files with 98 rules using 1 threads.
+Finished in <variable>ms on 7 files with 99 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_--experimental-nested-config -A no-console@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_--experimental-nested-config -A no-console@oxlint.snap
@@ -28,7 +28,7 @@ working directory: fixtures/nested_config
   help: Delete this code.
 
 Found 1 warning and 2 errors.
-Finished in <variable>ms on 7 files with 99 rules using 1 threads.
+Finished in <variable>ms on 7 files with 100 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_--experimental-nested-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_--experimental-nested-config@oxlint.snap
@@ -51,7 +51,7 @@ working directory: fixtures/nested_config
   help: Delete this console statement.
 
 Found 1 warning and 5 errors.
-Finished in <variable>ms on 7 files with 100 rules using 1 threads.
+Finished in <variable>ms on 7 files with 101 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=default test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=default test.js@oxlint.snap
@@ -33,7 +33,7 @@ working directory: fixtures/output_formatter_diagnostic
   help: Delete this code.
 
 Found 2 warnings and 1 error.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__overrides_env_globals_-c .oxlintrc.json .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__overrides_env_globals_-c .oxlintrc.json .@oxlint.snap
@@ -51,7 +51,7 @@ working directory: fixtures/overrides_env_globals
    `----
 
 Found 5 warnings and 0 errors.
-Finished in <variable>ms on 3 files with 99 rules using 1 threads.
+Finished in <variable>ms on 3 files with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -116,7 +116,6 @@ mod eslint {
     pub mod no_proto;
     pub mod no_prototype_builtins;
     pub mod no_redeclare;
-    pub mod no_redundant_constructor_init;
     pub mod no_regex_spaces;
     pub mod no_restricted_globals;
     pub mod no_restricted_imports;
@@ -461,6 +460,7 @@ mod oxc {
     pub mod no_const_enum;
     pub mod no_map_spread;
     pub mod no_optional_chaining;
+    pub mod no_redundant_constructor_init;
     pub mod no_rest_spread_properties;
     pub mod number_arg_out_of_range;
     pub mod only_used_in_recursion;
@@ -631,7 +631,6 @@ oxc_macros::declare_all_lint_rules! {
     eslint::no_proto,
     eslint::no_prototype_builtins,
     eslint::no_redeclare,
-    eslint::no_redundant_constructor_init,
     eslint::no_regex_spaces,
     eslint::no_restricted_globals,
     eslint::no_return_assign,
@@ -840,6 +839,7 @@ oxc_macros::declare_all_lint_rules! {
     oxc::no_const_enum,
     oxc::no_map_spread,
     oxc::no_optional_chaining,
+    oxc::no_redundant_constructor_init,
     oxc::no_rest_spread_properties,
     oxc::number_arg_out_of_range,
     oxc::only_used_in_recursion,

--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -116,6 +116,7 @@ mod eslint {
     pub mod no_proto;
     pub mod no_prototype_builtins;
     pub mod no_redeclare;
+    pub mod no_redundant_constructor_init;
     pub mod no_regex_spaces;
     pub mod no_restricted_globals;
     pub mod no_restricted_imports;
@@ -630,6 +631,7 @@ oxc_macros::declare_all_lint_rules! {
     eslint::no_proto,
     eslint::no_prototype_builtins,
     eslint::no_redeclare,
+    eslint::no_redundant_constructor_init,
     eslint::no_regex_spaces,
     eslint::no_restricted_globals,
     eslint::no_return_assign,

--- a/crates/oxc_linter/src/rules/eslint/no_redundant_constructor_init.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_redundant_constructor_init.rs
@@ -1,0 +1,165 @@
+use oxc_ast::{
+    AstKind,
+    ast::{AssignmentTarget, Expression, MethodDefinitionKind, Statement},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_redundant_constructor_init_diagnostic(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::warn("Explicit initialization of public members is redundant")
+        .with_help("Remove the explicit initialization")
+        .with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoRedundantConstructorInit;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Prevents redundant initialization of class members within a constructor.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Arguments marked as `public` within a constructor are automatically initialized.
+    /// Providing an explicit initialization is redundant and can be removed.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// class Foo {
+    ///   constructor(public name: unknown) {
+    ///     this.name = name;
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// class Foo {
+    ///   constructor(public name: unknown) {}
+    /// }
+    /// ```
+    NoRedundantConstructorInit,
+    eslint,
+    style,
+    pending,
+);
+
+impl Rule for NoRedundantConstructorInit {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::MethodDefinition(method) = node.kind() else {
+            return;
+        };
+        if method.kind != MethodDefinitionKind::Constructor {
+            return;
+        }
+        let public_members = method
+            .value
+            .params
+            .items
+            .iter()
+            .filter_map(|param| match param.is_public() {
+                true => param.pattern.get_identifier_name(),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        if public_members.is_empty() {
+            return;
+        }
+        let Some(body) = method.value.body.as_ref() else {
+            return;
+        };
+        body.statements.iter().for_each(|stmt| {
+            let Statement::ExpressionStatement(expr_stmt) = stmt else {
+                return;
+            };
+            let Expression::AssignmentExpression(assignment_expr) = &expr_stmt.expression else {
+                return;
+            };
+
+            // check for assigning to this: this.x = ?
+            let AssignmentTarget::StaticMemberExpression(static_member_expr) =
+                &assignment_expr.left
+            else {
+                return;
+            };
+            let Expression::ThisExpression(_this_expr) = &static_member_expr.object else {
+                return;
+            };
+            let assignment_name = static_member_expr.property.name;
+
+            // check both sides of assignment have the same name: this.x = x
+            let Expression::Identifier(assignment_target_ident) = &assignment_expr.right else {
+                return;
+            };
+            if assignment_target_ident.name != assignment_name {
+                return;
+            }
+
+            // check if this was a public param
+            if public_members.iter().any(|param| param == &assignment_name) {
+                ctx.diagnostic(no_redundant_constructor_init_diagnostic(expr_stmt.span));
+            }
+        });
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        r#"
+        class Foo {
+          constructor(public name: unknown) {}
+        }
+        "#,
+        r#"
+        class Foo {
+          constructor(public name: unknown, other: unknown) {
+            this.other = other;
+          }
+        }
+        "#,
+        r#"
+        class Foo {
+          constructor(public name: unknown) {
+            this.other = name;
+          }
+        }
+        "#,
+        r#"
+        class Foo {
+          constructor(name: unknown) {
+            this.name = name;
+          }
+        }
+        "#,
+    ];
+
+    let fail = vec![
+        r#"
+        class Foo {
+          constructor(public name: unknown) {
+            this.name = name;
+          }
+        }
+        "#,
+        r#"
+        class Foo {
+          constructor(other: unknown, public name: unknown) {
+            this.other = other;
+            this.name = name;
+          }
+        }
+        "#,
+    ];
+
+    Tester::new(NoRedundantConstructorInit::NAME, NoRedundantConstructorInit::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/oxc/no_redundant_constructor_init.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_redundant_constructor_init.rs
@@ -63,10 +63,9 @@ impl Rule for NoRedundantConstructorInit {
             .params
             .items
             .iter()
-            .filter_map(|param| match param.is_public() {
-                true => param.pattern.get_identifier_name(),
-                _ => None,
-            })
+            .filter_map(
+                |param| if param.is_public() { param.pattern.get_identifier_name() } else { None },
+            )
             .collect::<Vec<_>>();
         if public_members.is_empty() {
             return;
@@ -114,50 +113,50 @@ fn test() {
     use crate::tester::Tester;
 
     let pass = vec![
-        r#"
+        r"
         class Foo {
           constructor(public name: unknown) {}
         }
-        "#,
-        r#"
+        ",
+        r"
         class Foo {
           constructor(public name: unknown, other: unknown) {
             this.other = other;
           }
         }
-        "#,
-        r#"
+        ",
+        r"
         class Foo {
           constructor(public name: unknown) {
             this.other = name;
           }
         }
-        "#,
-        r#"
+        ",
+        r"
         class Foo {
           constructor(name: unknown) {
             this.name = name;
           }
         }
-        "#,
+        ",
     ];
 
     let fail = vec![
-        r#"
+        r"
         class Foo {
           constructor(public name: unknown) {
             this.name = name;
           }
         }
-        "#,
-        r#"
+        ",
+        r"
         class Foo {
           constructor(other: unknown, public name: unknown) {
             this.other = other;
             this.name = name;
           }
         }
-        "#,
+        ",
     ];
 
     Tester::new(NoRedundantConstructorInit::NAME, NoRedundantConstructorInit::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/oxc/no_redundant_constructor_init.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_redundant_constructor_init.rs
@@ -46,7 +46,7 @@ declare_oxc_lint!(
     /// ```
     NoRedundantConstructorInit,
     oxc,
-    style,
+    correctness,
     pending,
 );
 

--- a/crates/oxc_linter/src/rules/oxc/no_redundant_constructor_init.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_redundant_constructor_init.rs
@@ -45,7 +45,7 @@ declare_oxc_lint!(
     /// }
     /// ```
     NoRedundantConstructorInit,
-    eslint,
+    oxc,
     style,
     pending,
 );

--- a/crates/oxc_linter/src/snapshots/eslint_no_redundant_constructor_init.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_redundant_constructor_init.snap
@@ -1,0 +1,20 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint(no-redundant-constructor-init): Explicit initialization of public members is redundant
+   ╭─[no_redundant_constructor_init.tsx:4:13]
+ 3 │           constructor(public name: unknown) {
+ 4 │             this.name = name;
+   ·             ─────────────────
+ 5 │           }
+   ╰────
+  help: Remove the explicit initialization
+
+  ⚠ eslint(no-redundant-constructor-init): Explicit initialization of public members is redundant
+   ╭─[no_redundant_constructor_init.tsx:5:13]
+ 4 │             this.other = other;
+ 5 │             this.name = name;
+   ·             ─────────────────
+ 6 │           }
+   ╰────
+  help: Remove the explicit initialization

--- a/crates/oxc_linter/src/snapshots/oxc_no_redundant_constructor_init.snap
+++ b/crates/oxc_linter/src/snapshots/oxc_no_redundant_constructor_init.snap
@@ -1,7 +1,7 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-redundant-constructor-init): Explicit initialization of public members is redundant
+  ⚠ oxc(no-redundant-constructor-init): Explicit initialization of public members is redundant
    ╭─[no_redundant_constructor_init.tsx:4:13]
  3 │           constructor(public name: unknown) {
  4 │             this.name = name;
@@ -10,7 +10,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Remove the explicit initialization
 
-  ⚠ eslint(no-redundant-constructor-init): Explicit initialization of public members is redundant
+  ⚠ oxc(no-redundant-constructor-init): Explicit initialization of public members is redundant
    ╭─[no_redundant_constructor_init.tsx:5:13]
  4 │             this.other = other;
  5 │             this.name = name;


### PR DESCRIPTION
closes #9267

I'm unsure whether the rule naming is correct, I believe this is a rule that doesn't exist elsewhere so came up with the name `no_redundant_constructor_init`, if that needs to be changed or if the rule should be moved elsewhere then happy to do so.