### PR TITLE
refactor(linter): improve `eslint/no-duplicate-imports`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
@@ -62,7 +62,7 @@ declare_oxc_lint!(
     ///
     /// ### Options
     ///
-    /// ### includeExports
+    /// #### includeExports
     ///
     /// `{ "includeExports": boolean }`
     ///

--- a/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
@@ -35,14 +35,19 @@ pub struct NoDuplicateImports {
 
 declare_oxc_lint!(
     /// ### What it does
-    /// Disallow duplicate module imports
+    ///
+    /// Disallow duplicate module imports.
     ///
     /// ### Why is this bad?
-    /// Using a single import statement per module will make the code clearer because you can see everything being imported from that module on one line.
+    /// Using a single import statement per module will make the code clearer because you can see
+    /// everything being imported from that module on one line.
     ///
     /// ### Examples
     ///
     /// Examples of **incorrect** code for this rule:
+    ///
+    /// In the following example the module import on line 1 is repeated on line 3. These can be
+    /// combined to make the list of imports more succinct.
     /// ```js
     /// import { merge } from 'module';
     /// import something from 'another-module';
@@ -53,6 +58,43 @@ declare_oxc_lint!(
     /// ```js
     /// import { merge, find } from 'module';
     /// import something from 'another-module';
+    /// ```
+    ///
+    /// ### Options
+    ///
+    /// ### includeExports
+    ///
+    /// `{ "includeExports": boolean }`
+    ///
+    /// When `true` this rule will also look at exports to see if there is both a re-export of a
+    /// module as in `export ... from 'module'` and also a standard import statement for the same
+    /// module. This would count as a rule violation because there are in a sense two statements
+    /// importing from the same module.
+    ///
+    /// Examples of **incorrect** when this rule is set to `true`
+    /// ```js
+    /// import { merge } from 'module';
+    ///
+    /// export { find } from 'module'; // re-export which is an import and an export.
+    /// ```
+    ///
+    /// Examples of **correct** when this rule is set to `true`
+    ///
+    /// If re-exporting from an imported module, you should add the imports to the
+    /// `import` statement, and export that directly, not use `export ... from`.
+    /// ```js
+    /// import { merge } from "lodash-es";
+    /// export { merge as lodashMerge }
+    /// ```
+    ///
+    /// ```js
+    /// import { merge, find } from 'module';
+    ///
+    /// // cannot be merged with the above import
+    ///  export * as something from 'module';
+    ///
+    /// // cannot be written differently
+    /// export * from 'module';
     /// ```
     NoDuplicateImports,
     eslint,

--- a/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_duplicate_imports.rs
@@ -91,7 +91,7 @@ declare_oxc_lint!(
     /// import { merge, find } from 'module';
     ///
     /// // cannot be merged with the above import
-    ///  export * as something from 'module';
+    /// export * as something from 'module';
     ///
     /// // cannot be written differently
     /// export * from 'module';


### PR DESCRIPTION
- Refactor some nested `if let`s into `let else` to avoid unneeded nesting.
- Add missing docs for the `includeExports` option. I expanded on the Eslint docs for this option. Relates to #6050 

Rule details: https://eslint.org/docs/latest/rules/no-duplicate-imports