### PR TITLE
docs(linter): Better docs for `typescript-no-non-null-asserted-nullish-coalescing` rule

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
@@ -18,6 +18,7 @@ declare_oxc_lint!(
     /// Disallow non-null assertions in the left operand of a nullish coalescing operator.
     ///
     /// ### Why is this bad?
+    ///
     /// The ?? nullish coalescing runtime operator allows providing a default value when dealing
     /// with null or undefined. Using a ! non-null assertion type operator in the left operand of
     /// a nullish coalescing operator is redundant, and likely a sign of programmer error or

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
@@ -18,12 +18,39 @@ declare_oxc_lint!(
     /// Disallow non-null assertions in the left operand of a nullish coalescing operator.
     ///
     /// ### Why is this bad?
-    /// The ?? nullish coalescing runtime operator allows providing a default value when dealing with null or undefined. Using a ! non-null assertion type operator in the left operand of a nullish coalescing operator is redundant, and likely a sign of programmer error or confusion over the two operators.
+    /// The ?? nullish coalescing runtime operator allows providing a default value when dealing
+    /// with null or undefined. Using a ! non-null assertion type operator in the left operand of
+    /// a nullish coalescing operator is redundant, and likely a sign of programmer error or
+    /// confusion over the two operators.
     ///
-    /// ### Example
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```ts
     /// foo! ?? bar;
+    /// foo.bazz! ?? bar;
+    /// foo!.bazz! ?? bar;
+    /// foo()! ?? bar;
     ///
+    /// let x!: string;
+    /// x! ?? '';
+    ///
+    /// let x: string;
+    /// x = foo();
+    /// x! ?? '';
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// foo ?? bar;
+    /// foo ?? bar!;
+    /// foo!.bazz ?? bar;
+    /// foo!.bazz ?? bar!;
+    /// foo() ?? bar;
+    /// ```
+    ///
+    /// ```ts
+    /// // This is considered correct code because there's no way for the user to satisfy it.
     /// let x: string;
     /// x! ?? '';
     /// ```


### PR DESCRIPTION

Document the correctness examples for the rule as well according to #6050 .