### PR TITLE
refactor(ast_tools): add `Output::yaml_watch_list` method

### DIFF
--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -181,7 +181,7 @@
 //! [`AttrLocation`]: parse::attr::AttrLocation
 //! [`AttrPart`]: parse::attr::AttrPart
 
-use std::{fmt::Write, fs};
+use std::fs;
 
 use bpaf::{Bpaf, Parser};
 use quote::quote;
@@ -349,22 +349,13 @@ fn main() {
 fn generate_ci_filter(outputs: &[RawOutput]) -> RawOutput {
     log!("Generate CI filter... ");
 
-    let mut paths = SOURCE_PATHS
-        .iter()
-        .copied()
-        .chain(outputs.iter().map(|output| output.path.as_str()))
-        .chain(["tasks/ast_tools/src/**", AST_CHANGES_WATCH_LIST_PATH])
-        .collect::<Vec<_>>();
-    paths.sort_unstable();
-
-    let mut code = "src:\n".to_string();
-    for path in paths {
-        writeln!(&mut code, "  - '{path}'").unwrap();
-    }
+    let paths =
+        SOURCE_PATHS.iter().copied().chain(outputs.iter().map(|output| output.path.as_str()));
+    let output = Output::yaml_watch_list(AST_CHANGES_WATCH_LIST_PATH, paths);
 
     log_success!();
 
-    Output::Yaml { path: AST_CHANGES_WATCH_LIST_PATH.to_string(), code }.into_raw(file!())
+    output.into_raw(file!())
 }
 
 /// Generate function for proc macro in `oxc_ast_macros` crate.

--- a/tasks/ast_tools/src/output/yaml.rs
+++ b/tasks/ast_tools/src/output/yaml.rs
@@ -1,6 +1,31 @@
-use super::add_header;
+use std::fmt::Write;
+
+use super::{Output, add_header};
 
 /// Add header to YAML.
 pub fn print_yaml(code: &str, generator_path: &str) -> String {
     add_header(code, generator_path, "#")
+}
+
+impl Output {
+    /// Generate a watch list YAML file.
+    ///
+    /// The path of the watch list itself and `tasks/ast_tools/src/**` are added to the list.
+    pub fn yaml_watch_list<'s>(
+        watch_list_path: &'s str,
+        paths: impl IntoIterator<Item = &'s str>,
+    ) -> Self {
+        let mut paths = paths
+            .into_iter()
+            .chain([watch_list_path, "tasks/ast_tools/src/**"])
+            .collect::<Vec<_>>();
+        paths.sort_unstable();
+
+        let mut code = "src:\n".to_string();
+        for path in paths {
+            writeln!(&mut code, "  - '{path}'").unwrap();
+        }
+
+        Self::Yaml { path: watch_list_path.to_string(), code }
+    }
 }


### PR DESCRIPTION
Pure refactor. Move the logic for creating a YAML watch list into it's own function.

This was originally part of a change I was working on to make NAPI parser benchmarks only run when relevant files have changed. I've now realized that is not workable because of how Codspeed works, but I think this refactor is good anyway.
