### PR TITLE
fix(linter): Add missing fail cases in `eslint-no-array-constructor`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
@@ -10,7 +10,7 @@ use oxc_span::Span;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_array_constructor_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("Do not use `new` to create arrays")
+    OxcDiagnostic::warn("The array literal notation [] is preferable.")
         .with_help("Use an array literal instead")
         .with_label(span)
 }
@@ -67,19 +67,6 @@ impl Rule for NoArrayConstructor {
                 &new_expr.type_parameters,
                 false,
             ),
-            AstKind::ExpressionStatement(expr_stmt) => {
-                if let Expression::CallExpression(call_expr) = &expr_stmt.expression {
-                    (
-                        call_expr.span,
-                        &call_expr.callee,
-                        &call_expr.arguments,
-                        &call_expr.type_parameters,
-                        call_expr.optional,
-                    )
-                } else {
-                    return;
-                }
-            }
             _ => {
                 return;
             }

--- a/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
@@ -10,8 +10,8 @@ use oxc_span::Span;
 use crate::{AstNode, context::LintContext, rule::Rule};
 
 fn no_array_constructor_diagnostic(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::warn("The array literal notation [] is preferable.")
-        .with_help("Use an array literal instead")
+    OxcDiagnostic::warn("Avoid calls to the `Array` constructor")
+        .with_help("Use array literal notation [] instead.")
         .with_label(span)
 }
 

--- a/crates/oxc_linter/src/snapshots/eslint_no_array_constructor.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_array_constructor.snap
@@ -24,6 +24,13 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
    ╭─[no_array_constructor.tsx:1:1]
+ 1 │ Array();
+   · ───────
+   ╰────
+  help: Use an array literal instead
+
+  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
+   ╭─[no_array_constructor.tsx:1:1]
  1 │ new Array(x, y)
    · ───────────────
    ╰────
@@ -38,6 +45,20 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
    ╭─[no_array_constructor.tsx:1:1]
+ 1 │ new Array(...args);
+   · ──────────────────
+   ╰────
+  help: Use an array literal instead
+
+  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
+   ╭─[no_array_constructor.tsx:1:1]
+ 1 │ Array(x, y)
+   · ───────────
+   ╰────
+  help: Use an array literal instead
+
+  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
+   ╭─[no_array_constructor.tsx:1:1]
  1 │ Array(x, y)
    · ───────────
    ╰────
@@ -47,5 +68,40 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_array_constructor.tsx:1:1]
  1 │ Array(0, 1, 2)
    · ──────────────
+   ╰────
+  help: Use an array literal instead
+
+  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
+   ╭─[no_array_constructor.tsx:1:1]
+ 1 │ Array(0, 1, 2)
+   · ──────────────
+   ╰────
+  help: Use an array literal instead
+
+  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
+   ╭─[no_array_constructor.tsx:1:1]
+ 1 │ Array(...args);
+   · ──────────────
+   ╰────
+  help: Use an array literal instead
+
+  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
+   ╭─[no_array_constructor.tsx:1:1]
+ 1 │ Array(...args);
+   · ──────────────
+   ╰────
+  help: Use an array literal instead
+
+  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
+   ╭─[no_array_constructor.tsx:1:1]
+ 1 │ Array(1, 2, ...args);
+   · ────────────────────
+   ╰────
+  help: Use an array literal instead
+
+  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
+   ╭─[no_array_constructor.tsx:1:1]
+ 1 │ Array(1, 2, ...args);
+   · ────────────────────
    ╰────
   help: Use an array literal instead

--- a/crates/oxc_linter/src/snapshots/eslint_no_array_constructor.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_array_constructor.snap
@@ -24,13 +24,6 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
    ╭─[no_array_constructor.tsx:1:1]
- 1 │ Array();
-   · ───────
-   ╰────
-  help: Use an array literal instead
-
-  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
-   ╭─[no_array_constructor.tsx:1:1]
  1 │ new Array(x, y)
    · ───────────────
    ╰────
@@ -59,20 +52,6 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
    ╭─[no_array_constructor.tsx:1:1]
- 1 │ Array(x, y)
-   · ───────────
-   ╰────
-  help: Use an array literal instead
-
-  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
-   ╭─[no_array_constructor.tsx:1:1]
- 1 │ Array(0, 1, 2)
-   · ──────────────
-   ╰────
-  help: Use an array literal instead
-
-  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
-   ╭─[no_array_constructor.tsx:1:1]
  1 │ Array(0, 1, 2)
    · ──────────────
    ╰────
@@ -82,20 +61,6 @@ source: crates/oxc_linter/src/tester.rs
    ╭─[no_array_constructor.tsx:1:1]
  1 │ Array(...args);
    · ──────────────
