### PR TITLE
fix(ast/estree): visit `JSXOpeningFragment` and `JSXClosingFragment`

### DIFF
--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -126,7 +126,7 @@ pub struct JSXFragment<'a> {
 }
 
 /// JSX Opening Fragment (`<>`)
-#[ast]
+#[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct JSXOpeningFragment {
@@ -135,7 +135,7 @@ pub struct JSXOpeningFragment {
 }
 
 /// JSX Closing Fragment (`</>`)
-#[ast]
+#[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct JSXClosingFragment {

--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -334,16 +334,4 @@ impl<'a> AstBuilder<'a> {
             self.allocator,
         )
     }
-
-    /// Create an [`JSXOpeningElement`].
-    #[inline]
-    pub fn jsx_opening_fragment(self, span: Span) -> JSXOpeningFragment {
-        JSXOpeningFragment { span }
-    }
-
-    /// Create an [`JSXClosingElement`].
-    #[inline]
-    pub fn jsx_closing_fragment(self, span: Span) -> JSXClosingFragment {
-        JSXClosingFragment { span }
-    }
 }

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -7763,6 +7763,50 @@ impl<'a> AstBuilder<'a> {
         )
     }
 
+    /// Build a [`JSXOpeningFragment`].
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_opening_fragment`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    #[inline]
+    pub fn jsx_opening_fragment(self, span: Span) -> JSXOpeningFragment {
+        JSXOpeningFragment { span }
+    }
+
+    /// Build a [`JSXOpeningFragment`], and store it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_opening_fragment`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    #[inline]
+    pub fn alloc_jsx_opening_fragment(self, span: Span) -> Box<'a, JSXOpeningFragment> {
+        Box::new_in(self.jsx_opening_fragment(span), self.allocator)
+    }
+
+    /// Build a [`JSXClosingFragment`].
+    ///
+    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_closing_fragment`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    #[inline]
+    pub fn jsx_closing_fragment(self, span: Span) -> JSXClosingFragment {
+        JSXClosingFragment { span }
+    }
+
+    /// Build a [`JSXClosingFragment`], and store it in the memory arena.
+    ///
+    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_closing_fragment`] instead.
+    ///
+    /// ## Parameters
+    /// * `span`: Node location in source code
+    #[inline]
+    pub fn alloc_jsx_closing_fragment(self, span: Span) -> Box<'a, JSXClosingFragment> {
+        Box::new_in(self.jsx_closing_fragment(span), self.allocator)
+    }
+
     /// Build a [`JSXElementName::Identifier`].
     ///
     /// This node contains a [`JSXIdentifier`] that will be stored in the memory arena.

--- a/crates/oxc_ast/src/generated/visit.rs
+++ b/crates/oxc_ast/src/generated/visit.rs
@@ -676,6 +676,16 @@ pub trait Visit<'a>: Sized {
     }
 
     #[inline]
