### PR TITLE
fix(ast_tools/typescript): take field renaming into account when inserting `type` field

### DIFF
--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -413,7 +413,10 @@ fn should_add_type_field_to_struct(struct_def: &StructDef) -> bool {
     if struct_def.estree.no_type {
         false
     } else {
-        !struct_def.fields.iter().any(|field| matches!(field.name(), "type"))
+        !struct_def.fields.iter().any(|field| {
+            let field_name = field.estree.rename.as_deref().unwrap_or_else(|| field.name());
+            field_name == "type"
+        })
     }
 }
 


### PR DESCRIPTION
Fix TS type generation. Don't insert an extra `type` field where struct has a field already which is called something else, but is renamed to `type` in ESTree AST.
