### PR TITLE
perf(data_structures, ast/estree): add `CodeBuffer::print_bytes_iter_unchecked` method and use it in `ESTree` serializer

### DIFF
--- a/crates/oxc_data_structures/src/code_buffer.rs
+++ b/crates/oxc_data_structures/src/code_buffer.rs
@@ -370,6 +370,35 @@ impl CodeBuffer {
         self.buf.extend_from_slice(bytes);
     }
 
+    /// Print a sequence of bytes without checking that the buffer still
+    /// represents a valid UTF-8 string.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure that, after this method call, the buffer represents
+    /// a valid UTF-8 string. In practice, this means only two cases are valid:
+    ///
+    /// 1. The sequence of bytes yielded by `bytes` iterator forms a valid UTF-8 string. or
+    /// 2. The buffer became invalid after a call to [`print_byte_unchecked`] and `bytes` completes
+    ///    any incomplete Unicode characters, returning the buffer to a valid state.
+    ///
+    /// # Example
+    /// ```
+    /// # use oxc_data_structures::CodeBuffer;
+    /// let mut code = CodeBuffer::new();
+    ///
+    /// // SAFETY: All values yielded by this iterator are ASCII bytes
+    /// unsafe {
+    ///     code.print_bytes_iter_unchecked(std::iter::repeat_n(b' ', 20));
+    /// }
+    /// ```
+    ///
+    /// [`print_byte_unchecked`]: CodeBuffer::print_byte_unchecked
+    #[inline]
+    pub unsafe fn print_bytes_iter_unchecked<I: IntoIterator<Item = u8>>(&mut self, bytes: I) {
+        self.buf.extend(bytes);
+    }
+
     /// Print `n` tab characters into the buffer (indentation).
     ///
     /// Optimized on assumption that more that 16 levels of indentation is rare.

--- a/crates/oxc_estree/src/serialize/formatter.rs
+++ b/crates/oxc_estree/src/serialize/formatter.rs
@@ -1,3 +1,5 @@
+use std::iter;
+
 use oxc_data_structures::code_buffer::CodeBuffer;
 
 /// Formatter trait.
@@ -77,7 +79,7 @@ impl Formatter for PrettyFormatter {
     }
 
     fn before_first_element(&mut self, buffer: &mut CodeBuffer) {
-        self.indent += 1;
+        self.indent += 2;
         self.push_new_line_and_indent(buffer);
     }
 
@@ -90,7 +92,7 @@ impl Formatter for PrettyFormatter {
     }
 
     fn after_last_element(&mut self, buffer: &mut CodeBuffer) {
-        self.indent -= 1;
+        self.indent -= 2;
         self.push_new_line_and_indent(buffer);
     }
 }
@@ -99,6 +101,6 @@ impl PrettyFormatter {
     fn push_new_line_and_indent(&self, buffer: &mut CodeBuffer) {
         buffer.print_ascii_byte(b'\n');
         // SAFETY: Spaces are ASCII
-        unsafe { buffer.print_bytes_unchecked(&b"  ".repeat(self.indent)) };
+        unsafe { buffer.print_bytes_iter_unchecked(iter::repeat_n(b' ', self.indent)) };
     }
 }


### PR DESCRIPTION
Optimization to `ESTree` serialization. Avoid allocating a `String` when generating indentation, and use a "trusted length" iterator instead.

This only affects generation of pretty-printed JSON, so won't show on our benchmarks, which only use compact JSON form.
