### PR TITLE
feat(linter): support allowable method diagnostic for `eslint/no-console`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -11,12 +11,18 @@ use crate::{
 };
 
 fn no_console_diagnostic(span: Span, allow: &Vec<CompactStr>) -> OxcDiagnostic {
-    OxcDiagnostic::warn(format!(
-        "eslint(no-console): Unexpected console statement. Only supported methods: {}",
-        allow.iter().map(|s| s.to_string()).collect::<Vec<String>>().join(", ")
-    ))
-    .with_label(span)
-    .with_help("Delete this console statement.")
+    let only_msg = if allow.is_empty() {
+        "".to_string()
+    } else {
+        format!(
+            "Only supported methods: {}",
+            allow.iter().map(|s| s.to_string()).collect::<Vec<String>>().join(", ")
+        )
+    };
+
+    OxcDiagnostic::warn(format!("eslint(no-console): Unexpected console statement. {}", only_msg))
+        .with_label(span)
+        .with_help("Delete this console statement.")
 }
 
 #[derive(Debug, Default, Clone)]

--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -10,17 +10,17 @@ use crate::{
     rule::Rule,
 };
 
-fn no_console_diagnostic(span: Span, allow: &Vec<CompactStr>) -> OxcDiagnostic {
+fn no_console_diagnostic(span: Span, allow: &[CompactStr]) -> OxcDiagnostic {
     let only_msg = if allow.is_empty() {
-        "".to_string()
+        String::new()
     } else {
         format!(
             "Only supported methods: {}",
-            allow.iter().map(|s| s.to_string()).collect::<Vec<String>>().join(", ")
+            allow.iter().map(ToString::to_string).collect::<Vec<String>>().join(", ")
         )
     };
 
-    OxcDiagnostic::warn(format!("eslint(no-console): Unexpected console statement. {}", only_msg))
+    OxcDiagnostic::warn(format!("eslint(no-console): Unexpected console statement. {only_msg}"))
         .with_label(span)
         .with_help("Delete this console statement.")
 }

--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -16,7 +16,7 @@ fn no_console_diagnostic(span: Span, allow: &[CompactStr]) -> OxcDiagnostic {
     } else {
         format!(
             "Only supported methods: {}",
-            allow.iter().map(ToString::to_string).collect::<Vec<String>>().join(", ")
+            allow.iter().map(oxc_span::CompactStr::as_str).join(",")
         )
     };
 

--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -14,10 +14,7 @@ fn no_console_diagnostic(span: Span, allow: &[CompactStr]) -> OxcDiagnostic {
     let only_msg = if allow.is_empty() {
         String::new()
     } else {
-        format!(
-            "Only supported methods: {}",
-            allow.iter().map(oxc_span::CompactStr::as_str).join(",")
-        )
+        format!("Only supported methods: {}", allow.join(","))
     };
 
     OxcDiagnostic::warn(format!("eslint(no-console): Unexpected console statement. {only_msg}"))

--- a/crates/oxc_linter/src/snapshots/eslint_no_console.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_console.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/oxc_linter/src/tester.rs
+assertion_line: 357
 ---
   ⚠ eslint(no-console): eslint(no-console): Unexpected console statement.
    ╭─[no_console.tsx:1:1]
@@ -50,56 +51,56 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Delete this console statement.
 
-  ⚠ eslint(no-console): eslint(no-console): Unexpected console statement.
+  ⚠ eslint(no-console): eslint(no-console): Unexpected console statement. Only supported methods: error
    ╭─[no_console.tsx:1:1]
  1 │ console.log(foo)
    · ───────────
    ╰────
   help: Delete this console statement.
 
-  ⚠ eslint(no-console): eslint(no-console): Unexpected console statement.
+  ⚠ eslint(no-console): eslint(no-console): Unexpected console statement. Only supported methods: warn
    ╭─[no_console.tsx:1:1]
  1 │ console.error(foo)
    · ─────────────
    ╰────
   help: Delete this console statement.
 
-  ⚠ eslint(no-console): eslint(no-console): Unexpected console statement.
+  ⚠ eslint(no-console): eslint(no-console): Unexpected console statement. Only supported methods: log
    ╭─[no_console.tsx:1:1]
  1 │ console.info(foo)
    · ────────────
    ╰────
   help: Delete this console statement.
 
-  ⚠ eslint(no-console): eslint(no-console): Unexpected console statement.
+  ⚠ eslint(no-console): eslint(no-console): Unexpected console statement. Only supported methods: error
    ╭─[no_console.tsx:1:1]
  1 │ console.warn(foo)
    · ────────────
    ╰────
   help: Delete this console statement.
 
-  ⚠ eslint(no-console): eslint(no-console): Unexpected console statement.
+  ⚠ eslint(no-console): eslint(no-console): Unexpected console statement. Only supported methods: warn, info
    ╭─[no_console.tsx:1:1]
  1 │ console.log(foo)
    · ───────────
    ╰────
   help: Delete this console statement.
 
-  ⚠ eslint(no-console): eslint(no-console): Unexpected console statement.
+  ⚠ eslint(no-console): eslint(no-console): Unexpected console statement. Only supported methods: warn, info, log
    ╭─[no_console.tsx:1:1]
  1 │ console.error(foo)
    · ─────────────
    ╰────
   help: Delete this console statement.
 
-  ⚠ eslint(no-console): eslint(no-console): Unexpected console statement.
+  ⚠ eslint(no-console): eslint(no-console): Unexpected console statement. Only supported methods: warn, error, log
    ╭─[no_console.tsx:1:1]
  1 │ console.info(foo)
    · ────────────
    ╰────
   help: Delete this console statement.
 
-  ⚠ eslint(no-console): eslint(no-console): Unexpected console statement.
+  ⚠ eslint(no-console): eslint(no-console): Unexpected console statement. Only supported methods: info, log
    ╭─[no_console.tsx:1:1]
  1 │ console.warn(foo)
    · ────────────

--- a/crates/oxc_linter/src/snapshots/eslint_no_console.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_console.snap
@@ -79,28 +79,28 @@ assertion_line: 357
    ╰────
   help: Delete this console statement.
 
-  ⚠ eslint(no-console): eslint(no-console): Unexpected console statement. Only supported methods: warn, info
+  ⚠ eslint(no-console): eslint(no-console): Unexpected console statement. Only supported methods: warn,info
    ╭─[no_console.tsx:1:1]
  1 │ console.log(foo)
    · ───────────
    ╰────
   help: Delete this console statement.
 
-  ⚠ eslint(no-console): eslint(no-console): Unexpected console statement. Only supported methods: warn, info, log
+  ⚠ eslint(no-console): eslint(no-console): Unexpected console statement. Only supported methods: warn,info,log
    ╭─[no_console.tsx:1:1]
  1 │ console.error(foo)
    · ─────────────
    ╰────
   help: Delete this console statement.
 
-  ⚠ eslint(no-console): eslint(no-console): Unexpected console statement. Only supported methods: warn, error, log
+  ⚠ eslint(no-console): eslint(no-console): Unexpected console statement. Only supported methods: warn,error,log
    ╭─[no_console.tsx:1:1]
  1 │ console.info(foo)
    · ────────────
    ╰────
   help: Delete this console statement.
 
-  ⚠ eslint(no-console): eslint(no-console): Unexpected console statement. Only supported methods: info, log
+  ⚠ eslint(no-console): eslint(no-console): Unexpected console statement. Only supported methods: info,log
    ╭─[no_console.tsx:1:1]
  1 │ console.warn(foo)
    · ────────────


### PR DESCRIPTION
- Modified `no_console_diagnostic` function to add a list of allowed methods argument
- Include the list of allowed console methods in the prompt message.
- Updated diagnostic calls to support passing information about allowed methods.