### PR TITLE
refactor(traverse): reduce scope of `unsafe` blocks

### DIFF
--- a/crates/oxc_traverse/src/context/ancestry.rs
+++ b/crates/oxc_traverse/src/context/ancestry.rs
@@ -193,10 +193,8 @@ impl<'a> TraverseAncestry<'a> {
     #[inline]
     #[expect(clippy::ptr_as_ptr, clippy::ref_as_ptr)]
     pub(crate) unsafe fn retag_stack(&mut self, ty: AncestorType) {
-        unsafe {
-            debug_assert!(self.stack.len() >= 2);
-            *(self.stack.last_mut() as *mut _ as *mut AncestorType) = ty;
-        }
+        debug_assert!(self.stack.len() >= 2);
+        unsafe { *(self.stack.last_mut() as *mut _ as *mut AncestorType) = ty };
     }
 }
 

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -649,9 +649,7 @@ impl<'a> TraverseCtx<'a> {
     /// This method must not be public outside this crate, or consumer could break safety invariants.
     #[inline]
     pub(crate) unsafe fn retag_stack(&mut self, ty: AncestorType) {
-        unsafe {
-            self.ancestry.retag_stack(ty);
-        }
+        unsafe { self.ancestry.retag_stack(ty) };
     }
 
     /// Shortcut for `ctx.scoping.set_current_scope_id`, to make `walk_*` methods less verbose.


### PR DESCRIPTION
Same as #9316. In `oxc_traverse`, reduce scope of `unsafe {}` blocks in unsafe functions, so they cover only the unsafe operations.