### PR TITLE
refactor(semantic)!: rename `SymbolTable` and `ScopeTree` methods

### DIFF
--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -517,7 +517,7 @@ impl<'a> Codegen<'a> {
     fn get_binding_identifier_name(&self, ident: &BindingIdentifier<'a>) -> &'a str {
         if let Some(symbol_table) = &self.symbol_table {
             if let Some(symbol_id) = ident.symbol_id.get() {
-                let name = symbol_table.get_name(symbol_id);
+                let name = symbol_table.symbol_name(symbol_id);
                 // SAFETY: Hack the lifetime to be part of the allocator.
                 return unsafe { std::mem::transmute_copy(&name) };
             }

--- a/crates/oxc_linter/src/ast_util.rs
+++ b/crates/oxc_linter/src/ast_util.rs
@@ -284,7 +284,7 @@ pub fn get_declaration_of_variable<'a, 'b>(
 ) -> Option<&'b AstNode<'a>> {
     let symbol_id = get_symbol_id_of_variable(ident, semantic)?;
     let symbol_table = semantic.symbols();
-    Some(semantic.nodes().get_node(symbol_table.get_declaration(symbol_id)))
+    Some(semantic.nodes().get_node(symbol_table.get_symbol_declaration(symbol_id)))
 }
 
 pub fn get_declaration_from_reference_id<'a, 'b>(
@@ -293,7 +293,7 @@ pub fn get_declaration_from_reference_id<'a, 'b>(
 ) -> Option<&'b AstNode<'a>> {
     let symbol_table = semantic.symbols();
     let symbol_id = symbol_table.get_reference(reference_id).symbol_id()?;
-    Some(semantic.nodes().get_node(symbol_table.get_declaration(symbol_id)))
+    Some(semantic.nodes().get_node(symbol_table.get_symbol_declaration(symbol_id)))
 }
 
 pub fn get_symbol_id_of_variable(
@@ -569,7 +569,7 @@ pub fn could_be_error(ctx: &LintContext, expr: &Expression) -> bool {
             let Some(symbol_id) = reference.symbol_id() else {
                 return true;
             };
-            let decl = ctx.nodes().get_node(ctx.symbols().get_declaration(symbol_id));
+            let decl = ctx.nodes().get_node(ctx.symbols().get_symbol_declaration(symbol_id));
             match decl.kind() {
                 AstKind::VariableDeclarator(decl) => {
                     if let Some(init) = &decl.init {

--- a/crates/oxc_linter/src/rules/eslint/no_alert.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_alert.rs
@@ -66,7 +66,7 @@ fn is_global_this_ref_or_global_window<'a>(
     expr: &Expression<'a>,
 ) -> bool {
     if let Expression::ThisExpression(_) = expr {
-        if ctx.scopes().get_flags(scope_id).is_top() {
+        if ctx.scopes().scope_flags(scope_id).is_top() {
             return true;
         }
     }

--- a/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_class_assign.rs
@@ -37,12 +37,12 @@ declare_oxc_lint!(
 impl Rule for NoClassAssign {
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
         let symbol_table = ctx.semantic().symbols();
-        if symbol_table.get_flags(symbol_id).is_class() {
+        if symbol_table.symbol_flags(symbol_id).is_class() {
             for reference in symbol_table.get_resolved_references(symbol_id) {
                 if reference.is_write() {
                     ctx.diagnostic(no_class_assign_diagnostic(
-                        symbol_table.get_name(symbol_id),
-                        symbol_table.get_span(symbol_id),
+                        symbol_table.symbol_name(symbol_id),
+                        symbol_table.symbol_span(symbol_id),
                         ctx.semantic().reference_span(reference),
                     ));
                 }

--- a/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_const_assign.rs
@@ -53,12 +53,12 @@ declare_oxc_lint!(
 impl Rule for NoConstAssign {
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
         let symbol_table = ctx.semantic().symbols();
-        if symbol_table.get_flags(symbol_id).is_const_variable() {
+        if symbol_table.symbol_flags(symbol_id).is_const_variable() {
             for reference in symbol_table.get_resolved_references(symbol_id) {
                 if reference.is_write() {
                     ctx.diagnostic(no_const_assign_diagnostic(
-                        symbol_table.get_name(symbol_id),
-                        symbol_table.get_span(symbol_id),
+                        symbol_table.symbol_name(symbol_id),
+                        symbol_table.symbol_span(symbol_id),
                         ctx.semantic().reference_span(reference),
                     ));
                 }

--- a/crates/oxc_linter/src/rules/eslint/no_eval.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_eval.rs
@@ -165,13 +165,14 @@ impl Rule for NoEval {
                 let Some((span, name)) = mem_expr.static_property_info() else { return };
 
                 if name == "eval" {
-                    let scope_id = ctx.scopes().ancestors(parent.scope_id()).find(|scope_id| {
-                        let scope_flags = ctx.scopes().get_flags(*scope_id);
-                        scope_flags.is_var() && !scope_flags.is_arrow()
-                    });
+                    let scope_id =
+                        ctx.scopes().scope_ancestors(parent.scope_id()).find(|scope_id| {
+                            let scope_flags = ctx.scopes().scope_flags(*scope_id);
+                            scope_flags.is_var() && !scope_flags.is_arrow()
+                        });
 
                     let scope_id = scope_id.unwrap();
-                    let scope_flags = ctx.scopes().get_flags(scope_id);
+                    let scope_flags = ctx.scopes().scope_flags(scope_id);
 
                     // The `TsModuleBlock` shouldn't be considered
                     if scope_flags.is_ts_module_block() {

--- a/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_ex_assign.rs
@@ -39,7 +39,7 @@ declare_oxc_lint!(
 impl Rule for NoExAssign {
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
         let symbol_table = ctx.semantic().symbols();
-        if symbol_table.get_flags(symbol_id).is_catch_variable() {
+        if symbol_table.symbol_flags(symbol_id).is_catch_variable() {
             for reference in symbol_table.get_resolved_references(symbol_id) {
                 if reference.is_write() {
                     ctx.diagnostic(no_ex_assign_diagnostic(

--- a/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_func_assign.rs
@@ -68,12 +68,12 @@ declare_oxc_lint!(
 impl Rule for NoFuncAssign {
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
         let symbol_table = ctx.semantic().symbols();
-        let decl = symbol_table.get_declaration(symbol_id);
+        let decl = symbol_table.get_symbol_declaration(symbol_id);
         if let AstKind::Function(_) = ctx.nodes().kind(decl) {
             for reference in symbol_table.get_resolved_references(symbol_id) {
                 if reference.is_write() {
                     ctx.diagnostic(no_func_assign_diagnostic(
-                        symbol_table.get_name(symbol_id),
+                        symbol_table.symbol_name(symbol_id),
                         ctx.semantic().reference_span(reference),
                     ));
                 }

--- a/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_import_assign.rs
@@ -53,8 +53,8 @@ const REFLECT_MUTATION_METHODS: phf::Set<&'static str> =
 impl Rule for NoImportAssign {
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
         let symbol_table = ctx.semantic().symbols();
-        if symbol_table.get_flags(symbol_id).is_import() {
-            let kind = ctx.nodes().kind(symbol_table.get_declaration(symbol_id));
+        if symbol_table.symbol_flags(symbol_id).is_import() {
+            let kind = ctx.nodes().kind(symbol_table.get_symbol_declaration(symbol_id));
             let is_namespace_specifier = matches!(kind, AstKind::ImportNamespaceSpecifier(_));
             for reference in symbol_table.get_resolved_references(symbol_id) {
                 if is_namespace_specifier {

--- a/crates/oxc_linter/src/rules/eslint/no_label_var.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_label_var.rs
@@ -66,7 +66,7 @@ impl Rule for NoLabelVar {
         if let Some(symbol_id) =
             ctx.scopes().find_binding(node.scope_id(), &labeled_stmt.label.name)
         {
-            let decl_span = ctx.symbols().get_span(symbol_id);
+            let decl_span = ctx.symbols().symbol_span(symbol_id);
             let label_decl = labeled_stmt.span.start;
             ctx.diagnostic(no_label_var_diagnostic(
                 &labeled_stmt.label.name,

--- a/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
@@ -99,7 +99,7 @@ fn resolve_global_binding<'a, 'b: 'a>(
         return None;
     };
 
-    let decl = nodes.get_node(symbols.get_declaration(binding_id));
+    let decl = nodes.get_node(symbols.get_symbol_declaration(binding_id));
     match decl.kind() {
         AstKind::VariableDeclarator(parent_decl) => {
             if !parent_decl.id.kind.is_binding_identifier() {

--- a/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_redeclare.rs
@@ -62,13 +62,13 @@ impl Rule for NoRedeclare {
 
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext) {
         let symbol_table = ctx.semantic().symbols();
-        let decl_node_id = symbol_table.get_declaration(symbol_id);
+        let decl_node_id = symbol_table.get_symbol_declaration(symbol_id);
         match ctx.nodes().kind(decl_node_id) {
             AstKind::VariableDeclarator(var) => {
                 if let BindingPatternKind::BindingIdentifier(ident) = &var.id.kind {
-                    let symbol_name = symbol_table.get_name(symbol_id);
+                    let symbol_name = symbol_table.symbol_name(symbol_id);
                     if symbol_name == ident.name.as_str() {
-                        for span in ctx.symbols().get_redeclarations(symbol_id) {
+                        for span in ctx.symbols().get_symbol_redeclarations(symbol_id) {
                             self.report_diagnostic(ctx, *span, ident);
                         }
                     }
@@ -76,9 +76,9 @@ impl Rule for NoRedeclare {
             }
             AstKind::FormalParameter(param) => {
                 if let BindingPatternKind::BindingIdentifier(ident) = &param.pattern.kind {
-                    let symbol_name = symbol_table.get_name(symbol_id);
+                    let symbol_name = symbol_table.symbol_name(symbol_id);
                     if symbol_name == ident.name.as_str() {
-                        for span in ctx.symbols().get_redeclarations(symbol_id) {
+                        for span in ctx.symbols().get_symbol_redeclarations(symbol_id) {
                             self.report_diagnostic(ctx, *span, ident);
                         }
                     }

--- a/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_setter_return.rs
@@ -46,8 +46,8 @@ impl Rule for NoSetterReturn {
             return;
         }
 
-        for scope_id in ctx.scopes().ancestors(node.scope_id()) {
-            let flags = ctx.scopes().get_flags(scope_id);
+        for scope_id in ctx.scopes().scope_ancestors(node.scope_id()) {
+            let flags = ctx.scopes().scope_flags(scope_id);
             if flags.is_set_accessor() {
                 ctx.diagnostic(no_setter_return_diagnostic(stmt.span));
             } else if flags.is_function() {

--- a/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
@@ -77,7 +77,7 @@ declare_oxc_lint!(
 
 impl Rule for NoShadowRestrictedNames {
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
-        let name = ctx.symbols().get_name(symbol_id);
+        let name = ctx.symbols().symbol_name(symbol_id);
 
         if !PRE_DEFINE_VAR.contains_key(name) {
             return;
@@ -85,7 +85,7 @@ impl Rule for NoShadowRestrictedNames {
 
         if name == "undefined" {
             // Allow to declare `undefined` variable but not allow to assign value to it.
-            let node_id = ctx.semantic().symbols().get_declaration(symbol_id);
+            let node_id = ctx.semantic().symbols().get_symbol_declaration(symbol_id);
             if let AstKind::VariableDeclarator(declarator) = ctx.nodes().kind(node_id) {
                 if declarator.init.is_none()
                     && ctx
@@ -98,10 +98,10 @@ impl Rule for NoShadowRestrictedNames {
             }
         }
 
-        let span = ctx.symbols().get_span(symbol_id);
+        let span = ctx.symbols().symbol_span(symbol_id);
         ctx.diagnostic(no_shadow_restricted_names_diagnostic(name, span));
 
-        for &span in ctx.symbols().get_redeclarations(symbol_id) {
+        for &span in ctx.symbols().get_symbol_redeclarations(symbol_id) {
             ctx.diagnostic(no_shadow_restricted_names_diagnostic(name, span));
         }
     }

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/allowed.rs
@@ -65,7 +65,7 @@ impl Symbol<'_, '_> {
     pub fn is_in_declared_module(&self) -> bool {
         let scopes = self.scopes();
         let nodes = self.nodes();
-        scopes.ancestors(self.scope_id())
+        scopes.scope_ancestors(self.scope_id())
             .map(|scope_id| scopes.get_node_id(scope_id))
             .map(|node_id| nodes.get_node(node_id))
             .any(|node| matches!(node.kind(), AstKind::TSModuleDeclaration(namespace) if is_ambient_namespace(namespace)))

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/mod.rs
@@ -375,9 +375,9 @@ impl Symbol<'_, '_> {
 
     fn is_in_declare_global(&self) -> bool {
         self.scopes()
-            .ancestors(self.scope_id())
+            .scope_ancestors(self.scope_id())
             .filter(|&scope_id| {
-                let flags = self.scopes().get_flags(scope_id);
+                let flags = self.scopes().scope_flags(scope_id);
                 flags.contains(ScopeFlags::TsModuleBlock)
             })
             .any(|ambient_module_scope_id| {

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/symbol.rs
@@ -37,7 +37,7 @@ impl<'s, 'a> Symbol<'s, 'a> {
         module_record: &'s ModuleRecord,
         symbol_id: SymbolId,
     ) -> Self {
-        let flags = semantic.symbols().get_flags(symbol_id);
+        let flags = semantic.symbols().symbol_flags(symbol_id);
         Self { semantic, module_record, id: symbol_id, flags, span: OnceCell::new() }
     }
 
@@ -48,7 +48,7 @@ impl<'s, 'a> Symbol<'s, 'a> {
 
     #[inline]
     pub fn name(&self) -> &str {
-        self.symbols().get_name(self.id)
+        self.symbols().symbol_name(self.id)
     }
 
     #[inline]
@@ -58,7 +58,7 @@ impl<'s, 'a> Symbol<'s, 'a> {
 
     #[inline]
     pub fn scope_id(&self) -> ScopeId {
-        self.symbols().get_scope_id(self.id)
+        self.symbols().get_symbol_scope_id(self.id)
     }
 
     #[inline]
@@ -80,12 +80,12 @@ impl<'s, 'a> Symbol<'s, 'a> {
 
     /// Is this [`Symbol`] declared in the root scope?
     pub fn is_root(&self) -> bool {
-        self.symbols().get_scope_id(self.id) == self.scopes().root_scope_id()
+        self.symbols().get_symbol_scope_id(self.id) == self.scopes().root_scope_id()
     }
 
     #[inline]
     fn declaration_id(&self) -> NodeId {
-        self.symbols().get_declaration(self.id)
+        self.symbols().get_symbol_declaration(self.id)
     }
 
     #[inline]
@@ -159,13 +159,13 @@ impl<'s, 'a> Symbol<'s, 'a> {
                 _ => break,
             }
         }
-        self.symbols().get_span(self.id)
+        self.symbols().symbol_span(self.id)
     }
 
     /// <https://github.com/oxc-project/oxc/issues/4739>
     fn clean_binding_id(&self, binding: &BindingPattern) -> Span {
         if binding.kind.is_destructuring_pattern() {
-            return self.symbols().get_span(self.id);
+            return self.symbols().symbol_span(self.id);
         }
         let own = binding.kind.span();
         binding.type_annotation.as_ref().map_or(own, |ann| Span::new(own.start, ann.span.start))
@@ -185,7 +185,7 @@ impl<'a> Symbol<'_, 'a> {
 
     #[inline]
     fn is_in_ts_namespace(&self) -> bool {
-        self.scopes().get_flags(self.scope_id()).is_ts_module_block()
+        self.scopes().scope_flags(self.scope_id()).is_ts_module_block()
     }
 
     /// We need to do this due to limitations of [`Semantic`].

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
@@ -692,7 +692,7 @@ impl<'a> Symbol<'_, 'a> {
             return false;
         }
 
-        for scope_id in self.scopes().ancestors(call_scope_id) {
+        for scope_id in self.scopes().scope_ancestors(call_scope_id) {
             if scope_id == container_id {
                 return true;
             } else if scope_id == decl_scope_id {

--- a/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
+++ b/crates/oxc_linter/src/rules/jest/no_confusing_set_timeout.rs
@@ -185,7 +185,7 @@ fn handle_jest_set_time_out<'a>(
         };
 
         if expr.property.name == "setTimeout" {
-            if !scopes.get_flags(parent_node.scope_id()).is_top() {
+            if !scopes.scope_flags(parent_node.scope_id()).is_top() {
                 ctx.diagnostic(no_global_set_timeout_diagnostic(member_expr.span()));
             }
 

--- a/crates/oxc_linter/src/rules/jest/prefer_lowercase_title/mod.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_lowercase_title/mod.rs
@@ -219,7 +219,7 @@ impl Rule for PreferLowercaseTitle {
         }
 
         if matches!(jest_fn_call.kind, JestFnKind::General(JestGeneralFnKind::Describe)) {
-            if self.ignore_top_level_describe && scopes.get_flags(node.scope_id()).is_top() {
+            if self.ignore_top_level_describe && scopes.scope_flags(node.scope_id()).is_top() {
                 return;
             }
         } else if !matches!(

--- a/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
+++ b/crates/oxc_linter/src/rules/jest/require_top_level_describe.rs
@@ -142,7 +142,7 @@ impl RequireTopLevelDescribe {
     ) {
         let node = possible_jest_node.node;
         let scopes = ctx.scopes();
-        let is_top = scopes.get_flags(node.scope_id()).is_top();
+        let is_top = scopes.scope_flags(node.scope_id()).is_top();
 
         let AstKind::CallExpression(call_expr) = node.kind() else {
             return;

--- a/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
+++ b/crates/oxc_linter/src/rules/nextjs/no_duplicate_head.rs
@@ -48,17 +48,17 @@ declare_oxc_lint!(
 impl Rule for NoDuplicateHead {
     fn run_on_symbol(&self, symbol_id: oxc_semantic::SymbolId, ctx: &LintContext<'_>) {
         let symbols = ctx.symbols();
-        let name = symbols.get_name(symbol_id);
+        let name = symbols.symbol_name(symbol_id);
         if name != "Head" {
             return;
         }
 
-        let flags = symbols.get_flags(symbol_id);
+        let flags = symbols.symbol_flags(symbol_id);
         if !flags.is_import() {
             return;
         }
 
-        let scope_id = symbols.get_scope_id(symbol_id);
+        let scope_id = symbols.get_symbol_scope_id(symbol_id);
         if scope_id != ctx.scopes().root_scope_id() {
             return;
         }

--- a/crates/oxc_linter/src/rules/oxc/no_accumulating_spread.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_accumulating_spread.rs
@@ -140,7 +140,7 @@ impl Rule for NoAccumulatingSpread {
         let Some(referenced_symbol_id) = reference.symbol_id() else {
             return;
         };
-        let declaration_id = symbols.get_declaration(referenced_symbol_id);
+        let declaration_id = symbols.get_symbol_declaration(referenced_symbol_id);
         let Some(declaration) = ctx.semantic().nodes().parent_node(declaration_id) else {
             return;
         };

--- a/crates/oxc_linter/src/rules/oxc/no_async_endpoint_handlers.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_async_endpoint_handlers.rs
@@ -219,12 +219,12 @@ impl NoAsyncEndpointHandlers {
                 };
 
                 // Cannot check imported handlers without cross-file analysis.
-                let flags = ctx.symbols().get_flags(symbol_id);
+                let flags = ctx.symbols().symbol_flags(symbol_id);
                 if flags.is_import() {
                     return;
                 }
 
-                let decl_id = ctx.symbols().get_declaration(symbol_id);
+                let decl_id = ctx.symbols().get_symbol_declaration(symbol_id);
                 let decl_node = ctx.nodes().get_node(decl_id);
                 let registered_at = registered_at.or(Some(handler.span));
                 match decl_node.kind() {

--- a/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
@@ -423,7 +423,7 @@ impl NoMapSpread {
         }
 
         if self.ignore_args {
-            let declaration = ctx.nodes().get_node(ctx.symbols().get_declaration(symbol_id));
+            let declaration = ctx.nodes().get_node(ctx.symbols().get_symbol_declaration(symbol_id));
             if matches!(declaration.kind(), AstKind::FormalParameter(_)) {
                 return true;
             }
@@ -677,13 +677,13 @@ where
                 else {
                     return;
                 };
-                let declaration_scope = self.ctx.symbols().get_scope_id(symbol_id);
+                let declaration_scope = self.ctx.symbols().get_symbol_scope_id(symbol_id);
 
                 // symbol is not declared within the mapper callback
                 if !self
                     .ctx
                     .scopes()
-                    .ancestors(declaration_scope)
+                    .scope_ancestors(declaration_scope)
                     .any(|parent_id| parent_id == self.cb_scope_id)
                 {
                     return;
@@ -691,7 +691,7 @@ where
 
                 // walk the declaration
                 let declaration_node =
-                    self.ctx.nodes().get_node(self.ctx.symbols().get_declaration(symbol_id));
+                    self.ctx.nodes().get_node(self.ctx.symbols().get_symbol_declaration(symbol_id));
                 self.visit_kind(declaration_node.kind());
             }
             _ => {}

--- a/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
@@ -477,11 +477,11 @@ impl Rule for ExhaustiveDeps {
 
         for dependency in &declared_dependencies {
             if let Some(symbol_id) = dependency.symbol_id {
-                let dependency_scope_id = ctx.semantic().symbols().get_scope_id(symbol_id);
+                let dependency_scope_id = ctx.semantic().symbols().get_symbol_scope_id(symbol_id);
                 if !(ctx
                     .semantic()
                     .scopes()
-                    .ancestors(component_scope_id)
+                    .scope_ancestors(component_scope_id)
                     .skip(1)
                     .contains(&dependency_scope_id)
                     || dependency.chain.len() == 1 && dependency.chain[0] == "current")
@@ -794,7 +794,11 @@ fn is_identifier_a_dependency<'a>(
     //   return <div />;
     // }
     // ```
-    if scopes.ancestors(component_scope_id).skip(1).any(|parent| parent == declaration.scope_id()) {
+    if scopes
+        .scope_ancestors(component_scope_id)
+        .skip(1)
+        .any(|parent| parent == declaration.scope_id())
+    {
         return false;
     }
 
@@ -807,7 +811,7 @@ fn is_identifier_a_dependency<'a>(
     //   }, []);
     //  return <div />;
     // }
-    if scopes.iter_all_child_ids(component_scope_id).any(|id| id == declaration.scope_id()) {
+    if scopes.iter_all_scope_child_ids(component_scope_id).any(|id| id == declaration.scope_id()) {
         return false;
     }
 

--- a/crates/oxc_linter/src/rules/react/no_render_return_value.rs
+++ b/crates/oxc_linter/src/rules/react/no_render_return_value.rs
@@ -74,7 +74,7 @@ impl Rule for NoRenderReturnValue {
                         }
 
                         let scope_id = parent_node.scope_id();
-                        if ctx.scopes().get_flags(scope_id).is_arrow() {
+                        if ctx.scopes().scope_flags(scope_id).is_arrow() {
                             if let AstKind::ArrowFunctionExpression(e) =
                                 ctx.nodes().kind(ctx.scopes().get_node_id(scope_id))
                             {

--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_nullish_coalescing.rs
@@ -98,7 +98,7 @@ fn has_assignment_before_node(
         }
     }
 
-    let declaration_id = symbol_table.get_declaration(symbol_id);
+    let declaration_id = symbol_table.get_symbol_declaration(symbol_id);
     let AstKind::VariableDeclarator(decl) = ctx.nodes().kind(declaration_id) else {
         return false;
     };

--- a/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unsafe_declaration_merging.rs
@@ -83,7 +83,7 @@ fn check_and_diagnostic(
 }
 
 fn get_symbol_kind<'a>(symbol_id: SymbolId, ctx: &LintContext<'a>) -> AstKind<'a> {
-    ctx.nodes().get_node(ctx.symbols().get_declaration(symbol_id)).kind()
+    ctx.nodes().get_node(ctx.symbols().get_symbol_declaration(symbol_id)).kind()
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/unicorn/consistent_existence_index_check.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_existence_index_check.rs
@@ -91,7 +91,7 @@ impl Rule for ConsistentExistenceIndexCheck {
             return;
         };
 
-        let declaration_node_id = ctx.symbols().get_declaration(symbol_id);
+        let declaration_node_id = ctx.symbols().get_symbol_declaration(symbol_id);
         let node = ctx.nodes().get_node(declaration_node_id);
 
         if let AstKind::VariableDeclarator(variables_declarator) = node.kind() {

--- a/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
@@ -153,7 +153,7 @@ impl Rule for ConsistentFunctionScoping {
                     }
 
                     let func_scope_id = function.scope_id();
-                    if let Some(parent_scope_id) = ctx.scopes().get_parent_id(func_scope_id) {
+                    if let Some(parent_scope_id) = ctx.scopes().get_scope_parent_id(func_scope_id) {
                         // Example: const foo = function bar() {};
                         // The bar function scope id is 1. In order to ignore this rule,
                         // its parent's scope id (in this case `foo`'s scope id is 0 and is equal to root scope id)
@@ -193,7 +193,7 @@ impl Rule for ConsistentFunctionScoping {
             };
 
         // if the function is declared at the root scope, we don't need to check anything
-        if ctx.symbols().get_scope_id(function_declaration_symbol_id)
+        if ctx.symbols().get_symbol_scope_id(function_declaration_symbol_id)
             == ctx.scopes().root_scope_id()
         {
             return;
@@ -222,10 +222,11 @@ impl Rule for ConsistentFunctionScoping {
         }
 
         let parent_scope_ids = {
-            let mut current_scope_id = ctx.symbols().get_scope_id(function_declaration_symbol_id);
+            let mut current_scope_id =
+                ctx.symbols().get_symbol_scope_id(function_declaration_symbol_id);
             let mut parent_scope_ids = FxHashSet::default();
             parent_scope_ids.insert(current_scope_id);
-            while let Some(parent_scope_id) = ctx.scopes().get_parent_id(current_scope_id) {
+            while let Some(parent_scope_id) = ctx.scopes().get_scope_parent_id(current_scope_id) {
                 parent_scope_ids.insert(parent_scope_id);
                 current_scope_id = parent_scope_id;
             }
@@ -235,7 +236,7 @@ impl Rule for ConsistentFunctionScoping {
         for reference_id in function_body_var_references {
             let reference = ctx.symbols().get_reference(reference_id);
             let Some(symbol_id) = reference.symbol_id() else { continue };
-            let scope_id = ctx.symbols().get_scope_id(symbol_id);
+            let scope_id = ctx.symbols().get_symbol_scope_id(symbol_id);
             if parent_scope_ids.contains(&scope_id) && symbol_id != function_declaration_symbol_id {
                 return;
             }

--- a/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_invalid_fetch_options.rs
@@ -130,7 +130,7 @@ fn is_invalid_fetch_options<'a>(
                     let reference = symbols.get_reference(reference_id);
 
                     if let Some(symbol_id) = reference.symbol_id() {
-                        if ctx.symbols().get_flags(symbol_id).is_enum() {
+                        if ctx.symbols().symbol_flags(symbol_id).is_enum() {
                             let decl = ctx.semantic().symbol_declaration(symbol_id);
                             let enum_member_res: Option<CompactStr> = match decl.kind() {
                                 AstKind::TSEnumDeclaration(enum_decl) => {
@@ -169,7 +169,8 @@ fn is_invalid_fetch_options<'a>(
                         continue;
                     };
 
-                    let decl = ctx.semantic().nodes().get_node(symbols.get_declaration(symbol_id));
+                    let decl =
+                        ctx.semantic().nodes().get_node(symbols.get_symbol_declaration(symbol_id));
 
                     match decl.kind() {
                         AstKind::VariableDeclarator(declarator) => match &declarator.init {

--- a/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_thenable.rs
@@ -239,7 +239,8 @@ fn check_expression(expr: &Expression, ctx: &LintContext<'_>) -> Option<oxc_span
             let symbols = ctx.semantic().symbols();
             let reference_id = ident.reference_id();
             symbols.get_reference(reference_id).symbol_id().and_then(|symbol_id| {
-                let decl = ctx.semantic().nodes().get_node(symbols.get_declaration(symbol_id));
+                let decl =
+                    ctx.semantic().nodes().get_node(symbols.get_symbol_declaration(symbol_id));
                 let var_decl = decl.kind().as_variable_declarator()?;
 
                 match &var_decl.init {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_spread.rs
@@ -212,7 +212,7 @@ fn is_not_array(expr: &Expression, ctx: &LintContext) -> bool {
         Expression::Identifier(ident) => {
             if let Some(symbol_id) = ast_util::get_symbol_id_of_variable(ident, ctx) {
                 let symbol_table = ctx.semantic().symbols();
-                let node = ctx.nodes().get_node(symbol_table.get_declaration(symbol_id));
+                let node = ctx.nodes().get_node(symbol_table.get_symbol_declaration(symbol_id));
 
                 if let AstKind::VariableDeclarator(variable_declarator) = node.kind() {
                     if let Some(ref_expr) = &variable_declarator.init {

--- a/crates/oxc_linter/src/utils/jest.rs
+++ b/crates/oxc_linter/src/utils/jest.rs
@@ -211,14 +211,14 @@ fn collect_ids_referenced_to_import<'a, 'c>(
         .enumerate()
         .filter_map(|(symbol_id, reference_ids)| {
             let symbol_id = SymbolId::from_usize(symbol_id);
-            if semantic.symbols().get_flags(symbol_id).is_import() {
-                let id = semantic.symbols().get_declaration(symbol_id);
+            if semantic.symbols().symbol_flags(symbol_id).is_import() {
+                let id = semantic.symbols().get_symbol_declaration(symbol_id);
                 let Some(AstKind::ImportDeclaration(import_decl)) =
                     semantic.nodes().parent_kind(id)
                 else {
                     return None;
                 };
-                let name = semantic.symbols().get_name(symbol_id);
+                let name = semantic.symbols().symbol_name(symbol_id);
 
                 if matches!(import_decl.source.value.as_str(), "@jest/globals" | "vitest") {
                     let original = find_original_name(import_decl, name);

--- a/crates/oxc_linter/src/utils/react_perf.rs
+++ b/crates/oxc_linter/src/utils/react_perf.rs
@@ -100,11 +100,12 @@ where
         // Symbols declared at the root scope won't (or, at least, shouldn't) be
         // re-assigned inside component render functions, so we can safely
         // ignore them.
-        if ctx.symbols().get_scope_id(symbol_id) == ctx.scopes().root_scope_id() {
+        if ctx.symbols().get_symbol_scope_id(symbol_id) == ctx.scopes().root_scope_id() {
             return;
         }
 
-        let declaration_node = ctx.nodes().get_node(ctx.symbols().get_declaration(symbol_id));
+        let declaration_node =
+            ctx.nodes().get_node(ctx.symbols().get_symbol_declaration(symbol_id));
         if let Some((decl_span, init_span)) =
             self.check_for_violation_on_ast_kind(&declaration_node.kind(), symbol_id)
         {

--- a/crates/oxc_minifier/src/peephole/minimize_if_statement.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_if_statement.rs
@@ -128,7 +128,7 @@ impl<'a> PeepholeOptimizations {
     fn wrap_to_avoid_ambiguous_else(&mut self, if_stmt: &mut IfStatement<'a>, ctx: Ctx<'a, '_>) {
         if let Statement::IfStatement(if2) = &mut if_stmt.consequent {
             if if2.consequent.is_jump_statement() && if2.alternate.is_some() {
-                let scope_id = ScopeId::new(ctx.scoping.scopes().len() as u32);
+                let scope_id = ScopeId::new(ctx.scoping.scopes().scopes_len() as u32);
                 if_stmt.consequent = Statement::BlockStatement(ctx.ast.alloc(
                     ctx.ast.block_statement_with_scope_id(
                         if_stmt.consequent.span(),

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -514,7 +514,7 @@ impl<'a> PeepholeOptimizations {
                     let consequent = if body.len() == 1 {
                         body.remove(0)
                     } else {
-                        let scope_id = ScopeId::new(ctx.scopes().len() as u32);
+                        let scope_id = ScopeId::new(ctx.scopes().scopes_len() as u32);
                         let block_stmt =
                             ctx.ast.block_statement_with_scope_id(span, body, scope_id);
                         Statement::BlockStatement(ctx.ast.alloc(block_stmt))

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -45,8 +45,8 @@ impl<'a> Binder<'a> for VariableDeclarator<'a> {
             let mut var_scope_ids = vec![];
 
             // Collect all scopes where variable hoisting can occur
-            for scope_id in builder.scope.ancestors(target_scope_id) {
-                let flags = builder.scope.get_flags(scope_id);
+            for scope_id in builder.scope.scope_ancestors(target_scope_id) {
+                let flags = builder.scope.scope_flags(scope_id);
                 if flags.is_var() {
                     target_scope_id = scope_id;
                     break;
@@ -70,7 +70,7 @@ impl<'a> Binder<'a> for VariableDeclarator<'a> {
                         // avoid same symbols appear in multi-scopes
                         builder.scope.remove_binding(scope_id, &name);
                         builder.scope.add_binding(target_scope_id, &name, symbol_id);
-                        builder.symbols.scope_ids[symbol_id] = target_scope_id;
+                        builder.symbols.symbol_scope_ids[symbol_id] = target_scope_id;
                         break;
                     }
                 }
@@ -215,7 +215,7 @@ impl<'a> Binder<'a> for Function<'a> {
         if let Some(AstKind::ObjectProperty(prop)) =
             builder.nodes.parent_kind(builder.current_node_id)
         {
-            let flags = builder.scope.get_flags_mut(current_scope_id);
+            let flags = builder.scope.scope_flags_mut(current_scope_id);
             match prop.kind {
                 PropertyKind::Get => *flags |= ScopeFlags::GetAccessor,
                 PropertyKind::Set => *flags |= ScopeFlags::SetAccessor,
@@ -445,8 +445,8 @@ impl<'a> Binder<'a> for TSTypeParameter<'a> {
         ) {
             builder
                 .scope
-                .ancestors(builder.current_scope_id)
-                .find(|scope_id| builder.scope.get_flags(*scope_id).is_ts_conditional())
+                .scope_ancestors(builder.current_scope_id)
+                .find(|scope_id| builder.scope.scope_flags(*scope_id).is_ts_conditional())
         } else {
             None
         };

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -80,7 +80,7 @@ pub fn check_identifier<'a>(name: &str, span: Span, node: &AstNode<'a>, ctx: &Se
             return ctx.error(reserved_keyword(name, span));
         }
         // It is a Syntax Error if ClassStaticBlockStatementList Contains await is true.
-        if ctx.scope.get_flags(node.scope_id()).is_class_static_block() {
+        if ctx.scope.scope_flags(node.scope_id()).is_class_static_block() {
             return ctx.error(class_static_block_await(span));
         }
     }
@@ -382,8 +382,8 @@ pub fn check_meta_property<'a>(prop: &MetaProperty, node: &AstNode<'a>, ctx: &Se
         "new" => {
             if prop.property.name == "target" {
                 let mut in_function_scope = false;
-                for scope_id in ctx.scope.ancestors(node.scope_id()) {
-                    let flags = ctx.scope.get_flags(scope_id);
+                for scope_id in ctx.scope.scope_ancestors(node.scope_id()) {
+                    let flags = ctx.scope.scope_flags(scope_id);
                     // In arrow functions, new.target is inherited from the surrounding scope.
                     if flags.contains(ScopeFlags::Arrow) {
                         continue;
@@ -765,8 +765,8 @@ pub fn check_super<'a>(sup: &Super, node: &AstNode<'a>, ctx: &SemanticBuilder<'a
     };
 
     let Some(class_id) = ctx.class_table_builder.current_class_id else {
-        for scope_id in ctx.scope.ancestors(ctx.current_scope_id) {
-            let flags = ctx.scope.get_flags(scope_id);
+        for scope_id in ctx.scope.scope_ancestors(ctx.current_scope_id) {
+            let flags = ctx.scope.scope_flags(scope_id);
             if flags.is_function()
                 && matches!(
                     ctx.nodes.parent_kind(ctx.scope.get_node_id(scope_id)),
@@ -794,8 +794,8 @@ pub fn check_super<'a>(sup: &Super, node: &AstNode<'a>, ctx: &SemanticBuilder<'a
     let AstKind::Class(class) = ctx.nodes.kind(class_node_id) else { unreachable!() };
     let class_scope_id = class.scope_id();
 
-    for scope_id in ctx.scope.ancestors(ctx.current_scope_id) {
-        let flags = ctx.scope.get_flags(scope_id);
+    for scope_id in ctx.scope.scope_ancestors(ctx.current_scope_id) {
+        let flags = ctx.scope.scope_flags(scope_id);
 
         if flags.intersects(ScopeFlags::Constructor) {
             // ClassTail : ClassHeritageopt { ClassBody }
@@ -1051,7 +1051,7 @@ pub fn check_await_expression<'a>(
         ctx.error(await_or_yield_in_parameter("await", expr.span));
     }
     // It is a Syntax Error if ClassStaticBlockStatementList Contains await is true.
-    if ctx.scope.get_flags(node.scope_id()).is_class_static_block() {
+    if ctx.scope.scope_flags(node.scope_id()).is_class_static_block() {
         let start = expr.span.start;
         ctx.error(class_static_block_await(Span::new(start, start + 5)));
     }

--- a/crates/oxc_semantic/src/lib.rs
+++ b/crates/oxc_semantic/src/lib.rs
@@ -193,8 +193,8 @@ impl<'a> Semantic<'a> {
         #[expect(clippy::cast_possible_truncation)]
         Stats::new(
             self.nodes.len() as u32,
-            self.scopes.len() as u32,
-            self.symbols.len() as u32,
+            self.scopes.scopes_len() as u32,
+            self.symbols.symbols_len() as u32,
             self.symbols.references.len() as u32,
         )
     }
@@ -209,7 +209,7 @@ impl<'a> Semantic<'a> {
 
     /// Find which scope a symbol is declared in
     pub fn symbol_scope(&self, symbol_id: SymbolId) -> ScopeId {
-        self.symbols.get_scope_id(symbol_id)
+        self.symbols.get_symbol_scope_id(symbol_id)
     }
 
     /// Get all resolved references for a symbol
@@ -221,7 +221,7 @@ impl<'a> Semantic<'a> {
     }
 
     pub fn symbol_declaration(&self, symbol_id: SymbolId) -> &AstNode<'a> {
-        self.nodes.get_node(self.symbols.get_declaration(symbol_id))
+        self.nodes.get_node(self.symbols.get_symbol_declaration(symbol_id))
     }
 
     pub fn is_reference_to_global_variable(&self, ident: &IdentifierReference) -> bool {

--- a/crates/oxc_semantic/tests/conformance/test_symbol_declaration.rs
+++ b/crates/oxc_semantic/tests/conformance/test_symbol_declaration.rs
@@ -75,9 +75,9 @@ impl ConformanceTest for SymbolDeclarationTest {
         symbol_id: oxc_semantic::SymbolId,
         semantic: &Semantic<'_>,
     ) -> TestResult {
-        let declaration_id = semantic.symbols().get_declaration(symbol_id);
+        let declaration_id = semantic.symbols().get_symbol_declaration(symbol_id);
         let declaration = semantic.nodes().get_node(declaration_id);
-        let span = semantic.symbols().get_span(symbol_id);
+        let span = semantic.symbols().symbol_span(symbol_id);
 
         match declaration.kind() {
             AstKind::VariableDeclarator(decl) => check_binding_pattern(symbol_id, &decl.id),

--- a/crates/oxc_semantic/tests/integration/scopes.rs
+++ b/crates/oxc_semantic/tests/integration/scopes.rs
@@ -13,8 +13,8 @@ fn test_only_program() {
     let root = semantic.scopes().root_scope_id();
 
     // ScopeTree contains a single root scope
-    assert_eq!(scopes.len(), 1);
-    assert!(!scopes.is_empty());
+    assert_eq!(scopes.scopes_len(), 1);
+    assert!(!scopes.scopes_is_empty());
 
     // Root scope is associated with the Program
     let root_node_id = scopes.get_node_id(root);
@@ -22,8 +22,8 @@ fn test_only_program() {
     assert!(matches!(root_node.kind(), AstKind::Program(_)));
 
     // ancestors
-    assert_eq!(scopes.ancestors(root).count(), 1);
-    assert!(scopes.get_parent_id(root).is_none());
+    assert_eq!(scopes.scope_ancestors(root).count(), 1);
+    assert!(scopes.get_scope_parent_id(root).is_none());
 }
 
 #[test]
@@ -101,10 +101,10 @@ fn test_function_level_strict() {
         .is_in_scope(ScopeFlags::StrictMode | ScopeFlags::Function)
         .expect(|(semantic, symbol_id)| -> Result<(), &'static str> {
             let scope_id = semantic.symbol_scope(symbol_id);
-            let Some(parent_scope_id) = semantic.scopes().get_parent_id(scope_id) else {
+            let Some(parent_scope_id) = semantic.scopes().get_scope_parent_id(scope_id) else {
                 return Err("Expected x's scope to have a parent");
             };
-            let parent_flags = semantic.scopes().get_flags(parent_scope_id);
+            let parent_flags = semantic.scopes().scope_flags(parent_scope_id);
             if parent_flags.contains(ScopeFlags::Top) {
                 Ok(())
             } else {
@@ -236,9 +236,9 @@ fn get_child_ids() {
     let scoping = semantic.into_scoping();
     let scopes = scoping.scopes();
 
-    let child_scope_ids = scopes.get_child_ids(scopes.root_scope_id());
+    let child_scope_ids = scopes.get_scope_child_ids(scopes.root_scope_id());
     assert_eq!(child_scope_ids.len(), 1);
-    let child_scope_ids = scopes.get_child_ids(child_scope_ids[0]);
+    let child_scope_ids = scopes.get_scope_child_ids(child_scope_ids[0]);
     assert!(child_scope_ids.is_empty());
 }
 
@@ -270,7 +270,7 @@ fn test_eval() {
     for code in direct_evals {
         let tester = SemanticTester::js(code);
         let semantic = tester.build();
-        assert!(semantic.scopes().root_flags().contains_direct_eval());
+        assert!(semantic.scopes().root_scope_flags().contains_direct_eval());
     }
 
     let indirect_evals = [
@@ -282,6 +282,6 @@ fn test_eval() {
     for code in indirect_evals {
         let tester = SemanticTester::js(code);
         let semantic = tester.build();
-        assert!(!semantic.scopes().root_flags().contains_direct_eval());
+        assert!(!semantic.scopes().root_scope_flags().contains_direct_eval());
     }
 }

--- a/crates/oxc_semantic/tests/integration/symbols.rs
+++ b/crates/oxc_semantic/tests/integration/symbols.rs
@@ -430,7 +430,7 @@ fn test_module_like_declarations() {
 
     let test = SemanticTester::ts("declare global { interface Window { x: number; } }");
     let semantic = test.build();
-    let global = semantic.symbols().names().find(|name| *name == "global");
+    let global = semantic.symbols().symbol_names().find(|name| *name == "global");
     assert!(
         global.is_none(),
         "A symbol should not be created for global augmentation declarations."

--- a/crates/oxc_semantic/tests/integration/util/symbol_tester.rs
+++ b/crates/oxc_semantic/tests/integration/util/symbol_tester.rs
@@ -120,7 +120,7 @@ impl<'a> SymbolTester<'a> {
     pub fn contains_flags(mut self, flags: SymbolFlags) -> Self {
         self.test_result = match self.test_result {
             Ok(symbol_id) => {
-                let found_flags = self.semantic.symbols().get_flags(symbol_id);
+                let found_flags = self.semantic.symbols().symbol_flags(symbol_id);
                 if found_flags.contains(flags) {
                     Ok(symbol_id)
                 } else {
@@ -138,7 +138,7 @@ impl<'a> SymbolTester<'a> {
     pub fn intersects_flags(mut self, flags: SymbolFlags) -> Self {
         self.test_result = match self.test_result {
             Ok(symbol_id) => {
-                let found_flags = self.semantic.symbols().get_flags(symbol_id);
+                let found_flags = self.semantic.symbols().symbol_flags(symbol_id);
                 if found_flags.intersects(flags) {
                     Ok(symbol_id)
                 } else {
@@ -204,7 +204,7 @@ impl<'a> SymbolTester<'a> {
         self.test_result = match self.test_result {
             Ok(symbol_id) => {
                 let scope_id = self.semantic.symbol_scope(symbol_id);
-                let scope_flags = self.semantic.scopes().get_flags(scope_id);
+                let scope_flags = self.semantic.scopes().scope_flags(scope_id);
                 if scope_flags.contains(expected_flags) {
                     Ok(symbol_id)
                 } else {
@@ -223,7 +223,7 @@ impl<'a> SymbolTester<'a> {
         self.test_result = match self.test_result {
             Ok(symbol_id) => {
                 let scope_id = self.semantic.symbol_scope(symbol_id);
-                let scope_flags = self.semantic.scopes().get_flags(scope_id);
+                let scope_flags = self.semantic.scopes().scope_flags(scope_id);
                 if scope_flags.contains(excluded_flags) {
                     Err(OxcDiagnostic::error(format!(
                         "Binding {target_name} is in a scope with excluded flags.\n\tExpected: not {excluded_flags:?}\n\tActual: {scope_flags:?}"

--- a/crates/oxc_semantic/tests/main.rs
+++ b/crates/oxc_semantic/tests/main.rs
@@ -24,13 +24,13 @@ fn get_scope_snapshot(semantic: &Semantic, scopes: impl Iterator<Item = ScopeId>
         if index != 0 {
             result.push(',');
         }
-        let flags = scope_tree.get_flags(scope_id);
+        let flags = scope_tree.scope_flags(scope_id);
         result.push('{');
         let child_ids = semantic
             .scopes()
-            .descendants_from_root()
+            .scope_descendants_from_root()
             .filter(|id| {
-                scope_tree.get_parent_id(*id).is_some_and(|parent_id| parent_id == scope_id)
+                scope_tree.get_scope_parent_id(*id).is_some_and(|parent_id| parent_id == scope_id)
             })
             .collect::<Vec<_>>();
         result.push_str("\"children\":");
@@ -55,7 +55,8 @@ fn get_scope_snapshot(semantic: &Semantic, scopes: impl Iterator<Item = ScopeId>
             }
             result.push('{');
             result.push_str(
-                format!("\"flags\": \"{:?}\",", semantic.symbols().get_flags(symbol_id)).as_str(),
+                format!("\"flags\": \"{:?}\",", semantic.symbols().symbol_flags(symbol_id))
+                    .as_str(),
             );
             result.push_str(format!("\"id\": {},", symbol_id.index()).as_str());
             result.push_str(format!("\"name\": {name:?},").as_str());
@@ -64,7 +65,7 @@ fn get_scope_snapshot(semantic: &Semantic, scopes: impl Iterator<Item = ScopeId>
                     "\"node\": {:?},",
                     semantic
                         .nodes()
-                        .kind(semantic.symbols().get_declaration(symbol_id))
+                        .kind(semantic.symbols().get_symbol_declaration(symbol_id))
                         .debug_name()
                 )
                 .as_str(),

--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -399,7 +399,7 @@ impl<'a> LegacyDecorator<'a, '_> {
             let old_class_symbol_id = ident.symbol_id.replace(Some(new_class_binding.symbol_id));
             let old_class_symbol_id = old_class_symbol_id.expect("class always has a symbol id");
 
-            *ctx.symbols_mut().get_flags_mut(old_class_symbol_id) =
+            *ctx.symbols_mut().symbol_flags_mut(old_class_symbol_id) =
                 SymbolFlags::BlockScopedVariable;
             BoundIdentifier::new(ident.name, old_class_symbol_id)
         });

--- a/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
+++ b/crates/oxc_transformer/src/es2018/async_generator_functions/for_await.rs
@@ -323,7 +323,7 @@ impl<'a> AsyncGeneratorFunctions<'a, '_> {
                     // Handle the for-of statement move to the body of new for-statement
                     let for_statement_body_scope_id = for_of_scope_id;
                     {
-                        ctx.scopes_mut().change_parent_id(
+                        ctx.scopes_mut().change_scope_parent_id(
                             for_statement_body_scope_id,
                             Some(for_statement_scope_id),
                         );

--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -579,7 +579,7 @@ impl<'a> ObjectRestSpread<'a, '_> {
             // Remove `SymbolFlags::CatchVariable`.
             param.pattern.bound_names(&mut |ident| {
                 ctx.symbols_mut()
-                    .get_flags_mut(ident.symbol_id())
+                    .symbol_flags_mut(ident.symbol_id())
                     .remove(SymbolFlags::CatchVariable);
             });
             Self::replace_rest_element(
@@ -616,7 +616,7 @@ impl<'a> ObjectRestSpread<'a, '_> {
                 );
                 // Move the bindings from the for init scope to scope of the loop body.
                 for ident in bound_names {
-                    ctx.symbols_mut().set_scope_id(ident.symbol_id(), new_scope_id);
+                    ctx.symbols_mut().set_symbol_scope_id(ident.symbol_id(), new_scope_id);
                     ctx.scopes_mut().move_binding(scope_id, new_scope_id, ident.name.into());
                 }
             }
@@ -761,7 +761,8 @@ impl<'a> ObjectRestSpread<'a, '_> {
             ctx.ast.vec1(ctx.ast.variable_declarator(SPAN, kind, id, Some(init), false));
         let decl = ctx.ast.variable_declaration(SPAN, kind, declarations, false);
         decl.bound_names(&mut |ident| {
-            *ctx.symbols_mut().get_flags_mut(ident.symbol_id()) = SymbolFlags::BlockScopedVariable;
+            *ctx.symbols_mut().symbol_flags_mut(ident.symbol_id()) =
+                SymbolFlags::BlockScopedVariable;
         });
         decl
     }
@@ -810,8 +811,8 @@ impl<'a> ObjectRestSpread<'a, '_> {
         let symbols = ctx.symbols();
         decl.id.bound_names(&mut |ident| {
             let symbol_id = ident.symbol_id();
-            scope_id = symbols.get_scope_id(symbol_id);
-            symbol_flags.insert(symbols.get_flags(symbol_id));
+            scope_id = symbols.get_symbol_scope_id(symbol_id);
+            symbol_flags.insert(symbols.symbol_flags(symbol_id));
         });
 
         let state = State::new(decl.kind, symbol_flags, scope_id);

--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -426,7 +426,7 @@ impl<'a> ClassProperties<'a, '_> {
             } else {
                 // Class must be default export `export default class {}`, as all other class declarations
                 // always have a name. Set class name.
-                *ctx.symbols_mut().get_flags_mut(temp_binding.symbol_id) = SymbolFlags::Class;
+                *ctx.symbols_mut().symbol_flags_mut(temp_binding.symbol_id) = SymbolFlags::Class;
                 class.id = Some(temp_binding.create_binding_identifier(ctx));
             }
         }

--- a/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
@@ -375,7 +375,7 @@ impl<'a> ClassProperties<'a, '_> {
         // Add `"use strict"` directive if outer scope is not strict mode
         // TODO: This should be parent scope if insert `_super` function as expression before class expression.
         let outer_scope_id = ctx.current_block_scope_id();
-        let directives = if ctx.scopes().get_flags(outer_scope_id).is_strict_mode() {
+        let directives = if ctx.scopes().scope_flags(outer_scope_id).is_strict_mode() {
             ctx.ast.vec()
         } else {
             ctx.ast.vec1(ctx.ast.use_strict_directive())

--- a/crates/oxc_transformer/src/es2022/class_properties/instance_prop_init.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/instance_prop_init.rs
@@ -104,7 +104,7 @@ impl<'a> Visit<'a> for InstanceInitializerVisitor<'a, '_> {
 impl<'a> InstanceInitializerVisitor<'a, '_> {
     /// Update parent of scope.
     fn reparent_scope(&mut self, scope_id: ScopeId) {
-        self.ctx.scopes_mut().change_parent_id(scope_id, Some(self.parent_scope_id));
+        self.ctx.scopes_mut().change_scope_parent_id(scope_id, Some(self.parent_scope_id));
     }
 
     /// Check if symbol referenced by `ident` is shadowed by a binding in constructor's scope.
@@ -126,7 +126,7 @@ impl<'a> InstanceInitializerVisitor<'a, '_> {
         // This is an improvement over Babel.
         let reference_id = ident.reference_id();
         if let Some(ident_symbol_id) = self.ctx.symbols().get_reference(reference_id).symbol_id() {
-            let scope_id = self.ctx.symbols().get_scope_id(ident_symbol_id);
+            let scope_id = self.ctx.symbols().get_symbol_scope_id(ident_symbol_id);
             if self.scope_ids_stack.contains(&scope_id) {
                 return;
             }
@@ -212,6 +212,6 @@ impl FastInstanceInitializerVisitor<'_, '_> {
     /// Update parent of scope.
     fn reparent_scope(&mut self, scope_id: &Cell<Option<ScopeId>>) {
         let scope_id = scope_id.get().unwrap();
-        self.ctx.scopes_mut().change_parent_id(scope_id, Some(self.parent_scope_id));
+        self.ctx.scopes_mut().change_scope_parent_id(scope_id, Some(self.parent_scope_id));
     }
 }

--- a/crates/oxc_transformer/src/es2022/class_properties/private_method.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_method.rs
@@ -62,9 +62,9 @@ impl<'a> ClassProperties<'a, '_> {
         // strict mode flag if parent scope is not strict mode.
         let scope_id = function.scope_id();
         let new_parent_id = ctx.current_scope_id();
-        ctx.scopes_mut().change_parent_id(scope_id, Some(new_parent_id));
+        ctx.scopes_mut().change_scope_parent_id(scope_id, Some(new_parent_id));
         let is_strict_mode = ctx.current_scope_flags().is_strict_mode();
-        let flags = ctx.scopes_mut().get_flags_mut(scope_id);
+        let flags = ctx.scopes_mut().scope_flags_mut(scope_id);
         *flags -= ScopeFlags::GetAccessor | ScopeFlags::SetAccessor;
         if !is_strict_mode {
             // TODO: Needs to remove all child scopes' strict mode flag if child scope

--- a/crates/oxc_transformer/src/es2022/class_properties/static_block_and_prop_init.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/static_block_and_prop_init.rs
@@ -82,10 +82,10 @@ impl<'a> ClassProperties<'a, '_> {
         replacer.visit_statements(stmts);
 
         let scope_flags = outer_scope_strict_flag | ScopeFlags::Function | ScopeFlags::Arrow;
-        *ctx.scopes_mut().get_flags_mut(scope_id) = scope_flags;
+        *ctx.scopes_mut().scope_flags_mut(scope_id) = scope_flags;
 
         let outer_scope_id = ctx.current_scope_id();
-        ctx.scopes_mut().change_parent_id(scope_id, Some(outer_scope_id));
+        ctx.scopes_mut().change_scope_parent_id(scope_id, Some(outer_scope_id));
 
         wrap_statements_in_arrow_function_iife(ctx.ast.move_vec(stmts), scope_id, block.span, ctx)
     }
@@ -308,7 +308,7 @@ impl<'a> VisitMut<'a> for StaticVisitor<'a, '_, '_> {
     fn enter_scope(&mut self, _flags: ScopeFlags, scope_id: &Cell<Option<ScopeId>>) {
         if self.make_sloppy_mode {
             let scope_id = scope_id.get().unwrap();
-            *self.ctx.scopes_mut().get_flags_mut(scope_id) -= ScopeFlags::StrictMode;
+            *self.ctx.scopes_mut().scope_flags_mut(scope_id) -= ScopeFlags::StrictMode;
         }
     }
 
@@ -543,7 +543,7 @@ impl<'a> StaticVisitor<'a, '_, '_> {
         if self.scope_depth == 0 {
             let scope_id = scope_id.get().unwrap();
             let current_scope_id = self.ctx.current_scope_id();
-            self.ctx.scopes_mut().change_parent_id(scope_id, Some(current_scope_id));
+            self.ctx.scopes_mut().change_scope_parent_id(scope_id, Some(current_scope_id));
         }
     }
 }

--- a/crates/oxc_transformer/src/es2022/class_static_block.rs
+++ b/crates/oxc_transformer/src/es2022/class_static_block.rs
@@ -156,7 +156,7 @@ impl ClassStaticBlock {
 
         // Re-use the static block's scope for the arrow function.
         // Always strict mode since we're in a class.
-        *ctx.scopes_mut().get_flags_mut(scope_id) =
+        *ctx.scopes_mut().scope_flags_mut(scope_id) =
             ScopeFlags::Function | ScopeFlags::Arrow | ScopeFlags::StrictMode;
         wrap_statements_in_arrow_function_iife(ctx.ast.move_vec(stmts), scope_id, block.span, ctx)
     }

--- a/crates/oxc_transformer/src/jsx/jsx_self.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_self.rs
@@ -65,7 +65,7 @@ impl<'a> JsxSelf<'a, '_> {
 
     fn is_inside_constructor(ctx: &TraverseCtx<'a>) -> bool {
         for scope_id in ctx.ancestor_scopes() {
-            let flags = ctx.scopes().get_flags(scope_id);
+            let flags = ctx.scopes().scope_flags(scope_id);
             if flags.is_block() || flags.is_arrow() {
                 continue;
             }

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -307,7 +307,7 @@ impl<'a> Traverse<'a> for ReactRefresh<'a, '_> {
         ctx: &mut TraverseCtx<'a>,
     ) {
         let current_scope_id = ctx.current_scope_id();
-        if !ctx.scopes().get_flags(current_scope_id).is_function() {
+        if !ctx.scopes().scope_flags(current_scope_id).is_function() {
             return;
         }
 
@@ -339,7 +339,7 @@ impl<'a> Traverse<'a> for ReactRefresh<'a, '_> {
                 self.non_builtin_hooks_callee.entry(current_scope_id).or_default().push(
                     ctx.scopes()
                         .find_binding(
-                            ctx.scopes().get_parent_id(ctx.current_scope_id()).unwrap(),
+                            ctx.scopes().get_scope_parent_id(ctx.current_scope_id()).unwrap(),
                             binding_name.as_str(),
                         )
                         .map(|symbol_id| {

--- a/crates/oxc_transformer/src/plugins/module_runner_transform.rs
+++ b/crates/oxc_transformer/src/plugins/module_runner_transform.rs
@@ -328,7 +328,7 @@ impl<'a> ModuleRunnerTransform<'a> {
                 let mut local = specifier.unbox().local;
                 local.name = self.generate_import_binding_name(ctx);
                 let binding = BoundIdentifier::from_binding_ident(&local);
-                ctx.symbols_mut().set_name(binding.symbol_id, &binding.name);
+                ctx.symbols_mut().set_symbol_name(binding.symbol_id, &binding.name);
                 self.import_bindings.insert(binding.symbol_id, (binding, None));
 
                 let kind = BindingPatternKind::BindingIdentifier(ctx.alloc(local));

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -604,7 +604,7 @@ impl<'a> TypeScriptAnnotations<'a, '_> {
             // If the symbol is still a value symbol after SymbolFlags::Import is removed, then it's a value redeclaration.
             // That means the import is shadowed, and we can safely remove the import.
             let has_value_redeclaration =
-                (ctx.symbols().get_flags(symbol_id) - SymbolFlags::Import).is_value();
+                (ctx.symbols().symbol_flags(symbol_id) - SymbolFlags::Import).is_value();
             if has_value_redeclaration {
                 return false;
             }

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -79,7 +79,7 @@ impl<'a> TypeScriptEnum<'a> {
         let ast = ctx.ast;
 
         let is_export = export_span.is_some();
-        let is_not_top_scope = !ctx.scopes().get_flags(ctx.current_scope_id()).is_top();
+        let is_not_top_scope = !ctx.scopes().scope_flags(ctx.current_scope_id()).is_top();
 
         let enum_name = decl.id.name;
         let func_scope_id = decl.scope_id();
@@ -573,7 +573,7 @@ impl IdentifierReferenceRename<'_, '_> {
             return true;
         };
 
-        let symbol_scope_id = symbol_table.get_scope_id(symbol_id);
+        let symbol_scope_id = symbol_table.get_symbol_scope_id(symbol_id);
         // Don't need to rename the identifier when it references a nested enum member:
         //
         // ```ts

--- a/crates/oxc_transformer/src/typescript/module.rs
+++ b/crates/oxc_transformer/src/typescript/module.rs
@@ -123,7 +123,7 @@ impl<'a> TypeScriptModule<'a, '_> {
         let binding = ctx.ast.binding_pattern(binding_pattern_kind, NONE, false);
         let decl_span = decl.span;
 
-        let flags = ctx.symbols_mut().get_flags_mut(decl.id.symbol_id());
+        let flags = ctx.symbols_mut().symbol_flags_mut(decl.id.symbol_id());
         flags.remove(SymbolFlags::Import);
 
         let (kind, init) = match &mut decl.module_reference {

--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -309,7 +309,7 @@ impl<'a> TypeScriptNamespace<'a, '_> {
                     func_body,
                     scope_id,
                 ));
-            *ctx.scopes_mut().get_flags_mut(scope_id) =
+            *ctx.scopes_mut().scope_flags_mut(scope_id) =
                 ScopeFlags::Function | ScopeFlags::StrictMode;
             ctx.ast.expression_parenthesized(SPAN, function_expr)
         };
@@ -460,14 +460,14 @@ impl<'a> TypeScriptNamespace<'a, '_> {
         let symbol_id = id.symbol_id();
         // Only `enum`, `class`, `function` and `namespace` can be re-declared in same scope
         ctx.symbols()
-            .get_flags(symbol_id)
+            .symbol_flags(symbol_id)
             .intersects(SymbolFlags::RegularEnum | SymbolFlags::Class | SymbolFlags::Function)
             || {
                 // ```
                 // namespace Foo {}
                 // namespace Foo {} // is redeclaration
                 // ```
-                let redeclarations = ctx.symbols().get_redeclarations(symbol_id);
+                let redeclarations = ctx.symbols().get_symbol_redeclarations(symbol_id);
                 !redeclarations.is_empty() && redeclarations.contains(&id.span)
             }
     }

--- a/crates/oxc_wasm/src/lib.rs
+++ b/crates/oxc_wasm/src/lib.rs
@@ -427,7 +427,7 @@ impl Oxc {
             fn enter_scope(&mut self, _: ScopeFlags, scope_id: &Cell<Option<ScopeId>>) {
                 let scope_id = scope_id.get().unwrap();
                 let scopes = self.scoping.scopes();
-                let flags = scopes.get_flags(scope_id);
+                let flags = scopes.scope_flags(scope_id);
                 self.write_line(format!("Scope {} ({flags:?}) {{", scope_id.index()));
                 self.indent_in();
 
@@ -435,7 +435,7 @@ impl Oxc {
                 if !bindings.is_empty() {
                     self.write_line("Bindings: {");
                     for (name, &symbol_id) in bindings {
-                        let symbol_flags = self.scoping.symbols().get_flags(symbol_id);
+                        let symbol_flags = self.scoping.symbols().symbol_flags(symbol_id);
                         self.write_line(format!("  {name} ({symbol_id:?} {symbol_flags:?})",));
                     }
                     self.write_line("}");
@@ -470,10 +470,10 @@ impl Oxc {
         let data = symbols
             .symbol_ids()
             .map(|symbol_id| Data {
-                span: symbols.get_span(symbol_id),
-                name: symbols.get_name(symbol_id).into(),
-                flags: symbols.get_flags(symbol_id),
-                scope_id: symbols.get_scope_id(symbol_id),
+                span: symbols.symbol_span(symbol_id),
+                name: symbols.symbol_name(symbol_id).into(),
+                flags: symbols.symbol_flags(symbol_id),
+                scope_id: symbols.get_symbol_scope_id(symbol_id),
                 resolved_references: symbols
                     .get_resolved_reference_ids(symbol_id)
                     .iter()


### PR DESCRIPTION
part of #9607