### PR TITLE
docs(allocator): add safety constraint for `String::from_raw_parts_in`

### DIFF
--- a/crates/oxc_allocator/src/string.rs
+++ b/crates/oxc_allocator/src/string.rs
@@ -196,6 +196,8 @@ impl<'alloc> String<'alloc> {
     /// * The memory at `ptr` needs to have been previously allocated by the same [`Allocator`].
     /// * `length` needs to be less than or equal to `capacity`.
     /// * `capacity` needs to be the correct value.
+    /// * The region of memory starting at `ptr` and spanning `length` bytes must contain a valid
+    ///   UTF-8 string.
     ///
     /// Violating these may cause problems like corrupting the allocator's internal data structures.
     ///
@@ -205,7 +207,6 @@ impl<'alloc> String<'alloc> {
     ///
     /// # Examples
     /// ```
-    /// use std::mem;
     /// use oxc_allocator::{Allocator, String};
     ///
     /// let allocator = Allocator::default();


### PR DESCRIPTION
Add a safety constraint to docs for `String::from_raw_parts_in`. That the `Vec` provided comprises a valid UTF-8 string is a pivotal requirement of this method. I'm not sure how we missed documenting that!

Also remove a line of extraneous code from the example.