### PR TITLE
refactor(linter): move rule `no-restricted-imports` to category `restriction`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_restricted_imports.rs
@@ -544,7 +544,7 @@ declare_oxc_lint!(
     /// ```
     NoRestrictedImports,
     eslint,
-    nursery,
+    restriction,
 );
 
 fn add_configuration_path_from_object(


### PR DESCRIPTION
it was moved from style to nursery here https://github.com/oxc-project/oxc/pull/7897
I think restriction is a better place? 