### PR TITLE
fix(minifier): do not remove `=== 0` if the lhs can be NaN

### DIFF
--- a/crates/oxc_ecmascript/src/constant_evaluation/is_int32_or_uint32.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/is_int32_or_uint32.rs
@@ -1,0 +1,82 @@
+use num_traits::ToPrimitive;
+use oxc_ast::ast::*;
+
+use crate::is_global_reference::IsGlobalReference;
+
+use super::DetermineValueType;
+
+pub trait IsInt32OrUint32 {
+    /// Whether the value of the expression is a int32 or uint32.
+    /// If this method returns `true`, we know that the value cannot be NaN or Infinity.
+    ///
+    /// - true means it is int32 or uint32.
+    /// - false means it is neither int32 nor uint32, or it is unknown.
+    ///
+    /// Based on <https://github.com/evanw/esbuild/blob/v0.25.0/internal/js_ast/js_ast_helpers.go#L950>
+    fn is_int32_or_uint32(&self, is_global_reference: &impl IsGlobalReference) -> bool;
+}
+
+impl IsInt32OrUint32 for Expression<'_> {
+    fn is_int32_or_uint32(&self, is_global_reference: &impl IsGlobalReference) -> bool {
+        match self {
+            Expression::NumericLiteral(n) => n.is_int32_or_uint32(is_global_reference),
+            Expression::UnaryExpression(e) => e.is_int32_or_uint32(is_global_reference),
+            Expression::BinaryExpression(e) => e.is_int32_or_uint32(is_global_reference),
+            Expression::LogicalExpression(e) => e.is_int32_or_uint32(is_global_reference),
+            Expression::ConditionalExpression(e) => {
+                e.consequent.is_int32_or_uint32(is_global_reference)
+                    && e.alternate.is_int32_or_uint32(is_global_reference)
+            }
+            Expression::SequenceExpression(e) => {
+                e.expressions.last().is_some_and(|e| e.is_int32_or_uint32(is_global_reference))
+            }
+            Expression::ParenthesizedExpression(e) => {
+                e.expression.is_int32_or_uint32(is_global_reference)
+            }
+            _ => false,
+        }
+    }
+}
+
+impl IsInt32OrUint32 for NumericLiteral<'_> {
+    fn is_int32_or_uint32(&self, _is_global_reference: &impl IsGlobalReference) -> bool {
+        self.value.fract() == 0.0
+            && (self.value.to_i32().is_some() || self.value.to_u32().is_some())
+    }
+}
+
+impl IsInt32OrUint32 for UnaryExpression<'_> {
+    fn is_int32_or_uint32(&self, is_global_reference: &impl IsGlobalReference) -> bool {
+        match self.operator {
+            UnaryOperator::BitwiseNot => self.value_type(is_global_reference).is_number(),
+            UnaryOperator::UnaryPlus => self.argument.is_int32_or_uint32(is_global_reference),
+            _ => false,
+        }
+    }
+}
+
+impl IsInt32OrUint32 for BinaryExpression<'_> {
+    fn is_int32_or_uint32(&self, is_global_reference: &impl IsGlobalReference) -> bool {
+        match self.operator {
+            BinaryOperator::ShiftLeft
+            | BinaryOperator::ShiftRight
+            | BinaryOperator::BitwiseAnd
+            | BinaryOperator::BitwiseOR
+            | BinaryOperator::BitwiseXOR => self.value_type(is_global_reference).is_number(),
+            BinaryOperator::ShiftRightZeroFill => true,
+            _ => false,
+        }
+    }
+}
+
+impl IsInt32OrUint32 for LogicalExpression<'_> {
+    fn is_int32_or_uint32(&self, is_global_reference: &impl IsGlobalReference) -> bool {
+        match self.operator {
+            LogicalOperator::And | LogicalOperator::Or => {
+                self.left.is_int32_or_uint32(is_global_reference)
+                    && self.right.is_int32_or_uint32(is_global_reference)
+            }
+            LogicalOperator::Coalesce => self.left.is_int32_or_uint32(is_global_reference),
+        }
+    }
+}

