### PR TITLE
docs(linter): improve the documentation of `typescript-no-namespace`

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_namespace.rs
@@ -198,49 +198,39 @@ fn test() {
         ("declare module foo {}", Some(serde_json::json!([{ "allowDeclarations": true }]))),
         ("declare namespace foo {}", Some(serde_json::json!([{ "allowDeclarations": true }]))),
         (
-            "
-    		declare global {
-    		  namespace foo {}
-    		}
-    		      ",
+            "declare global {
+    		   namespace foo {}
+    		 }",
             Some(serde_json::json!([{ "allowDeclarations": true }])),
         ),
         (
-            "
-    		declare module foo {
-    		  namespace bar {}
-    		}
-    		      ",
+            "declare module foo {
+    		   namespace bar {}
+    		 }",
             Some(serde_json::json!([{ "allowDeclarations": true }])),
         ),
         (
-            "
-    		declare global {
-    		  namespace foo {
-    		    namespace bar {}
-    		  }
-    		}
-    		      ",
+            "declare global {
+    		   namespace foo {
+    		     namespace bar {}
+    		   }
+    		 }",
             Some(serde_json::json!([{ "allowDeclarations": true }])),
         ),
         (
-            "
-    		declare namespace foo {
-    		  namespace bar {
-    		    namespace baz {}
-    		  }
-    		}
-    		      ",
+            "declare namespace foo {
+    		   namespace bar {
+    		     namespace baz {}
+    		   }
+    		 }",
             Some(serde_json::json!([{ "allowDeclarations": true }])),
         ),
         (
-            "
-    		export declare namespace foo {
-    		  export namespace bar {
-    		    namespace baz {}
-    		  }
-    		}
-    		      ",
+            "export declare namespace foo {
+    		   export namespace bar {
+    		     namespace baz {}
+    		   }
+    		 }",
             Some(serde_json::json!([{ "allowDeclarations": true }])),
         ),
     ];
