### PR TITLE
feat(minifier): support binary expression in `remove_unused_expression`

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_conditions.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditions.rs
@@ -1308,8 +1308,8 @@ mod test {
         test("if((-0 != +0) !== false){}", "");
         test_same("foo(x >> y == 0)");
 
-        test("(x = 1) === 1", "(x = 1) == 1");
-        test("(x = 1) !== 1", "(x = 1) != 1");
+        test("v = (x = 1) === 1", "v = (x = 1) == 1");
+        test("v = (x = 1) !== 1", "v = (x = 1) != 1");
         test("v = !0 + null !== 1", "v = !1");
     }
 
@@ -1360,39 +1360,39 @@ mod test {
 
     #[test]
     fn test_fold_is_null_or_undefined() {
-        test("foo === null || foo === undefined", "foo == null");
-        test("foo === undefined || foo === null", "foo == null");
-        test("foo === null || foo === void 0", "foo == null");
-        test("foo === null || foo === void 0 || foo === 1", "foo == null || foo === 1");
-        test("foo === 1 || foo === null || foo === void 0", "foo === 1 || foo == null");
-        test_same("foo === void 0 || bar === null");
-        test_same("var undefined = 1; foo === null || foo === undefined");
-        test_same("foo !== 1 && foo === void 0 || foo === null");
-        test_same("foo.a === void 0 || foo.a === null"); // cannot be folded because accessing foo.a might have a side effect
+        test("v = foo === null || foo === undefined", "v = foo == null");
+        test("v = foo === undefined || foo === null", "v = foo == null");
+        test("v = foo === null || foo === void 0", "v = foo == null");
+        test("v = foo === null || foo === void 0 || foo === 1", "v = foo == null || foo === 1");
+        test("v = foo === 1 || foo === null || foo === void 0", "v = foo === 1 || foo == null");
+        test_same("v = foo === void 0 || bar === null");
+        test_same("var undefined = 1; v = foo === null || foo === undefined");
+        test_same("v = foo !== 1 && foo === void 0 || foo === null");
+        test_same("v = foo.a === void 0 || foo.a === null"); // cannot be folded because accessing foo.a might have a side effect
 
-        test("foo !== null && foo !== undefined", "foo != null");
-        test("foo !== undefined && foo !== null", "foo != null");
-        test("foo !== null && foo !== void 0", "foo != null");
-        test("foo !== null && foo !== void 0 && foo !== 1", "foo != null && foo !== 1");
-        test("foo !== 1 && foo !== null && foo !== void 0", "foo !== 1 && foo != null");
-        test("foo !== 1 || foo !== void 0 && foo !== null", "foo !== 1 || foo != null");
-        test_same("foo !== void 0 && bar !== null");
+        test("v = foo !== null && foo !== undefined", "v = foo != null");
+        test("v = foo !== undefined && foo !== null", "v = foo != null");
+        test("v = foo !== null && foo !== void 0", "v = foo != null");
+        test("v = foo !== null && foo !== void 0 && foo !== 1", "v = foo != null && foo !== 1");
+        test("v = foo !== 1 && foo !== null && foo !== void 0", "v = foo !== 1 && foo != null");
+        test("v = foo !== 1 || foo !== void 0 && foo !== null", "v = foo !== 1 || foo != null");
+        test_same("v = foo !== void 0 && bar !== null");
 
-        test("(_foo = foo) === null || _foo === undefined", "(_foo = foo) == null");
-        test("(_foo = foo) === null || _foo === void 0", "(_foo = foo) == null");
-        test("(_foo = foo.bar) === null || _foo === undefined", "(_foo = foo.bar) == null");
-        test("(_foo = foo) !== null && _foo !== undefined", "(_foo = foo) != null");
-        test("(_foo = foo) === undefined || _foo === null", "(_foo = foo) == null");
-        test("(_foo = foo) === void 0 || _foo === null", "(_foo = foo) == null");
+        test("v = (_foo = foo) === null || _foo === undefined", "v = (_foo = foo) == null");
+        test("v = (_foo = foo) === null || _foo === void 0", "v = (_foo = foo) == null");
+        test("v = (_foo = foo.bar) === null || _foo === undefined", "v = (_foo = foo.bar) == null");
+        test("v = (_foo = foo) !== null && _foo !== undefined", "v = (_foo = foo) != null");
+        test("v = (_foo = foo) === undefined || _foo === null", "v = (_foo = foo) == null");
+        test("v = (_foo = foo) === void 0 || _foo === null", "v = (_foo = foo) == null");
         test(
-            "(_foo = foo) === null || _foo === void 0 || _foo === 1",
-            "(_foo = foo) == null || _foo === 1",
+            "v = (_foo = foo) === null || _foo === void 0 || _foo === 1",
+            "v = (_foo = foo) == null || _foo === 1",
         );
         test(
-            "_foo === 1 || (_foo = foo) === null || _foo === void 0",
-            "_foo === 1 || (_foo = foo) == null",
+            "v = _foo === 1 || (_foo = foo) === null || _foo === void 0",
+            "v = _foo === 1 || (_foo = foo) == null",
         );
-        test_same("(_foo = foo) === void 0 || bar === null");
+        test_same("v = (_foo = foo) === void 0 || bar === null");
     }
 
     #[test]

--- a/crates/oxc_minifier/src/peephole/minimize_not_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_not_expression.rs
@@ -82,10 +82,10 @@ mod test {
 
     #[test]
     fn minimize_nots_with_binary_expressions() {
-        test("!(x === undefined)", "x !== void 0");
+        test("!(x === undefined)", "x");
         test("!(typeof(x) === 'undefined')", "");
-        test("!(typeof(x()) === 'undefined')", "x() !== void 0");
-        test("!(x === void 0)", "x !== void 0");
+        test("!(typeof(x()) === 'undefined')", "x()");
+        test("!(x === void 0)", "x");
         test("!!delete x.y", "delete x.y");
         test("!!!delete x.y", "delete x.y");
         test("!!!!delete x.y", "delete x.y");

--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -470,7 +470,7 @@ mod test {
         test("{if(false)if(false)if(false)foo(); {bar()}}", "bar()");
 
         test("{'hi'}", "");
-        test("{x==3}", "x == 3");
+        test("{x==3}", "x");
         test("{`hello ${foo}`}", "`${foo}`");
         test("{ (function(){x++}) }", "");
         test("{ (function foo(){x++; foo()}) }", "");

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1215,25 +1215,25 @@ mod test {
 
     #[test]
     fn test_fold_true_false_comparison() {
-        test("x == true", "x == !0");
-        test("x == false", "x == !1");
-        test("x != true", "x != !0");
-        test("x < true", "x < !0");
-        test("x <= true", "x <= !0");
-        test("x > true", "x > !0");
-        test("x >= true", "x >= !0");
+        test("v = x == true", "v = x == !0");
+        test("v = x == false", "v = x == !1");
+        test("v = x != true", "v = x != !0");
+        test("v = x < true", "v = x < !0");
+        test("v = x <= true", "v = x <= !0");
+        test("v = x > true", "v = x > !0");
+        test("v = x >= true", "v = x >= !0");
 
-        test("x instanceof true", "x instanceof !0");
-        test("x + false", "x + !1");
+        test("v = x instanceof true", "v = x instanceof !0");
+        test("v = x + false", "v = x + !1");
 
         // Order: should perform the nearest.
-        test("x == x instanceof false", "x == x instanceof !1");
-        test("x in x >> true", "x in x >> !0");
-        test("x == fake(false)", "x == fake(!1)");
+        test("v = x == x instanceof false", "v = x == x instanceof !1");
+        test("v = x in x >> true", "v = x in x >> !0");
+        test("v = x == fake(false)", "v = x == fake(!1)");
 
         // The following should not be folded.
-        test("x === true", "x === !0");
-        test("x !== false", "x !== !1");
+        test("v = x === true", "v = x === !0");
+        test("v = x !== false", "v = x !== !1");
     }
 
     /// Based on https://github.com/terser/terser/blob/58ba5c163fa1684f2a63c7bc19b7ebcf85b74f73/test/compress/assignment.js
@@ -1622,11 +1622,11 @@ mod test {
 
     #[test]
     fn test_fold_loose_equals_undefined() {
-        test_same("foo != null");
-        test("foo != undefined", "foo != null");
-        test("foo != void 0", "foo != null");
-        test("undefined != foo", "foo != null");
-        test("void 0 != foo", "foo != null");
+        test_same("v = foo != null");
+        test("v = foo != undefined", "v = foo != null");
+        test("v = foo != void 0", "v = foo != null");
+        test("v = undefined != foo", "v = foo != null");
+        test("v = void 0 != foo", "v = foo != null");
     }
 
     #[test]

--- a/crates/oxc_minifier/tests/peephole/esbuild.rs
+++ b/crates/oxc_minifier/tests/peephole/esbuild.rs
@@ -623,7 +623,7 @@ fn js_parser_test() {
     test("a ? b() : b()", "a, b();");
     test("a ? b?.() : b?.()", "a, b?.();");
     test("a ? b?.[c] : b?.[c]", "a, b?.[c];");
-    test("a ? b == c : b == c", "a, b == c;");
+    test("a ? b == c : b == c", "a, b, c;");
     test("a ? b.c(d + e[f]) : b.c(d + e[f])", "a, b.c(d + e[f]);");
     // test("a ? -b : !b", "a ? -b : b;");
     test("a ? b() : b(c)", "a ? b() : b(c);");
@@ -631,7 +631,7 @@ fn js_parser_test() {
     test("a ? b?.c : b.c", "a ? b?.c : b.c;");
     test("a ? b?.() : b()", "a ? b?.() : b();");
     test("a ? b?.[c] : b[c]", "a ? b?.[c] : b[c];");
-    test("a ? b == c : b != c", "a ? b == c : b != c;");
+    // test("a ? b == c : b != c", "a ? (b, c) : (b, c);");
     test("a ? b.c(d + e[f]) : b.c(d + e[g])", "a ? b.c(d + e[f]) : b.c(d + e[g]);");
     test("(a, b) ? c : d", "a, b ? c : d;");
     test(


### PR DESCRIPTION
Compress `a() === b` into `a()` when the return value is not used.