### PR TITLE
fix(napi): do not support raw transfer on WASM32

### DIFF
--- a/napi/parser/bindings.js
+++ b/napi/parser/bindings.js
@@ -379,4 +379,5 @@ module.exports.ImportNameKind = nativeBinding.ImportNameKind
 module.exports.parseAsync = nativeBinding.parseAsync
 module.exports.parseSync = nativeBinding.parseSync
 module.exports.parseSyncRaw = nativeBinding.parseSyncRaw
+module.exports.rawTransferSupported = nativeBinding.rawTransferSupported
 module.exports.Severity = nativeBinding.Severity

--- a/napi/parser/index.d.ts
+++ b/napi/parser/index.d.ts
@@ -201,6 +201,9 @@ export declare function parseSync(filename: string, sourceText: string, options?
  */
 export declare function parseSyncRaw(filename: string, buffer: Uint8Array, sourceLen: number, options?: ParserOptions | undefined | null): void
 
+/** Returns `true` if raw transfer is supported on this platform. */
+export declare function rawTransferSupported(): boolean
+
 export declare const enum Severity {
   Error = 'Error',
   Warning = 'Warning',

--- a/napi/parser/index.js
+++ b/napi/parser/index.js
@@ -68,6 +68,10 @@ module.exports.parseSync = function parseSync(filename, sourceText, options) {
 let buffer, encoder;
 
 function parseSyncRaw(filename, sourceText, options) {
+  if (!rawTransferSupported()) {
+    throw new Error('`experimentalRawTransfer` option is not supported on 32-bit or big-endian systems');
+  }
+
   // Delete `experimentalRawTransfer` option
   let experimentalRawTransfer;
   ({ experimentalRawTransfer, ...options } = options);
@@ -138,3 +142,14 @@ function createBuffer() {
   const offset = bindings.getBufferOffset(new Uint8Array(arrayBuffer));
   return new Uint8Array(arrayBuffer, offset, TWO_GIB);
 }
+
+let rawTransferIsSupported = null;
+
+// Returns `true` if `experimentalRawTransfer` is option is supported.
+// Raw transfer is only available on 64-bit little-endian systems.
+function rawTransferSupported() {
+  if (rawTransferIsSupported === null) rawTransferIsSupported = bindings.rawTransferSupported();
+  return rawTransferIsSupported;
+}
+
+module.exports.rawTransferSupported = rawTransferSupported;

--- a/napi/parser/src/lib.rs
+++ b/napi/parser/src/lib.rs
@@ -20,7 +20,7 @@ mod convert;
 mod raw_transfer;
 mod raw_transfer_types;
 mod types;
-pub use raw_transfer::{get_buffer_offset, parse_sync_raw};
+pub use raw_transfer::{get_buffer_offset, parse_sync_raw, raw_transfer_supported};
 pub use types::{Comment, EcmaScriptModule, ParseResult, ParserOptions};
 
 mod generated {


### PR DESCRIPTION
Prevent compilation errors on 32-bit platforms by avoiding calculating `usize: 1 << 32` unless on a 64-bit platform.

`parseSync` will throw an error if called with `experimentalRawTransfer` on an unsupported system.

Add a function `rawTransferSupported` to check if raw transfer is supported on current system or not, so user can avoid these errors.
