### PR TITLE
perf(codegen): use `iter::repeat_n` in `CodeBuffer`

### DIFF
--- a/crates/oxc_codegen/src/code_buffer.rs
+++ b/crates/oxc_codegen/src/code_buffer.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use assert_unchecked::assert_unchecked;
 
 /// A string builder for constructing source code.
@@ -392,7 +394,7 @@ impl CodeBuffer {
         #[cold]
         #[inline(never)]
         fn write_slow(code_buffer: &mut CodeBuffer, n: usize) {
-            code_buffer.buf.extend(std::iter::repeat(b'\t').take(n));
+            code_buffer.buf.extend(iter::repeat_n(b'\t', n));
         }
 
         let len = self.len();


### PR DESCRIPTION
`CodeBuffer::print_indent` use `iter::repeat_n(...)` instead of `iter::repeat(...).take(...)`. `repeat_n` is faster as its iterator has a guaranteed size bound, and so doesn't bounds check repeatedly before pushing each individual byte.
