### PR TITLE
ci(ast_tools): move AST changes watch list file

### DIFF
--- a/.github/generated/ast_changes_watch_list.yml
+++ b/.github/generated/ast_changes_watch_list.yml
@@ -2,7 +2,7 @@
 # To edit this generated file you have to edit `tasks/ast_tools/src/main.rs`
 
 src:
-  - '.github/.generated_ast_watch_list.yml'
+  - '.github/generated/ast_changes_watch_list.yml'
   - 'crates/oxc_ast/src/ast/comment.rs'
   - 'crates/oxc_ast/src/ast/js.rs'
   - 'crates/oxc_ast/src/ast/jsx.rs'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,7 @@ jobs:
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
-          filters: ".github/.generated_ast_watch_list.yml"
+          filters: ".github/generated/ast_changes_watch_list.yml"
 
       - uses: oxc-project/setup-rust@cd82e1efec7fef815e2c23d296756f31c7cdc03d # v1.0.0
         if: steps.filter.outputs.src == 'true'

--- a/dprint.json
+++ b/dprint.json
@@ -24,7 +24,7 @@
     "npm/oxlint/configuration_schema.json",
     "npm/oxc-wasm/**",
     "npm/runtime/src",
-    ".github/.generated_ast_watch_list.yml"
+    ".github/generated/ast_changes_watch_list.yml"
   ],
   "plugins": [
     "https://plugins.dprint.dev/typescript-0.93.3.wasm",

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -243,8 +243,8 @@ const TYPESCRIPT_DEFINITIONS_PATH: &str = "npm/oxc-types/types.d.ts";
 const RAW_TRANSFER_JS_DESERIALIZER_PATH: &str = "napi/parser/deserialize-js.js";
 const RAW_TRANSFER_TS_DESERIALIZER_PATH: &str = "napi/parser/deserialize-ts.js";
 
-/// Path to write CI filter list to
-const GITHUB_WATCH_LIST_PATH: &str = ".github/.generated_ast_watch_list.yml";
+/// Path to write AST changes filter list to
+const AST_CHANGES_WATCH_LIST_PATH: &str = ".github/generated/ast_changes_watch_list.yml";
 
 /// Derives (for use with `#[generate_derive]`)
 const DERIVES: &[&(dyn Derive + Sync)] = &[
@@ -353,7 +353,7 @@ fn generate_ci_filter(outputs: &[RawOutput]) -> RawOutput {
         .iter()
         .copied()
         .chain(outputs.iter().map(|output| output.path.as_str()))
-        .chain(["tasks/ast_tools/src/**", GITHUB_WATCH_LIST_PATH])
+        .chain(["tasks/ast_tools/src/**", AST_CHANGES_WATCH_LIST_PATH])
         .collect::<Vec<_>>();
     paths.sort_unstable();
 
@@ -364,7 +364,7 @@ fn generate_ci_filter(outputs: &[RawOutput]) -> RawOutput {
 
     log_success!();
 
-    Output::Yaml { path: GITHUB_WATCH_LIST_PATH.to_string(), code }.into_raw(file!())
+    Output::Yaml { path: AST_CHANGES_WATCH_LIST_PATH.to_string(), code }.into_raw(file!())
 }
 
 /// Generate function for proc macro in `oxc_ast_macros` crate.


### PR DESCRIPTION
Pure refactor. Move the YAML file for AST changes watch list to a `generated` sub-directory. This follows our convention that all generated files go in a `generated` directory.
