### PR TITLE
perf(allocator): remove overflow checks from `String::from_strs_array_in`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1589,6 +1589,7 @@ name = "oxc_allocator"
 version = "0.57.0"
 dependencies = [
  "allocator-api2",
+ "assert-unchecked",
  "bumpalo",
  "hashbrown 0.15.2",
  "oxc_estree",

--- a/crates/oxc_allocator/Cargo.toml
+++ b/crates/oxc_allocator/Cargo.toml
@@ -22,6 +22,7 @@ doctest = false
 oxc_estree = { workspace = true, optional = true }
 
 allocator-api2 = { workspace = true }
+assert-unchecked = { workspace = true }
 bumpalo = { workspace = true, features = ["allocator-api2", "collections"] }
 hashbrown = { workspace = true, default-features = false, features = ["inline-more", "allocator-api2"] }
 rustc-hash = { workspace = true }


### PR DESCRIPTION
Optimize `String::from_strs_array_in` to remove overflow checks in common cases.

`&str` has a maximum length of `isize::MAX`, so in many cases, if we communicate this constraint to the compiler, it can remove the overflow checks, as it can see that overflowing `usize` is impossible.

I was unsure if max length of `&str` was guaranteed, but wiser minds confirm it is: https://users.rust-lang.org/t/does-str-reliably-have-length-isize-max/126777
