### PR TITLE
fix(data_structures): stack types correctly report allocation size if allocation failure during grow

### DIFF
--- a/crates/oxc_data_structures/src/stack/common.rs
+++ b/crates/oxc_data_structures/src/stack/common.rs
@@ -271,7 +271,7 @@ unsafe fn grow(
     let new_ptr = unsafe { alloc::realloc(old_start.as_ptr(), old_layout, new_capacity_bytes) };
     let Some(new_start) = NonNull::new(new_ptr) else {
         let new_layout =
-            unsafe { Layout::from_size_align_unchecked(old_capacity_bytes, old_layout.align()) };
+            unsafe { Layout::from_size_align_unchecked(new_capacity_bytes, old_layout.align()) };
         alloc::handle_alloc_error(new_layout);
     };
 


### PR DESCRIPTION
If an allocation failure during growth in `Stack`, `NonEmptyStack` and `SparseStack`, they would report the failure with details of the old allocation size, rather than the new one. Fix that.

This bug only affected error reporting, not soundness - and allocation failures should never happen anyway. But still, better to report it correctly.
