### PR TITLE
ci(benchmarks): exclude parser from isolated declarations benchmark timing

### DIFF
--- a/tasks/benchmark/benches/isolated_declarations.rs
+++ b/tasks/benchmark/benches/isolated_declarations.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::Allocator;
-use oxc_benchmark::{BenchmarkId, Criterion, criterion_group, criterion_main};
+use oxc_benchmark::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
 use oxc_isolated_declarations::{IsolatedDeclarations, IsolatedDeclarationsOptions};
-use oxc_parser::{Parser, ParserReturn};
+use oxc_parser::Parser;
 use oxc_span::SourceType;
 use oxc_tasks_common::TestFile;
 
@@ -16,16 +16,25 @@ fn bench_isolated_declarations(criterion: &mut Criterion) {
     let source_text = file.source_text.as_str();
     let source_type = SourceType::from_path(&file.file_name).unwrap();
 
+    let ast_allocator = Allocator::new();
+    let program = Parser::new(&ast_allocator, source_text, source_type).parse().program;
+    let program = black_box(program);
+
+    // Create `Allocator` outside of `bench_function`, so same allocator is used for
+    // both the warmup and measurement phases
+    let mut output_allocator = Allocator::new();
     group.bench_function(id, |b| {
-        b.iter_with_large_drop(|| {
-            let allocator = Allocator::default();
-            let ParserReturn { program, .. } =
-                Parser::new(&allocator, source_text, source_type).parse();
-            IsolatedDeclarations::new(
-                &allocator,
-                IsolatedDeclarationsOptions { strip_internal: true },
-            )
-            .build(&program);
+        b.iter_with_setup_wrapper(|runner| {
+            // Reset allocator at start of each iteration
+            output_allocator.reset();
+
+            // Include dropping `IsolatedDeclarations::build`'s return value in benchmark timing.
+            // Drop time is part of the cost of using this API.
+            runner.run(|| {
+                let options = IsolatedDeclarationsOptions { strip_internal: true };
+                let ret = IsolatedDeclarations::new(&output_allocator, options).build(&program);
+                black_box(ret);
+            });
         });
     });
 


### PR DESCRIPTION
Similar to other benchmarks, in benchmark for isolated declarations, only time the component under test - the actual generation of isolated declarations file. Previously, the benchmark also included parsing.

This removes a source of variance from the benchmark and "zooms in" on performance of the thing itself. It'll be easier to see improvements/degradations in performance.
