### PR TITLE
fix(transformer/optional-chaning): keep `this` when transforming `this.f?.()`

### DIFF
--- a/crates/oxc_transformer/src/es2020/optional_chaining.rs
+++ b/crates/oxc_transformer/src/es2020/optional_chaining.rs
@@ -572,7 +572,7 @@ impl<'a> OptionalChaining<'a, '_> {
                             binding.to_maybe_bound_identifier()
                         });
                     self.set_binding_context(binding);
-                } else if object.is_super() {
+                } else if matches!(object, Expression::Super(_) | Expression::ThisExpression(_)) {
                     self.set_this_context();
                 }
             }

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,12 +1,13 @@
 commit: 578ac4df
 
-Passed: 137/223
+Passed: 138/224
 
 # All Passed:
 * babel-plugin-transform-class-static-block
 * babel-plugin-transform-private-methods
 * babel-plugin-transform-logical-assignment-operators
 * babel-plugin-transform-nullish-coalescing-operator
+* babel-plugin-transform-optional-chaining
 * babel-plugin-transform-optional-catch-binding
 * babel-plugin-transform-async-generator-functions
 * babel-plugin-transform-object-rest-spread

--- a/tasks/transform_conformance/tests/babel-plugin-transform-optional-chaining/test/fixtures/oxc/keep-this/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-optional-chaining/test/fixtures/oxc/keep-this/input.ts
@@ -1,0 +1,5 @@
+export class Repro {
+  test() {
+    this.y?.();
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-optional-chaining/test/fixtures/oxc/keep-this/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-optional-chaining/test/fixtures/oxc/keep-this/output.js
@@ -1,0 +1,8 @@
+export class Repro {
+  test() {
+    var _this$y;
+    (_this$y = this.y) === null || _this$y === void 0
+      ? void 0
+      : _this$y.call(this);
+  }
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-optional-chaining/test/fixtures/oxc/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-optional-chaining/test/fixtures/oxc/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-optional-chaining"]
+}


### PR DESCRIPTION
closes #9498