### PR TITLE
fix(linter): correct default for `eslint/no-eval`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_eval.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_eval.rs
@@ -15,9 +15,15 @@ fn no_eval_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("eval can be harmful.").with_label(span)
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct NoEval {
     allow_indirect: bool,
+}
+
+impl Default for NoEval {
+    fn default() -> Self {
+        NoEval { allow_indirect: true }
+    }
 }
 
 declare_oxc_lint!(


### PR DESCRIPTION
closes #9311 

Incredible, I had overlooked this before. I always thought `from_configuration` was enough, until the `correctness` rule exposed this issue.