### PR TITLE
refactor(ast/estree): simplify serializing `RegExpLiteral`s

### DIFF
--- a/.github/actions/clone-submodules/action.yml
+++ b/.github/actions/clone-submodules/action.yml
@@ -38,4 +38,4 @@ runs:
         show-progress: false
         repository: oxc-project/acorn-test262
         path: tasks/coverage/acorn-test262
-        ref: 7b7fa95e055352d76ddccc98cabc37ca1448cf92 # Latest main at 4/3/25
+        ref: 3d7013e145499268dc8f985d087208aa013e0ba2 # Latest main at 4/3/25

--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -122,7 +122,6 @@ pub struct RegExpLiteral<'a> {
     pub span: Span,
     /// The parsed regular expression. See [`oxc_regular_expression`] for more
     /// details.
-    #[estree(via = RegExpLiteralRegex)]
     pub regex: RegExp<'a>,
     /// The regular expression as it appears in source code
     ///

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1945,7 +1945,7 @@ impl ESTree for RegExpLiteral<'_> {
         state.serialize_field("end", &self.span.end);
         state.serialize_field("value", &crate::serialize::RegExpLiteralValue(self));
         state.serialize_field("raw", &self.raw);
-        state.serialize_field("regex", &crate::serialize::RegExpLiteralRegex(self));
+        state.serialize_field("regex", &self.regex);
         state.end();
     }
 }

--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ submodules:
   just clone-submodule tasks/coverage/babel https://github.com/babel/babel.git 578ac4df1c8a05f01350553950dbfbbeaac013c2
   just clone-submodule tasks/coverage/typescript https://github.com/microsoft/TypeScript.git 15392346d05045742e653eab5c87538ff2a3c863
   just clone-submodule tasks/prettier_conformance/prettier https://github.com/prettier/prettier.git 7584432401a47a26943dd7a9ca9a8e032ead7285
-  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 7b7fa95e055352d76ddccc98cabc37ca1448cf92
+  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 3d7013e145499268dc8f985d087208aa013e0ba2
   just update-transformer-fixtures
 
 # Install git pre-commit to format files

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -1131,34 +1131,18 @@ function deserializeBigIntLiteral(pos) {
 }
 
 function deserializeRegExpLiteral(pos) {
-  const raw = deserializeOptionStr(pos + 40);
-  let pattern, flags, value = null;
-  if (raw === null) {
-    pattern = deserializeRegExpPattern(pos + 8);
-    const flagBits = deserializeU8(pos + 32);
-    flags = '';
-    if (flagBits & 1) flags += 'g';
-    if (flagBits & 2) flags += 'i';
-    if (flagBits & 4) flags += 'm';
-    if (flagBits & 8) flags += 's';
-    if (flagBits & 16) flags += 'u';
-    if (flagBits & 32) flags += 'y';
-    if (flagBits & 64) flags += 'd';
-    if (flagBits & 128) flags += 'v';
-  } else {
-    [, pattern, flags] = raw.match(/^\/(.*)\/([a-z]*)$/);
-  }
-
+  const regex = deserializeRegExp(pos + 8);
+  let value = null;
   try {
-    value = new RegExp(pattern, flags);
+    value = new RegExp(regex.pattern, regex.flags);
   } catch (e) {}
   return {
     type: 'Literal',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     value,
-    raw,
-    regex: { pattern, flags },
+    raw: deserializeOptionStr(pos + 40),
+    regex,
   };
 }
 
@@ -1170,10 +1154,18 @@ function deserializeRegExp(pos) {
 }
 
 function deserializeRegExpFlags(pos) {
-  return {
-    type: 'RegExpFlags',
-    0: deserializeU8(pos),
-  };
+  const flagBits = deserializeU8(pos);
+  let flags = '';
+  // Alphabetical order
+  if (flagBits & 64) flags += 'd';
+  if (flagBits & 1) flags += 'g';
+  if (flagBits & 2) flags += 'i';
+  if (flagBits & 4) flags += 'm';
+  if (flagBits & 8) flags += 's';
+  if (flagBits & 16) flags += 'u';
+  if (flagBits & 128) flags += 'v';
+  if (flagBits & 32) flags += 'y';
+  return flags;
 }
 
 function deserializeJSXElement(pos) {

--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -377,6 +377,7 @@ impl<'s> StructDeserializerGenerator<'s> {
         let value = DESER_REGEX.replace_all(&value, DeserReplacer::new(self.schema));
         let value = POS_OFFSET_REGEX
             .replace_all(&value, PosOffsetReplacer::new(self, struct_def, struct_offset));
+        let value = POS_REGEX.replace_all(&value, PosReplacer::new(struct_offset));
         let value = value.cow_replace("SOURCE_TEXT", "sourceText");
 
         let value = if let Some((preamble, value)) = value.trim().rsplit_once('\n') {


### PR DESCRIPTION
Similar to #9546. Acorn outputs `RegExpLiteral`'s flags in same order as in source text. There is nothing wrong with this, but it makes our serialization/deserialization code more complex than it needs to be, just to match Acorn. I don't think we need to follow Acorn here - there's no particular "good" order for the flags.

Bump `acorn-test262` to include commit https://github.com/oxc-project/acorn-test262/commit/3d7013e145499268dc8f985d087208aa013e0ba2, which reorders the flags in alphabetical order in Acorn's AST.

This allows simplifying serialization/deserialization code on our side.
