### PR TITLE
feat(ast_tools): add `#[estree(no_flatten)]` attr for struct fields

### DIFF
--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -140,6 +140,7 @@ fn parse_estree_attr(location: AttrLocation, part: AttrPart) -> Result<()> {
         AttrLocation::StructField(struct_def, field_index) => match part {
             AttrPart::Tag("skip") => struct_def.fields[field_index].estree.skip = true,
             AttrPart::Tag("flatten") => struct_def.fields[field_index].estree.flatten = true,
+            AttrPart::Tag("no_flatten") => struct_def.fields[field_index].estree.no_flatten = true,
             AttrPart::Tag("json_safe") => struct_def.fields[field_index].estree.json_safe = true,
             AttrPart::String("rename", value) => {
                 struct_def.fields[field_index].estree.rename = Some(value);
@@ -488,6 +489,8 @@ pub fn should_skip_field(field: &FieldDef, schema: &Schema) -> bool {
 pub fn should_flatten_field(field: &FieldDef, schema: &Schema) -> bool {
     if field.estree.flatten {
         true
+    } else if field.estree.no_flatten {
+        false
     } else {
         let field_type = field.type_def(schema);
         matches!(field_type, TypeDef::Struct(field_struct_def) if field_struct_def.estree.flatten)

--- a/tasks/ast_tools/src/schema/extensions/estree.rs
+++ b/tasks/ast_tools/src/schema/extensions/estree.rs
@@ -56,6 +56,7 @@ pub struct ESTreeStructField {
     pub append_field_index: Option<usize>,
     pub skip: bool,
     pub flatten: bool,
+    pub no_flatten: bool,
     // `true` for fields containing a `&str` or `Atom` which does not need escaping in JSON
     pub json_safe: bool,
     pub is_ts: bool,


### PR DESCRIPTION
Add an `#[estree(no_flatten)]` attribute which can be used on a struct field to override an `#[estree(flatten)]` attribute on the type of the field. e.g. if you want to *not* flatten a `Span`.