### PR TITLE
refactor(ast): re-order `ExportDefaultDeclaration` fields

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -2474,9 +2474,9 @@ pub struct ExportNamedDeclaration<'a> {
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 pub struct ExportDefaultDeclaration<'a> {
     pub span: Span,
-    pub declaration: ExportDefaultDeclarationKind<'a>,
     #[estree(skip)]
     pub exported: ModuleExportName<'a>, // the `default` Keyword
+    pub declaration: ExportDefaultDeclarationKind<'a>,
 }
 
 /// Export All Declaration

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -724,8 +724,8 @@ const _: () = {
     assert!(size_of::<ExportDefaultDeclaration>() == 72);
     assert!(align_of::<ExportDefaultDeclaration>() == 8);
     assert!(offset_of!(ExportDefaultDeclaration, span) == 0);
-    assert!(offset_of!(ExportDefaultDeclaration, declaration) == 8);
-    assert!(offset_of!(ExportDefaultDeclaration, exported) == 24);
+    assert!(offset_of!(ExportDefaultDeclaration, exported) == 8);
+    assert!(offset_of!(ExportDefaultDeclaration, declaration) == 56);
 
     assert!(size_of::<ExportAllDeclaration>() == 112);
     assert!(align_of::<ExportAllDeclaration>() == 8);
@@ -2301,8 +2301,8 @@ const _: () = {
     assert!(size_of::<ExportDefaultDeclaration>() == 44);
     assert!(align_of::<ExportDefaultDeclaration>() == 4);
     assert!(offset_of!(ExportDefaultDeclaration, span) == 0);
-    assert!(offset_of!(ExportDefaultDeclaration, declaration) == 8);
-    assert!(offset_of!(ExportDefaultDeclaration, exported) == 16);
+    assert!(offset_of!(ExportDefaultDeclaration, exported) == 8);
+    assert!(offset_of!(ExportDefaultDeclaration, declaration) == 36);
 
     assert!(size_of::<ExportAllDeclaration>() == 68);
     assert!(align_of::<ExportAllDeclaration>() == 4);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -6431,19 +6431,19 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `declaration`
     /// * `exported`
+    /// * `declaration`
     #[inline]
     pub fn module_declaration_export_default_declaration(
         self,
         span: Span,
-        declaration: ExportDefaultDeclarationKind<'a>,
         exported: ModuleExportName<'a>,
+        declaration: ExportDefaultDeclarationKind<'a>,
     ) -> ModuleDeclaration<'a> {
         ModuleDeclaration::ExportDefaultDeclaration(self.alloc_export_default_declaration(
             span,
-            declaration,
             exported,
+            declaration,
         ))
     }
 
@@ -7060,16 +7060,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `declaration`
     /// * `exported`
+    /// * `declaration`
     #[inline]
     pub fn export_default_declaration(
         self,
         span: Span,
-        declaration: ExportDefaultDeclarationKind<'a>,
         exported: ModuleExportName<'a>,
+        declaration: ExportDefaultDeclarationKind<'a>,
     ) -> ExportDefaultDeclaration<'a> {
-        ExportDefaultDeclaration { span, declaration, exported }
+        ExportDefaultDeclaration { span, exported, declaration }
     }
 
     /// Build an [`ExportDefaultDeclaration`], and store it in the memory arena.
@@ -7078,16 +7078,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `declaration`
     /// * `exported`
