### PR TITLE
refactor(ast/estree): implement custom serializers as meta types

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -324,7 +324,7 @@ pub enum ArrayExpressionElement<'a> {
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(custom_serialize, ts_alias = "null")]
+#[estree(via = ElisionConverter)]
 pub struct Elision {
     pub span: Span,
 }
@@ -365,8 +365,8 @@ pub enum ObjectPropertyKind<'a> {
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(
     rename = "Property",
+    via = ObjectPropertyConverter,
     field_order(span, method, shorthand, computed, key, kind, value),
-    custom_serialize
 )]
 pub struct ObjectProperty<'a> {
     pub span: Span,
@@ -1551,9 +1551,9 @@ pub struct ObjectPattern<'a> {
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(
     rename = "Property",
+    via = BindingPropertyConverter,
     add_fields(method = False, kind = Init),
     field_order(span, method, shorthand, computed, key, kind, value),
-    custom_serialize,
 )]
 pub struct BindingProperty<'a> {
     pub span: Span,
@@ -1683,7 +1683,6 @@ pub struct Function<'a> {
     /// Function parameters.
     ///
     /// Does not include `this` parameters used by some TypeScript functions.
-    #[estree(ts_type = "ParamPattern[]")]
     pub params: Box<'a, FormalParameters<'a>>,
     /// The TypeScript return type annotation.
     #[ts]
@@ -1721,7 +1720,7 @@ pub enum FunctionType {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(
-    custom_serialize,
+    via = FormalParametersConverter,
     add_ts_def = "
         interface FormalParameterRest extends Span {
             type: 'RestElement';
@@ -1808,7 +1807,6 @@ pub struct ArrowFunctionExpression<'a> {
     pub r#async: bool,
     #[ts]
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
-    #[estree(ts_type = "ParamPattern[]")]
     pub params: Box<'a, FormalParameters<'a>>,
     #[ts]
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
@@ -2446,7 +2444,7 @@ pub enum ImportAttributeKey<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(custom_serialize)]
+#[estree(via = ExportNamedDeclarationConverter)]
 pub struct ExportNamedDeclaration<'a> {
     pub span: Span,
     pub declaration: Option<Declaration<'a>>,

--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -148,7 +148,7 @@ pub struct JSXClosingFragment {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
 #[estree(
-    custom_serialize,
+    via = JSXElementNameConverter,
     custom_ts_def = "type JSXElementName = JSXIdentifier | JSXNamespacedName | JSXMemberExpression"
 )]
 pub enum JSXElementName<'a> {
@@ -230,7 +230,7 @@ pub struct JSXMemberExpression<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
 #[estree(
-    custom_serialize,
+    via = JSXMemberExpressionObjectConverter,
     custom_ts_def = "type JSXMemberExpressionObject = JSXIdentifier | JSXMemberExpression"
 )]
 pub enum JSXMemberExpressionObject<'a> {

--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -151,7 +151,7 @@ pub struct RegExp<'a> {
 #[ast]
 #[derive(Debug)]
 #[generate_derive(CloneIn, ESTree)]
-#[estree(custom_serialize, ts_alias = "string")]
+#[estree(via = RegExpPatternConverter)]
 pub enum RegExpPattern<'a> {
     /// Unparsed pattern. Contains string slice of the pattern.
     /// Pattern was not parsed, so may be valid or invalid.
@@ -209,6 +209,6 @@ bitflags! {
 /// Dummy type to communicate the content of `RegExpFlags` to `oxc_ast_tools`.
 #[ast(foreign = RegExpFlags)]
 #[generate_derive(ESTree)]
-#[estree(custom_serialize, ts_alias = "string")]
+#[estree(via = RegExpFlagsConverter)]
 #[expect(dead_code)]
 struct RegExpFlagsAlias(u8);

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -969,7 +969,6 @@ pub struct TSCallSignatureDeclaration<'a> {
     pub span: Span,
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
     pub this_param: Option<TSThisParameter<'a>>,
-    #[estree(ts_type = "ParamPattern[]")]
     pub params: Box<'a, FormalParameters<'a>>,
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
 }
