### PR TITLE
chore(linter): include plugin name in panic message of Tester for easier troubleshooting

### DIFF
--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -509,6 +509,8 @@ impl Tester {
         RULES
             .iter()
             .find(|rule| rule.plugin_name() == self.plugin_name && rule.name() == self.rule_name)
-            .unwrap_or_else(|| panic!("Rule not found: {}", &self.rule_name))
+            .unwrap_or_else(|| {
+                panic!("Rule in plugin {} not found: {}", &self.plugin_name, &self.rule_name)
+            })
     }
 }


### PR DESCRIPTION
This makes it easier to troubleshoot a wrong plugin declaration in `declare_oxc_lint!`.