### PR TITLE
feat(parser): apply `pure` to argument of unary expression

### DIFF
--- a/crates/oxc_codegen/tests/integration/pure_comments.rs
+++ b/crates/oxc_codegen/tests/integration/pure_comments.rs
@@ -199,6 +199,11 @@ const defineSSRCustomElement = () => {
         ",
         "{ /* @__PURE__ */ (function() {})(); }",
         "{ /* @__PURE__ */ (() => {})(); }",
+        "
+void /* @__PURE__ */ function() {}();
+typeof /* @__PURE__ */ function() {}();
+! /* @__PURE__ */ function() {}();
+delete /* @__PURE__ */ (() => {})();",
     ];
 
     snapshot("pure_comments", &cases);

--- a/crates/oxc_codegen/tests/integration/snapshots/pure_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/pure_comments.snap
@@ -423,3 +423,15 @@ let new_exp_no = /* @__PURE__ */ new foo() ** foo();
 {
 	/* @__PURE__ */ (() => {})();
 }
+
+########## 24
+
+void /* @__PURE__ */ function() {}();
+typeof /* @__PURE__ */ function() {}();
+! /* @__PURE__ */ function() {}();
+delete /* @__PURE__ */ (() => {})();
+----------
+void /* @__PURE__ */ function() {}();
+typeof /* @__PURE__ */ function() {}();
+!/* @__PURE__ */ function() {}();
+delete /* @__PURE__ */ (() => {})();

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -1005,7 +1005,11 @@ impl<'a> ParserImpl<'a> {
         let span = self.start_span();
         let operator = map_unary_operator(self.cur_kind());
         self.bump_any();
-        let argument = self.parse_simple_unary_expression(span)?;
+        let has_pure_comment = self.lexer.trivia_builder.previous_token_has_pure_comment();
+        let mut argument = self.parse_simple_unary_expression(span)?;
+        if has_pure_comment {
+            Self::set_pure_on_call_or_new_expr(&mut argument);
+        }
         Ok(self.ast.expression_unary(self.end_span(span), operator, argument))
     }
 

--- a/tasks/coverage/snapshots/transformer_babel.snap
+++ b/tasks/coverage/snapshots/transformer_babel.snap
@@ -2,7 +2,6 @@ commit: 578ac4df
 
 transformer_babel Summary:
 AST Parsed     : 2322/2322 (100.00%)
-Positive Passed: 2319/2322 (99.87%)
-Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2017/async-functions/context-division-after-expression/input.js
+Positive Passed: 2320/2322 (99.91%)
 Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-private-properties/await-in-private-property-in-async/input.js
 Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-properties/await-in-class-property-in-async/input.js

--- a/tasks/coverage/snapshots/transformer_typescript.snap
+++ b/tasks/coverage/snapshots/transformer_typescript.snap
@@ -2,8 +2,7 @@ commit: 15392346
 
 transformer_typescript Summary:
 AST Parsed     : 6531/6531 (100.00%)
-Positive Passed: 6527/6531 (99.94%)
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxDiscriminantPropertyInference.tsx
+Positive Passed: 6528/6531 (99.95%)
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-staticPrivateAccessor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxAndJsxFragPragmaOverridesCompilerOptions.tsx


### PR DESCRIPTION
Follow-up #9424