### PR TITLE
refactor(mangler): reduce scope of `unsafe` blocks

### DIFF
--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -491,13 +491,12 @@ impl<const CAPACITY: usize> InlineString<CAPACITY> {
     /// * `byte` must be < 128 (an ASCII character).
     #[inline]
     unsafe fn push_unchecked(&mut self, byte: u8) {
-        unsafe {
-            debug_assert!((self.len as usize) < CAPACITY);
-            debug_assert!(byte.is_ascii());
+        debug_assert!((self.len as usize) < CAPACITY);
+        debug_assert!(byte.is_ascii());
 
-            *self.bytes.get_unchecked_mut(self.len as usize) = byte;
-            self.len += 1;
-        }
+        // SAFETY: Caller guarantees not pushing more than `CAPACITY` bytes, so `len` is in bounds
+        unsafe { *self.bytes.get_unchecked_mut(self.len as usize) = byte };
+        self.len += 1;
     }
 
     /// Get length of string as `u32`.


### PR DESCRIPTION
Same as #9316. In mangler, reduce scope of `unsafe {}` blocks in unsafe functions, so they cover only the unsafe operations.