### PR TITLE
fix(ecmascript): fix may_have_side_effects for `${a() === b}`

### DIFF
--- a/crates/oxc_ecmascript/src/side_effects/may_have_side_effects.rs
+++ b/crates/oxc_ecmascript/src/side_effects/may_have_side_effects.rs
@@ -89,6 +89,7 @@ impl MayHaveSideEffects for TemplateLiteral<'_> {
             // If the expression is a Symbol or ToPrimitive returns a Symbol, an error is thrown.
             // ToPrimitive returns the value as-is for non-Object values, so we can use it instead of ToString here.
             e.to_primitive(is_global_reference).is_symbol() != Some(false)
+                || e.may_have_side_effects(is_global_reference)
         })
     }
 }

--- a/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
+++ b/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
@@ -354,6 +354,7 @@ fn test_template_literal() {
     test("`${{ [s]() { console.log('sideeffect') } }}`", true); // assuming s is Symbol.toPrimitive
     test("`${a}`", true); // a maybe a symbol
     test("`${a()}`", true);
+    test("`${a() === b}`", true);
 }
 
 #[test]


### PR DESCRIPTION
`${a() === b}` has a sideeffect, but was not detected.