### PR TITLE
docs(linter): add end code tag on rule doc

### DIFF
--- a/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
+++ b/crates/oxc_linter/src/rules/jest/consistent_test_it.rs
@@ -171,6 +171,7 @@ declare_oxc_lint!(
     ///      "vitest/consistent-test-it": "error"
     ///   }
     /// }
+    /// ```
     ConsistentTestIt,
     jest,
     style,


### PR DESCRIPTION
The missing end code tag break the generated html page of the rule for the "how tu use" chapter: https://oxc.rs/docs/guide/usage/linter/rules/jest/consistent-test-it.html