### PR TITLE
refactor(data_structures): reduce scope of `unsafe` blocks

### DIFF
--- a/crates/oxc_data_structures/src/stack/common.rs
+++ b/crates/oxc_data_structures/src/stack/common.rs
@@ -32,14 +32,15 @@ pub trait StackCommon<T>: StackCapacity<T> {
     /// * `capacity_bytes` must not exceed `Self::MAX_CAPACITY_BYTES`.
     #[inline]
     unsafe fn allocate(capacity_bytes: usize) -> (NonNull<T>, NonNull<T>) {
-        unsafe {
-            // SAFETY: Caller guarantees `capacity_bytes` satisfies requirements
-            let layout = Self::layout_for(capacity_bytes);
-            let (start, end) = allocate(layout);
+        // SAFETY: Caller guarantees `capacity_bytes` satisfies requirements
+        let layout = unsafe { Self::layout_for(capacity_bytes) };
 
-            // SAFETY: `layout_for` produces a layout with `T`'s alignment, so pointers are aligned for `T`
-            (start.cast::<T>(), end.cast::<T>())
-        }
+        // SAFETY: Caller guarantees `capacity_bytes` is not zero,
+        // so `layout_for` produces a non-zero size layout
+        let (start, end) = unsafe { allocate(layout) };
+
+        // `layout_for` produces a layout with `T`'s alignment, so pointers are aligned for `T`
+        (start.cast::<T>(), end.cast::<T>())
     }
 
     /// Grow allocation.
@@ -55,30 +56,30 @@ pub trait StackCommon<T>: StackCapacity<T> {
     /// Stack must have already allocated. i.e. `start` is not a dangling pointer.
     #[inline]
     unsafe fn grow(&mut self) {
-        unsafe {
-            // Grow allocation.
-            // SAFETY: Caller guarantees stack has allocated.
-            // `start` and `end` are boundaries of that allocation (`alloc` and `grow` ensure that).
-            // So `old_start_ptr` and `old_layout` accurately describe the current allocation.
-            // `grow` creates new allocation with byte size double what it currently is, or caps it
-            // at `MAX_CAPACITY_BYTES`.
-            // Old capacity in bytes was a multiple of `size_of::<T>()`, so double that must be too.
-            // `MAX_CAPACITY_BYTES` is also a multiple of `size_of::<T>()`.
-            // So new capacity in bytes must be a multiple of `size_of::<T>()`.
-            // `MAX_CAPACITY_BYTES <= isize::MAX`.
-            let old_start_ptr = self.start().cast::<u8>();
-            let old_layout = Self::layout_for(self.capacity_bytes());
-            let (start, end, current) = grow(old_start_ptr, old_layout, Self::MAX_CAPACITY_BYTES);
+        let old_start_ptr = self.start().cast::<u8>();
+        // SAFETY: Caller guarantees stack has allocated.
+        let old_layout = unsafe { Self::layout_for(self.capacity_bytes()) };
 
-            // Update pointers.
-            // SAFETY: `start`, `end`, and `current` are all `NonNull` - just casting them.
-            // All pointers returned from `grow` are aligned for `T`.
-            // Old capacity and new capacity in bytes are both multiples of `size_of::<T>()`,
-            // so distances `end - start` and `current - start` are both multiples of `size_of::<T>()`.
-            self.set_start(start.cast::<T>());
-            self.set_end(end.cast::<T>());
-            self.set_cursor(current.cast::<T>());
-        }
+        // Grow allocation.
+        // `start` and `end` are boundaries of the allocation (`alloc` and `grow` ensure that).
+        // So `old_start_ptr` and `old_layout` accurately describe the current allocation.
+        // `grow` creates new allocation with byte size double what it currently is, or caps it
+        // at `MAX_CAPACITY_BYTES`.
+        // Old capacity in bytes was a multiple of `size_of::<T>()`, so double that must be too.
+        // `MAX_CAPACITY_BYTES` is also a multiple of `size_of::<T>()`.
+        // So new capacity in bytes must be a multiple of `size_of::<T>()`.
+        // `MAX_CAPACITY_BYTES <= isize::MAX`.
+        let (start, end, current) =
+            unsafe { grow(old_start_ptr, old_layout, Self::MAX_CAPACITY_BYTES) };
+
+        // Update pointers.
+        // `start`, `end`, and `current` are all `NonNull` - just casting them.
+        // All pointers returned from `grow` are aligned for `T`.
+        // Old capacity and new capacity in bytes are both multiples of `size_of::<T>()`,
+        // so distances `end - start` and `current - start` are both multiples of `size_of::<T>()`.
+        self.set_start(start.cast::<T>());
+        self.set_end(end.cast::<T>());
+        self.set_cursor(current.cast::<T>());
     }
 
     /// Deallocate stack memory.
@@ -90,13 +91,11 @@ pub trait StackCommon<T>: StackCapacity<T> {
     /// Stack must have already allocated. i.e. `start` is not a dangling pointer.
     #[inline]
     unsafe fn deallocate(&self) {
-        unsafe {
-            // SAFETY: Caller guarantees stack is allocated.
-            // `start` and `end` are boundaries of that allocation (`allocate` and `grow` ensure that).
-            // So `start` and `layout` accurately describe the current allocation.
-            let layout = Self::layout_for(self.capacity_bytes());
-            alloc::dealloc(self.start().as_ptr().cast::<u8>(), layout);
-        }
+        // SAFETY: Caller guarantees stack is allocated.
+        let layout = unsafe { Self::layout_for(self.capacity_bytes()) };
+        // SAFETY: `start` and `end` are boundaries of that allocation (`allocate` and `grow` ensure that).
+        // So `start` and `layout` accurately describe the current allocation.
+        unsafe { alloc::dealloc(self.start().as_ptr().cast::<u8>(), layout) };
     }
 
     /// Drop contents of stack.
@@ -109,9 +108,9 @@ pub trait StackCommon<T>: StackCapacity<T> {
     /// * Stack must contain `self.len()` initialized entries, starting at `self.start()`.
     #[inline]
     unsafe fn drop_contents(&self) {
+        // Drop contents. Next line copied from `std`'s `Vec`.
+        // SAFETY: Caller guarantees stack contains `len` initialized entries, starting at `start`.
         unsafe {
-            // Drop contents. Next line copied from `std`'s `Vec`.
-            // SAFETY: Caller guarantees stack contains `len` initialized entries, starting at `start`.
             ptr::drop_in_place(ptr::slice_from_raw_parts_mut(self.start().as_ptr(), self.len()));
         }
     }
@@ -124,21 +123,19 @@ pub trait StackCommon<T>: StackCapacity<T> {
     /// * `capacity_bytes` must not exceed `Self::MAX_CAPACITY_BYTES`.
     #[inline]
     unsafe fn layout_for(capacity_bytes: usize) -> Layout {
-        unsafe {
-            // `capacity_bytes` must not be 0 because cannot make 0-size allocations.
-            debug_assert!(capacity_bytes > 0);
-            // `capacity_bytes` must be a multiple of `size_of::<T>()` so that `cursor == end`
-            // checks in `push` methods accurately detects when full to capacity
-            debug_assert!(capacity_bytes % size_of::<T>() == 0);
-            // `capacity_bytes` must not exceed `Self::MAX_CAPACITY_BYTES` to prevent creating an allocation
-            // of illegal size
-            debug_assert!(capacity_bytes <= Self::MAX_CAPACITY_BYTES);
+        // `capacity_bytes` must not be 0 because cannot make 0-size allocations.
+        debug_assert!(capacity_bytes > 0);
+        // `capacity_bytes` must be a multiple of `size_of::<T>()` so that `cursor == end`
+        // checks in `push` methods accurately detects when full to capacity
+        debug_assert!(capacity_bytes % size_of::<T>() == 0);
+        // `capacity_bytes` must not exceed `Self::MAX_CAPACITY_BYTES` to prevent creating
+        // an allocation of illegal size
+        debug_assert!(capacity_bytes <= Self::MAX_CAPACITY_BYTES);
 
-            // SAFETY: `align_of::<T>()` trivially satisfies alignment requirements.
-            // Caller guarantees `capacity_bytes <= MAX_CAPACITY_BYTES`.
-            // `MAX_CAPACITY_BYTES` takes into account the rounding-up by alignment requirement.
-            Layout::from_size_align_unchecked(capacity_bytes, align_of::<T>())
-        }
+        // SAFETY: `align_of::<T>()` trivially satisfies alignment requirements.
+        // Caller guarantees `capacity_bytes <= MAX_CAPACITY_BYTES`.
+        // `MAX_CAPACITY_BYTES` takes into account the rounding-up by alignment requirement.
+        unsafe { Layout::from_size_align_unchecked(capacity_bytes, align_of::<T>()) }
     }
 
     /// Get offset of `cursor` in number of `T`s.
@@ -223,20 +220,17 @@ pub trait StackCommon<T>: StackCapacity<T> {
 /// `layout` must have non-zero size.
 #[inline]
 unsafe fn allocate(layout: Layout) -> (/* start */ NonNull<u8>, /* end */ NonNull<u8>) {
-    unsafe {
-        // SAFETY: Caller guarantees `layout` has non-zero-size
-        let ptr = alloc::alloc(layout);
-        if ptr.is_null() {
-            alloc::handle_alloc_error(layout);
-        }
+    // SAFETY: Caller guarantees `layout` has non-zero-size
+    let ptr = unsafe { alloc::alloc(layout) };
 
-        // SAFETY: We checked `ptr` is non-null
-        let start = NonNull::new_unchecked(ptr);
-        // SAFETY: We allocated `layout.size()` bytes, so `end` is end of allocation
-        let end = start.add(layout.size());
+    let Some(start) = NonNull::new(ptr) else {
+        alloc::handle_alloc_error(layout);
+    };
 
-        (start, end)
-    }
+    // SAFETY: We allocated `layout.size()` bytes, so `end` is end of allocation
+    let end = unsafe { start.add(layout.size()) };
+
+    (start, end)
 }
 
 /// Grow existing allocation.
@@ -252,59 +246,51 @@ unsafe fn grow(
     old_layout: Layout,
     max_capacity_bytes: usize,
 ) -> (/* start */ NonNull<u8>, /* end */ NonNull<u8>, /* current */ NonNull<u8>) {
+    // Get new capacity.
+    // Capacity in bytes cannot be larger than `isize::MAX`, so `* 2` cannot overflow.
+    let old_capacity_bytes = old_layout.size();
+    let mut new_capacity_bytes = old_capacity_bytes * 2;
+    if new_capacity_bytes > max_capacity_bytes {
+        assert!(old_capacity_bytes < max_capacity_bytes, "Cannot grow beyond `Self::MAX_CAPACITY`");
+        new_capacity_bytes = max_capacity_bytes;
+    }
+    debug_assert!(new_capacity_bytes > old_capacity_bytes);
+
+    // Reallocate.
+    // SAFETY: Caller guarantees `old_start` and `old_layout` describe an existing allocation.
+    // Caller guarantees that `max_capacity_bytes <= isize::MAX`.
+    // `new_capacity_bytes` is capped above at `max_capacity_bytes`, so is a legal allocation size.
+
+    // `start` and `end` are boundaries of that allocation (`alloc` and `grow` ensure that).
+    // So `start` and `old_layout` accurately describe the current allocation.
+    // `old_capacity_bytes` was a multiple of `size_of::<T>()`, so double that must be too.
+    // `MAX_CAPACITY_BYTES` is also a multiple of `size_of::<T>()`.
+    // So `new_capacity_bytes` must be a multiple of `size_of::<T>()`.
+    // `new_capacity_bytes` is `<= MAX_CAPACITY_BYTES`, so is a legal allocation size.
+    // `layout_for` produces a layout with `T`'s alignment, so `new_ptr` is aligned for `T`.
+    let new_ptr = unsafe { alloc::realloc(old_start.as_ptr(), old_layout, new_capacity_bytes) };
+    let Some(new_start) = NonNull::new(new_ptr) else {
+        let new_layout =
+            unsafe { Layout::from_size_align_unchecked(old_capacity_bytes, old_layout.align()) };
+        alloc::handle_alloc_error(new_layout);
+    };
+
+    // Update pointers.
+    //
+    // Stack was full to capacity, so new last index after push is the old capacity.
+    // i.e. `new_cursor - new_start == old_end - old_start`.
+    // Note: All pointers need to be updated even if allocation grew in place.
+    // From docs for `GlobalAlloc::realloc`:
+    // "Any access to the old `ptr` is Undefined Behavior, even if the allocation remained in-place."
+    // <https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html#method.realloc>
+    // `end` changes whatever happens, so always need to be updated.
+    // `cursor` needs to be derived from `start` to make `offset_from` valid, so also needs updating.
+    //
+    // SAFETY: We checked that `new_ptr` is non-null.
+    // `old_capacity_bytes < new_capacity_bytes` (ensured above), so `new_cursor` must be in bounds.
     unsafe {
-        // Get new capacity
-        // Capacity in bytes cannot be larger than `isize::MAX`, so `* 2` cannot overflow
-        let old_capacity_bytes = old_layout.size();
-        let mut new_capacity_bytes = old_capacity_bytes * 2;
-        if new_capacity_bytes > max_capacity_bytes {
-            assert!(
-                old_capacity_bytes < max_capacity_bytes,
-                "Cannot grow beyond `Self::MAX_CAPACITY`"
-            );
-            new_capacity_bytes = max_capacity_bytes;
-        }
-        debug_assert!(new_capacity_bytes > old_capacity_bytes);
-
-        // Reallocate.
-        // SAFETY: Caller guarantees `old_start` and `old_layout` describe an existing allocation.
-        // Caller guarantees that `max_capacity_bytes <= isize::MAX`.
-        // `new_capacity_bytes` is capped above at `max_capacity_bytes`, so is a legal allocation size.
-
-        // `start` and `end` are boundaries of that allocation (`alloc` and `grow` ensure that).
-        // So `start` and `old_layout` accurately describe the current allocation.
-        // `old_capacity_bytes` was a multiple of `size_of::<T>()`, so double that must be too.
-        // `MAX_CAPACITY_BYTES` is also a multiple of `size_of::<T>()`.
-        // So `new_capacity_bytes` must be a multiple of `size_of::<T>()`.
-        // `new_capacity_bytes` is `<= MAX_CAPACITY_BYTES`, so is a legal allocation size.
-        // `layout_for` produces a layout with `T`'s alignment, so `new_ptr` is aligned for `T`.
-        let new_start = unsafe {
-            let old_ptr = old_start.as_ptr();
-            let new_ptr = alloc::realloc(old_ptr, old_layout, new_capacity_bytes);
-            if new_ptr.is_null() {
-                let new_layout =
-                    Layout::from_size_align_unchecked(old_capacity_bytes, old_layout.align());
-                alloc::handle_alloc_error(new_layout);
-            }
-            NonNull::new_unchecked(new_ptr)
-        };
-
-        // Update pointers.
-        //
-        // Stack was full to capacity, so new last index after push is the old capacity.
-        // i.e. `new_cursor - new_start == old_end - old_start`.
-        // Note: All pointers need to be updated even if allocation grew in place.
-        // From docs for `GlobalAlloc::realloc`:
-        // "Any access to the old `ptr` is Undefined Behavior, even if the allocation remained in-place."
-        // <https://doc.rust-lang.org/std/alloc/trait.GlobalAlloc.html#method.realloc>
-        // `end` changes whatever happens, so always need to be updated.
-        // `cursor` needs to be derived from `start` to make `offset_from` valid, so also needs updating.
-        //
-        // SAFETY: We checked that `new_ptr` is non-null.
-        // `old_capacity_bytes < new_capacity_bytes` (ensured above), so `new_cursor` must be in bounds.
         let new_end = new_start.add(new_capacity_bytes);
         let new_cursor = new_start.add(old_capacity_bytes);
-
         (new_start, new_end, new_cursor)
     }
 }

--- a/crates/oxc_data_structures/src/stack/non_empty.rs
+++ b/crates/oxc_data_structures/src/stack/non_empty.rs
@@ -178,15 +178,15 @@ impl<T> NonEmptyStack<T> {
     /// * `capacity` must not exceed [`Self::MAX_CAPACITY`].
     #[inline]
     pub unsafe fn with_capacity_unchecked(capacity: usize, initial_value: T) -> Self {
-        unsafe {
-            debug_assert!(capacity > 0);
-            debug_assert!(capacity <= Self::MAX_CAPACITY);
-            // Cannot overflow if `capacity <= MAX_CAPACITY`
-            let capacity_bytes = capacity * size_of::<T>();
-            // SAFETY: Safety invariants which caller must satisfy guarantee that `capacity_bytes`
-            // satisfies requirements
-            Self::new_with_capacity_bytes_unchecked(capacity_bytes, initial_value)
-        }
+        debug_assert!(capacity > 0);
+        debug_assert!(capacity <= Self::MAX_CAPACITY);
+
+        // Cannot overflow if `capacity <= MAX_CAPACITY`
+        let capacity_bytes = capacity * size_of::<T>();
+
+        // SAFETY: Safety invariants which caller must satisfy guarantee that `capacity_bytes`
+        // satisfies requirements
+        unsafe { Self::new_with_capacity_bytes_unchecked(capacity_bytes, initial_value) }
     }
 
     /// Create new [`NonEmptyStack`] with provided capacity in bytes, and initial value `initial_value`,
@@ -201,21 +201,19 @@ impl<T> NonEmptyStack<T> {
     /// * `capacity_bytes` must not exceed [`Self::MAX_CAPACITY_BYTES`].
     #[inline]
     unsafe fn new_with_capacity_bytes_unchecked(capacity_bytes: usize, initial_value: T) -> Self {
-        unsafe {
-            // ZSTs are not supported for simplicity
-            assert!(size_of::<T>() > 0, "Zero sized types are not supported");
+        // ZSTs are not supported for simplicity
+        assert!(size_of::<T>() > 0, "Zero sized types are not supported");
 
-            // SAFETY: Caller guarantees `capacity_bytes` satisfies requirements
-            let (start, end) = Self::allocate(capacity_bytes);
+        // SAFETY: Caller guarantees `capacity_bytes` satisfies requirements
+        let (start, end) = unsafe { Self::allocate(capacity_bytes) };
 
-            // Write initial value to start of allocation.
-            // SAFETY: Allocation was created with alignment of `T`, and with capacity for at least 1 entry,
-            // so `start` is valid for writing a `T`.
-            start.as_ptr().write(initial_value);
+        // Write initial value to start of allocation.
+        // SAFETY: Allocation was created with alignment of `T`, and with capacity for at least 1 entry,
+        // so `start` is valid for writing a `T`.
+        unsafe { start.as_ptr().write(initial_value) };
 
-            // `cursor` is positioned at start i.e. pointing at initial value
-            Self { cursor: start, start, end }
-        }
+        // `cursor` is positioned at start i.e. pointing at initial value
+        Self { cursor: start, start, end }
     }
 
     /// Get reference to first value on stack.
@@ -289,16 +287,14 @@ impl<T> NonEmptyStack<T> {
     #[cold]
     #[inline(never)]
     unsafe fn push_slow(&mut self, value: T) {
-        unsafe {
-            // Grow allocation.
-            // SAFETY: Stack is always allocated.
-            self.grow();
+        // Grow allocation.
+        // SAFETY: Stack is always allocated.
+        unsafe { self.grow() };
 
-            // Write value.
-            // SAFETY: We just allocated additional capacity, so `self.cursor` is in bounds.
-            // `self.cursor` is aligned for `T`.
-            unsafe { self.cursor.as_ptr().write(value) }
-        }
+        // Write value.
+        // SAFETY: We just allocated additional capacity, so `self.cursor` is in bounds.
+        // `self.cursor` is aligned for `T`.
+        unsafe { self.cursor.as_ptr().write(value) };
     }
 
     /// Pop value from stack.
@@ -335,17 +331,18 @@ impl<T> NonEmptyStack<T> {
     /// * Stack must have at least 2 entries, so that after pop, it still has at least 1.
     #[inline]
     pub unsafe fn pop_unchecked(&mut self) -> T {
-        unsafe {
-            debug_assert!(self.cursor > self.start);
-            debug_assert!(self.cursor < self.end);
-            // SAFETY: All methods ensure `self.cursor` is always in bounds, is aligned for `T`,
-            // and points to a valid initialized `T`
-            let value = self.cursor.read();
-            // SAFETY: Caller guarantees there's at least 2 entries on stack, so subtracting 1
-            // cannot be out of bounds
-            self.cursor = self.cursor.sub(1);
-            value
-        }
+        debug_assert!(self.cursor > self.start);
+        debug_assert!(self.cursor < self.end);
+
+        // SAFETY: All methods ensure `self.cursor` is always in bounds, is aligned for `T`,
+        // and points to a valid initialized `T`
+        let value = unsafe { self.cursor.read() };
+
+        // SAFETY: Caller guarantees there's at least 2 entries on stack, so subtracting 1
+        // cannot be out of bounds
+        unsafe { self.cursor = self.cursor.sub(1) };
+
+        value
     }
 
     /// Get number of values on stack.

--- a/crates/oxc_data_structures/src/stack/standard.rs
+++ b/crates/oxc_data_structures/src/stack/standard.rs
@@ -152,15 +152,15 @@ impl<T> Stack<T> {
     /// * `capacity` must not exceed [`Self::MAX_CAPACITY`].
     #[inline]
     pub unsafe fn with_capacity_unchecked(capacity: usize) -> Self {
-        unsafe {
-            debug_assert!(capacity > 0);
-            debug_assert!(capacity <= Self::MAX_CAPACITY);
-            // Cannot overflow if `capacity <= MAX_CAPACITY`
-            let capacity_bytes = capacity * size_of::<T>();
-            // SAFETY: Safety invariants which caller must satisfy guarantee that `capacity_bytes`
-            // satisfies requirements
-            Self::new_with_capacity_bytes_unchecked(capacity_bytes)
-        }
+        debug_assert!(capacity > 0);
+        debug_assert!(capacity <= Self::MAX_CAPACITY);
+
+        // Cannot overflow if `capacity <= MAX_CAPACITY`
+        let capacity_bytes = capacity * size_of::<T>();
+
+        // SAFETY: Safety invariants which caller must satisfy guarantee that `capacity_bytes`
+        // satisfies requirements
+        unsafe { Self::new_with_capacity_bytes_unchecked(capacity_bytes) }
     }
 
     /// Create new `Stack` with provided capacity in bytes, without checks.
@@ -174,16 +174,14 @@ impl<T> Stack<T> {
     /// * `capacity_bytes` must not exceed [`Self::MAX_CAPACITY_BYTES`].
     #[inline]
     unsafe fn new_with_capacity_bytes_unchecked(capacity_bytes: usize) -> Self {
-        unsafe {
-            // ZSTs are not supported for simplicity
-            assert!(size_of::<T>() > 0, "Zero sized types are not supported");
+        // ZSTs are not supported for simplicity
+        assert!(size_of::<T>() > 0, "Zero sized types are not supported");
 
-            // SAFETY: Caller guarantees `capacity_bytes` satisfies requirements
-            let (start, end) = Self::allocate(capacity_bytes);
+        // SAFETY: Caller guarantees `capacity_bytes` satisfies requirements
+        let (start, end) = unsafe { Self::allocate(capacity_bytes) };
 
-            // `cursor` is positioned at start
-            Self { cursor: start, start, end }
-        }
+        // `cursor` is positioned at start
+        Self { cursor: start, start, end }
     }
 
     // Note: There is no need to implement `first` and `first_mut` methods.
@@ -211,15 +209,14 @@ impl<T> Stack<T> {
     /// * Stack must not be empty.
     #[inline]
     pub unsafe fn last_unchecked(&self) -> &T {
-        unsafe {
-            debug_assert!(self.end > self.start);
-            debug_assert!(self.cursor > self.start);
-            debug_assert!(self.cursor <= self.end);
-            // SAFETY: All methods ensure `self.cursor` is always in bounds, is aligned for `T`,
-            // and `self.current.sub(1)` points to a valid initialized `T`, if stack is not empty.
-            // Caller guarantees stack is not empty.
-            self.cursor.sub(1).as_ref()
-        }
+        debug_assert!(self.end > self.start);
+        debug_assert!(self.cursor > self.start);
+        debug_assert!(self.cursor <= self.end);
+
+        // SAFETY: All methods ensure `self.cursor` is always in bounds, is aligned for `T`,
+        // and `self.current.sub(1)` points to a valid initialized `T`, if stack is not empty.
+        // Caller guarantees stack is not empty.
+        unsafe { self.cursor.sub(1).as_ref() }
     }
 
     /// Get mutable reference to last value on stack.
@@ -241,15 +238,14 @@ impl<T> Stack<T> {
     /// * Stack must not be empty.
     #[inline]
     pub unsafe fn last_unchecked_mut(&mut self) -> &mut T {
-        unsafe {
-            debug_assert!(self.end > self.start);
-            debug_assert!(self.cursor > self.start);
-            debug_assert!(self.cursor <= self.end);
-            // SAFETY: All methods ensure `self.cursor` is always in bounds, is aligned for `T`,
-            // and `self.current.sub(1)` points to a valid initialized `T`, if stack is not empty.
-            // Caller guarantees stack is not empty.
-            self.cursor.sub(1).as_mut()
-        }
+        debug_assert!(self.end > self.start);
+        debug_assert!(self.cursor > self.start);
+        debug_assert!(self.cursor <= self.end);
+
+        // SAFETY: All methods ensure `self.cursor` is always in bounds, is aligned for `T`,
+        // and `self.current.sub(1)` points to a valid initialized `T`, if stack is not empty.
+        // Caller guarantees stack is not empty.
+        unsafe { self.cursor.sub(1).as_mut() }
     }
 
     /// Push value to stack.
@@ -285,28 +281,26 @@ impl<T> Stack<T> {
     #[cold]
     #[inline(never)]
     unsafe fn push_slow(&mut self, value: T) {
-        unsafe {
-            #[expect(clippy::if_not_else)]
-            if self.end != self.start {
-                // Stack was already allocated. Grow capacity.
-                // SAFETY: Checked above that is already allocated.
-                self.grow();
-            } else {
-                // Stack was not allocated yet.
-                // SAFETY: `DEFAULT_CAPACITY_BYTES` satisfies requirements.
-                let (start, end) = Self::allocate(Self::DEFAULT_CAPACITY_BYTES);
-                self.start = start;
-                self.cursor = start;
-                self.end = end;
-            }
-
-            // Write value + increment cursor.
-            // SAFETY: We just allocated additional capacity, so `self.cursor` is in bounds.
-            // `self.cursor` is aligned for `T`.
-            unsafe { self.cursor.as_ptr().write(value) }
-            // SAFETY: Cursor is not at end, so advancing by a `T` cannot be out of bounds
-            self.cursor = unsafe { self.cursor.add(1) };
+        #[expect(clippy::if_not_else)]
+        if self.end != self.start {
+            // Stack was already allocated. Grow capacity.
+            // SAFETY: Checked above that is already allocated.
+            unsafe { self.grow() };
+        } else {
+            // Stack was not allocated yet.
+            // SAFETY: `DEFAULT_CAPACITY_BYTES` satisfies requirements.
+            let (start, end) = unsafe { Self::allocate(Self::DEFAULT_CAPACITY_BYTES) };
+            self.start = start;
+            self.cursor = start;
+            self.end = end;
         }
+
+        // Write value + increment cursor.
+        // SAFETY: We just allocated additional capacity, so `self.cursor` is in bounds.
+        // `self.cursor` is aligned for `T`.
+        unsafe { self.cursor.as_ptr().write(value) }
+        // SAFETY: Cursor is not at end, so advancing by a `T` cannot be out of bounds
+        self.cursor = unsafe { self.cursor.add(1) };
     }
 
     /// Pop value from stack.
@@ -328,17 +322,16 @@ impl<T> Stack<T> {
     /// * Stack must not be empty.
     #[inline]
     pub unsafe fn pop_unchecked(&mut self) -> T {
-        unsafe {
-            debug_assert!(self.end > self.start);
-            debug_assert!(self.cursor > self.start);
-            debug_assert!(self.cursor <= self.end);
-            // SAFETY: Caller guarantees stack is not empty, so subtracting 1 cannot be out of bounds
-            self.cursor = self.cursor.sub(1);
-            // SAFETY: All methods ensure `self.cursor` is always in bounds, is aligned for `T`,
-            // and points to a valid initialized `T`, if stack is not empty.
-            // Caller guarantees stack was not empty.
-            self.cursor.read()
-        }
+        debug_assert!(self.end > self.start);
+        debug_assert!(self.cursor > self.start);
+        debug_assert!(self.cursor <= self.end);
+
+        // SAFETY: Caller guarantees stack is not empty, so subtracting 1 cannot be out of bounds
+        self.cursor = unsafe { self.cursor.sub(1) };
+        // SAFETY: All methods ensure `self.cursor` is always in bounds, is aligned for `T`,
+        // and points to a valid initialized `T`, if stack is not empty.
+        // Caller guarantees stack was not empty.
+        unsafe { self.cursor.read() }
     }
 
     /// Get number of entries on stack.


### PR DESCRIPTION
The new lint in Rust 1.85.0 `unsafe_op_in_unsafe_fn` is good - even in an unsafe function, it's good to make it clear what the unsafe operations are.

But the auto-fix for this lint was not good - it just encased entire function body in an `unsafe {}` block. If anything this has the opposite effect - making it *less* clear where unsafe invariants are generated and satisfied.

In `oxc_data_structures`, reduce the scope of these `unsafe {}` blocks, so they cover only the unsafe operations.