@@ -258,173 +248,139 @@ fn test() {
         ("declare namespace foo {}", Some(serde_json::json!([{ "allowDeclarations": false }]))),
         ("namespace Foo.Bar {}", Some(serde_json::json!([{ "allowDeclarations": false }]))),
         (
-            "
-    		namespace Foo.Bar {
-    		  namespace Baz.Bas {
-    		    interface X {}
-    		  }
-    		}
-    		      ",
+            "namespace Foo.Bar {
+    		   namespace Baz.Bas {
+    		     interface X {}
+    		   }
+    		 }",
             None,
         ),
         (
-            "
-    		namespace A {
-    		  namespace B {
-    		    declare namespace C {}
-    		  }
-    		}
-    		      ",
+            "namespace A {
+    		   namespace B {
+    		     declare namespace C {}
+    		   }
+    		 }",
             Some(serde_json::json!([{ "allowDeclarations": true }])),
         ),
         (
-            "
-    		namespace A {
-    		  namespace B {
-    		    export declare namespace C {}
-    		  }
-    		}
-    		      ",
+            "namespace A {
+    		   namespace B {
+    		     export declare namespace C {}
+    		   }
+    		 }",
             Some(serde_json::json!([{ "allowDeclarations": true }])),
         ),
         (
-            "
-    		namespace A {
-    		  declare namespace B {
-    		    namespace C {}
-    		  }
-    		}
-    		      ",
+            "namespace A {
+    		   declare namespace B {
+    		     namespace C {}
+    		   }
+    		 }",
             Some(serde_json::json!([{ "allowDeclarations": true }])),
         ),
         (
-            "
-    		namespace A {
-    		  export declare namespace B {
-    		    namespace C {}
-    		  }
-    		}
-    		      ",
+            "namespace A {
+    		   export declare namespace B {
+    		     namespace C {}
+    		   }
+    		 }",
             Some(serde_json::json!([{ "allowDeclarations": true }])),
         ),
         (
-            "
-    		namespace A {
-    		  export declare namespace B {
-    		    declare namespace C {}
-    		  }
-    		}
-    		      ",
+            "namespace A {
+    		   export declare namespace B {
+    		     declare namespace C {}
+    		   }
+    		 }",
             Some(serde_json::json!([{ "allowDeclarations": true }])),
         ),
         (
-            "
-    		namespace A {
-    		  export declare namespace B {
-    		    export declare namespace C {}
-    		  }
-    		}
-    		      ",
+            "namespace A {
+    		   export declare namespace B {
+    		     export declare namespace C {}
+    		   }
+    		 }",
             Some(serde_json::json!([{ "allowDeclarations": true }])),
         ),
         (
-            "
-    		namespace A {
-    		  declare namespace B {
-    		    export declare namespace C {}
-    		  }
-    		}
-    		      ",
+            "namespace A {
+    		   declare namespace B {
+    		     export declare namespace C {}
+    		   }
+    		 }",
             Some(serde_json::json!([{ "allowDeclarations": true }])),
         ),
         (
-            "
-    		namespace A {
-    		  export namespace B {
-    		    export declare namespace C {}
-    		  }
-    		}
-    		      ",
+            "namespace A {
+    		   export namespace B {
+    		     export declare namespace C {}
+    		   }
+    	 	 }",
             Some(serde_json::json!([{ "allowDeclarations": true }])),
         ),
         (
-            "
-    		export namespace A {
-    		  namespace B {
-    		    declare namespace C {}
-    		  }
-    		}
-    		      ",
+            "export namespace A {
+    		   namespace B {
+    		     declare namespace C {}
+    		   }
+    		 }",
             Some(serde_json::json!([{ "allowDeclarations": true }])),
         ),
         (
-            "
-    		export namespace A {
-    		  namespace B {
-    		    export declare namespace C {}
-    		  }
-    		}
-    		      ",
+            "export namespace A {
+    		   namespace B {
+    		     export declare namespace C {}
+    		   }
+    		 }",
             Some(serde_json::json!([{ "allowDeclarations": true }])),
         ),
         (
-            "
-    		export namespace A {
-    		  declare namespace B {
-    		    namespace C {}
-    		  }
-    		}
-    		      ",
+            "export namespace A {
+    		   declare namespace B {
+    		     namespace C {}
+    		   }
+    	 	 }",
             Some(serde_json::json!([{ "allowDeclarations": true }])),
         ),
         (
-            "
-    		export namespace A {
-    		  export declare namespace B {
-    		    namespace C {}
-    		  }
-    		}
-    		      ",
+            "export namespace A {
+    		   export declare namespace B {
+    		     namespace C {}
+    		   }
+    		 }",
             Some(serde_json::json!([{ "allowDeclarations": true }])),
         ),
         (
-            "
-    		export namespace A {
-    		  export declare namespace B {
-    		    declare namespace C {}
-    		  }
-    		}
-    		      ",
+            "export namespace A {
+    		   export declare namespace B {
+    		     declare namespace C {}
+    		   }
+    		 }",
             Some(serde_json::json!([{ "allowDeclarations": true }])),
         ),
         (
-            "
-    		export namespace A {
-    		  export declare namespace B {
-    		    export declare namespace C {}
-    		  }
-    		}
-    		      ",
+            "export namespace A {
+    		   export declare namespace B {
+    		     export declare namespace C {}
+    		   }
+    		 }",
             Some(serde_json::json!([{ "allowDeclarations": true }])),
         ),
         (
-            "
-    		export namespace A {
-    		  declare namespace B {
-    		    export declare namespace C {}
-    		  }
-    		}
-    		      ",
+            "export namespace A {
+    		   declare namespace B {
+    		     export declare namespace C {}
+    		   }
+    	 	}",
             Some(serde_json::json!([{ "allowDeclarations": true }])),
         ),
         (
-            "
-    		export namespace A {
-    		  export namespace B {
-    		    export declare namespace C {}
-    		  }
-    		}
-    		      ",
+            "export namespace A {
+    		   export namespace B {
+    		     export declare namespace C {}
+    		   }
+    		 }",
             Some(serde_json::json!([{ "allowDeclarations": true }])),
         ),
     ];

