### PR TITLE
perf(ast/estree): skip escaping identifiers

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -209,6 +209,7 @@ pub use match_expression;
 #[estree(rename = "Identifier")]
 pub struct IdentifierName<'a> {
     pub span: Span,
+    #[estree(json_safe)]
     pub name: Atom<'a>,
 }
 
@@ -224,6 +225,7 @@ pub struct IdentifierName<'a> {
 pub struct IdentifierReference<'a> {
     pub span: Span,
     /// The name of the identifier being referenced.
+    #[estree(json_safe)]
     pub name: Atom<'a>,
     /// Reference ID
     ///
@@ -246,6 +248,7 @@ pub struct IdentifierReference<'a> {
 pub struct BindingIdentifier<'a> {
     pub span: Span,
     /// The identifier name being bound.
+    #[estree(json_safe)]
     pub name: Atom<'a>,
     /// Unique identifier for this binding.
     ///
@@ -267,6 +270,7 @@ pub struct BindingIdentifier<'a> {
 #[estree(rename = "Identifier")]
 pub struct LabelIdentifier<'a> {
     pub span: Span,
+    #[estree(json_safe)]
     pub name: Atom<'a>,
 }
 

--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -430,6 +430,7 @@ pub struct JSXIdentifier<'a> {
     /// Node location in source code
     pub span: Span,
     /// The name of the identifier.
+    #[estree(json_safe)]
     pub name: Atom<'a>,
 }
 

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1029,6 +1029,7 @@ pub struct TSConstructSignatureDeclaration<'a> {
 #[estree(rename = "Identifier")]
 pub struct TSIndexSignatureName<'a> {
     pub span: Span,
+    #[estree(json_safe)]
     pub name: Atom<'a>,
     pub type_annotation: Box<'a, TSTypeAnnotation<'a>>,
 }

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -84,7 +84,7 @@ impl ESTree for IdentifierName<'_> {
         state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("name", &self.name);
+        state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.end();
     }
 }
@@ -95,7 +95,7 @@ impl ESTree for IdentifierReference<'_> {
         state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("name", &self.name);
+        state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.end();
     }
 }
@@ -106,7 +106,7 @@ impl ESTree for BindingIdentifier<'_> {
         state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("name", &self.name);
+        state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.end();
     }
 }
@@ -117,7 +117,7 @@ impl ESTree for LabelIdentifier<'_> {
         state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("name", &self.name);
+        state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.end();
     }
 }
@@ -2156,7 +2156,7 @@ impl ESTree for JSXIdentifier<'_> {
         state.serialize_field("type", &JsonSafeString("JSXIdentifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("name", &self.name);
+        state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.end();
     }
 }
@@ -2879,7 +2879,7 @@ impl ESTree for TSIndexSignatureName<'_> {
         state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("name", &self.name);
+        state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.serialize_field("typeAnnotation", &self.type_annotation);
         state.end();
     }

--- a/tasks/ast_tools/src/schema/extensions/estree.rs
+++ b/tasks/ast_tools/src/schema/extensions/estree.rs
@@ -56,6 +56,8 @@ pub struct ESTreeStructField {
     pub append_field_index: Option<usize>,
     pub skip: bool,
     pub flatten: bool,
+    // `true` for fields containing a `&str` or `Atom` which does not need escaping in JSON
+    pub json_safe: bool,
     pub is_ts: bool,
 }
 


### PR DESCRIPTION
Similar to #9396. JS identifiers cannot contain any of the characters which require escaping in JSON (whitespace, control characters, `"`, `\`).

Mark struct fields containing a JS identifier name with `#[estree(json_safe)]` to cause codegen to wrap them in `JsonSafeString` before serializing. This removes the work of escaping identifiers during serialization.

Note: Identifiers *can* contain `\` in source text as start of an escape sequence. But such escape sequences are unescaped in parser, so the `Atom` in AST representing identifier name cannot contain `\`.