### PR TITLE
fix(linter): rule `unicorn/no-invalid-fetch-options`

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
@@ -326,6 +326,13 @@ fn test() {
            method: Method.Get,
            body: "",
           });"#,
+        r#"enum Method {
+            Foo = "GET",
+          }
+          const response = await fetch("/", {
+           method: Method.Foo,
+           body: "",
+          });"#,
     ];
 
     Tester::new(NoInvalidFetchOptions::NAME, NoInvalidFetchOptions::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
@@ -134,36 +134,46 @@ fn is_invalid_fetch_options<'a>(
                     // Check if static member object is an enum and get the enum value to
                     // determine if the value equals "GET".
                     let reference = symbols.get_reference(reference_id);
+
                     if let Some(symbol_id) = reference.symbol_id() {
                         if ctx.symbols().get_flags(symbol_id).is_enum() {
+
+                            let decl = ctx.semantic().symbol_declaration(symbol_id);
+
                             // Look up enum member value by identifier ref
-                            let enum_node_id = reference.node_id();
-                            let enum_node = ctx.nodes().parent_node(enum_node_id).unwrap();
+                          //  let enum_node_id = reference.node_id();
+                        //    let enum_node = ctx.nodes().parent_node(enum_node_id).unwrap();
                             //    let enum_node = ctx.nodes().parent(enum_node_id).unwrap();
 
                             // todo Make sure the `x` in `MyEnum.x` is actually an enum member.
 
                             //println!("aaaaaaaaa {0:?}", ctx.nodes().parent_node(enum_node_id)enum_node.parent());
-                            println!("aaaaaaaaa {0:?}", enum_node_id);
+                            println!("aaaaaaaaa {0:?}", reference);
 
                             //let Some(parent) = ctx.nodes().parent_node(enum_node_id) else {
                             //    continue;
                             //};
 
-                            let enum_member_res = match enum_node.kind() {
-                                AstKind::TSEnumDeclaration(tsenum_decl) => {
+                            let enum_member_res = match decl.kind() {
+                                AstKind::TSEnumDeclaration(enum_decl) => {
                                     let prop_ident = s.property.name.to_compact_str();
 
                                     println!("fooooo {tsenum_decl:?}");
 
-                                    tsenum_decl.members.iter().find_map(|m| match &m.id {
-                                        oxc_ast::ast::TSEnumMemberName::Identifier(
-                                            identifier_name,
-                                        ) => None,
-                                        oxc_ast::ast::TSEnumMemberName::String(str_lit) => {
-                                            Some(str_lit)
-                                        }
-                                    })
+                                    for ts_enum_member in  &enum_decl.members {
+
+                                        let Identifier(ident) = ts_enum_member.id;
+                                    }
+                                    None
+
+//tsenum_decl.members.iter().find_map(|m| match &m.id {
+//    oxc_ast::ast::TSEnumMemberName::Identifier(
+//        identifier_name,
+//    ) => None,
+//    oxc_ast::ast::TSEnumMemberName::String(str_lit) => {
+//        Some(str_lit)
+//    }
+//})
                                 }
                                 d => {
                                     println!("unknown {d:?}");

--- a/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
@@ -81,9 +81,6 @@ impl Rule for NoInvalidFetchOptions {
         let result = is_invalid_fetch_options(expr, ctx);
 
         if let Some((method_name, body_span)) = result {
-            println!("method result : {method_name:?}"); // Issue is that the num Method.Post is "GET" in the method_name here
-            // `if let Some((method_name, body_span)) = result {`
-
             ctx.diagnostic(no_invalid_fetch_options_diagnostic(body_span, &method_name));
         }
     }

--- a/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
@@ -322,6 +322,13 @@ fn test() {
         r#"function foo(method: "HEAD" | "GET") {
             return new Request(url, {method, body: ""});
         }"#,
+        r#"enum Method {
+            Get = "GET",
+          }
+          const response = await fetch("/", {
+           method: Method.Get,
+           body: "",
+          });"#,
     ];
 
     Tester::new(NoInvalidFetchOptions::NAME, NoInvalidFetchOptions::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/unicorn_no_invalid_fetch_options.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_invalid_fetch_options.snap
@@ -122,3 +122,11 @@ source: crates/oxc_linter/src/tester.rs
    ·                                              ────
  3 │         }
    ╰────
+
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
+   ╭─[no_invalid_fetch_options.tsx:6:12]
+ 5 │            method: Method.Get,
+ 6 │            body: "",
+   ·            ────
+ 7 │           });
+   ╰────

--- a/crates/oxc_linter/src/snapshots/unicorn_no_invalid_fetch_options.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_invalid_fetch_options.snap
@@ -130,3 +130,11 @@ source: crates/oxc_linter/src/tester.rs
    ·            ────
  7 │           });
    ╰────
+
+  ⚠ eslint-plugin-unicorn(no-invalid-fetch-options): "body" is not allowed when method is "GET"
+   ╭─[no_invalid_fetch_options.tsx:6:12]
+ 5 │            method: Method.Foo,
+ 6 │            body: "",
+   ·            ────
+ 7 │           });
+   ╰────


### PR DESCRIPTION
closes #9405 

Fixes the the rule for cases where the value for the `method` key in the fetch options object references an enum member.  