### PR TITLE
perf(ast/estree): pre-allocate `CodeBuffer` for JSON output

### DIFF
--- a/crates/oxc_estree/src/serialize/mod.rs
+++ b/crates/oxc_estree/src/serialize/mod.rs
@@ -79,6 +79,11 @@ impl<C: Config, F: Formatter> ESTreeSerializer<C, F> {
         Self { buffer: CodeBuffer::new(), formatter: F::new(), config: C::new() }
     }
 
+    /// Create new [`ESTreeSerializer`] with specified buffer capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self { buffer: CodeBuffer::with_capacity(capacity), formatter: F::new(), config: C::new() }
+    }
+
     /// Consume this [`ESTreeSerializer`] and convert buffer to string.
     pub fn into_string(self) -> String {
         self.buffer.into_string()


### PR DESCRIPTION
`ESTree` serialization pre-allocate capacity in `CodeBuffer` for JSON, based on an heuristic ratio of source text length to JSON length, to avoid the buffer having to grow during serialization.