+    fn visit_jsx_opening_fragment(&mut self, it: &JSXOpeningFragment) {
+        walk_jsx_opening_fragment(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_closing_fragment(&mut self, it: &JSXClosingFragment) {
+        walk_jsx_closing_fragment(self, it);
+    }
+
+    #[inline]
     fn visit_jsx_element_name(&mut self, it: &JSXElementName<'a>) {
         walk_jsx_element_name(self, it);
     }
@@ -2953,8 +2963,22 @@ pub mod walk {
         let kind = AstKind::JSXFragment(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
+        visitor.visit_jsx_opening_fragment(&it.opening_fragment);
+        visitor.visit_jsx_closing_fragment(&it.closing_fragment);
         visitor.visit_jsx_children(&it.children);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_opening_fragment<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXOpeningFragment) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
+    }
+
+    #[inline]
+    pub fn walk_jsx_closing_fragment<'a, V: Visit<'a>>(visitor: &mut V, it: &JSXClosingFragment) {
+        // No `AstKind` for this type
+        visitor.visit_span(&it.span);
     }
 
     #[inline]

--- a/crates/oxc_ast/src/generated/visit_mut.rs
+++ b/crates/oxc_ast/src/generated/visit_mut.rs
@@ -668,6 +668,16 @@ pub trait VisitMut<'a>: Sized {
     }
 
     #[inline]
+    fn visit_jsx_opening_fragment(&mut self, it: &mut JSXOpeningFragment) {
+        walk_jsx_opening_fragment(self, it);
+    }
+
+    #[inline]
+    fn visit_jsx_closing_fragment(&mut self, it: &mut JSXClosingFragment) {
+        walk_jsx_closing_fragment(self, it);
+    }
+
+    #[inline]
     fn visit_jsx_element_name(&mut self, it: &mut JSXElementName<'a>) {
         walk_jsx_element_name(self, it);
     }
@@ -3075,8 +3085,28 @@ pub mod walk_mut {
         let kind = AstType::JSXFragment;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
+        visitor.visit_jsx_opening_fragment(&mut it.opening_fragment);
+        visitor.visit_jsx_closing_fragment(&mut it.closing_fragment);
         visitor.visit_jsx_children(&mut it.children);
         visitor.leave_node(kind);
+    }
+
+    #[inline]
+    pub fn walk_jsx_opening_fragment<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXOpeningFragment,
+    ) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
+    }
+
+    #[inline]
+    pub fn walk_jsx_closing_fragment<'a, V: VisitMut<'a>>(
+        visitor: &mut V,
+        it: &mut JSXClosingFragment,
+    ) {
+        // No `AstType` for this type
+        visitor.visit_span(&mut it.span);
     }
 
     #[inline]

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -196,124 +196,126 @@ pub(crate) enum AncestorType {
     JSXOpeningElementAttributes = 173,
     JSXOpeningElementTypeParameters = 174,
     JSXClosingElementName = 175,
-    JSXFragmentChildren = 176,
-    JSXNamespacedNameNamespace = 177,
-    JSXNamespacedNameProperty = 178,
-    JSXMemberExpressionObject = 179,
-    JSXMemberExpressionProperty = 180,
-    JSXExpressionContainerExpression = 181,
-    JSXAttributeName = 182,
-    JSXAttributeValue = 183,
-    JSXSpreadAttributeArgument = 184,
-    JSXSpreadChildExpression = 185,
-    TSThisParameterTypeAnnotation = 186,
-    TSEnumDeclarationId = 187,
-    TSEnumDeclarationMembers = 188,
-    TSEnumMemberId = 189,
-    TSEnumMemberInitializer = 190,
-    TSTypeAnnotationTypeAnnotation = 191,
-    TSLiteralTypeLiteral = 192,
-    TSConditionalTypeCheckType = 193,
-    TSConditionalTypeExtendsType = 194,
-    TSConditionalTypeTrueType = 195,
-    TSConditionalTypeFalseType = 196,
-    TSUnionTypeTypes = 197,
-    TSIntersectionTypeTypes = 198,
-    TSParenthesizedTypeTypeAnnotation = 199,
-    TSTypeOperatorTypeAnnotation = 200,
-    TSArrayTypeElementType = 201,
-    TSIndexedAccessTypeObjectType = 202,
-    TSIndexedAccessTypeIndexType = 203,
-    TSTupleTypeElementTypes = 204,
-    TSNamedTupleMemberElementType = 205,
-    TSNamedTupleMemberLabel = 206,
-    TSOptionalTypeTypeAnnotation = 207,
-    TSRestTypeTypeAnnotation = 208,
-    TSTypeReferenceTypeName = 209,
-    TSTypeReferenceTypeParameters = 210,
-    TSQualifiedNameLeft = 211,
-    TSQualifiedNameRight = 212,
-    TSTypeParameterInstantiationParams = 213,
-    TSTypeParameterName = 214,
-    TSTypeParameterConstraint = 215,
-    TSTypeParameterDefault = 216,
-    TSTypeParameterDeclarationParams = 217,
-    TSTypeAliasDeclarationId = 218,
-    TSTypeAliasDeclarationTypeParameters = 219,
-    TSTypeAliasDeclarationTypeAnnotation = 220,
-    TSClassImplementsExpression = 221,
-    TSClassImplementsTypeParameters = 222,
-    TSInterfaceDeclarationId = 223,
-    TSInterfaceDeclarationExtends = 224,
-    TSInterfaceDeclarationTypeParameters = 225,
-    TSInterfaceDeclarationBody = 226,
-    TSInterfaceBodyBody = 227,
-    TSPropertySignatureKey = 228,
-    TSPropertySignatureTypeAnnotation = 229,
-    TSIndexSignatureParameters = 230,
-    TSIndexSignatureTypeAnnotation = 231,
-    TSCallSignatureDeclarationTypeParameters = 232,
-    TSCallSignatureDeclarationThisParam = 233,
-    TSCallSignatureDeclarationParams = 234,
-    TSCallSignatureDeclarationReturnType = 235,
-    TSMethodSignatureKey = 236,
-    TSMethodSignatureTypeParameters = 237,
-    TSMethodSignatureThisParam = 238,
-    TSMethodSignatureParams = 239,
-    TSMethodSignatureReturnType = 240,
-    TSConstructSignatureDeclarationTypeParameters = 241,
-    TSConstructSignatureDeclarationParams = 242,
-    TSConstructSignatureDeclarationReturnType = 243,
-    TSIndexSignatureNameTypeAnnotation = 244,
-    TSInterfaceHeritageExpression = 245,
-    TSInterfaceHeritageTypeParameters = 246,
-    TSTypePredicateParameterName = 247,
-    TSTypePredicateTypeAnnotation = 248,
-    TSModuleDeclarationId = 249,
-    TSModuleDeclarationBody = 250,
-    TSModuleBlockDirectives = 251,
-    TSModuleBlockBody = 252,
-    TSTypeLiteralMembers = 253,
-    TSInferTypeTypeParameter = 254,
-    TSTypeQueryExprName = 255,
-    TSTypeQueryTypeParameters = 256,
-    TSImportTypeParameter = 257,
-    TSImportTypeQualifier = 258,
-    TSImportTypeAttributes = 259,
-    TSImportTypeTypeParameters = 260,
-    TSImportAttributesAttributesKeyword = 261,
-    TSImportAttributesElements = 262,
-    TSImportAttributeName = 263,
-    TSImportAttributeValue = 264,
-    TSFunctionTypeTypeParameters = 265,
-    TSFunctionTypeThisParam = 266,
-    TSFunctionTypeParams = 267,
-    TSFunctionTypeReturnType = 268,
-    TSConstructorTypeTypeParameters = 269,
-    TSConstructorTypeParams = 270,
-    TSConstructorTypeReturnType = 271,
-    TSMappedTypeTypeParameter = 272,
-    TSMappedTypeNameType = 273,
-    TSMappedTypeTypeAnnotation = 274,
-    TSTemplateLiteralTypeQuasis = 275,
-    TSTemplateLiteralTypeTypes = 276,
-    TSAsExpressionExpression = 277,
-    TSAsExpressionTypeAnnotation = 278,
-    TSSatisfiesExpressionExpression = 279,
-    TSSatisfiesExpressionTypeAnnotation = 280,
-    TSTypeAssertionExpression = 281,
-    TSTypeAssertionTypeAnnotation = 282,
-    TSImportEqualsDeclarationId = 283,
-    TSImportEqualsDeclarationModuleReference = 284,
-    TSExternalModuleReferenceExpression = 285,
-    TSNonNullExpressionExpression = 286,
-    DecoratorExpression = 287,
-    TSExportAssignmentExpression = 288,
-    TSNamespaceExportDeclarationId = 289,
-    TSInstantiationExpressionExpression = 290,
-    TSInstantiationExpressionTypeParameters = 291,
-    JSDocNullableTypeTypeAnnotation = 292,
-    JSDocNonNullableTypeTypeAnnotation = 293,
+    JSXFragmentOpeningFragment = 176,
+    JSXFragmentClosingFragment = 177,
+    JSXFragmentChildren = 178,
+    JSXNamespacedNameNamespace = 179,
+    JSXNamespacedNameProperty = 180,
+    JSXMemberExpressionObject = 181,
+    JSXMemberExpressionProperty = 182,
+    JSXExpressionContainerExpression = 183,
+    JSXAttributeName = 184,
+    JSXAttributeValue = 185,
+    JSXSpreadAttributeArgument = 186,
+    JSXSpreadChildExpression = 187,
+    TSThisParameterTypeAnnotation = 188,
+    TSEnumDeclarationId = 189,
+    TSEnumDeclarationMembers = 190,
+    TSEnumMemberId = 191,
+    TSEnumMemberInitializer = 192,
+    TSTypeAnnotationTypeAnnotation = 193,
+    TSLiteralTypeLiteral = 194,
+    TSConditionalTypeCheckType = 195,
+    TSConditionalTypeExtendsType = 196,
+    TSConditionalTypeTrueType = 197,
+    TSConditionalTypeFalseType = 198,
+    TSUnionTypeTypes = 199,
+    TSIntersectionTypeTypes = 200,
+    TSParenthesizedTypeTypeAnnotation = 201,
+    TSTypeOperatorTypeAnnotation = 202,
+    TSArrayTypeElementType = 203,
+    TSIndexedAccessTypeObjectType = 204,
+    TSIndexedAccessTypeIndexType = 205,
+    TSTupleTypeElementTypes = 206,
+    TSNamedTupleMemberElementType = 207,
+    TSNamedTupleMemberLabel = 208,
+    TSOptionalTypeTypeAnnotation = 209,
+    TSRestTypeTypeAnnotation = 210,
+    TSTypeReferenceTypeName = 211,
+    TSTypeReferenceTypeParameters = 212,
+    TSQualifiedNameLeft = 213,
+    TSQualifiedNameRight = 214,
+    TSTypeParameterInstantiationParams = 215,
+    TSTypeParameterName = 216,
+    TSTypeParameterConstraint = 217,
+    TSTypeParameterDefault = 218,
+    TSTypeParameterDeclarationParams = 219,
+    TSTypeAliasDeclarationId = 220,
+    TSTypeAliasDeclarationTypeParameters = 221,
+    TSTypeAliasDeclarationTypeAnnotation = 222,
+    TSClassImplementsExpression = 223,
+    TSClassImplementsTypeParameters = 224,
+    TSInterfaceDeclarationId = 225,
+    TSInterfaceDeclarationExtends = 226,
+    TSInterfaceDeclarationTypeParameters = 227,
+    TSInterfaceDeclarationBody = 228,
+    TSInterfaceBodyBody = 229,
+    TSPropertySignatureKey = 230,
+    TSPropertySignatureTypeAnnotation = 231,
+    TSIndexSignatureParameters = 232,
+    TSIndexSignatureTypeAnnotation = 233,
+    TSCallSignatureDeclarationTypeParameters = 234,
+    TSCallSignatureDeclarationThisParam = 235,
+    TSCallSignatureDeclarationParams = 236,
+    TSCallSignatureDeclarationReturnType = 237,
+    TSMethodSignatureKey = 238,
+    TSMethodSignatureTypeParameters = 239,
+    TSMethodSignatureThisParam = 240,
+    TSMethodSignatureParams = 241,
+    TSMethodSignatureReturnType = 242,
+    TSConstructSignatureDeclarationTypeParameters = 243,
+    TSConstructSignatureDeclarationParams = 244,
+    TSConstructSignatureDeclarationReturnType = 245,
+    TSIndexSignatureNameTypeAnnotation = 246,
+    TSInterfaceHeritageExpression = 247,
+    TSInterfaceHeritageTypeParameters = 248,
+    TSTypePredicateParameterName = 249,
+    TSTypePredicateTypeAnnotation = 250,
+    TSModuleDeclarationId = 251,
+    TSModuleDeclarationBody = 252,
+    TSModuleBlockDirectives = 253,
+    TSModuleBlockBody = 254,
+    TSTypeLiteralMembers = 255,
+    TSInferTypeTypeParameter = 256,
+    TSTypeQueryExprName = 257,
+    TSTypeQueryTypeParameters = 258,
+    TSImportTypeParameter = 259,
+    TSImportTypeQualifier = 260,
+    TSImportTypeAttributes = 261,
+    TSImportTypeTypeParameters = 262,
+    TSImportAttributesAttributesKeyword = 263,
+    TSImportAttributesElements = 264,
+    TSImportAttributeName = 265,
+    TSImportAttributeValue = 266,
+    TSFunctionTypeTypeParameters = 267,
+    TSFunctionTypeThisParam = 268,
+    TSFunctionTypeParams = 269,
+    TSFunctionTypeReturnType = 270,
+    TSConstructorTypeTypeParameters = 271,
+    TSConstructorTypeParams = 272,
+    TSConstructorTypeReturnType = 273,
+    TSMappedTypeTypeParameter = 274,
+    TSMappedTypeNameType = 275,
+    TSMappedTypeTypeAnnotation = 276,
+    TSTemplateLiteralTypeQuasis = 277,
+    TSTemplateLiteralTypeTypes = 278,
+    TSAsExpressionExpression = 279,
+    TSAsExpressionTypeAnnotation = 280,
+    TSSatisfiesExpressionExpression = 281,
+    TSSatisfiesExpressionTypeAnnotation = 282,
+    TSTypeAssertionExpression = 283,
+    TSTypeAssertionTypeAnnotation = 284,
+    TSImportEqualsDeclarationId = 285,
+    TSImportEqualsDeclarationModuleReference = 286,
+    TSExternalModuleReferenceExpression = 287,
+    TSNonNullExpressionExpression = 288,
+    DecoratorExpression = 289,
+    TSExportAssignmentExpression = 290,
+    TSNamespaceExportDeclarationId = 291,
+    TSInstantiationExpressionExpression = 292,
+    TSInstantiationExpressionTypeParameters = 293,
+    JSDocNullableTypeTypeAnnotation = 294,
+    JSDocNonNullableTypeTypeAnnotation = 295,
 }
 
 /// Ancestor type used in AST traversal.