@@ -1006,7 +1005,6 @@ pub struct TSMethodSignature<'a> {
     pub kind: TSMethodSignatureKind,
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
     pub this_param: Option<Box<'a, TSThisParameter<'a>>>,
-    #[estree(ts_type = "ParamPattern[]")]
     pub params: Box<'a, FormalParameters<'a>>,
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
     pub scope_id: Cell<Option<ScopeId>>,
@@ -1020,7 +1018,6 @@ pub struct TSMethodSignature<'a> {
 pub struct TSConstructSignatureDeclaration<'a> {
     pub span: Span,
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
-    #[estree(ts_type = "ParamPattern[]")]
     pub params: Box<'a, FormalParameters<'a>>,
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
     pub scope_id: Cell<Option<ScopeId>>,
@@ -1342,7 +1339,6 @@ pub struct TSFunctionType<'a> {
     /// ```
     pub this_param: Option<Box<'a, TSThisParameter<'a>>>,
     /// Function parameters. Akin to [`Function::params`].
-    #[estree(ts_type = "ParamPattern[]")]
     pub params: Box<'a, FormalParameters<'a>>,
     /// Return type of the function.
     /// ```ts
@@ -1359,7 +1355,6 @@ pub struct TSConstructorType<'a> {
     pub span: Span,
     pub r#abstract: bool,
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
-    #[estree(ts_type = "ParamPattern[]")]
     pub params: Box<'a, FormalParameters<'a>>,
     pub return_type: Box<'a, TSTypeAnnotation<'a>>,
 }

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -194,6 +194,12 @@ impl ESTree for ArrayExpressionElement<'_> {
     }
 }
 
+impl ESTree for Elision {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        crate::serialize::ElisionConverter(self).serialize(serializer)
+    }
+}
+
 impl ESTree for ObjectExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
@@ -211,6 +217,12 @@ impl ESTree for ObjectPropertyKind<'_> {
             Self::ObjectProperty(it) => it.serialize(serializer),
             Self::SpreadProperty(it) => it.serialize(serializer),
         }
+    }
+}
+
+impl ESTree for ObjectProperty<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        crate::serialize::ObjectPropertyConverter(self).serialize(serializer)
     }
 }
 
@@ -1262,6 +1274,12 @@ impl ESTree for ObjectPattern<'_> {
     }
 }
 
+impl ESTree for BindingProperty<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        crate::serialize::BindingPropertyConverter(self).serialize(serializer)
+    }
+}
+
 impl ESTree for ArrayPattern<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
@@ -1314,6 +1332,12 @@ impl ESTree for FunctionType {
                 "TSEmptyBodyFunctionExpression".serialize(serializer)
             }
         }
+    }
+}
+
+impl ESTree for FormalParameters<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        crate::serialize::FormalParametersConverter(self).serialize(serializer)
     }
 }
 
@@ -1684,6 +1708,12 @@ impl ESTree for ImportAttributeKey<'_> {
     }
 }
 
+impl ESTree for ExportNamedDeclaration<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        crate::serialize::ExportNamedDeclarationConverter(self).serialize(serializer)
+    }
+}
+
 impl ESTree for ExportDefaultDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
@@ -1868,6 +1898,18 @@ impl ESTree for RegExp<'_> {
     }
 }
 
+impl ESTree for RegExpPattern<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        crate::serialize::RegExpPatternConverter(self).serialize(serializer)
+    }
+}
+
+impl ESTree for RegExpFlags {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        crate::serialize::RegExpFlagsConverter(self).serialize(serializer)
+    }
+}
+
 impl ESTree for JSXElement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
@@ -1939,6 +1981,12 @@ impl ESTree for JSXClosingFragment {
     }
 }
 
+impl ESTree for JSXElementName<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        crate::serialize::JSXElementNameConverter(self).serialize(serializer)
+    }
+}
+
 impl ESTree for JSXNamespacedName<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
