### PR TITLE
refactor(estree): make `itoa` dependency optional

### DIFF
--- a/crates/oxc_estree/Cargo.toml
+++ b/crates/oxc_estree/Cargo.toml
@@ -19,9 +19,9 @@ workspace = true
 doctest = false
 
 [dependencies]
-itoa = { workspace = true }
+itoa = { workspace = true, optional = true }
 ryu-js = { workspace = true, optional = true }
 
 [features]
 default = []
-serialize = ["dep:ryu-js"]
+serialize = ["dep:itoa", "dep:ryu-js"]


### PR DESCRIPTION
Make `itoa` dependency of `oxc_estree` optional. It's only required if `serialize` feature is enabled.

(as pointed out in https://github.com/oxc-project/oxc/pull/9331#issuecomment-2678713071, we want to avoid `oxc_ast` crate having unnecessary dependencies)

