### PR TITLE
fix(linter): fix example lint declaration and macro syntax

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_obj_calls.rs
@@ -27,7 +27,7 @@ impl Default for NoObjCalls {
     }
 }
 
-declare_oxc_lint! {
+declare_oxc_lint!(
     /// ### What it does
     /// Disallow calling some global objects as functions
     ///
@@ -65,7 +65,7 @@ declare_oxc_lint! {
     NoObjCalls,
     eslint,
     correctness,
-}
+);
 
 fn is_global_obj(s: &str) -> bool {
     NON_CALLABLE_GLOBALS.contains(&s)

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_unsupported_elements.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_unsupported_elements.rs
@@ -12,7 +12,7 @@ use crate::{
     utils::{get_element_type, get_jsx_attribute_name},
 };
 
-declare_oxc_lint! {
+declare_oxc_lint!(
     /// ### What it does
     ///
     /// Certain reserved DOM elements do not support ARIA roles, states and
@@ -36,7 +36,7 @@ declare_oxc_lint! {
     jsx_a11y,
     correctness,
     fix
-}
+);
 
 #[derive(Debug, Default, Clone)]
 pub struct AriaUnsupportedElements;

--- a/crates/oxc_macros/src/lib.rs
+++ b/crates/oxc_macros/src/lib.rs
@@ -55,7 +55,7 @@ mod declare_oxc_lint;
 /// #[derive(Debug, Default, Clone)]
 /// pub struct NoDebugger;
 ///
-/// declare_oxc_lint! {
+/// declare_oxc_lint!(
 ///     /// ### What it does
 ///     ///
 ///     /// Checks for usage of the `debugger` statement
@@ -64,7 +64,6 @@ mod declare_oxc_lint;
 ///     ///
 ///     /// `debugger` statements do not affect functionality when a debugger isn't attached.
 ///     /// They're most commonly an accidental debugging leftover.
-///     ///
 ///     ///
 ///     /// ### Examples
 ///     ///
@@ -81,9 +80,10 @@ mod declare_oxc_lint;
 ///     /// var debug = require('foo');
 ///     /// ```
 ///     NoDebugger,
+///     eslint,
 ///     correctness,
 ///     fix
-/// }
+/// );
 /// ```
 #[proc_macro]
 pub fn declare_oxc_lint(input: TokenStream) -> TokenStream {


### PR DESCRIPTION
1. Add missing plugin to example declaration
2. Remove double empty line in example declaration
3. Normalize way of using `declare_oxc_lint!` to round braces