### PR TITLE
refactor(linter): improve `promise/no-nesting`

### DIFF
--- a/crates/oxc_linter/src/rules/promise/no_nesting.rs
+++ b/crates/oxc_linter/src/rules/promise/no_nesting.rs
@@ -32,26 +32,20 @@ declare_oxc_lint!(
     /// Examples of **incorrect** code for this rule:
     /// ```javascript
     /// doThing().then(() => a.then())
-    /// ```
     ///
-    /// ```javascript
     /// doThing().then(function() { a.then() })
-    /// ```
     ///
-    /// ```javascript
     /// doThing().then(() => { b.catch() })
+    ///
+    /// doThing().catch((val) => doSomething(val).catch(errors))
     /// ```
     ///
     /// Examples of **correct** code for this rule:
     /// ```javascript
     /// doThing().then(() => 4)
-    /// ```
     ///
-    /// ```javascript
     /// doThing().then(function() { return 4 })
-    /// ```
     ///
-    /// ```javascript
     /// doThing().catch(() => 4)
     /// ```
     ///
@@ -273,6 +267,8 @@ fn test() {
         "doThing().then(() => { b.catch() })",
         "doThing().then(() => a.then())",
         "doThing().then(() => b.catch())",
+        "doThing().then((val) => doSomething(val).catch(errors))",
+        "doThing().catch((val) => doSomething(val).catch(errors))",
         "doThing()
           .then(() =>
             a.then(() => Promise.resolve(1)))",

--- a/crates/oxc_linter/src/snapshots/promise_no_nesting.snap
+++ b/crates/oxc_linter/src/snapshots/promise_no_nesting.snap
@@ -58,6 +58,20 @@ source: crates/oxc_linter/src/tester.rs
   help: Refactor so that promises are chained in a flat manner.
 
   ⚠ eslint-plugin-promise(no-nesting): Avoid nesting promises.
+   ╭─[no_nesting.tsx:1:25]
+ 1 │ doThing().then((val) => doSomething(val).catch(errors))
+   ·                         ──────────────────────
+   ╰────
+  help: Refactor so that promises are chained in a flat manner.
+
+  ⚠ eslint-plugin-promise(no-nesting): Avoid nesting promises.
+   ╭─[no_nesting.tsx:1:26]
+ 1 │ doThing().catch((val) => doSomething(val).catch(errors))
+   ·                          ──────────────────────
+   ╰────
+  help: Refactor so that promises are chained in a flat manner.
+
+  ⚠ eslint-plugin-promise(no-nesting): Avoid nesting promises.
    ╭─[no_nesting.tsx:3:13]
  2 │           .then(() =>
  3 │             a.then(() => Promise.resolve(1)))


### PR DESCRIPTION
- Use the `utils::is_promise` function where possible instead of duplicating this logic in this rule.
- Condense some of the doc examples.
- Add missing test cases related to `.catch`, which are cited in the eslint-plugin-promise documentation [here ](https://github.com/eslint-community/eslint-plugin-promise/blob/main/docs/rules/no-nesting.md).