### PR TITLE
fix(linter): support nested extending

### DIFF
--- a/apps/oxlint/fixtures/extends_config/relative_paths/extends_extends_config.json
+++ b/apps/oxlint/fixtures/extends_config/relative_paths/extends_extends_config.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["../extends_rules_config.json"]
+}

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1022,4 +1022,11 @@ mod test {
         let args = &["--config", "extends_rules_config.json", "console.js"];
         Tester::new().with_cwd("fixtures/extends_config".into()).test_and_snapshot(args);
     }
+
+    #[test]
+    fn test_extends_extends_config() {
+        // Check that using a config that extends a config which extends a config works
+        let args = &["--config", "relative_paths/extends_extends_config.json", "console.js"];
+        Tester::new().with_cwd("fixtures/extends_config".into()).test_and_snapshot(args);
+    }
 }

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--config relative_paths__extends_extends_config.json console.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--config relative_paths__extends_extends_config.json console.js@oxlint.snap
@@ -1,0 +1,20 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --config relative_paths/extends_extends_config.json console.js
+working directory: fixtures/extends_config
+----------
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: eslint(no-console): Unexpected console statement.
+   ,-[console.js:1:1]
+ 1 | console.log("test");
+   : ^^^^^^^^^^^
+   `----
+  help: Delete this console statement.
+
+Found 0 warnings and 1 error.
+Finished in <variable>ms on 1 file with 102 rules using 1 threads.
+----------
+CLI result: LintFoundErrors
+----------


### PR DESCRIPTION
- part of https://github.com/oxc-project/oxc/issues/9307

Allows for using the `extends` keyword to chain multiple extended config files together: for example, a package config that extends a base config that extends a config from `node_modules` and so on.

I don't really love what we're having to do here with using both `override_rules` and `ConfigStoreBuilder.with_rule`. I think there is a refactoring opportunity to merge some functionality together here, but I don't want to refactor and optimize before we have a more comprehensive test suite.