@@ -649,6 +651,10 @@ pub enum Ancestor<'a, 't> {
         AncestorType::JSXOpeningElementTypeParameters as u16,
     JSXClosingElementName(JSXClosingElementWithoutName<'a, 't>) =
         AncestorType::JSXClosingElementName as u16,
+    JSXFragmentOpeningFragment(JSXFragmentWithoutOpeningFragment<'a, 't>) =
+        AncestorType::JSXFragmentOpeningFragment as u16,
+    JSXFragmentClosingFragment(JSXFragmentWithoutClosingFragment<'a, 't>) =
+        AncestorType::JSXFragmentClosingFragment as u16,
     JSXFragmentChildren(JSXFragmentWithoutChildren<'a, 't>) =
         AncestorType::JSXFragmentChildren as u16,
     JSXNamespacedNameNamespace(JSXNamespacedNameWithoutNamespace<'a, 't>) =
@@ -1445,7 +1451,12 @@ impl<'a, 't> Ancestor<'a, 't> {
 
     #[inline]
     pub fn is_jsx_fragment(self) -> bool {
-        matches!(self, Self::JSXFragmentChildren(_))
+        matches!(
+            self,
+            Self::JSXFragmentOpeningFragment(_)
+                | Self::JSXFragmentClosingFragment(_)
+                | Self::JSXFragmentChildren(_)
+        )
     }
 
     #[inline]
@@ -2370,6 +2381,8 @@ impl<'a, 't> GetAddress for Ancestor<'a, 't> {
             Self::JSXOpeningElementAttributes(a) => a.address(),
             Self::JSXOpeningElementTypeParameters(a) => a.address(),
             Self::JSXClosingElementName(a) => a.address(),
+            Self::JSXFragmentOpeningFragment(a) => a.address(),
+            Self::JSXFragmentClosingFragment(a) => a.address(),
             Self::JSXFragmentChildren(a) => a.address(),
             Self::JSXNamespacedNameNamespace(a) => a.address(),
             Self::JSXNamespacedNameProperty(a) => a.address(),
@@ -10577,6 +10590,80 @@ pub(crate) const OFFSET_JSX_FRAGMENT_OPENING_FRAGMENT: usize =
 pub(crate) const OFFSET_JSX_FRAGMENT_CLOSING_FRAGMENT: usize =
     offset_of!(JSXFragment, closing_fragment);
 pub(crate) const OFFSET_JSX_FRAGMENT_CHILDREN: usize = offset_of!(JSXFragment, children);
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
+pub struct JSXFragmentWithoutOpeningFragment<'a, 't>(
+    pub(crate) *const JSXFragment<'a>,
+    pub(crate) PhantomData<&'t ()>,
+);
+
+impl<'a, 't> JSXFragmentWithoutOpeningFragment<'a, 't> {
+    #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_JSX_FRAGMENT_SPAN) as *const Span) }
+    }
+
+    #[inline]
+    pub fn closing_fragment(self) -> &'t JSXClosingFragment {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_JSX_FRAGMENT_CLOSING_FRAGMENT)
+                as *const JSXClosingFragment)
+        }
+    }
+
+    #[inline]
+    pub fn children(self) -> &'t Vec<'a, JSXChild<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_JSX_FRAGMENT_CHILDREN)
+                as *const Vec<'a, JSXChild<'a>>)
+        }
+    }
+}
+
+impl<'a, 't> GetAddress for JSXFragmentWithoutOpeningFragment<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
+pub struct JSXFragmentWithoutClosingFragment<'a, 't>(
+    pub(crate) *const JSXFragment<'a>,
+    pub(crate) PhantomData<&'t ()>,
+);
+
+impl<'a, 't> JSXFragmentWithoutClosingFragment<'a, 't> {
+    #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe { &*((self.0 as *const u8).add(OFFSET_JSX_FRAGMENT_SPAN) as *const Span) }
+    }
+
+    #[inline]
+    pub fn opening_fragment(self) -> &'t JSXOpeningFragment {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_JSX_FRAGMENT_OPENING_FRAGMENT)
+                as *const JSXOpeningFragment)
+        }
+    }
+
+    #[inline]
+    pub fn children(self) -> &'t Vec<'a, JSXChild<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_JSX_FRAGMENT_CHILDREN)
+                as *const Vec<'a, JSXChild<'a>>)
+        }
+    }
+}
+
+impl<'a, 't> GetAddress for JSXFragmentWithoutClosingFragment<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]

