### PR TITLE
ci(benchmarks): create new AST for each benchmark run

### DIFF
--- a/tasks/benchmark/benches/semantic.rs
+++ b/tasks/benchmark/benches/semantic.rs
@@ -11,17 +11,29 @@ fn bench_semantic(criterion: &mut Criterion) {
         let id = BenchmarkId::from_parameter(&file.file_name);
         let source_text = file.source_text.as_str();
         let source_type = SourceType::from_path(&file.file_name).unwrap();
+
+        // Create `Allocator` outside of `bench_function`, so same allocator is used for
+        // both the warmup and measurement phases
+        let mut allocator = Allocator::default();
+
         group.bench_function(id, |b| {
-            let allocator = Allocator::default();
-            let ret = Parser::new(&allocator, source_text, source_type).parse();
-            b.iter_with_large_drop(|| {
-                // We drop `Semantic` inside this closure as drop time is part of cost of using this API.
-                // We return `error`s to be dropped outside of the measured section, as usually
-                // code would have no errors. One of our benchmarks `cal.com.tsx` has a lot of errors,
-                // but that's atypical, so don't want to include it in benchmark time.
-                let ret = SemanticBuilder::new().with_build_jsdoc(true).build(&ret.program);
-                let ret = black_box(ret);
-                ret.errors
+            b.iter_with_setup_wrapper(|runner| {
+                // Reset allocator at start of each iteration
+                allocator.reset();
+
+                // Create fresh AST for each iteration, as `SemanticBuilder` alters the AST
+                let program = Parser::new(&allocator, source_text, source_type).parse().program;
+                let program = black_box(program);
+
+                runner.run(|| {
+                    // We drop `Semantic` inside this closure as drop time is part of cost of using this API.
+                    // We return `errors` to be dropped outside of the measured section, as usually
+                    // code would have no errors. One of our benchmarks `cal.com.tsx` has a lot of errors,
+                    // but that's atypical, so don't want to include it in benchmark time.
+                    let ret = SemanticBuilder::new().with_build_jsdoc(true).build(&program);
+                    let ret = black_box(ret);
+                    ret.errors
+                });
             });
         });
     }


### PR DESCRIPTION
Make 2 changes to `oxc_semantic` benchmark:

1. Re-use a single allocator.
2. Create a fresh AST (in that same allocator) for each benchmark run - because `SemanticBuilder` mutates the AST.

Hopefully this will reduce noise in the benchmark a bit, and is a closer analog to real-world usage.
