### PR TITLE
perf(ast/estree): reduce overhead serializing static strings

### DIFF
--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -4,7 +4,7 @@
 #![allow(unused_imports, clippy::match_same_arms, clippy::semicolon_if_nothing_returned)]
 
 use oxc_estree::{
-    ESTree, FlatStructSerializer, Serializer, StructSerializer,
+    ESTree, FlatStructSerializer, JsonSafeString, Serializer, StructSerializer,
     ser::{AppendTo, AppendToConcat},
 };
 
@@ -16,7 +16,7 @@ use crate::ast::ts::*;
 impl ESTree for Program<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "Program");
+        state.serialize_field("type", &JsonSafeString("Program"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field(
@@ -81,7 +81,7 @@ impl ESTree for Expression<'_> {
 impl ESTree for IdentifierName<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "Identifier");
+        state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &self.name);
@@ -92,7 +92,7 @@ impl ESTree for IdentifierName<'_> {
 impl ESTree for IdentifierReference<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "Identifier");
+        state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &self.name);
@@ -103,7 +103,7 @@ impl ESTree for IdentifierReference<'_> {
 impl ESTree for BindingIdentifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "Identifier");
+        state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &self.name);
@@ -114,7 +114,7 @@ impl ESTree for BindingIdentifier<'_> {
 impl ESTree for LabelIdentifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "Identifier");