+    /// * `declaration`
     #[inline]
     pub fn alloc_export_default_declaration(
         self,
         span: Span,
-        declaration: ExportDefaultDeclarationKind<'a>,
         exported: ModuleExportName<'a>,
+        declaration: ExportDefaultDeclarationKind<'a>,
     ) -> Box<'a, ExportDefaultDeclaration<'a>> {
-        Box::new_in(self.export_default_declaration(span, declaration, exported), self.allocator)
+        Box::new_in(self.export_default_declaration(span, exported, declaration), self.allocator)
     }
 
     /// Build an [`ExportAllDeclaration`].

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -2273,8 +2273,8 @@ impl<'new_alloc> CloneIn<'new_alloc> for ExportDefaultDeclaration<'_> {
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         ExportDefaultDeclaration {
             span: CloneIn::clone_in(&self.span, allocator),
-            declaration: CloneIn::clone_in(&self.declaration, allocator),
             exported: CloneIn::clone_in(&self.exported, allocator),
+            declaration: CloneIn::clone_in(&self.declaration, allocator),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -1353,8 +1353,8 @@ impl ContentEq for ExportNamedDeclaration<'_> {
 
 impl ContentEq for ExportDefaultDeclaration<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.declaration, &other.declaration)
-            && ContentEq::content_eq(&self.exported, &other.exported)
+        ContentEq::content_eq(&self.exported, &other.exported)
+            && ContentEq::content_eq(&self.declaration, &other.declaration)
     }
 }
 

--- a/crates/oxc_ast/src/generated/visit.rs
+++ b/crates/oxc_ast/src/generated/visit.rs
@@ -2811,8 +2811,8 @@ pub mod walk {
         let kind = AstKind::ExportDefaultDeclaration(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
-        visitor.visit_export_default_declaration_kind(&it.declaration);
         visitor.visit_module_export_name(&it.exported);
+        visitor.visit_export_default_declaration_kind(&it.declaration);
         visitor.leave_node(kind);
     }
 

--- a/crates/oxc_ast/src/generated/visit_mut.rs
+++ b/crates/oxc_ast/src/generated/visit_mut.rs
@@ -2921,8 +2921,8 @@ pub mod walk_mut {
         let kind = AstType::ExportDefaultDeclaration;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
-        visitor.visit_export_default_declaration_kind(&mut it.declaration);
         visitor.visit_module_export_name(&mut it.exported);
+        visitor.visit_export_default_declaration_kind(&mut it.declaration);
         visitor.leave_node(kind);
     }
 

--- a/crates/oxc_isolated_declarations/src/module.rs
+++ b/crates/oxc_isolated_declarations/src/module.rs
@@ -61,8 +61,8 @@ impl<'a> IsolatedDeclarations<'a> {
                 ModuleExportName::IdentifierName(self.ast.identifier_name(SPAN, "default"));
             let declaration = self.ast.module_declaration_export_default_declaration(
                 decl.span,
-                declaration,
                 exported,
+                declaration,
             );
             (var_decl, Statement::from(declaration))
         })

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -419,7 +419,7 @@ impl<'a> ParserImpl<'a> {
         };
         let exported = ModuleExportName::IdentifierName(exported);
         let span = self.end_span(span);
-        Ok(self.ast.alloc_export_default_declaration(span, declaration, exported))
+        Ok(self.ast.alloc_export_default_declaration(span, exported, declaration))
     }
 
     // export ExportFromClause FromClause ;

--- a/crates/oxc_semantic/tests/fixtures/oxc/ts/exports/default/type-alias.snap
+++ b/crates/oxc_semantic/tests/fixtures/oxc/ts/exports/default/type-alias.snap
@@ -27,7 +27,7 @@ input_file: crates/oxc_semantic/tests/fixtures/oxc/ts/exports/default/type-alias
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
-            "node_id": 6
+            "node_id": 7
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-type.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-type.snap
@@ -27,7 +27,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default-
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "T",
-            "node_id": 11
+            "node_id": 12
           }
         ]
       }

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2.snap
@@ -19,7 +19,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/export/default2
             "flags": "ReferenceFlags(Read)",
             "id": 0,
             "name": "a",
-            "node_id": 7
+            "node_id": 8
           }
         ]
       }

