### PR TITLE
chore(deps): bump `fast-glob`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,9 +655,9 @@ dependencies = [
 
 [[package]]
 name = "fast-glob"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eca69ef247d19faa15ac0156968637440824e5ff22baa5ee0cd35b2f7ea6a0f"
+checksum = "a43e28342e6608e53d694e6a12f56ebd1c9228df61b8edbe6a9a882cab5f4a93"
 dependencies = [
  "arrayvec",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -169,7 +169,7 @@ criterion2 = { version = "3.0.0", default-features = false }
 encoding_rs = "0.8.35"
 encoding_rs_io = "0.1.7"
 env_logger = { version = "0.11.6", default-features = false }
-fast-glob = "0.4.3"
+fast-glob = "0.4.4"
 fixedbitset = "0.5.7"
 flate2 = "1.0.35"
 futures = "0.3.31"


### PR DESCRIPTION
Related to https://github.com/shulaoda/fast-glob/pull/10

Fixed some matching issues.