### PR TITLE
refactor(ast/estree): convert enums with converters on variants

### DIFF
--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -147,20 +147,18 @@ pub struct JSXClosingFragment {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
-#[estree(
-    via = JSXElementNameConverter,
-    custom_ts_def = "type JSXElementName = JSXIdentifier | JSXNamespacedName | JSXMemberExpression"
-)]
 pub enum JSXElementName<'a> {
     /// `<div />`
     Identifier(Box<'a, JSXIdentifier<'a>>) = 0,
     /// `<Apple />`
+    #[estree(via = JSXElementIdentifierReference)]
     IdentifierReference(Box<'a, IdentifierReference<'a>>) = 1,
     /// `<Apple:Orange />`
     NamespacedName(Box<'a, JSXNamespacedName<'a>>) = 2,
     /// `<Apple.Orange />`
     MemberExpression(Box<'a, JSXMemberExpression<'a>>) = 3,
     /// `<this />`
+    #[estree(via = JSXElementThisExpression)]
     ThisExpression(Box<'a, ThisExpression>) = 4,
 }
 
@@ -229,16 +227,14 @@ pub struct JSXMemberExpression<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
-#[estree(
-    via = JSXMemberExpressionObjectConverter,
-    custom_ts_def = "type JSXMemberExpressionObject = JSXIdentifier | JSXMemberExpression"
-)]
 pub enum JSXMemberExpressionObject<'a> {
     /// `<Apple.Orange />`
+    #[estree(via = JSXElementIdentifierReference)]
     IdentifierReference(Box<'a, IdentifierReference<'a>>) = 0,
     /// `<Apple.Orange.Banana />`
     MemberExpression(Box<'a, JSXMemberExpression<'a>>) = 1,
     /// `<this.Orange />`
+    #[estree(via = JSXElementThisExpression)]
     ThisExpression(Box<'a, ThisExpression>) = 2,
 }
 

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1993,7 +1993,17 @@ impl ESTree for JSXClosingFragment {
 
 impl ESTree for JSXElementName<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        crate::serialize::JSXElementNameConverter(self).serialize(serializer)
+        match self {
+            Self::Identifier(it) => it.serialize(serializer),
+            Self::IdentifierReference(it) => {
+                crate::serialize::JSXElementIdentifierReference(it).serialize(serializer)
+            }
+            Self::NamespacedName(it) => it.serialize(serializer),
+            Self::MemberExpression(it) => it.serialize(serializer),
+            Self::ThisExpression(it) => {
+                crate::serialize::JSXElementThisExpression(it).serialize(serializer)
+            }
+        }
     }
 }
 
@@ -2023,7 +2033,15 @@ impl ESTree for JSXMemberExpression<'_> {
 
 impl ESTree for JSXMemberExpressionObject<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        crate::serialize::JSXMemberExpressionObjectConverter(self).serialize(serializer)
+        match self {
+            Self::IdentifierReference(it) => {
+                crate::serialize::JSXElementIdentifierReference(it).serialize(serializer)
+            }
+            Self::MemberExpression(it) => it.serialize(serializer),
+            Self::ThisExpression(it) => {
+                crate::serialize::JSXElementThisExpression(it).serialize(serializer)
+            }
+        }
     }
 }
 

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -512,38 +512,28 @@ impl ESTree for ExportAllDeclarationWithClause<'_, '_> {
 // JSX
 // --------------------
 
+/// Serializer for `IdentifierReference` variant of `JSXElementName` and `JSXMemberExpressionObject`.
+///
+/// Convert to `JSXIdentifier`.
 #[ast_meta]
-pub struct JSXElementNameConverter<'a, 'b>(pub &'b JSXElementName<'a>);
+#[estree(ts_type = "JSXIdentifier")]
+pub struct JSXElementIdentifierReference<'a, 'b>(pub &'b IdentifierReference<'a>);
 
-impl ESTree for JSXElementNameConverter<'_, '_> {
+impl ESTree for JSXElementIdentifierReference<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        match self.0 {
-            JSXElementName::Identifier(ident) => ident.serialize(serializer),
-            JSXElementName::IdentifierReference(ident) => {
-                JSXIdentifier { span: ident.span, name: ident.name }.serialize(serializer);
-            }
-            JSXElementName::NamespacedName(name) => name.serialize(serializer),
-            JSXElementName::MemberExpression(expr) => expr.serialize(serializer),
-            JSXElementName::ThisExpression(expr) => {
-                JSXIdentifier { span: expr.span, name: "this".into() }.serialize(serializer);
-            }
-        }
+        JSXIdentifier { span: self.0.span, name: self.0.name }.serialize(serializer);
     }
 }
 
+/// Serializer for `ThisExpression` variant of `JSXElementName` and `JSXMemberExpressionObject`.
+///
+/// Convert to `JSXIdentifier`.
 #[ast_meta]
-pub struct JSXMemberExpressionObjectConverter<'a, 'b>(pub &'b JSXMemberExpressionObject<'a>);
+#[estree(ts_type = "JSXIdentifier")]
+pub struct JSXElementThisExpression<'b>(pub &'b ThisExpression);
 
-impl ESTree for JSXMemberExpressionObjectConverter<'_, '_> {
+impl ESTree for JSXElementThisExpression<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        match self.0 {
-            JSXMemberExpressionObject::IdentifierReference(ident) => {
-                JSXIdentifier { span: ident.span, name: ident.name }.serialize(serializer);
-            }
-            JSXMemberExpressionObject::MemberExpression(expr) => expr.serialize(serializer),
-            JSXMemberExpressionObject::ThisExpression(expr) => {
-                JSXIdentifier { span: expr.span, name: "this".into() }.serialize(serializer);
-            }
-        }
+        JSXIdentifier { span: self.0.span, name: Atom::from("this") }.serialize(serializer);
     }
 }

--- a/tasks/ast_tools/src/schema/extensions/estree.rs
+++ b/tasks/ast_tools/src/schema/extensions/estree.rs
@@ -65,6 +65,7 @@ pub struct ESTreeStructField {
 #[derive(Default, Debug)]
 pub struct ESTreeEnumVariant {
     pub rename: Option<String>,
+    pub via: Option<String>,
     pub is_ts: bool,
 }
 


### PR DESCRIPTION
Add support for `#[estree(via = Converter)]` on enum variants. This simplifies the conversion of JSX types, where only a subset of variants need conversion.