--- a/crates/oxc_traverse/src/generated/traverse.rs
+++ b/crates/oxc_traverse/src/generated/traverse.rs
@@ -1308,6 +1308,36 @@ pub trait Traverse<'a> {
     fn exit_jsx_fragment(&mut self, node: &mut JSXFragment<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
+    fn enter_jsx_opening_fragment(
+        &mut self,
+        node: &mut JSXOpeningFragment,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_jsx_opening_fragment(
+        &mut self,
+        node: &mut JSXOpeningFragment,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
+    fn enter_jsx_closing_fragment(
+        &mut self,
+        node: &mut JSXClosingFragment,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+    #[inline]
+    fn exit_jsx_closing_fragment(
+        &mut self,
+        node: &mut JSXClosingFragment,
+        ctx: &mut TraverseCtx<'a>,
+    ) {
+    }
+
+    #[inline]
     fn enter_jsx_element_name(&mut self, node: &mut JSXElementName<'a>, ctx: &mut TraverseCtx<'a>) {
     }
     #[inline]

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -3240,9 +3240,23 @@ unsafe fn walk_jsx_fragment<'a, Tr: Traverse<'a>>(
     ctx: &mut TraverseCtx<'a>,
 ) {
     traverser.enter_jsx_fragment(&mut *node, ctx);
-    let pop_token = ctx.push_stack(Ancestor::JSXFragmentChildren(
-        ancestor::JSXFragmentWithoutChildren(node, PhantomData),
+    let pop_token = ctx.push_stack(Ancestor::JSXFragmentOpeningFragment(
+        ancestor::JSXFragmentWithoutOpeningFragment(node, PhantomData),
     ));
+    walk_jsx_opening_fragment(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_JSX_FRAGMENT_OPENING_FRAGMENT)
+            as *mut JSXOpeningFragment,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::JSXFragmentClosingFragment);
+    walk_jsx_closing_fragment(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_JSX_FRAGMENT_CLOSING_FRAGMENT)
+            as *mut JSXClosingFragment,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::JSXFragmentChildren);
     for item in
         &mut *((node as *mut u8).add(ancestor::OFFSET_JSX_FRAGMENT_CHILDREN) as *mut Vec<JSXChild>)
     {
@@ -3250,6 +3264,24 @@ unsafe fn walk_jsx_fragment<'a, Tr: Traverse<'a>>(
     }
     ctx.pop_stack(pop_token);
     traverser.exit_jsx_fragment(&mut *node, ctx);
+}
+
+unsafe fn walk_jsx_opening_fragment<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSXOpeningFragment,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_jsx_opening_fragment(&mut *node, ctx);
+    traverser.exit_jsx_opening_fragment(&mut *node, ctx);
+}
+
+unsafe fn walk_jsx_closing_fragment<'a, Tr: Traverse<'a>>(
+    traverser: &mut Tr,
+    node: *mut JSXClosingFragment,
+    ctx: &mut TraverseCtx<'a>,
+) {
+    traverser.enter_jsx_closing_fragment(&mut *node, ctx);
+    traverser.exit_jsx_closing_fragment(&mut *node, ctx);
 }
 
 unsafe fn walk_jsx_element_name<'a, Tr: Traverse<'a>>(

--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -22,7 +22,7 @@ use super::define_generator;
 /// Types to omit creating an `AstKind` for.
 ///
 /// Apart from this list every type with `#[ast(visit)]` attr gets an `AstKind`.
-const BLACK_LIST: [&str; 62] = [
+const BLACK_LIST: [&str; 64] = [
     "Span",
     "Expression",
     "ObjectPropertyKind",
@@ -50,6 +50,8 @@ const BLACK_LIST: [&str; 62] = [
     "ImportAttributeKey",
     "ExportDefaultDeclarationKind",
     "ModuleExportName",
+    "JSXOpeningFragment",
+    "JSXClosingFragment",
     "TSEnumMemberName",
     "TSLiteral",
     "TSType",


### PR DESCRIPTION
Add visitors for `JSXOpeningFragment` and `JSXClosingFragment` to `Visit` and `VisitMut`.

Because these nodes were not visited, their `Span`s also did not get visited when converting `Span`s from UTF-8 to UTF-16, and they retained UTF-8 offsets.

Any other visitors using `Visit::visit_span` / `VisitMut::visit_span` would have also been affected by this bug.