--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -903,10 +903,10 @@ impl<'a> LegacyDecorator<'a, '_> {
     ) -> Statement<'a> {
         let export_default_class_reference = ctx.ast.module_declaration_export_default_declaration(
             SPAN,
+            ctx.ast.module_export_name_identifier_name(SPAN, "default"),
             ExportDefaultDeclarationKind::Identifier(
                 ctx.ast.alloc(class_binding.create_read_reference(ctx)),
             ),
-            ctx.ast.module_export_name_identifier_name(SPAN, "default"),
         );
         Statement::from(export_default_class_reference)
     }

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -182,8 +182,8 @@ pub(crate) enum AncestorType {
     ExportNamedDeclarationSpecifiers = 159,
     ExportNamedDeclarationSource = 160,
     ExportNamedDeclarationWithClause = 161,
-    ExportDefaultDeclarationDeclaration = 162,
-    ExportDefaultDeclarationExported = 163,
+    ExportDefaultDeclarationExported = 162,
+    ExportDefaultDeclarationDeclaration = 163,
     ExportAllDeclarationExported = 164,
     ExportAllDeclarationSource = 165,
     ExportAllDeclarationWithClause = 166,
@@ -624,10 +624,10 @@ pub enum Ancestor<'a, 't> {
         AncestorType::ExportNamedDeclarationSource as u16,
     ExportNamedDeclarationWithClause(ExportNamedDeclarationWithoutWithClause<'a, 't>) =
         AncestorType::ExportNamedDeclarationWithClause as u16,
-    ExportDefaultDeclarationDeclaration(ExportDefaultDeclarationWithoutDeclaration<'a, 't>) =
-        AncestorType::ExportDefaultDeclarationDeclaration as u16,
     ExportDefaultDeclarationExported(ExportDefaultDeclarationWithoutExported<'a, 't>) =
         AncestorType::ExportDefaultDeclarationExported as u16,
+    ExportDefaultDeclarationDeclaration(ExportDefaultDeclarationWithoutDeclaration<'a, 't>) =
+        AncestorType::ExportDefaultDeclarationDeclaration as u16,
     ExportAllDeclarationExported(ExportAllDeclarationWithoutExported<'a, 't>) =
         AncestorType::ExportAllDeclarationExported as u16,
     ExportAllDeclarationSource(ExportAllDeclarationWithoutSource<'a, 't>) =
@@ -1404,8 +1404,8 @@ impl<'a, 't> Ancestor<'a, 't> {
     pub fn is_export_default_declaration(self) -> bool {
         matches!(
             self,
-            Self::ExportDefaultDeclarationDeclaration(_)
-                | Self::ExportDefaultDeclarationExported(_)
+            Self::ExportDefaultDeclarationExported(_)
+                | Self::ExportDefaultDeclarationDeclaration(_)
         )
     }
 
@@ -2367,8 +2367,8 @@ impl<'a, 't> GetAddress for Ancestor<'a, 't> {
             Self::ExportNamedDeclarationSpecifiers(a) => a.address(),
             Self::ExportNamedDeclarationSource(a) => a.address(),
             Self::ExportNamedDeclarationWithClause(a) => a.address(),
-            Self::ExportDefaultDeclarationDeclaration(a) => a.address(),
             Self::ExportDefaultDeclarationExported(a) => a.address(),
+            Self::ExportDefaultDeclarationDeclaration(a) => a.address(),
             Self::ExportAllDeclarationExported(a) => a.address(),
             Self::ExportAllDeclarationSource(a) => a.address(),
             Self::ExportAllDeclarationWithClause(a) => a.address(),
@@ -10009,41 +10009,10 @@ impl<'a, 't> GetAddress for ExportNamedDeclarationWithoutWithClause<'a, 't> {
 
 pub(crate) const OFFSET_EXPORT_DEFAULT_DECLARATION_SPAN: usize =
     offset_of!(ExportDefaultDeclaration, span);
-pub(crate) const OFFSET_EXPORT_DEFAULT_DECLARATION_DECLARATION: usize =
-    offset_of!(ExportDefaultDeclaration, declaration);
 pub(crate) const OFFSET_EXPORT_DEFAULT_DECLARATION_EXPORTED: usize =
     offset_of!(ExportDefaultDeclaration, exported);
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct ExportDefaultDeclarationWithoutDeclaration<'a, 't>(
-    pub(crate) *const ExportDefaultDeclaration<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> ExportDefaultDeclarationWithoutDeclaration<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_EXPORT_DEFAULT_DECLARATION_SPAN) as *const Span)
-        }
-    }
-
-    #[inline]
-    pub fn exported(self) -> &'t ModuleExportName<'a> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_EXPORT_DEFAULT_DECLARATION_EXPORTED)
-                as *const ModuleExportName<'a>)
-        }
-    }
-}
-
-impl<'a, 't> GetAddress for ExportDefaultDeclarationWithoutDeclaration<'a, 't> {
-    #[inline]
-    fn address(&self) -> Address {
-        Address::from_ptr(self.0)
-    }
-}
+pub(crate) const OFFSET_EXPORT_DEFAULT_DECLARATION_DECLARATION: usize =
+    offset_of!(ExportDefaultDeclaration, declaration);
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -10070,6 +10039,37 @@ impl<'a, 't> ExportDefaultDeclarationWithoutExported<'a, 't> {
 }
 
 impl<'a, 't> GetAddress for ExportDefaultDeclarationWithoutExported<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
