### PR TITLE
test(napi): add tests for `hashbang` field

### DIFF
--- a/napi/parser/test/parse.test.ts
+++ b/napi/parser/test/parse.test.ts
@@ -109,6 +109,27 @@ describe('parse', () => {
       });
     });
   });
+
+  describe('hashbang', () => {
+    it('is `null` when no hashbang', () => {
+      const ret = parseSync('test.js', 'let x;');
+      expect(ret.errors.length).toBe(0);
+      expect(ret.program.body.length).toBe(1);
+      expect(ret.program.hashbang).toBeNull();
+    });
+
+    it('is defined when hashbang', () => {
+      const ret = parseSync('test.js', '#!/usr/bin/env node\nlet x;');
+      expect(ret.errors.length).toBe(0);
+      expect(ret.program.body.length).toBe(1);
+      expect(ret.program.hashbang).toEqual({
+        type: 'Hashbang',
+        start: 0,
+        end: 19,
+        value: '/usr/bin/env node',
+      });
+    });
+  });
 });
 
 describe('UTF-16 span', () => {

--- a/tasks/coverage/src/tools/estree.rs
+++ b/tasks/coverage/src/tools/estree.rs
@@ -47,6 +47,7 @@ impl Case for EstreeTest262Case {
         // in order to match Oxc's output.
         // But these fixtures *do* include hashbangs, so there's a mismatch, because `hashbang`
         // field is (correctly) not `null` in these cases.
+        // `napi/parser` contains tests for correct parsing of hashbangs.
         if self.path().starts_with("test262/test/language/comments/hashbang/") {
             return true;
         }


### PR DESCRIPTION
ESTree conformance tester does not test `hashbang` field, so add tests to `napi/parser` instead.