### PR TITLE
fix(ecmascript): `(foo() + "").length` may have a side effect

### DIFF
--- a/crates/oxc_ecmascript/src/side_effects/may_have_side_effects.rs
+++ b/crates/oxc_ecmascript/src/side_effects/may_have_side_effects.rs
@@ -479,6 +479,10 @@ fn property_access_may_have_side_effects(
     property: &str,
     is_global_reference: &impl IsGlobalReference,
 ) -> bool {
+    if object.may_have_side_effects(is_global_reference) {
+        return true;
+    }
+
     match property {
         "length" => {
             !(matches!(object, Expression::ArrayExpression(_))

--- a/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
+++ b/crates/oxc_minifier/tests/ecmascript/may_have_side_effects.rs
@@ -639,6 +639,7 @@ fn test_property_access() {
     test("[].length", false);
     test("[]['length']", false);
     test("[][`length`]", false);
+    test("(foo() + '').length", true);
 
     test("a[0]", true);
     test("''[-1]", true); // String.prototype[-1] may be overridden


### PR DESCRIPTION
`(foo() + "").length` may have a side effect because `foo()` may have a side effect.