--- a/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
+++ b/crates/oxc_ecmascript/src/constant_evaluation/mod.rs
@@ -12,9 +12,11 @@ use crate::{
 };
 
 mod equality_comparison;
+mod is_int32_or_uint32;
 mod is_literal_value;
 mod value;
 mod value_type;
+pub use is_int32_or_uint32::IsInt32OrUint32;
 pub use is_literal_value::IsLiteralValue;
 pub use value::ConstantValue;
 pub use value_type::{DetermineValueType, ValueType};

--- a/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
@@ -1,5 +1,5 @@
 use oxc_ast::ast::*;
-use oxc_ecmascript::constant_evaluation::{ConstantEvaluation, DetermineValueType};
+use oxc_ecmascript::constant_evaluation::{ConstantEvaluation, IsInt32OrUint32};
 use oxc_span::GetSpan;
 use oxc_traverse::Ancestor;
 
@@ -53,7 +53,7 @@ impl<'a> PeepholeOptimizations {
             Expression::BinaryExpression(e)
                 if e.operator.is_equality()
                     && matches!(&e.right, Expression::NumericLiteral(lit) if lit.value == 0.0)
-                    && e.left.value_type(&ctx).is_number() =>
+                    && e.left.is_int32_or_uint32(&ctx) =>
             {
                 let argument = ctx.ast.move_expression(&mut e.left);
                 *expr = if matches!(
@@ -151,5 +151,6 @@ mod test {
         test("if (anything1 ? anything2 : (0, true));", "!anything1 || anything2");
         test("if (anything1 ? anything2 : (0, false));", "anything1 && anything2");
         test("if(!![]);", "");
+        test("if (+a === 0) { b } else { c }", "+a == 0 ? b : c"); // should not be folded to `a ? b : c` (`+a` might be NaN)
     }
 }

--- a/crates/oxc_minifier/tests/ecmascript/is_int32_or_uint32.rs
+++ b/crates/oxc_minifier/tests/ecmascript/is_int32_or_uint32.rs
@@ -1,0 +1,115 @@
+use oxc_allocator::Allocator;
+use oxc_ast::ast::Statement;
+use oxc_ecmascript::{
+    constant_evaluation::IsInt32OrUint32, is_global_reference::WithoutGlobalReferenceInformation,
+};
+use oxc_parser::Parser;
+use oxc_span::SourceType;
+
+fn test(source_text: &str, expected: bool) {
+    let allocator = Allocator::default();
+    let ret = Parser::new(&allocator, source_text, SourceType::mjs()).parse();
+    assert!(!ret.panicked, "{source_text}");
+    assert!(ret.errors.is_empty(), "{source_text}");
+
+    let Some(Statement::ExpressionStatement(stmt)) = &ret.program.body.first() else {
+        panic!("should have a expression statement body: {source_text}");
+    };
+    let result = stmt.expression.is_int32_or_uint32(&WithoutGlobalReferenceInformation {});
+    assert_eq!(result, expected, "{source_text}");
+}
+
+#[test]
+fn literal_tests() {
+    test("1n", false);
+    test("true", false);
+    test("null", false);
+    test("0", true);
+    test("-0", false);
+    test("0.1", false);
+    test("0/0", false);
+    test("1/0", false);
+    test("-1/0", false);
+    test("('')", false);
+}
+
+#[test]
+fn unary_tests() {
+    test("~foo", false); // maybe bigint
+    test("~+foo", true);
+    test("~0", true);
+
+    test("+foo", false); // maybe non-int32/uint32 number
+    test("+0", true);
+
+    test("void 0", false);
+    test("-foo", false);
+    test("!foo", false);
+    test("delete foo", false);
+    test("typeof foo", false);
+}
+
+#[test]
+fn binary_tests() {
+    test("foo << bar", false); // maybe bigint
+    test("foo << 0", true);
+    test("foo >> bar", false); // maybe bigint
+    test("foo >> 0", true);
+    test("foo >>> bar", true); // always number
+    test("foo & bar", false); // maybe bigint
+    test("foo & 0", true);
+    test("foo | bar", false); // maybe bigint
+    test("foo | 0", true);
+    test("foo ^ bar", false); // maybe bigint
+    test("foo ^ 0", true);
+
+    test("foo + bar", false);
+    test("foo - bar", false);
+    test("foo * bar", false);
+    test("foo / bar", false);
+    test("foo % bar", false);
+    test("foo ** bar", false);
+    test("foo instanceof Object", false);
+    test("'foo' in foo", false);
+    test("foo == bar", false);
+    test("foo != bar", false);
+    test("foo === bar", false);
+    test("foo !== bar", false);
+    test("foo < bar", false);
+    test("foo <= bar", false);
+    test("foo > bar", false);
+    test("foo >= bar", false);
+    test("#foo in bar", false);
+}
+
+#[test]
+fn sequence_tests() {
+    test("(1, 0)", true);
+    test("(1, foo)", false);
+}
+
+#[test]
+fn conditional_tests() {
+    test("foo ? 0 : 0.1", false);
+    test("foo ? 0.1 : 0", false);
+    test("foo ? 0 : 1", true);
+}
+
+#[test]
+fn logical_tests() {
+    test("~+foo && 0.1", false);
+    test("0.1 && ~+foo", false);
+    test("~+foo && 1", true);
+
+    test("~+foo || 0.1", false);
+    test("0.1 || ~+foo", false);
+    test("~+foo || 0", true);
+
+    test("~+foo ?? 0.1", true);
+    test("0.1 ?? ~+foo", false);
+}
+
+#[test]
+fn undetermined_tests() {
+    test("foo", false);
+}

--- a/crates/oxc_minifier/tests/ecmascript/mod.rs
+++ b/crates/oxc_minifier/tests/ecmascript/mod.rs
@@ -1,4 +1,5 @@
 mod array_join;
+mod is_int32_or_uint32;
 mod may_have_side_effects;
 mod prop_name;
 mod to_boolean;

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -11,17 +11,17 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 
 544.10 kB  | 71.38 kB   | 72.48 kB   | 25.85 kB   | 26.20 kB   | lodash.js 
 
-555.77 kB  | 270.83 kB  | 270.13 kB  | 88.26 kB   | 90.80 kB   | d3.js     
+555.77 kB  | 270.84 kB  | 270.13 kB  | 88.26 kB   | 90.80 kB   | d3.js     
 
 1.01 MB    | 440.17 kB  | 458.89 kB  | 122.38 kB  | 126.71 kB  | bundle.min.js
 
 1.25 MB    | 647.03 kB  | 646.76 kB  | 160.30 kB  | 163.73 kB  | three.js  
 
-2.14 MB    | 716.14 kB  | 724.14 kB  | 161.79 kB  | 181.07 kB  | victory.js
+2.14 MB    | 716.15 kB  | 724.14 kB  | 161.79 kB  | 181.07 kB  | victory.js
 
 3.20 MB    | 1.01 MB    | 1.01 MB    | 324.14 kB  | 331.56 kB  | echarts.js
 
-6.69 MB    | 2.28 MB    | 2.31 MB    | 466.11 kB  | 488.28 kB  | antd.js   
+6.69 MB    | 2.28 MB    | 2.31 MB    | 466.12 kB  | 488.28 kB  | antd.js   
 
-10.95 MB   | 3.35 MB    | 3.49 MB    | 861 kB     | 915.50 kB  | typescript.js
+10.95 MB   | 3.35 MB    | 3.49 MB    | 861.00 kB  | 915.50 kB  | typescript.js
 


### PR DESCRIPTION
Example problem code:
```js
function foo(a) {
  if (+a === 0) {
    console.log(true)
  } else {
    console.log(false)
  }
}
foo(NaN)
```