### PR TITLE
refactor(isolated_declarations): use aliases `ArenaBox` / `ArenaVec`

### DIFF
--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -1,6 +1,6 @@
 use std::borrow::Cow;
 
-use oxc_allocator::{Box, CloneIn};
+use oxc_allocator::{Box as ArenaBox, CloneIn, Vec as ArenaVec};
 use oxc_ast::{NONE, ast::*};
 use oxc_span::{GetSpan, SPAN};
 use rustc_hash::FxHashMap;
@@ -133,8 +133,8 @@ impl<'a> IsolatedDeclarations<'a> {
     fn transform_class_method_definition(
         &self,
         definition: &MethodDefinition<'a>,
-        params: Box<'a, FormalParameters<'a>>,
-        return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
+        params: ArenaBox<'a, FormalParameters<'a>>,
+        return_type: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
     ) -> ClassElement<'a> {
         let function = &definition.value;
 
@@ -197,7 +197,7 @@ impl<'a> IsolatedDeclarations<'a> {
     fn transform_formal_parameter_to_class_property(
         &self,
         param: &FormalParameter<'a>,
-        type_annotation: Option<Box<'a, TSTypeAnnotation<'a>>>,
+        type_annotation: Option<ArenaBox<'a, TSTypeAnnotation<'a>>>,
     ) -> Option<ClassElement<'a>> {
         let Some(ident_name) = param.pattern.get_identifier_name() else {
             // A parameter property may not be declared using a binding pattern.(1187)
@@ -264,7 +264,7 @@ impl<'a> IsolatedDeclarations<'a> {
         &self,
         function: &Function<'a>,
         params: &FormalParameters<'a>,
-    ) -> oxc_allocator::Vec<'a, ClassElement<'a>> {
+    ) -> ArenaVec<'a, ClassElement<'a>> {
         let mut elements = self.ast.vec();
         for (index, param) in function.params.items.iter().enumerate() {
             if param.accessibility.is_some() || param.readonly {
@@ -299,7 +299,7 @@ impl<'a> IsolatedDeclarations<'a> {
     fn collect_getter_or_setter_annotations(
         &self,
         decl: &Class<'a>,
-    ) -> FxHashMap<Cow<str>, Box<'a, TSTypeAnnotation<'a>>> {
+    ) -> FxHashMap<Cow<str>, ArenaBox<'a, TSTypeAnnotation<'a>>> {
         let mut method_annotations = FxHashMap::default();
         for element in &decl.body.body {
             if let ClassElement::MethodDefinition(method) = element {
@@ -347,7 +347,7 @@ impl<'a> IsolatedDeclarations<'a> {
         &self,
         decl: &Class<'a>,
         declare: Option<bool>,
-    ) -> Box<'a, Class<'a>> {
+    ) -> ArenaBox<'a, Class<'a>> {
         if let Some(super_class) = &decl.super_class {
             let is_not_allowed = match super_class {
                 Expression::Identifier(_) => false,
@@ -569,7 +569,7 @@ impl<'a> IsolatedDeclarations<'a> {
     pub(crate) fn create_formal_parameters(
         &self,
         kind: BindingPatternKind<'a>,
-    ) -> Box<'a, FormalParameters<'a>> {
+    ) -> ArenaBox<'a, FormalParameters<'a>> {
         let pattern = self.ast.binding_pattern(kind, NONE, false);
         let parameter =
             self.ast.formal_parameter(SPAN, self.ast.vec(), pattern, None, false, false);

--- a/crates/oxc_isolated_declarations/src/function.rs
+++ b/crates/oxc_isolated_declarations/src/function.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Box, CloneIn};
+use oxc_allocator::{Box as ArenaBox, CloneIn};
 use oxc_ast::{NONE, ast::*};
 use oxc_span::{SPAN, Span};
 
@@ -16,7 +16,7 @@ impl<'a> IsolatedDeclarations<'a> {
         &self,
         func: &Function<'a>,
         declare: Option<bool>,
-    ) -> Box<'a, Function<'a>> {
+    ) -> ArenaBox<'a, Function<'a>> {
         let return_type = self.infer_function_return_type(func);
         if return_type.is_none() {
             self.error(function_must_have_explicit_return_type(get_function_span(func)));
@@ -113,7 +113,7 @@ impl<'a> IsolatedDeclarations<'a> {
     pub(crate) fn transform_formal_parameters(
         &self,
         params: &FormalParameters<'a>,
-    ) -> Box<'a, FormalParameters<'a>> {
+    ) -> ArenaBox<'a, FormalParameters<'a>> {
         if params.kind.is_signature() || (params.rest.is_none() && params.items.is_empty()) {
             return self.ast.alloc(params.clone_in(self.ast.allocator));
         }

--- a/crates/oxc_isolated_declarations/src/inferrer.rs
+++ b/crates/oxc_isolated_declarations/src/inferrer.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Box, CloneIn};
+use oxc_allocator::{Box as ArenaBox, CloneIn};
 use oxc_ast::ast::{
     ArrowFunctionExpression, BindingPatternKind, Expression, FormalParameter, Function, Statement,
     TSType, TSTypeAnnotation, UnaryExpression,
@@ -101,7 +101,7 @@ impl<'a> IsolatedDeclarations<'a> {
     pub(crate) fn infer_function_return_type(
         &self,
         function: &Function<'a>,
-    ) -> Option<Box<'a, TSTypeAnnotation<'a>>> {
+    ) -> Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         if function.return_type.is_some() {
             return function.return_type.clone_in(self.ast.allocator);
         }
@@ -119,7 +119,7 @@ impl<'a> IsolatedDeclarations<'a> {
     pub(crate) fn infer_arrow_function_return_type(
         &self,
         function: &ArrowFunctionExpression<'a>,
-    ) -> Option<Box<'a, TSTypeAnnotation<'a>>> {
+    ) -> Option<ArenaBox<'a, TSTypeAnnotation<'a>>> {
         if function.return_type.is_some() {
             return function.return_type.clone_in(self.ast.allocator);
         }

--- a/crates/oxc_isolated_declarations/src/literal.rs
+++ b/crates/oxc_isolated_declarations/src/literal.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::Box;
+use oxc_allocator::Box as ArenaBox;
 use oxc_ast::ast::{StringLiteral, TemplateLiteral};
 
 use crate::IsolatedDeclarations;
@@ -7,7 +7,7 @@ impl<'a> IsolatedDeclarations<'a> {
     pub(crate) fn transform_template_to_string(
         &self,
         lit: &TemplateLiteral<'a>,
-    ) -> Option<Box<'a, StringLiteral<'a>>> {
+    ) -> Option<ArenaBox<'a, StringLiteral<'a>>> {
         if lit.expressions.is_empty() {
             lit.quasis.first().map(|item| {
                 self.ast.alloc(self.ast.string_literal(

--- a/crates/oxc_isolated_declarations/src/module.rs
+++ b/crates/oxc_isolated_declarations/src/module.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Box, CloneIn, Vec};
+use oxc_allocator::{Box as ArenaBox, CloneIn, Vec as ArenaVec};
 use oxc_ast::{NONE, ast::*};
 use oxc_span::{Atom, GetSpan, SPAN};
 
@@ -116,7 +116,7 @@ impl<'a> IsolatedDeclarations<'a> {
     pub(crate) fn transform_import_declaration(
         &self,
         decl: &ImportDeclaration<'a>,
-    ) -> Option<Box<'a, ImportDeclaration<'a>>> {
+    ) -> Option<ArenaBox<'a, ImportDeclaration<'a>>> {
         let specifiers = decl.specifiers.as_ref()?;
 
         let mut new_specifiers = self.ast.vec_with_capacity(specifiers.len());
@@ -163,7 +163,7 @@ impl<'a> IsolatedDeclarations<'a> {
     /// const a = 1;
     /// function b() {}
     /// ```
-    pub(crate) fn strip_export_keyword(&self, stmts: &mut Vec<'a, Statement<'a>>) {
+    pub(crate) fn strip_export_keyword(&self, stmts: &mut ArenaVec<'a, Statement<'a>>) {
         stmts.iter_mut().for_each(|stmt| {
             if let Statement::ExportNamedDeclaration(decl) = stmt {
                 if let Some(declaration) = &mut decl.declaration {

--- a/crates/oxc_isolated_declarations/src/signatures.rs
+++ b/crates/oxc_isolated_declarations/src/signatures.rs
@@ -1,6 +1,6 @@
 use rustc_hash::FxHashMap;
 
-use oxc_allocator::{CloneIn, Vec};
+use oxc_allocator::{CloneIn, Vec as ArenaVec};
 use oxc_ast::ast::{TSMethodSignatureKind, TSSignature};
 use oxc_span::GetSpan;
 
@@ -11,7 +11,7 @@ impl<'a> IsolatedDeclarations<'a> {
     ///
     /// Infer get accessor return type from set accessor's param type
     /// Infer set accessor parameter type from get accessor return type
-    pub fn transform_ts_signatures(&mut self, signatures: &mut Vec<'a, TSSignature<'a>>) {
+    pub fn transform_ts_signatures(&mut self, signatures: &mut ArenaVec<'a, TSSignature<'a>>) {
         // <name, (requires_inference, first_param_annotation, return_type)>
         let mut method_annotations: FxHashMap<_, (bool, _, _)> = FxHashMap::default();
 


### PR DESCRIPTION
Pure refactor. Like in transformer, import `oxc_allocator::Box` and `Vec` as `ArenaBox` / `ArenaVec`. This reduces confusion about when `Vec` means `oxc_allocator::Vec`, and when it means `std::vec::Vec` (the code uses both).
