### PR TITLE
fix(codegen): do not print comments when only `annotation_comments` is enabled

### DIFF
--- a/crates/oxc_codegen/src/options.rs
+++ b/crates/oxc_codegen/src/options.rs
@@ -92,8 +92,7 @@ impl Default for CodegenOptions {
 
 impl CodegenOptions {
     pub(crate) fn print_comments(&self) -> bool {
-        !self.minify
-            && (self.comments || self.annotation_comments || self.legal_comments.is_inline())
+        !self.minify && (self.comments || self.legal_comments.is_inline())
     }
 
     pub(crate) fn print_annotation_comments(&self) -> bool {


### PR DESCRIPTION
When only `annotation_comments` enabled, we only need to print annotation comments