### PR TITLE
feat(linter): add react/no-namespace rule

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -291,6 +291,7 @@ mod react {
     pub mod no_direct_mutation_state;
     pub mod no_find_dom_node;
     pub mod no_is_mounted;
+    pub mod no_namespace;
     pub mod no_render_return_value;
     pub mod no_set_state;
     pub mod no_string_refs;
@@ -870,6 +871,7 @@ oxc_macros::declare_all_lint_rules! {
     react::jsx_no_undef,
     react::jsx_no_useless_fragment,
     react::jsx_props_no_spread_multi,
+    react::no_namespace,
     react::no_array_index_key,
     react::no_children_prop,
     react::no_danger_with_children,

--- a/crates/oxc_linter/src/rules/react/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/react/no_namespace.rs
@@ -1,0 +1,133 @@
+use oxc_ast::{
+    AstKind,
+    ast::{Argument, JSXElementName},
+};
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule, utils::is_create_element_call};
+
+fn no_namespace_diagnostic(span: Span, component_name: &str) -> OxcDiagnostic {
+    let message = format!(
+        r#"React component {component_name} must not be in a namespace, as React does not support them."#
+    );
+
+    OxcDiagnostic::warn(message).with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoNamespace;
+
+declare_oxc_lint!(
+    /// ### What it does
+    /// Enforce that namespaces are not used in React elements.
+    ///
+    /// ### Why is this bad?
+    /// Namespaces in React elements, such as svg:circle, are not supported by React.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```jsx
+    /// <ns:TestComponent />
+    /// <Ns:TestComponent />
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```jsx
+    /// <TestComponent />
+    /// <testComponent />
+    /// ```
+    NoNamespace,
+    react,
+    suspicious,
+);
+
+impl Rule for NoNamespace {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        match node.kind() {
+            AstKind::JSXOpeningElement(element) => {
+                if let JSXElementName::NamespacedName(namespaced_name) = &element.name {
+                    let component_name_with_ns = format!(
+                        "{}:{}",
+                        namespaced_name.namespace.name, namespaced_name.property.name
+                    );
+
+                    ctx.diagnostic(no_namespace_diagnostic(
+                        namespaced_name.span,
+                        &component_name_with_ns,
+                    ));
+                }
+            }
+            AstKind::CallExpression(call_expr) => {
+                if is_create_element_call(call_expr) {
+                    let Some(Argument::StringLiteral(str_lit)) = call_expr.arguments.first() else {
+                        return;
+                    };
+
+                    if str_lit.value.contains(":") {
+                        ctx.diagnostic(no_namespace_diagnostic(str_lit.span, &str_lit.value));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "<testcomponent />",
+        r#"React.createElement("testcomponent")"#,
+        "<testComponent />",
+        r#"React.createElement("testComponent")"#,
+        "<test_component />",
+        r#"React.createElement("test_component")"#,
+        "<TestComponent />",
+        r#"React.createElement("TestComponent")"#,
+        "<object.testcomponent />",
+        r#"React.createElement("object.testcomponent")"#,
+        "<object.testComponent />",
+        r#"React.createElement("object.testComponent")"#,
+        "<object.test_component />",
+        r#"React.createElement("object.test_component")"#,
+        "<object.TestComponent />",
+        r#"React.createElement("object.TestComponent")"#,
+        "<Object.testcomponent />",
+        r#"React.createElement("Object.testcomponent")"#,
+        "<Object.testComponent />",
+        r#"React.createElement("Object.testComponent")"#,
+        "<Object.test_component />",
+        r#"React.createElement("Object.test_component")"#,
+        "<Object.TestComponent />",
+        r#"React.createElement("Object.TestComponent")"#,
+        "React.createElement(null)",
+        "React.createElement(true)",
+        "React.createElement({})",
+    ];
+
+    let fail = vec![
+        "<ns:testcomponent />",
+        r#"React.createElement("ns:testcomponent")"#,
+        "<ns:testComponent />",
+        r#"React.createElement("ns:testComponent")"#,
+        "<ns:test_component />",
+        r#"React.createElement("ns:test_component")"#,
+        "<ns:TestComponent />",
+        r#"React.createElement("ns:TestComponent")"#,
+        "<Ns:testcomponent />",
+        r#"React.createElement("Ns:testcomponent")"#,
+        "<Ns:testComponent />",
+        r#"React.createElement("Ns:testComponent")"#,
+        "<Ns:test_component />",
+        r#"React.createElement("Ns:test_component")"#,
+        "<Ns:TestComponent />",
+        r#"React.createElement("Ns:TestComponent")"#,
+    ];
+
+    Tester::new(NoNamespace::NAME, NoNamespace::PLUGIN, pass, fail).test_and_snapshot();
+}

--- a/crates/oxc_linter/src/rules/react/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/react/no_namespace.rs
@@ -10,7 +10,7 @@ use crate::{AstNode, context::LintContext, rule::Rule, utils::is_create_element_
 
 fn no_namespace_diagnostic(span: Span, component_name: &str) -> OxcDiagnostic {
     let message = format!(
-        r#"React component {component_name} must not be in a namespace, as React does not support them."#
+        r"React component {component_name} must not be in a namespace, as React does not support them."
     );
 
     OxcDiagnostic::warn(message).with_label(span)
@@ -66,7 +66,7 @@ impl Rule for NoNamespace {
                         return;
                     };
 
-                    if str_lit.value.contains(":") {
+                    if str_lit.value.contains(':') {
                         ctx.diagnostic(no_namespace_diagnostic(str_lit.span, &str_lit.value));
                     }
                 }

--- a/crates/oxc_linter/src/snapshots/react_no_namespace.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_namespace.snap
@@ -1,0 +1,98 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint-plugin-react(no-namespace): React component ns:testcomponent must not be in a namespace, as React does not support them.
+   ╭─[no_namespace.tsx:1:2]
+ 1 │ <ns:testcomponent />
+   ·  ────────────────
+   ╰────
+
+  ⚠ eslint-plugin-react(no-namespace): React component ns:testcomponent must not be in a namespace, as React does not support them.
+   ╭─[no_namespace.tsx:1:21]
+ 1 │ React.createElement("ns:testcomponent")
+   ·                     ──────────────────
+   ╰────
+
+  ⚠ eslint-plugin-react(no-namespace): React component ns:testComponent must not be in a namespace, as React does not support them.
+   ╭─[no_namespace.tsx:1:2]
+ 1 │ <ns:testComponent />
+   ·  ────────────────
+   ╰────
+
+  ⚠ eslint-plugin-react(no-namespace): React component ns:testComponent must not be in a namespace, as React does not support them.
+   ╭─[no_namespace.tsx:1:21]
+ 1 │ React.createElement("ns:testComponent")
+   ·                     ──────────────────
+   ╰────
+
+  ⚠ eslint-plugin-react(no-namespace): React component ns:test_component must not be in a namespace, as React does not support them.
+   ╭─[no_namespace.tsx:1:2]
+ 1 │ <ns:test_component />
+   ·  ─────────────────
+   ╰────
+
+  ⚠ eslint-plugin-react(no-namespace): React component ns:test_component must not be in a namespace, as React does not support them.
+   ╭─[no_namespace.tsx:1:21]
+ 1 │ React.createElement("ns:test_component")
+   ·                     ───────────────────
+   ╰────
+
+  ⚠ eslint-plugin-react(no-namespace): React component ns:TestComponent must not be in a namespace, as React does not support them.
+   ╭─[no_namespace.tsx:1:2]
+ 1 │ <ns:TestComponent />
+   ·  ────────────────
+   ╰────
+
+  ⚠ eslint-plugin-react(no-namespace): React component ns:TestComponent must not be in a namespace, as React does not support them.
+   ╭─[no_namespace.tsx:1:21]
+ 1 │ React.createElement("ns:TestComponent")
+   ·                     ──────────────────
+   ╰────
+
+  ⚠ eslint-plugin-react(no-namespace): React component Ns:testcomponent must not be in a namespace, as React does not support them.
+   ╭─[no_namespace.tsx:1:2]
+ 1 │ <Ns:testcomponent />
+   ·  ────────────────
+   ╰────
+
+  ⚠ eslint-plugin-react(no-namespace): React component Ns:testcomponent must not be in a namespace, as React does not support them.
+   ╭─[no_namespace.tsx:1:21]
+ 1 │ React.createElement("Ns:testcomponent")
+   ·                     ──────────────────
+   ╰────
+
+  ⚠ eslint-plugin-react(no-namespace): React component Ns:testComponent must not be in a namespace, as React does not support them.
+   ╭─[no_namespace.tsx:1:2]
+ 1 │ <Ns:testComponent />
+   ·  ────────────────
+   ╰────
+
+  ⚠ eslint-plugin-react(no-namespace): React component Ns:testComponent must not be in a namespace, as React does not support them.
+   ╭─[no_namespace.tsx:1:21]
+ 1 │ React.createElement("Ns:testComponent")
+   ·                     ──────────────────
+   ╰────
+
+  ⚠ eslint-plugin-react(no-namespace): React component Ns:test_component must not be in a namespace, as React does not support them.
+   ╭─[no_namespace.tsx:1:2]
+ 1 │ <Ns:test_component />
+   ·  ─────────────────
+   ╰────
+
+  ⚠ eslint-plugin-react(no-namespace): React component Ns:test_component must not be in a namespace, as React does not support them.
+   ╭─[no_namespace.tsx:1:21]
+ 1 │ React.createElement("Ns:test_component")
+   ·                     ───────────────────
+   ╰────
+
+  ⚠ eslint-plugin-react(no-namespace): React component Ns:TestComponent must not be in a namespace, as React does not support them.
+   ╭─[no_namespace.tsx:1:2]
+ 1 │ <Ns:TestComponent />
+   ·  ────────────────
+   ╰────
+
+  ⚠ eslint-plugin-react(no-namespace): React component Ns:TestComponent must not be in a namespace, as React does not support them.
+   ╭─[no_namespace.tsx:1:21]
+ 1 │ React.createElement("Ns:TestComponent")
+   ·                     ──────────────────
+   ╰────


### PR DESCRIPTION
This PR adds [react/no-namespace](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-namespace.md) rule
issue: https://github.com/oxc-project/oxc/issues/1022