+        state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &self.name);
@@ -125,7 +125,7 @@ impl ESTree for LabelIdentifier<'_> {
 impl ESTree for ThisExpression {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ThisExpression");
+        state.serialize_field("type", &JsonSafeString("ThisExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.end();
@@ -135,7 +135,7 @@ impl ESTree for ThisExpression {
 impl ESTree for ArrayExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ArrayExpression");
+        state.serialize_field("type", &JsonSafeString("ArrayExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("elements", &self.elements);
@@ -203,7 +203,7 @@ impl ESTree for Elision {
 impl ESTree for ObjectExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ObjectExpression");
+        state.serialize_field("type", &JsonSafeString("ObjectExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("properties", &self.properties);
@@ -280,9 +280,9 @@ impl ESTree for PropertyKey<'_> {
 impl ESTree for PropertyKind {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::Init => "init".serialize(serializer),
-            Self::Get => "get".serialize(serializer),
-            Self::Set => "set".serialize(serializer),
+            Self::Init => JsonSafeString("init").serialize(serializer),
+            Self::Get => JsonSafeString("get").serialize(serializer),
+            Self::Set => JsonSafeString("set").serialize(serializer),
         }
     }
 }
@@ -290,7 +290,7 @@ impl ESTree for PropertyKind {
 impl ESTree for TemplateLiteral<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TemplateLiteral");
+        state.serialize_field("type", &JsonSafeString("TemplateLiteral"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expressions", &self.expressions);
@@ -302,7 +302,7 @@ impl ESTree for TemplateLiteral<'_> {
 impl ESTree for TaggedTemplateExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TaggedTemplateExpression");
+        state.serialize_field("type", &JsonSafeString("TaggedTemplateExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("tag", &self.tag);
@@ -315,7 +315,7 @@ impl ESTree for TaggedTemplateExpression<'_> {
 impl ESTree for TemplateElement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TemplateElement");
+        state.serialize_field("type", &JsonSafeString("TemplateElement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &self.value);
@@ -346,7 +346,7 @@ impl ESTree for MemberExpression<'_> {
 impl ESTree for ComputedMemberExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "MemberExpression");
+        state.serialize_field("type", &JsonSafeString("MemberExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("object", &self.object);
@@ -360,7 +360,7 @@ impl ESTree for ComputedMemberExpression<'_> {
 impl ESTree for StaticMemberExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "MemberExpression");
+        state.serialize_field("type", &JsonSafeString("MemberExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("object", &self.object);
@@ -374,7 +374,7 @@ impl ESTree for StaticMemberExpression<'_> {
 impl ESTree for PrivateFieldExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "MemberExpression");
+        state.serialize_field("type", &JsonSafeString("MemberExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("object", &self.object);
@@ -388,7 +388,7 @@ impl ESTree for PrivateFieldExpression<'_> {
 impl ESTree for CallExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "CallExpression");
+        state.serialize_field("type", &JsonSafeString("CallExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("callee", &self.callee);
@@ -402,7 +402,7 @@ impl ESTree for CallExpression<'_> {
 impl ESTree for NewExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "NewExpression");
+        state.serialize_field("type", &JsonSafeString("NewExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("callee", &self.callee);
@@ -415,7 +415,7 @@ impl ESTree for NewExpression<'_> {
 impl ESTree for MetaProperty<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "MetaProperty");
+        state.serialize_field("type", &JsonSafeString("MetaProperty"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("meta", &self.meta);
@@ -427,7 +427,7 @@ impl ESTree for MetaProperty<'_> {
 impl ESTree for SpreadElement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "SpreadElement");
+        state.serialize_field("type", &JsonSafeString("SpreadElement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("argument", &self.argument);
@@ -488,7 +488,7 @@ impl ESTree for Argument<'_> {
 impl ESTree for UpdateExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "UpdateExpression");
+        state.serialize_field("type", &JsonSafeString("UpdateExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("operator", &self.operator);
@@ -501,7 +501,7 @@ impl ESTree for UpdateExpression<'_> {
 impl ESTree for UnaryExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "UnaryExpression");
+        state.serialize_field("type", &JsonSafeString("UnaryExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("operator", &self.operator);
@@ -514,7 +514,7 @@ impl ESTree for UnaryExpression<'_> {
 impl ESTree for BinaryExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "BinaryExpression");
+        state.serialize_field("type", &JsonSafeString("BinaryExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("left", &self.left);
@@ -527,7 +527,7 @@ impl ESTree for BinaryExpression<'_> {
 impl ESTree for PrivateInExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "BinaryExpression");
+        state.serialize_field("type", &JsonSafeString("BinaryExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("left", &self.left);
@@ -540,7 +540,7 @@ impl ESTree for PrivateInExpression<'_> {
 impl ESTree for LogicalExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "LogicalExpression");
+        state.serialize_field("type", &JsonSafeString("LogicalExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("left", &self.left);
@@ -553,7 +553,7 @@ impl ESTree for LogicalExpression<'_> {
 impl ESTree for ConditionalExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ConditionalExpression");
+        state.serialize_field("type", &JsonSafeString("ConditionalExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("test", &self.test);
@@ -566,7 +566,7 @@ impl ESTree for ConditionalExpression<'_> {
 impl ESTree for AssignmentExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "AssignmentExpression");
+        state.serialize_field("type", &JsonSafeString("AssignmentExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("operator", &self.operator);
@@ -622,7 +622,7 @@ impl ESTree for AssignmentTargetPattern<'_> {
 impl ESTree for ArrayAssignmentTarget<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ArrayPattern");
+        state.serialize_field("type", &JsonSafeString("ArrayPattern"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("elements", &AppendTo { array: &self.elements, after: &self.rest });
@@ -633,7 +633,7 @@ impl ESTree for ArrayAssignmentTarget<'_> {
 impl ESTree for ObjectAssignmentTarget<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ObjectPattern");
+        state.serialize_field("type", &JsonSafeString("ObjectPattern"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field(
@@ -647,7 +647,7 @@ impl ESTree for ObjectAssignmentTarget<'_> {
 impl ESTree for AssignmentTargetRest<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "RestElement");
+        state.serialize_field("type", &JsonSafeString("RestElement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("argument", &self.target);
@@ -677,7 +677,7 @@ impl ESTree for AssignmentTargetMaybeDefault<'_> {
 impl ESTree for AssignmentTargetWithDefault<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "AssignmentPattern");
+        state.serialize_field("type", &JsonSafeString("AssignmentPattern"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("left", &self.binding);
@@ -698,7 +698,7 @@ impl ESTree for AssignmentTargetProperty<'_> {
 impl ESTree for AssignmentTargetPropertyIdentifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "Property");
+        state.serialize_field("type", &JsonSafeString("Property"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("method", &crate::serialize::False(self));
@@ -717,7 +717,7 @@ impl ESTree for AssignmentTargetPropertyIdentifier<'_> {
 impl ESTree for AssignmentTargetPropertyProperty<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "Property");
+        state.serialize_field("type", &JsonSafeString("Property"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("method", &crate::serialize::False(self));
@@ -733,7 +733,7 @@ impl ESTree for AssignmentTargetPropertyProperty<'_> {
 impl ESTree for SequenceExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "SequenceExpression");
+        state.serialize_field("type", &JsonSafeString("SequenceExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expressions", &self.expressions);
@@ -744,7 +744,7 @@ impl ESTree for SequenceExpression<'_> {
 impl ESTree for Super {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "Super");
+        state.serialize_field("type", &JsonSafeString("Super"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.end();
@@ -754,7 +754,7 @@ impl ESTree for Super {
 impl ESTree for AwaitExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "AwaitExpression");
+        state.serialize_field("type", &JsonSafeString("AwaitExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("argument", &self.argument);
@@ -765,7 +765,7 @@ impl ESTree for AwaitExpression<'_> {
 impl ESTree for ChainExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ChainExpression");
+        state.serialize_field("type", &JsonSafeString("ChainExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
@@ -788,7 +788,7 @@ impl ESTree for ChainElement<'_> {
 impl ESTree for ParenthesizedExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ParenthesizedExpression");
+        state.serialize_field("type", &JsonSafeString("ParenthesizedExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
@@ -838,7 +838,7 @@ impl ESTree for Statement<'_> {
 impl ESTree for Directive<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ExpressionStatement");
+        state.serialize_field("type", &JsonSafeString("ExpressionStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
@@ -850,7 +850,7 @@ impl ESTree for Directive<'_> {
 impl ESTree for Hashbang<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "Hashbang");
+        state.serialize_field("type", &JsonSafeString("Hashbang"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &self.value);
@@ -861,7 +861,7 @@ impl ESTree for Hashbang<'_> {
 impl ESTree for BlockStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "BlockStatement");
+        state.serialize_field("type", &JsonSafeString("BlockStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("body", &self.body);
@@ -887,7 +887,7 @@ impl ESTree for Declaration<'_> {
 impl ESTree for VariableDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "VariableDeclaration");
+        state.serialize_field("type", &JsonSafeString("VariableDeclaration"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("declarations", &self.declarations);
@@ -900,11 +900,11 @@ impl ESTree for VariableDeclaration<'_> {
 impl ESTree for VariableDeclarationKind {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::Var => "var".serialize(serializer),
-            Self::Const => "const".serialize(serializer),
-            Self::Let => "let".serialize(serializer),
-            Self::Using => "using".serialize(serializer),
-            Self::AwaitUsing => "await using".serialize(serializer),
+            Self::Var => JsonSafeString("var").serialize(serializer),
+            Self::Const => JsonSafeString("const").serialize(serializer),
+            Self::Let => JsonSafeString("let").serialize(serializer),
+            Self::Using => JsonSafeString("using").serialize(serializer),
+            Self::AwaitUsing => JsonSafeString("await using").serialize(serializer),
         }
     }
 }
@@ -912,7 +912,7 @@ impl ESTree for VariableDeclarationKind {
 impl ESTree for VariableDeclarator<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "VariableDeclarator");
+        state.serialize_field("type", &JsonSafeString("VariableDeclarator"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("id", &self.id);
@@ -925,7 +925,7 @@ impl ESTree for VariableDeclarator<'_> {
 impl ESTree for EmptyStatement {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "EmptyStatement");
+        state.serialize_field("type", &JsonSafeString("EmptyStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.end();
@@ -935,7 +935,7 @@ impl ESTree for EmptyStatement {
 impl ESTree for ExpressionStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ExpressionStatement");
+        state.serialize_field("type", &JsonSafeString("ExpressionStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
@@ -946,7 +946,7 @@ impl ESTree for ExpressionStatement<'_> {
 impl ESTree for IfStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "IfStatement");
+        state.serialize_field("type", &JsonSafeString("IfStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("test", &self.test);
@@ -959,7 +959,7 @@ impl ESTree for IfStatement<'_> {
 impl ESTree for DoWhileStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "DoWhileStatement");
+        state.serialize_field("type", &JsonSafeString("DoWhileStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("body", &self.body);
@@ -971,7 +971,7 @@ impl ESTree for DoWhileStatement<'_> {
 impl ESTree for WhileStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "WhileStatement");
+        state.serialize_field("type", &JsonSafeString("WhileStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("test", &self.test);
@@ -983,7 +983,7 @@ impl ESTree for WhileStatement<'_> {
 impl ESTree for ForStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ForStatement");
+        state.serialize_field("type", &JsonSafeString("ForStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("init", &self.init);
@@ -1047,7 +1047,7 @@ impl ESTree for ForStatementInit<'_> {
 impl ESTree for ForInStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ForInStatement");
+        state.serialize_field("type", &JsonSafeString("ForInStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("left", &self.left);
@@ -1079,7 +1079,7 @@ impl ESTree for ForStatementLeft<'_> {
 impl ESTree for ForOfStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ForOfStatement");
+        state.serialize_field("type", &JsonSafeString("ForOfStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("await", &self.r#await);
@@ -1093,7 +1093,7 @@ impl ESTree for ForOfStatement<'_> {
 impl ESTree for ContinueStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ContinueStatement");
+        state.serialize_field("type", &JsonSafeString("ContinueStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("label", &self.label);
@@ -1104,7 +1104,7 @@ impl ESTree for ContinueStatement<'_> {
 impl ESTree for BreakStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "BreakStatement");
+        state.serialize_field("type", &JsonSafeString("BreakStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("label", &self.label);
@@ -1115,7 +1115,7 @@ impl ESTree for BreakStatement<'_> {
 impl ESTree for ReturnStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ReturnStatement");
+        state.serialize_field("type", &JsonSafeString("ReturnStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("argument", &self.argument);
@@ -1126,7 +1126,7 @@ impl ESTree for ReturnStatement<'_> {
 impl ESTree for WithStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "WithStatement");
+        state.serialize_field("type", &JsonSafeString("WithStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("object", &self.object);
@@ -1138,7 +1138,7 @@ impl ESTree for WithStatement<'_> {
 impl ESTree for SwitchStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "SwitchStatement");
+        state.serialize_field("type", &JsonSafeString("SwitchStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("discriminant", &self.discriminant);
@@ -1150,7 +1150,7 @@ impl ESTree for SwitchStatement<'_> {
 impl ESTree for SwitchCase<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "SwitchCase");
+        state.serialize_field("type", &JsonSafeString("SwitchCase"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("consequent", &self.consequent);
@@ -1162,7 +1162,7 @@ impl ESTree for SwitchCase<'_> {
 impl ESTree for LabeledStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "LabeledStatement");
+        state.serialize_field("type", &JsonSafeString("LabeledStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("body", &self.body);
@@ -1174,7 +1174,7 @@ impl ESTree for LabeledStatement<'_> {
 impl ESTree for ThrowStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ThrowStatement");
+        state.serialize_field("type", &JsonSafeString("ThrowStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("argument", &self.argument);
@@ -1185,7 +1185,7 @@ impl ESTree for ThrowStatement<'_> {
 impl ESTree for TryStatement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TryStatement");
+        state.serialize_field("type", &JsonSafeString("TryStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("block", &self.block);
@@ -1198,7 +1198,7 @@ impl ESTree for TryStatement<'_> {
 impl ESTree for CatchClause<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "CatchClause");
+        state.serialize_field("type", &JsonSafeString("CatchClause"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("param", &self.param);
@@ -1220,7 +1220,7 @@ impl ESTree for CatchParameter<'_> {
 impl ESTree for DebuggerStatement {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "DebuggerStatement");
+        state.serialize_field("type", &JsonSafeString("DebuggerStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.end();
@@ -1251,7 +1251,7 @@ impl ESTree for BindingPatternKind<'_> {
 impl ESTree for AssignmentPattern<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "AssignmentPattern");
+        state.serialize_field("type", &JsonSafeString("AssignmentPattern"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("left", &self.left);
@@ -1263,7 +1263,7 @@ impl ESTree for AssignmentPattern<'_> {
 impl ESTree for ObjectPattern<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ObjectPattern");
+        state.serialize_field("type", &JsonSafeString("ObjectPattern"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field(
@@ -1283,7 +1283,7 @@ impl ESTree for BindingProperty<'_> {
 impl ESTree for ArrayPattern<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ArrayPattern");
+        state.serialize_field("type", &JsonSafeString("ArrayPattern"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("elements", &AppendTo { array: &self.elements, after: &self.rest });
@@ -1294,7 +1294,7 @@ impl ESTree for ArrayPattern<'_> {
 impl ESTree for BindingRestElement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "RestElement");
+        state.serialize_field("type", &JsonSafeString("RestElement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("argument", &self.argument);
@@ -1325,11 +1325,13 @@ impl ESTree for Function<'_> {
 impl ESTree for FunctionType {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::FunctionDeclaration => "FunctionDeclaration".serialize(serializer),
-            Self::FunctionExpression => "FunctionExpression".serialize(serializer),
-            Self::TSDeclareFunction => "TSDeclareFunction".serialize(serializer),
+            Self::FunctionDeclaration => {
+                JsonSafeString("FunctionDeclaration").serialize(serializer)
+            }
+            Self::FunctionExpression => JsonSafeString("FunctionExpression").serialize(serializer),
+            Self::TSDeclareFunction => JsonSafeString("TSDeclareFunction").serialize(serializer),
             Self::TSEmptyBodyFunctionExpression => {
-                "TSEmptyBodyFunctionExpression".serialize(serializer)
+                JsonSafeString("TSEmptyBodyFunctionExpression").serialize(serializer)
             }
         }
     }
@@ -1358,10 +1360,14 @@ impl ESTree for FormalParameter<'_> {
 impl ESTree for FormalParameterKind {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::FormalParameter => "FormalParameter".serialize(serializer),
-            Self::UniqueFormalParameters => "UniqueFormalParameters".serialize(serializer),
-            Self::ArrowFormalParameters => "ArrowFormalParameters".serialize(serializer),
-            Self::Signature => "Signature".serialize(serializer),
+            Self::FormalParameter => JsonSafeString("FormalParameter").serialize(serializer),
+            Self::UniqueFormalParameters => {
+                JsonSafeString("UniqueFormalParameters").serialize(serializer)
+            }
+            Self::ArrowFormalParameters => {
+                JsonSafeString("ArrowFormalParameters").serialize(serializer)
+            }
+            Self::Signature => JsonSafeString("Signature").serialize(serializer),
         }
     }
 }
@@ -1369,7 +1375,7 @@ impl ESTree for FormalParameterKind {
 impl ESTree for FunctionBody<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "BlockStatement");
+        state.serialize_field("type", &JsonSafeString("BlockStatement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field(
@@ -1383,7 +1389,7 @@ impl ESTree for FunctionBody<'_> {
 impl ESTree for ArrowFunctionExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ArrowFunctionExpression");
+        state.serialize_field("type", &JsonSafeString("ArrowFunctionExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("id", &crate::serialize::Null(self));
@@ -1401,7 +1407,7 @@ impl ESTree for ArrowFunctionExpression<'_> {
 impl ESTree for YieldExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "YieldExpression");
+        state.serialize_field("type", &JsonSafeString("YieldExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("delegate", &self.delegate);
@@ -1432,8 +1438,8 @@ impl ESTree for Class<'_> {
 impl ESTree for ClassType {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::ClassDeclaration => "ClassDeclaration".serialize(serializer),
-            Self::ClassExpression => "ClassExpression".serialize(serializer),
+            Self::ClassDeclaration => JsonSafeString("ClassDeclaration").serialize(serializer),
+            Self::ClassExpression => JsonSafeString("ClassExpression").serialize(serializer),
         }
     }
 }
@@ -1441,7 +1447,7 @@ impl ESTree for ClassType {
 impl ESTree for ClassBody<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ClassBody");
+        state.serialize_field("type", &JsonSafeString("ClassBody"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("body", &self.body);
@@ -1483,8 +1489,10 @@ impl ESTree for MethodDefinition<'_> {
 impl ESTree for MethodDefinitionType {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::MethodDefinition => "MethodDefinition".serialize(serializer),
-            Self::TSAbstractMethodDefinition => "TSAbstractMethodDefinition".serialize(serializer),
+            Self::MethodDefinition => JsonSafeString("MethodDefinition").serialize(serializer),
+            Self::TSAbstractMethodDefinition => {
+                JsonSafeString("TSAbstractMethodDefinition").serialize(serializer)
+            }
         }
     }
 }
@@ -1514,9 +1522,9 @@ impl ESTree for PropertyDefinition<'_> {
 impl ESTree for PropertyDefinitionType {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::PropertyDefinition => "PropertyDefinition".serialize(serializer),
+            Self::PropertyDefinition => JsonSafeString("PropertyDefinition").serialize(serializer),
             Self::TSAbstractPropertyDefinition => {
-                "TSAbstractPropertyDefinition".serialize(serializer)
+                JsonSafeString("TSAbstractPropertyDefinition").serialize(serializer)
             }
         }
     }
@@ -1525,10 +1533,10 @@ impl ESTree for PropertyDefinitionType {
 impl ESTree for MethodDefinitionKind {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::Constructor => "constructor".serialize(serializer),
-            Self::Method => "method".serialize(serializer),
-            Self::Get => "get".serialize(serializer),
-            Self::Set => "set".serialize(serializer),
+            Self::Constructor => JsonSafeString("constructor").serialize(serializer),
+            Self::Method => JsonSafeString("method").serialize(serializer),
+            Self::Get => JsonSafeString("get").serialize(serializer),
+            Self::Set => JsonSafeString("set").serialize(serializer),
         }
     }
 }
@@ -1536,7 +1544,7 @@ impl ESTree for MethodDefinitionKind {
 impl ESTree for PrivateIdentifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "PrivateIdentifier");
+        state.serialize_field("type", &JsonSafeString("PrivateIdentifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &self.name);
@@ -1547,7 +1555,7 @@ impl ESTree for PrivateIdentifier<'_> {
 impl ESTree for StaticBlock<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "StaticBlock");
+        state.serialize_field("type", &JsonSafeString("StaticBlock"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("body", &self.body);
@@ -1571,8 +1579,10 @@ impl ESTree for ModuleDeclaration<'_> {
 impl ESTree for AccessorPropertyType {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::AccessorProperty => "AccessorProperty".serialize(serializer),
-            Self::TSAbstractAccessorProperty => "TSAbstractAccessorProperty".serialize(serializer),
+            Self::AccessorProperty => JsonSafeString("AccessorProperty").serialize(serializer),
+            Self::TSAbstractAccessorProperty => {
+                JsonSafeString("TSAbstractAccessorProperty").serialize(serializer)
+            }
         }
     }
 }
@@ -1598,7 +1608,7 @@ impl ESTree for AccessorProperty<'_> {
 impl ESTree for ImportExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ImportExpression");
+        state.serialize_field("type", &JsonSafeString("ImportExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("source", &self.source);
@@ -1610,7 +1620,7 @@ impl ESTree for ImportExpression<'_> {
 impl ESTree for ImportDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ImportDeclaration");
+        state.serialize_field("type", &JsonSafeString("ImportDeclaration"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("specifiers", &crate::serialize::ImportDeclarationSpecifiers(self));
@@ -1624,8 +1634,8 @@ impl ESTree for ImportDeclaration<'_> {
 impl ESTree for ImportPhase {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::Source => "source".serialize(serializer),
-            Self::Defer => "defer".serialize(serializer),
+            Self::Source => JsonSafeString("source").serialize(serializer),
+            Self::Defer => JsonSafeString("defer").serialize(serializer),
         }
     }
 }
@@ -1643,7 +1653,7 @@ impl ESTree for ImportDeclarationSpecifier<'_> {
 impl ESTree for ImportSpecifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ImportSpecifier");
+        state.serialize_field("type", &JsonSafeString("ImportSpecifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("imported", &self.imported);
@@ -1656,7 +1666,7 @@ impl ESTree for ImportSpecifier<'_> {
 impl ESTree for ImportDefaultSpecifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ImportDefaultSpecifier");
+        state.serialize_field("type", &JsonSafeString("ImportDefaultSpecifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("local", &self.local);
@@ -1667,7 +1677,7 @@ impl ESTree for ImportDefaultSpecifier<'_> {
 impl ESTree for ImportNamespaceSpecifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ImportNamespaceSpecifier");
+        state.serialize_field("type", &JsonSafeString("ImportNamespaceSpecifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("local", &self.local);
@@ -1678,7 +1688,7 @@ impl ESTree for ImportNamespaceSpecifier<'_> {
 impl ESTree for WithClause<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "WithClause");
+        state.serialize_field("type", &JsonSafeString("WithClause"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("attributesKeyword", &self.attributes_keyword);
@@ -1690,7 +1700,7 @@ impl ESTree for WithClause<'_> {
 impl ESTree for ImportAttribute<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ImportAttribute");
+        state.serialize_field("type", &JsonSafeString("ImportAttribute"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("key", &self.key);
@@ -1717,7 +1727,7 @@ impl ESTree for ExportNamedDeclaration<'_> {
 impl ESTree for ExportDefaultDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ExportDefaultDeclaration");
+        state.serialize_field("type", &JsonSafeString("ExportDefaultDeclaration"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("declaration", &self.declaration);
@@ -1728,7 +1738,7 @@ impl ESTree for ExportDefaultDeclaration<'_> {
 impl ESTree for ExportAllDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ExportAllDeclaration");
+        state.serialize_field("type", &JsonSafeString("ExportAllDeclaration"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("exported", &self.exported);
@@ -1743,7 +1753,7 @@ impl ESTree for ExportAllDeclaration<'_> {
 impl ESTree for ExportSpecifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ExportSpecifier");
+        state.serialize_field("type", &JsonSafeString("ExportSpecifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("local", &self.local);
@@ -1818,7 +1828,7 @@ impl ESTree for ModuleExportName<'_> {
 impl ESTree for BooleanLiteral {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "Literal");
+        state.serialize_field("type", &JsonSafeString("Literal"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &self.value);
@@ -1830,7 +1840,7 @@ impl ESTree for BooleanLiteral {
 impl ESTree for NullLiteral {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "Literal");
+        state.serialize_field("type", &JsonSafeString("Literal"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &crate::serialize::Null(self));
@@ -1842,7 +1852,7 @@ impl ESTree for NullLiteral {
 impl ESTree for NumericLiteral<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "Literal");
+        state.serialize_field("type", &JsonSafeString("Literal"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &self.value);
@@ -1854,7 +1864,7 @@ impl ESTree for NumericLiteral<'_> {
 impl ESTree for StringLiteral<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "Literal");
+        state.serialize_field("type", &JsonSafeString("Literal"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &self.value);
@@ -1866,7 +1876,7 @@ impl ESTree for StringLiteral<'_> {
 impl ESTree for BigIntLiteral<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "Literal");
+        state.serialize_field("type", &JsonSafeString("Literal"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &crate::serialize::BigIntLiteralValue(self));
@@ -1879,7 +1889,7 @@ impl ESTree for BigIntLiteral<'_> {
 impl ESTree for RegExpLiteral<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "Literal");
+        state.serialize_field("type", &JsonSafeString("Literal"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &crate::serialize::RegExpLiteralValue(self));
@@ -1913,7 +1923,7 @@ impl ESTree for RegExpFlags {
 impl ESTree for JSXElement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "JSXElement");
+        state.serialize_field("type", &JsonSafeString("JSXElement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("openingElement", &self.opening_element);
@@ -1926,7 +1936,7 @@ impl ESTree for JSXElement<'_> {
 impl ESTree for JSXOpeningElement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "JSXOpeningElement");
+        state.serialize_field("type", &JsonSafeString("JSXOpeningElement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("selfClosing", &self.self_closing);
@@ -1940,7 +1950,7 @@ impl ESTree for JSXOpeningElement<'_> {
 impl ESTree for JSXClosingElement<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "JSXClosingElement");
+        state.serialize_field("type", &JsonSafeString("JSXClosingElement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &self.name);
@@ -1951,7 +1961,7 @@ impl ESTree for JSXClosingElement<'_> {
 impl ESTree for JSXFragment<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "JSXFragment");
+        state.serialize_field("type", &JsonSafeString("JSXFragment"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("openingFragment", &self.opening_fragment);
@@ -1964,7 +1974,7 @@ impl ESTree for JSXFragment<'_> {
 impl ESTree for JSXOpeningFragment {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "JSXOpeningFragment");
+        state.serialize_field("type", &JsonSafeString("JSXOpeningFragment"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.end();
@@ -1974,7 +1984,7 @@ impl ESTree for JSXOpeningFragment {
 impl ESTree for JSXClosingFragment {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "JSXClosingFragment");
+        state.serialize_field("type", &JsonSafeString("JSXClosingFragment"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.end();
@@ -1990,7 +2000,7 @@ impl ESTree for JSXElementName<'_> {
 impl ESTree for JSXNamespacedName<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "JSXNamespacedName");
+        state.serialize_field("type", &JsonSafeString("JSXNamespacedName"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("namespace", &self.namespace);
@@ -2002,7 +2012,7 @@ impl ESTree for JSXNamespacedName<'_> {
 impl ESTree for JSXMemberExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "JSXMemberExpression");
+        state.serialize_field("type", &JsonSafeString("JSXMemberExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("object", &self.object);
@@ -2020,7 +2030,7 @@ impl ESTree for JSXMemberExpressionObject<'_> {
 impl ESTree for JSXExpressionContainer<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "JSXExpressionContainer");
+        state.serialize_field("type", &JsonSafeString("JSXExpressionContainer"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
@@ -2081,7 +2091,7 @@ impl ESTree for JSXExpression<'_> {
 impl ESTree for JSXEmptyExpression {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "JSXEmptyExpression");
+        state.serialize_field("type", &JsonSafeString("JSXEmptyExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.end();
@@ -2100,7 +2110,7 @@ impl ESTree for JSXAttributeItem<'_> {
 impl ESTree for JSXAttribute<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "JSXAttribute");
+        state.serialize_field("type", &JsonSafeString("JSXAttribute"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &self.name);
@@ -2112,7 +2122,7 @@ impl ESTree for JSXAttribute<'_> {
 impl ESTree for JSXSpreadAttribute<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "JSXSpreadAttribute");
+        state.serialize_field("type", &JsonSafeString("JSXSpreadAttribute"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("argument", &self.argument);
@@ -2143,7 +2153,7 @@ impl ESTree for JSXAttributeValue<'_> {
 impl ESTree for JSXIdentifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "JSXIdentifier");
+        state.serialize_field("type", &JsonSafeString("JSXIdentifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &self.name);
@@ -2166,7 +2176,7 @@ impl ESTree for JSXChild<'_> {
 impl ESTree for JSXSpreadChild<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "JSXSpreadChild");
+        state.serialize_field("type", &JsonSafeString("JSXSpreadChild"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
@@ -2177,7 +2187,7 @@ impl ESTree for JSXSpreadChild<'_> {
 impl ESTree for JSXText<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "JSXText");
+        state.serialize_field("type", &JsonSafeString("JSXText"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &self.value);
@@ -2188,7 +2198,7 @@ impl ESTree for JSXText<'_> {
 impl ESTree for TSThisParameter<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSThisParameter");
+        state.serialize_field("type", &JsonSafeString("TSThisParameter"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeAnnotation", &self.type_annotation);
@@ -2199,7 +2209,7 @@ impl ESTree for TSThisParameter<'_> {
 impl ESTree for TSEnumDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSEnumDeclaration");
+        state.serialize_field("type", &JsonSafeString("TSEnumDeclaration"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("id", &self.id);
@@ -2213,7 +2223,7 @@ impl ESTree for TSEnumDeclaration<'_> {
 impl ESTree for TSEnumMember<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSEnumMember");
+        state.serialize_field("type", &JsonSafeString("TSEnumMember"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("id", &self.id);
@@ -2234,7 +2244,7 @@ impl ESTree for TSEnumMemberName<'_> {
 impl ESTree for TSTypeAnnotation<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSTypeAnnotation");
+        state.serialize_field("type", &JsonSafeString("TSTypeAnnotation"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeAnnotation", &self.type_annotation);
@@ -2245,7 +2255,7 @@ impl ESTree for TSTypeAnnotation<'_> {
 impl ESTree for TSLiteralType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSLiteralType");
+        state.serialize_field("type", &JsonSafeString("TSLiteralType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("literal", &self.literal);
@@ -2313,7 +2323,7 @@ impl ESTree for TSType<'_> {
 impl ESTree for TSConditionalType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSConditionalType");
+        state.serialize_field("type", &JsonSafeString("TSConditionalType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("checkType", &self.check_type);
@@ -2327,7 +2337,7 @@ impl ESTree for TSConditionalType<'_> {
 impl ESTree for TSUnionType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSUnionType");
+        state.serialize_field("type", &JsonSafeString("TSUnionType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("types", &self.types);
@@ -2338,7 +2348,7 @@ impl ESTree for TSUnionType<'_> {
 impl ESTree for TSIntersectionType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSIntersectionType");
+        state.serialize_field("type", &JsonSafeString("TSIntersectionType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("types", &self.types);
@@ -2349,7 +2359,7 @@ impl ESTree for TSIntersectionType<'_> {
 impl ESTree for TSParenthesizedType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSParenthesizedType");
+        state.serialize_field("type", &JsonSafeString("TSParenthesizedType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeAnnotation", &self.type_annotation);
@@ -2360,7 +2370,7 @@ impl ESTree for TSParenthesizedType<'_> {
 impl ESTree for TSTypeOperator<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSTypeOperator");
+        state.serialize_field("type", &JsonSafeString("TSTypeOperator"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("operator", &self.operator);
@@ -2372,9 +2382,9 @@ impl ESTree for TSTypeOperator<'_> {
 impl ESTree for TSTypeOperatorOperator {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::Keyof => "keyof".serialize(serializer),
-            Self::Unique => "unique".serialize(serializer),
-            Self::Readonly => "readonly".serialize(serializer),
+            Self::Keyof => JsonSafeString("keyof").serialize(serializer),
+            Self::Unique => JsonSafeString("unique").serialize(serializer),
+            Self::Readonly => JsonSafeString("readonly").serialize(serializer),
         }
     }
 }
@@ -2382,7 +2392,7 @@ impl ESTree for TSTypeOperatorOperator {
 impl ESTree for TSArrayType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSArrayType");
+        state.serialize_field("type", &JsonSafeString("TSArrayType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("elementType", &self.element_type);
@@ -2393,7 +2403,7 @@ impl ESTree for TSArrayType<'_> {
 impl ESTree for TSIndexedAccessType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSIndexedAccessType");
+        state.serialize_field("type", &JsonSafeString("TSIndexedAccessType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("objectType", &self.object_type);
@@ -2405,7 +2415,7 @@ impl ESTree for TSIndexedAccessType<'_> {
 impl ESTree for TSTupleType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSTupleType");
+        state.serialize_field("type", &JsonSafeString("TSTupleType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("elementTypes", &self.element_types);
@@ -2416,7 +2426,7 @@ impl ESTree for TSTupleType<'_> {
 impl ESTree for TSNamedTupleMember<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSNamedTupleMember");
+        state.serialize_field("type", &JsonSafeString("TSNamedTupleMember"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("elementType", &self.element_type);
@@ -2429,7 +2439,7 @@ impl ESTree for TSNamedTupleMember<'_> {
 impl ESTree for TSOptionalType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSOptionalType");
+        state.serialize_field("type", &JsonSafeString("TSOptionalType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeAnnotation", &self.type_annotation);
@@ -2440,7 +2450,7 @@ impl ESTree for TSOptionalType<'_> {
 impl ESTree for TSRestType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSRestType");
+        state.serialize_field("type", &JsonSafeString("TSRestType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeAnnotation", &self.type_annotation);
@@ -2497,7 +2507,7 @@ impl ESTree for TSTupleElement<'_> {
 impl ESTree for TSAnyKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSAnyKeyword");
+        state.serialize_field("type", &JsonSafeString("TSAnyKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.end();
@@ -2507,7 +2517,7 @@ impl ESTree for TSAnyKeyword {
 impl ESTree for TSStringKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSStringKeyword");
+        state.serialize_field("type", &JsonSafeString("TSStringKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.end();
@@ -2517,7 +2527,7 @@ impl ESTree for TSStringKeyword {
 impl ESTree for TSBooleanKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSBooleanKeyword");
+        state.serialize_field("type", &JsonSafeString("TSBooleanKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.end();
@@ -2527,7 +2537,7 @@ impl ESTree for TSBooleanKeyword {
 impl ESTree for TSNumberKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSNumberKeyword");
+        state.serialize_field("type", &JsonSafeString("TSNumberKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.end();
@@ -2537,7 +2547,7 @@ impl ESTree for TSNumberKeyword {
 impl ESTree for TSNeverKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSNeverKeyword");
+        state.serialize_field("type", &JsonSafeString("TSNeverKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.end();
@@ -2547,7 +2557,7 @@ impl ESTree for TSNeverKeyword {
 impl ESTree for TSIntrinsicKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSIntrinsicKeyword");
+        state.serialize_field("type", &JsonSafeString("TSIntrinsicKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.end();
@@ -2557,7 +2567,7 @@ impl ESTree for TSIntrinsicKeyword {
 impl ESTree for TSUnknownKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSUnknownKeyword");
+        state.serialize_field("type", &JsonSafeString("TSUnknownKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.end();
@@ -2567,7 +2577,7 @@ impl ESTree for TSUnknownKeyword {
 impl ESTree for TSNullKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSNullKeyword");
+        state.serialize_field("type", &JsonSafeString("TSNullKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.end();
@@ -2577,7 +2587,7 @@ impl ESTree for TSNullKeyword {
 impl ESTree for TSUndefinedKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSUndefinedKeyword");
+        state.serialize_field("type", &JsonSafeString("TSUndefinedKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.end();
@@ -2587,7 +2597,7 @@ impl ESTree for TSUndefinedKeyword {
 impl ESTree for TSVoidKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSVoidKeyword");
+        state.serialize_field("type", &JsonSafeString("TSVoidKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.end();
@@ -2597,7 +2607,7 @@ impl ESTree for TSVoidKeyword {
 impl ESTree for TSSymbolKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSSymbolKeyword");
+        state.serialize_field("type", &JsonSafeString("TSSymbolKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.end();
@@ -2607,7 +2617,7 @@ impl ESTree for TSSymbolKeyword {
 impl ESTree for TSThisType {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSThisType");
+        state.serialize_field("type", &JsonSafeString("TSThisType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.end();
@@ -2617,7 +2627,7 @@ impl ESTree for TSThisType {
 impl ESTree for TSObjectKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSObjectKeyword");
+        state.serialize_field("type", &JsonSafeString("TSObjectKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.end();
@@ -2627,7 +2637,7 @@ impl ESTree for TSObjectKeyword {
 impl ESTree for TSBigIntKeyword {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSBigIntKeyword");
+        state.serialize_field("type", &JsonSafeString("TSBigIntKeyword"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.end();
@@ -2637,7 +2647,7 @@ impl ESTree for TSBigIntKeyword {
 impl ESTree for TSTypeReference<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSTypeReference");
+        state.serialize_field("type", &JsonSafeString("TSTypeReference"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeName", &self.type_name);
@@ -2658,7 +2668,7 @@ impl ESTree for TSTypeName<'_> {
 impl ESTree for TSQualifiedName<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSQualifiedName");
+        state.serialize_field("type", &JsonSafeString("TSQualifiedName"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("left", &self.left);
@@ -2670,7 +2680,7 @@ impl ESTree for TSQualifiedName<'_> {
 impl ESTree for TSTypeParameterInstantiation<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSTypeParameterInstantiation");
+        state.serialize_field("type", &JsonSafeString("TSTypeParameterInstantiation"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("params", &self.params);
@@ -2681,7 +2691,7 @@ impl ESTree for TSTypeParameterInstantiation<'_> {
 impl ESTree for TSTypeParameter<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSTypeParameter");
+        state.serialize_field("type", &JsonSafeString("TSTypeParameter"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &self.name);
@@ -2697,7 +2707,7 @@ impl ESTree for TSTypeParameter<'_> {
 impl ESTree for TSTypeParameterDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSTypeParameterDeclaration");
+        state.serialize_field("type", &JsonSafeString("TSTypeParameterDeclaration"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("params", &self.params);
@@ -2708,7 +2718,7 @@ impl ESTree for TSTypeParameterDeclaration<'_> {
 impl ESTree for TSTypeAliasDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSTypeAliasDeclaration");
+        state.serialize_field("type", &JsonSafeString("TSTypeAliasDeclaration"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("id", &self.id);
@@ -2722,9 +2732,9 @@ impl ESTree for TSTypeAliasDeclaration<'_> {
 impl ESTree for TSAccessibility {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::Private => "private".serialize(serializer),
-            Self::Protected => "protected".serialize(serializer),
-            Self::Public => "public".serialize(serializer),
+            Self::Private => JsonSafeString("private").serialize(serializer),
+            Self::Protected => JsonSafeString("protected").serialize(serializer),
+            Self::Public => JsonSafeString("public").serialize(serializer),
         }
     }
 }
@@ -2732,7 +2742,7 @@ impl ESTree for TSAccessibility {
 impl ESTree for TSClassImplements<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSClassImplements");
+        state.serialize_field("type", &JsonSafeString("TSClassImplements"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
@@ -2744,7 +2754,7 @@ impl ESTree for TSClassImplements<'_> {
 impl ESTree for TSInterfaceDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSInterfaceDeclaration");
+        state.serialize_field("type", &JsonSafeString("TSInterfaceDeclaration"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("id", &self.id);
@@ -2759,7 +2769,7 @@ impl ESTree for TSInterfaceDeclaration<'_> {
 impl ESTree for TSInterfaceBody<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSInterfaceBody");
+        state.serialize_field("type", &JsonSafeString("TSInterfaceBody"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("body", &self.body);
@@ -2770,7 +2780,7 @@ impl ESTree for TSInterfaceBody<'_> {
 impl ESTree for TSPropertySignature<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSPropertySignature");
+        state.serialize_field("type", &JsonSafeString("TSPropertySignature"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("computed", &self.computed);
@@ -2797,7 +2807,7 @@ impl ESTree for TSSignature<'_> {
 impl ESTree for TSIndexSignature<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSIndexSignature");
+        state.serialize_field("type", &JsonSafeString("TSIndexSignature"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("parameters", &self.parameters);
@@ -2811,7 +2821,7 @@ impl ESTree for TSIndexSignature<'_> {
 impl ESTree for TSCallSignatureDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSCallSignatureDeclaration");
+        state.serialize_field("type", &JsonSafeString("TSCallSignatureDeclaration"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeParameters", &self.type_parameters);
@@ -2825,9 +2835,9 @@ impl ESTree for TSCallSignatureDeclaration<'_> {
 impl ESTree for TSMethodSignatureKind {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::Method => "method".serialize(serializer),
-            Self::Get => "get".serialize(serializer),
-            Self::Set => "set".serialize(serializer),
+            Self::Method => JsonSafeString("method").serialize(serializer),
+            Self::Get => JsonSafeString("get").serialize(serializer),
+            Self::Set => JsonSafeString("set").serialize(serializer),
         }
     }
 }
@@ -2835,7 +2845,7 @@ impl ESTree for TSMethodSignatureKind {
 impl ESTree for TSMethodSignature<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSMethodSignature");
+        state.serialize_field("type", &JsonSafeString("TSMethodSignature"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("key", &self.key);
@@ -2853,7 +2863,7 @@ impl ESTree for TSMethodSignature<'_> {
 impl ESTree for TSConstructSignatureDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSConstructSignatureDeclaration");
+        state.serialize_field("type", &JsonSafeString("TSConstructSignatureDeclaration"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeParameters", &self.type_parameters);
@@ -2866,7 +2876,7 @@ impl ESTree for TSConstructSignatureDeclaration<'_> {
 impl ESTree for TSIndexSignatureName<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "Identifier");
+        state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &self.name);
@@ -2878,7 +2888,7 @@ impl ESTree for TSIndexSignatureName<'_> {
 impl ESTree for TSInterfaceHeritage<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSInterfaceHeritage");
+        state.serialize_field("type", &JsonSafeString("TSInterfaceHeritage"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
@@ -2890,7 +2900,7 @@ impl ESTree for TSInterfaceHeritage<'_> {
 impl ESTree for TSTypePredicate<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSTypePredicate");
+        state.serialize_field("type", &JsonSafeString("TSTypePredicate"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("parameterName", &self.parameter_name);
@@ -2912,7 +2922,7 @@ impl ESTree for TSTypePredicateName<'_> {
 impl ESTree for TSModuleDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSModuleDeclaration");
+        state.serialize_field("type", &JsonSafeString("TSModuleDeclaration"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("id", &self.id);
@@ -2926,9 +2936,9 @@ impl ESTree for TSModuleDeclaration<'_> {
 impl ESTree for TSModuleDeclarationKind {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::Global => "global".serialize(serializer),
-            Self::Module => "module".serialize(serializer),
-            Self::Namespace => "namespace".serialize(serializer),
+            Self::Global => JsonSafeString("global").serialize(serializer),
+            Self::Module => JsonSafeString("module").serialize(serializer),
+            Self::Namespace => JsonSafeString("namespace").serialize(serializer),
         }
     }
 }
@@ -2954,7 +2964,7 @@ impl ESTree for TSModuleDeclarationBody<'_> {
 impl ESTree for TSModuleBlock<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSModuleBlock");
+        state.serialize_field("type", &JsonSafeString("TSModuleBlock"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field(
@@ -2968,7 +2978,7 @@ impl ESTree for TSModuleBlock<'_> {
 impl ESTree for TSTypeLiteral<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSTypeLiteral");
+        state.serialize_field("type", &JsonSafeString("TSTypeLiteral"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("members", &self.members);
@@ -2979,7 +2989,7 @@ impl ESTree for TSTypeLiteral<'_> {
 impl ESTree for TSInferType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSInferType");
+        state.serialize_field("type", &JsonSafeString("TSInferType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeParameter", &self.type_parameter);
@@ -2990,7 +3000,7 @@ impl ESTree for TSInferType<'_> {
 impl ESTree for TSTypeQuery<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSTypeQuery");
+        state.serialize_field("type", &JsonSafeString("TSTypeQuery"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("exprName", &self.expr_name);
@@ -3012,7 +3022,7 @@ impl ESTree for TSTypeQueryExprName<'_> {
 impl ESTree for TSImportType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSImportType");
+        state.serialize_field("type", &JsonSafeString("TSImportType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("isTypeOf", &self.is_type_of);
@@ -3027,7 +3037,7 @@ impl ESTree for TSImportType<'_> {
 impl ESTree for TSImportAttributes<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSImportAttributes");
+        state.serialize_field("type", &JsonSafeString("TSImportAttributes"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("attributesKeyword", &self.attributes_keyword);
@@ -3039,7 +3049,7 @@ impl ESTree for TSImportAttributes<'_> {
 impl ESTree for TSImportAttribute<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSImportAttribute");
+        state.serialize_field("type", &JsonSafeString("TSImportAttribute"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &self.name);
@@ -3060,7 +3070,7 @@ impl ESTree for TSImportAttributeName<'_> {
 impl ESTree for TSFunctionType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSFunctionType");
+        state.serialize_field("type", &JsonSafeString("TSFunctionType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeParameters", &self.type_parameters);
@@ -3074,7 +3084,7 @@ impl ESTree for TSFunctionType<'_> {
 impl ESTree for TSConstructorType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSConstructorType");
+        state.serialize_field("type", &JsonSafeString("TSConstructorType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("abstract", &self.r#abstract);
@@ -3088,7 +3098,7 @@ impl ESTree for TSConstructorType<'_> {
 impl ESTree for TSMappedType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSMappedType");
+        state.serialize_field("type", &JsonSafeString("TSMappedType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeParameter", &self.type_parameter);
@@ -3103,10 +3113,10 @@ impl ESTree for TSMappedType<'_> {
 impl ESTree for TSMappedTypeModifierOperator {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::True => "true".serialize(serializer),
-            Self::Plus => "+".serialize(serializer),
-            Self::Minus => "-".serialize(serializer),
-            Self::None => "none".serialize(serializer),
+            Self::True => JsonSafeString("true").serialize(serializer),
+            Self::Plus => JsonSafeString("+").serialize(serializer),
+            Self::Minus => JsonSafeString("-").serialize(serializer),
+            Self::None => JsonSafeString("none").serialize(serializer),
         }
     }
 }
@@ -3114,7 +3124,7 @@ impl ESTree for TSMappedTypeModifierOperator {
 impl ESTree for TSTemplateLiteralType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSTemplateLiteralType");
+        state.serialize_field("type", &JsonSafeString("TSTemplateLiteralType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("quasis", &self.quasis);
@@ -3126,7 +3136,7 @@ impl ESTree for TSTemplateLiteralType<'_> {
 impl ESTree for TSAsExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSAsExpression");
+        state.serialize_field("type", &JsonSafeString("TSAsExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
@@ -3138,7 +3148,7 @@ impl ESTree for TSAsExpression<'_> {
 impl ESTree for TSSatisfiesExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSSatisfiesExpression");
+        state.serialize_field("type", &JsonSafeString("TSSatisfiesExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
@@ -3150,7 +3160,7 @@ impl ESTree for TSSatisfiesExpression<'_> {
 impl ESTree for TSTypeAssertion<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSTypeAssertion");
+        state.serialize_field("type", &JsonSafeString("TSTypeAssertion"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
@@ -3162,7 +3172,7 @@ impl ESTree for TSTypeAssertion<'_> {
 impl ESTree for TSImportEqualsDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSImportEqualsDeclaration");
+        state.serialize_field("type", &JsonSafeString("TSImportEqualsDeclaration"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("id", &self.id);
@@ -3185,7 +3195,7 @@ impl ESTree for TSModuleReference<'_> {
 impl ESTree for TSExternalModuleReference<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSExternalModuleReference");
+        state.serialize_field("type", &JsonSafeString("TSExternalModuleReference"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
@@ -3196,7 +3206,7 @@ impl ESTree for TSExternalModuleReference<'_> {
 impl ESTree for TSNonNullExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSNonNullExpression");
+        state.serialize_field("type", &JsonSafeString("TSNonNullExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
@@ -3207,7 +3217,7 @@ impl ESTree for TSNonNullExpression<'_> {
 impl ESTree for Decorator<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "Decorator");
+        state.serialize_field("type", &JsonSafeString("Decorator"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
@@ -3218,7 +3228,7 @@ impl ESTree for Decorator<'_> {
 impl ESTree for TSExportAssignment<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSExportAssignment");
+        state.serialize_field("type", &JsonSafeString("TSExportAssignment"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
@@ -3229,7 +3239,7 @@ impl ESTree for TSExportAssignment<'_> {
 impl ESTree for TSNamespaceExportDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSNamespaceExportDeclaration");
+        state.serialize_field("type", &JsonSafeString("TSNamespaceExportDeclaration"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("id", &self.id);
@@ -3240,7 +3250,7 @@ impl ESTree for TSNamespaceExportDeclaration<'_> {
 impl ESTree for TSInstantiationExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "TSInstantiationExpression");
+        state.serialize_field("type", &JsonSafeString("TSInstantiationExpression"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
@@ -3252,8 +3262,8 @@ impl ESTree for TSInstantiationExpression<'_> {
 impl ESTree for ImportOrExportKind {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::Value => "value".serialize(serializer),
-            Self::Type => "type".serialize(serializer),
+            Self::Value => JsonSafeString("value").serialize(serializer),
+            Self::Type => JsonSafeString("type").serialize(serializer),
         }
     }
 }
@@ -3261,7 +3271,7 @@ impl ESTree for ImportOrExportKind {
 impl ESTree for JSDocNullableType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "JSDocNullableType");
+        state.serialize_field("type", &JsonSafeString("JSDocNullableType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeAnnotation", &self.type_annotation);
@@ -3273,7 +3283,7 @@ impl ESTree for JSDocNullableType<'_> {
 impl ESTree for JSDocNonNullableType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "JSDocNonNullableType");
+        state.serialize_field("type", &JsonSafeString("JSDocNonNullableType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeAnnotation", &self.type_annotation);
@@ -3285,7 +3295,7 @@ impl ESTree for JSDocNonNullableType<'_> {
 impl ESTree for JSDocUnknownType {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "JSDocUnknownType");
+        state.serialize_field("type", &JsonSafeString("JSDocUnknownType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.end();

--- a/crates/oxc_estree/src/serialize/mod.rs
+++ b/crates/oxc_estree/src/serialize/mod.rs
@@ -16,6 +16,7 @@ use sequences::ESTreeSequenceSerializer;
 use structs::ESTreeStructSerializer;
 
 pub use sequences::SequenceSerializer;
+pub use strings::JsonSafeString;
 pub use structs::{FlatStructSerializer, StructSerializer};
 
 /// Trait for types which can be serialized to ESTree.

--- a/crates/oxc_estree/src/serialize/strings.rs
+++ b/crates/oxc_estree/src/serialize/strings.rs
@@ -2,6 +2,24 @@ use oxc_data_structures::code_buffer::CodeBuffer;
 
 use super::{ESTree, Serializer};
 
+/// A string which does not need any escaping in JSON.
+///
+/// This provides better performance when you know that the string definitely contains no characters
+/// that require escaping, as it avoids the cost of checking that.
+///
+/// If the string does in fact contain characters that did need escaping, it will result in invalid JSON.
+pub struct JsonSafeString<'s>(pub &'s str);
+
+impl ESTree for JsonSafeString<'_> {
+    #[inline(always)]
+    fn serialize<S: Serializer>(&self, mut serializer: S) {
+        let buffer = serializer.buffer_mut();
+        buffer.print_ascii_byte(b'"');
+        buffer.print_str(self.0);
+        buffer.print_ascii_byte(b'"');
+    }
+}
+
 /// [`ESTree`] implementation for string slice.
 impl ESTree for str {
     fn serialize<S: Serializer>(&self, mut serializer: S) {

--- a/crates/oxc_regular_expression/src/generated/derive_estree.rs
+++ b/crates/oxc_regular_expression/src/generated/derive_estree.rs
@@ -4,7 +4,7 @@
 #![allow(unused_imports, clippy::match_same_arms, clippy::semicolon_if_nothing_returned)]
 
 use oxc_estree::{
-    ESTree, FlatStructSerializer, Serializer, StructSerializer,
+    ESTree, FlatStructSerializer, JsonSafeString, Serializer, StructSerializer,
     ser::{AppendTo, AppendToConcat},
 };
 
@@ -13,7 +13,7 @@ use crate::ast::*;
 impl ESTree for Pattern<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "Pattern");
+        state.serialize_field("type", &JsonSafeString("Pattern"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("body", &self.body);
@@ -24,7 +24,7 @@ impl ESTree for Pattern<'_> {
 impl ESTree for Disjunction<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "Disjunction");
+        state.serialize_field("type", &JsonSafeString("Disjunction"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("body", &self.body);
@@ -35,7 +35,7 @@ impl ESTree for Disjunction<'_> {
 impl ESTree for Alternative<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "Alternative");
+        state.serialize_field("type", &JsonSafeString("Alternative"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("body", &self.body);
@@ -65,7 +65,7 @@ impl ESTree for Term<'_> {
 impl ESTree for BoundaryAssertion {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "BoundaryAssertion");
+        state.serialize_field("type", &JsonSafeString("BoundaryAssertion"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("kind", &self.kind);
@@ -76,10 +76,10 @@ impl ESTree for BoundaryAssertion {
 impl ESTree for BoundaryAssertionKind {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::Start => "start".serialize(serializer),
-            Self::End => "end".serialize(serializer),
-            Self::Boundary => "boundary".serialize(serializer),
-            Self::NegativeBoundary => "negativeBoundary".serialize(serializer),
+            Self::Start => JsonSafeString("start").serialize(serializer),
+            Self::End => JsonSafeString("end").serialize(serializer),
+            Self::Boundary => JsonSafeString("boundary").serialize(serializer),
+            Self::NegativeBoundary => JsonSafeString("negativeBoundary").serialize(serializer),
         }
     }
 }
@@ -87,7 +87,7 @@ impl ESTree for BoundaryAssertionKind {
 impl ESTree for LookAroundAssertion<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "LookAroundAssertion");
+        state.serialize_field("type", &JsonSafeString("LookAroundAssertion"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("kind", &self.kind);
@@ -99,10 +99,10 @@ impl ESTree for LookAroundAssertion<'_> {
 impl ESTree for LookAroundAssertionKind {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::Lookahead => "lookahead".serialize(serializer),
-            Self::NegativeLookahead => "negativeLookahead".serialize(serializer),
-            Self::Lookbehind => "lookbehind".serialize(serializer),
-            Self::NegativeLookbehind => "negativeLookbehind".serialize(serializer),
+            Self::Lookahead => JsonSafeString("lookahead").serialize(serializer),
+            Self::NegativeLookahead => JsonSafeString("negativeLookahead").serialize(serializer),
+            Self::Lookbehind => JsonSafeString("lookbehind").serialize(serializer),
+            Self::NegativeLookbehind => JsonSafeString("negativeLookbehind").serialize(serializer),
         }
     }
 }
@@ -110,7 +110,7 @@ impl ESTree for LookAroundAssertionKind {
 impl ESTree for Quantifier<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "Quantifier");
+        state.serialize_field("type", &JsonSafeString("Quantifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("min", &self.min);
@@ -124,7 +124,7 @@ impl ESTree for Quantifier<'_> {
 impl ESTree for Character {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "Character");
+        state.serialize_field("type", &JsonSafeString("Character"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("kind", &self.kind);
@@ -136,16 +136,16 @@ impl ESTree for Character {
 impl ESTree for CharacterKind {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::ControlLetter => "controlLetter".serialize(serializer),
-            Self::HexadecimalEscape => "hexadecimalEscape".serialize(serializer),
-            Self::Identifier => "identifier".serialize(serializer),
-            Self::Null => "null".serialize(serializer),
-            Self::Octal1 => "octal1".serialize(serializer),
-            Self::Octal2 => "octal2".serialize(serializer),
-            Self::Octal3 => "octal3".serialize(serializer),
-            Self::SingleEscape => "singleEscape".serialize(serializer),
-            Self::Symbol => "symbol".serialize(serializer),
-            Self::UnicodeEscape => "unicodeEscape".serialize(serializer),
+            Self::ControlLetter => JsonSafeString("controlLetter").serialize(serializer),
+            Self::HexadecimalEscape => JsonSafeString("hexadecimalEscape").serialize(serializer),
+            Self::Identifier => JsonSafeString("identifier").serialize(serializer),
+            Self::Null => JsonSafeString("null").serialize(serializer),
+            Self::Octal1 => JsonSafeString("octal1").serialize(serializer),
+            Self::Octal2 => JsonSafeString("octal2").serialize(serializer),
+            Self::Octal3 => JsonSafeString("octal3").serialize(serializer),
+            Self::SingleEscape => JsonSafeString("singleEscape").serialize(serializer),
+            Self::Symbol => JsonSafeString("symbol").serialize(serializer),
+            Self::UnicodeEscape => JsonSafeString("unicodeEscape").serialize(serializer),
         }
     }
 }
@@ -153,7 +153,7 @@ impl ESTree for CharacterKind {
 impl ESTree for CharacterClassEscape {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "CharacterClassEscape");
+        state.serialize_field("type", &JsonSafeString("CharacterClassEscape"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("kind", &self.kind);
@@ -164,12 +164,12 @@ impl ESTree for CharacterClassEscape {
 impl ESTree for CharacterClassEscapeKind {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::D => "d".serialize(serializer),
-            Self::NegativeD => "negativeD".serialize(serializer),
-            Self::S => "s".serialize(serializer),
-            Self::NegativeS => "negativeS".serialize(serializer),
-            Self::W => "w".serialize(serializer),
-            Self::NegativeW => "negativeW".serialize(serializer),
+            Self::D => JsonSafeString("d").serialize(serializer),
+            Self::NegativeD => JsonSafeString("negativeD").serialize(serializer),
+            Self::S => JsonSafeString("s").serialize(serializer),
+            Self::NegativeS => JsonSafeString("negativeS").serialize(serializer),
+            Self::W => JsonSafeString("w").serialize(serializer),
+            Self::NegativeW => JsonSafeString("negativeW").serialize(serializer),
         }
     }
 }
@@ -177,7 +177,7 @@ impl ESTree for CharacterClassEscapeKind {
 impl ESTree for UnicodePropertyEscape<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "UnicodePropertyEscape");
+        state.serialize_field("type", &JsonSafeString("UnicodePropertyEscape"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("negative", &self.negative);
@@ -191,7 +191,7 @@ impl ESTree for UnicodePropertyEscape<'_> {
 impl ESTree for Dot {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "Dot");
+        state.serialize_field("type", &JsonSafeString("Dot"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.end();
@@ -201,7 +201,7 @@ impl ESTree for Dot {
 impl ESTree for CharacterClass<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "CharacterClass");
+        state.serialize_field("type", &JsonSafeString("CharacterClass"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("negative", &self.negative);
@@ -215,9 +215,9 @@ impl ESTree for CharacterClass<'_> {
 impl ESTree for CharacterClassContentsKind {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::Union => "union".serialize(serializer),
-            Self::Intersection => "intersection".serialize(serializer),
-            Self::Subtraction => "subtraction".serialize(serializer),
+            Self::Union => JsonSafeString("union").serialize(serializer),
+            Self::Intersection => JsonSafeString("intersection").serialize(serializer),
+            Self::Subtraction => JsonSafeString("subtraction").serialize(serializer),
         }
     }
 }
@@ -238,7 +238,7 @@ impl ESTree for CharacterClassContents<'_> {
 impl ESTree for CharacterClassRange {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "CharacterClassRange");
+        state.serialize_field("type", &JsonSafeString("CharacterClassRange"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("min", &self.min);
@@ -250,7 +250,7 @@ impl ESTree for CharacterClassRange {
 impl ESTree for ClassStringDisjunction<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ClassStringDisjunction");
+        state.serialize_field("type", &JsonSafeString("ClassStringDisjunction"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("strings", &self.strings);
@@ -262,7 +262,7 @@ impl ESTree for ClassStringDisjunction<'_> {
 impl ESTree for ClassString<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "ClassString");
+        state.serialize_field("type", &JsonSafeString("ClassString"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("strings", &self.strings);
@@ -274,7 +274,7 @@ impl ESTree for ClassString<'_> {
 impl ESTree for CapturingGroup<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "CapturingGroup");
+        state.serialize_field("type", &JsonSafeString("CapturingGroup"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &self.name);
@@ -286,7 +286,7 @@ impl ESTree for CapturingGroup<'_> {
 impl ESTree for IgnoreGroup<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "IgnoreGroup");
+        state.serialize_field("type", &JsonSafeString("IgnoreGroup"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("modifiers", &self.modifiers);
@@ -298,7 +298,7 @@ impl ESTree for IgnoreGroup<'_> {
 impl ESTree for Modifiers {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "Modifiers");
+        state.serialize_field("type", &JsonSafeString("Modifiers"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("enabling", &self.enabling);
@@ -310,7 +310,7 @@ impl ESTree for Modifiers {
 impl ESTree for Modifier {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "Modifier");
+        state.serialize_field("type", &JsonSafeString("Modifier"));
         state.serialize_field("ignoreCase", &self.ignore_case);
         state.serialize_field("multiline", &self.multiline);
         state.serialize_field("sticky", &self.sticky);
@@ -321,7 +321,7 @@ impl ESTree for Modifier {
 impl ESTree for IndexedReference {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "IndexedReference");
+        state.serialize_field("type", &JsonSafeString("IndexedReference"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("index", &self.index);
@@ -332,7 +332,7 @@ impl ESTree for IndexedReference {
 impl ESTree for NamedReference<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", "NamedReference");
+        state.serialize_field("type", &JsonSafeString("NamedReference"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &self.name);

--- a/crates/oxc_span/src/generated/derive_estree.rs
+++ b/crates/oxc_span/src/generated/derive_estree.rs
@@ -4,7 +4,7 @@
 #![allow(unused_imports, clippy::match_same_arms, clippy::semicolon_if_nothing_returned)]
 
 use oxc_estree::{
-    ESTree, FlatStructSerializer, Serializer, StructSerializer,
+    ESTree, FlatStructSerializer, JsonSafeString, Serializer, StructSerializer,
     ser::{AppendTo, AppendToConcat},
 };
 
@@ -31,9 +31,9 @@ impl ESTree for SourceType {
 impl ESTree for ModuleKind {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::Script => "script".serialize(serializer),
-            Self::Module => "module".serialize(serializer),
-            Self::Unambiguous => "unambiguous".serialize(serializer),
+            Self::Script => JsonSafeString("script").serialize(serializer),
+            Self::Module => JsonSafeString("module").serialize(serializer),
+            Self::Unambiguous => JsonSafeString("unambiguous").serialize(serializer),
         }
     }
 }

--- a/crates/oxc_syntax/src/generated/derive_estree.rs
+++ b/crates/oxc_syntax/src/generated/derive_estree.rs
@@ -4,7 +4,7 @@
 #![allow(unused_imports, clippy::match_same_arms, clippy::semicolon_if_nothing_returned)]
 
 use oxc_estree::{
-    ESTree, FlatStructSerializer, Serializer, StructSerializer,
+    ESTree, FlatStructSerializer, JsonSafeString, Serializer, StructSerializer,
     ser::{AppendTo, AppendToConcat},
 };
 
@@ -13,22 +13,22 @@ use crate::operator::*;
 impl ESTree for AssignmentOperator {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::Assign => "=".serialize(serializer),
-            Self::Addition => "+=".serialize(serializer),
-            Self::Subtraction => "-=".serialize(serializer),
-            Self::Multiplication => "*=".serialize(serializer),
-            Self::Division => "/=".serialize(serializer),
-            Self::Remainder => "%=".serialize(serializer),
-            Self::Exponential => "**=".serialize(serializer),
-            Self::ShiftLeft => "<<=".serialize(serializer),
-            Self::ShiftRight => ">>=".serialize(serializer),
-            Self::ShiftRightZeroFill => ">>>=".serialize(serializer),
-            Self::BitwiseOR => "|=".serialize(serializer),
-            Self::BitwiseXOR => "^=".serialize(serializer),
-            Self::BitwiseAnd => "&=".serialize(serializer),
-            Self::LogicalOr => "||=".serialize(serializer),
-            Self::LogicalAnd => "&&=".serialize(serializer),
-            Self::LogicalNullish => "??=".serialize(serializer),
+            Self::Assign => JsonSafeString("=").serialize(serializer),
+            Self::Addition => JsonSafeString("+=").serialize(serializer),
+            Self::Subtraction => JsonSafeString("-=").serialize(serializer),
+            Self::Multiplication => JsonSafeString("*=").serialize(serializer),
+            Self::Division => JsonSafeString("/=").serialize(serializer),
+            Self::Remainder => JsonSafeString("%=").serialize(serializer),
+            Self::Exponential => JsonSafeString("**=").serialize(serializer),
+            Self::ShiftLeft => JsonSafeString("<<=").serialize(serializer),
+            Self::ShiftRight => JsonSafeString(">>=").serialize(serializer),
+            Self::ShiftRightZeroFill => JsonSafeString(">>>=").serialize(serializer),
+            Self::BitwiseOR => JsonSafeString("|=").serialize(serializer),
+            Self::BitwiseXOR => JsonSafeString("^=").serialize(serializer),
+            Self::BitwiseAnd => JsonSafeString("&=").serialize(serializer),
+            Self::LogicalOr => JsonSafeString("||=").serialize(serializer),
+            Self::LogicalAnd => JsonSafeString("&&=").serialize(serializer),
+            Self::LogicalNullish => JsonSafeString("??=").serialize(serializer),
         }
     }
 }
@@ -36,28 +36,28 @@ impl ESTree for AssignmentOperator {
 impl ESTree for BinaryOperator {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::Equality => "==".serialize(serializer),
-            Self::Inequality => "!=".serialize(serializer),
-            Self::StrictEquality => "===".serialize(serializer),
-            Self::StrictInequality => "!==".serialize(serializer),
-            Self::LessThan => "<".serialize(serializer),
-            Self::LessEqualThan => "<=".serialize(serializer),
-            Self::GreaterThan => ">".serialize(serializer),
-            Self::GreaterEqualThan => ">=".serialize(serializer),
-            Self::Addition => "+".serialize(serializer),
-            Self::Subtraction => "-".serialize(serializer),
-            Self::Multiplication => "*".serialize(serializer),
-            Self::Division => "/".serialize(serializer),
-            Self::Remainder => "%".serialize(serializer),
-            Self::Exponential => "**".serialize(serializer),
-            Self::ShiftLeft => "<<".serialize(serializer),
-            Self::ShiftRight => ">>".serialize(serializer),
-            Self::ShiftRightZeroFill => ">>>".serialize(serializer),
-            Self::BitwiseOR => "|".serialize(serializer),
-            Self::BitwiseXOR => "^".serialize(serializer),
-            Self::BitwiseAnd => "&".serialize(serializer),
-            Self::In => "in".serialize(serializer),
-            Self::Instanceof => "instanceof".serialize(serializer),
+            Self::Equality => JsonSafeString("==").serialize(serializer),
+            Self::Inequality => JsonSafeString("!=").serialize(serializer),
+            Self::StrictEquality => JsonSafeString("===").serialize(serializer),
+            Self::StrictInequality => JsonSafeString("!==").serialize(serializer),
+            Self::LessThan => JsonSafeString("<").serialize(serializer),
+            Self::LessEqualThan => JsonSafeString("<=").serialize(serializer),
+            Self::GreaterThan => JsonSafeString(">").serialize(serializer),
+            Self::GreaterEqualThan => JsonSafeString(">=").serialize(serializer),
+            Self::Addition => JsonSafeString("+").serialize(serializer),
+            Self::Subtraction => JsonSafeString("-").serialize(serializer),
+            Self::Multiplication => JsonSafeString("*").serialize(serializer),
+            Self::Division => JsonSafeString("/").serialize(serializer),
+            Self::Remainder => JsonSafeString("%").serialize(serializer),
+            Self::Exponential => JsonSafeString("**").serialize(serializer),
+            Self::ShiftLeft => JsonSafeString("<<").serialize(serializer),
+            Self::ShiftRight => JsonSafeString(">>").serialize(serializer),
+            Self::ShiftRightZeroFill => JsonSafeString(">>>").serialize(serializer),
+            Self::BitwiseOR => JsonSafeString("|").serialize(serializer),
+            Self::BitwiseXOR => JsonSafeString("^").serialize(serializer),
+            Self::BitwiseAnd => JsonSafeString("&").serialize(serializer),
+            Self::In => JsonSafeString("in").serialize(serializer),
+            Self::Instanceof => JsonSafeString("instanceof").serialize(serializer),
         }
     }
 }
@@ -65,9 +65,9 @@ impl ESTree for BinaryOperator {
 impl ESTree for LogicalOperator {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::Or => "||".serialize(serializer),
-            Self::And => "&&".serialize(serializer),
-            Self::Coalesce => "??".serialize(serializer),
+            Self::Or => JsonSafeString("||").serialize(serializer),
+            Self::And => JsonSafeString("&&").serialize(serializer),
+            Self::Coalesce => JsonSafeString("??").serialize(serializer),
         }
     }
 }
@@ -75,13 +75,13 @@ impl ESTree for LogicalOperator {
 impl ESTree for UnaryOperator {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::UnaryPlus => "+".serialize(serializer),
-            Self::UnaryNegation => "-".serialize(serializer),
-            Self::LogicalNot => "!".serialize(serializer),
-            Self::BitwiseNot => "~".serialize(serializer),
-            Self::Typeof => "typeof".serialize(serializer),
-            Self::Void => "void".serialize(serializer),
-            Self::Delete => "delete".serialize(serializer),
+            Self::UnaryPlus => JsonSafeString("+").serialize(serializer),
+            Self::UnaryNegation => JsonSafeString("-").serialize(serializer),
+            Self::LogicalNot => JsonSafeString("!").serialize(serializer),
+            Self::BitwiseNot => JsonSafeString("~").serialize(serializer),
+            Self::Typeof => JsonSafeString("typeof").serialize(serializer),
+            Self::Void => JsonSafeString("void").serialize(serializer),
+            Self::Delete => JsonSafeString("delete").serialize(serializer),
         }
     }
 }
@@ -89,8 +89,8 @@ impl ESTree for UnaryOperator {
 impl ESTree for UpdateOperator {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::Increment => "++".serialize(serializer),
-            Self::Decrement => "--".serialize(serializer),
+            Self::Increment => JsonSafeString("++").serialize(serializer),
+            Self::Decrement => JsonSafeString("--").serialize(serializer),
         }
     }
 }


### PR DESCRIPTION
By default, strings have to be processed to ensure they contain no characters which need to be escaped in JSON, and escape those characters when they do. This is quite slow. But many strings the codegen produces are statically known not to require escaping e.g. `"IdentifierReference"` in `{"type":"IdentifierReference",...}`.

Introduce `JsonSafeString` type. Wrapping a string in this type asserts that the string definitely doesn't need to be escaped, and serializer can skip checks.

In codegen for `ESTree` impls, check if static strings need escaping, and wrap them in `JsonSafeString` if they don't.