### PR TITLE
feat(ast/estree): ESTree AST `ExportNamedDeclaration` always have `attributes` field

### DIFF
--- a/.github/actions/clone-submodules/action.yml
+++ b/.github/actions/clone-submodules/action.yml
@@ -38,4 +38,4 @@ runs:
         show-progress: false
         repository: oxc-project/acorn-test262
         path: tasks/coverage/acorn-test262
-        ref: ed8b455fd9775089444d53c09ea18fedf220da8b # Latest main at 21/2/24
+        ref: 96faefa7644f16bb163484ee50fa13d6ecff7e72 # Latest main at 4/3/25

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -2467,7 +2467,6 @@ pub enum ImportAttributeKey<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(via = ExportNamedDeclarationConverter)]
 pub struct ExportNamedDeclaration<'a> {
     pub span: Span,
     pub declaration: Option<Declaration<'a>>,

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1726,7 +1726,19 @@ impl ESTree for ImportAttributeKey<'_> {
 
 impl ESTree for ExportNamedDeclaration<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        crate::serialize::ExportNamedDeclarationConverter(self).serialize(serializer)
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", &JsonSafeString("ExportNamedDeclaration"));
+        state.serialize_field("start", &self.span.start);
+        state.serialize_field("end", &self.span.end);
+        state.serialize_field("declaration", &self.declaration);
+        state.serialize_field("specifiers", &self.specifiers);
+        state.serialize_field("source", &self.source);
+        state.serialize_ts_field("exportKind", &self.export_kind);
+        state.serialize_field(
+            "attributes",
+            &crate::serialize::ExportNamedDeclarationWithClause(self),
+        );
+        state.end();
     }
 }
 

--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ submodules:
   just clone-submodule tasks/coverage/babel https://github.com/babel/babel.git 578ac4df1c8a05f01350553950dbfbbeaac013c2
   just clone-submodule tasks/coverage/typescript https://github.com/microsoft/TypeScript.git 15392346d05045742e653eab5c87538ff2a3c863
   just clone-submodule tasks/prettier_conformance/prettier https://github.com/prettier/prettier.git 7584432401a47a26943dd7a9ca9a8e032ead7285
-  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 ed8b455fd9775089444d53c09ea18fedf220da8b
+  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 96faefa7644f16bb163484ee50fa13d6ecff7e72
   just update-transformer-fixtures
 
 # Install git pre-commit to format files

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -967,26 +967,16 @@ function deserializeImportAttribute(pos) {
 }
 
 function deserializeExportNamedDeclaration(pos) {
-  const start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    declaration = deserializeOptionDeclaration(pos + 8),
-    specifiers = deserializeVecExportSpecifier(pos + 24),
-    source = deserializeOptionStringLiteral(pos + 56);
-
-  if (source !== null) {
-    const withClause = deserializeOptionBoxWithClause(pos + 104);
-    return {
-      type: 'ExportNamedDeclaration',
-      start,
-      end,
-      declaration,
-      specifiers,
-      source,
-      attributes: withClause === null ? [] : withClause.withEntries,
-    };
-  }
-
-  return { type: 'ExportNamedDeclaration', start, end, declaration, specifiers, source };
+  const withClause = deserializeOptionBoxWithClause(pos + 104);
+  return {
+    type: 'ExportNamedDeclaration',
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+    declaration: deserializeOptionDeclaration(pos + 8),
+    specifiers: deserializeVecExportSpecifier(pos + 24),
+    source: deserializeOptionStringLiteral(pos + 56),
+    attributes: withClause === null ? [] : withClause.withEntries,
+  };
 }
 
 function deserializeExportDefaultDeclaration(pos) {

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -1016,28 +1016,17 @@ function deserializeImportAttribute(pos) {
 }
 
 function deserializeExportNamedDeclaration(pos) {
-  const start = deserializeU32(pos),
-    end = deserializeU32(pos + 4),
-    declaration = deserializeOptionDeclaration(pos + 8),
-    specifiers = deserializeVecExportSpecifier(pos + 24),
-    source = deserializeOptionStringLiteral(pos + 56),
-    exportKind = deserializeImportOrExportKind(pos + 96);
-
-  if (source !== null) {
-    const withClause = deserializeOptionBoxWithClause(pos + 104);
-    return {
-      type: 'ExportNamedDeclaration',
-      start,
-      end,
-      declaration,
-      specifiers,
-      source,
-      exportKind,
-      attributes: withClause === null ? [] : withClause.withEntries,
-    };
-  }
-
-  return { type: 'ExportNamedDeclaration', start, end, declaration, specifiers, source, exportKind };
+  const withClause = deserializeOptionBoxWithClause(pos + 104);
+  return {
+    type: 'ExportNamedDeclaration',
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+    declaration: deserializeOptionDeclaration(pos + 8),
+    specifiers: deserializeVecExportSpecifier(pos + 24),
+    source: deserializeOptionStringLiteral(pos + 56),
+    exportKind: deserializeImportOrExportKind(pos + 96),
+    attributes: withClause === null ? [] : withClause.withEntries,
+  };
 }
 
 function deserializeExportDefaultDeclaration(pos) {


### PR DESCRIPTION
Acorn does not include an `attributes` field on `ExportNamedDeclaration` when `source == null`. I think that's an oversight - https://github.com/acornjs/acorn/pull/1346.

Bump `acorn-test262` to include commit https://github.com/oxc-project/acorn-test262/commit/96faefa7644f16bb163484ee50fa13d6ecff7e72 which adds the missing `attributes` field to Acorn's AST.

This allows simplifying serialization/deserialization code, as we now don't need to deal with this special case.