### PR TITLE
docs(linter): Improve the documentation of `eslint-no-func-assign`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
@@ -19,13 +19,46 @@ declare_oxc_lint!(
     /// Disallow reassigning `function` declarations
     ///
     /// ### Why is this bad?
-    /// Overwriting/reassigning a function written as a FunctionDeclaration is often indicative of a mistake or issue.
     ///
-    /// ### Example
+    /// Overwriting/reassigning a function written as a FunctionDeclaration is often indicative of
+    /// a mistake or issue.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
-    ///
     /// function foo() {}
     /// foo = bar;
+    /// ```
+    ///
+    /// ```javascript
+    /// function foo() {
+    ///   foo = bar;
+    /// }
+    /// ```
+    ///
+    /// ```javascript
+    /// let a = function hello() {
+    ///   hello = 123;
+    /// };
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```javascript
+    /// let foo = function () {}
+    /// foo = bar;
+    /// ```
+    ///
+    /// ```javascript
+    /// function baz(baz) { // `baz` is shadowed.
+    ///   baz = bar;
+    /// }
+    /// ```
+    ///
+    /// ```
+    /// function qux() {
+    ///   const qux = bar;  // `qux` is shadowed.
+    /// }
     /// ```
     NoFuncAssign,
     eslint,
@@ -72,6 +105,7 @@ fn test() {
         ("function foo() { [foo] = bar; }", None),
         ("(function() { ({x: foo = 0} = bar); function foo() { }; })();", None),
         ("var a = function foo() { foo = 123; };", None),
+        ("let a = function hello() { hello = 123;};", None)
     ];
 
     Tester::new(NoFuncAssign::NAME, NoFuncAssign::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
@@ -105,7 +105,7 @@ fn test() {
         ("function foo() { [foo] = bar; }", None),
         ("(function() { ({x: foo = 0} = bar); function foo() { }; })();", None),
         ("var a = function foo() { foo = 123; };", None),
-        ("let a = function hello() { hello = 123;};", None)
+        ("let a = function hello() { hello = 123;};", None),
     ];
 
     Tester::new(NoFuncAssign::NAME, NoFuncAssign::PLUGIN, pass, fail).test_and_snapshot();

--- a/crates/oxc_linter/src/snapshots/eslint_no_func_assign.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_func_assign.snap
@@ -56,3 +56,10 @@ source: crates/oxc_linter/src/tester.rs
    ·                          ─┬─
    ·                           ╰── foo is re-assigned here
    ╰────
+
+  ⚠ eslint(no-func-assign): 'hello' is a function.
+   ╭─[no_func_assign.tsx:1:28]
+ 1 │ let a = function hello() { hello = 123;};
+   ·                            ──┬──
+   ·                              ╰── hello is re-assigned here
+   ╰────


### PR DESCRIPTION
Add correctness examples to docs and a single extra test case. 

Relates to #6050 