--- a/crates/oxc_linter/src/rules/typescript/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_namespace.rs
@@ -33,12 +33,83 @@ declare_oxc_lint!(
     /// later renamed to "namespaces" (namespace Example). Namespaces are an outdated way to organize TypeScript code.
     /// ES2015 module syntax is now preferred (import/export).
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```typescript
     /// module foo {}
     /// namespace foo {}
     /// declare module foo {}
     /// declare namespace foo {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```typescript
+    /// declare module 'foo' {}
+    /// // anything inside a d.ts file
+    /// ```
+    ///
+    /// #### allowDeclarations
+    ///
+    /// `{ type: boolean, allowDeclarations: false }`
+    ///
+    /// Whether to allow declare with custom TypeScript namespaces.
+    ///
+    /// Examples of **incorrect** code for this rule when `{ "allowDeclarations": true }`
+    /// ```typescript
+    /// module foo {}
+    /// namespace foo {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule when `{ "allowDeclarations": true }`
+    /// ```typescript
+    /// declare module 'foo' {}
+    /// declare module foo {}
+    /// declare namespace foo {}
+    ///
+    /// declare global {
+    ///   namespace foo {}
+    /// }
+    ///
+    /// declare module foo {
+    ///   namespace foo {}
+    /// }
+    /// ```
+    ///
+    /// Examples of **incorrect** code for this rule when `{ "allowDeclarations": false }`
+    /// ```typescript
+    /// module foo {}
+    /// namespace foo {}
+    /// declare module foo {}
+    /// declare namespace foo {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule when `{ "allowDeclarations": false }`
+    /// ```typescript
+    /// declare module 'foo' {}
+    /// ```
+    ///
+    /// #### allowDefinitionFiles
+    ///
+    /// `{ type: boolean, allowDefinitionFiles: true }`
+    ///
+    /// Examples of **incorrect** code for this rule when `{ "allowDefinitionFiles": true }`
+    /// ```typescript
+    /// // if outside a d.ts file
+    /// module foo {}
+    /// namespace foo {}
+    ///
+    /// // if outside a d.ts file
+    /// module foo {}
+    /// namespace foo {}
+    /// declare module foo {}
+    /// declare namespace foo {}
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule when `{ "allowDefinitionFiles": true }`
+    /// ```typescript
+    /// declare module 'foo' {}
+    /// // anything inside a d.ts file
     /// ```
     NoNamespace,
     typescript,

--- a/crates/oxc_linter/src/snapshots/typescript_no_namespace.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_namespace.snap
@@ -79,217 +79,200 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace the namespace with an ES2015 module or use `declare module`
 
   ⚠ typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.
-   ╭─[no_namespace.tsx:2:7]
- 1 │ 
- 2 │             namespace Foo.Bar {
-   ·             ─────────
- 3 │               namespace Baz.Bas {
+   ╭─[no_namespace.tsx:1:1]
+ 1 │ namespace Foo.Bar {
+   · ─────────
+ 2 │                namespace Baz.Bas {
    ╰────
   help: Replace the namespace with an ES2015 module or use `declare module`
 
   ⚠ typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.
-   ╭─[no_namespace.tsx:3:9]
- 2 │             namespace Foo.Bar {
- 3 │               namespace Baz.Bas {
-   ·               ─────────
- 4 │                 interface X {}
+   ╭─[no_namespace.tsx:2:10]
+ 1 │ namespace Foo.Bar {
+ 2 │                namespace Baz.Bas {
+   ·                ─────────
+ 3 │                  interface X {}
    ╰────
   help: Replace the namespace with an ES2015 module or use `declare module`
 
   ⚠ typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.
-   ╭─[no_namespace.tsx:2:7]
- 1 │ 
- 2 │             namespace A {
-   ·             ─────────
- 3 │               namespace B {
+   ╭─[no_namespace.tsx:1:1]
+ 1 │ namespace A {
+   · ─────────
+ 2 │                namespace B {
    ╰────
   help: Replace the namespace with an ES2015 module or use `declare module`
 
   ⚠ typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.
-   ╭─[no_namespace.tsx:3:9]
- 2 │             namespace A {
- 3 │               namespace B {
-   ·               ─────────
- 4 │                 declare namespace C {}
+   ╭─[no_namespace.tsx:2:10]
+ 1 │ namespace A {
+ 2 │                namespace B {
+   ·                ─────────
+ 3 │                  declare namespace C {}
    ╰────
   help: Replace the namespace with an ES2015 module or use `declare module`
 
   ⚠ typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.
-   ╭─[no_namespace.tsx:2:7]
- 1 │ 
- 2 │             namespace A {
-   ·             ─────────
- 3 │               namespace B {
+   ╭─[no_namespace.tsx:1:1]
+ 1 │ namespace A {
+   · ─────────
+ 2 │                namespace B {
    ╰────
   help: Replace the namespace with an ES2015 module or use `declare module`
 
   ⚠ typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.
-   ╭─[no_namespace.tsx:3:9]
- 2 │             namespace A {
- 3 │               namespace B {
-   ·               ─────────
- 4 │                 export declare namespace C {}
+   ╭─[no_namespace.tsx:2:10]
+ 1 │ namespace A {
+ 2 │                namespace B {
+   ·                ─────────
+ 3 │                  export declare namespace C {}
    ╰────
   help: Replace the namespace with an ES2015 module or use `declare module`
 
   ⚠ typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.
-   ╭─[no_namespace.tsx:2:7]
- 1 │ 
- 2 │             namespace A {
-   ·             ─────────
- 3 │               declare namespace B {
+   ╭─[no_namespace.tsx:1:1]
+ 1 │ namespace A {
+   · ─────────
+ 2 │                declare namespace B {
    ╰────
   help: Replace the namespace with an ES2015 module or use `declare module`
 
   ⚠ typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.
-   ╭─[no_namespace.tsx:2:7]
- 1 │ 
- 2 │             namespace A {
-   ·             ─────────
- 3 │               export declare namespace B {
+   ╭─[no_namespace.tsx:1:1]
+ 1 │ namespace A {
+   · ─────────
+ 2 │                export declare namespace B {
    ╰────
   help: Replace the namespace with an ES2015 module or use `declare module`
 
   ⚠ typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.
-   ╭─[no_namespace.tsx:2:7]
- 1 │ 
- 2 │             namespace A {
-   ·             ─────────
- 3 │               export declare namespace B {
+   ╭─[no_namespace.tsx:1:1]
+ 1 │ namespace A {
+   · ─────────
+ 2 │                export declare namespace B {
    ╰────
   help: Replace the namespace with an ES2015 module or use `declare module`
 
   ⚠ typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.
-   ╭─[no_namespace.tsx:2:7]
- 1 │ 
- 2 │             namespace A {
-   ·             ─────────
- 3 │               export declare namespace B {
+   ╭─[no_namespace.tsx:1:1]
+ 1 │ namespace A {
+   · ─────────
+ 2 │                export declare namespace B {
    ╰────
   help: Replace the namespace with an ES2015 module or use `declare module`
 
   ⚠ typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.
-   ╭─[no_namespace.tsx:2:7]
- 1 │ 
- 2 │             namespace A {
-   ·             ─────────
- 3 │               declare namespace B {
+   ╭─[no_namespace.tsx:1:1]
+ 1 │ namespace A {
+   · ─────────
+ 2 │                declare namespace B {
    ╰────
   help: Replace the namespace with an ES2015 module or use `declare module`
 
   ⚠ typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.
-   ╭─[no_namespace.tsx:2:7]
- 1 │ 
- 2 │             namespace A {
-   ·             ─────────
- 3 │               export namespace B {
+   ╭─[no_namespace.tsx:1:1]
+ 1 │ namespace A {
+   · ─────────
+ 2 │                export namespace B {
    ╰────
   help: Replace the namespace with an ES2015 module or use `declare module`
 
   ⚠ typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.
-   ╭─[no_namespace.tsx:3:16]
- 2 │             namespace A {
- 3 │               export namespace B {
-   ·                      ─────────
- 4 │                 export declare namespace C {}
+   ╭─[no_namespace.tsx:2:17]
+ 1 │ namespace A {
+ 2 │                export namespace B {
+   ·                       ─────────
+ 3 │                  export declare namespace C {}
    ╰────
   help: Replace the namespace with an ES2015 module or use `declare module`
 
   ⚠ typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.
-   ╭─[no_namespace.tsx:2:14]
- 1 │ 
- 2 │             export namespace A {
-   ·                    ─────────
- 3 │               namespace B {
+   ╭─[no_namespace.tsx:1:8]
+ 1 │ export namespace A {
+   ·        ─────────
+ 2 │                namespace B {
    ╰────
   help: Replace the namespace with an ES2015 module or use `declare module`
 
   ⚠ typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.
-   ╭─[no_namespace.tsx:3:9]
- 2 │             export namespace A {
- 3 │               namespace B {
-   ·               ─────────
- 4 │                 declare namespace C {}
+   ╭─[no_namespace.tsx:2:10]
+ 1 │ export namespace A {
+ 2 │                namespace B {
+   ·                ─────────
+ 3 │                  declare namespace C {}
    ╰────
   help: Replace the namespace with an ES2015 module or use `declare module`
 
   ⚠ typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.
-   ╭─[no_namespace.tsx:2:14]
- 1 │ 
- 2 │             export namespace A {
-   ·                    ─────────
- 3 │               namespace B {
+   ╭─[no_namespace.tsx:1:8]
+ 1 │ export namespace A {
+   ·        ─────────
+ 2 │                namespace B {
    ╰────
   help: Replace the namespace with an ES2015 module or use `declare module`
 
   ⚠ typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.
-   ╭─[no_namespace.tsx:3:9]
- 2 │             export namespace A {
- 3 │               namespace B {
-   ·               ─────────
- 4 │                 export declare namespace C {}
+   ╭─[no_namespace.tsx:2:10]
+ 1 │ export namespace A {
+ 2 │                namespace B {
+   ·                ─────────
+ 3 │                  export declare namespace C {}
    ╰────
   help: Replace the namespace with an ES2015 module or use `declare module`
 
   ⚠ typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.
-   ╭─[no_namespace.tsx:2:14]
- 1 │ 
- 2 │             export namespace A {
-   ·                    ─────────
- 3 │               declare namespace B {
+   ╭─[no_namespace.tsx:1:8]
+ 1 │ export namespace A {
+   ·        ─────────
+ 2 │                declare namespace B {
    ╰────
   help: Replace the namespace with an ES2015 module or use `declare module`
 
   ⚠ typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.
-   ╭─[no_namespace.tsx:2:14]
- 1 │ 
- 2 │             export namespace A {
-   ·                    ─────────
- 3 │               export declare namespace B {
+   ╭─[no_namespace.tsx:1:8]
+ 1 │ export namespace A {
+   ·        ─────────
+ 2 │                export declare namespace B {
    ╰────
   help: Replace the namespace with an ES2015 module or use `declare module`
 
   ⚠ typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.
-   ╭─[no_namespace.tsx:2:14]
- 1 │ 
- 2 │             export namespace A {
-   ·                    ─────────
- 3 │               export declare namespace B {
+   ╭─[no_namespace.tsx:1:8]
+ 1 │ export namespace A {
+   ·        ─────────
+ 2 │                export declare namespace B {
    ╰────
   help: Replace the namespace with an ES2015 module or use `declare module`
 
   ⚠ typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.
-   ╭─[no_namespace.tsx:2:14]
- 1 │ 
- 2 │             export namespace A {
-   ·                    ─────────
- 3 │               export declare namespace B {
+   ╭─[no_namespace.tsx:1:8]
+ 1 │ export namespace A {
+   ·        ─────────
+ 2 │                export declare namespace B {
    ╰────
   help: Replace the namespace with an ES2015 module or use `declare module`
 
   ⚠ typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.
-   ╭─[no_namespace.tsx:2:14]
- 1 │ 
- 2 │             export namespace A {
-   ·                    ─────────
- 3 │               declare namespace B {
+   ╭─[no_namespace.tsx:1:8]
+ 1 │ export namespace A {
+   ·        ─────────
+ 2 │                declare namespace B {
    ╰────
   help: Replace the namespace with an ES2015 module or use `declare module`
 
   ⚠ typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.
-   ╭─[no_namespace.tsx:2:14]
- 1 │ 
- 2 │             export namespace A {
-   ·                    ─────────
- 3 │               export namespace B {
+   ╭─[no_namespace.tsx:1:8]
+ 1 │ export namespace A {
+   ·        ─────────
+ 2 │                export namespace B {
    ╰────
   help: Replace the namespace with an ES2015 module or use `declare module`
 
   ⚠ typescript-eslint(no-namespace): ES2015 module syntax is preferred over namespaces.
-   ╭─[no_namespace.tsx:3:16]
- 2 │             export namespace A {
- 3 │               export namespace B {
-   ·                      ─────────
- 4 │                 export declare namespace C {}
+   ╭─[no_namespace.tsx:2:17]
+ 1 │ export namespace A {
+ 2 │                export namespace B {
+   ·                       ─────────
+ 3 │                  export declare namespace C {}
    ╰────
   help: Replace the namespace with an ES2015 module or use `declare module`


### PR DESCRIPTION
- Document the options for the rule as well as adding correctness examples according to #6050 .
- Format the strings to make them more readable in the test cases.