### PR TITLE
test(transformer): fix warning when running `oxc_transformer` tests under Miri

### DIFF
--- a/crates/oxc_transformer/tests/integrations/plugins/replace_global_defines.rs
+++ b/crates/oxc_transformer/tests/integrations/plugins/replace_global_defines.rs
@@ -2,7 +2,6 @@ use oxc_allocator::Allocator;
 use oxc_codegen::{CodeGenerator, CodegenOptions};
 use oxc_parser::Parser;
 use oxc_semantic::SemanticBuilder;
-use oxc_sourcemap::SourcemapVisualizer;
 use oxc_span::SourceType;
 use oxc_transformer::{ReplaceGlobalDefines, ReplaceGlobalDefinesConfig};
 
@@ -240,6 +239,8 @@ console.log(
 #[cfg(not(miri))]
 #[test]
 fn test_sourcemap() {
+    use oxc_sourcemap::SourcemapVisualizer;
+
     let config = ReplaceGlobalDefinesConfig::new(&[
         ("__OBJECT__", r#"{"hello": "test"}"#),
         ("__STRING__", r#""development""#),


### PR DESCRIPTION
`oxc_sourcemap::SourcemapVisualizer` is only used in a test which does not run under Miri, so it was producing an "unused import" lint warning when the crate's tests are run under Miri. Fix that.
