### PR TITLE
refactor(codegen, data_structures): move `CodeBuffer` into `oxc_data_structures` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1667,7 +1667,6 @@ dependencies = [
 name = "oxc_codegen"
 version = "0.52.0"
 dependencies = [
- "assert-unchecked",
  "base64",
  "bitflags 2.8.0",
  "cow-utils",

--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -29,7 +29,6 @@ oxc_sourcemap = { workspace = true }
 oxc_span = { workspace = true }
 oxc_syntax = { workspace = true }
 
-assert-unchecked = { workspace = true }
 bitflags = { workspace = true }
 cow-utils = { workspace = true }
 nonmax = { workspace = true }

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -5,7 +5,6 @@
 #![warn(missing_docs)]
 
 mod binary_expr_visitor;
-mod code_buffer;
 mod comment;
 mod context;
 mod r#gen;
@@ -19,7 +18,7 @@ use oxc_ast::ast::{
     BindingIdentifier, BlockStatement, Comment, Expression, IdentifierReference, Program,
     Statement, StringLiteral,
 };
-use oxc_data_structures::stack::Stack;
+use oxc_data_structures::{code_buffer::CodeBuffer, stack::Stack};
 use oxc_semantic::SymbolTable;
 use oxc_span::{GetSpan, SPAN, Span};
 use oxc_syntax::{
@@ -29,8 +28,8 @@ use oxc_syntax::{
 };
 
 use crate::{
-    binary_expr_visitor::BinaryExpressionVisitor, code_buffer::CodeBuffer, comment::CommentsMap,
-    operator::Operator, sourcemap_builder::SourcemapBuilder,
+    binary_expr_visitor::BinaryExpressionVisitor, comment::CommentsMap, operator::Operator,
+    sourcemap_builder::SourcemapBuilder,
 };
 pub use crate::{
     context::Context,

--- a/crates/oxc_data_structures/src/code_buffer.rs
+++ b/crates/oxc_data_structures/src/code_buffer.rs
@@ -1,3 +1,5 @@
+//! A string builder for constructing source code.
+
 use std::iter;
 
 use assert_unchecked::assert_unchecked;
@@ -12,7 +14,7 @@ use assert_unchecked::assert_unchecked;
 ///
 /// # Example
 /// ```
-/// use oxc_codegen::CodeBuffer;
+/// # use oxc_data_structures::CodeBuffer;
 /// let mut code = CodeBuffer::new();
 ///
 /// // mock settings
@@ -40,7 +42,7 @@ impl CodeBuffer {
     ///
     /// # Example
     /// ```
-    /// use oxc_codegen::CodeBuffer;
+    /// # use oxc_data_structures::CodeBuffer;
     /// let mut code = CodeBuffer::new();
     ///
     /// // use `code` to build new source text
@@ -90,7 +92,7 @@ impl CodeBuffer {
     ///
     /// # Example
     /// ```
-    /// use oxc_codegen::CodeBuffer;
+    /// # use oxc_data_structures::CodeBuffer;
     /// let mut code = CodeBuffer::new();
     /// assert!(code.is_empty());
     ///
@@ -113,7 +115,7 @@ impl CodeBuffer {
     ///
     /// # Example
     /// ```
-    /// use oxc_codegen::CodeBuffer;
+    /// # use oxc_data_structures::CodeBuffer;
     /// let mut code = CodeBuffer::default();
     /// code.reserve(10);
     /// ```
@@ -129,7 +131,7 @@ impl CodeBuffer {
     ///
     /// # Example
     /// ```
-    /// use oxc_codegen::CodeBuffer;
+    /// # use oxc_data_structures::CodeBuffer;
     /// let mut code = CodeBuffer::new();
     /// code.print_str("foo");
     ///
@@ -151,7 +153,7 @@ impl CodeBuffer {
     ///
     /// # Example
     /// ```
-    /// use oxc_codegen::CodeBuffer;
+    /// # use oxc_data_structures::CodeBuffer;
     /// let mut code = CodeBuffer::new();
     /// code.print_str("foo");
     ///
@@ -185,7 +187,7 @@ impl CodeBuffer {
     ///
     /// # Example
     /// ```
-    /// use oxc_codegen::CodeBuffer;
+    /// # use oxc_data_structures::CodeBuffer;
     /// let mut code = CodeBuffer::new();
     /// code.print_ascii_byte(b'f');
     /// code.print_ascii_byte(b'o');
@@ -222,7 +224,7 @@ impl CodeBuffer {
     ///
     /// # Example
     /// ```
-    /// use oxc_codegen::CodeBuffer;
+    /// # use oxc_data_structures::CodeBuffer;
     /// let mut code = CodeBuffer::new();
     /// // Safe: 'a' is a valid ASCII character. Its UTF-8 representation only
     /// // requires a single byte.
@@ -283,7 +285,7 @@ impl CodeBuffer {
     ///
     /// # Example
     /// ```
-    /// use oxc_codegen::CodeBuffer;
+    /// # use oxc_data_structures::CodeBuffer;
     /// let mut code = CodeBuffer::new();
     ///
     /// code.print_char('f');
@@ -305,7 +307,7 @@ impl CodeBuffer {
     ///
     /// # Example
     /// ```
-    /// use oxc_codegen::CodeBuffer;
+    /// # use oxc_data_structures::CodeBuffer;
     /// let mut code = CodeBuffer::new();
     /// code.print_str("function main() { console.log('Hello, world!') }");
     /// ```
@@ -321,7 +323,7 @@ impl CodeBuffer {
     ///
     /// # Example
     /// ```
-    /// use oxc_codegen::CodeBuffer;
+    /// # use oxc_data_structures::CodeBuffer;
     /// let mut code = CodeBuffer::new();
     ///
     /// code.print_ascii_bytes([b'f', b'o', b'o']);
@@ -353,7 +355,7 @@ impl CodeBuffer {
     ///
     /// # Example
     /// ```
-    /// use oxc_codegen::CodeBuffer;
+    /// # use oxc_data_structures::CodeBuffer;
     /// let mut code = CodeBuffer::new();
     ///
     /// // Indent to a dynamic level.
@@ -425,7 +427,7 @@ impl CodeBuffer {
     ///
     /// # Example
     /// ```
-    /// use oxc_codegen::CodeBuffer;
+    /// # use oxc_data_structures::CodeBuffer;
     /// let mut code = CodeBuffer::new();
     /// code.print_str("foo");
     /// assert_eq!(code.as_bytes(), &[b'f', b'o', b'o']);
@@ -439,13 +441,14 @@ impl CodeBuffer {
     ///
     /// # Example
     /// ```
-    /// use oxc_codegen::CodeBuffer;
+    /// # use oxc_data_structures::CodeBuffer;
     /// let mut code = CodeBuffer::new();
     /// code.print_str("console.log('foo');");
     ///
     /// let source = code.into_string();
     /// assert_eq!(source, "console.log('foo');");
     /// ```
+    #[expect(clippy::missing_panics_doc)]
     #[must_use]
     #[inline]
     pub fn into_string(self) -> String {

--- a/crates/oxc_data_structures/src/lib.rs
+++ b/crates/oxc_data_structures/src/lib.rs
@@ -2,5 +2,6 @@
 
 #![warn(missing_docs)]
 
+pub mod code_buffer;
 pub mod rope;
 pub mod stack;


### PR DESCRIPTION
Pure refactor. Move `CodeBuffer` from `oxc_codegen` crate into `oxc_data_structures`, so `ESTree` serializer can also use it for constructing JSON string.
