### PR TITLE
feat(ast_tools): allow using `#[ast]` in NAPI packages

### DIFF
--- a/tasks/ast_tools/src/derives/mod.rs
+++ b/tasks/ast_tools/src/derives/mod.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use convert_case::{Case, Casing};
 use proc_macro2::TokenStream;
 use quote::quote;
@@ -184,8 +186,14 @@ pub trait Derive: Runner {
                     .collect::<Vec<_>>();
                 import_paths.sort_unstable();
 
+                let crate_path = if krate.starts_with("napi/") {
+                    Cow::Borrowed(krate)
+                } else {
+                    Cow::Owned(format!("crates/{krate}"))
+                };
+
                 Output::Rust {
-                    path: output_path(&format!("crates/{krate}"), &filename),
+                    path: output_path(&crate_path, &filename),
                     tokens: self.template(&import_paths, content.output),
                 }
             })


### PR DESCRIPTION
Previously `#[ast]` attr was only usable inside the `crates` directory. Extend that to also NAPI packages in the `napi` directory.