### PR TITLE
style(benchmarks): reformat `unsafe` block

### DIFF
--- a/tasks/benchmark/src/lib.rs
+++ b/tasks/benchmark/src/lib.rs
@@ -34,8 +34,6 @@ unsafe impl GlobalAlloc for NeverGrowInPlaceAllocator {
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        unsafe {
-            System.dealloc(ptr, layout);
-        }
+        unsafe { System.dealloc(ptr, layout) };
     }
 }


### PR DESCRIPTION
Similar to #9316. In `NeverGrowInPlaceAllocator` used in benchmarks, reformat `unsafe {}` block introduced by the `unsafe_op_in_unsafe_fn` lint rule.
