### PR TITLE
feat(ast_tools): record visibility of structs and enums in `Schema`

### DIFF
--- a/tasks/ast_tools/src/parse/parse.rs
+++ b/tasks/ast_tools/src/parse/parse.rs
@@ -207,6 +207,7 @@ impl<'c> Parser<'c> {
         let StructSkeleton { name, item, is_foreign, file_id } = skeleton;
         let has_lifetime = check_generics(&item.generics, &name);
         let fields = self.parse_fields(&item.fields);
+        let visibility = convert_visibility(&item.vis);
         let (generated_derives, plural_name) =
             self.get_generated_derives_and_plural_name(&item.attrs, &name);
         let mut type_def = TypeDef::Struct(StructDef::new(
@@ -216,6 +217,7 @@ impl<'c> Parser<'c> {
             has_lifetime,
             is_foreign,
             file_id,
+            visibility,
             generated_derives,
             fields,
         ));
@@ -282,6 +284,7 @@ impl<'c> Parser<'c> {
         let has_lifetime = check_generics(&item.generics, &name);
         let variants = item.variants.iter().map(|variant| self.parse_variant(variant)).collect();
         let inherits = inherits.into_iter().map(|name| self.type_id(&name)).collect();
+        let visibility = convert_visibility(&item.vis);
         let (generated_derives, plural_name) =
             self.get_generated_derives_and_plural_name(&item.attrs, &name);
         let mut type_def = TypeDef::Enum(EnumDef::new(
@@ -291,6 +294,7 @@ impl<'c> Parser<'c> {
             has_lifetime,
             is_foreign,
             file_id,
+            visibility,
             generated_derives,
             variants,
             inherits,
@@ -370,11 +374,7 @@ impl<'c> Parser<'c> {
         let type_id = self
             .parse_type_name(ty)
             .unwrap_or_else(|| panic!("Cannot parse type reference: {}", ty.to_token_stream()));
-        let visibility = match &field.vis {
-            SynVisibility::Public(_) => Visibility::Public,
-            SynVisibility::Restricted(_) => Visibility::Restricted,
-            SynVisibility::Inherited => Visibility::Private,
-        };
+        let visibility = convert_visibility(&field.vis);
 
         // Get doc comment
         let mut doc_comment = None;
@@ -912,4 +912,13 @@ fn check_attr_position(
         "`{type_name}` type has `#[{attr_name}]` attribute on a {position_debug_str}, \
         but `#[{attr_name}]` is not legal in this position."
     );
+}
+
+/// Convert `syn::Visibility` to our `Visibility` type.
+fn convert_visibility(vis: &SynVisibility) -> Visibility {
+    match vis {
+        SynVisibility::Public(_) => Visibility::Public,
+        SynVisibility::Restricted(_) => Visibility::Restricted,
+        SynVisibility::Inherited => Visibility::Private,
+    }
 }

--- a/tasks/ast_tools/src/schema/defs/enum.rs
+++ b/tasks/ast_tools/src/schema/defs/enum.rs
@@ -8,7 +8,7 @@ use syn::Ident;
 use crate::utils::{create_ident, pluralize};
 
 use super::{
-    Def, Derives, File, FileId, Schema, TypeDef, TypeId,
+    Def, Derives, File, FileId, Schema, TypeDef, TypeId, Visibility,
     extensions::{
         ast_builder::AstBuilderType,
         clone_in::CloneInType,
@@ -32,6 +32,8 @@ pub struct EnumDef {
     #[expect(unused)]
     pub is_foreign: bool,
     pub file_id: FileId,
+    #[expect(unused)]
+    pub visibility: Visibility,
     pub generated_derives: Derives,
     pub variants: Vec<VariantDef>,
     /// For `@inherits` inherited enum variants
@@ -55,6 +57,7 @@ impl EnumDef {
         has_lifetime: bool,
         is_foreign: bool,
         file_id: FileId,
+        visibility: Visibility,
         generated_derives: Derives,
         variants: Vec<VariantDef>,
         inherits: Vec<TypeId>,
@@ -66,6 +69,7 @@ impl EnumDef {
             has_lifetime,
             is_foreign,
             file_id,
+            visibility,
             generated_derives,
             variants,
             inherits,

--- a/tasks/ast_tools/src/schema/defs/mod.rs
+++ b/tasks/ast_tools/src/schema/defs/mod.rs
@@ -24,7 +24,7 @@ pub use cell::CellDef;
 pub use r#enum::{Discriminant, EnumDef, VariantDef};
 pub use option::OptionDef;
 pub use primitive::PrimitiveDef;
-pub use r#struct::{FieldDef, StructDef, Visibility};
+pub use r#struct::{FieldDef, StructDef};
 pub use r#type::TypeDef;
 pub use vec::VecDef;
 
@@ -113,4 +113,13 @@ pub trait Def {
             &schema.types[self.id()]
         }
     }
+}
+
+/// Visibility of a struct / enum / struct field.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Visibility {
+    Public,
+    /// `pub(crate)` or `pub(super)`
+    Restricted,
+    Private,
 }

--- a/tasks/ast_tools/src/schema/defs/struct.rs
+++ b/tasks/ast_tools/src/schema/defs/struct.rs
@@ -7,7 +7,7 @@ use quote::quote;
 use crate::utils::{create_ident_tokens, pluralize};
 
 use super::{
-    Def, Derives, File, FileId, Schema, TypeDef, TypeId,
+    Def, Derives, File, FileId, Schema, TypeDef, TypeId, Visibility,
     extensions::{
         ast_builder::{AstBuilderStructField, AstBuilderType},
         clone_in::{CloneInStructField, CloneInType},
@@ -29,6 +29,8 @@ pub struct StructDef {
     pub has_lifetime: bool,
     pub is_foreign: bool,
     pub file_id: FileId,
+    #[expect(unused)]
+    pub visibility: Visibility,
     pub generated_derives: Derives,
     pub fields: Vec<FieldDef>,
     pub builder: AstBuilderType,
@@ -51,6 +53,7 @@ impl StructDef {
         has_lifetime: bool,
         is_foreign: bool,
         file_id: FileId,
+        visibility: Visibility,
         generated_derives: Derives,
         fields: Vec<FieldDef>,
     ) -> Self {
@@ -61,6 +64,7 @@ impl StructDef {
             has_lifetime,
             is_foreign,
             file_id,
+            visibility,
             generated_derives,
             fields,
             builder: AstBuilderType::default(),
@@ -191,13 +195,4 @@ impl FieldDef {
     pub fn type_def<'s>(&self, schema: &'s Schema) -> &'s TypeDef {
         &schema.types[self.type_id]
     }
-}
-
-/// Visibility of a struct field.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Visibility {
-    Public,
-    /// `pub(crate)` or `pub(super)`
-    Restricted,
-    Private,
 }


### PR DESCRIPTION
Add `visibility` field to `StructDef` and `EnumDef`, recording whether types are `pub`, `pub(crate)`, or private.
