### PR TITLE
ci(miri): skip slow tests in `oxc_parser` under Miri

### DIFF
--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -7,8 +7,6 @@ use oxc_syntax::precedence::Precedence;
 use super::Tristate;
 use crate::{ParserImpl, diagnostics, lexer::Kind};
 
-// Dummy comment to run Miri
-
 struct ArrowFunctionHead<'a> {
     type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
     params: Box<'a, FormalParameters<'a>>,

--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -7,6 +7,8 @@ use oxc_syntax::precedence::Precedence;
 use super::Tristate;
 use crate::{ParserImpl, diagnostics, lexer::Kind};
 
+// Dummy comment to run Miri
+
 struct ArrowFunctionHead<'a> {
     type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
     params: Box<'a, FormalParameters<'a>>,

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -714,7 +714,9 @@ mod test {
 
     // Source with length MAX_LEN + 1 fails to parse.
     // Skip this test on 32-bit systems as impossible to allocate a string longer than `isize::MAX`.
+    // Also skip running under Miri since it takes so long.
     #[cfg(target_pointer_width = "64")]
+    #[cfg(not(miri))]
     #[test]
     fn overlong_source() {
         // Build string in 16 KiB chunks for speed
@@ -743,7 +745,9 @@ mod test {
     // Source with length MAX_LEN parses OK.
     // This test takes over 1 minute on an M1 Macbook Pro unless compiled in release mode.
     // `not(debug_assertions)` is a proxy for detecting release mode.
+    // Also skip running under Miri since it takes so long.
     #[cfg(not(debug_assertions))]
+    #[cfg(not(miri))]
     #[test]
     fn legal_length_source() {
         // Build a string MAX_LEN bytes long which doesn't take too long to parse


### PR DESCRIPTION
There are 2 tests in `oxc_parser` which take an extremely long time to run under Miri. Skip them. These 2 tests don't really exercise the unsafe code in lexer much anyway.

Locally, this cuts down time to run `cargo +nightly miri test -p oxc_parser` from 1m57s to 16s. Presumably it'll have a similar effect in CI.
