### PR TITLE
docs(linter): Improve the documentation of `eslint-no-console`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -28,6 +28,7 @@ pub struct NoConsole(Box<NoConsoleConfig>);
 #[derive(Debug, Default, Clone)]
 pub struct NoConsoleConfig {
     /// ### What it does
+    ///
     /// Disallow the use of console.
     ///
     /// ### Why is this bad?

--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -217,6 +217,7 @@ fn test() {
 
     let fail = vec![
         ("console.log()", None, None),
+        ("(console.log())", None, None),
         ("console.log(foo)", None, None),
         ("console.error(foo)", None, None),
         ("console.info(foo)", None, None),

--- a/crates/oxc_linter/src/rules/eslint/no_console.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_console.rs
@@ -27,12 +27,52 @@ pub struct NoConsole(Box<NoConsoleConfig>);
 
 #[derive(Debug, Default, Clone)]
 pub struct NoConsoleConfig {
-    /// A list of methods allowed to be used.
+    /// ### What it does
+    /// Disallow the use of console.
     ///
+    /// ### Why is this bad?
+    ///
+    /// In JavaScript that is designed to be executed in the browser, it’s considered a best
+    /// practice to avoid using methods on console. Such messages are considered to be for
+    /// debugging purposes and therefore not suitable to ship to the client. In general, calls
+    /// using console should be stripped before being pushed to production.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```javascript
-    /// // allowed: ['info']
-    /// console.log('foo'); // will error
-    /// console.info('bar'); // will not error
+    /// console.log("Log a debug level message.");
+    /// console.warn("Log a warn level message.");
+    /// console.error("Log an error level message.");
+    /// console.log = foo();
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    ///  ```javascript
+    /// // custom console
+    /// Console.log("Hello world!");
+    /// ```
+    ///
+    /// ### Options
+    ///
+    /// ### allow
+    ///
+    /// `{ "allow": string[] }`
+    ///
+    /// The `allow` option permits the given list of console methods to be used as exceptions to
+    /// this rule.
+    ///
+    /// Say the option was configured as `{ "allow": ["info"] }` then the rule would behave as
+    /// follows:
+    ///
+    /// Example of **incorrect** code for this option:
+    /// ```javascript
+    /// console.log('foo');
+    /// ```
+    ///
+    /// Example of **incorrect** code for this option:
+    /// ```javascript
+    /// console.info('foo');
     /// ```
     pub allow: Vec<CompactStr>,
 }

--- a/crates/oxc_linter/src/snapshots/eslint_no_console.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_console.snap
@@ -9,6 +9,13 @@ source: crates/oxc_linter/src/tester.rs
   help: Delete this console statement.
 
   ⚠ eslint(no-console): eslint(no-console): Unexpected console statement.
+   ╭─[no_console.tsx:1:2]
+ 1 │ (console.log())
+   ·  ───────────
+   ╰────
+  help: Delete this console statement.
+
+  ⚠ eslint(no-console): eslint(no-console): Unexpected console statement.
    ╭─[no_console.tsx:1:1]
  1 │ console.log(foo)
    · ───────────


### PR DESCRIPTION
- Add `Why is this bad section`
- Add correctness examples
- Correct the documented option name which is `allow` and not `allowed`
- Add options documentation

Above relates to #6050 

- Also adds the following missing parenthesized test case for `(console.log())`.