### PR TITLE
fix(transformer/legacy-decorator): metadata incorrectly wrapped by decorateParam

### DIFF
--- a/crates/oxc_transformer/src/decorator/legacy/metadata.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/metadata.rs
@@ -107,9 +107,6 @@ impl<'a, 'ctx> LegacyDecoratorMetadata<'a, 'ctx> {
 
 impl<'a> Traverse<'a> for LegacyDecoratorMetadata<'a, '_> {
     fn enter_class(&mut self, class: &mut Class<'a>, ctx: &mut TraverseCtx<'a>) {
-        if class.decorators.is_empty() {
-            return;
-        }
         let constructor = class.body.body.iter_mut().find_map(|item| match item {
             ClassElement::MethodDefinition(method) if method.kind.is_constructor() => Some(method),
             _ => None,
@@ -121,12 +118,7 @@ impl<'a> Traverse<'a> for LegacyDecoratorMetadata<'a, '_> {
             let metadata_decorator =
                 self.create_metadata_decorate("design:paramtypes", serialized_type, ctx);
 
-            if let Some(param) = constructor.value.params.items.last_mut() {
-                // We need to make sure all metadata decorators are placed after parameter decorators
-                param.decorators.push(metadata_decorator);
-            } else {
-                class.decorators.push(metadata_decorator);
-            }
+            class.decorators.push(metadata_decorator);
         }
     }
 
@@ -158,12 +150,7 @@ impl<'a> Traverse<'a> for LegacyDecoratorMetadata<'a, '_> {
             },
         ]);
 
-        if let Some(param) = method.value.params.items.last_mut() {
-            // We need to make sure all metadata decorators are placed after parameter decorators
-            param.decorators.extend(metadata_decorators);
-        } else {
-            method.decorators.extend(metadata_decorators);
-        }
+        method.decorators.extend(metadata_decorators);
     }
 
     #[inline]

--- a/napi/transform/test/transform.test.ts
+++ b/napi/transform/test/transform.test.ts
@@ -303,10 +303,10 @@ describe('legacy decorator', () => {
         };
         _decorate([dce, _decorateMetadata("design:type", Object)], C.prototype, "prop", void 0);
         _decorate([
-        	_decorateParam(0, dce),
-        	_decorateParam(0, _decorateMetadata("design:type", Function)),
-        	_decorateParam(0, _decorateMetadata("design:paramtypes", [Object])),
-        	_decorateParam(0, _decorateMetadata("design:returntype", void 0))
+        	_decorateMetadata("design:type", Function),
+        	_decorateMetadata("design:paramtypes", [Object]),
+        	_decorateMetadata("design:returntype", void 0),
+        	_decorateParam(0, dce)
         ], C.prototype, "method", null);
         C = _decorate([dce], C);
         export default C;

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -396,7 +396,39 @@ rebuilt        : SymbolId(2): Span { start: 74, end: 75 }
 x Output mismatch
 
 * typescript/constructor/decoratorOnClassConstructor4/input.ts
-x Output mismatch
+Bindings mismatch:
+after transform: ScopeId(0): ["A", "B", "C", "dec"]
+rebuilt        : ScopeId(0): ["A", "B", "C"]
+Symbol span mismatch for "A":
+after transform: SymbolId(1): Span { start: 139, end: 140 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol span mismatch for "A":
+after transform: SymbolId(5): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(1): Span { start: 139, end: 140 }
+Symbol span mismatch for "B":
+after transform: SymbolId(2): Span { start: 157, end: 158 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol span mismatch for "B":
+after transform: SymbolId(6): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(3): Span { start: 157, end: 158 }
+Symbol span mismatch for "C":
+after transform: SymbolId(4): Span { start: 205, end: 206 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
+Symbol span mismatch for "C":
+after transform: SymbolId(7): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(6): Span { start: 205, end: 206 }
+Reference symbol mismatch for "dec":
+after transform: SymbolId(0) "dec"
+rebuilt        : <None>
+Reference symbol mismatch for "dec":
+after transform: SymbolId(0) "dec"
+rebuilt        : <None>
+Reference symbol mismatch for "dec":
+after transform: SymbolId(0) "dec"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: ["Number", "babelHelpers"]
+rebuilt        : ["Number", "babelHelpers", "dec"]
 
 * typescript/constructor/parameter/decoratorOnClassConstructorParameter1/input.ts
 Scope children mismatch:


### PR DESCRIPTION
close: https://github.com/rolldown/rolldown/issues/3728#issuecomment-2693097569

Before, we need to make sure all metadata decorators are placed after parameter decorators. I tried to push them to the last parameter decorators. But it caused it to be incorrectly wrapped by `decorateParam`. 

I re-check decorate helper implementation, I didn't see any potential runtime will caused by the decorators order. So I decide to always push to method's decorators

Before:
```js
_decorate([
  _decorateParam(0, dce),
  _decorateParam(0, _decorateMetadata("design:type", Function)),
  _decorateParam(0, _decorateMetadata("design:paramtypes", [Object])),
  _decorateParam(0, _decorateMetadata("design:returntype", void 0))
], C.prototype, "method", null);
```

After:
```js
_decorate([
  _decorateMetadata("design:type", Function),
  _decorateMetadata("design:paramtypes", [Object]),
  _decorateMetadata("design:returntype", void 0),
  _decorateParam(0, dce)
], C.prototype, "method", null);
```