### PR TITLE
feat(minifier): concatenate strings with template literals on right side

### DIFF
--- a/crates/oxc_ecmascript/src/lib.rs
+++ b/crates/oxc_ecmascript/src/lib.rs
@@ -45,5 +45,6 @@ pub use self::{
     to_boolean::ToBoolean,
     to_int_32::ToInt32,
     to_number::ToNumber,
+    to_primitive::ToPrimitive,
     to_string::ToJsString,
 };

--- a/crates/oxc_ecmascript/src/to_primitive.rs
+++ b/crates/oxc_ecmascript/src/to_primitive.rs
@@ -13,7 +13,6 @@ pub enum ToPrimitiveResult {
     BigInt,
     String,
     Boolean,
-    #[expect(dead_code)]
     Symbol,
     Undetermined,
 }


### PR DESCRIPTION
Improve #9355 to handle cases on right side (e.g. ``foo() + `a${b}` + "b"`` -> `` foo() + `a${b}b` ``).