### PR TITLE
refactor(data_structures): `CodeBuffer::print_bytes_unchecked` take a byte slice

### DIFF
--- a/crates/oxc_data_structures/src/code_buffer.rs
+++ b/crates/oxc_data_structures/src/code_buffer.rs
@@ -358,20 +358,16 @@ impl CodeBuffer {
     /// # use oxc_data_structures::CodeBuffer;
     /// let mut code = CodeBuffer::new();
     ///
-    /// // Indent to a dynamic level.
-    /// // Sound because all elements in this iterator are ASCII characters.
+    /// // Sound because all bytes in this byte slice are ASCII characters
     /// unsafe {
-    ///     code.print_bytes_unchecked(std::iter::repeat(b' ').take(4));
+    ///     code.print_bytes_unchecked("abcd".as_bytes());
     /// }
     /// ```
     ///
     /// [`print_byte_unchecked`]: CodeBuffer::print_byte_unchecked
     #[inline]
-    pub unsafe fn print_bytes_unchecked<I>(&mut self, bytes: I)
-    where
-        I: IntoIterator<Item = u8>,
-    {
-        self.buf.extend(bytes);
+    pub unsafe fn print_bytes_unchecked(&mut self, bytes: &[u8]) {
+        self.buf.extend_from_slice(bytes);
     }
 
     /// Print `n` tab characters into the buffer (indentation).


### PR DESCRIPTION
Alter signature of `CodeBuffer::print_bytes_unchecked`, to take a byte slice instead of an iterator.

This would be a breaking change, but `CodeBuffer` was only made public in last PR (#9326), so no-one will have had a chance to depend on it yet!
