### PR TITLE
fix(minifier): skip `try_fold_stmt_in_boolean_context` on `ExpressionStatement`

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
@@ -1,7 +1,6 @@
 use oxc_ast::ast::*;
 use oxc_ecmascript::constant_evaluation::{ConstantEvaluation, IsInt32OrUint32};
 use oxc_span::GetSpan;
-use oxc_traverse::Ancestor;
 
 use crate::ctx::Ctx;
 
@@ -14,14 +13,6 @@ impl<'a> PeepholeOptimizations {
             Statement::WhileStatement(s) => Some(&mut s.test),
             Statement::ForStatement(s) => s.test.as_mut(),
             Statement::DoWhileStatement(s) => Some(&mut s.test),
-            Statement::ExpressionStatement(s)
-                if !matches!(
-                    ctx.ancestry.ancestor(1),
-                    Ancestor::ArrowFunctionExpressionBody(_)
-                ) =>
-            {
-                Some(&mut s.expression)
-            }
             _ => None,
         };
 

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -367,7 +367,7 @@ impl<'a> PeepholeOptimizations {
         if alternate {
             *e = self.join_with_left_associative_op(
                 conditional_expr.span,
-                LogicalOperator::Or,
+                LogicalOperator::And,
                 ctx.ast.move_expression(&mut conditional_expr.test),
                 ctx.ast.move_expression(&mut conditional_expr.consequent),
                 ctx,
@@ -630,7 +630,7 @@ mod test {
         test("(1, foo()) ? 1 : 2", "foo()");
         test("foo() ? 1 : 2", "foo()");
         test("foo() ? 1 : bar()", "foo() || bar()");
-        test("foo() ? bar() : 2", "!foo() || bar()"); // can be improved to "foo() && bar()"
+        test("foo() ? bar() : 2", "foo() && bar()");
         test_same("foo() ? bar() : baz()");
     }
 

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -23,5 +23,5 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 
 6.69 MB    | 2.28 MB    | 2.31 MB    | 466.12 kB  | 488.28 kB  | antd.js   
 
-10.95 MB   | 3.35 MB    | 3.49 MB    | 860.99 kB  | 915.50 kB  | typescript.js
+10.95 MB   | 3.35 MB    | 3.49 MB    | 860.95 kB  | 915.50 kB  | typescript.js
 


### PR DESCRIPTION
`remove_unused_expression` can handle this case better than `try_fold_stmt_in_boolean_context`.