### PR TITLE
fix(rulegen): make finding end of module also work on windows

### DIFF
--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -800,7 +800,7 @@ fn add_rules_entry(ctx: &Context, rule_kind: RuleKind) -> Result<(), Box<dyn std
         return Err(format!("failed to find '{mod_def}' in {rules_path}").into());
     };
     let mod_end = &rules[mod_start..]
-        .find("}\n")
+        .find('}')
         .ok_or(format!("failed to find end of '{mod_def}' module in {rules_path}"))?;
     let mod_rules = &rules[mod_start..(*mod_end + mod_start)];
 


### PR DESCRIPTION
```
> just new-ts-rule class-literal-property-style

Reading test file from https://raw.githubusercontent.com/typescript-eslint/typescript-eslint/main/packages/eslint-plugin/tests/rules/class-literal-property-style.test.ts
File parsed and 31 pass cases, 19 fail cases are found
Saved test file to "crates/oxc_linter/src/rules/typescript\\class_literal_property_style.rs"
failed to add class-literal-property-style to rules file: failed to find end of 'mod typescript' module in crates/oxc_linter/src/rules.rs
```

Running rulegen on Windows fails because it can't find the end of the correct module in crates\oxc_linter\src\rules.rs because it treats "}\n" as the end but on Windows it would be "}\r\n". Replacing the parameter of find with '}' would fix the rulegen tool for Windows users while still behaving the same for all other users.