### PR TITLE
fix(minifier): call mark_current_function_as_changed in remove_unused_expression

### DIFF
--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -332,7 +332,7 @@ impl<'a, 'b> PeepholeOptimizations {
 
     /// Try folding conditional expression (?:) if the condition results of the condition is known.
     fn try_fold_conditional_expression(
-        &self,
+        &mut self,
         expr: &mut ConditionalExpression<'a>,
         ctx: Ctx<'a, 'b>,
     ) -> Option<Expression<'a>> {

--- a/crates/oxc_minifier/tests/peephole/esbuild.rs
+++ b/crates/oxc_minifier/tests/peephole/esbuild.rs
@@ -631,7 +631,7 @@ fn js_parser_test() {
     test("a ? b?.c : b.c", "a ? b?.c : b.c;");
     test("a ? b?.() : b()", "a ? b?.() : b();");
     test("a ? b?.[c] : b[c]", "a ? b?.[c] : b[c];");
-    // test("a ? b == c : b != c", "a ? (b, c) : (b, c);");
+    test("a ? b == c : b != c", "a, b, c;");
     test("a ? b.c(d + e[f]) : b.c(d + e[g])", "a ? b.c(d + e[f]) : b.c(d + e[g]);");
     test("(a, b) ? c : d", "a, b ? c : d;");
     test(


### PR DESCRIPTION
Added `mark_current_function_as_changed` calls in `remove_unused_expression` to make it idenpotent for `a ? b == c : b != c` -> `a, b, c`.