### PR TITLE
refactor(linter): improve `eslint/no-new`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_new.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new.rs
@@ -1,7 +1,4 @@
-use oxc_ast::{
-    AstKind,
-    ast::{Expression, NewExpression},
-};
+use oxc_ast::AstKind;
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_semantic::AstNode;

--- a/crates/oxc_linter/src/rules/eslint/no_new.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new.rs
@@ -28,18 +28,14 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// new Person();
-    /// ```
     ///
-    /// ```javascript
     /// (() => { new Date() })
     /// ```
     ///
     /// Examples of **correct** code for this rule:
     /// ```javascript
     /// var a = new Date()
-    /// ```
     ///
-    /// ```javascript
     /// (() => new Date())
     /// ```
     NoNew,

--- a/crates/oxc_linter/src/rules/eslint/no_new.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_new.rs
@@ -1,9 +1,13 @@
-use oxc_ast::AstKind;
+use oxc_ast::{
+    AstKind,
+    ast::{Expression, NewExpression},
+};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
+use oxc_semantic::AstNode;
 use oxc_span::{GetSpan, Span};
 
-use crate::{AstNode, context::LintContext, rule::Rule};
+use crate::{context::LintContext, rule::Rule};
 
 fn no_new_diagnostic(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Do not use 'new' for side effects.").with_label(span)
@@ -22,9 +26,24 @@ declare_oxc_lint!(
     /// Calling new without assigning or comparing it the reference is thrown away and in many
     /// cases the constructor can be replaced with a function.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// new Person();
+    /// ```
+    ///
+    /// ```javascript
+    /// (() => { new Date() })
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// var a = new Date()
+    /// ```
+    ///
+    /// ```javascript
+    /// (() => new Date())
     /// ```
     NoNew,
     eslint,
@@ -37,7 +56,12 @@ impl Rule for NoNew {
             return;
         };
 
-        let mut ancestors = ctx.nodes().ancestor_ids(node.id()).skip(1);
+        let mut ancestors = ctx
+            .nodes()
+            .ancestors(node.id())
+            .filter(|a| !matches!(a.kind(), AstKind::ParenthesizedExpression(_)))
+            .map(AstNode::id)
+            .skip(1);
         let Some(node_id) = ancestors.next() else { return };
 
         let kind = ctx.nodes().kind(node_id);
@@ -65,7 +89,7 @@ fn test() {
         "(() => new Date())",
     ];
 
-    let fail = vec!["new Date()", "(() => { new Date() })"];
+    let fail = vec!["new Date()", "(() => { new Date() })", "(new Date())", "((new Date()))"];
 
     Tester::new(NoNew::NAME, NoNew::PLUGIN, pass, fail).test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/eslint_no_new.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_new.snap
@@ -12,3 +12,15 @@ source: crates/oxc_linter/src/tester.rs
  1 │ (() => { new Date() })
    ·          ────────
    ╰────
+
+  ⚠ eslint(no-new): Do not use 'new' for side effects.
+   ╭─[no_new.tsx:1:2]
+ 1 │ (new Date())
+   ·  ────────
+   ╰────
+
+  ⚠ eslint(no-new): Do not use 'new' for side effects.
+   ╭─[no_new.tsx:1:3]
+ 1 │ ((new Date()))
+   ·   ────────
+   ╰────


### PR DESCRIPTION
- Improve the documentation
- Add a missing case for parenthesised new expression which is covered by the equivalent eslint rule. (See eslint playground for rule [here](https://eslint.org/play/#eyJ0ZXh0IjoiLyplc2xpbnQgbm8tbmV3OiBcImVycm9yXCIqL1xuXG5uZXcgVGhpbmcoKTsifQ==)