+pub struct ExportDefaultDeclarationWithoutDeclaration<'a, 't>(
+    pub(crate) *const ExportDefaultDeclaration<'a>,
+    pub(crate) PhantomData<&'t ()>,
+);
+
+impl<'a, 't> ExportDefaultDeclarationWithoutDeclaration<'a, 't> {
+    #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_EXPORT_DEFAULT_DECLARATION_SPAN) as *const Span)
+        }
+    }
+
+    #[inline]
+    pub fn exported(self) -> &'t ModuleExportName<'a> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_EXPORT_DEFAULT_DECLARATION_EXPORTED)
+                as *const ModuleExportName<'a>)
+        }
+    }
+}
+
+impl<'a, 't> GetAddress for ExportDefaultDeclarationWithoutDeclaration<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -2994,20 +2994,20 @@ unsafe fn walk_export_default_declaration<'a, Tr: Traverse<'a>>(
     ctx: &mut TraverseCtx<'a>,
 ) {
     traverser.enter_export_default_declaration(&mut *node, ctx);
-    let pop_token = ctx.push_stack(Ancestor::ExportDefaultDeclarationDeclaration(
-        ancestor::ExportDefaultDeclarationWithoutDeclaration(node, PhantomData),
+    let pop_token = ctx.push_stack(Ancestor::ExportDefaultDeclarationExported(
+        ancestor::ExportDefaultDeclarationWithoutExported(node, PhantomData),
     ));
-    walk_export_default_declaration_kind(
-        traverser,
-        (node as *mut u8).add(ancestor::OFFSET_EXPORT_DEFAULT_DECLARATION_DECLARATION)
-            as *mut ExportDefaultDeclarationKind,
-        ctx,
-    );
-    ctx.retag_stack(AncestorType::ExportDefaultDeclarationExported);
     walk_module_export_name(
         traverser,
         (node as *mut u8).add(ancestor::OFFSET_EXPORT_DEFAULT_DECLARATION_EXPORTED)
             as *mut ModuleExportName,
+        ctx,
+    );
+    ctx.retag_stack(AncestorType::ExportDefaultDeclarationDeclaration);
+    walk_export_default_declaration_kind(
+        traverser,
+        (node as *mut u8).add(ancestor::OFFSET_EXPORT_DEFAULT_DECLARATION_DECLARATION)
+            as *mut ExportDefaultDeclarationKind,
         ctx,
     );
     ctx.pop_stack(pop_token);


### PR DESCRIPTION
`ExportDefaultDeclaration` has a field `exported` which represents the `default` keyword. Our convention is that fields are ordered in source code order or evaluation order. Move `exported` field to before `declaration`.
