### PR TITLE
feat(linter): add `eslint/no-spaced-func`

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -125,6 +125,7 @@ mod eslint {
     pub mod no_self_compare;
     pub mod no_setter_return;
     pub mod no_shadow_restricted_names;
+    pub mod no_spaced_func;
     pub mod no_sparse_arrays;
     pub mod no_template_curly_in_string;
     pub mod no_ternary;
@@ -564,6 +565,7 @@ oxc_macros::declare_all_lint_rules! {
     eslint::max_lines,
     eslint::max_params,
     eslint::new_cap,
+    eslint::no_spaced_func,
     eslint::no_useless_call,
     eslint::no_unneeded_ternary,
     eslint::no_extra_label,

--- a/crates/oxc_linter/src/rules/eslint/no_spaced_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_spaced_func.rs
@@ -70,6 +70,12 @@ enum FuncSpace {
     Spaced(Span),
 }
 
+/// Given an identifier reference will determine
+/// if there is spacing in the span from the end of the
+/// identifier name to the next `(` char.
+///
+/// For example `foo  ()` would return `FuncSpace::Spaced(span)`
+/// where span refers to the whitespace between `foo` and `()`.
 fn is_ident_end_to_l_parens_whitespace(
     ctx: &LintContext,
     ident: &IdentifierReference,
@@ -121,10 +127,6 @@ impl Rule for NoSpacedFunc {
                     FuncSpace::NotSpaced => {}
                     FuncSpace::Spaced(span) => ctx.diagnostic(no_spaced_func_diagnostic(span)),
                 }
-                //if is_whitespace {
-                //    println!("error");
-                //    ctx.diagnostic(no_spaced_func_diagnostic(span_to_l_parens));
-                //}
             }
             Expression::StaticMemberExpression(exp) => {
                 let span_end = exp.span().end;
@@ -138,17 +140,6 @@ impl Rule for NoSpacedFunc {
             }
             _ => {} //     Expression::StaticMemberExpression(static_member_expression) => todo!(),
         }
-        //let Expression::FunctionExpression(func) = call_expr.callee else {
-        //    return;
-        //};
-        //println!("call_expr span {0:?}", func);
-
-        //        if let
-        // match on func call expression
-        // `foo  ( )`
-        //  ^^^
-        //let callee_ident_end: u32 =
-        //get call
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/no_spaced_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_spaced_func.rs
@@ -140,7 +140,6 @@ impl Rule for NoSpacedFunc {
             }
             // f.a ()
             Expression::StaticMemberExpression(exp) => {
-                //  let span_end = exp.span().end;
                 let ident_name_span_end = exp.property.span().end;
 
                 match get_substring_to_lparens(ctx, Span::new(ident_name_span_end, callee_end)) {

--- a/crates/oxc_linter/src/rules/eslint/no_spaced_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_spaced_func.rs
@@ -117,9 +117,9 @@ impl Rule for NoSpacedFunc {
         let callee_end = call_expr.span().end; //.contains_inclusive();
         println!("callee_end {0:?}", callee_end);
         println!("{node:?}");
-        let ss = call_expr.callee.get_inner_expression(); //.contains_inclusive();
+        let callee = call_expr.callee.get_inner_expression(); //.contains_inclusive();
 
-        match ss.without_parentheses() {
+        match callee.without_parentheses() {
             // f()
             Expression::Identifier(ident) => {
                 let ident_end = ident.span().end;
@@ -146,6 +146,13 @@ impl Rule for NoSpacedFunc {
                 println!("static ident name {0:?}", ident.name);
 
                 match is_ident_end_to_l_parens_whitespace(ctx, ident_name_span_end, callee_end) {
+                    FuncSpace::NotSpaced => {}
+                    FuncSpace::Spaced(span) => ctx.diagnostic(no_spaced_func_diagnostic(span)),
+                }
+            }
+            // function(){ }() <-- second parens
+            Expression::FunctionExpression(func) => {
+                match is_ident_end_to_l_parens_whitespace(ctx, func.span().end, callee_end) {
                     FuncSpace::NotSpaced => {}
                     FuncSpace::Spaced(span) => ctx.diagnostic(no_spaced_func_diagnostic(span)),
                 }

--- a/crates/oxc_linter/src/rules/eslint/no_spaced_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_spaced_func.rs
@@ -163,6 +163,7 @@ fn test() {
     let pass = vec![
         "foo(1);",
         "f();",
+        "f( );", // I added
         "f(a, b);",
         "a.b",  // I added
         "a. b", // I added
@@ -193,6 +194,7 @@ fn test() {
         "f.b().c ();",
         "f.b().c().d ();", // I added
         "f() ()",
+        "f( )( ) ( )", // I added
         "(function() {} ())",
         "var f = new Foo ()",
         "f ( (0) )",

--- a/crates/oxc_linter/src/rules/eslint/no_spaced_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_spaced_func.rs
@@ -80,24 +80,23 @@ fn is_ident_end_to_l_parens_whitespace(
     ident_end: u32,
     search_end: u32,
 ) -> FuncSpace {
-    let sx = Span::new(ident_end, search_end);
+    let source_span = Span::new(ident_end, search_end);
+    let src = ctx.source_range(source_span);
 
-    let src = ctx.source_range(sx);
-
-    let Some(r_parens_pos_usize) = memchr(b'(', src.as_bytes()) else {
+    let Some(char_count) = memchr(b'(', src.as_bytes()) else {
         return FuncSpace::NotSpaced;
     };
 
-    let l_parens_after_n_chars: u32 = u32::try_from(r_parens_pos_usize).unwrap();
-    let l_parens_pos = ident_end + l_parens_after_n_chars;
+    let char_count_to_l_parens: u32 = u32::try_from(char_count).unwrap();
+    let l_parens_pos = ident_end + char_count_to_l_parens;
     let span_to_l_parens = Span::new(ident_end, l_parens_pos);
-    let str_between_ident_and_l_parens = ctx.source_range(span_to_l_parens);
+    let src_to_l_parens = ctx.source_range(span_to_l_parens);
 
-    if str_between_ident_and_l_parens.is_empty() {
+    if src_to_l_parens.is_empty() {
         return FuncSpace::NotSpaced;
     }
 
-    if str_between_ident_and_l_parens.trim().is_empty() {
+    if src_to_l_parens.trim().is_empty() {
         return FuncSpace::Spaced(span_to_l_parens);
     } else {
         return FuncSpace::NotSpaced;

--- a/crates/oxc_linter/src/rules/eslint/no_spaced_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_spaced_func.rs
@@ -128,6 +128,14 @@ impl Rule for NoSpacedFunc {
                     FuncSpace::Spaced(span) => ctx.diagnostic(no_spaced_func_diagnostic(span)),
                 }
             }
+            // f() () <- case where the AST node if the second parens
+            // and we are matching on the first parens below.
+            Expression::CallExpression(c) => {
+                match is_ident_end_to_l_parens_whitespace(ctx, c.span().end, callee_end) {
+                    FuncSpace::NotSpaced => {}
+                    FuncSpace::Spaced(span) => ctx.diagnostic(no_spaced_func_diagnostic(span)),
+                }
+            }
             Expression::StaticMemberExpression(exp) => {
                 let span_end = exp.span().end;
                 let ident = &exp.property;

--- a/crates/oxc_linter/src/rules/eslint/no_spaced_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_spaced_func.rs
@@ -116,7 +116,7 @@ impl Rule for NoSpacedFunc {
 
         let callee_end = call_expr.span().end; //.contains_inclusive();
         println!("callee_end {0:?}", callee_end);
-
+        println!("{node:?}");
         let ss = call_expr.callee.get_inner_expression(); //.contains_inclusive();
 
         match ss {

--- a/crates/oxc_linter/src/rules/eslint/no_spaced_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_spaced_func.rs
@@ -54,7 +54,7 @@ declare_oxc_lint!(
     NoSpacedFunc,
     eslint,
     style,
-    pending
+    fix
 );
 
 #[derive(PartialEq, Debug)]
@@ -98,7 +98,9 @@ fn get_substring_to_lparens(ctx: &LintContext, search_span: Span) -> FuncSpace {
 fn check_ident_to_application(ctx: &LintContext, span: Span) {
     match get_substring_to_lparens(ctx, span) {
         FuncSpace::NotSpaced => {}
-        FuncSpace::Spaced(span) => ctx.diagnostic(no_spaced_func_diagnostic(span)),
+        FuncSpace::Spaced(span) => {
+            ctx.diagnostic_with_fix(no_spaced_func_diagnostic(span), |fixer| fixer.delete(&span));
+        }
     }
 }
 
@@ -201,14 +203,14 @@ fn test() {
 			 t   ();",
     ];
 
-    /*
-    Fix pending.
     let fix = vec![
         ("f ();", "f();", None),
         ("f (a, b);", "f(a, b);", None),
         (
             "f
-            ();", "f();", None,
+            ();",
+            "f();",
+            None,
         ),
         ("f.b ();", "f.b();", None),
         ("f.b().c ();", "f.b().c();", None),
@@ -226,9 +228,8 @@ fn test() {
             None,
         ),
     ];
-    */
 
     Tester::new(NoSpacedFunc::NAME, NoSpacedFunc::PLUGIN, pass, fail)
-        //.expect_fix(fix)
+        .expect_fix(fix)
         .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/rules/eslint/no_spaced_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_spaced_func.rs
@@ -76,7 +76,10 @@ fn get_substring_to_lparens(ctx: &LintContext, search_span: Span) -> FuncSpace {
         return FuncSpace::NotSpaced;
     };
 
-    let char_count_to_l_parens: u32 = u32::try_from(char_count).unwrap();
+    let Ok(char_count_to_l_parens) = u32::try_from(char_count) else {
+        return FuncSpace::NotSpaced;
+    };
+
     let l_parens_pos = search_span.start + char_count_to_l_parens;
     let span_to_l_parens = Span::new(search_span.start, l_parens_pos);
     let src_to_l_parens = ctx.source_range(span_to_l_parens);

--- a/crates/oxc_linter/src/rules/eslint/no_spaced_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_spaced_func.rs
@@ -1,17 +1,11 @@
 use memchr::memchr;
-use oxc_ast::AstKind::IdentifierName;
+use oxc_ast::AstKind;
 use oxc_ast::ast::Expression;
-use oxc_ast::{AstKind, ast::IdentifierReference};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
 
-use crate::{
-    AstNode,
-    context::LintContext,
-    fixer::{RuleFix, RuleFixer},
-    rule::Rule,
-};
+use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_spaced_func_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn(
@@ -92,9 +86,9 @@ fn get_substring_to_lparens(ctx: &LintContext, search_span: Span) -> FuncSpace {
     }
 
     if src_to_l_parens.trim().is_empty() {
-        return FuncSpace::Spaced(span_to_l_parens);
+        FuncSpace::Spaced(span_to_l_parens)
     } else {
-        return FuncSpace::NotSpaced;
+        FuncSpace::NotSpaced
     }
 }
 
@@ -127,14 +121,13 @@ impl Rule for NoSpacedFunc {
         match &call_expr.callee {
             // f ()
             Expression::Identifier(ident) => {
-                check_identifier_callee(ctx, ident.span().end, callee_end)
+                check_identifier_callee(ctx, ident.span().end, callee_end);
             }
-            Expression::ParenthesizedExpression(paren_exp) => match &paren_exp.expression {
-                Expression::Identifier(ident) => {
-                    check_identifier_callee(ctx, paren_exp.span().end, callee_end)
+            Expression::ParenthesizedExpression(paren_exp) => {
+                if let Expression::Identifier(_ident) = &paren_exp.expression {
+                    check_identifier_callee(ctx, paren_exp.span().end, callee_end);
                 }
-                _ => {}
-            },
+            }
             // f() () <-- second parens
             Expression::CallExpression(c) => {
                 match get_substring_to_lparens(ctx, Span::new(c.span().end, callee_end)) {
@@ -144,7 +137,7 @@ impl Rule for NoSpacedFunc {
             }
             // f.a ()
             Expression::StaticMemberExpression(exp) => {
-                let span_end = exp.span().end;
+                //  let span_end = exp.span().end;
                 let ident_name_span_end = exp.property.span().end;
 
                 match get_substring_to_lparens(ctx, Span::new(ident_name_span_end, callee_end)) {

--- a/crates/oxc_linter/src/rules/eslint/no_spaced_func.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_spaced_func.rs
@@ -1,6 +1,8 @@
 use memchr::memchr;
 use oxc_ast::AstKind;
+use oxc_ast::AstKind::IdentifierName;
 use oxc_ast::ast::Expression;
+//use oxc_ast::ast::ModuleExportName::IdentifierName;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
@@ -102,6 +104,16 @@ impl Rule for NoSpacedFunc {
                     ctx.diagnostic(no_spaced_func_diagnostic(span_to_l_parens));
                 }
             }
+            Expression::StaticMemberExpression(exp) => {
+                let span_end = exp.span().end;
+                let ident = &exp.property;
+                let ident_name_span = ident.span().end;
+
+                println!("static ident span {ident_name_span:?}");
+                println!("static ident name {0:?}", ident.name);
+                // need to check each method call in the chain i.e =f.a().b ()`
+                //let fst_method_call;
+            }
             _ => {} //     Expression::StaticMemberExpression(static_member_expression) => todo!(),
         }
         //let Expression::FunctionExpression(func) = call_expr.callee else {
@@ -126,9 +138,13 @@ fn test() {
         "foo(1);",
         "f();",
         "f(a, b);",
+        "a.b",  // I added
+        "a. b", // I added
         "f.b();",
         "f.b().c();",
+        "f.b(1).c( );", // I added
         "f()()",
+        "f()( )()", // I added
         "(function() {}())",
         "var f = new Foo()",
         "var f = new Foo",
@@ -149,6 +165,7 @@ fn test() {
 			();",
         "f.b ();",
         "f.b().c ();",
+        "f.b().c().d ();", // I added
         "f() ()",
         "(function() {} ())",
         "var f = new Foo ()",

--- a/crates/oxc_linter/src/snapshots/eslint_no_spaced_func.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_spaced_func.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/oxc_linter/src/tester.rs
-assertion_line: 357
 ---
   ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
    ╭─[no_spaced_func.tsx:1:2]

--- a/crates/oxc_linter/src/snapshots/eslint_no_spaced_func.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_spaced_func.snap
@@ -6,78 +6,91 @@ source: crates/oxc_linter/src/tester.rs
  1 │ f ();
    ·  ─
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
    ╭─[no_spaced_func.tsx:1:2]
  1 │ f (a, b);
    ·  ─
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
    ╭─[no_spaced_func.tsx:1:2]
  1 │ ╭─▶ f
  2 │ ╰─▶             ();
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
    ╭─[no_spaced_func.tsx:1:4]
  1 │ f.b ();
    ·    ─
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
    ╭─[no_spaced_func.tsx:1:8]
  1 │ f.b().c ();
    ·        ─
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
    ╭─[no_spaced_func.tsx:1:12]
  1 │ f.b().c().d ();
    ·            ─
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
    ╭─[no_spaced_func.tsx:1:4]
  1 │ f() ()
    ·    ─
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
    ╭─[no_spaced_func.tsx:1:6]
  1 │ f()() ()
    ·      ─
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
    ╭─[no_spaced_func.tsx:1:15]
  1 │ (function() {} ())
    ·               ─
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
    ╭─[no_spaced_func.tsx:1:16]
  1 │ var f = new Foo ()
    ·                ─
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
    ╭─[no_spaced_func.tsx:1:2]
  1 │ f ( (0) )
    ·  ─
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
    ╭─[no_spaced_func.tsx:1:5]
  1 │ f(0) (1)
    ·     ─
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
    ╭─[no_spaced_func.tsx:1:4]
  1 │ (f) (0)
    ·    ─
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
    ╭─[no_spaced_func.tsx:1:2]
@@ -85,6 +98,7 @@ source: crates/oxc_linter/src/tester.rs
    ·  ─
  2 │              t   ();
    ╰────
+  help: Delete this code.
 
   ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
    ╭─[no_spaced_func.tsx:2:6]
@@ -92,3 +106,4 @@ source: crates/oxc_linter/src/tester.rs
  2 │              t   ();
    ·               ───
    ╰────
+  help: Delete this code.

--- a/crates/oxc_linter/src/snapshots/eslint_no_spaced_func.snap.new
+++ b/crates/oxc_linter/src/snapshots/eslint_no_spaced_func.snap.new
@@ -1,0 +1,5 @@
+---
+source: crates/oxc_linter/src/tester.rs
+assertion_line: 357
+---
+

--- a/crates/oxc_linter/src/snapshots/eslint_no_spaced_func.snap.new
+++ b/crates/oxc_linter/src/snapshots/eslint_no_spaced_func.snap.new
@@ -2,25 +2,94 @@
 source: crates/oxc_linter/src/tester.rs
 assertion_line: 357
 ---
-  ⚠ eslint(no-spaced-func): Should be an imperative statement about what is wrong
-   ╭─[no_spaced_func.tsx:1:3]
- 1 │ (f) (0)
-   ·   ──
+  ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
+   ╭─[no_spaced_func.tsx:1:2]
+ 1 │ f ();
+   ·  ─
    ╰────
-  help: Should be a command-like statement that tells the user how to fix the issue
 
-  ⚠ eslint(no-spaced-func): Should be an imperative statement about what is wrong
+  ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
+   ╭─[no_spaced_func.tsx:1:2]
+ 1 │ f (a, b);
+   ·  ─
+   ╰────
+
+  ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
+   ╭─[no_spaced_func.tsx:1:2]
+ 1 │ ╭─▶ f
+ 2 │ ╰─▶             ();
+   ╰────
+
+  ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
+   ╭─[no_spaced_func.tsx:1:4]
+ 1 │ f.b ();
+   ·    ─
+   ╰────
+
+  ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
+   ╭─[no_spaced_func.tsx:1:8]
+ 1 │ f.b().c ();
+   ·        ─
+   ╰────
+
+  ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
+   ╭─[no_spaced_func.tsx:1:12]
+ 1 │ f.b().c().d ();
+   ·            ─
+   ╰────
+
+  ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
+   ╭─[no_spaced_func.tsx:1:4]
+ 1 │ f() ()
+   ·    ─
+   ╰────
+
+  ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
+   ╭─[no_spaced_func.tsx:1:6]
+ 1 │ f()() ()
+   ·      ─
+   ╰────
+
+  ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
+   ╭─[no_spaced_func.tsx:1:15]
+ 1 │ (function() {} ())
+   ·               ─
+   ╰────
+
+  ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
+   ╭─[no_spaced_func.tsx:1:16]
+ 1 │ var f = new Foo ()
+   ·                ─
+   ╰────
+
+  ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
+   ╭─[no_spaced_func.tsx:1:2]
+ 1 │ f ( (0) )
+   ·  ─
+   ╰────
+
+  ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
+   ╭─[no_spaced_func.tsx:1:5]
+ 1 │ f(0) (1)
+   ·     ─
+   ╰────
+
+  ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
+   ╭─[no_spaced_func.tsx:1:4]
+ 1 │ (f) (0)
+   ·    ─
+   ╰────
+
+  ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
    ╭─[no_spaced_func.tsx:1:2]
  1 │ f ();
    ·  ─
  2 │              t   ();
    ╰────
-  help: Should be a command-like statement that tells the user how to fix the issue
 
-  ⚠ eslint(no-spaced-func): Should be an imperative statement about what is wrong
+  ⚠ eslint(no-spaced-func): Spacing between function identifiers and their applications is disallowed.
    ╭─[no_spaced_func.tsx:2:6]
  1 │ f ();
  2 │              t   ();
    ·               ───
    ╰────
-  help: Should be a command-like statement that tells the user how to fix the issue

--- a/crates/oxc_linter/src/snapshots/eslint_no_spaced_func.snap.new
+++ b/crates/oxc_linter/src/snapshots/eslint_no_spaced_func.snap.new
@@ -2,4 +2,25 @@
 source: crates/oxc_linter/src/tester.rs
 assertion_line: 357
 ---
+  ⚠ eslint(no-spaced-func): Should be an imperative statement about what is wrong
+   ╭─[no_spaced_func.tsx:1:3]
+ 1 │ (f) (0)
+   ·   ──
+   ╰────
+  help: Should be a command-like statement that tells the user how to fix the issue
 
+  ⚠ eslint(no-spaced-func): Should be an imperative statement about what is wrong
+   ╭─[no_spaced_func.tsx:1:2]
+ 1 │ f ();
+   ·  ─
+ 2 │              t   ();
+   ╰────
+  help: Should be a command-like statement that tells the user how to fix the issue
+
+  ⚠ eslint(no-spaced-func): Should be an imperative statement about what is wrong
+   ╭─[no_spaced_func.tsx:2:6]
+ 1 │ f ();
+ 2 │              t   ();
+   ·               ───
+   ╰────
+  help: Should be a command-like statement that tells the user how to fix the issue


### PR DESCRIPTION
Relates to #479 

Rule details: https://eslint.org/docs/latest/rules/no-spaced-func
