### PR TITLE
fix(linter): do not output number of rules with nested configs

### DIFF
--- a/apps/oxlint/src/output_formatter/mod.rs
+++ b/apps/oxlint/src/output_formatter/mod.rs
@@ -55,8 +55,9 @@ impl FromStr for OutputFormat {
 pub struct LintCommandInfo {
     /// The number of files that were linted.
     pub number_of_files: usize,
-    /// The number of lint rules that were run.
-    pub number_of_rules: usize,
+    /// The number of lint rules that were run. If the number varies and can't be clearly
+    /// computed, then this defaults to None.
+    pub number_of_rules: Option<usize>,
     /// The used CPU threads count
     pub threads_count: usize,
     /// Some reporters want to output the duration it took to finished the task

--- a/apps/oxlint/src/snapshots/_--ignore-path fixtures__issue_7566__.oxlintignore fixtures__issue_7566__tests__main.js fixtures__issue_7566__tests__function__main.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-path fixtures__issue_7566__.oxlintignore fixtures__issue_7566__tests__main.js fixtures__issue_7566__tests__function__main.js@oxlint.snap
@@ -5,7 +5,7 @@ source: apps/oxlint/src/tester.rs
 arguments: --ignore-path fixtures/issue_7566/.oxlintignore fixtures/issue_7566/tests/main.js fixtures/issue_7566/tests/function/main.js
 working directory: 
 ----------
-Finished in <variable>ms on 0 files with 0 rules using 1 threads.
+Finished in <variable>ms on 0 files using 1 threads.
 ----------
 CLI result: LintNoFilesFound
 ----------

--- a/apps/oxlint/src/snapshots/_--ignore-path fixtures__linter__.customignore fixtures__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-path fixtures__linter__.customignore fixtures__linter__nan.js@oxlint.snap
@@ -5,7 +5,7 @@ source: apps/oxlint/src/tester.rs
 arguments: --ignore-path fixtures/linter/.customignore fixtures/linter/nan.js
 working directory: 
 ----------
-Finished in <variable>ms on 0 files with 0 rules using 1 threads.
+Finished in <variable>ms on 0 files using 1 threads.
 ----------
 CLI result: LintNoFilesFound
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension__main.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension__main.js@oxlint.snap
@@ -5,7 +5,7 @@ source: apps/oxlint/src/tester.rs
 arguments: -c fixtures/config_ignore_patterns/ignore_extension/eslintrc.json fixtures/config_ignore_patterns/ignore_extension/main.js
 working directory: 
 ----------
-Finished in <variable>ms on 0 files with 0 rules using 1 threads.
+Finished in <variable>ms on 0 files using 1 threads.
 ----------
 CLI result: LintNoFilesFound
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--experimental-nested-config overrides@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--experimental-nested-config overrides@oxlint.snap
@@ -30,7 +30,7 @@ working directory: fixtures/extends_config
    `----
 
 Found 0 warnings and 3 errors.
-Finished in <variable>ms on 2 files with 100 rules using 1 threads.
+Finished in <variable>ms on 2 files using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--experimental-nested-config overrides_same_directory@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--experimental-nested-config overrides_same_directory@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/extends_config
   help: Delete this code.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 100 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_--experimental-nested-config -A no-console@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_--experimental-nested-config -A no-console@oxlint.snap
@@ -28,7 +28,7 @@ working directory: fixtures/nested_config
   help: Delete this code.
 
 Found 1 warning and 2 errors.
-Finished in <variable>ms on 7 files with 100 rules using 1 threads.
+Finished in <variable>ms on 7 files using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_--experimental-nested-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_--experimental-nested-config@oxlint.snap
@@ -51,7 +51,7 @@ working directory: fixtures/nested_config
   help: Delete this console statement.
 
 Found 1 warning and 5 errors.
-Finished in <variable>ms on 7 files with 101 rules using 1 threads.
+Finished in <variable>ms on 7 files using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -106,8 +106,11 @@ impl Linter {
         &self.options
     }
 
-    pub fn number_of_rules(&self) -> usize {
-        self.config.number_of_rules()
+    /// Returns the number of rules that will are being used, unless there
+    /// nested configurations in use, in which case it returns `None` since the
+    /// number of rules depends on which file is being linted.
+    pub fn number_of_rules(&self) -> Option<usize> {
+        self.nested_configs.is_empty().then_some(self.config.number_of_rules())
     }
 
     pub fn run<'a>(


### PR DESCRIPTION
This is a small output update to fix some noisy snapshot tests that output the number of rules. When using nested configs, outputting the number of rules is not helpful I think since it varies from file to file, but open to feedback on this.