### PR TITLE
fix(parser)!: align JSXNamespacedName with ESTree

### DIFF
--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -178,7 +178,7 @@ pub struct JSXNamespacedName<'a> {
     /// Namespace portion of the name, e.g. `Apple` in `<Apple:Orange />`
     pub namespace: JSXIdentifier<'a>,
     /// Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
-    pub property: JSXIdentifier<'a>,
+    pub name: JSXIdentifier<'a>,
 }
 
 /// JSX Member Expression

--- a/crates/oxc_ast/src/ast_impl/jsx.rs
+++ b/crates/oxc_ast/src/ast_impl/jsx.rs
@@ -16,7 +16,7 @@ impl fmt::Display for JSXIdentifier<'_> {
 
 impl fmt::Display for JSXNamespacedName<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}:{}", self.namespace.name, self.property.name)
+        write!(f, "{}:{}", self.namespace.name, self.name.name)
     }
 }
 
@@ -173,7 +173,7 @@ impl<'a> JSXAttributeName<'a> {
     pub fn get_identifier(&self) -> &JSXIdentifier<'a> {
         match self {
             Self::Identifier(ident) => ident.as_ref(),
-            Self::NamespacedName(namespaced) => &namespaced.property,
+            Self::NamespacedName(namespaced) => &namespaced.name,
         }
     }
 }

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -842,7 +842,7 @@ const _: () = {
     assert!(align_of::<JSXNamespacedName>() == 8);
     assert!(offset_of!(JSXNamespacedName, span) == 0);
     assert!(offset_of!(JSXNamespacedName, namespace) == 8);
-    assert!(offset_of!(JSXNamespacedName, property) == 32);
+    assert!(offset_of!(JSXNamespacedName, name) == 32);
 
     assert!(size_of::<JSXMemberExpression>() == 48);
     assert!(align_of::<JSXMemberExpression>() == 8);
@@ -2246,7 +2246,7 @@ const _: () = {
     assert!(align_of::<JSXNamespacedName>() == 4);
     assert!(offset_of!(JSXNamespacedName, span) == 0);
     assert!(offset_of!(JSXNamespacedName, namespace) == 8);
-    assert!(offset_of!(JSXNamespacedName, property) == 24);
+    assert!(offset_of!(JSXNamespacedName, name) == 24);
 
     assert!(size_of::<JSXMemberExpression>() == 32);
     assert!(align_of::<JSXMemberExpression>() == 4);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -8933,15 +8933,15 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     /// * `namespace`: Namespace portion of the name, e.g. `Apple` in `<Apple:Orange />`
-    /// * `property`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
+    /// * `name`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
     #[inline]
     pub fn jsx_element_name_namespaced_name(
         self,
         span: Span,
         namespace: JSXIdentifier<'a>,
-        property: JSXIdentifier<'a>,
+        name: JSXIdentifier<'a>,
     ) -> JSXElementName<'a> {
-        JSXElementName::NamespacedName(self.alloc_jsx_namespaced_name(span, namespace, property))
+        JSXElementName::NamespacedName(self.alloc_jsx_namespaced_name(span, namespace, name))
     }
 
     /// Build a [`JSXElementName::MemberExpression`].
@@ -8980,15 +8980,15 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     /// * `namespace`: Namespace portion of the name, e.g. `Apple` in `<Apple:Orange />`
-    /// * `property`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
+    /// * `name`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
     #[inline]
     pub fn jsx_namespaced_name(
         self,
         span: Span,
         namespace: JSXIdentifier<'a>,
-        property: JSXIdentifier<'a>,
+        name: JSXIdentifier<'a>,
     ) -> JSXNamespacedName<'a> {
-        JSXNamespacedName { span, namespace, property }
+        JSXNamespacedName { span, namespace, name }
     }
 
     /// Build a [`JSXNamespacedName`], and store it in the memory arena.
@@ -8998,15 +8998,15 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     /// * `namespace`: Namespace portion of the name, e.g. `Apple` in `<Apple:Orange />`
-    /// * `property`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
+    /// * `name`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
     #[inline]
     pub fn alloc_jsx_namespaced_name(
         self,
         span: Span,
         namespace: JSXIdentifier<'a>,
-        property: JSXIdentifier<'a>,
+        name: JSXIdentifier<'a>,
     ) -> Box<'a, JSXNamespacedName<'a>> {
-        Box::new_in(self.jsx_namespaced_name(span, namespace, property), self.allocator)
+        Box::new_in(self.jsx_namespaced_name(span, namespace, name), self.allocator)
     }
 
     /// Build a [`JSXMemberExpression`].
