### PR TITLE
test(napi): add tests for worker threads

### DIFF
--- a/napi/minify/test/minify.test.ts
+++ b/napi/minify/test/minify.test.ts
@@ -1,3 +1,4 @@
+import { Worker } from 'node:worker_threads';
 import { describe, expect, it } from 'vitest';
 
 import { minify } from '../index';
@@ -30,5 +31,20 @@ describe('simple', () => {
     expect(ret).toStrictEqual({
       'code': 'function foo() {\n\tvar bar;\n\tbar(undefined);\n}\nfoo();\n',
     });
+  });
+});
+
+describe('worker', () => {
+  it('should run', async () => {
+    const code = await new Promise((resolve, reject) => {
+      const worker = new Worker('./test/worker.mjs');
+      worker.on('error', (err) => {
+        reject(err);
+      });
+      worker.on('exit', (code) => {
+        resolve(code);
+      });
+    });
+    expect(code).toBe(0);
   });
 });

--- a/napi/minify/test/worker.mjs
+++ b/napi/minify/test/worker.mjs
@@ -1,0 +1,2 @@
+import { minify } from '../index.js';
+minify('test.js', '');

--- a/napi/parser/test/parse.test.ts
+++ b/napi/parser/test/parse.test.ts
@@ -1,3 +1,4 @@
+import { Worker } from 'node:worker_threads';
 import { describe, expect, it } from 'vitest';
 
 import { parseAsync, parseSync } from '../index.js';
@@ -273,5 +274,20 @@ describe('error', () => {
       'message': 'Expected a semicolon or an implicit semicolon after a statement, but found none',
       'severity': 'Error',
     });
+  });
+});
+
+describe('worker', () => {
+  it('should run', async () => {
+    const code = await new Promise((resolve, reject) => {
+      const worker = new Worker('./test/worker.mjs');
+      worker.on('error', (err) => {
+        reject(err);
+      });
+      worker.on('exit', (code) => {
+        resolve(code);
+      });
+    });
+    expect(code).toBe(0);
   });
 });

--- a/napi/parser/test/worker.mjs
+++ b/napi/parser/test/worker.mjs
@@ -1,0 +1,2 @@
+import { parseSync } from '../index.js';
+parseSync('test.js', '');

--- a/napi/transform/test/transform.test.ts
+++ b/napi/transform/test/transform.test.ts
@@ -1,3 +1,4 @@
+import { Worker } from 'node:worker_threads';
 import { describe, expect, it, test } from 'vitest';
 
 import { HelperMode, transform } from '../index';
@@ -312,5 +313,20 @@ describe('legacy decorator', () => {
         "
       `);
     });
+  });
+});
+
+describe('worker', () => {
+  it('should run', async () => {
+    const code = await new Promise((resolve, reject) => {
+      const worker = new Worker('./test/worker.mjs');
+      worker.on('error', (err) => {
+        reject(err);
+      });
+      worker.on('exit', (code) => {
+        resolve(code);
+      });
+    });
+    expect(code).toBe(0);
   });
 });

--- a/napi/transform/test/worker.mjs
+++ b/napi/transform/test/worker.mjs
@@ -1,0 +1,2 @@
+import { transform } from '../index.js';
+transform('test.js', '');


### PR DESCRIPTION
There are user code which may crash under some random circumstances
that we don't understand. Prevent these crashes with a test.