### PR TITLE
fix(parser): fix end span for optional binding pattern without type annotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ target/
 /editors/vscode/out/
 /editors/vscode/*.vsix
 
+# Jetbrains
+/.idea/
+
 # Cloned conformance repos
 tasks/coverage/babel/
 tasks/coverage/test262/


### PR DESCRIPTION
TS-ESLint: https://ast-explorer.dev/#eNolyjEKwzAMRuGrmH9qob1Alt6ikxbVKODiysZWA8H47lHI+r03kLHgyxv32FI1PFAdbK9ywVN6Tnp6dF//Gi0VDWsptw+31z2M6a14G6QhECT++C2t+0VYHDKbdCOQTswDPEYlSw==

Feel free to close and fix yourself if there is a simpler way to do it!