### PR TITLE
fix(linter): output right file line and column for `.vue`, `.astro` and `.svelte` files

### DIFF
--- a/apps/oxlint/src/snapshots/_fixtures__astro__debugger.astro@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__astro__debugger.astro@oxlint.snap
@@ -8,34 +8,38 @@ working directory:
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
    ,-[fixtures/astro/debugger.astro:2:1]
- 1 | 
+ 1 | ---
  2 | debugger
    : ^^^^^^^^
+ 3 | ---
    `----
   help: Delete this code.
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
-   ,-[fixtures/astro/debugger.astro:2:3]
- 1 | 
- 2 |   debugger
-   :   ^^^^^^^^
-   `----
+    ,-[fixtures/astro/debugger.astro:11:3]
+ 10 | <script asdf >
+ 11 |   debugger
+    :   ^^^^^^^^
+ 12 | </script>
+    `----
   help: Delete this code.
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
-   ,-[fixtures/astro/debugger.astro:2:3]
- 1 | 
- 2 |   debugger
-   :   ^^^^^^^^
-   `----
+    ,-[fixtures/astro/debugger.astro:15:3]
+ 14 | <script asdf>
+ 15 |   debugger
+    :   ^^^^^^^^
+ 16 | </script>
+    `----
   help: Delete this code.
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
-   ,-[fixtures/astro/debugger.astro:2:3]
- 1 | 
- 2 |   debugger
-   :   ^^^^^^^^
-   `----
+    ,-[fixtures/astro/debugger.astro:19:3]
+ 18 | <script>
+ 19 |   debugger
+    :   ^^^^^^^^
+ 20 | </script>
+    `----
   help: Delete this code.
 
 Found 4 warnings and 0 errors.

--- a/apps/oxlint/src/snapshots/_fixtures__svelte__debugger.svelte@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__svelte__debugger.svelte@oxlint.snap
@@ -8,7 +8,7 @@ working directory:
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
    ,-[fixtures/svelte/debugger.svelte:2:2]
- 1 | 
+ 1 | <script>
  2 |     debugger;
    :     ^^^^^^^^^
  3 | 

--- a/apps/oxlint/src/snapshots/_fixtures__vue__debugger.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__vue__debugger.vue@oxlint.snap
@@ -7,19 +7,21 @@ working directory:
 ----------
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
-   ,-[fixtures/vue/debugger.vue:2:5]
- 1 | 
- 2 |     debugger
+   ,-[fixtures/vue/debugger.vue:6:5]
+ 5 | <script>
+ 6 |     debugger
    :     ^^^^^^^^
+ 7 | </script>
    `----
   help: Delete this code.
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
-   ,-[fixtures/vue/debugger.vue:3:5]
- 2 |     let foo: T; // test ts syntax
- 3 |     debugger;
-   :     ^^^^^^^^^
-   `----
+    ,-[fixtures/vue/debugger.vue:11:5]
+ 10 |     let foo: T; // test ts syntax
+ 11 |     debugger;
+    :     ^^^^^^^^^
+ 12 | </script>
+    `----
   help: Delete this code.
 
 Found 2 warnings and 0 errors.

--- a/crates/oxc_diagnostics/src/service.rs
+++ b/crates/oxc_diagnostics/src/service.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use cow_utils::CowUtils;
+use miette::LabeledSpan;
 
 use crate::{
     Error, NamedSource, OxcDiagnostic, Severity,
@@ -130,6 +131,7 @@ impl DiagnosticService {
     pub fn wrap_diagnostics<P: AsRef<Path>>(
         path: P,
         source_text: &str,
+        source_start: u32,
         diagnostics: Vec<OxcDiagnostic>,
     ) -> (PathBuf, Vec<Error>) {
         let path = path.as_ref();
@@ -141,7 +143,29 @@ impl DiagnosticService {
         let source = Arc::new(NamedSource::new(path_display, source_text.to_owned()));
         let diagnostics = diagnostics
             .into_iter()
-            .map(|diagnostic| diagnostic.with_source_code(Arc::clone(&source)))
+            .map(|diagnostic| {
+                if source_start == 0 {
+                    return diagnostic.with_source_code(Arc::clone(&source));
+                }
+
+                match &diagnostic.labels {
+                    None => diagnostic.with_source_code(Arc::clone(&source)),
+                    Some(labels) => {
+                        let new_labels = labels
+                            .iter()
+                            .map(|labeled_span| {
+                                LabeledSpan::new(
+                                    labeled_span.label().map(std::string::ToString::to_string),
+                                    labeled_span.offset() + source_start as usize,
+                                    labeled_span.len(),
+                                )
+                            })
+                            .collect::<Vec<_>>();
+
+                        diagnostic.with_labels(new_labels).with_source_code(Arc::clone(&source))
+                    }
+                }
+            })
             .collect();
         (path.to_path_buf(), diagnostics)
     }

--- a/crates/oxc_linter/src/service/runtime.rs
+++ b/crates/oxc_linter/src/service/runtime.rs
@@ -180,7 +180,7 @@ impl Runtime {
                 let errors = messages.into_iter().map(Into::into).collect();
                 let path = path.strip_prefix(&self.cwd).unwrap_or(path);
                 let diagnostics =
-                    DiagnosticService::wrap_diagnostics(path, source.source_text, errors);
+                    DiagnosticService::wrap_diagnostics(path, &source_text, source.start, errors);
                 tx_error.send(Some(diagnostics)).unwrap();
             }
         }


### PR DESCRIPTION
closes #9333