### PR TITLE
fix(linter): rule `eslint/no-unsafe-optional-chaining`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unsafe_optional_chaining.rs
@@ -1,6 +1,6 @@
 use oxc_ast::{
     AstKind,
-    ast::{Argument, AssignmentTarget, Expression, match_assignment_target_pattern},
+    ast::{Argument, ArrayExpressionElement, AssignmentTarget, Expression, match_assignment_target_pattern},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -164,6 +164,17 @@ impl NoUnsafeOptionalChaining {
             Expression::AwaitExpression(expr) => {
                 Self::check_undefined_short_circuit(&expr.argument, error_type, ctx);
             }
+            Expression::ExpressionStatement(expr) => {
+             let Expression::ArrayExpression(arr_expr) = expr.expression else {return;};
+                println!("aa {expr:?}");
+
+                for elem in arr_expr.elements.iter() {
+                    if let ArrayExpressionElement::SpreadElement(spread_exp) = elem {
+                        println!("foo {elem:?}");
+                        Self::check_undefined_short_circuit(&spread_exp.argument, error_type, ctx);
+                    }
+                }
+            }
             Expression::ConditionalExpression(expr) => {
                 Self::check_undefined_short_circuit(&expr.consequent, error_type, ctx);
                 Self::check_undefined_short_circuit(&expr.alternate, error_type, ctx);
@@ -273,6 +284,9 @@ fn test() {
         ("with (obj?.foo) {};", None),
         ("async function foo() { with ( await obj?.foo) {}; }", None),
         ("(foo ? obj?.foo : obj?.bar).bar", None),
+        ("const a = [...obj?.foo];", None),
+      //  ("const b = [...c, ...obj?.foo];", None),
+       // ("const c = () => ([...(obj?.foo)]);", None),
     ];
 
     Tester::new(NoUnsafeOptionalChaining::NAME, NoUnsafeOptionalChaining::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/snapshots/eslint_no_unsafe_optional_chaining.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unsafe_optional_chaining.snap
@@ -42,3 +42,31 @@ source: crates/oxc_linter/src/tester.rs
    ·                   ────────
    ╰────
   help: If this short-circuits with 'undefined' the evaluation will throw TypeError
+
+  ⚠ eslint(no-unsafe-optional-chaining): Unsafe usage of optional chaining
+   ╭─[no_unsafe_optional_chaining.tsx:1:15]
+ 1 │ const a = [...obj?.foo];
+   ·               ────────
+   ╰────
+  help: If this short-circuits with 'undefined' the evaluation will throw TypeError
+
+  ⚠ eslint(no-unsafe-optional-chaining): Unsafe usage of optional chaining
+   ╭─[no_unsafe_optional_chaining.tsx:1:21]
+ 1 │ const b = [...c, ...obj?.foo];
+   ·                     ────────
+   ╰────
+  help: If this short-circuits with 'undefined' the evaluation will throw TypeError
+
+  ⚠ eslint(no-unsafe-optional-chaining): Unsafe usage of optional chaining
+   ╭─[no_unsafe_optional_chaining.tsx:1:23]
+ 1 │ const s = [], t = [...obj?.foo];
+   ·                       ────────
+   ╰────
+  help: If this short-circuits with 'undefined' the evaluation will throw TypeError
+
+  ⚠ eslint(no-unsafe-optional-chaining): Unsafe usage of optional chaining
+   ╭─[no_unsafe_optional_chaining.tsx:1:23]
+ 1 │ const c = () => ([...(obj?.foo)]);
+   ·                       ────────
+   ╰────
+  help: If this short-circuits with 'undefined' the evaluation will throw TypeError


### PR DESCRIPTION
This PR implements missing cases for the rule relating to spread elements in array expressions.

The following fail test cases were missing and not yet implemented for this oxc rule but are implemented for the eslint version. See the eslint playground [here](https://eslint.org/play/#eyJ0ZXh0IjoiLyplc2xpbnQgbm8tdW5zYWZlLW9wdGlvbmFsLWNoYWluaW5nOiBcImVycm9yXCIqL1xuXG5jb25zdCBhID0gWy4uLm9iaj8uZm9vXTtcblxuY29uc3QgYiA9IFsuLi5jLCAuLi5vYmo/LmZvb107XG5cbmNvbnN0IHMgPSBbXSwgdCA9IFsuLi5vYmo/LmZvb107XG5cbmNvbnN0IGMgPSAoKSA9PiAoWy4uLihvYmo/LmZvbyldKTsiLCJvcHRpb25zIjp7InJ1bGVzIjp7fSwibGFuZ3VhZ2VPcHRpb25zIjp7InBhcnNlck9wdGlvbnMiOnsiZWNtYUZlYXR1cmVzIjp7fX19fX0=) which I set up.

```js
const a = [...obj?.foo];

const b = [...c, ...obj?.foo];

const s = [], t = [...obj?.foo];

const c = () => ([...(obj?.foo)]);
```