### PR TITLE
fix(parser): parsing errors occur when type parameters are followed by `as` or `satisfies`

### DIFF
--- a/crates/oxc_parser/src/lexer/kind.rs
+++ b/crates/oxc_parser/src/lexer/kind.rs
@@ -250,6 +250,16 @@ impl Kind {
         self.is_identifier_name() && !self.is_reserved_keyword()
     }
 
+    /// TypeScript Identifier
+    ///
+    /// <https://github.com/microsoft/TypeScript/blob/15392346d05045742e653eab5c87538ff2a3c863/src/compiler/parser.ts#L2316-L2335>
+    #[inline]
+    pub fn is_ts_identifier(self, r#yield: bool, r#await: bool) -> bool {
+        self.is_identifier_reference(r#yield, r#await)
+            && !self.is_strict_mode_contextual_keyword()
+            && !self.is_contextual_keyword()
+    }
+
     /// `IdentifierName`
     #[inline]
     pub fn is_identifier_name(self) -> bool {

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1382,7 +1382,7 @@ impl<'a> ParserImpl<'a> {
             kind if kind.is_update_operator() => true,
             Kind::LAngle | Kind::Await | Kind::Yield | Kind::Private | Kind::At => true,
             kind if kind.is_binary_operator() => true,
-            kind => kind.is_identifier(),
+            kind => kind.is_ts_identifier(self.ctx.has_yield(), self.ctx.has_await()),
         }
     }
 
@@ -1403,7 +1403,7 @@ impl<'a> ParserImpl<'a> {
             Kind::Import => {
                 matches!(self.peek_kind(), Kind::LParen | Kind::LAngle | Kind::Dot)
             }
-            kind => kind.is_identifier(),
+            _ => false,
         }
     }
 }

--- a/tasks/coverage/misc/pass/oxc-9541.ts
+++ b/tasks/coverage/misc/pass/oxc-9541.ts
@@ -1,0 +1,2 @@
+Type<number> as any;
+Type<number> satisfies any;

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 32/32 (100.00%)
-Positive Passed: 32/32 (100.00%)
+AST Parsed     : 33/33 (100.00%)
+Positive Passed: 33/33 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,6 +1,6 @@
 parser_misc Summary:
-AST Parsed     : 32/32 (100.00%)
-Positive Passed: 32/32 (100.00%)
+AST Parsed     : 33/33 (100.00%)
+Positive Passed: 33/33 (100.00%)
 Negative Passed: 30/30 (100.00%)
 
   × Unexpected token

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 32/32 (100.00%)
-Positive Passed: 19/32 (59.38%)
+AST Parsed     : 33/33 (100.00%)
+Positive Passed: 20/33 (60.61%)
 tasks/coverage/misc/pass/oxc-1288.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["from"]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 32/32 (100.00%)
-Positive Passed: 32/32 (100.00%)
+AST Parsed     : 33/33 (100.00%)
+Positive Passed: 33/33 (100.00%)


### PR DESCRIPTION
close: #9541