@@ -9308,15 +9308,15 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     /// * `namespace`: Namespace portion of the name, e.g. `Apple` in `<Apple:Orange />`
-    /// * `property`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
+    /// * `name`: Name portion of the name, e.g. `Orange` in `<Apple:Orange />`
     #[inline]
     pub fn jsx_attribute_name_namespaced_name(
         self,
         span: Span,
         namespace: JSXIdentifier<'a>,
-        property: JSXIdentifier<'a>,
+        name: JSXIdentifier<'a>,
     ) -> JSXAttributeName<'a> {
-        JSXAttributeName::NamespacedName(self.alloc_jsx_namespaced_name(span, namespace, property))
+        JSXAttributeName::NamespacedName(self.alloc_jsx_namespaced_name(span, namespace, name))
     }
 
     /// Build a [`JSXAttributeValue::StringLiteral`].

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -2670,7 +2670,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXNamespacedName<'_> {
         JSXNamespacedName {
             span: CloneIn::clone_in(&self.span, allocator),
             namespace: CloneIn::clone_in(&self.namespace, allocator),
-            property: CloneIn::clone_in(&self.property, allocator),
+            name: CloneIn::clone_in(&self.name, allocator),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -1552,7 +1552,7 @@ impl ContentEq for JSXElementName<'_> {
 impl ContentEq for JSXNamespacedName<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.namespace, &other.namespace)
-            && ContentEq::content_eq(&self.property, &other.property)
+            && ContentEq::content_eq(&self.name, &other.name)
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -2061,7 +2061,7 @@ impl ESTree for JSXNamespacedName<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("namespace", &self.namespace);
-        state.serialize_field("property", &self.property);
+        state.serialize_field("name", &self.name);
         state.end();
     }
 }

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -3022,7 +3022,7 @@ pub mod walk {
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
         visitor.visit_jsx_identifier(&it.namespace);
-        visitor.visit_jsx_identifier(&it.property);
+        visitor.visit_jsx_identifier(&it.name);
         visitor.leave_node(kind);
     }
 

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -3156,7 +3156,7 @@ pub mod walk_mut {
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
         visitor.visit_jsx_identifier(&mut it.namespace);
-        visitor.visit_jsx_identifier(&mut it.property);
+        visitor.visit_jsx_identifier(&mut it.name);
         visitor.leave_node(kind);
     }
 

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2431,7 +2431,7 @@ impl Gen for JSXNamespacedName<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         self.namespace.print(p, ctx);
         p.print_colon();
-        self.property.print(p, ctx);
+        self.name.print(p, ctx);
     }
 }
 

