### PR TITLE
fix(oxlint): current dir as arg

### DIFF
--- a/apps/oxlint/fixtures/ignore_file_current_dir/.oxlintrc.json
+++ b/apps/oxlint/fixtures/ignore_file_current_dir/.oxlintrc.json
@@ -1,0 +1,10 @@
+{
+  "ignorePatterns": [
+    "foo.js",
+    "a/bar.js"
+  ],
+  "rules": {
+    "no-debugger": "deny"
+  }
+}
+

--- a/apps/oxlint/fixtures/ignore_file_current_dir/a/bar.js
+++ b/apps/oxlint/fixtures/ignore_file_current_dir/a/bar.js
@@ -1,0 +1,2 @@
+debugger
+console.log("Don't lint me!!")

--- a/apps/oxlint/fixtures/ignore_file_current_dir/foo.js
+++ b/apps/oxlint/fixtures/ignore_file_current_dir/foo.js
@@ -1,0 +1,2 @@
+debugger
+console.log("Don't lint me!!")

--- a/apps/oxlint/src/snapshots/fixtures__ignore_file_current_dir_ .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__ignore_file_current_dir_ .@oxlint.snap
@@ -1,0 +1,22 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: 
+working directory: fixtures/ignore_file_current_dir
+----------
+Found 0 warnings and 0 errors.
+Finished in <variable>ms on 0 files with 99 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------
+
+########## 
+arguments: .
+working directory: fixtures/ignore_file_current_dir
+----------
+Found 0 warnings and 0 errors.
+Finished in <variable>ms on 0 files with 99 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------


### PR DESCRIPTION
closes #9023

When passing `.` as an arg it would result in a path like `{cwd}/.`, which when being used to resolve other paths obviously caused issues. This canonicalizes any path args before doing anything else.

Adds test to verify this based on original issue. This also caused another snapshot to change for an invalid file extension, changing from `LintSucceeded` to `LintNoFilesFound`, which I believe is actually correct? If you only pass files that do not exist it would make more sense to return an error to me so I'm viewing this as a side effect fix.