### PR TITLE
fix(parser): correctly fail parsing when parsing `foo.bar?.`

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -711,6 +711,9 @@ impl<'a> ParserImpl<'a> {
                         kind if kind.is_identifier_name() => {
                             self.parse_static_member_expression(lhs_span, lhs, true)?
                         }
+                        Kind::Eof => {
+                            return Err(diagnostics::unexpected_end(self.cur_token().span()));
+                        }
                         _ => break,
                     }
                 }

--- a/tasks/coverage/misc/fail/oxc-9497.js
+++ b/tasks/coverage/misc/fail/oxc-9497.js
@@ -1,0 +1,2 @@
+let repro = {};
+repro.f?.

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,7 +1,7 @@
 parser_misc Summary:
 AST Parsed     : 32/32 (100.00%)
 Positive Passed: 32/32 (100.00%)
-Negative Passed: 26/26 (100.00%)
+Negative Passed: 27/27 (100.00%)
 
   × Unexpected token
    ╭─[misc/fail/oxc-169.js:2:1]
@@ -270,6 +270,13 @@ Negative Passed: 26/26 (100.00%)
  4 │     obj.#x;
    ·         ──
  5 │   }
+   ╰────
+
+  × Unexpected end of file
+   ╭─[misc/fail/oxc-9497.js:2:8]
+ 1 │ let repro = {};
+ 2 │ repro.f?.
+   ·        ──
    ╰────
 
   × The keyword 'let' is reserved


### PR DESCRIPTION
closes #9497

[swc](https://play.swc.rs/?version=1.11.5&code=H4sIAAAAAAAAA8tJLVEoSi0oylewVaiuteYCs%2FXS7PUAMGIdLBkAAAA%3D&config=H4sIAAAAAAAAA1WPSw7DIAwF9zkF8rrbdtE79BAWdSIifrKJVBTl7iUE0maH3xsz8jooBbNoeKq1PMsQkYX4nEsi2Sf8lARIOxTNJia49XaWvRrRCtVoOxpIyBOluiX3hoMNQajjLXPGmzH%2FC3VwkUnkCu4o%2BsnSVTc0JbjwXmrZDkk50qF%2FwA%2FqsvNjMPLqm4kXGrYvhlQioBQBAAA%3D)

[typescript](https://www.typescriptlang.org/play/?#code/PTAEAEBcGcFoDsD2BjAFgU2QawFABt1JQAndAB2MVAF5QBvAXwG4dSLEA6AMwH4Og)

[babel](https://babeljs.io/repl#?browsers=defaults%2C%20not%20ie%2011%2C%20not%20ie_mob%2011&build=&builtIns=false&corejs=3.21&spec=false&loose=false&code_lz=DYUwLgBATiAOUHsIF4IG8C-BuAUDeCAdAGYD8hQA&debug=false&forceAllTransforms=false&modules=false&shippedProposals=false&evaluate=false&fileSize=false&timeTravel=false&sourceType=module&lineWrap=true&presets=env%2Creact%2Cstage-2%2Cstage-3&prettier=false&targets=&version=7.26.9&externalPlugins=&assumptions=%7B%7D)

[esbuild](https://esbuild.github.io/try/#dAAwLjI1LjAAAGxldCByZXBybyA9IHt9OwpyZXByby5mPy4)