### PR TITLE
feat(transformer, napi/transform): expose `moduleRunnerTransform` function

### DIFF
--- a/napi/transform/index.d.ts
+++ b/napi/transform/index.d.ts
@@ -199,6 +199,59 @@ export interface JsxOptions {
   refresh?: boolean | ReactRefreshOptions
 }
 
+/**
+ * Transform JavaScript code to a Vite Node runnable module.
+ *
+ * @param filename The name of the file being transformed.
+ * @param sourceText the source code itself
+ * @param options The options for the transformation. See {@link
+ * ModuleRunnerTransformOptions} for more information.
+ *
+ * @returns an object containing the transformed code, source maps, and any
+ * errors that occurred during parsing or transformation.
+ *
+ * @deprecated Only works for Vite.
+ */
+export declare function moduleRunnerTransform(filename: string, sourceText: string, options?: ModuleRunnerTransformOptions | undefined | null): ModuleRunnerTransformResult
+
+export interface ModuleRunnerTransformOptions {
+  /**
+   * Enable source map generation.
+   *
+   * When `true`, the `sourceMap` field of transform result objects will be populated.
+   *
+   * @default false
+   *
+   * @see {@link SourceMap}
+   */
+  sourcemap?: boolean
+}
+
+export interface ModuleRunnerTransformResult {
+  /**
+   * The transformed code.
+   *
+   * If parsing failed, this will be an empty string.
+   */
+  code: string
+  /**
+   * The source map for the transformed code.
+   *
+   * This will be set if {@link TransformOptions#sourcemap} is `true`.
+   */
+  map?: SourceMap
+  deps: Array<string>
+  dynamicDeps: Array<string>
+  /**
+   * Parse and transformation errors.
+   *
+   * Oxc's parser recovers from common syntax errors, meaning that
+   * transformed code may still be available even if there are errors in this
+   * list.
+   */
+  errors: Array<OxcError>
+}
+
 export interface OxcError {
   severity: Severity
   message: string

--- a/napi/transform/index.js
+++ b/napi/transform/index.js
@@ -372,5 +372,6 @@ if (!nativeBinding) {
 
 module.exports.HelperMode = nativeBinding.HelperMode
 module.exports.isolatedDeclaration = nativeBinding.isolatedDeclaration
+module.exports.moduleRunnerTransform = nativeBinding.moduleRunnerTransform
 module.exports.Severity = nativeBinding.Severity
 module.exports.transform = nativeBinding.transform

--- a/napi/transform/test/moduleRunnerTransform.test.ts
+++ b/napi/transform/test/moduleRunnerTransform.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'vitest';
+import { moduleRunnerTransform } from '../index';
+
+describe('moduleRunnerTransform', () => {
+  test('dynamic import', async () => {
+    const result = await moduleRunnerTransform('index.js', `export const i = () => import('./foo')`);
+    expect(result?.code).toMatchInlineSnapshot(`
+			"const i = () => __vite_ssr_dynamic_import__("./foo");
+			Object.defineProperty(__vite_ssr_exports__, "i", {
+				enumerable: true,
+				configurable: true,
+				get() {
+					return i;
+				}
+			});
+			"
+		`);
+    expect(result?.deps).toEqual([]);
+    expect(result?.dynamicDeps).toEqual(['./foo']);
+  });
+
+  test('sourcemap', async () => {
+    const map = (
+      moduleRunnerTransform(
+        'index.js',
+        `export const a = 1`,
+        {
+          sourcemap: true,
+        },
+      )
+    )?.map;
+
+    expect(map).toMatchInlineSnapshot(`
+      {
+        "mappings": "AAAO,MAAM,IAAI;AAAjB",
+        "names": [],
+        "sources": [
+          "index.js",
+        ],
+        "sourcesContent": [
+          "export const a = 1",
+        ],
+        "version": 3,
+      }
+    `);
+  });
+});


### PR DESCRIPTION
Expose a `moduleRunnerTransform` function that `Vite` can directly use it to speed-up ssr transform. In this way, `Vitest` also benefits without having to wait for `rolldown-vite`.