### PR TITLE
feat(minifier): inline simple IIFEs in `remove_unused_expression`

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -1429,6 +1429,16 @@ impl<'a> ArrowFunctionExpression<'a> {
         None
     }
 
+    /// Get expression part of `ArrowFunctionExpression`: `() => expression_part`.
+    pub fn get_expression_mut(&mut self) -> Option<&mut Expression<'a>> {
+        if self.expression {
+            if let Statement::ExpressionStatement(expr_stmt) = &mut self.body.statements[0] {
+                return Some(&mut expr_stmt.expression);
+            }
+        }
+        None
+    }
+
     /// Returns `true` if this arrow function's body has a `"use strict"` directive.
     pub fn has_use_strict_directive(&self) -> bool {
         self.body.has_use_strict_directive()

--- a/crates/oxc_minifier/src/peephole/normalize.rs
+++ b/crates/oxc_minifier/src/peephole/normalize.rs
@@ -250,7 +250,11 @@ mod test {
     #[test]
     fn drop_console() {
         test("console.log()", "");
-        test("(() => console.log())()", "(() => void 0)()");
+        test("(() => console.log())()", "");
+        test(
+            "(() => { try { return console.log() } catch {} })()",
+            "(() => { try { return } catch {} })()",
+        );
     }
 
     #[test]


### PR DESCRIPTION
Compress `(() => { foo() })` to `foo()` when the return value is not used.