### PR TITLE
feat(ecmascript): support `/* @__PURE__ */` in may_have_side_effects

### DIFF
--- a/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
+++ b/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
@@ -619,6 +619,29 @@ fn test_property_access() {
 }
 
 #[test]
+fn test_call_like_expressions() {
+    test("foo()", true);
+    test("/* #__PURE__ */ foo()", false);
+    test("/* #__PURE__ */ foo(1)", false);
+    test("/* #__PURE__ */ foo(bar())", true);
+    test("/* #__PURE__ */ foo(...[])", false);
+    test("/* #__PURE__ */ foo(...[1])", false);
+    test("/* #__PURE__ */ foo(...[bar()])", true);
+    test("/* #__PURE__ */ foo(...bar)", true);
+    test("/* #__PURE__ */ (() => { foo() })()", false);
+
+    test("new Foo()", true);
+    test("/* #__PURE__ */ new Foo()", false);
+    test("/* #__PURE__ */ new Foo(1)", false);
+    test("/* #__PURE__ */ new Foo(bar())", true);
+    test("/* #__PURE__ */ new Foo(...[])", false);
+    test("/* #__PURE__ */ new Foo(...[1])", false);
+    test("/* #__PURE__ */ new Foo(...[bar()])", true);
+    test("/* #__PURE__ */ new Foo(...bar)", true);
+    test("/* #__PURE__ */ new class { constructor() { foo() } }()", false);
+}
+
+#[test]
 fn test_object_with_to_primitive_related_properties_overridden() {
     test("+{}", false);
     test("+{ foo: 0 }", false);


### PR DESCRIPTION
Actually this PR alone won't remove `/* @__PURE__ */ foo()`. We probably need to call `.may_have_side_effects` in `remove_unused_expression`.

close #9397