@@ -1960,6 +2008,12 @@ impl ESTree for JSXMemberExpression<'_> {
         state.serialize_field("object", &self.object);
         state.serialize_field("property", &self.property);
         state.end();
+    }
+}
+
+impl ESTree for JSXMemberExpressionObject<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        crate::serialize::JSXMemberExpressionObjectConverter(self).serialize(serializer)
     }
 }
 

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -227,15 +227,23 @@ impl ESTree for RegExpLiteralValue<'_, '_> {
     }
 }
 
-impl ESTree for RegExpFlags {
+#[ast_meta]
+#[estree(ts_type = "string")]
+pub struct RegExpPatternConverter<'a, 'b>(pub &'b RegExpPattern<'a>);
+
+impl ESTree for RegExpPatternConverter<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        self.to_string().as_str().serialize(serializer);
+        self.0.to_string().serialize(serializer);
     }
 }
 
-impl ESTree for RegExpPattern<'_> {
+#[ast_meta]
+#[estree(ts_type = "string")]
+pub struct RegExpFlagsConverter<'b>(pub &'b RegExpFlags);
+
+impl ESTree for RegExpFlagsConverter<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        self.to_string().as_str().serialize(serializer);
+        self.0.to_string().serialize(serializer);
     }
 }
 
@@ -244,7 +252,11 @@ impl ESTree for RegExpPattern<'_> {
 // --------------------
 
 /// Serialize `ArrayExpressionElement::Elision` variant as `null`.
-impl ESTree for Elision {
+#[ast_meta]
+#[estree(ts_type = "null")]
+pub struct ElisionConverter<'b>(#[expect(dead_code)] pub &'b Elision);
+
+impl ESTree for ElisionConverter<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         ().serialize(serializer);
     }
