### PR TITLE
feat(wasm): support codegen sourcemap

### DIFF
--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -67,6 +67,9 @@ pub struct Oxc {
     #[wasm_bindgen(readonly, skip_typescript, js_name = "codegenText")]
     pub codegen_text: String,
 
+    #[wasm_bindgen(readonly, skip_typescript, js_name = "codegenSourcemapText")]
+    pub codegen_sourcemap_text: Option<String>,
+
     #[wasm_bindgen(readonly, skip_typescript, js_name = "formattedText")]
     pub formatted_text: String,
 
@@ -178,7 +181,7 @@ impl Oxc {
         let parser_options = parser_options.unwrap_or_default();
         let _linter_options = linter_options.unwrap_or_default();
         let minifier_options = minifier_options.unwrap_or_default();
-        let _codegen_options = codegen_options.unwrap_or_default();
+        let codegen_options = codegen_options.unwrap_or_default();
         let transform_options = transform_options.unwrap_or_default();
         let control_flow_options = control_flow_options.unwrap_or_default();
 
@@ -252,10 +255,22 @@ impl Oxc {
                     IsolatedDeclarations::new(&allocator, IsolatedDeclarationsOptions::default())
                         .build(&program);
                 if ret.errors.is_empty() {
-                    self.codegen_text = CodeGenerator::new().build(&ret.program).code;
+                    let codegen_result = CodeGenerator::new()
+                        .with_options(CodegenOptions {
+                            source_map_path: codegen_options
+                                .enable_sourcemap
+                                .unwrap_or_default()
+                                .then(|| path.clone()),
+                            ..CodegenOptions::default()
+                        })
+                        .build(&ret.program);
+                    self.codegen_text = codegen_result.code;
+                    self.codegen_sourcemap_text =
+                        codegen_result.map.map(|map| map.to_json_string());
                 } else {
                     self.save_diagnostics(ret.errors.into_iter().collect::<Vec<_>>());
                     self.codegen_text = String::new();
+                    self.codegen_sourcemap_text = None;
                 }
                 return Ok(());
             }
@@ -301,14 +316,19 @@ impl Oxc {
             None
         };
 
-        self.codegen_text = CodeGenerator::new()
+        let codegen_result = CodeGenerator::new()
             .with_symbol_table(symbol_table)
             .with_options(CodegenOptions {
                 minify: minifier_options.whitespace.unwrap_or_default(),
+                source_map_path: codegen_options
+                    .enable_sourcemap
+                    .unwrap_or_default()
+                    .then(|| path.clone()),
                 ..CodegenOptions::default()
             })
-            .build(&program)
-            .code;
+            .build(&program);
+        self.codegen_text = codegen_result.code;
+        self.codegen_sourcemap_text = codegen_result.map.map(|map| map.to_json_string());
         self.ir = format!("{:#?}", program.body);
         self.convert_ast(&mut program);
 

--- a/crates/oxc_wasm/src/options.rs
+++ b/crates/oxc_wasm/src/options.rs
@@ -86,6 +86,8 @@ pub struct OxcCodegenOptions {
     pub indentation: Option<u8>,
     #[tsify(optional)]
     pub enable_typescript: Option<bool>,
+    #[tsify(optional)]
+    pub enable_sourcemap: Option<bool>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Tsify)]

--- a/npm/oxc-wasm/oxc_wasm.d.ts
+++ b/npm/oxc-wasm/oxc_wasm.d.ts
@@ -1,6 +1,34 @@
 /* tslint:disable */
 /* eslint-disable */
 export function browserslist(query: string, opts: any): any;
+
+import type { Program, Span } from "@oxc-project/types";
+export * from "@oxc-project/types";
+
+
+export interface Oxc {
+    ast: Program;
+    astJson: string;
+    ir: string;
+    controlFlowGraph: string;
+    symbols: any;
+    scopeText: string;
+    codegenText: string;
+    codegenSourcemapText: string | null;
+    formattedText: string;
+    prettierFormattedText: string;
+    prettierIrText: string;
+}
+
+export interface Comment {
+    type: CommentType;
+    value: string;
+    start: number;
+    end: number;
+}
+
+export type CommentType = "Line" | "Block";
+
 export interface OxcOptions {
     run?: OxcRunOptions;
     parser?: OxcParserOptions;
@@ -40,6 +68,7 @@ export interface OxcTransformerOptions {
 export interface OxcCodegenOptions {
     indentation?: number;
     enableTypescript?: boolean;
+    enableSourcemap?: boolean;
 }
 
 export interface OxcControlFlowOptions {
@@ -64,43 +93,6 @@ export interface OxcCompressOptions {
 }
 
 
-import type { Program, Span } from "@oxc-project/types";
-export * from "@oxc-project/types";
-
-
-export interface Oxc {
-    ast: Program;
-    astJson: string;
-    ir: string;
-    controlFlowGraph: string;
-    symbols: any;
-    scopeText: string;
-    codegenText: string;
-    formattedText: string;
-    prettierFormattedText: string;
-    prettierIrText: string;
-}
-
-export interface Comment {
-    type: CommentType;
-    value: string;
-    start: number;
-    end: number;
-}
-
-export type CommentType = "Line" | "Block";
-
-
-export type NodeId = number;
-export type NodeFlags = {
-    JSDoc: 1,
-    Class: 2,
-    HasYield: 4
-    Parameter: 8
-};
-
-
-
 export type ReferenceId = number;
 export type ReferenceFlags = {
     None: 0,
@@ -112,13 +104,23 @@ export type ReferenceFlags = {
 
 
 
+export type SymbolId = number;
+export type SymbolFlags = unknown;
+export type RedeclarationId = unknown;
+
+
+
 export type ScopeId = number;
 
 
 
-export type SymbolId = number;
-export type SymbolFlags = unknown;
-export type RedeclarationId = unknown;
+export type NodeId = number;
+export type NodeFlags = {
+    JSDoc: 1,
+    Class: 2,
+    HasYield: 4
+    Parameter: 8
+};
 
 
 export class Oxc {
@@ -153,6 +155,7 @@ export interface InitOutput {
   readonly __wbg_get_oxc_symbols: (a: number) => any;
   readonly __wbg_get_oxc_scopeText: (a: number) => [number, number];
   readonly __wbg_get_oxc_codegenText: (a: number) => [number, number];
+  readonly __wbg_get_oxc_codegenSourcemapText: (a: number) => [number, number];
   readonly __wbg_get_oxc_formattedText: (a: number) => [number, number];
   readonly __wbg_get_oxc_prettierFormattedText: (a: number) => [number, number];
   readonly __wbg_get_oxc_prettierIrText: (a: number) => [number, number];

--- a/npm/oxc-wasm/oxc_wasm.js
+++ b/npm/oxc-wasm/oxc_wasm.js
@@ -1,5 +1,21 @@
 let wasm;
 
+function logError(f, args) {
+    try {
+        return f.apply(this, args);
+    } catch (e) {
+        let error = (function () {
+            try {
+                return e instanceof Error ? `${e.message}\n\nStack:\n${e.stack}` : e.toString();
+            } catch(_) {
+                return "<failed to stringify thrown value>";
+            }
+        }());
+        console.error("wasm-bindgen: imported JS function that was not marked as `catch` threw an error:", error);
+        throw e;
+    }
+}
+
 function addToExternrefTable0(obj) {
     const idx = wasm.__externref_table_alloc();
     wasm.__wbindgen_export_2.set(idx, obj);
@@ -33,6 +49,16 @@ function getStringFromWasm0(ptr, len) {
     return cachedTextDecoder.decode(getUint8ArrayMemory0().subarray(ptr, ptr + len));
 }
 
+function _assertBoolean(n) {
+    if (typeof(n) !== 'boolean') {
+        throw new Error(`expected a boolean argument, found ${typeof(n)}`);
+    }
+}
+
+function _assertNum(n) {
+    if (typeof(n) !== 'number') throw new Error(`expected a number argument, found ${typeof(n)}`);
+}
+
 let WASM_VECTOR_LEN = 0;
 
 const cachedTextEncoder = (typeof TextEncoder !== 'undefined' ? new TextEncoder('utf-8') : { encode: () => { throw Error('TextEncoder not available') } } );
@@ -51,6 +77,8 @@ const encodeString = (typeof cachedTextEncoder.encodeInto === 'function'
 });
 
 function passStringToWasm0(arg, malloc, realloc) {
+
+    if (typeof(arg) !== 'string') throw new Error(`expected a string argument, found ${typeof(arg)}`);
 
     if (realloc === undefined) {
         const buf = cachedTextEncoder.encode(arg);
@@ -80,7 +108,7 @@ function passStringToWasm0(arg, malloc, realloc) {
         ptr = realloc(ptr, len, len = offset + arg.length * 3, 1) >>> 0;
         const view = getUint8ArrayMemory0().subarray(ptr + offset, ptr + len);
         const ret = encodeString(arg, view);
-
+        if (ret.read !== arg.length) throw new Error('failed to pass whole string');
         offset += ret.written;
         ptr = realloc(ptr, len, offset, 1) >>> 0;
     }
@@ -238,6 +266,8 @@ export class Oxc {
         let deferred1_0;
         let deferred1_1;
         try {
+            if (this.__wbg_ptr == 0) throw new Error('Attempt to use a moved value');
+            _assertNum(this.__wbg_ptr);
             const ret = wasm.__wbg_get_oxc_astJson(this.__wbg_ptr);
             deferred1_0 = ret[0];
             deferred1_1 = ret[1];
@@ -253,6 +283,8 @@ export class Oxc {
         let deferred1_0;
         let deferred1_1;
         try {
+            if (this.__wbg_ptr == 0) throw new Error('Attempt to use a moved value');
+            _assertNum(this.__wbg_ptr);
             const ret = wasm.__wbg_get_oxc_ir(this.__wbg_ptr);
             deferred1_0 = ret[0];
             deferred1_1 = ret[1];
@@ -268,6 +300,8 @@ export class Oxc {
         let deferred1_0;
         let deferred1_1;
         try {
+            if (this.__wbg_ptr == 0) throw new Error('Attempt to use a moved value');
+            _assertNum(this.__wbg_ptr);
             const ret = wasm.__wbg_get_oxc_controlFlowGraph(this.__wbg_ptr);
             deferred1_0 = ret[0];
             deferred1_1 = ret[1];
@@ -280,6 +314,8 @@ export class Oxc {
      * @returns {any}
      */
     get symbols() {
+        if (this.__wbg_ptr == 0) throw new Error('Attempt to use a moved value');
+        _assertNum(this.__wbg_ptr);
         const ret = wasm.__wbg_get_oxc_symbols(this.__wbg_ptr);
         return ret;
     }
@@ -290,6 +326,8 @@ export class Oxc {
         let deferred1_0;
         let deferred1_1;
         try {
+            if (this.__wbg_ptr == 0) throw new Error('Attempt to use a moved value');
+            _assertNum(this.__wbg_ptr);
             const ret = wasm.__wbg_get_oxc_scopeText(this.__wbg_ptr);
             deferred1_0 = ret[0];
             deferred1_1 = ret[1];
@@ -305,6 +343,8 @@ export class Oxc {
         let deferred1_0;
         let deferred1_1;
         try {
+            if (this.__wbg_ptr == 0) throw new Error('Attempt to use a moved value');
+            _assertNum(this.__wbg_ptr);
             const ret = wasm.__wbg_get_oxc_codegenText(this.__wbg_ptr);
             deferred1_0 = ret[0];
             deferred1_1 = ret[1];
@@ -314,12 +354,28 @@ export class Oxc {
         }
     }
     /**
+     * @returns {string | undefined}
+     */
+    get codegenSourcemapText() {
+        if (this.__wbg_ptr == 0) throw new Error('Attempt to use a moved value');
+        _assertNum(this.__wbg_ptr);
+        const ret = wasm.__wbg_get_oxc_codegenSourcemapText(this.__wbg_ptr);
+        let v1;
+        if (ret[0] !== 0) {
+            v1 = getStringFromWasm0(ret[0], ret[1]).slice();
+            wasm.__wbindgen_free(ret[0], ret[1] * 1, 1);
+        }
+        return v1;
+    }
+    /**
      * @returns {string}
      */
     get formattedText() {
         let deferred1_0;
         let deferred1_1;
         try {
+            if (this.__wbg_ptr == 0) throw new Error('Attempt to use a moved value');
+            _assertNum(this.__wbg_ptr);
             const ret = wasm.__wbg_get_oxc_formattedText(this.__wbg_ptr);
             deferred1_0 = ret[0];
             deferred1_1 = ret[1];
@@ -335,6 +391,8 @@ export class Oxc {
         let deferred1_0;
         let deferred1_1;
         try {
+            if (this.__wbg_ptr == 0) throw new Error('Attempt to use a moved value');
+            _assertNum(this.__wbg_ptr);
             const ret = wasm.__wbg_get_oxc_prettierFormattedText(this.__wbg_ptr);
             deferred1_0 = ret[0];
             deferred1_1 = ret[1];
@@ -350,6 +408,8 @@ export class Oxc {
         let deferred1_0;
         let deferred1_1;
         try {
+            if (this.__wbg_ptr == 0) throw new Error('Attempt to use a moved value');
+            _assertNum(this.__wbg_ptr);
             const ret = wasm.__wbg_get_oxc_prettierIrText(this.__wbg_ptr);
             deferred1_0 = ret[0];
             deferred1_1 = ret[1];
@@ -371,6 +431,8 @@ export class Oxc {
      * @returns {any[]}
      */
     getDiagnostics() {
+        if (this.__wbg_ptr == 0) throw new Error('Attempt to use a moved value');
+        _assertNum(this.__wbg_ptr);
         const ret = wasm.oxc_getDiagnostics(this.__wbg_ptr);
         if (ret[3]) {
             throw takeFromExternrefTable0(ret[2]);
@@ -385,6 +447,8 @@ export class Oxc {
      * @returns {any[]}
      */
     getComments() {
+        if (this.__wbg_ptr == 0) throw new Error('Attempt to use a moved value');
+        _assertNum(this.__wbg_ptr);
         const ret = wasm.oxc_getComments(this.__wbg_ptr);
         if (ret[3]) {
             throw takeFromExternrefTable0(ret[2]);
@@ -400,6 +464,8 @@ export class Oxc {
      * @param {OxcOptions} options
      */
     run(source_text, options) {
+        if (this.__wbg_ptr == 0) throw new Error('Attempt to use a moved value');
+        _assertNum(this.__wbg_ptr);
         const ptr0 = passStringToWasm0(source_text, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
         const len0 = WASM_VECTOR_LEN;
         const ret = wasm.oxc_run(this.__wbg_ptr, ptr0, len0, options);
@@ -443,15 +509,15 @@ async function __wbg_load(module, imports) {
 function __wbg_get_imports() {
     const imports = {};
     imports.wbg = {};
-    imports.wbg.__wbg_buffer_609cc3eee51ed158 = function(arg0) {
+    imports.wbg.__wbg_buffer_609cc3eee51ed158 = function() { return logError(function (arg0) {
         const ret = arg0.buffer;
         return ret;
-    };
+    }, arguments) };
     imports.wbg.__wbg_call_672a4d21634d4a24 = function() { return handleError(function (arg0, arg1) {
         const ret = arg0.call(arg1);
         return ret;
     }, arguments) };
-    imports.wbg.__wbg_error_7534b8e9a36f1ab4 = function(arg0, arg1) {
+    imports.wbg.__wbg_error_7534b8e9a36f1ab4 = function() { return logError(function (arg0, arg1) {
         let deferred0_0;
         let deferred0_1;
         try {
@@ -461,20 +527,20 @@ function __wbg_get_imports() {
         } finally {
             wasm.__wbindgen_free(deferred0_0, deferred0_1, 1);
         }
-    };
-    imports.wbg.__wbg_getTime_46267b1c24877e30 = function(arg0) {
+    }, arguments) };
+    imports.wbg.__wbg_getTime_46267b1c24877e30 = function() { return logError(function (arg0) {
         const ret = arg0.getTime();
         return ret;
-    };
+    }, arguments) };
     imports.wbg.__wbg_get_67b2ba62fc30de12 = function() { return handleError(function (arg0, arg1) {
         const ret = Reflect.get(arg0, arg1);
         return ret;
     }, arguments) };
-    imports.wbg.__wbg_getwithrefkey_1dc361bd10053bfe = function(arg0, arg1) {
+    imports.wbg.__wbg_getwithrefkey_1dc361bd10053bfe = function() { return logError(function (arg0, arg1) {
         const ret = arg0[arg1];
         return ret;
-    };
-    imports.wbg.__wbg_instanceof_ArrayBuffer_e14585432e3737fc = function(arg0) {
+    }, arguments) };
+    imports.wbg.__wbg_instanceof_ArrayBuffer_e14585432e3737fc = function() { return logError(function (arg0) {
         let result;
         try {
             result = arg0 instanceof ArrayBuffer;
@@ -482,9 +548,10 @@ function __wbg_get_imports() {
             result = false;
         }
         const ret = result;
+        _assertBoolean(ret);
         return ret;
-    };
-    imports.wbg.__wbg_instanceof_Uint8Array_17156bcf118086a9 = function(arg0) {
+    }, arguments) };
+    imports.wbg.__wbg_instanceof_Uint8Array_17156bcf118086a9 = function() { return logError(function (arg0) {
         let result;
         try {
             result = arg0 instanceof Uint8Array;
@@ -492,76 +559,78 @@ function __wbg_get_imports() {
             result = false;
         }
         const ret = result;
+        _assertBoolean(ret);
         return ret;
-    };
-    imports.wbg.__wbg_length_a446193dc22c12f8 = function(arg0) {
+    }, arguments) };
+    imports.wbg.__wbg_length_a446193dc22c12f8 = function() { return logError(function (arg0) {
         const ret = arg0.length;
+        _assertNum(ret);
         return ret;
-    };
-    imports.wbg.__wbg_new0_f788a2397c7ca929 = function() {
+    }, arguments) };
+    imports.wbg.__wbg_new0_f788a2397c7ca929 = function() { return logError(function () {
         const ret = new Date();
         return ret;
-    };
-    imports.wbg.__wbg_new_405e22f390576ce2 = function() {
+    }, arguments) };
+    imports.wbg.__wbg_new_405e22f390576ce2 = function() { return logError(function () {
         const ret = new Object();
         return ret;
-    };
-    imports.wbg.__wbg_new_5e0be73521bc8c17 = function() {
+    }, arguments) };
+    imports.wbg.__wbg_new_5e0be73521bc8c17 = function() { return logError(function () {
         const ret = new Map();
         return ret;
-    };
-    imports.wbg.__wbg_new_78feb108b6472713 = function() {
+    }, arguments) };
+    imports.wbg.__wbg_new_78feb108b6472713 = function() { return logError(function () {
         const ret = new Array();
         return ret;
-    };
-    imports.wbg.__wbg_new_8a6f238a6ece86ea = function() {
+    }, arguments) };
+    imports.wbg.__wbg_new_8a6f238a6ece86ea = function() { return logError(function () {
         const ret = new Error();
         return ret;
-    };
-    imports.wbg.__wbg_new_a12002a7f91c75be = function(arg0) {
+    }, arguments) };
+    imports.wbg.__wbg_new_a12002a7f91c75be = function() { return logError(function (arg0) {
         const ret = new Uint8Array(arg0);
         return ret;
-    };
-    imports.wbg.__wbg_newnoargs_105ed471475aaf50 = function(arg0, arg1) {
+    }, arguments) };
+    imports.wbg.__wbg_newnoargs_105ed471475aaf50 = function() { return logError(function (arg0, arg1) {
         const ret = new Function(getStringFromWasm0(arg0, arg1));
         return ret;
-    };
-    imports.wbg.__wbg_set_37837023f3d740e8 = function(arg0, arg1, arg2) {
+    }, arguments) };
+    imports.wbg.__wbg_set_37837023f3d740e8 = function() { return logError(function (arg0, arg1, arg2) {
         arg0[arg1 >>> 0] = arg2;
-    };
-    imports.wbg.__wbg_set_3f1d0b984ed272ed = function(arg0, arg1, arg2) {
+    }, arguments) };
+    imports.wbg.__wbg_set_3f1d0b984ed272ed = function() { return logError(function (arg0, arg1, arg2) {
         arg0[arg1] = arg2;
-    };
-    imports.wbg.__wbg_set_65595bdd868b3009 = function(arg0, arg1, arg2) {
+    }, arguments) };
+    imports.wbg.__wbg_set_65595bdd868b3009 = function() { return logError(function (arg0, arg1, arg2) {
         arg0.set(arg1, arg2 >>> 0);
-    };
-    imports.wbg.__wbg_set_8fc6bf8a5b1071d1 = function(arg0, arg1, arg2) {
+    }, arguments) };
+    imports.wbg.__wbg_set_8fc6bf8a5b1071d1 = function() { return logError(function (arg0, arg1, arg2) {
         const ret = arg0.set(arg1, arg2);
         return ret;
-    };
-    imports.wbg.__wbg_stack_0ed75d68575b0f3c = function(arg0, arg1) {
+    }, arguments) };
+    imports.wbg.__wbg_stack_0ed75d68575b0f3c = function() { return logError(function (arg0, arg1) {
         const ret = arg1.stack;
         const ptr1 = passStringToWasm0(ret, wasm.__wbindgen_malloc, wasm.__wbindgen_realloc);
         const len1 = WASM_VECTOR_LEN;
         getDataViewMemory0().setInt32(arg0 + 4 * 1, len1, true);
         getDataViewMemory0().setInt32(arg0 + 4 * 0, ptr1, true);
-    };
-    imports.wbg.__wbg_static_accessor_GLOBAL_88a902d13a557d07 = function() {
+    }, arguments) };
+    imports.wbg.__wbg_static_accessor_GLOBAL_88a902d13a557d07 = function() { return logError(function () {
         const ret = typeof global === 'undefined' ? null : global;
         return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
-    };
-    imports.wbg.__wbg_static_accessor_GLOBAL_THIS_56578be7e9f832b0 = function() {
+    }, arguments) };
+    imports.wbg.__wbg_static_accessor_GLOBAL_THIS_56578be7e9f832b0 = function() { return logError(function () {
         const ret = typeof globalThis === 'undefined' ? null : globalThis;
         return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
-    };
-    imports.wbg.__wbg_static_accessor_SELF_37c5d418e4bf5819 = function() {
+    }, arguments) };
+    imports.wbg.__wbg_static_accessor_SELF_37c5d418e4bf5819 = function() { return logError(function () {
         const ret = typeof self === 'undefined' ? null : self;
         return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
-    };
-    imports.wbg.__wbg_static_accessor_WINDOW_5de37043a91a9c40 = function() {
+    }, arguments) };
+    imports.wbg.__wbg_static_accessor_WINDOW_5de37043a91a9c40 = function() { return logError(function () {
         const ret = typeof window === 'undefined' ? null : window;
         return isLikeNone(ret) ? 0 : addToExternrefTable0(ret);
-    };
+    }, arguments) };
     imports.wbg.__wbg_stringify_f7ed6987935b4a24 = function() { return handleError(function (arg0) {
         const ret = JSON.stringify(arg0);
         return ret;
@@ -577,6 +646,7 @@ function __wbg_get_imports() {
     imports.wbg.__wbindgen_boolean_get = function(arg0) {
         const v = arg0;
         const ret = typeof(v) === 'boolean' ? (v ? 1 : 0) : 2;
+        _assertNum(ret);
         return ret;
     };
     imports.wbg.__wbindgen_debug_string = function(arg0, arg1) {
@@ -592,6 +662,7 @@ function __wbg_get_imports() {
     };
     imports.wbg.__wbindgen_in = function(arg0, arg1) {
         const ret = arg0 in arg1;
+        _assertBoolean(ret);
         return ret;
     };
     imports.wbg.__wbindgen_init_externref_table = function() {
@@ -607,18 +678,22 @@ function __wbg_get_imports() {
     imports.wbg.__wbindgen_is_object = function(arg0) {
         const val = arg0;
         const ret = typeof(val) === 'object' && val !== null;
+        _assertBoolean(ret);
         return ret;
     };
     imports.wbg.__wbindgen_is_string = function(arg0) {
         const ret = typeof(arg0) === 'string';
+        _assertBoolean(ret);
         return ret;
     };
     imports.wbg.__wbindgen_is_undefined = function(arg0) {
         const ret = arg0 === undefined;
+        _assertBoolean(ret);
         return ret;
     };
     imports.wbg.__wbindgen_jsval_loose_eq = function(arg0, arg1) {
         const ret = arg0 == arg1;
+        _assertBoolean(ret);
         return ret;
     };
     imports.wbg.__wbindgen_memory = function() {
@@ -628,6 +703,9 @@ function __wbg_get_imports() {
     imports.wbg.__wbindgen_number_get = function(arg0, arg1) {
         const obj = arg1;
         const ret = typeof(obj) === 'number' ? obj : undefined;
+        if (!isLikeNone(ret)) {
+            _assertNum(ret);
+        }
         getDataViewMemory0().setFloat64(arg0 + 8 * 1, isLikeNone(ret) ? 0 : ret, true);
         getDataViewMemory0().setInt32(arg0 + 4 * 0, !isLikeNone(ret), true);
     };

--- a/npm/oxc-wasm/oxc_wasm_bg.wasm.d.ts
+++ b/npm/oxc-wasm/oxc_wasm_bg.wasm.d.ts
@@ -8,6 +8,7 @@ export const __wbg_get_oxc_controlFlowGraph: (a: number) => [number, number];
 export const __wbg_get_oxc_symbols: (a: number) => any;
 export const __wbg_get_oxc_scopeText: (a: number) => [number, number];
 export const __wbg_get_oxc_codegenText: (a: number) => [number, number];
+export const __wbg_get_oxc_codegenSourcemapText: (a: number) => [number, number];
 export const __wbg_get_oxc_formattedText: (a: number) => [number, number];
 export const __wbg_get_oxc_prettierFormattedText: (a: number) => [number, number];
 export const __wbg_get_oxc_prettierIrText: (a: number) => [number, number];


### PR DESCRIPTION
- Related https://github.com/oxc-project/playground/issues/52
- Required by https://github.com/oxc-project/playground/pull/63

This PR adds `CodegenOption.enable_sourcemap` option and `codegen_sourcemap_text` state for https://github.com/oxc-project/playground/issues/52.