-   ╰────
-  help: Use an array literal instead
-
-  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
-   ╭─[no_array_constructor.tsx:1:1]
- 1 │ Array(...args);
-   · ──────────────
-   ╰────
-  help: Use an array literal instead
-
-  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
-   ╭─[no_array_constructor.tsx:1:1]
- 1 │ Array(1, 2, ...args);
-   · ────────────────────
    ╰────
   help: Use an array literal instead
 

--- a/crates/oxc_linter/src/snapshots/eslint_no_array_constructor.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_array_constructor.snap
@@ -1,72 +1,72 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
+  ⚠ eslint(no-array-constructor): Avoid calls to the `Array` constructor
    ╭─[no_array_constructor.tsx:1:1]
  1 │ new Array()
    · ───────────
    ╰────
-  help: Use an array literal instead
+  help: Use array literal notation [] instead.
 
-  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
+  ⚠ eslint(no-array-constructor): Avoid calls to the `Array` constructor
    ╭─[no_array_constructor.tsx:1:1]
  1 │ new Array
    · ─────────
    ╰────
-  help: Use an array literal instead
+  help: Use array literal notation [] instead.
 
-  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
+  ⚠ eslint(no-array-constructor): Avoid calls to the `Array` constructor
    ╭─[no_array_constructor.tsx:1:1]
  1 │ Array();
    · ───────
    ╰────
-  help: Use an array literal instead
+  help: Use array literal notation [] instead.
 
-  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
+  ⚠ eslint(no-array-constructor): Avoid calls to the `Array` constructor
    ╭─[no_array_constructor.tsx:1:1]
  1 │ new Array(x, y)
    · ───────────────
    ╰────
-  help: Use an array literal instead
+  help: Use array literal notation [] instead.
 
-  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
+  ⚠ eslint(no-array-constructor): Avoid calls to the `Array` constructor
    ╭─[no_array_constructor.tsx:1:1]
  1 │ new Array(0, 1, 2)
    · ──────────────────
    ╰────
-  help: Use an array literal instead
+  help: Use array literal notation [] instead.
 
-  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
+  ⚠ eslint(no-array-constructor): Avoid calls to the `Array` constructor
    ╭─[no_array_constructor.tsx:1:1]
  1 │ new Array(...args);
    · ──────────────────
    ╰────
-  help: Use an array literal instead
+  help: Use array literal notation [] instead.
 
-  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
+  ⚠ eslint(no-array-constructor): Avoid calls to the `Array` constructor
    ╭─[no_array_constructor.tsx:1:1]
  1 │ Array(x, y)
    · ───────────
    ╰────
-  help: Use an array literal instead
+  help: Use array literal notation [] instead.
 
-  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
+  ⚠ eslint(no-array-constructor): Avoid calls to the `Array` constructor
    ╭─[no_array_constructor.tsx:1:1]
  1 │ Array(0, 1, 2)
    · ──────────────
    ╰────
-  help: Use an array literal instead
+  help: Use array literal notation [] instead.
 
-  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
+  ⚠ eslint(no-array-constructor): Avoid calls to the `Array` constructor
    ╭─[no_array_constructor.tsx:1:1]
  1 │ Array(...args);
    · ──────────────
    ╰────
-  help: Use an array literal instead
+  help: Use array literal notation [] instead.
 
-  ⚠ eslint(no-array-constructor): Do not use `new` to create arrays
+  ⚠ eslint(no-array-constructor): Avoid calls to the `Array` constructor
    ╭─[no_array_constructor.tsx:1:1]
  1 │ Array(1, 2, ...args);
    · ────────────────────
    ╰────
-  help: Use an array literal instead
+  help: Use array literal notation [] instead.


### PR DESCRIPTION
Adds the following missing fail cases for the rule where the last argument to the array constructor is a spread element:

```js
new Array(...args);
Array(...args);
Array(1, 2, ...args);
```

I setup an eslint playground to show the cases failing [here](https://eslint.org/play/#eyJ0ZXh0IjoiLyplc2xpbnQgbm8tYXJyYXktY29uc3RydWN0b3I6IFwiZXJyb3JcIiovXG5cblxubmV3IEFycmF5KC4uLmFyZ3MpO1xuXG5BcnJheSguLi5hcmdzKTtcblxuQXJyYXkoMSwgMiwgLi4uYXJncyk7Iiwib3B0aW9ucyI6eyJydWxlcyI6e30sImxhbmd1YWdlT3B0aW9ucyI6eyJwYXJzZXJPcHRpb25zIjp7ImVjbWFGZWF0dXJlcyI6e319fX19)