@@ -252,14 +264,18 @@ impl ESTree for Elision {
 
 /// Serialize `FormalParameters`, to be estree compatible, with `items` and `rest` fields combined
 /// and `argument` field flattened.
-impl ESTree for FormalParameters<'_> {
+#[ast_meta]
+#[estree(ts_type = "ParamPattern[]")]
+pub struct FormalParametersConverter<'a, 'b>(pub &'b FormalParameters<'a>);
+
+impl ESTree for FormalParametersConverter<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut seq = serializer.serialize_sequence();
-        for item in &self.items {
+        for item in &self.0.items {
             seq.serialize_element(item);
         }
 
-        if let Some(rest) = &self.rest {
+        if let Some(rest) = &self.0.rest {
             seq.serialize_element(&FormalParametersRest(rest));
         }
 
@@ -301,45 +317,53 @@ impl ESTree for ImportDeclarationSpecifiers<'_, '_> {
 }
 
 /// Serialize `ObjectProperty` with fields in same order as Acorn.
-impl ESTree for ObjectProperty<'_> {
+#[ast_meta]
+pub struct ObjectPropertyConverter<'a, 'b>(pub &'b ObjectProperty<'a>);
+
+impl ESTree for ObjectPropertyConverter<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
+        let prop = self.0;
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", "Property");
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
-        state.serialize_field("method", &self.method);
-        state.serialize_field("shorthand", &self.shorthand);
-        state.serialize_field("computed", &self.computed);
-        state.serialize_field("key", &self.key);
+        state.serialize_field("start", &prop.span.start);
+        state.serialize_field("end", &prop.span.end);
+        state.serialize_field("method", &prop.method);
+        state.serialize_field("shorthand", &prop.shorthand);
+        state.serialize_field("computed", &prop.computed);
+        state.serialize_field("key", &prop.key);
         // Acorn has `kind` field before `value` for methods and shorthand properties
-        if self.method || self.kind != PropertyKind::Init || self.shorthand {
-            state.serialize_field("kind", &self.kind);
-            state.serialize_field("value", &self.value);
+        if prop.method || prop.kind != PropertyKind::Init || prop.shorthand {
+            state.serialize_field("kind", &prop.kind);
+            state.serialize_field("value", &prop.value);
         } else {
-            state.serialize_field("value", &self.value);
-            state.serialize_field("kind", &self.kind);
+            state.serialize_field("value", &prop.value);
+            state.serialize_field("kind", &prop.kind);
         }
         state.end();
     }
 }
 
 /// Serialize `BindingProperty` with fields in same order as Acorn.
-impl ESTree for BindingProperty<'_> {
+#[ast_meta]
+pub struct BindingPropertyConverter<'a, 'b>(pub &'b BindingProperty<'a>);
+
+impl ESTree for BindingPropertyConverter<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
+        let prop = self.0;
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", "Property");
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
+        state.serialize_field("start", &prop.span.start);
+        state.serialize_field("end", &prop.span.end);
         state.serialize_field("method", &false);
-        state.serialize_field("shorthand", &self.shorthand);
-        state.serialize_field("computed", &self.computed);
-        state.serialize_field("key", &self.key);
+        state.serialize_field("shorthand", &prop.shorthand);
+        state.serialize_field("computed", &prop.computed);
+        state.serialize_field("key", &prop.key);
         // Acorn has `kind` field before `value` for shorthand properties
-        if self.shorthand {
+        if prop.shorthand {
             state.serialize_field("kind", "init");
-            state.serialize_field("value", &self.value);
+            state.serialize_field("value", &prop.value);
         } else {
-            state.serialize_field("value", &self.value);
+            state.serialize_field("value", &prop.value);
             state.serialize_field("kind", "init");
         }
         state.end();
@@ -410,20 +434,24 @@ impl ESTree for ImportExpressionArguments<'_> {
 ///
 /// Omit `with_clause` field (which is renamed to `attributes` in ESTree)
 /// unless `source` field is `Some`.
-impl ESTree for ExportNamedDeclaration<'_> {
+#[ast_meta]
+pub struct ExportNamedDeclarationConverter<'a, 'b>(pub &'b ExportNamedDeclaration<'a>);
+
+impl ESTree for ExportNamedDeclarationConverter<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
+        let decl = self.0;
         let mut state = serializer.serialize_struct();
         state.serialize_field("type", "ExportNamedDeclaration");
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
-        state.serialize_field("declaration", &self.declaration);
-        state.serialize_field("specifiers", &self.specifiers);
-        state.serialize_field("source", &self.source);
-        state.serialize_ts_field("exportKind", &self.export_kind);
-        if self.source.is_some() {
+        state.serialize_field("start", &decl.span.start);
+        state.serialize_field("end", &decl.span.end);
+        state.serialize_field("declaration", &decl.declaration);
+        state.serialize_field("specifiers", &decl.specifiers);
+        state.serialize_field("source", &decl.source);
+        state.serialize_ts_field("exportKind", &decl.export_kind);
+        if decl.source.is_some() {
             state.serialize_field(
                 "attributes",
-                &crate::serialize::ExportNamedDeclarationWithClause(self),
+                &crate::serialize::ExportNamedDeclarationWithClause(decl),
             );
         }
         state.end();
@@ -484,30 +512,36 @@ impl ESTree for ExportAllDeclarationWithClause<'_, '_> {
 // JSX
 // --------------------
 
-impl ESTree for JSXElementName<'_> {
+#[ast_meta]
+pub struct JSXElementNameConverter<'a, 'b>(pub &'b JSXElementName<'a>);
+
+impl ESTree for JSXElementNameConverter<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        match self {
-            Self::Identifier(ident) => ident.serialize(serializer),
-            Self::IdentifierReference(ident) => {
+        match self.0 {
+            JSXElementName::Identifier(ident) => ident.serialize(serializer),
+            JSXElementName::IdentifierReference(ident) => {
                 JSXIdentifier { span: ident.span, name: ident.name }.serialize(serializer);
             }
-            Self::NamespacedName(name) => name.serialize(serializer),
-            Self::MemberExpression(expr) => expr.serialize(serializer),
-            Self::ThisExpression(expr) => {
+            JSXElementName::NamespacedName(name) => name.serialize(serializer),
+            JSXElementName::MemberExpression(expr) => expr.serialize(serializer),
+            JSXElementName::ThisExpression(expr) => {
                 JSXIdentifier { span: expr.span, name: "this".into() }.serialize(serializer);
             }
         }
     }
 }
 
-impl ESTree for JSXMemberExpressionObject<'_> {
+#[ast_meta]
+pub struct JSXMemberExpressionObjectConverter<'a, 'b>(pub &'b JSXMemberExpressionObject<'a>);
+
+impl ESTree for JSXMemberExpressionObjectConverter<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        match self {
-            Self::IdentifierReference(ident) => {
+        match self.0 {
+            JSXMemberExpressionObject::IdentifierReference(ident) => {
                 JSXIdentifier { span: ident.span, name: ident.name }.serialize(serializer);
             }
-            Self::MemberExpression(expr) => expr.serialize(serializer),
-            Self::ThisExpression(expr) => {
+            JSXMemberExpressionObject::MemberExpression(expr) => expr.serialize(serializer),
+            JSXMemberExpressionObject::ThisExpression(expr) => {
                 JSXIdentifier { span: expr.span, name: "this".into() }.serialize(serializer);
             }
         }

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -555,12 +555,6 @@ export type FunctionType =
   | 'TSDeclareFunction'
   | 'TSEmptyBodyFunctionExpression';
 
-export interface FormalParameters extends Span {
-  type: 'FormalParameters';
-  kind: FormalParameterKind;
-  items: Array<FormalParameter | FormalParameterRest>;
-}
-
 export interface FormalParameterRest extends Span {
   type: 'RestElement';
   argument: BindingPatternKind;

--- a/tasks/ast_tools/src/schema/defs/enum.rs
+++ b/tasks/ast_tools/src/schema/defs/enum.rs
@@ -104,7 +104,6 @@ impl EnumDef {
     }
 
     /// Get the [`File`] which this struct is defined in.
-    #[expect(dead_code)]
     pub fn file<'s>(&self, schema: &'s Schema) -> &'s File {
         &schema.files[self.file_id]
     }

--- a/tasks/ast_tools/src/schema/extensions/estree.rs
+++ b/tasks/ast_tools/src/schema/extensions/estree.rs
@@ -6,8 +6,6 @@ pub struct ESTreeStruct {
     pub skip: bool,
     pub flatten: bool,
     pub no_type: bool,
-    /// `true` if serializer is implemented manually and should not be generated
-    pub custom_serialize: bool,
     /// Additional fields to add to struct in ESTree AST.
     /// `(name, converter)` where `name` is the name of the field, and `converter` is name of
     /// a converter meta type.
@@ -33,10 +31,9 @@ pub struct ESTreeStruct {
 /// Configuration for ESTree generator on an enum.
 #[derive(Default, Debug)]
 pub struct ESTreeEnum {
+    pub via: Option<String>,
     pub skip: bool,
     pub no_rename_variants: bool,
-    /// `true` if serializer is implemented manually and should not be generated
-    pub custom_serialize: bool,
     /// TS alias.
     /// e.g. `#[estree(ts_alias = "null")]` means this type won't have a type def generated,
     /// and any struct / enum referencing it will substitute `null` as the type.


### PR DESCRIPTION
Refactor. For structs and enums with custom serializers, use `#[estree(via = Converter)]` instead of `#[estree(custom_serialize)]`. Converter must be a meta type defined with `#[ast_meta]`.

This reduces the number of `#[estree]` attributes on the AST Rust type definitions, and makes it consistent with struct field converters. All custom conversion is now performed via meta types.

A side effect is that it removes TS type def for `FormalParameters`, which is not part of ESTree AST, so shouldn't be included in TS typings.
