### PR TITLE
refactor(transformer/object-rest-spread): use `helper_call` instead of `helper_load` + `call_expression`

### DIFF
--- a/crates/oxc_transformer/src/common/helper_loader.rs
+++ b/crates/oxc_transformer/src/common/helper_loader.rs
@@ -230,7 +230,6 @@ impl HelperLoaderStore<'_> {
 // Public methods implemented directly on `TransformCtx`, as they need access to `TransformCtx::module_imports`.
 impl<'a> TransformCtx<'a> {
     /// Load and call a helper function and return a `CallExpression`.
-    #[expect(dead_code)]
     pub fn helper_call(
         &self,
         helper: Helper,

--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -515,21 +515,19 @@ impl<'a, 'ctx> ObjectRestSpread<'a, 'ctx> {
     ) {
         let had_props = !props.is_empty();
         let obj = ctx.ast.expression_object(SPAN, ctx.ast.vec_from_iter(props.drain(..)), None);
-        let new_expr = if let Some(call_expr) = expr.take() {
-            let callee = transform_ctx.helper_load(Helper::ObjectSpread2, ctx);
+        let arguments = if let Some(call_expr) = expr.take() {
             let arg = Expression::CallExpression(ctx.ast.alloc(call_expr));
-            let mut arguments = ctx.ast.vec1(Argument::from(arg));
+            let arg = Argument::from(arg);
             if had_props {
                 let empty_object = ctx.ast.expression_object(SPAN, ctx.ast.vec(), None);
-                arguments.push(Argument::from(empty_object));
-                arguments.push(Argument::from(obj));
+                ctx.ast.vec_from_array([arg, Argument::from(empty_object), Argument::from(obj)])
+            } else {
+                ctx.ast.vec1(arg)
             }
-            ctx.ast.call_expression(SPAN, callee, NONE, arguments, false)
         } else {
-            let callee = transform_ctx.helper_load(Helper::ObjectSpread2, ctx);
-            let arguments = ctx.ast.vec1(Argument::from(obj));
-            ctx.ast.call_expression(SPAN, callee, NONE, arguments, false)
+            ctx.ast.vec1(Argument::from(obj))
         };
+        let new_expr = transform_ctx.helper_call(Helper::ObjectSpread2, SPAN, arguments, ctx);
         expr.replace(new_expr);
     }
 }


### PR DESCRIPTION
`helper_call` consists of `helper_load` and `call_expression`, so it can be simplified by using `helper_call`