### PR TITLE
test(ast/estree): do not skip tests that we should pass

### DIFF
--- a/tasks/coverage/snapshots/estree_test262.snap
+++ b/tasks/coverage/snapshots/estree_test262.snap
@@ -1,5 +1,50 @@
 commit: bc5c1417
 
 estree_test262 Summary:
-AST Parsed     : 44006/44006 (100.00%)
-Positive Passed: 44006/44006 (100.00%)
+AST Parsed     : 44047/44047 (100.00%)
+Positive Passed: 44002/44047 (99.90%)
+Mismatch: tasks/coverage/test262/test/annexB/built-ins/RegExp/prototype/compile/pattern-string-u.js
+Mismatch: tasks/coverage/test262/test/annexB/built-ins/String/prototype/substr/surrogate-pairs.js
+Mismatch: tasks/coverage/test262/test/built-ins/Array/prototype/concat/Array.prototype.concat_spreadable-string-wrapper.js
+Mismatch: tasks/coverage/test262/test/built-ins/JSON/stringify/value-string-escape-unicode.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/dotall/with-dotall-unicode.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/dotall/with-dotall.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/dotall/without-dotall-unicode.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/dotall/without-dotall.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/escape/escaped-surrogates.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/named-groups/non-unicode-property-names-invalid.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/named-groups/unicode-property-names-invalid.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/prototype/Symbol.replace/coerce-unicode.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/prototype/exec/u-captured-value.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-dotAll.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/changing-dotAll-flag-does-not-affect-dotAll-modifier.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/nesting-add-dotAll-within-remove-dotAll.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/nesting-remove-dotAll-within-add-dotAll.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-dotAll.js
+Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/at/returns-code-unit.js
+Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/codePointAt/return-first-code-unit.js
+Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/codePointAt/return-single-code-unit.js
+Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/isWellFormed/returns-boolean.js
+Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/match/regexp-prototype-match-v-u-flag.js
+Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/padEnd/normal-operation.js
+Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/padStart/normal-operation.js
+Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/toWellFormed/returns-well-formed-string.js
+Mismatch: tasks/coverage/test262/test/built-ins/StringIteratorPrototype/next/next-iteration-surrogate-pairs.js
+Mismatch: tasks/coverage/test262/test/intl402/NumberFormat/prototype/format/format-non-finite-numbers.js
+Mismatch: tasks/coverage/test262/test/intl402/Segmenter/prototype/segment/containing/breakable-input.js
+Mismatch: tasks/coverage/test262/test/intl402/Segmenter/prototype/segment/containing/unbreakable-input.js
+Mismatch: tasks/coverage/test262/test/intl402/Segmenter/prototype/segment/containing/zero-index.js
+Mismatch: tasks/coverage/test262/test/language/expressions/assignment/fn-name-lhs-cover.js
+Mismatch: tasks/coverage/test262/test/language/expressions/assignment/target-cover-id.js
+Mismatch: tasks/coverage/test262/test/language/expressions/postfix-decrement/target-cover-id.js
+Mismatch: tasks/coverage/test262/test/language/expressions/postfix-increment/target-cover-id.js
+Mismatch: tasks/coverage/test262/test/language/expressions/prefix-decrement/target-cover-id.js
+Mismatch: tasks/coverage/test262/test/language/expressions/prefix-increment/target-cover-id.js
+Mismatch: tasks/coverage/test262/test/language/literals/regexp/named-groups/invalid-lone-surrogate-groupname.js
+Mismatch: tasks/coverage/test262/test/language/literals/regexp/u-astral.js
+Mismatch: tasks/coverage/test262/test/language/literals/regexp/u-surrogate-pairs-atom-char-class.js
+Mismatch: tasks/coverage/test262/test/language/literals/regexp/u-surrogate-pairs-atom-escape-decimal.js
+Mismatch: tasks/coverage/test262/test/language/statements/for-in/head-lhs-cover.js
+Mismatch: tasks/coverage/test262/test/language/statements/for-of/head-lhs-async-parens.js
+Mismatch: tasks/coverage/test262/test/language/statements/for-of/head-lhs-cover.js
+Mismatch: tasks/coverage/test262/test/language/statements/for-of/string-astral-truncated.js

--- a/tasks/coverage/src/tools/estree.rs
+++ b/tasks/coverage/src/tools/estree.rs
@@ -41,9 +41,20 @@ impl Case for EstreeTest262Case {
     }
 
     fn skip_test_case(&self) -> bool {
-        // In an ideal world, we would not ignore these tests as we should be able to pass them.
-        // But ignoring them for now just to reduce noise in the conformance snapshot file.
-        // TODO: Re-enable these tests.
+        // Skip tests where fixture starts with a hashbang.
+        // We intentionally diverge from Acorn, by including an extra `hashbang` field on `Program`.
+        // `acorn-test262` adapts Acorn's AST to add a `hashbang: null` field to `Program`,
+        // in order to match Oxc's output.
+        // But these fixtures *do* include hashbangs, so there's a mismatch, because `hashbang`
+        // field is (correctly) not `null` in these cases.
+        if self.path().starts_with("test262/test/language/comments/hashbang/") {
+            return true;
+        }
+
+        // These tests fail, due to lack of support in Oxc's parser.
+        // We don't filter them out because they are genuine test fails, but leaving this list here so
+        // can uncomment this block when debugging any new test failures, to filter out "known bad".
+        /*
         static IGNORE_PATHS: &[&str] = &[
             // Missing `ParenthesizedExpression` on left side of assignment.
             // Oxc's parser does not support this, and we do not intend to fix.
@@ -57,6 +68,7 @@ impl Case for EstreeTest262Case {
             "test262/test/language/statements/for-in/head-lhs-cover.js",
             "test262/test/language/statements/for-of/head-lhs-async-parens.js",
             "test262/test/language/statements/for-of/head-lhs-cover.js",
+
             // Lone surrogates in strings.
             // We cannot pass these tests at present, as Oxc's parser does not handle them correctly.
             // https://github.com/oxc-project/oxc/issues/3526#issuecomment-2650260735
@@ -96,24 +108,13 @@ impl Case for EstreeTest262Case {
             "test262/test/language/literals/regexp/u-surrogate-pairs-atom-char-class.js",
             "test262/test/language/literals/regexp/u-surrogate-pairs-atom-escape-decimal.js",
             "test262/test/language/statements/for-of/string-astral-truncated.js",
-            // Hashbangs.
-            // We intentionally diverge from Acorn, by including an extra `hashbang` field on `Program`.
-            // `acorn-test262` adapts Acorn's AST to add a `hashbang: null` field to `Program`,
-            // in order to match Oxc's output.
-            // But these fixtures *do* include hashbangs, so there's a mismatch, because `hashbang`
-            // field is (correctly) not `null` in these cases.
-            "test262/test/language/comments/hashbang/line-terminator-carriage-return.js",
-            "test262/test/language/comments/hashbang/line-terminator-line-separator.js",
-            "test262/test/language/comments/hashbang/line-terminator-paragraph-separator.js",
-            "test262/test/language/comments/hashbang/module.js",
-            "test262/test/language/comments/hashbang/not-empty.js",
-            "test262/test/language/comments/hashbang/use-strict.js",
         ];
 
         let path = &*self.path().to_string_lossy();
         if IGNORE_PATHS.contains(&path) {
             return true;
         }
+        */
 
         // Skip tests where no Acorn JSON file
         matches!(fs::exists(&self.acorn_json_path), Ok(false))


### PR DESCRIPTION
Re-enable ESTree conformance test cases which we should pass, but don't currently.