### PR TITLE
ci(wasm): check `wasm32-wasip1-threads` build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
 
   test-wasm32-wasip1-threads:
     name: Test wasm32-wasip1-threads
-    if: ${{ github.ref_name == 'main' }}
+    # if: ${{ github.ref_name == 'main' }}
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: "--cfg tokio_unstable -C target-feature=+atomics,+bulk-memory,+mutable-globals,+simd128 -C link-args=--max-memory=67108864"
@@ -105,8 +105,14 @@ jobs:
         with:
           cache-key: wasi
           save-cache: ${{ github.ref_name == 'main' }}
+      - uses: ./.github/actions/pnpm
       - run: rustup target add wasm32-wasip1-threads
       - uses: bytecodealliance/actions/wasmtime/setup@3b93676295fd6f7eaa7af2c2785539e052fa8349 # v1.1.1
+      - run: pnpm napi build --target wasm32-wasip1-threads --manifest-path ./napi/parser/Cargo.toml
+      - run: pnpm napi build --target wasm32-wasip1-threads --manifest-path ./napi/transform/Cargo.toml
+      - run: pnpm napi build --target wasm32-wasip1-threads --manifest-path ./napi/minify/Cargo.toml
+      # Fix `index.d.ts`
+      - run: node napi/parser/scripts/fix-wasm-dts.mjs
       - run: cargo test --target wasm32-wasip1-threads ${TEST_FLAGS}
       - run: git diff --exit-code # Must commit everything
 

--- a/napi/parser/scripts/fix-wasm-dts.mjs
+++ b/napi/parser/scripts/fix-wasm-dts.mjs
@@ -1,0 +1,10 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join as pathJoin } from 'node:path';
+
+// Add missing `export * from '@oxc-project/types';` line to `index.d.ts`
+const path = pathJoin(import.meta.dirname, '../index.d.ts');
+let dts = readFileSync(path, 'utf8');
+const lines = dts.split('\n');
+lines.splice(2, 0, '', "export * from '@oxc-project/types';");
+dts = lines.join('\n');
+writeFileSync(path, dts);

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "devDependencies": {
     "@napi-rs/cli": "catalog:",
+    "emnapi": "1.3.1",
     "typescript": "catalog:",
     "vitest": "catalog:"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,10 @@ importers:
     devDependencies:
       '@napi-rs/cli':
         specifier: 'catalog:'
-        version: 3.0.0-alpha.72(@emnapi/runtime@1.3.1)(@types/node@22.13.8)
+        version: 3.0.0-alpha.72(@emnapi/runtime@1.3.1)(@types/node@22.13.8)(emnapi@1.3.1)
+      emnapi:
+        specifier: 1.3.1
+        version: 1.3.1
       typescript:
         specifier: 'catalog:'
         version: 5.8.2
@@ -1905,6 +1908,14 @@ packages:
 
   electron-to-chromium@1.5.109:
     resolution: {integrity: sha512-AidaH9JETVRr9DIPGfp1kAarm/W6hRJTPuCnkF+2MqhF4KaAgRIcBc8nvjk+YMXZhwfISof/7WG29eS4iGxQLQ==}
+
+  emnapi@1.3.1:
+    resolution: {integrity: sha512-8rnw2VLJmHAXBSyhtrL9O5aW1VdbXA1ovRslp0IyTwnM62Fz83jQIo+VaIObgzdo6r1A98J9AHEq4KTqIR67Aw==}
+    peerDependencies:
+      node-addon-api: '>= 6.1.0'
+    peerDependenciesMeta:
+      node-addon-api:
+        optional: true
 
   emoji-regex@10.4.0:
     resolution: {integrity: sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==}
@@ -4054,7 +4065,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@napi-rs/cli@3.0.0-alpha.72(@emnapi/runtime@1.3.1)(@types/node@22.13.8)':
+  '@napi-rs/cli@3.0.0-alpha.72(@emnapi/runtime@1.3.1)(@types/node@22.13.8)(emnapi@1.3.1)':
     dependencies:
       '@inquirer/prompts': 7.3.2(@types/node@22.13.8)
       '@napi-rs/cross-toolchain': 0.0.19
@@ -4071,6 +4082,7 @@ snapshots:
       wasm-sjlj: 1.0.6
     optionalDependencies:
       '@emnapi/runtime': 1.3.1
+      emnapi: 1.3.1
     transitivePeerDependencies:
       - '@napi-rs/cross-toolchain-arm64-target-aarch64'
       - '@napi-rs/cross-toolchain-arm64-target-armv7'
@@ -5135,6 +5147,8 @@ snapshots:
       safe-buffer: 5.2.1
 
   electron-to-chromium@1.5.109: {}
+
+  emnapi@1.3.1: {}
 
   emoji-regex@10.4.0: {}
 


### PR DESCRIPTION
Duplicate of #9555, but just stacked on top of #9566.

`napi-rs` for some reason omits the `export * from '@oxc-project/types';` line from `index.d.ts` when building for WASM.

I don't know how to fix that, so added a hacky script to fix up `index.d.ts` manually. This is not at all ideal, but at least it now compiles and CI passes.