### PR TITLE
docs(linter): Improve the docs and add test case for `typescript-no-extra-non-null-assertion`

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
@@ -122,7 +122,6 @@ fn test() {
 
     let fail = vec![
         "const foo: { bar: number } | null = null; const bar = foo!!!.bar;",
-        "function foo(bar: number | undefined) { const bar: number = bar!!!; }",
         "const foo: { bar: number } | null = null; const bar = foo!!.bar; ",
         "function foo(bar: number | undefined) { const a: number = bar!!; }",
         "function foo(bar?: { n: number }) { return bar!?.n; }",

--- a/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
@@ -22,12 +22,47 @@ declare_oxc_lint!(
     /// Disallow extra non-null assertions.
     ///
     /// ### Why is this bad?
-    /// The `!` non-null assertion operator in TypeScript is used to assert that a value's type does not include null or undefined. Using the operator any more than once on a single value does nothing.
     ///
-    /// ### Example
+    /// The `!` non-null assertion operator in TypeScript is used to assert that a value's type
+    /// does not include null or undefined. Using the operator any more than once on a single value
+    /// does nothing.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```ts
     /// const foo: { bar: number } | null = null;
     /// const bar = foo!!!.bar;
+    /// ```
+    ///
+    /// ```ts
+    /// function foo(bar: number | undefined) {
+    ///   const bar: number = bar!!!;
+    /// }
+    /// ```
+    ///
+    /// ```ts
+    /// function foo(bar?: { n: number }) {
+    ///   return bar!?.n;
+    /// }
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// const foo: { bar: number } | null = null;
+    /// const bar = foo!.bar;
+    /// ```
+    ///
+    /// ```ts
+    /// function foo(bar: number | undefined) {
+    ///  const bar: number = bar!;
+    /// }
+    /// ```
+    ///
+    /// ```ts
+    /// function foo(bar?: { n: number }) {
+    ///   return bar?.n;
+    /// }
     /// ```
     NoExtraNonNullAssertion,
     typescript,

--- a/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_extra_non_null_assertion.rs
@@ -121,6 +121,8 @@ fn test() {
     ];
 
     let fail = vec![
+        "const foo: { bar: number } | null = null; const bar = foo!!!.bar;",
+        "function foo(bar: number | undefined) { const bar: number = bar!!!; }",
         "const foo: { bar: number } | null = null; const bar = foo!!.bar; ",
         "function foo(bar: number | undefined) { const a: number = bar!!; }",
         "function foo(bar?: { n: number }) { return bar!?.n; }",

--- a/crates/oxc_linter/src/snapshots/typescript_no_extra_non_null_assertion.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_extra_non_null_assertion.snap
@@ -2,6 +2,26 @@
 source: crates/oxc_linter/src/tester.rs
 ---
   ⚠ typescript-eslint(no-extra-non-null-assertion): extra non-null assertion
+   ╭─[no_extra_non_null_assertion.tsx:1:59]
+ 1 │ const foo: { bar: number } | null = null; const bar = foo!!!.bar;
+   ·                                                           ▲
+   ╰────
+
+  ⚠ typescript-eslint(no-extra-non-null-assertion): extra non-null assertion
+   ╭─[no_extra_non_null_assertion.tsx:1:58]
+ 1 │ const foo: { bar: number } | null = null; const bar = foo!!!.bar;
+   ·                                                          ▲
+   ╰────
+
+  × Identifier `bar` has already been declared
+   ╭─[no_extra_non_null_assertion.tsx:1:14]
+ 1 │ function foo(bar: number | undefined) { const bar: number = bar!!!; }
+   ·              ───────────┬───────────          ─────┬─────
+   ·                         │                          ╰── It can not be redeclared here
+   ·                         ╰── `bar` has already been declared here
+   ╰────
+
+  ⚠ typescript-eslint(no-extra-non-null-assertion): extra non-null assertion
    ╭─[no_extra_non_null_assertion.tsx:1:58]
  1 │ const foo: { bar: number } | null = null; const bar = foo!!.bar; 
    ·                                                          ▲

--- a/crates/oxc_linter/src/snapshots/typescript_no_extra_non_null_assertion.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_extra_non_null_assertion.snap
@@ -13,14 +13,6 @@ source: crates/oxc_linter/src/tester.rs
    ·                                                          ▲
    ╰────
 
-  × Identifier `bar` has already been declared
-   ╭─[no_extra_non_null_assertion.tsx:1:14]
- 1 │ function foo(bar: number | undefined) { const bar: number = bar!!!; }
-   ·              ───────────┬───────────          ─────┬─────
-   ·                         │                          ╰── It can not be redeclared here
-   ·                         ╰── `bar` has already been declared here
-   ╰────
-
   ⚠ typescript-eslint(no-extra-non-null-assertion): extra non-null assertion
    ╭─[no_extra_non_null_assertion.tsx:1:58]
  1 │ const foo: { bar: number } | null = null; const bar = foo!!.bar; 


### PR DESCRIPTION
- Adds correctness examples to rule docs according to #6050 .
- Adds a missing test case which features in eslint's docs for rule.