### PR TITLE
refactor(syntax): reduce scope of `unsafe` blocks

### DIFF
--- a/crates/oxc_syntax/src/node.rs
+++ b/crates/oxc_syntax/src/node.rs
@@ -31,10 +31,8 @@ impl NodeId {
     /// # SAFETY
     /// `idx` must not be `u32::MAX`.
     pub const unsafe fn new_unchecked(idx: u32) -> Self {
-        unsafe {
-            // SAFETY: Caller must ensure `idx` is not `u32::MAX`
-            Self(NonMaxU32::new_unchecked(idx))
-        }
+        // SAFETY: Caller must ensure `idx` is not `u32::MAX`
+        unsafe { Self(NonMaxU32::new_unchecked(idx)) }
     }
 }
 

--- a/crates/oxc_syntax/src/scope.rs
+++ b/crates/oxc_syntax/src/scope.rs
@@ -32,10 +32,8 @@ impl ScopeId {
     /// # SAFETY
     /// `idx` must not be `u32::MAX`.
     pub const unsafe fn new_unchecked(idx: u32) -> Self {
-        unsafe {
-            // SAFETY: Caller must ensure `idx` is not `u32::MAX`
-            Self(NonMaxU32::new_unchecked(idx))
-        }
+        // SAFETY: Caller must ensure `idx` is not `u32::MAX`
+        unsafe { Self(NonMaxU32::new_unchecked(idx)) }
     }
 }
 

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -32,10 +32,8 @@ impl SymbolId {
     /// # SAFETY
     /// `idx` must not be `u32::MAX`.
     pub const unsafe fn new_unchecked(idx: u32) -> Self {
-        unsafe {
-            // SAFETY: Caller must ensure `idx` is not `u32::MAX`
-            Self(NonMaxU32::new_unchecked(idx))
-        }
+        // SAFETY: Caller must ensure `idx` is not `u32::MAX`
+        unsafe { Self(NonMaxU32::new_unchecked(idx)) }
     }
 }
 


### PR DESCRIPTION
Similar to #9316. In `oxc_syntax`, move safety comments to outside `unsafe {}` blocks.