### PR TITLE
refactor(ast_tools): move `FxIndexMap` and `FxIndexSet` into `utils` module

### DIFF
--- a/tasks/ast_tools/src/parse/mod.rs
+++ b/tasks/ast_tools/src/parse/mod.rs
@@ -47,15 +47,13 @@
 //! [`Derive`]: crate::Derive
 //! [`Generator`]: crate::Generator
 
-use indexmap::{IndexMap, IndexSet};
 use oxc_index::IndexVec;
-use rustc_hash::FxBuildHasher;
 use syn::Ident;
 
 use crate::{
     Codegen, log, log_success,
-    schema::Derives,
-    schema::{File, FileId, Schema},
+    schema::{Derives, File, FileId, Schema},
+    utils::FxIndexMap,
 };
 
 pub mod attr;
@@ -66,9 +64,6 @@ mod skeleton;
 use load::load_file;
 use parse::parse;
 use skeleton::Skeleton;
-
-type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;
-type FxIndexSet<K> = IndexSet<K, FxBuildHasher>;
 
 /// Analyse the files with provided paths, and generate a [`Schema`].
 pub fn parse_files(file_paths: &[&str], codegen: &Codegen) -> Schema {

--- a/tasks/ast_tools/src/parse/parse.rs
+++ b/tasks/ast_tools/src/parse/parse.rs
@@ -14,10 +14,11 @@ use crate::{
         BoxDef, CellDef, Def, EnumDef, FieldDef, File, FileId, MetaId, MetaType, OptionDef,
         PrimitiveDef, Schema, StructDef, TypeDef, TypeId, VariantDef, VecDef, Visibility,
     },
+    utils::{FxIndexMap, FxIndexSet},
 };
 
 use super::{
-    Derives, FxIndexMap, FxIndexSet,
+    Derives,
     attr::{AttrLocation, AttrPart, AttrPartListElement, AttrPositions, AttrProcessor},
     ident_name,
     skeleton::{EnumSkeleton, Skeleton, StructSkeleton},

--- a/tasks/ast_tools/src/utils.rs
+++ b/tasks/ast_tools/src/utils.rs
@@ -1,7 +1,12 @@
+use indexmap::{IndexMap, IndexSet};
 use phf::{Set as PhfSet, phf_set};
 use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote};
+use rustc_hash::FxBuildHasher;
 use syn::{Ident, LitInt};
+
+pub type FxIndexMap<K, V> = IndexMap<K, V, FxBuildHasher>;
+pub type FxIndexSet<K> = IndexSet<K, FxBuildHasher>;
 
 /// Reserved word in Rust.
 /// From <https://doc.rust-lang.org/reference/keywords.html>.


### PR DESCRIPTION
Pure refactor. Just move these type aliases into a shared module.