### PR TITLE
ci(miri): run `oxc_data_structures` tests under Miri on CI

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -52,5 +52,6 @@ jobs:
       - name: Test with Miri
         run: |
           cargo miri test -p oxc_ast --all-features
+          cargo miri test -p oxc_data_structures
           cargo miri test -p oxc_parser
           cargo miri test -p oxc_transformer


### PR DESCRIPTION
`oxc_data_structures` crate is stuffed full of unsafe code. Run its tests under Miri on CI.

We already had `crates/oxc_data_structures/**` included in the filter for Miri CI task, but it wasn't actually running the tests for the crate. This appears to have been an oversight.
