### PR TITLE
fix(linter): rule `unicorn/escape-case`

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/escape_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/escape_case.rs
@@ -65,7 +65,9 @@ fn check_case(value: &str, is_regex: bool) -> Option<String> {
             match c {
                 'x' if is_hex(&p, 2) => {
                     for _ in 0..2 {
-                        result.push(p.next().unwrap().to_ascii_uppercase());
+                        if let Some(nxt) = p.next() {
+                            result.push(nxt.to_ascii_uppercase());
+                        }
                     }
                 }
                 'u' => {
@@ -88,20 +90,26 @@ fn check_case(value: &str, is_regex: bool) -> Option<String> {
                             p.next();
                             result.push('{');
                             for _ in 0..count {
-                                result.push(p.next().unwrap().to_ascii_uppercase());
+                                if let Some(nxt) = p.next() {
+                                    result.push(nxt.to_ascii_uppercase());
+                                }
                             }
                             p.next();
                             result.push('}');
                         }
                     } else if is_hex(&p, 4) {
                         for _ in 0..4 {
-                            result.push(p.next().unwrap().to_ascii_uppercase());
+                            if let Some(nxt) = p.next() {
+                                result.push(nxt.to_ascii_uppercase());
+                            }
                         }
                     }
                 }
                 'c' if is_regex => {
                     if matches!(p.clone().next(), Some(c) if c.is_ascii_lowercase()) {
-                        result.push(p.next().unwrap().to_ascii_uppercase());
+                        if let Some(nxt) = p.next() {
+                            result.push(nxt.to_ascii_uppercase());
+                        }
                     }
                 }
                 _ => {}

--- a/crates/oxc_linter/src/rules/unicorn/escape_case.rs
+++ b/crates/oxc_linter/src/rules/unicorn/escape_case.rs
@@ -107,9 +107,7 @@ fn check_case(value: &str, is_regex: bool) -> Option<String> {
                 }
                 'c' if is_regex => {
                     if matches!(p.clone().next(), Some(c) if c.is_ascii_lowercase()) {
-                        if let Some(nxt) = p.next() {
-                            result.push(nxt.to_ascii_uppercase());
-                        }
+                        result.push(p.next().unwrap().to_ascii_uppercase());
                     }
                 }
                 _ => {}


### PR DESCRIPTION
Fixes #9583 

Remove the unwraps from the rule so panics cannot happen.