### PR TITLE
refactor(ast_tools): add `format_cow!` macro

### DIFF
--- a/tasks/ast_tools/src/derives/mod.rs
+++ b/tasks/ast_tools/src/derives/mod.rs
@@ -11,6 +11,7 @@ use crate::{
     output::{Output, output_path},
     parse::attr::{AttrLocation, AttrPart, AttrPositions, attr_positions},
     schema::{Def, Derives, EnumDef, FileId, Schema, StructDef, TypeDef, TypeId},
+    utils::format_cow,
 };
 
 mod clone_in;
@@ -189,7 +190,7 @@ pub trait Derive: Runner {
                 let crate_path = if krate.starts_with("napi/") {
                     Cow::Borrowed(krate)
                 } else {
-                    Cow::Owned(format!("crates/{krate}"))
+                    format_cow!("crates/{krate}")
                 };
 
                 Output::Rust {

--- a/tasks/ast_tools/src/generators/assert_layouts.rs
+++ b/tasks/ast_tools/src/generators/assert_layouts.rs
@@ -22,7 +22,7 @@ use crate::{
         Def, Discriminant, EnumDef, PrimitiveDef, Schema, StructDef, TypeDef, TypeId, Visibility,
         extensions::layout::{GetLayout, GetOffset, Layout, Niche, Offset, PlatformLayout},
     },
-    utils::number_lit,
+    utils::{format_cow, number_lit},
 };
 
 use super::define_generator;
@@ -406,7 +406,7 @@ fn generate_assertions(schema: &Schema) -> Vec<Output> {
             let crate_path = if krate.starts_with("napi/") {
                 Cow::Borrowed(krate)
             } else {
-                Cow::Owned(format!("crates/{krate}"))
+                format_cow!("crates/{krate}")
             };
             Output::Rust { path: output_path(&crate_path, "assert_layouts.rs"), tokens: output }
         })

--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -11,7 +11,7 @@ use crate::{
     },
     output::Output,
     schema::{Def, EnumDef, FieldDef, Schema, StructDef, TypeDef},
-    utils::FxIndexSet,
+    utils::{FxIndexSet, format_cow},
 };
 
 use super::define_generator;
@@ -333,7 +333,7 @@ fn generate_ts_type_def_for_enum(enum_def: &EnumDef, schema: &Schema) -> Option<
                     ts_type_name(variant_type, schema)
                 }
             } else {
-                Cow::Owned(format!("'{}'", get_fieldless_variant_value(enum_def, variant)))
+                format_cow!("'{}'", get_fieldless_variant_value(enum_def, variant))
             }
         })
         .collect::<FxIndexSet<_>>();
@@ -385,10 +385,10 @@ fn ts_type_name<'s>(type_def: &'s TypeDef, schema: &'s Schema) -> Cow<'s, str> {
             name => name,
         }),
         TypeDef::Option(option_def) => {
-            Cow::Owned(format!("{} | null", ts_type_name(option_def.inner_type(schema), schema)))
+            format_cow!("{} | null", ts_type_name(option_def.inner_type(schema), schema))
         }
         TypeDef::Vec(vec_def) => {
-            Cow::Owned(format!("Array<{}>", ts_type_name(vec_def.inner_type(schema), schema)))
+            format_cow!("Array<{}>", ts_type_name(vec_def.inner_type(schema), schema))
         }
         TypeDef::Box(box_def) => ts_type_name(box_def.inner_type(schema), schema),
         TypeDef::Cell(cell_def) => ts_type_name(cell_def.inner_type(schema), schema),

--- a/tasks/ast_tools/src/utils.rs
+++ b/tasks/ast_tools/src/utils.rs
@@ -82,3 +82,11 @@ pub fn pluralize(name: &str) -> String {
         }
     }
 }
+
+/// Macro to `format!` arguments, and wrap the formatted string in a `Cow::Owned`.
+macro_rules! format_cow {
+    ($($tokens:tt)+) => {
+        std::borrow::Cow::Owned(format!($($tokens)+))
+    }
+}
+pub(crate) use format_cow;


### PR DESCRIPTION
Pure refactor. Add a `format_cow!` macro to shorten code. `Cow::Owned(format!(...))` -> `format_cow!(...)`.