### PR TITLE
feat(data_structures): move `InlineString` into `oxc_data_structures` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,6 +1890,7 @@ dependencies = [
  "itertools",
  "oxc_allocator",
  "oxc_ast",
+ "oxc_data_structures",
  "oxc_index",
  "oxc_semantic",
  "oxc_span",

--- a/crates/oxc_data_structures/src/inline_string.rs
+++ b/crates/oxc_data_structures/src/inline_string.rs
@@ -1,0 +1,203 @@
+//! Fixed capacity string, stored on the stack.
+
+use std::{
+    fmt::{self, Display},
+    ops::{Add, AddAssign, Deref},
+};
+
+/// Short inline string.
+///
+/// `CAPACITY` determines the maximum length of the string.
+///
+/// `Len` type is the type used to store string length.
+/// It can be `u8`, `u16`, `u32`, or `usize`. On 64-bit platforms, it can also be `u64`.
+///
+/// To make this type maximally efficient, select a `CAPACITY` value and `Len` type
+/// which make the total byte size of `InlineString<CAPACITY, Len>` a multiple of 8.
+///
+/// Failure to do this results in the type containing padding bytes, which makes operations on it
+/// more expensive. Invalid combinations of `CAPACITY` and `Len` will produce an error at compile time.
+///
+/// Generally, you want to use the largest `Len` type you can while allowing your required maximum
+/// capacity, but without growing the size of the type. Then increase `CAPACITY` to fill any spare bytes.
+///
+/// Examples of valid `CAPACITY` / `Len` combinations:
+///
+/// * `FixedSizeString<7, u8>` = 8 bytes
+/// * `FixedSizeString<8, usize>` = 16 bytes (on 64-bit platforms)
+/// * `FixedSizeString<12, u32>` = 16 bytes
+#[repr(C)]
+pub struct InlineString<const CAPACITY: usize, Len: UnsignedInt> {
+    bytes: [u8; CAPACITY],
+    len: Len,
+    // Aligned on 8 on 64-bit platforms, aligned on 4 on 32-bit platforms
+    _align: [usize; 0],
+}
+
+impl<const CAPACITY: usize, Len: UnsignedInt> InlineString<CAPACITY, Len> {
+    const ASSERTS: () = {
+        assert!(CAPACITY <= Len::MAX_USIZE, "`CAPACITY` is too large for `Len`");
+        assert!(
+            (CAPACITY + size_of::<Len>()) % size_of::<usize>() == 0,
+            "`CAPACITY + size_of::<Len>()` is not a multiple of `size_of::<usize>()`"
+        );
+    };
+
+    /// Create empty [`InlineString`].
+    #[inline]
+    pub fn new() -> Self {
+        const { Self::ASSERTS };
+
+        Self { bytes: [0; CAPACITY], len: Len::ZERO, _align: [] }
+    }
+
+    /// Create [`InlineString`] from `&str`.
+    ///
+    /// # Panics
+    /// Panics if `s.len() > CAPACITY`.
+    #[expect(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> Self {
+        const { Self::ASSERTS };
+
+        let mut bytes = [0; CAPACITY];
+        let slice = &mut bytes[..s.len()];
+        slice.copy_from_slice(s.as_bytes());
+        Self { bytes, len: Len::from_usize(s.len()), _align: [] }
+    }
+
+    /// Push a byte to the string.
+    ///
+    /// # Panics
+    ///
+    /// Panics if:
+    /// * String is already full to capacity.
+    /// * `byte` is >= 128 (not an ASCII character).
+    #[inline]
+    pub fn push(&mut self, byte: u8) {
+        assert!(self.len.to_usize() < CAPACITY);
+        assert!(byte.is_ascii());
+
+        // SAFETY: We just checked the safety constraints
+        unsafe { self.push_unchecked(byte) }
+    }
+
+    /// Push a byte to the string, without checks.
+    ///
+    /// # SAFETY
+    /// * Must not push more than `CAPACITY` bytes.
+    /// * `byte` must be < 128 (an ASCII character).
+    #[inline]
+    pub unsafe fn push_unchecked(&mut self, byte: u8) {
+        debug_assert!(self.len.to_usize() < CAPACITY);
+        debug_assert!(byte.is_ascii());
+
+        // SAFETY: Caller guarantees not pushing more than `CAPACITY` bytes, so `len` is in bounds
+        unsafe { *self.bytes.get_unchecked_mut(self.len.to_usize()) = byte };
+        self.len += Len::from_usize(1);
+    }
+
+    /// Get length of string as `Len`.
+    #[inline]
+    pub fn len(&self) -> Len {
+        self.len
+    }
+
+    /// Get length of string as `usize`.
+    #[inline]
+    pub fn len_usize(&self) -> usize {
+        self.len.to_usize()
+    }
+
+    /// Get if string is empty.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.len == Len::ZERO
+    }
+
+    /// Get string as `&str` slice.
+    #[inline]
+    pub fn as_str(&self) -> &str {
+        // SAFETY: If safety conditions of `push_unchecked` have been upheld,
+        // slice cannot be out of bounds, and contents of that slice is a valid UTF-8 string
+        unsafe {
+            let slice = self.bytes.get_unchecked(..self.len.to_usize());
+            std::str::from_utf8_unchecked(slice)
+        }
+    }
+}
+
+impl<const CAPACITY: usize, Len: UnsignedInt> Default for InlineString<CAPACITY, Len> {
+    #[inline]
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const CAPACITY: usize, Len: UnsignedInt> Deref for InlineString<CAPACITY, Len> {
+    type Target = str;
+
+    #[inline]
+    fn deref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl<const CAPACITY: usize, Len: UnsignedInt> Display for InlineString<CAPACITY, Len> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Trait for type which can be `len` field.
+///
+/// Private trait to prevent code outside this module implementing this trait on other types.
+#[expect(private_bounds)]
+pub trait UnsignedInt: Copy + PartialEq + Eq + Add + AddAssign + Sealed {
+    /// Zero.
+    const ZERO: Self;
+
+    /// Maximum value for this type as a `usize`.
+    const MAX_USIZE: usize;
+
+    /// Convert to `usize`.
+    fn to_usize(self) -> usize;
+
+    /// Convert from `usize`.
+    fn from_usize(n: usize) -> Self;
+}
+
+/// Trait which isn't public, and is a bound of `UnsignedInt`.
+/// Prevents code outside this module implementing `UnsignedInt` on any other types.
+trait Sealed {}
+
+macro_rules! impl_unsigned_int {
+    ($ty:ident) => {
+        #[allow(clippy::cast_possible_truncation, clippy::allow_attributes)]
+        impl UnsignedInt for $ty {
+            const ZERO: Self = 0;
+
+            const MAX_USIZE: usize = $ty::MAX as usize;
+
+            #[inline(always)]
+            fn to_usize(self) -> usize {
+                self as usize
+            }
+
+            #[inline(always)]
+            fn from_usize(n: usize) -> Self {
+                n.try_into().unwrap()
+            }
+        }
+
+        impl Sealed for $ty {}
+    };
+}
+
+impl_unsigned_int!(u8);
+impl_unsigned_int!(u16);
+impl_unsigned_int!(u32);
+// Only implement for `u64` on 64-bit systems so that conversion from this type to `usize`
+// cannot truncate value
+#[cfg(target_pointer_width = "64")]
+impl_unsigned_int!(u64);
+impl_unsigned_int!(usize);

--- a/crates/oxc_data_structures/src/lib.rs
+++ b/crates/oxc_data_structures/src/lib.rs
@@ -3,5 +3,6 @@
 #![warn(missing_docs)]
 
 pub mod code_buffer;
+pub mod inline_string;
 pub mod rope;
 pub mod stack;

--- a/crates/oxc_mangler/Cargo.toml
+++ b/crates/oxc_mangler/Cargo.toml
@@ -23,6 +23,7 @@ doctest = false
 [dependencies]
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
+oxc_data_structures = { workspace = true }
 oxc_index = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }

--- a/crates/oxc_mangler/src/base54.rs
+++ b/crates/oxc_mangler/src/base54.rs
@@ -1,4 +1,4 @@
-use crate::InlineString;
+use oxc_data_structures::inline_string::InlineString;
 
 #[repr(C, align(64))]
 struct Aligned64([u8; 64]);
@@ -38,7 +38,7 @@ const BASE54_CHARS: Aligned64 =
 // Then initializing the `InlineString` is a single `xmm` set, and with luck it'll sit in a register
 // throughout this function.
 #[expect(clippy::items_after_statements)]
-pub fn base54(n: usize) -> InlineString<12> {
+pub fn base54(n: usize) -> InlineString<12, u32> {
     let mut str = InlineString::new();
 
     let mut num = n;


### PR DESCRIPTION
Move `InlineString` from `oxc_mangler` crate into `oxc_data_structures`, so we can use it for other things.

Also add a `Len` type parameter, so you can select the desired type for the length field. For some uses, `u32` is not ideal.
