### PR TITLE
refactor(linter): improve `typescript/explicit-function-return-type`

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -749,7 +749,7 @@ fn test() {
         	function test(): void {
         	  return;
         	}
-        	      ",
+        	",
             None,
             None,
             None,
@@ -759,19 +759,12 @@ fn test() {
         	var fn = function (): number {
         	  return 1;
         	};
-        	      ",
+            ",
             None,
             None,
             None,
         ),
-        (
-            "
-        	var arrowFn = (): string => 'test';
-        	      ",
-            None,
-            None,
-            None,
-        ),
+        ("var arrowFn = (): string => 'test';", None, None, None),
         (
             "
         	class Test {
@@ -785,7 +778,7 @@ fn test() {
         	  }
         	  arrow = (): string => 'arrow';
         	}
-        	      ",
+        	",
             None,
             None,
             None,
@@ -817,9 +810,7 @@ fn test() {
             None,
         ),
         (
-            "
-        	var arrowFn: Foo = () => 'test';
-        	      ",
+            "var arrowFn: Foo = () => 'test';",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
@@ -829,7 +820,7 @@ fn test() {
         	var funcExpr: Foo = function () {
         	  return 'test';
         	};
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
@@ -851,7 +842,7 @@ fn test() {
         	const x = {
         	  foo: () => {},
         	} as Foo;
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
             None,
             None,
@@ -861,7 +852,7 @@ fn test() {
         	const x = <Foo>{
         	  foo: () => {},
         	};
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
             None,
             Some(PathBuf::from("test.ts")),
@@ -871,7 +862,7 @@ fn test() {
         	const x: Foo = {
         	  foo: () => {},
         	};
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
             None,
             None,
@@ -881,7 +872,7 @@ fn test() {
         	const x = {
         	  foo: { bar: () => {} },
         	} as Foo;
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
             None,
             None,
@@ -891,7 +882,7 @@ fn test() {
         	const x = <Foo>{
         	  foo: { bar: () => {} },
         	};
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
             None,
             Some(PathBuf::from("test.ts")),
@@ -901,7 +892,7 @@ fn test() {
         	const x: Foo = {
         	  foo: { bar: () => {} },
         	};
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
             None,
             None,
@@ -913,7 +904,7 @@ fn test() {
         	class App {
         	  private method: MethodType = () => {};
         	}
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
             None,
             None,
@@ -955,23 +946,19 @@ fn test() {
         	    this.myProp = val;
         	  },
         	};
-        	      ",
+            ",
             None,
             None,
             None,
         ),
         (
-            "
-        	() => (): void => {};
-        	      ",
+            "() => (): void => {};",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
         ),
         (
-            "
-        	() => function (): void {};
-        	      ",
+            "() => function (): void {};",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
@@ -981,7 +968,7 @@ fn test() {
         	() => {
         	  return (): void => {};
         	};
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
@@ -991,7 +978,7 @@ fn test() {
         	() => {
         	  return function (): void {};
         	};
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
@@ -1004,7 +991,7 @@ fn test() {
         	    return foo;
         	  };
         	};
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
@@ -1014,7 +1001,7 @@ fn test() {
         	function fn() {
         	  return (): void => {};
         	}
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
@@ -1024,7 +1011,7 @@ fn test() {
         	function fn() {
         	  return function (): void {};
         	}
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
@@ -1035,7 +1022,7 @@ fn test() {
         	  const bar = () => (): number => 1;
         	  return function (): void {};
         	}
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
@@ -1053,7 +1040,7 @@ fn test() {
 
         	  return function (): void {};
         	}
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
@@ -1073,7 +1060,7 @@ fn test() {
         	    };
         	  };
         	}
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
@@ -1085,7 +1072,7 @@ fn test() {
         	    return;
         	  };
         	};
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
@@ -1098,7 +1085,7 @@ fn test() {
         	foo(() => null);
         	foo(() => true);
         	foo(() => '');
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
@@ -1111,7 +1098,7 @@ fn test() {
         	foo?.bar?.(() => null);
         	foo.bar?.(() => true);
         	foo?.(() => '');
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
@@ -1127,7 +1114,7 @@ fn test() {
         	}
 
         	new Accumulator().accumulate(() => 1);
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
@@ -1150,7 +1137,7 @@ fn test() {
         	    return 1;
         	  },
         	});
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
@@ -1161,7 +1148,7 @@ fn test() {
         	const func2 = (value: number) => ({ type: 'X', value }) as const;
         	const func3 = (value: number) => x as const;
         	const func4 = (value: number) => x as const;
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowDirectConstAssertionInArrowFunctions": true,  }, ])),
             None,
             None,
@@ -1170,7 +1157,7 @@ fn test() {
             "
         	new Promise(resolve => {});
         	new Foo(1, () => {});
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
@@ -1200,7 +1187,7 @@ fn test() {
         	function log<A>(a: A): A {
         	  return a;
         	}
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowFunctionsWithoutTypeParameters": true }])),
             None,
             None,
@@ -1210,7 +1197,7 @@ fn test() {
         	function log(a: string) {
         	  return a;
         	}
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowFunctionsWithoutTypeParameters": true }])),
             None,
             None,
@@ -1220,7 +1207,7 @@ fn test() {
         	const log = function <A>(a: A): A {
         	  return a;
         	};
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowFunctionsWithoutTypeParameters": true }])),
             None,
             None,
@@ -1230,7 +1217,7 @@ fn test() {
         	const log = function (a: A): string {
         	  return a;
         	};
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowFunctionsWithoutTypeParameters": true }])),
             None,
             None,
@@ -1244,7 +1231,7 @@ fn test() {
         	const foo = function test2() {
         	  return;
         	};
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowedNames": ["test1", "test2"],  }, ])),
             None,
             None,
@@ -1257,7 +1244,7 @@ fn test() {
         	const foo = function () {
         	  return function test2() {};
         	};
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowedNames": ["test1", "test2"],  }, ])),
             None,
             None,
@@ -1272,7 +1259,7 @@ fn test() {
         	    return 0;
         	  },
         	};
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowedNames": ["test1", "test2"],  }, ])),
             None,
             None,
@@ -1293,7 +1280,7 @@ fn test() {
         	    return;
         	  }
         	}
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowedNames": ["prop", "method", "arrow"],  }, ])),
             None,
             None,
@@ -1308,7 +1295,7 @@ fn test() {
         	    return;
         	  },
         	};
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowedNames": ["arrowFn", "fn"],  }, ])),
             None,
             None,
@@ -1317,7 +1304,7 @@ fn test() {
             "
         	type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
         	const x: HigherOrderType = () => arg1 => arg2 => 'foo';
-        	      ",
+        	",
             Some(
                 serde_json::json!([ { "allowTypedFunctionExpressions": true,  "allowHigherOrderFunctions": true,  }, ]),
             ),
@@ -1328,7 +1315,7 @@ fn test() {
             "
         	type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
         	const x: HigherOrderType = () => arg1 => arg2 => 'foo';
-        	      ",
+        	",
             Some(
                 serde_json::json!([ { "allowTypedFunctionExpressions": true,  "allowHigherOrderFunctions": false,  }, ]),
             ),
@@ -1348,7 +1335,7 @@ fn test() {
         	    arrowFn: () => 'test',
         	  };
         	}
-        	      ",
+        	",
             Some(
                 serde_json::json!([ { "allowTypedFunctionExpressions": true,  "allowHigherOrderFunctions": true,  }, ]),
             ),
@@ -1360,7 +1347,7 @@ fn test() {
         	type Foo = (arg1: string) => string;
         	type Bar<T> = (arg2: string) => T;
         	const x: Bar<Foo> = arg1 => arg2 => arg1 + arg2;
-        	      ",
+        	",
             Some(
                 serde_json::json!([ { "allowTypedFunctionExpressions": true,  "allowHigherOrderFunctions": true,  }, ]),
             ),
@@ -1372,7 +1359,7 @@ fn test() {
         	let foo = function (): number {
         	  return 1;
         	};
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowIIFEs": true,  }, ])),
             None,
             None,
@@ -1382,7 +1369,7 @@ fn test() {
         	const foo = (function () {
         	  return 1;
         	})();
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowIIFEs": true,  }, ])),
             None,
             None,
@@ -1392,7 +1379,7 @@ fn test() {
         	const foo = (() => {
         	  return 1;
         	})();
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowIIFEs": true,  }, ])),
             None,
             None,
@@ -1402,15 +1389,13 @@ fn test() {
         	const foo = ((arg: number): number => {
         	  return arg;
         	})(0);
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowIIFEs": true,  }, ])),
             None,
             None,
         ),
         (
-            "
-        	const foo = (() => (() => 'foo')())();
-        	      ",
+            "const foo = (() => (() => 'foo')())();",
             Some(serde_json::json!([ { "allowIIFEs": true,  }, ])),
             None,
             None,
@@ -1420,7 +1405,7 @@ fn test() {
         	let foo = (() => (): string => {
         	  return 'foo';
         	})()();
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowIIFEs": true,  }, ])),
             None,
             None,
@@ -1430,7 +1415,7 @@ fn test() {
         	let foo = (() => (): string => {
         	  return 'foo';
         	})();
-        	      ",
+        	",
             Some(
                 serde_json::json!([ { "allowIIFEs": true,  "allowHigherOrderFunctions": false,  }, ]),
             ),
@@ -1442,7 +1427,7 @@ fn test() {
         	let foo = (() => (): string => {
         	  return 'foo';
         	})()();
-        	      ",
+        	",
             Some(
                 serde_json::json!([ { "allowIIFEs": true,  "allowHigherOrderFunctions": true,  }, ]),
             ),
@@ -1452,7 +1437,7 @@ fn test() {
         (
             "
         	let foo = (() => (): void => {})()();
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowIIFEs": true,  }, ])),
             None,
             None,
@@ -1460,7 +1445,7 @@ fn test() {
         (
             "
         	let foo = (() => (() => {})())();
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowIIFEs": true,  }, ])),
             None,
             None,
@@ -1472,7 +1457,7 @@ fn test() {
         	    foo: x => x + 1,
         	  };
         	}
-        	      ",
+        	",
             None,
             None,
             None,
@@ -1486,7 +1471,7 @@ fn test() {
         	    },
         	  ];
         	}
-        	      ",
+        	",
             None,
             None,
             None,
@@ -1496,7 +1481,7 @@ fn test() {
         	type CallBack = () => void;
 
         	function f(gotcha: CallBack = () => {}): void {}
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
             None,
             None,
@@ -1506,7 +1491,7 @@ fn test() {
         	type CallBack = () => void;
 
         	const f = (gotcha: CallBack = () => {}): void => {};
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
             None,
             None,
@@ -1516,7 +1501,7 @@ fn test() {
         	type ObjectWithCallback = { callback: () => void };
 
         	const f = (gotcha: ObjectWithCallback = { callback: () => {} }): void => {};
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
             None,
             None,
@@ -1529,7 +1514,7 @@ fn test() {
         	function test(a: number, b: number) {
         	  return;
         	}
-        	      ",
+        	",
             None,
             None,
             None,
@@ -1539,7 +1524,7 @@ fn test() {
         	function test() {
         	  return;
         	}
-        	      ",
+        	",
             None,
             None,
             None,
@@ -1549,7 +1534,7 @@ fn test() {
         	var fn = function () {
         	  return 1;
         	};
-        	      ",
+        	",
             None,
             None,
             None,
@@ -1557,7 +1542,7 @@ fn test() {
         (
             "
         	var arrowFn = () => 'test';
-        	      ",
+        	",
             None,
             None,
             None,
@@ -1578,7 +1563,7 @@ fn test() {
         	    return;
         	  }
         	}
-        	      ",
+        	",
             None,
             None,
             None,
@@ -1588,7 +1573,7 @@ fn test() {
         	function test() {
         	  return;
         	}
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowExpressions": true }])),
             None,
             None,
@@ -1627,7 +1612,7 @@ fn test() {
         	  static d = () => {};
         	  static e = function () {};
         	}
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowExpressions": true }])),
             None,
             None,
@@ -1643,7 +1628,7 @@ fn test() {
         	function foo(): any {
         	  const bar = () => () => console.log('aa');
         	}
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
@@ -1654,7 +1639,7 @@ fn test() {
         	function foo(): any {
         	  anyValue = () => () => console.log('aa');
         	}
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
@@ -1668,7 +1653,7 @@ fn test() {
         	    };
         	  }
         	}
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
@@ -1678,7 +1663,7 @@ fn test() {
         	var funcExpr = function () {
         	  return 'test';
         	};
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": true }])),
             None,
             None,
@@ -1695,7 +1680,7 @@ fn test() {
         	const x = {
         	  foo: () => {},
         	} as Foo;
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": false }])),
             None,
             None,
@@ -1706,7 +1691,7 @@ fn test() {
         	const x: Foo = {
         	  foo: () => {},
         	};
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": false }])),
             None,
             None,
@@ -1750,7 +1735,7 @@ fn test() {
         	    };
         	  }
         	}
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
@@ -1772,7 +1757,7 @@ fn test() {
         	() => {
         	  return () => {};
         	};
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
@@ -1782,7 +1767,7 @@ fn test() {
         	() => {
         	  return function () {};
         	};
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
@@ -1792,7 +1777,7 @@ fn test() {
         	function fn() {
         	  return () => {};
         	}
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
@@ -1802,7 +1787,7 @@ fn test() {
         	function fn() {
         	  return function () {};
         	}
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
@@ -1814,7 +1799,7 @@ fn test() {
         	  const baz = () => () => 'baz';
         	  return function (): void {};
         	}
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
@@ -1825,7 +1810,7 @@ fn test() {
         	  if (arg) return 'string';
         	  return function (): void {};
         	}
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
@@ -1845,7 +1830,7 @@ fn test() {
         	    };
         	  };
         	}
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
@@ -1857,7 +1842,7 @@ fn test() {
         	    return;
         	  };
         	};
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowHigherOrderFunctions": true }])),
             None,
             None,
@@ -1870,7 +1855,7 @@ fn test() {
         	foo(() => null);
         	foo(() => true);
         	foo(() => '');
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": false,  }, ])),
             None,
             None,
@@ -1886,7 +1871,7 @@ fn test() {
         	}
 
         	new Accumulator().accumulate(() => 1);
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": false,  }, ])),
             None,
             None,
@@ -1915,7 +1900,7 @@ fn test() {
         	    return 1;
         	  },
         	});
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowTypedFunctionExpressions": false,  }, ])),
             None,
             None,
@@ -1924,7 +1909,7 @@ fn test() {
             "
         	type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
         	const x: HigherOrderType = () => arg1 => arg2 => 'foo';
-        	      ",
+        	",
             Some(
                 serde_json::json!([ { "allowTypedFunctionExpressions": false,  "allowHigherOrderFunctions": true,  }, ]),
             ),
@@ -1935,7 +1920,7 @@ fn test() {
             "
         	type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
         	const x: HigherOrderType = () => arg1 => arg2 => 'foo';
-        	      ",
+        	",
             Some(
                 serde_json::json!([ { "allowTypedFunctionExpressions": false,  "allowHigherOrderFunctions": false,  }, ]),
             ),
@@ -1946,15 +1931,13 @@ fn test() {
             "
         	const func1 = (value: number) => ({ type: 'X', value }) as any;
         	const func2 = (value: number) => ({ type: 'X', value }) as Action;
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowDirectConstAssertionInArrowFunctions": true,  }, ])),
             None,
             None,
         ),
         (
-            "
-        	const func = (value: number) => ({ type: 'X', value }) as const;
-        	      ",
+            "const func = (value: number) => ({ type: 'X', value }) as const;",
             Some(serde_json::json!([ { "allowDirectConstAssertionInArrowFunctions": false,  }, ])),
             None,
             None,
@@ -1969,10 +1952,10 @@ fn test() {
         ),
         (
             "
-        	        const log = (message: string) => {
-        	          void console.log(message);
-        	        };
-        	      ",
+        	const log = (message: string) => {
+              void console.log(message);
+        	};
+            ",
             Some(
                 serde_json::json!([{ "allowConciseArrowFunctionExpressionsStartingWithVoid": true }]),
             ),
@@ -1990,7 +1973,7 @@ fn test() {
         	function log<A>(a: A) {
         	  return a;
         	}
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowFunctionsWithoutTypeParameters": true }])),
             None,
             None,
@@ -2000,7 +1983,7 @@ fn test() {
         	const log = function <A>(a: A) {
         	  return a;
         	};
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowFunctionsWithoutTypeParameters": true }])),
             None,
             None,
@@ -2029,7 +2012,7 @@ fn test() {
         	    return;
         	  },
         	};
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowedNames": ["test", "1"],  }, ])),
             None,
             None,
@@ -2040,7 +2023,7 @@ fn test() {
         	class Foo {
         	  [ignoredName]() {}
         	}
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowedNames": ["ignoredName"] }])),
             None,
             None,
@@ -2054,7 +2037,7 @@ fn test() {
         	    },
         	  ];
         	}
-        	      ",
+        	",
             None,
             None,
             None,
@@ -2064,7 +2047,7 @@ fn test() {
         	const foo = (function () {
         	  return 'foo';
         	})();
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowIIFEs": false,  }, ])),
             None,
             None,
@@ -2076,7 +2059,7 @@ fn test() {
         	    return 1;
         	  };
         	})();
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowIIFEs": true,  }, ])),
             None,
             None,
@@ -2086,15 +2069,13 @@ fn test() {
         	let foo = function () {
         	  return 'foo';
         	};
-        	      ",
+        	",
             Some(serde_json::json!([ { "allowIIFEs": true,  }, ])),
             None,
             None,
         ),
         (
-            "
-        	let foo = (() => () => {})()();
-        	      ",
+            "let foo = (() => () => {})()();",
             Some(serde_json::json!([ { "allowIIFEs": true,  }, ])),
             None,
             None,
@@ -2104,7 +2085,7 @@ fn test() {
         	type CallBack = () => void;
 
         	function f(gotcha: CallBack = () => {}): void {}
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": false }])),
             None,
             None,
@@ -2114,7 +2095,7 @@ fn test() {
         	type CallBack = () => void;
 
         	const f = (gotcha: CallBack = () => {}): void => {};
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": false }])),
             None,
             None,
@@ -2124,7 +2105,7 @@ fn test() {
         	type ObjectWithCallback = { callback: () => void };
 
         	const f = (gotcha: ObjectWithCallback = { callback: () => {} }): void => {};
-        	      ",
+        	",
             Some(serde_json::json!([{ "allowTypedFunctionExpressions": false }])),
             None,
             None,

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -7,13 +7,13 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::{CompactStr, Span};
+use oxc_span::{CompactStr, GetSpan, Span};
 use oxc_syntax::operator::UnaryOperator;
 use rustc_hash::FxHashSet;
 
 use crate::{
     AstNode,
-    ast_util::{outermost_paren_parent, iter_outer_expressions},
+    ast_util::{iter_outer_expressions, outermost_paren_parent},
     context::{ContextHost, LintContext},
     rule::Rule,
     rules::eslint::array_callback_return::return_checker::{
@@ -471,13 +471,14 @@ impl ExplicitFunctionReturnType {
 
 // check function is IIFE (Immediately Invoked Function Expression)
 fn is_iife<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
-    let Some(AstKind::CallExpression(call)) = iter_outer_expressions(ctx.semantic(), node.id()).next()
+    let Some(AstKind::CallExpression(call)) =
+        iter_outer_expressions(ctx.semantic(), node.id()).next()
     else {
-    return false;
+        return false;
     };
     call.callee.span().contains_inclusive(node.span())
-
 }
+
 /**
  * Checks if a node belongs to:
  * ```

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -790,39 +790,29 @@ fn test() {
             None,
             None,
         ),
-        (
-            "fn(() => {});",
-            Some(serde_json::json!([        {          "allowExpressions": true,        },      ])),
-            None,
-            None,
-        ),
+        ("fn(() => {});", Some(serde_json::json!([ { "allowExpressions": true,  }, ])), None, None),
         (
             "fn(function () {});",
-            Some(serde_json::json!([        {          "allowExpressions": true,        },      ])),
+            Some(serde_json::json!([ { "allowExpressions": true,  }, ])),
             None,
             None,
         ),
         (
             "[function () {}, () => {}];",
-            Some(serde_json::json!([        {          "allowExpressions": true,        },      ])),
+            Some(serde_json::json!([ { "allowExpressions": true,  }, ])),
             None,
             None,
         ),
         (
             "(function () {});",
-            Some(serde_json::json!([        {          "allowExpressions": true,        },      ])),
+            Some(serde_json::json!([ { "allowExpressions": true,  }, ])),
             None,
             None,
         ),
-        (
-            "(() => {})();",
-            Some(serde_json::json!([        {          "allowExpressions": true,        },      ])),
-            None,
-            None,
-        ),
+        ("(() => {})();", Some(serde_json::json!([ { "allowExpressions": true,  }, ])), None, None),
         (
             "export default (): void => {};",
-            Some(serde_json::json!([        {          "allowExpressions": true,        },      ])),
+            Some(serde_json::json!([ { "allowExpressions": true,  }, ])),
             None,
             None,
         ),
@@ -830,9 +820,7 @@ fn test() {
             "
         	var arrowFn: Foo = () => 'test';
         	      ",
-            Some(
-                serde_json::json!([        {          "allowTypedFunctionExpressions": true,        },      ]),
-            ),
+            Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
         ),
@@ -842,9 +830,7 @@ fn test() {
         	  return 'test';
         	};
         	      ",
-            Some(
-                serde_json::json!([        {          "allowTypedFunctionExpressions": true,        },      ]),
-            ),
+            Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
         ),
@@ -1113,9 +1099,7 @@ fn test() {
         	foo(() => true);
         	foo(() => '');
         	      ",
-            Some(
-                serde_json::json!([        {          "allowTypedFunctionExpressions": true,        },      ]),
-            ),
+            Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
         ),
@@ -1128,9 +1112,7 @@ fn test() {
         	foo.bar?.(() => true);
         	foo?.(() => '');
         	      ",
-            Some(
-                serde_json::json!([        {          "allowTypedFunctionExpressions": true,        },      ]),
-            ),
+            Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
         ),
@@ -1146,9 +1128,7 @@ fn test() {
 
         	new Accumulator().accumulate(() => 1);
         	      ",
-            Some(
-                serde_json::json!([        {          "allowTypedFunctionExpressions": true,        },      ]),
-            ),
+            Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
         ),
@@ -1171,9 +1151,7 @@ fn test() {
         	  },
         	});
         	      ",
-            Some(
-                serde_json::json!([        {          "allowTypedFunctionExpressions": true,        },      ]),
-            ),
+            Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
         ),
@@ -1184,9 +1162,7 @@ fn test() {
         	const func3 = (value: number) => x as const;
         	const func4 = (value: number) => x as const;
         	      ",
-            Some(
-                serde_json::json!([        {          "allowDirectConstAssertionInArrowFunctions": true,        },      ]),
-            ),
+            Some(serde_json::json!([ { "allowDirectConstAssertionInArrowFunctions": true,  }, ])),
             None,
             None,
         ),
@@ -1195,9 +1171,7 @@ fn test() {
         	new Promise(resolve => {});
         	new Foo(1, () => {});
         	      ",
-            Some(
-                serde_json::json!([        {          "allowTypedFunctionExpressions": true,        },      ]),
-            ),
+            Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
         ),
@@ -1271,9 +1245,7 @@ fn test() {
         	  return;
         	};
         	      ",
-            Some(
-                serde_json::json!([        {          "allowedNames": ["test1", "test2"],        },      ]),
-            ),
+            Some(serde_json::json!([ { "allowedNames": ["test1", "test2"],  }, ])),
             None,
             None,
         ),
@@ -1286,9 +1258,7 @@ fn test() {
         	  return function test2() {};
         	};
         	      ",
-            Some(
-                serde_json::json!([        {          "allowedNames": ["test1", "test2"],        },      ]),
-            ),
+            Some(serde_json::json!([ { "allowedNames": ["test1", "test2"],  }, ])),
             None,
             None,
         ),
@@ -1303,9 +1273,7 @@ fn test() {
         	  },
         	};
         	      ",
-            Some(
-                serde_json::json!([        {          "allowedNames": ["test1", "test2"],        },      ]),
-            ),
+            Some(serde_json::json!([ { "allowedNames": ["test1", "test2"],  }, ])),
             None,
             None,
         ),
@@ -1326,9 +1294,7 @@ fn test() {
         	  }
         	}
         	      ",
-            Some(
-                serde_json::json!([        {          "allowedNames": ["prop", "method", "arrow"],        },      ]),
-            ),
+            Some(serde_json::json!([ { "allowedNames": ["prop", "method", "arrow"],  }, ])),
             None,
             None,
         ),
@@ -1343,8 +1309,17 @@ fn test() {
         	  },
         	};
         	      ",
+            Some(serde_json::json!([ { "allowedNames": ["arrowFn", "fn"],  }, ])),
+            None,
+            None,
+        ),
+        (
+            "
+        	type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
+        	const x: HigherOrderType = () => arg1 => arg2 => 'foo';
+        	      ",
             Some(
-                serde_json::json!([        {          "allowedNames": ["arrowFn", "fn"],        },      ]),
+                serde_json::json!([ { "allowTypedFunctionExpressions": true,  "allowHigherOrderFunctions": true,  }, ]),
             ),
             None,
             None,
@@ -1355,18 +1330,7 @@ fn test() {
         	const x: HigherOrderType = () => arg1 => arg2 => 'foo';
         	      ",
             Some(
-                serde_json::json!([        {          "allowTypedFunctionExpressions": true,          "allowHigherOrderFunctions": true,        },      ]),
-            ),
-            None,
-            None,
-        ),
-        (
-            "
-        	type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
-        	const x: HigherOrderType = () => arg1 => arg2 => 'foo';
-        	      ",
-            Some(
-                serde_json::json!([        {          "allowTypedFunctionExpressions": true,          "allowHigherOrderFunctions": false,        },      ]),
+                serde_json::json!([ { "allowTypedFunctionExpressions": true,  "allowHigherOrderFunctions": false,  }, ]),
             ),
             None,
             None,
@@ -1386,7 +1350,7 @@ fn test() {
         	}
         	      ",
             Some(
-                serde_json::json!([        {          "allowTypedFunctionExpressions": true,          "allowHigherOrderFunctions": true,        },      ]),
+                serde_json::json!([ { "allowTypedFunctionExpressions": true,  "allowHigherOrderFunctions": true,  }, ]),
             ),
             None,
             None,
@@ -1398,7 +1362,7 @@ fn test() {
         	const x: Bar<Foo> = arg1 => arg2 => arg1 + arg2;
         	      ",
             Some(
-                serde_json::json!([        {          "allowTypedFunctionExpressions": true,          "allowHigherOrderFunctions": true,        },      ]),
+                serde_json::json!([ { "allowTypedFunctionExpressions": true,  "allowHigherOrderFunctions": true,  }, ]),
             ),
             None,
             None,
@@ -1409,7 +1373,7 @@ fn test() {
         	  return 1;
         	};
         	      ",
-            Some(serde_json::json!([        {          "allowIIFEs": true,        },      ])),
+            Some(serde_json::json!([ { "allowIIFEs": true,  }, ])),
             None,
             None,
         ),
@@ -1419,7 +1383,7 @@ fn test() {
         	  return 1;
         	})();
         	      ",
-            Some(serde_json::json!([        {          "allowIIFEs": true,        },      ])),
+            Some(serde_json::json!([ { "allowIIFEs": true,  }, ])),
             None,
             None,
         ),
@@ -1429,7 +1393,7 @@ fn test() {
         	  return 1;
         	})();
         	      ",
-            Some(serde_json::json!([        {          "allowIIFEs": true,        },      ])),
+            Some(serde_json::json!([ { "allowIIFEs": true,  }, ])),
             None,
             None,
         ),
@@ -1439,7 +1403,7 @@ fn test() {
         	  return arg;
         	})(0);
         	      ",
-            Some(serde_json::json!([        {          "allowIIFEs": true,        },      ])),
+            Some(serde_json::json!([ { "allowIIFEs": true,  }, ])),
             None,
             None,
         ),
@@ -1447,7 +1411,7 @@ fn test() {
             "
         	const foo = (() => (() => 'foo')())();
         	      ",
-            Some(serde_json::json!([        {          "allowIIFEs": true,        },      ])),
+            Some(serde_json::json!([ { "allowIIFEs": true,  }, ])),
             None,
             None,
         ),
@@ -1457,7 +1421,7 @@ fn test() {
         	  return 'foo';
         	})()();
         	      ",
-            Some(serde_json::json!([        {          "allowIIFEs": true,        },      ])),
+            Some(serde_json::json!([ { "allowIIFEs": true,  }, ])),
             None,
             None,
         ),
@@ -1468,7 +1432,7 @@ fn test() {
         	})();
         	      ",
             Some(
-                serde_json::json!([        {          "allowIIFEs": true,          "allowHigherOrderFunctions": false,        },      ]),
+                serde_json::json!([ { "allowIIFEs": true,  "allowHigherOrderFunctions": false,  }, ]),
             ),
             None,
             None,
@@ -1480,7 +1444,7 @@ fn test() {
         	})()();
         	      ",
             Some(
-                serde_json::json!([        {          "allowIIFEs": true,          "allowHigherOrderFunctions": true,        },      ]),
+                serde_json::json!([ { "allowIIFEs": true,  "allowHigherOrderFunctions": true,  }, ]),
             ),
             None,
             None,
@@ -1489,7 +1453,7 @@ fn test() {
             "
         	let foo = (() => (): void => {})()();
         	      ",
-            Some(serde_json::json!([        {          "allowIIFEs": true,        },      ])),
+            Some(serde_json::json!([ { "allowIIFEs": true,  }, ])),
             None,
             None,
         ),
@@ -1497,7 +1461,7 @@ fn test() {
             "
         	let foo = (() => (() => {})())();
         	      ",
-            Some(serde_json::json!([        {          "allowIIFEs": true,        },      ])),
+            Some(serde_json::json!([ { "allowIIFEs": true,  }, ])),
             None,
             None,
         ),
@@ -1680,9 +1644,7 @@ fn test() {
         	  const bar = () => () => console.log('aa');
         	}
         	      ",
-            Some(
-                serde_json::json!([        {          "allowTypedFunctionExpressions": true,        },      ]),
-            ),
+            Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
         ),
@@ -1693,9 +1655,7 @@ fn test() {
         	  anyValue = () => () => console.log('aa');
         	}
         	      ",
-            Some(
-                serde_json::json!([        {          "allowTypedFunctionExpressions": true,        },      ]),
-            ),
+            Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
         ),
@@ -1709,9 +1669,7 @@ fn test() {
         	  }
         	}
         	      ",
-            Some(
-                serde_json::json!([        {          "allowTypedFunctionExpressions": true,        },      ]),
-            ),
+            Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
         ),
@@ -1793,9 +1751,7 @@ fn test() {
         	  }
         	}
         	      ",
-            Some(
-                serde_json::json!([        {          "allowTypedFunctionExpressions": true,        },      ]),
-            ),
+            Some(serde_json::json!([ { "allowTypedFunctionExpressions": true,  }, ])),
             None,
             None,
         ),
@@ -1915,9 +1871,7 @@ fn test() {
         	foo(() => true);
         	foo(() => '');
         	      ",
-            Some(
-                serde_json::json!([        {          "allowTypedFunctionExpressions": false,        },      ]),
-            ),
+            Some(serde_json::json!([ { "allowTypedFunctionExpressions": false,  }, ])),
             None,
             None,
         ),
@@ -1933,17 +1887,13 @@ fn test() {
 
         	new Accumulator().accumulate(() => 1);
         	      ",
-            Some(
-                serde_json::json!([        {          "allowTypedFunctionExpressions": false,        },      ]),
-            ),
+            Some(serde_json::json!([ { "allowTypedFunctionExpressions": false,  }, ])),
             None,
             None,
         ),
         (
             "(() => true)();",
-            Some(
-                serde_json::json!([        {          "allowTypedFunctionExpressions": false,        },      ]),
-            ),
+            Some(serde_json::json!([ { "allowTypedFunctionExpressions": false,  }, ])),
             None,
             None,
         ),
@@ -1966,8 +1916,17 @@ fn test() {
         	  },
         	});
         	      ",
+            Some(serde_json::json!([ { "allowTypedFunctionExpressions": false,  }, ])),
+            None,
+            None,
+        ),
+        (
+            "
+        	type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
+        	const x: HigherOrderType = () => arg1 => arg2 => 'foo';
+        	      ",
             Some(
-                serde_json::json!([        {          "allowTypedFunctionExpressions": false,        },      ]),
+                serde_json::json!([ { "allowTypedFunctionExpressions": false,  "allowHigherOrderFunctions": true,  }, ]),
             ),
             None,
             None,
@@ -1978,18 +1937,7 @@ fn test() {
         	const x: HigherOrderType = () => arg1 => arg2 => 'foo';
         	      ",
             Some(
-                serde_json::json!([        {          "allowTypedFunctionExpressions": false,          "allowHigherOrderFunctions": true,        },      ]),
-            ),
-            None,
-            None,
-        ),
-        (
-            "
-        	type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
-        	const x: HigherOrderType = () => arg1 => arg2 => 'foo';
-        	      ",
-            Some(
-                serde_json::json!([        {          "allowTypedFunctionExpressions": false,          "allowHigherOrderFunctions": false,        },      ]),
+                serde_json::json!([ { "allowTypedFunctionExpressions": false,  "allowHigherOrderFunctions": false,  }, ]),
             ),
             None,
             None,
@@ -1999,9 +1947,7 @@ fn test() {
         	const func1 = (value: number) => ({ type: 'X', value }) as any;
         	const func2 = (value: number) => ({ type: 'X', value }) as Action;
         	      ",
-            Some(
-                serde_json::json!([        {          "allowDirectConstAssertionInArrowFunctions": true,        },      ]),
-            ),
+            Some(serde_json::json!([ { "allowDirectConstAssertionInArrowFunctions": true,  }, ])),
             None,
             None,
         ),
@@ -2009,16 +1955,14 @@ fn test() {
             "
         	const func = (value: number) => ({ type: 'X', value }) as const;
         	      ",
-            Some(
-                serde_json::json!([        {          "allowDirectConstAssertionInArrowFunctions": false,        },      ]),
-            ),
+            Some(serde_json::json!([ { "allowDirectConstAssertionInArrowFunctions": false,  }, ])),
             None,
             None,
         ),
         (
             "const log = (message: string) => void console.log(message);",
             Some(
-                serde_json::json!([        { "allowConciseArrowFunctionExpressionsStartingWithVoid": false },      ]),
+                serde_json::json!([ { "allowConciseArrowFunctionExpressionsStartingWithVoid": false },      ]),
             ),
             None,
             None,
@@ -2086,9 +2030,7 @@ fn test() {
         	  },
         	};
         	      ",
-            Some(
-                serde_json::json!([        {          "allowedNames": ["test", "1"],        },      ]),
-            ),
+            Some(serde_json::json!([ { "allowedNames": ["test", "1"],  }, ])),
             None,
             None,
         ),
@@ -2123,7 +2065,7 @@ fn test() {
         	  return 'foo';
         	})();
         	      ",
-            Some(serde_json::json!([        {          "allowIIFEs": false,        },      ])),
+            Some(serde_json::json!([ { "allowIIFEs": false,  }, ])),
             None,
             None,
         ),
@@ -2135,7 +2077,7 @@ fn test() {
         	  };
         	})();
         	      ",
-            Some(serde_json::json!([        {          "allowIIFEs": true,        },      ])),
+            Some(serde_json::json!([ { "allowIIFEs": true,  }, ])),
             None,
             None,
         ),
@@ -2145,7 +2087,7 @@ fn test() {
         	  return 'foo';
         	};
         	      ",
-            Some(serde_json::json!([        {          "allowIIFEs": true,        },      ])),
+            Some(serde_json::json!([ { "allowIIFEs": true,  }, ])),
             None,
             None,
         ),
@@ -2153,7 +2095,7 @@ fn test() {
             "
         	let foo = (() => () => {})()();
         	      ",
-            Some(serde_json::json!([        {          "allowIIFEs": true,        },      ])),
+            Some(serde_json::json!([ { "allowIIFEs": true,  }, ])),
             None,
             None,
         ),

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -47,13 +47,16 @@ impl std::ops::Deref for ExplicitFunctionReturnType {
 declare_oxc_lint!(
     /// ### What it does
     ///
-    /// This rule enforces that functions do have an explicit return type annotation.
+    /// This rule enforces that functions have an explicit return type annotation.
     ///
     /// ### Why is this bad?
     ///
-    /// Explicit return types do make it visually more clear what type is
-    /// returned by a function. They can also speed up TypeScript type checking
-    /// performance in large codebases with many large functions.
+    /// Explicit return types make it clearer what type is returned by a function. Making the
+    /// type returned by a function obvious allows the reader to infer what the function does
+    /// and how it can be used from a quick glance.
+    ///
+    /// Another benefit of explicit return types is the potential for a speed up of type
+    /// checking in large codebases with many large functions.
     ///
     /// ### Example
     ///

--- a/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/explicit_function_return_type.rs
@@ -13,7 +13,7 @@ use rustc_hash::FxHashSet;
 
 use crate::{
     AstNode,
-    ast_util::outermost_paren_parent,
+    ast_util::{outermost_paren_parent, iter_outer_expressions},
     context::{ContextHost, LintContext},
     rule::Rule,
     rules::eslint::array_callback_return::return_checker::{
@@ -468,10 +468,12 @@ impl ExplicitFunctionReturnType {
 
 // check function is IIFE (Immediately Invoked Function Expression)
 fn is_iife<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> bool {
-    let Some(parent) = get_parent_node(node, ctx) else {
-        return false;
+    let Some(AstKind::CallExpression(call)) = iter_outer_expressions(ctx.semantic(), node.id()).next()
+    else {
+    return false;
     };
-    matches!(parent.kind(), AstKind::CallExpression(_))
+    call.callee.span().contains_inclusive(node.span())
+
 }
 /**
  * Checks if a node belongs to:

--- a/crates/oxc_linter/src/snapshots/typescript_explicit_function_return_type.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_explicit_function_return_type.snap
@@ -33,7 +33,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ 
  2 │             var arrowFn = () => 'test';
    ·                              ──
- 3 │                   
+ 3 │             
    ╰────
   help: Require explicit return types on functions and class methods.
 
@@ -394,7 +394,7 @@ source: crates/oxc_linter/src/tester.rs
  6 │             foo(() => true);
  7 │             foo(() => '');
    ·                    ──
- 8 │                   
+ 8 │             
    ╰────
   help: Require explicit return types on functions and class methods.
 
@@ -403,7 +403,7 @@ source: crates/oxc_linter/src/tester.rs
   9 │ 
  10 │             new Accumulator().accumulate(() => 1);
     ·                                             ──
- 11 │                   
+ 11 │             
     ╰────
   help: Require explicit return types on functions and class methods.
 
@@ -446,7 +446,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │             type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
  3 │             const x: HigherOrderType = () => arg1 => arg2 => 'foo';
    ·                                                           ──
- 4 │                   
+ 4 │             
    ╰────
   help: Require explicit return types on functions and class methods.
 
@@ -455,7 +455,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │             type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
  3 │             const x: HigherOrderType = () => arg1 => arg2 => 'foo';
    ·                                           ──
- 4 │                   
+ 4 │             
    ╰────
   help: Require explicit return types on functions and class methods.
 
@@ -464,7 +464,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │             type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
  3 │             const x: HigherOrderType = () => arg1 => arg2 => 'foo';
    ·                                                   ──
- 4 │                   
+ 4 │             
    ╰────
   help: Require explicit return types on functions and class methods.
 
@@ -473,7 +473,7 @@ source: crates/oxc_linter/src/tester.rs
  2 │             type HigherOrderType = () => (arg1: string) => (arg2: number) => string;
  3 │             const x: HigherOrderType = () => arg1 => arg2 => 'foo';
    ·                                                           ──
- 4 │                   
+ 4 │             
    ╰────
   help: Require explicit return types on functions and class methods.
 
@@ -491,16 +491,14 @@ source: crates/oxc_linter/src/tester.rs
  2 │             const func1 = (value: number) => ({ type: 'X', value }) as any;
  3 │             const func2 = (value: number) => ({ type: 'X', value }) as Action;
    ·                                           ──
- 4 │                   
+ 4 │             
    ╰────
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:2:39]
- 1 │ 
- 2 │             const func = (value: number) => ({ type: 'X', value }) as const;
-   ·                                          ──
- 3 │                   
+   ╭─[explicit_function_return_type.tsx:1:30]
+ 1 │ const func = (value: number) => ({ type: 'X', value }) as const;
+   ·                              ──
    ╰────
   help: Require explicit return types on functions and class methods.
 
@@ -512,11 +510,11 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:2:48]
+   ╭─[explicit_function_return_type.tsx:2:40]
  1 │ 
- 2 │                     const log = (message: string) => {
-   ·                                                   ──
- 3 │                       void console.log(message);
+ 2 │             const log = (message: string) => {
+   ·                                           ──
+ 3 │               void console.log(message);
    ╰────
   help: Require explicit return types on functions and class methods.
 
@@ -645,11 +643,9 @@ source: crates/oxc_linter/src/tester.rs
   help: Require explicit return types on functions and class methods.
 
   ⚠ typescript-eslint(explicit-function-return-type): Missing return type on function.
-   ╭─[explicit_function_return_type.tsx:2:30]
- 1 │ 
- 2 │             let foo = (() => () => {})()();
-   ·                                 ──
- 3 │                   
+   ╭─[explicit_function_return_type.tsx:1:21]
+ 1 │ let foo = (() => () => {})()();
+   ·                     ──
    ╰────
   help: Require explicit return types on functions and class methods.
 
@@ -658,7 +654,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │ 
  4 │             function f(gotcha: CallBack = () => {}): void {}
    ·                                              ──
- 5 │                   
+ 5 │             
    ╰────
   help: Require explicit return types on functions and class methods.
 
@@ -667,7 +663,7 @@ source: crates/oxc_linter/src/tester.rs
  3 │ 
  4 │             const f = (gotcha: CallBack = () => {}): void => {};
    ·                                              ──
- 5 │                   
+ 5 │             
    ╰────
   help: Require explicit return types on functions and class methods.
 
@@ -676,6 +672,6 @@ source: crates/oxc_linter/src/tester.rs
  3 │ 
  4 │             const f = (gotcha: ObjectWithCallback = { callback: () => {} }): void => {};
    ·                                                       ──────────
- 5 │                   
+ 5 │             
    ╰────
   help: Require explicit return types on functions and class methods.


### PR DESCRIPTION
A minor refactor of the rule.
 
- [Use ast utils function instead of duplicating logic](https://github.com/oxc-project/oxc/commit/0bbf67b59093a64cb57b37f51599e5ef1edac406)

- [Improve the documentation with clearer motivation for the rule](https://github.com/oxc-project/oxc/commit/739769bca29985da28b0af5c65f345b44129f02e)

- [Fix formatting in test cases that cargo fmt wouldn't fix](https://github.com/oxc-project/oxc/commit/842f4d580f6b92318429524a72da9d69a52a2540)

- [Remove trailing whitespace from the test case strings](https://github.com/oxc-project/oxc/commit/6a931522b4df66cd2a4e17150c5199418617e140)