### PR TITLE
feat(linter): allowing `plugins` to be extended with `extends`

### DIFF
--- a/apps/oxlint/fixtures/extends_config/plugins/jest.json
+++ b/apps/oxlint/fixtures/extends_config/plugins/jest.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["jest"]
+}

--- a/apps/oxlint/fixtures/extends_config/plugins/react.json
+++ b/apps/oxlint/fixtures/extends_config/plugins/react.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["react"]
+}

--- a/crates/oxc_linter/src/config/config_store.rs
+++ b/crates/oxc_linter/src/config/config_store.rs
@@ -55,6 +55,10 @@ impl ConfigStore {
         &self.base.base.rules
     }
 
+    pub fn plugins(&self) -> LintPlugins {
+        self.base.base.config.plugins
+    }
+
     pub(crate) fn resolve(&self, path: &Path) -> ResolvedLinterState {
         // TODO: based on the `path` provided, resolve the configuration file to use.
         let resolved_config = &self.base;


### PR DESCRIPTION
Adds support for merging the `plugins` arrays in configuration files referenced in `extends` to the top-level `plugins` array of a configuration file. Essentially acts as if you had placed it in the plugins array at the top-level to begin with.