### PR TITLE
refactor(data_structures): `CodeBuffer::print_str` use `Vec::extend_from_slice`

### DIFF
--- a/crates/oxc_data_structures/src/code_buffer.rs
+++ b/crates/oxc_data_structures/src/code_buffer.rs
@@ -300,7 +300,7 @@ impl CodeBuffer {
     #[inline]
     pub fn print_char(&mut self, ch: char) {
         let mut b = [0; 4];
-        self.buf.extend(ch.encode_utf8(&mut b).as_bytes());
+        self.buf.extend_from_slice(ch.encode_utf8(&mut b).as_bytes());
     }
 
     /// Push a string into the buffer.
@@ -313,7 +313,7 @@ impl CodeBuffer {
     /// ```
     #[inline]
     pub fn print_str<S: AsRef<str>>(&mut self, s: S) {
-        self.buf.extend(s.as_ref().as_bytes());
+        self.buf.extend_from_slice(s.as_ref().as_bytes());
     }
 
     /// Push a sequence of ASCII characters into the buffer.


### PR DESCRIPTION
`Vec::extend_from_slice` may be more efficient than `Vec::extend`. I'm not 100% sure of that - specialization may make the two equivalent where the iterator passed to `Vec::extend` is a slice iterator. But anyway `extend_from_slice` is intended for this use case, so better to use it.
