### PR TITLE
fix(parser): fix end span for optional binding pattern without type annotation

### DIFF
--- a/crates/oxc_parser/src/js/binding.rs
+++ b/crates/oxc_parser/src/js/binding.rs
@@ -22,7 +22,9 @@ impl<'a> ParserImpl<'a> {
         let optional = if allow_question && self.is_ts { self.eat(Kind::Question) } else { false };
         let type_annotation = self.parse_ts_type_annotation()?;
         if let Some(type_annotation) = &type_annotation {
-            Self::extend_binding_pattern_span_end(type_annotation.span, &mut kind);
+            Self::extend_binding_pattern_span_end(type_annotation.span.end, &mut kind);
+        } else if optional {
+            Self::extend_binding_pattern_span_end(self.prev_token_end, &mut kind);
         }
         Ok(self.ast.binding_pattern(kind, type_annotation, optional))
     }
@@ -178,13 +180,13 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
-    pub(super) fn extend_binding_pattern_span_end(span: Span, kind: &mut BindingPatternKind<'a>) {
+    pub(super) fn extend_binding_pattern_span_end(end: u32, kind: &mut BindingPatternKind<'a>) {
         let pat_span = match kind {
             BindingPatternKind::BindingIdentifier(pat) => &mut pat.span,
             BindingPatternKind::ObjectPattern(pat) => &mut pat.span,
             BindingPatternKind::ArrayPattern(pat) => &mut pat.span,
             BindingPatternKind::AssignmentPattern(pat) => &mut pat.span,
         };
-        pat_span.end = span.end;
+        pat_span.end = end;
     }
 }

--- a/crates/oxc_parser/src/js/declaration.rs
+++ b/crates/oxc_parser/src/js/declaration.rs
@@ -104,7 +104,7 @@ impl<'a> ParserImpl<'a> {
             let optional = self.eat(Kind::Question); // not allowed, but checked in checker/typescript.rs
             let type_annotation = self.parse_ts_type_annotation()?;
             if let Some(type_annotation) = &type_annotation {
-                Self::extend_binding_pattern_span_end(type_annotation.span, &mut binding_kind);
+                Self::extend_binding_pattern_span_end(type_annotation.span.end, &mut binding_kind);
             }
             (self.ast.binding_pattern(binding_kind, type_annotation, optional), definite)
         } else {


### PR DESCRIPTION
closes #9636

```
function foo(bar?) {}
             ^^^^ span for `Identifier`
```