### PR TITLE
refactor(data_structures): stack types const assert `T` is not zero-size type

### DIFF
--- a/crates/oxc_data_structures/src/stack/non_empty.rs
+++ b/crates/oxc_data_structures/src/stack/non_empty.rs
@@ -202,7 +202,7 @@ impl<T> NonEmptyStack<T> {
     #[inline]
     unsafe fn new_with_capacity_bytes_unchecked(capacity_bytes: usize, initial_value: T) -> Self {
         // ZSTs are not supported for simplicity
-        assert!(size_of::<T>() > 0, "Zero sized types are not supported");
+        const { assert!(size_of::<T>() > 0, "Zero sized types are not supported") };
 
         // SAFETY: Caller guarantees `capacity_bytes` satisfies requirements
         let (start, end) = unsafe { Self::allocate(capacity_bytes) };

--- a/crates/oxc_data_structures/src/stack/standard.rs
+++ b/crates/oxc_data_structures/src/stack/standard.rs
@@ -112,7 +112,7 @@ impl<T> Stack<T> {
     #[inline]
     pub const fn new() -> Self {
         // ZSTs are not supported for simplicity
-        assert!(size_of::<T>() > 0, "Zero sized types are not supported");
+        const { assert!(size_of::<T>() > 0, "Zero sized types are not supported") };
 
         // Create stack with equal `start` and `end`
         let dangling = NonNull::dangling();
@@ -175,7 +175,7 @@ impl<T> Stack<T> {
     #[inline]
     unsafe fn new_with_capacity_bytes_unchecked(capacity_bytes: usize) -> Self {
         // ZSTs are not supported for simplicity
-        assert!(size_of::<T>() > 0, "Zero sized types are not supported");
+        const { assert!(size_of::<T>() > 0, "Zero sized types are not supported") };
 
         // SAFETY: Caller guarantees `capacity_bytes` satisfies requirements
         let (start, end) = unsafe { Self::allocate(capacity_bytes) };


### PR DESCRIPTION
`Stack`, `NonEmptyStack` and `SparseStack` do not support zero-sized types, for simplicity of implementation (a `Stack<()>` would be pretty pointless anyway).

Promote panics if attempt to construct a `Stack<()>` from run time to build time, by putting the size assertions in `const {}` blocks. These assertions should be const-folded out by compiler anyway, but the `const {}` blocks make sure.
