### PR TITLE
chore(lint): enable `unused_unsafe` lint rule

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ unit-bindings = "warn"
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)', 'cfg(coverage_nightly)'] }
 tail_expr_drop_order = "warn"
 unsafe_op_in_unsafe_fn = "warn"
-unused_unsafe = "allow"
+unused_unsafe = "warn"
 
 [workspace.lints.clippy]
 all = { level = "warn", priority = -1 }


### PR DESCRIPTION
Enable the `unused_unsafe` lint rule. I think I fixed all the warnings in #9316 and following PRs.