### PR TITLE
feat(minifier): support template literals in `remove_unused_expression`

### DIFF
--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -470,7 +470,7 @@ mod test {
 
         test("{'hi'}", "");
         test("{x==3}", "x == 3");
-        test("{`hello ${foo}`}", "`hello ${foo}`");
+        test("{`hello ${foo}`}", "`${foo}`");
         test("{ (function(){x++}) }", "");
         test("{ (function foo(){x++; foo()}) }", "");
         test("function f(){return;}", "function f(){}");

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1457,7 +1457,7 @@ mod test {
     fn test_template_string_to_string() {
         test("x = `abcde`", "x = 'abcde'");
         test("x = `ab cd ef`", "x = 'ab cd ef'");
-        test_same("`hello ${name}`");
+        test_same("x = `hello ${name}`");
         test_same("tag `hello ${name}`");
         test_same("tag `hello`");
         test("x = `hello ${'foo'}`", "x = 'hello foo'");


### PR DESCRIPTION
Compress `` `${1}2${foo()}3` `` into `` `${foo()}` `` when it's not used.