--- a/crates/oxc_linter/src/rules/react/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/react/no_namespace.rs
@@ -51,7 +51,7 @@ impl Rule for NoNamespace {
                 if let JSXElementName::NamespacedName(namespaced_name) = &element.name {
                     let component_name_with_ns = format!(
                         "{}:{}",
-                        namespaced_name.namespace.name, namespaced_name.property.name
+                        namespaced_name.namespace.name, namespaced_name.name.name
                     );
 
                     ctx.diagnostic(no_namespace_diagnostic(

--- a/crates/oxc_linter/src/rules/react/no_namespace.rs
+++ b/crates/oxc_linter/src/rules/react/no_namespace.rs
@@ -49,10 +49,8 @@ impl Rule for NoNamespace {
         match node.kind() {
             AstKind::JSXOpeningElement(element) => {
                 if let JSXElementName::NamespacedName(namespaced_name) = &element.name {
-                    let component_name_with_ns = format!(
-                        "{}:{}",
-                        namespaced_name.namespace.name, namespaced_name.name.name
-                    );
+                    let component_name_with_ns =
+                        format!("{}:{}", namespaced_name.namespace.name, namespaced_name.name.name);
 
                     ctx.diagnostic(no_namespace_diagnostic(
                         namespaced_name.span,

--- a/crates/oxc_linter/src/utils/react.rs
+++ b/crates/oxc_linter/src/utils/react.rs
@@ -52,7 +52,7 @@ pub fn get_prop_value<'a, 'b>(item: &'b JSXAttributeItem<'a>) -> Option<&'b JSXA
 pub fn get_jsx_attribute_name<'a>(attr: &JSXAttributeName<'a>) -> Cow<'a, str> {
     match attr {
         JSXAttributeName::NamespacedName(name) => {
-            Cow::Owned(format!("{}:{}", name.namespace.name, name.property.name))
+            Cow::Owned(format!("{}:{}", name.namespace.name, name.name.name))
         }
         JSXAttributeName::Identifier(ident) => Cow::Borrowed(ident.name.as_str()),
     }
@@ -228,7 +228,7 @@ pub fn get_element_type<'c, 'a>(
         JSXElementName::Identifier(id) => Cow::Borrowed(id.as_ref().name.as_str()),
         JSXElementName::IdentifierReference(id) => Cow::Borrowed(id.as_ref().name.as_str()),
         JSXElementName::NamespacedName(namespaced) => {
-            Cow::Owned(format!("{}:{}", namespaced.namespace.name, namespaced.property.name))
+            Cow::Owned(format!("{}:{}", namespaced.namespace.name, namespaced.name.name))
         }
         JSXElementName::MemberExpression(jsx_mem_expr) => get_jsx_mem_expr_name(jsx_mem_expr),
         JSXElementName::ThisExpression(_) => Cow::Borrowed("this"),

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -432,7 +432,7 @@ impl<'a> ParserImpl<'a> {
                 JSXElementName::IdentifierReference(rhs),
             ) => lhs.name == rhs.name,
             (JSXElementName::NamespacedName(lhs), JSXElementName::NamespacedName(rhs)) => {
-                lhs.namespace.name == rhs.namespace.name && lhs.property.name == rhs.property.name
+                lhs.namespace.name == rhs.namespace.name && lhs.name.name == rhs.name.name
             }
             (JSXElementName::MemberExpression(lhs), JSXElementName::MemberExpression(rhs)) => {
                 Self::jsx_member_expression_eq(lhs, rhs)

--- a/crates/oxc_prettier/src/format/jsx.rs
+++ b/crates/oxc_prettier/src/format/jsx.rs
@@ -45,8 +45,8 @@ impl<'a> Format<'a> for JSXElementName<'a> {
 impl<'a> Format<'a> for JSXNamespacedName<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         let namespace_doc = self.namespace.format(p);
-        let property_doc = self.property.format(p);
-        array!(p, [namespace_doc, text!(":"), property_doc])
+        let name_doc = self.name.format(p);
+        array!(p, [namespace_doc, text!(":"), name_doc])
     }
 }
 

--- a/crates/oxc_traverse/src/ast_operations/gather_node_parts.rs
+++ b/crates/oxc_traverse/src/ast_operations/gather_node_parts.rs
@@ -527,7 +527,7 @@ impl<'a> GatherNodeParts<'a> for JSXElementName<'a> {
 impl<'a> GatherNodeParts<'a> for JSXNamespacedName<'a> {
     fn gather<F: FnMut(&str)>(&self, f: &mut F) {
         self.namespace.gather(f);
-        self.property.gather(f);
+        self.name.gather(f);
     }
 }
 

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -202,7 +202,7 @@ pub(crate) enum AncestorType {
     JSXFragmentClosingFragment = 179,
     JSXFragmentChildren = 180,
     JSXNamespacedNameNamespace = 181,
-    JSXNamespacedNameProperty = 182,
+    JSXNamespacedNameName = 182,
     JSXMemberExpressionObject = 183,
     JSXMemberExpressionProperty = 184,
     JSXExpressionContainerExpression = 185,
@@ -665,8 +665,8 @@ pub enum Ancestor<'a, 't> {
         AncestorType::JSXFragmentChildren as u16,
     JSXNamespacedNameNamespace(JSXNamespacedNameWithoutNamespace<'a, 't>) =
         AncestorType::JSXNamespacedNameNamespace as u16,
-    JSXNamespacedNameProperty(JSXNamespacedNameWithoutProperty<'a, 't>) =
-        AncestorType::JSXNamespacedNameProperty as u16,
+    JSXNamespacedNameName(JSXNamespacedNameWithoutName<'a, 't>) =
+        AncestorType::JSXNamespacedNameName as u16,
     JSXMemberExpressionObject(JSXMemberExpressionWithoutObject<'a, 't>) =
         AncestorType::JSXMemberExpressionObject as u16,
     JSXMemberExpressionProperty(JSXMemberExpressionWithoutProperty<'a, 't>) =
@@ -1472,7 +1472,7 @@ impl<'a, 't> Ancestor<'a, 't> {
 
     #[inline]
     pub fn is_jsx_namespaced_name(self) -> bool {
-        matches!(self, Self::JSXNamespacedNameNamespace(_) | Self::JSXNamespacedNameProperty(_))
+        matches!(self, Self::JSXNamespacedNameNamespace(_) | Self::JSXNamespacedNameName(_))
     }
 
     #[inline]
@@ -2403,7 +2403,7 @@ impl<'a, 't> GetAddress for Ancestor<'a, 't> {
             Self::JSXFragmentClosingFragment(a) => a.address(),
             Self::JSXFragmentChildren(a) => a.address(),
             Self::JSXNamespacedNameNamespace(a) => a.address(),
-            Self::JSXNamespacedNameProperty(a) => a.address(),
+            Self::JSXNamespacedNameName(a) => a.address(),
             Self::JSXMemberExpressionObject(a) => a.address(),
             Self::JSXMemberExpressionProperty(a) => a.address(),
             Self::JSXExpressionContainerExpression(a) => a.address(),
@@ -10881,8 +10881,7 @@ impl<'a, 't> GetAddress for JSXFragmentWithoutChildren<'a, 't> {
 pub(crate) const OFFSET_JSX_NAMESPACED_NAME_SPAN: usize = offset_of!(JSXNamespacedName, span);
 pub(crate) const OFFSET_JSX_NAMESPACED_NAME_NAMESPACE: usize =
     offset_of!(JSXNamespacedName, namespace);
-pub(crate) const OFFSET_JSX_NAMESPACED_NAME_PROPERTY: usize =
-    offset_of!(JSXNamespacedName, property);
+pub(crate) const OFFSET_JSX_NAMESPACED_NAME_NAME: usize = offset_of!(JSXNamespacedName, name);
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -10898,9 +10897,9 @@ impl<'a, 't> JSXNamespacedNameWithoutNamespace<'a, 't> {
     }
 
     #[inline]
-    pub fn property(self) -> &'t JSXIdentifier<'a> {
+    pub fn name(self) -> &'t JSXIdentifier<'a> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_JSX_NAMESPACED_NAME_PROPERTY)
+            &*((self.0 as *const u8).add(OFFSET_JSX_NAMESPACED_NAME_NAME)
                 as *const JSXIdentifier<'a>)
         }
     }
@@ -10915,12 +10914,12 @@ impl<'a, 't> GetAddress for JSXNamespacedNameWithoutNamespace<'a, 't> {
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
-pub struct JSXNamespacedNameWithoutProperty<'a, 't>(
+pub struct JSXNamespacedNameWithoutName<'a, 't>(
     pub(crate) *const JSXNamespacedName<'a>,
     pub(crate) PhantomData<&'t ()>,
 );
 
-impl<'a, 't> JSXNamespacedNameWithoutProperty<'a, 't> {
+impl<'a, 't> JSXNamespacedNameWithoutName<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_JSX_NAMESPACED_NAME_SPAN) as *const Span) }
@@ -10935,7 +10934,7 @@ impl<'a, 't> JSXNamespacedNameWithoutProperty<'a, 't> {
     }
 }
 
-impl<'a, 't> GetAddress for JSXNamespacedNameWithoutProperty<'a, 't> {
+impl<'a, 't> GetAddress for JSXNamespacedNameWithoutName<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -3350,10 +3350,10 @@ unsafe fn walk_jsx_namespaced_name<'a, Tr: Traverse<'a>>(
         (node as *mut u8).add(ancestor::OFFSET_JSX_NAMESPACED_NAME_NAMESPACE) as *mut JSXIdentifier,
         ctx,
     );
-    ctx.retag_stack(AncestorType::JSXNamespacedNameProperty);
+    ctx.retag_stack(AncestorType::JSXNamespacedNameName);
     walk_jsx_identifier(
         traverser,
-        (node as *mut u8).add(ancestor::OFFSET_JSX_NAMESPACED_NAME_PROPERTY) as *mut JSXIdentifier,
+        (node as *mut u8).add(ancestor::OFFSET_JSX_NAMESPACED_NAME_NAME) as *mut JSXIdentifier,
         ctx,
     );
     ctx.pop_stack(pop_token);

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -1180,7 +1180,7 @@ function deserializeJSXNamespacedName(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     namespace: deserializeJSXIdentifier(pos + 8),
-    property: deserializeJSXIdentifier(pos + 32),
+    name: deserializeJSXIdentifier(pos + 32),
   };
 }
 

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -1233,7 +1233,7 @@ function deserializeJSXNamespacedName(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     namespace: deserializeJSXIdentifier(pos + 8),
-    property: deserializeJSXIdentifier(pos + 32),
+    name: deserializeJSXIdentifier(pos + 32),
   };
 }
 

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -848,7 +848,7 @@ export type JSXElementName = JSXIdentifier | JSXNamespacedName | JSXMemberExpres
 export interface JSXNamespacedName extends Span {
   type: 'JSXNamespacedName';
   namespace: JSXIdentifier;
-  property: JSXIdentifier;
+  name: JSXIdentifier;
 }
 
 export interface JSXMemberExpression extends Span {


### PR DESCRIPTION
See in https://ast-explorer.dev/#eNolyUEOgyAQheGrkLc26Z40PUV3nS4A0WiQISBGY7y7Q9z973snAjRms5ni8pRWdEgC1lgfpJ30e2DW1mT1+oiwyElRKULhmp3/HskTtOyF+xqku+dOoY5TLO37NWk2l53Qxp/ihesGhcgmng==
and https://ast-explorer.dev/#eNpFy8EKAjEMBNBfKTmveC/i0U/w1EssEbrUtiRZUZb+u4kePM6bmR0qRFjxiZK5DIUFhoG+B/3gQFJLc8/mp3vv8YYcjmeTbrKnFkICyg+8EkvpLUE0qKgkmmD59xdC3ZjEB9+bF6u8PCtv5DRTmzA/PxwwOA==