### PR TITLE
fix(rulegen): update test path and extensions for unicorn and react-perf rules

### DIFF
--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -51,7 +51,7 @@ const JSDOC_TEST_PATH: &str =
     "https://raw.githubusercontent.com/gajus/eslint-plugin-jsdoc/main/test/rules/assertions";
 
 const REACT_PERF_TEST_PATH: &str =
-    "https://raw.githubusercontent.com/cvazac/eslint-plugin-react-perf/main/tests/lib/rules";
+    "https://raw.githubusercontent.com/cvazac/eslint-plugin-react-perf/master/tests/lib/rules";
 
 const NODE_TEST_PATH: &str =
     "https://raw.githubusercontent.com/eslint-community/eslint-plugin-n/master/tests/lib/rules";
@@ -655,10 +655,10 @@ fn main() {
         RuleKind::ESLint => format!("{ESLINT_TEST_PATH}/{kebab_rule_name}.js"),
         RuleKind::Jest => format!("{JEST_TEST_PATH}/{kebab_rule_name}.test.ts"),
         RuleKind::Typescript => format!("{TYPESCRIPT_ESLINT_TEST_PATH}/{kebab_rule_name}.test.ts"),
-        RuleKind::Unicorn => format!("{UNICORN_TEST_PATH}/{kebab_rule_name}.mjs"),
+        RuleKind::Unicorn => format!("{UNICORN_TEST_PATH}/{kebab_rule_name}.js"),
         RuleKind::Import => format!("{IMPORT_TEST_PATH}/{kebab_rule_name}.js"),
         RuleKind::React => format!("{REACT_TEST_PATH}/{kebab_rule_name}.js"),
-        RuleKind::ReactPerf => format!("{REACT_PERF_TEST_PATH}/{kebab_rule_name}.test.ts"),
+        RuleKind::ReactPerf => format!("{REACT_PERF_TEST_PATH}/{kebab_rule_name}.js"),
         RuleKind::JSXA11y => format!("{JSX_A11Y_TEST_PATH}/{kebab_rule_name}-test.js"),
         RuleKind::NextJS => format!("{NEXT_JS_TEST_PATH}/{kebab_rule_name}.test.ts"),
         RuleKind::JSDoc => format!("{JSDOC_TEST_PATH}/{camel_rule_name}.js"),


### PR DESCRIPTION
Fixes #9303

Now when running `just new-unicorn-rule consistent-empty-array-spread`
```
Reading test file from https://raw.githubusercontent.com/sindresorhus/eslint-plugin-unicorn/main/test/consistent-empty-array-spread.js
File parsed and 15 pass cases, 5 fail cases are found
Saved test file to "crates/oxc_linter/src/rules/unicorn\\consistent_empty_array_spread.rs"
```

Now when running `just new-react-perf-rule jsx-no-jsx-as-prop`
```
Reading test file from https://raw.githubusercontent.com/cvazac/eslint-plugin-react-perf/master/tests/lib/rules/jsx-no-jsx-as-prop.js
File parsed and 0 pass cases, 0 fail cases are found
Saved test file to "crates/oxc_linter/src/rules/react_perf\\jsx_no_jsx_as_prop.rs"
```