### PR TITLE
fix(parser)!: parse TS import attributes options as object expression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ target/
 /editors/vscode/out/
 /editors/vscode/*.vsix
 
+# JetBrains
+/.idea/
+
 # Cloned conformance repos
 tasks/coverage/babel/
 tasks/coverage/test262/

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1280,38 +1280,10 @@ pub struct TSImportType<'a> {
     pub span: Span,
     /// `true` for `typeof import("foo")`
     pub is_type_of: bool,
-    pub parameter: TSType<'a>,
+    pub argument: TSType<'a>,
     pub qualifier: Option<TSTypeName<'a>>,
-    pub attributes: Option<Box<'a, TSImportAttributes<'a>>>,
+    pub options: Option<ObjectExpression<'a>>,
     pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
-}
-
-#[ast(visit)]
-#[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-pub struct TSImportAttributes<'a> {
-    pub span: Span,
-    pub attributes_keyword: IdentifierName<'a>, // `with` or `assert`
-    pub elements: Vec<'a, TSImportAttribute<'a>>,
-}
-
-#[ast(visit)]
-#[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-// Pluralize as `TSImportAttributeList` to avoid naming clash with `TSImportAttributes`.
-#[plural(TSImportAttributeList)]
-pub struct TSImportAttribute<'a> {
-    pub span: Span,
-    pub name: TSImportAttributeName<'a>,
-    pub value: Expression<'a>,
-}
-
-#[ast(visit)]
-#[derive(Debug)]
-#[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-pub enum TSImportAttributeName<'a> {
-    Identifier(IdentifierName<'a>) = 0,
-    StringLiteral(StringLiteral<'a>) = 1,
 }
 
 /// TypeScript Function Type

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -1253,29 +1253,14 @@ const _: () = {
     assert!(size_of::<TSTypeQueryExprName>() == 16);
     assert!(align_of::<TSTypeQueryExprName>() == 8);
 
-    assert!(size_of::<TSImportType>() == 64);
+    assert!(size_of::<TSImportType>() == 112);
     assert!(align_of::<TSImportType>() == 8);
     assert!(offset_of!(TSImportType, span) == 0);
     assert!(offset_of!(TSImportType, is_type_of) == 8);
-    assert!(offset_of!(TSImportType, parameter) == 16);
+    assert!(offset_of!(TSImportType, argument) == 16);
     assert!(offset_of!(TSImportType, qualifier) == 32);
-    assert!(offset_of!(TSImportType, attributes) == 48);
-    assert!(offset_of!(TSImportType, type_parameters) == 56);
-
-    assert!(size_of::<TSImportAttributes>() == 64);
-    assert!(align_of::<TSImportAttributes>() == 8);
-    assert!(offset_of!(TSImportAttributes, span) == 0);
-    assert!(offset_of!(TSImportAttributes, attributes_keyword) == 8);
-    assert!(offset_of!(TSImportAttributes, elements) == 32);
-
-    assert!(size_of::<TSImportAttribute>() == 72);
-    assert!(align_of::<TSImportAttribute>() == 8);
-    assert!(offset_of!(TSImportAttribute, span) == 0);
-    assert!(offset_of!(TSImportAttribute, name) == 8);
-    assert!(offset_of!(TSImportAttribute, value) == 56);
-
-    assert!(size_of::<TSImportAttributeName>() == 48);
-    assert!(align_of::<TSImportAttributeName>() == 8);
+    assert!(offset_of!(TSImportType, options) == 48);
+    assert!(offset_of!(TSImportType, type_parameters) == 104);
 
     assert!(size_of::<TSFunctionType>() == 48);
     assert!(align_of::<TSFunctionType>() == 8);
@@ -2657,29 +2642,14 @@ const _: () = {
     assert!(size_of::<TSTypeQueryExprName>() == 8);
     assert!(align_of::<TSTypeQueryExprName>() == 4);
 
-    assert!(size_of::<TSImportType>() == 36);
+    assert!(size_of::<TSImportType>() == 68);
     assert!(align_of::<TSImportType>() == 4);
     assert!(offset_of!(TSImportType, span) == 0);
     assert!(offset_of!(TSImportType, is_type_of) == 8);
-    assert!(offset_of!(TSImportType, parameter) == 12);
+    assert!(offset_of!(TSImportType, argument) == 12);
     assert!(offset_of!(TSImportType, qualifier) == 20);
-    assert!(offset_of!(TSImportType, attributes) == 28);
-    assert!(offset_of!(TSImportType, type_parameters) == 32);
-
-    assert!(size_of::<TSImportAttributes>() == 40);
-    assert!(align_of::<TSImportAttributes>() == 4);
-    assert!(offset_of!(TSImportAttributes, span) == 0);
-    assert!(offset_of!(TSImportAttributes, attributes_keyword) == 8);
-    assert!(offset_of!(TSImportAttributes, elements) == 24);
-
-    assert!(size_of::<TSImportAttribute>() == 44);
-    assert!(align_of::<TSImportAttribute>() == 4);
-    assert!(offset_of!(TSImportAttribute, span) == 0);
-    assert!(offset_of!(TSImportAttribute, name) == 8);
-    assert!(offset_of!(TSImportAttribute, value) == 36);
-
-    assert!(size_of::<TSImportAttributeName>() == 28);
-    assert!(align_of::<TSImportAttributeName>() == 4);
+    assert!(offset_of!(TSImportType, options) == 28);
+    assert!(offset_of!(TSImportType, type_parameters) == 64);
 
     assert!(size_of::<TSFunctionType>() == 28);
     assert!(align_of::<TSFunctionType>() == 4);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -10307,30 +10307,29 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `is_type_of`: `true` for `typeof import("foo")`
-    /// * `parameter`
+    /// * `argument`
     /// * `qualifier`
-    /// * `attributes`
+    /// * `options`
     /// * `type_parameters`
     #[inline]
-    pub fn ts_type_import_type<T1, T2>(
+    pub fn ts_type_import_type<T1>(
         self,
         span: Span,
         is_type_of: bool,
-        parameter: TSType<'a>,
+        argument: TSType<'a>,
         qualifier: Option<TSTypeName<'a>>,
-        attributes: T1,
-        type_parameters: T2,
+        options: Option<ObjectExpression<'a>>,
+        type_parameters: T1,
     ) -> TSType<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSImportAttributes<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         TSType::TSImportType(self.alloc_ts_import_type(
             span,
             is_type_of,
-            parameter,
+            argument,
             qualifier,
-            attributes,
+            options,
             type_parameters,
         ))
     }
@@ -13423,30 +13422,29 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `is_type_of`: `true` for `typeof import("foo")`
-    /// * `parameter`
+    /// * `argument`
     /// * `qualifier`
-    /// * `attributes`
+    /// * `options`
     /// * `type_parameters`
     #[inline]
-    pub fn ts_type_query_expr_name_import_type<T1, T2>(
+    pub fn ts_type_query_expr_name_import_type<T1>(
         self,
         span: Span,
         is_type_of: bool,
-        parameter: TSType<'a>,
+        argument: TSType<'a>,
         qualifier: Option<TSTypeName<'a>>,
-        attributes: T1,
-        type_parameters: T2,
+        options: Option<ObjectExpression<'a>>,
+        type_parameters: T1,
     ) -> TSTypeQueryExprName<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSImportAttributes<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         TSTypeQueryExprName::TSImportType(self.alloc_ts_import_type(
             span,
             is_type_of,
-            parameter,
+            argument,
             qualifier,
-            attributes,
+            options,
             type_parameters,
         ))
     }
@@ -13458,30 +13456,29 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `is_type_of`: `true` for `typeof import("foo")`
-    /// * `parameter`
+    /// * `argument`
     /// * `qualifier`
-    /// * `attributes`
+    /// * `options`
     /// * `type_parameters`
     #[inline]
-    pub fn ts_import_type<T1, T2>(
+    pub fn ts_import_type<T1>(
         self,
         span: Span,
         is_type_of: bool,
-        parameter: TSType<'a>,
+        argument: TSType<'a>,
         qualifier: Option<TSTypeName<'a>>,
-        attributes: T1,
-        type_parameters: T2,
+        options: Option<ObjectExpression<'a>>,
+        type_parameters: T1,
     ) -> TSImportType<'a>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSImportAttributes<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         TSImportType {
             span,
             is_type_of,
-            parameter,
+            argument,
             qualifier,
-            attributes: attributes.into_in(self.allocator),
+            options,
             type_parameters: type_parameters.into_in(self.allocator),
         }
     }
@@ -13493,143 +13490,27 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `is_type_of`: `true` for `typeof import("foo")`
-    /// * `parameter`
+    /// * `argument`
     /// * `qualifier`
-    /// * `attributes`
+    /// * `options`
     /// * `type_parameters`
     #[inline]
-    pub fn alloc_ts_import_type<T1, T2>(
+    pub fn alloc_ts_import_type<T1>(
         self,
         span: Span,
         is_type_of: bool,
-        parameter: TSType<'a>,
+        argument: TSType<'a>,
         qualifier: Option<TSTypeName<'a>>,
-        attributes: T1,
-        type_parameters: T2,
+        options: Option<ObjectExpression<'a>>,
+        type_parameters: T1,
     ) -> Box<'a, TSImportType<'a>>
     where
-        T1: IntoIn<'a, Option<Box<'a, TSImportAttributes<'a>>>>,
-        T2: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
+        T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         Box::new_in(
-            self.ts_import_type(
-                span,
-                is_type_of,
-                parameter,
-                qualifier,
-                attributes,
-                type_parameters,
-            ),
+            self.ts_import_type(span, is_type_of, argument, qualifier, options, type_parameters),
             self.allocator,
         )
-    }
-
-    /// Build a [`TSImportAttributes`].
-    ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_import_attributes`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: The [`Span`] covering this node
-    /// * `attributes_keyword`
-    /// * `elements`
-    #[inline]
-    pub fn ts_import_attributes(
-        self,
-        span: Span,
-        attributes_keyword: IdentifierName<'a>,
-        elements: Vec<'a, TSImportAttribute<'a>>,
-    ) -> TSImportAttributes<'a> {
-        TSImportAttributes { span, attributes_keyword, elements }
-    }
-
-    /// Build a [`TSImportAttributes`], and store it in the memory arena.
-    ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_import_attributes`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: The [`Span`] covering this node
-    /// * `attributes_keyword`
-    /// * `elements`
-    #[inline]
-    pub fn alloc_ts_import_attributes(
-        self,
-        span: Span,
-        attributes_keyword: IdentifierName<'a>,
-        elements: Vec<'a, TSImportAttribute<'a>>,
-    ) -> Box<'a, TSImportAttributes<'a>> {
-        Box::new_in(self.ts_import_attributes(span, attributes_keyword, elements), self.allocator)
-    }
-
-    /// Build a [`TSImportAttribute`].
-    ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_import_attribute`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: The [`Span`] covering this node
-    /// * `name`
-    /// * `value`
-    #[inline]
-    pub fn ts_import_attribute(
-        self,
-        span: Span,
-        name: TSImportAttributeName<'a>,
-        value: Expression<'a>,
-    ) -> TSImportAttribute<'a> {
-        TSImportAttribute { span, name, value }
-    }
-
-    /// Build a [`TSImportAttribute`], and store it in the memory arena.
-    ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_import_attribute`] instead.
-    ///
-    /// ## Parameters
-    /// * `span`: The [`Span`] covering this node
-    /// * `name`
-    /// * `value`
-    #[inline]
-    pub fn alloc_ts_import_attribute(
-        self,
-        span: Span,
-        name: TSImportAttributeName<'a>,
-        value: Expression<'a>,
-    ) -> Box<'a, TSImportAttribute<'a>> {
-        Box::new_in(self.ts_import_attribute(span, name, value), self.allocator)
-    }
-
-    /// Build a [`TSImportAttributeName::Identifier`].
-    ///
-    /// ## Parameters
-    /// * `span`: The [`Span`] covering this node
-    /// * `name`
-    #[inline]
-    pub fn ts_import_attribute_name_identifier<A>(
-        self,
-        span: Span,
-        name: A,
-    ) -> TSImportAttributeName<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        TSImportAttributeName::Identifier(self.identifier_name(span, name))
-    }
-
-    /// Build a [`TSImportAttributeName::StringLiteral`].
-    ///
-    /// ## Parameters
-    /// * `span`: Node location in source code
-    /// * `value`: The value of the string.
-    /// * `raw`: The raw string as it appears in source code.
-    #[inline]
-    pub fn ts_import_attribute_name_string_literal<A>(
-        self,
-        span: Span,
-        value: A,
-        raw: Option<Atom<'a>>,
-    ) -> TSImportAttributeName<'a>
-    where
-        A: IntoIn<'a, Atom<'a>>,
-    {
-        TSImportAttributeName::StringLiteral(self.string_literal(span, value, raw))
     }
 
     /// Build a [`TSFunctionType`].

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -3850,46 +3850,10 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSImportType<'_> {
         TSImportType {
             span: CloneIn::clone_in(&self.span, allocator),
             is_type_of: CloneIn::clone_in(&self.is_type_of, allocator),
-            parameter: CloneIn::clone_in(&self.parameter, allocator),
+            argument: CloneIn::clone_in(&self.argument, allocator),
             qualifier: CloneIn::clone_in(&self.qualifier, allocator),
-            attributes: CloneIn::clone_in(&self.attributes, allocator),
+            options: CloneIn::clone_in(&self.options, allocator),
             type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
-        }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for TSImportAttributes<'_> {
-    type Cloned = TSImportAttributes<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSImportAttributes {
-            span: CloneIn::clone_in(&self.span, allocator),
-            attributes_keyword: CloneIn::clone_in(&self.attributes_keyword, allocator),
-            elements: CloneIn::clone_in(&self.elements, allocator),
-        }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for TSImportAttribute<'_> {
-    type Cloned = TSImportAttribute<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        TSImportAttribute {
-            span: CloneIn::clone_in(&self.span, allocator),
-            name: CloneIn::clone_in(&self.name, allocator),
-            value: CloneIn::clone_in(&self.value, allocator),
-        }
-    }
-}
-
-impl<'new_alloc> CloneIn<'new_alloc> for TSImportAttributeName<'_> {
-    type Cloned = TSImportAttributeName<'new_alloc>;
-    fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Identifier(it) => {
-                TSImportAttributeName::Identifier(CloneIn::clone_in(it, allocator))
-            }
-            Self::StringLiteral(it) => {
-                TSImportAttributeName::StringLiteral(CloneIn::clone_in(it, allocator))
-            }
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -2298,34 +2298,10 @@ impl ContentEq for TSTypeQueryExprName<'_> {
 impl ContentEq for TSImportType<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.is_type_of, &other.is_type_of)
-            && ContentEq::content_eq(&self.parameter, &other.parameter)
+            && ContentEq::content_eq(&self.argument, &other.argument)
             && ContentEq::content_eq(&self.qualifier, &other.qualifier)
-            && ContentEq::content_eq(&self.attributes, &other.attributes)
+            && ContentEq::content_eq(&self.options, &other.options)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
-    }
-}
-
-impl ContentEq for TSImportAttributes<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.attributes_keyword, &other.attributes_keyword)
-            && ContentEq::content_eq(&self.elements, &other.elements)
-    }
-}
-
-impl ContentEq for TSImportAttribute<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.name, &other.name)
-            && ContentEq::content_eq(&self.value, &other.value)
-    }
-}
-
-impl ContentEq for TSImportAttributeName<'_> {
-    fn content_eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Identifier(a), Self::Identifier(b)) => a.content_eq(b),
-            (Self::StringLiteral(a), Self::StringLiteral(b)) => a.content_eq(b),
-            _ => false,
-        }
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -3092,44 +3092,11 @@ impl ESTree for TSImportType<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("isTypeOf", &self.is_type_of);
-        state.serialize_field("parameter", &self.parameter);
+        state.serialize_field("argument", &self.argument);
         state.serialize_field("qualifier", &self.qualifier);
-        state.serialize_field("attributes", &self.attributes);
+        state.serialize_field("options", &self.options);
         state.serialize_field("typeParameters", &self.type_parameters);
         state.end();
-    }
-}
-
-impl ESTree for TSImportAttributes<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) {
-        let mut state = serializer.serialize_struct();
-        state.serialize_field("type", &JsonSafeString("TSImportAttributes"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
-        state.serialize_field("attributesKeyword", &self.attributes_keyword);
-        state.serialize_field("elements", &self.elements);
-        state.end();
-    }
-}
-
-impl ESTree for TSImportAttribute<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) {
-        let mut state = serializer.serialize_struct();
-        state.serialize_field("type", &JsonSafeString("TSImportAttribute"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
-        state.serialize_field("name", &self.name);
-        state.serialize_field("value", &self.value);
-        state.end();
-    }
-}
-
-impl ESTree for TSImportAttributeName<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) {
-        match self {
-            Self::Identifier(it) => it.serialize(serializer),
-            Self::StringLiteral(it) => it.serialize(serializer),
-        }
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_get_span.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span.rs
@@ -2015,29 +2015,6 @@ impl GetSpan for TSImportType<'_> {
     }
 }
 
-impl GetSpan for TSImportAttributes<'_> {
-    #[inline]
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
-impl GetSpan for TSImportAttribute<'_> {
-    #[inline]
-    fn span(&self) -> Span {
-        self.span
-    }
-}
-
-impl GetSpan for TSImportAttributeName<'_> {
-    fn span(&self) -> Span {
-        match self {
-            Self::Identifier(it) => GetSpan::span(it),
-            Self::StringLiteral(it) => GetSpan::span(it),
-        }
-    }
-}
-
 impl GetSpan for TSFunctionType<'_> {
     #[inline]
     fn span(&self) -> Span {

--- a/crates/oxc_ast/src/generated/derive_get_span_mut.rs
+++ b/crates/oxc_ast/src/generated/derive_get_span_mut.rs
@@ -2015,29 +2015,6 @@ impl GetSpanMut for TSImportType<'_> {
     }
 }
 
-impl GetSpanMut for TSImportAttributes<'_> {
-    #[inline]
-    fn span_mut(&mut self) -> &mut Span {
-        &mut self.span
-    }
-}
-
-impl GetSpanMut for TSImportAttribute<'_> {
-    #[inline]
-    fn span_mut(&mut self) -> &mut Span {
-        &mut self.span
-    }
-}
-
-impl GetSpanMut for TSImportAttributeName<'_> {
-    fn span_mut(&mut self) -> &mut Span {
-        match self {
-            Self::Identifier(it) => GetSpanMut::span_mut(it),
-            Self::StringLiteral(it) => GetSpanMut::span_mut(it),
-        }
-    }
-}
-
 impl GetSpanMut for TSFunctionType<'_> {
     #[inline]
     fn span_mut(&mut self) -> &mut Span {

--- a/crates/oxc_ast_visit/src/generated/utf8_to_utf16_converter.rs
+++ b/crates/oxc_ast_visit/src/generated/utf8_to_utf16_converter.rs
@@ -983,18 +983,6 @@ impl<'a> VisitMut<'a> for Utf8ToUtf16Converter<'_> {
         self.convert_offset(&mut it.span.end);
     }
 
-    fn visit_ts_import_attributes(&mut self, it: &mut TSImportAttributes<'a>) {
-        self.convert_offset(&mut it.span.start);
-        walk_mut::walk_ts_import_attributes(self, it);
-        self.convert_offset(&mut it.span.end);
-    }
-
-    fn visit_ts_import_attribute(&mut self, it: &mut TSImportAttribute<'a>) {
-        self.convert_offset(&mut it.span.start);
-        walk_mut::walk_ts_import_attribute(self, it);
-        self.convert_offset(&mut it.span.end);
-    }
-
     fn visit_ts_function_type(&mut self, it: &mut TSFunctionType<'a>) {
         self.convert_offset(&mut it.span.start);
         walk_mut::walk_ts_function_type(self, it);

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -1089,21 +1089,6 @@ pub trait Visit<'a>: Sized {
     }
 
     #[inline]
-    fn visit_ts_import_attributes(&mut self, it: &TSImportAttributes<'a>) {
-        walk_ts_import_attributes(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_import_attribute(&mut self, it: &TSImportAttribute<'a>) {
-        walk_ts_import_attribute(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_import_attribute_name(&mut self, it: &TSImportAttributeName<'a>) {
-        walk_ts_import_attribute_name(self, it);
-    }
-
-    #[inline]
     fn visit_ts_function_type(&mut self, it: &TSFunctionType<'a>) {
         walk_ts_function_type(self, it);
     }
@@ -1334,11 +1319,6 @@ pub trait Visit<'a>: Sized {
     #[inline]
     fn visit_ts_index_signature_names(&mut self, it: &Vec<'a, TSIndexSignatureName<'a>>) {
         walk_ts_index_signature_names(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_import_attribute_list(&mut self, it: &Vec<'a, TSImportAttribute<'a>>) {
-        walk_ts_import_attribute_list(self, it);
     }
 
     #[inline]
@@ -3909,48 +3889,17 @@ pub mod walk {
         let kind = AstKind::TSImportType(visitor.alloc(it));
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
-        visitor.visit_ts_type(&it.parameter);
+        visitor.visit_ts_type(&it.argument);
         if let Some(qualifier) = &it.qualifier {
             visitor.visit_ts_type_name(qualifier);
         }
-        if let Some(attributes) = &it.attributes {
-            visitor.visit_ts_import_attributes(attributes);
+        if let Some(options) = &it.options {
+            visitor.visit_object_expression(options);
         }
         if let Some(type_parameters) = &it.type_parameters {
             visitor.visit_ts_type_parameter_instantiation(type_parameters);
         }
         visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_import_attributes<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &TSImportAttributes<'a>,
-    ) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-        visitor.visit_identifier_name(&it.attributes_keyword);
-        visitor.visit_ts_import_attribute_list(&it.elements);
-    }
-
-    #[inline]
-    pub fn walk_ts_import_attribute<'a, V: Visit<'a>>(visitor: &mut V, it: &TSImportAttribute<'a>) {
-        // No `AstKind` for this type
-        visitor.visit_span(&it.span);
-        visitor.visit_ts_import_attribute_name(&it.name);
-        visitor.visit_expression(&it.value);
-    }
-
-    #[inline]
-    pub fn walk_ts_import_attribute_name<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &TSImportAttributeName<'a>,
-    ) {
-        // No `AstKind` for this type
-        match it {
-            TSImportAttributeName::Identifier(it) => visitor.visit_identifier_name(it),
-            TSImportAttributeName::StringLiteral(it) => visitor.visit_string_literal(it),
-        }
     }
 
     #[inline]
@@ -4404,16 +4353,6 @@ pub mod walk {
     ) {
         for el in it {
             visitor.visit_ts_index_signature_name(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_import_attribute_list<'a, V: Visit<'a>>(
-        visitor: &mut V,
-        it: &Vec<'a, TSImportAttribute<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_ts_import_attribute(el);
         }
     }
 

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -1081,21 +1081,6 @@ pub trait VisitMut<'a>: Sized {
     }
 
     #[inline]
-    fn visit_ts_import_attributes(&mut self, it: &mut TSImportAttributes<'a>) {
-        walk_ts_import_attributes(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_import_attribute(&mut self, it: &mut TSImportAttribute<'a>) {
-        walk_ts_import_attribute(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_import_attribute_name(&mut self, it: &mut TSImportAttributeName<'a>) {
-        walk_ts_import_attribute_name(self, it);
-    }
-
-    #[inline]
     fn visit_ts_function_type(&mut self, it: &mut TSFunctionType<'a>) {
         walk_ts_function_type(self, it);
     }
@@ -1329,11 +1314,6 @@ pub trait VisitMut<'a>: Sized {
     #[inline]
     fn visit_ts_index_signature_names(&mut self, it: &mut Vec<'a, TSIndexSignatureName<'a>>) {
         walk_ts_index_signature_names(self, it);
-    }
-
-    #[inline]
-    fn visit_ts_import_attribute_list(&mut self, it: &mut Vec<'a, TSImportAttribute<'a>>) {
-        walk_ts_import_attribute_list(self, it);
     }
 
     #[inline]
@@ -4118,51 +4098,17 @@ pub mod walk_mut {
         let kind = AstType::TSImportType;
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
-        visitor.visit_ts_type(&mut it.parameter);
+        visitor.visit_ts_type(&mut it.argument);
         if let Some(qualifier) = &mut it.qualifier {
             visitor.visit_ts_type_name(qualifier);
         }
-        if let Some(attributes) = &mut it.attributes {
-            visitor.visit_ts_import_attributes(attributes);
+        if let Some(options) = &mut it.options {
+            visitor.visit_object_expression(options);
         }
         if let Some(type_parameters) = &mut it.type_parameters {
             visitor.visit_ts_type_parameter_instantiation(type_parameters);
         }
         visitor.leave_node(kind);
-    }
-
-    #[inline]
-    pub fn walk_ts_import_attributes<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSImportAttributes<'a>,
-    ) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-        visitor.visit_identifier_name(&mut it.attributes_keyword);
-        visitor.visit_ts_import_attribute_list(&mut it.elements);
-    }
-
-    #[inline]
-    pub fn walk_ts_import_attribute<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSImportAttribute<'a>,
-    ) {
-        // No `AstType` for this type
-        visitor.visit_span(&mut it.span);
-        visitor.visit_ts_import_attribute_name(&mut it.name);
-        visitor.visit_expression(&mut it.value);
-    }
-
-    #[inline]
-    pub fn walk_ts_import_attribute_name<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut TSImportAttributeName<'a>,
-    ) {
-        // No `AstType` for this type
-        match it {
-            TSImportAttributeName::Identifier(it) => visitor.visit_identifier_name(it),
-            TSImportAttributeName::StringLiteral(it) => visitor.visit_string_literal(it),
-        }
     }
 
     #[inline]
@@ -4649,16 +4595,6 @@ pub mod walk_mut {
     ) {
         for el in it {
             visitor.visit_ts_index_signature_name(el);
-        }
-    }
-
-    #[inline]
-    pub fn walk_ts_import_attribute_list<'a, V: VisitMut<'a>>(
-        visitor: &mut V,
-        it: &mut Vec<'a, TSImportAttribute<'a>>,
-    ) {
-        for el in it {
-            visitor.visit_ts_import_attribute(el);
         }
     }
 

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -281,43 +281,39 @@ pub(crate) enum AncestorType {
     TSInferTypeTypeParameter = 258,
     TSTypeQueryExprName = 259,
     TSTypeQueryTypeParameters = 260,
-    TSImportTypeParameter = 261,
+    TSImportTypeArgument = 261,
     TSImportTypeQualifier = 262,
-    TSImportTypeAttributes = 263,
+    TSImportTypeOptions = 263,
     TSImportTypeTypeParameters = 264,
-    TSImportAttributesAttributesKeyword = 265,
-    TSImportAttributesElements = 266,
-    TSImportAttributeName = 267,
-    TSImportAttributeValue = 268,
-    TSFunctionTypeTypeParameters = 269,
-    TSFunctionTypeThisParam = 270,
-    TSFunctionTypeParams = 271,
-    TSFunctionTypeReturnType = 272,
-    TSConstructorTypeTypeParameters = 273,
-    TSConstructorTypeParams = 274,
-    TSConstructorTypeReturnType = 275,
-    TSMappedTypeTypeParameter = 276,
-    TSMappedTypeNameType = 277,
-    TSMappedTypeTypeAnnotation = 278,
-    TSTemplateLiteralTypeQuasis = 279,
-    TSTemplateLiteralTypeTypes = 280,
-    TSAsExpressionExpression = 281,
-    TSAsExpressionTypeAnnotation = 282,
-    TSSatisfiesExpressionExpression = 283,
-    TSSatisfiesExpressionTypeAnnotation = 284,
-    TSTypeAssertionExpression = 285,
-    TSTypeAssertionTypeAnnotation = 286,
-    TSImportEqualsDeclarationId = 287,
-    TSImportEqualsDeclarationModuleReference = 288,
-    TSExternalModuleReferenceExpression = 289,
-    TSNonNullExpressionExpression = 290,
-    DecoratorExpression = 291,
-    TSExportAssignmentExpression = 292,
-    TSNamespaceExportDeclarationId = 293,
-    TSInstantiationExpressionExpression = 294,
-    TSInstantiationExpressionTypeParameters = 295,
-    JSDocNullableTypeTypeAnnotation = 296,
-    JSDocNonNullableTypeTypeAnnotation = 297,
+    TSFunctionTypeTypeParameters = 265,
+    TSFunctionTypeThisParam = 266,
+    TSFunctionTypeParams = 267,
+    TSFunctionTypeReturnType = 268,
+    TSConstructorTypeTypeParameters = 269,
+    TSConstructorTypeParams = 270,
+    TSConstructorTypeReturnType = 271,
+    TSMappedTypeTypeParameter = 272,
+    TSMappedTypeNameType = 273,
+    TSMappedTypeTypeAnnotation = 274,
+    TSTemplateLiteralTypeQuasis = 275,
+    TSTemplateLiteralTypeTypes = 276,
+    TSAsExpressionExpression = 277,
+    TSAsExpressionTypeAnnotation = 278,
+    TSSatisfiesExpressionExpression = 279,
+    TSSatisfiesExpressionTypeAnnotation = 280,
+    TSTypeAssertionExpression = 281,
+    TSTypeAssertionTypeAnnotation = 282,
+    TSImportEqualsDeclarationId = 283,
+    TSImportEqualsDeclarationModuleReference = 284,
+    TSExternalModuleReferenceExpression = 285,
+    TSNonNullExpressionExpression = 286,
+    DecoratorExpression = 287,
+    TSExportAssignmentExpression = 288,
+    TSNamespaceExportDeclarationId = 289,
+    TSInstantiationExpressionExpression = 290,
+    TSInstantiationExpressionTypeParameters = 291,
+    JSDocNullableTypeTypeAnnotation = 292,
+    JSDocNonNullableTypeTypeAnnotation = 293,
 }
 
 /// Ancestor type used in AST traversal.
@@ -821,22 +817,14 @@ pub enum Ancestor<'a, 't> {
         AncestorType::TSTypeQueryExprName as u16,
     TSTypeQueryTypeParameters(TSTypeQueryWithoutTypeParameters<'a, 't>) =
         AncestorType::TSTypeQueryTypeParameters as u16,
-    TSImportTypeParameter(TSImportTypeWithoutParameter<'a, 't>) =
-        AncestorType::TSImportTypeParameter as u16,
+    TSImportTypeArgument(TSImportTypeWithoutArgument<'a, 't>) =
+        AncestorType::TSImportTypeArgument as u16,
     TSImportTypeQualifier(TSImportTypeWithoutQualifier<'a, 't>) =
         AncestorType::TSImportTypeQualifier as u16,
-    TSImportTypeAttributes(TSImportTypeWithoutAttributes<'a, 't>) =
-        AncestorType::TSImportTypeAttributes as u16,
+    TSImportTypeOptions(TSImportTypeWithoutOptions<'a, 't>) =
+        AncestorType::TSImportTypeOptions as u16,
     TSImportTypeTypeParameters(TSImportTypeWithoutTypeParameters<'a, 't>) =
         AncestorType::TSImportTypeTypeParameters as u16,
-    TSImportAttributesAttributesKeyword(TSImportAttributesWithoutAttributesKeyword<'a, 't>) =
-        AncestorType::TSImportAttributesAttributesKeyword as u16,
-    TSImportAttributesElements(TSImportAttributesWithoutElements<'a, 't>) =
-        AncestorType::TSImportAttributesElements as u16,
-    TSImportAttributeName(TSImportAttributeWithoutName<'a, 't>) =
-        AncestorType::TSImportAttributeName as u16,
-    TSImportAttributeValue(TSImportAttributeWithoutValue<'a, 't>) =
-        AncestorType::TSImportAttributeValue as u16,
     TSFunctionTypeTypeParameters(TSFunctionTypeWithoutTypeParameters<'a, 't>) =
         AncestorType::TSFunctionTypeTypeParameters as u16,
     TSFunctionTypeThisParam(TSFunctionTypeWithoutThisParam<'a, 't>) =
@@ -1749,24 +1737,11 @@ impl<'a, 't> Ancestor<'a, 't> {
     pub fn is_ts_import_type(self) -> bool {
         matches!(
             self,
-            Self::TSImportTypeParameter(_)
+            Self::TSImportTypeArgument(_)
                 | Self::TSImportTypeQualifier(_)
-                | Self::TSImportTypeAttributes(_)
+                | Self::TSImportTypeOptions(_)
                 | Self::TSImportTypeTypeParameters(_)
         )
-    }
-
-    #[inline]
-    pub fn is_ts_import_attributes(self) -> bool {
-        matches!(
-            self,
-            Self::TSImportAttributesAttributesKeyword(_) | Self::TSImportAttributesElements(_)
-        )
-    }
-
-    #[inline]
-    pub fn is_ts_import_attribute(self) -> bool {
-        matches!(self, Self::TSImportAttributeName(_) | Self::TSImportAttributeValue(_))
     }
 
     #[inline]
@@ -1977,7 +1952,6 @@ impl<'a, 't> Ancestor<'a, 't> {
                 | Self::JSXSpreadChildExpression(_)
                 | Self::TSEnumMemberInitializer(_)
                 | Self::TSInterfaceHeritageExpression(_)
-                | Self::TSImportAttributeValue(_)
                 | Self::TSAsExpressionExpression(_)
                 | Self::TSSatisfiesExpressionExpression(_)
                 | Self::TSTypeAssertionExpression(_)
@@ -2146,7 +2120,7 @@ impl<'a, 't> Ancestor<'a, 't> {
                 | Self::TSTypeParameterConstraint(_)
                 | Self::TSTypeParameterDefault(_)
                 | Self::TSTypeAliasDeclarationTypeAnnotation(_)
-                | Self::TSImportTypeParameter(_)
+                | Self::TSImportTypeArgument(_)
                 | Self::TSMappedTypeNameType(_)
                 | Self::TSMappedTypeTypeAnnotation(_)
                 | Self::TSTemplateLiteralTypeTypes(_)
@@ -2202,11 +2176,6 @@ impl<'a, 't> Ancestor<'a, 't> {
     #[inline]
     pub fn is_parent_of_ts_type_query_expr_name(self) -> bool {
         matches!(self, Self::TSTypeQueryExprName(_))
-    }
-
-    #[inline]
-    pub fn is_parent_of_ts_import_attribute_name(self) -> bool {
-        matches!(self, Self::TSImportAttributeName(_))
     }
 
     #[inline]
@@ -2482,14 +2451,10 @@ impl<'a, 't> GetAddress for Ancestor<'a, 't> {
             Self::TSInferTypeTypeParameter(a) => a.address(),
             Self::TSTypeQueryExprName(a) => a.address(),
             Self::TSTypeQueryTypeParameters(a) => a.address(),
-            Self::TSImportTypeParameter(a) => a.address(),
+            Self::TSImportTypeArgument(a) => a.address(),
             Self::TSImportTypeQualifier(a) => a.address(),
-            Self::TSImportTypeAttributes(a) => a.address(),
+            Self::TSImportTypeOptions(a) => a.address(),
             Self::TSImportTypeTypeParameters(a) => a.address(),
-            Self::TSImportAttributesAttributesKeyword(a) => a.address(),
-            Self::TSImportAttributesElements(a) => a.address(),
-            Self::TSImportAttributeName(a) => a.address(),
-            Self::TSImportAttributeValue(a) => a.address(),
             Self::TSFunctionTypeTypeParameters(a) => a.address(),
             Self::TSFunctionTypeThisParam(a) => a.address(),
             Self::TSFunctionTypeParams(a) => a.address(),
@@ -14249,20 +14214,20 @@ impl<'a, 't> GetAddress for TSTypeQueryWithoutTypeParameters<'a, 't> {
 
 pub(crate) const OFFSET_TS_IMPORT_TYPE_SPAN: usize = offset_of!(TSImportType, span);
 pub(crate) const OFFSET_TS_IMPORT_TYPE_IS_TYPE_OF: usize = offset_of!(TSImportType, is_type_of);
-pub(crate) const OFFSET_TS_IMPORT_TYPE_PARAMETER: usize = offset_of!(TSImportType, parameter);
+pub(crate) const OFFSET_TS_IMPORT_TYPE_ARGUMENT: usize = offset_of!(TSImportType, argument);
 pub(crate) const OFFSET_TS_IMPORT_TYPE_QUALIFIER: usize = offset_of!(TSImportType, qualifier);
-pub(crate) const OFFSET_TS_IMPORT_TYPE_ATTRIBUTES: usize = offset_of!(TSImportType, attributes);
+pub(crate) const OFFSET_TS_IMPORT_TYPE_OPTIONS: usize = offset_of!(TSImportType, options);
 pub(crate) const OFFSET_TS_IMPORT_TYPE_TYPE_PARAMETERS: usize =
     offset_of!(TSImportType, type_parameters);
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
-pub struct TSImportTypeWithoutParameter<'a, 't>(
+pub struct TSImportTypeWithoutArgument<'a, 't>(
     pub(crate) *const TSImportType<'a>,
     pub(crate) PhantomData<&'t ()>,
 );
 
-impl<'a, 't> TSImportTypeWithoutParameter<'a, 't> {
+impl<'a, 't> TSImportTypeWithoutArgument<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_SPAN) as *const Span) }
@@ -14282,10 +14247,10 @@ impl<'a, 't> TSImportTypeWithoutParameter<'a, 't> {
     }
 
     #[inline]
-    pub fn attributes(self) -> &'t Option<Box<'a, TSImportAttributes<'a>>> {
+    pub fn options(self) -> &'t Option<ObjectExpression<'a>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_ATTRIBUTES)
-                as *const Option<Box<'a, TSImportAttributes<'a>>>)
+            &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_OPTIONS)
+                as *const Option<ObjectExpression<'a>>)
         }
     }
 
@@ -14298,7 +14263,7 @@ impl<'a, 't> TSImportTypeWithoutParameter<'a, 't> {
     }
 }
 
-impl<'a, 't> GetAddress for TSImportTypeWithoutParameter<'a, 't> {
+impl<'a, 't> GetAddress for TSImportTypeWithoutArgument<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)
@@ -14324,17 +14289,17 @@ impl<'a, 't> TSImportTypeWithoutQualifier<'a, 't> {
     }
 
     #[inline]
-    pub fn parameter(self) -> &'t TSType<'a> {
+    pub fn argument(self) -> &'t TSType<'a> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_PARAMETER) as *const TSType<'a>)
+            &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_ARGUMENT) as *const TSType<'a>)
         }
     }
 
     #[inline]
-    pub fn attributes(self) -> &'t Option<Box<'a, TSImportAttributes<'a>>> {
+    pub fn options(self) -> &'t Option<ObjectExpression<'a>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_ATTRIBUTES)
-                as *const Option<Box<'a, TSImportAttributes<'a>>>)
+            &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_OPTIONS)
+                as *const Option<ObjectExpression<'a>>)
         }
     }
 
@@ -14356,12 +14321,12 @@ impl<'a, 't> GetAddress for TSImportTypeWithoutQualifier<'a, 't> {
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
-pub struct TSImportTypeWithoutAttributes<'a, 't>(
+pub struct TSImportTypeWithoutOptions<'a, 't>(
     pub(crate) *const TSImportType<'a>,
     pub(crate) PhantomData<&'t ()>,
 );
 
-impl<'a, 't> TSImportTypeWithoutAttributes<'a, 't> {
+impl<'a, 't> TSImportTypeWithoutOptions<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_SPAN) as *const Span) }
@@ -14373,9 +14338,9 @@ impl<'a, 't> TSImportTypeWithoutAttributes<'a, 't> {
     }
 
     #[inline]
-    pub fn parameter(self) -> &'t TSType<'a> {
+    pub fn argument(self) -> &'t TSType<'a> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_PARAMETER) as *const TSType<'a>)
+            &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_ARGUMENT) as *const TSType<'a>)
         }
     }
 
@@ -14396,7 +14361,7 @@ impl<'a, 't> TSImportTypeWithoutAttributes<'a, 't> {
     }
 }
 
-impl<'a, 't> GetAddress for TSImportTypeWithoutAttributes<'a, 't> {
+impl<'a, 't> GetAddress for TSImportTypeWithoutOptions<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)
@@ -14422,9 +14387,9 @@ impl<'a, 't> TSImportTypeWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn parameter(self) -> &'t TSType<'a> {
+    pub fn argument(self) -> &'t TSType<'a> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_PARAMETER) as *const TSType<'a>)
+            &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_ARGUMENT) as *const TSType<'a>)
         }
     }
 
@@ -14437,140 +14402,15 @@ impl<'a, 't> TSImportTypeWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn attributes(self) -> &'t Option<Box<'a, TSImportAttributes<'a>>> {
+    pub fn options(self) -> &'t Option<ObjectExpression<'a>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_ATTRIBUTES)
-                as *const Option<Box<'a, TSImportAttributes<'a>>>)
+            &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_TYPE_OPTIONS)
+                as *const Option<ObjectExpression<'a>>)
         }
     }
 }
 
 impl<'a, 't> GetAddress for TSImportTypeWithoutTypeParameters<'a, 't> {
-    #[inline]
-    fn address(&self) -> Address {
-        Address::from_ptr(self.0)
-    }
-}
-
-pub(crate) const OFFSET_TS_IMPORT_ATTRIBUTES_SPAN: usize = offset_of!(TSImportAttributes, span);
-pub(crate) const OFFSET_TS_IMPORT_ATTRIBUTES_ATTRIBUTES_KEYWORD: usize =
-    offset_of!(TSImportAttributes, attributes_keyword);
-pub(crate) const OFFSET_TS_IMPORT_ATTRIBUTES_ELEMENTS: usize =
-    offset_of!(TSImportAttributes, elements);
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct TSImportAttributesWithoutAttributesKeyword<'a, 't>(
-    pub(crate) *const TSImportAttributes<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> TSImportAttributesWithoutAttributesKeyword<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_ATTRIBUTES_SPAN) as *const Span) }
-    }
-
-    #[inline]
-    pub fn elements(self) -> &'t Vec<'a, TSImportAttribute<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_ATTRIBUTES_ELEMENTS)
-                as *const Vec<'a, TSImportAttribute<'a>>)
-        }
-    }
-}
-
-impl<'a, 't> GetAddress for TSImportAttributesWithoutAttributesKeyword<'a, 't> {
-    #[inline]
-    fn address(&self) -> Address {
-        Address::from_ptr(self.0)
-    }
-}
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct TSImportAttributesWithoutElements<'a, 't>(
-    pub(crate) *const TSImportAttributes<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> TSImportAttributesWithoutElements<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_ATTRIBUTES_SPAN) as *const Span) }
-    }
-
-    #[inline]
-    pub fn attributes_keyword(self) -> &'t IdentifierName<'a> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_ATTRIBUTES_ATTRIBUTES_KEYWORD)
-                as *const IdentifierName<'a>)
-        }
-    }
-}
-
-impl<'a, 't> GetAddress for TSImportAttributesWithoutElements<'a, 't> {
-    #[inline]
-    fn address(&self) -> Address {
-        Address::from_ptr(self.0)
-    }
-}
-
-pub(crate) const OFFSET_TS_IMPORT_ATTRIBUTE_SPAN: usize = offset_of!(TSImportAttribute, span);
-pub(crate) const OFFSET_TS_IMPORT_ATTRIBUTE_NAME: usize = offset_of!(TSImportAttribute, name);
-pub(crate) const OFFSET_TS_IMPORT_ATTRIBUTE_VALUE: usize = offset_of!(TSImportAttribute, value);
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct TSImportAttributeWithoutName<'a, 't>(
-    pub(crate) *const TSImportAttribute<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> TSImportAttributeWithoutName<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_ATTRIBUTE_SPAN) as *const Span) }
-    }
-
-    #[inline]
-    pub fn value(self) -> &'t Expression<'a> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_ATTRIBUTE_VALUE) as *const Expression<'a>)
-        }
-    }
-}
-
-impl<'a, 't> GetAddress for TSImportAttributeWithoutName<'a, 't> {
-    #[inline]
-    fn address(&self) -> Address {
-        Address::from_ptr(self.0)
-    }
-}
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct TSImportAttributeWithoutValue<'a, 't>(
-    pub(crate) *const TSImportAttribute<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> TSImportAttributeWithoutValue<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe { &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_ATTRIBUTE_SPAN) as *const Span) }
-    }
-
-    #[inline]
-    pub fn name(self) -> &'t TSImportAttributeName<'a> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_IMPORT_ATTRIBUTE_NAME)
-                as *const TSImportAttributeName<'a>)
-        }
-    }
-}
-
-impl<'a, 't> GetAddress for TSImportAttributeWithoutValue<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)

--- a/crates/oxc_traverse/src/generated/traverse.rs
+++ b/crates/oxc_traverse/src/generated/traverse.rs
@@ -2205,51 +2205,6 @@ pub trait Traverse<'a> {
     fn exit_ts_import_type(&mut self, node: &mut TSImportType<'a>, ctx: &mut TraverseCtx<'a>) {}
 
     #[inline]
-    fn enter_ts_import_attributes(
-        &mut self,
-        node: &mut TSImportAttributes<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
-    }
-    #[inline]
-    fn exit_ts_import_attributes(
-        &mut self,
-        node: &mut TSImportAttributes<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
-    }
-
-    #[inline]
-    fn enter_ts_import_attribute(
-        &mut self,
-        node: &mut TSImportAttribute<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
-    }
-    #[inline]
-    fn exit_ts_import_attribute(
-        &mut self,
-        node: &mut TSImportAttribute<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
-    }
-
-    #[inline]
-    fn enter_ts_import_attribute_name(
-        &mut self,
-        node: &mut TSImportAttributeName<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
-    }
-    #[inline]
-    fn exit_ts_import_attribute_name(
-        &mut self,
-        node: &mut TSImportAttributeName<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
-    }
-
-    #[inline]
     fn enter_ts_function_type(&mut self, node: &mut TSFunctionType<'a>, ctx: &mut TraverseCtx<'a>) {
     }
     #[inline]

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -5122,12 +5122,12 @@ unsafe fn walk_ts_import_type<'a, Tr: Traverse<'a>>(
     ctx: &mut TraverseCtx<'a>,
 ) {
     traverser.enter_ts_import_type(&mut *node, ctx);
-    let pop_token = ctx.push_stack(Ancestor::TSImportTypeParameter(
-        ancestor::TSImportTypeWithoutParameter(node, PhantomData),
+    let pop_token = ctx.push_stack(Ancestor::TSImportTypeArgument(
+        ancestor::TSImportTypeWithoutArgument(node, PhantomData),
     ));
     walk_ts_type(
         traverser,
-        (node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_TYPE_PARAMETER) as *mut TSType,
+        (node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_TYPE_ARGUMENT) as *mut TSType,
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_TYPE_QUALIFIER)
@@ -5136,11 +5136,11 @@ unsafe fn walk_ts_import_type<'a, Tr: Traverse<'a>>(
         ctx.retag_stack(AncestorType::TSImportTypeQualifier);
         walk_ts_type_name(traverser, field as *mut _, ctx);
     }
-    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_TYPE_ATTRIBUTES)
-        as *mut Option<Box<TSImportAttributes>>)
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_TYPE_OPTIONS)
+        as *mut Option<ObjectExpression>)
     {
-        ctx.retag_stack(AncestorType::TSImportTypeAttributes);
-        walk_ts_import_attributes(traverser, (&mut **field) as *mut _, ctx);
+        ctx.retag_stack(AncestorType::TSImportTypeOptions);
+        walk_object_expression(traverser, field as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_IMPORT_TYPE_TYPE_PARAMETERS)
@@ -5151,73 +5151,6 @@ unsafe fn walk_ts_import_type<'a, Tr: Traverse<'a>>(
     }
     ctx.pop_stack(pop_token);
     traverser.exit_ts_import_type(&mut *node, ctx);
-}
-
-unsafe fn walk_ts_import_attributes<'a, Tr: Traverse<'a>>(
-    traverser: &mut Tr,
-    node: *mut TSImportAttributes<'a>,
-    ctx: &mut TraverseCtx<'a>,
-) {
-    traverser.enter_ts_import_attributes(&mut *node, ctx);
-    let pop_token = ctx.push_stack(Ancestor::TSImportAttributesAttributesKeyword(
-        ancestor::TSImportAttributesWithoutAttributesKeyword(node, PhantomData),
-    ));
-    walk_identifier_name(
-        traverser,
-        (node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_ATTRIBUTES_ATTRIBUTES_KEYWORD)
-            as *mut IdentifierName,
-        ctx,
-    );
-    ctx.retag_stack(AncestorType::TSImportAttributesElements);
-    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_ATTRIBUTES_ELEMENTS)
-        as *mut Vec<TSImportAttribute>)
-    {
-        walk_ts_import_attribute(traverser, item as *mut _, ctx);
-    }
-    ctx.pop_stack(pop_token);
-    traverser.exit_ts_import_attributes(&mut *node, ctx);
-}
-
-unsafe fn walk_ts_import_attribute<'a, Tr: Traverse<'a>>(
-    traverser: &mut Tr,
-    node: *mut TSImportAttribute<'a>,
-    ctx: &mut TraverseCtx<'a>,
-) {
-    traverser.enter_ts_import_attribute(&mut *node, ctx);
-    let pop_token = ctx.push_stack(Ancestor::TSImportAttributeName(
-        ancestor::TSImportAttributeWithoutName(node, PhantomData),
-    ));
-    walk_ts_import_attribute_name(
-        traverser,
-        (node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_ATTRIBUTE_NAME)
-            as *mut TSImportAttributeName,
-        ctx,
-    );
-    ctx.retag_stack(AncestorType::TSImportAttributeValue);
-    walk_expression(
-        traverser,
-        (node as *mut u8).add(ancestor::OFFSET_TS_IMPORT_ATTRIBUTE_VALUE) as *mut Expression,
-        ctx,
-    );
-    ctx.pop_stack(pop_token);
-    traverser.exit_ts_import_attribute(&mut *node, ctx);
-}
-
-unsafe fn walk_ts_import_attribute_name<'a, Tr: Traverse<'a>>(
-    traverser: &mut Tr,
-    node: *mut TSImportAttributeName<'a>,
-    ctx: &mut TraverseCtx<'a>,
-) {
-    traverser.enter_ts_import_attribute_name(&mut *node, ctx);
-    match &mut *node {
-        TSImportAttributeName::Identifier(node) => {
-            walk_identifier_name(traverser, node as *mut _, ctx)
-        }
-        TSImportAttributeName::StringLiteral(node) => {
-            walk_string_literal(traverser, node as *mut _, ctx)
-        }
-    }
-    traverser.exit_ts_import_attribute_name(&mut *node, ctx);
 }
 
 unsafe fn walk_ts_function_type<'a, Tr: Traverse<'a>>(

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -1772,30 +1772,10 @@ function deserializeTSImportType(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     isTypeOf: deserializeBool(pos + 8),
-    parameter: deserializeTSType(pos + 16),
+    argument: deserializeTSType(pos + 16),
     qualifier: deserializeOptionTSTypeName(pos + 32),
-    attributes: deserializeOptionBoxTSImportAttributes(pos + 48),
-    typeParameters: deserializeOptionBoxTSTypeParameterInstantiation(pos + 56),
-  };
-}
-
-function deserializeTSImportAttributes(pos) {
-  return {
-    type: 'TSImportAttributes',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
-    attributesKeyword: deserializeIdentifierName(pos + 8),
-    elements: deserializeVecTSImportAttribute(pos + 32),
-  };
-}
-
-function deserializeTSImportAttribute(pos) {
-  return {
-    type: 'TSImportAttribute',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
-    name: deserializeTSImportAttributeName(pos + 8),
-    value: deserializeExpression(pos + 56),
+    options: deserializeOptionObjectExpression(pos + 48),
+    typeParameters: deserializeOptionBoxTSTypeParameterInstantiation(pos + 104),
   };
 }
 
@@ -3859,17 +3839,6 @@ function deserializeTSTypeQueryExprName(pos) {
   }
 }
 
-function deserializeTSImportAttributeName(pos) {
-  switch (uint8[pos]) {
-    case 0:
-      return deserializeIdentifierName(pos + 8);
-    case 1:
-      return deserializeStringLiteral(pos + 8);
-    default:
-      throw new Error(`Unexpected discriminant ${uint8[pos]} for TSImportAttributeName`);
-  }
-}
-
 function deserializeTSMappedTypeModifierOperator(pos) {
   switch (uint8[pos]) {
     case 0:
@@ -5520,25 +5489,9 @@ function deserializeOptionTSTypeName(pos) {
   return deserializeTSTypeName(pos);
 }
 
-function deserializeBoxTSImportAttributes(pos) {
-  return deserializeTSImportAttributes(uint32[pos >> 2]);
-}
-
-function deserializeOptionBoxTSImportAttributes(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSImportAttributes(pos);
-}
-
-function deserializeVecTSImportAttribute(pos) {
-  const arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(deserializeTSImportAttribute(pos));
-    pos += 72;
-  }
-  return arr;
+function deserializeOptionObjectExpression(pos) {
+  if (uint8[pos + 40] === 2) return null;
+  return deserializeObjectExpression(pos);
 }
 
 function deserializeBoxTSExternalModuleReference(pos) {

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -1825,30 +1825,10 @@ function deserializeTSImportType(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     isTypeOf: deserializeBool(pos + 8),
-    parameter: deserializeTSType(pos + 16),
+    argument: deserializeTSType(pos + 16),
     qualifier: deserializeOptionTSTypeName(pos + 32),
-    attributes: deserializeOptionBoxTSImportAttributes(pos + 48),
-    typeParameters: deserializeOptionBoxTSTypeParameterInstantiation(pos + 56),
-  };
-}
-
-function deserializeTSImportAttributes(pos) {
-  return {
-    type: 'TSImportAttributes',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
-    attributesKeyword: deserializeIdentifierName(pos + 8),
-    elements: deserializeVecTSImportAttribute(pos + 32),
-  };
-}
-
-function deserializeTSImportAttribute(pos) {
-  return {
-    type: 'TSImportAttribute',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
-    name: deserializeTSImportAttributeName(pos + 8),
-    value: deserializeExpression(pos + 56),
+    options: deserializeOptionObjectExpression(pos + 48),
+    typeParameters: deserializeOptionBoxTSTypeParameterInstantiation(pos + 104),
   };
 }
 
@@ -3912,17 +3892,6 @@ function deserializeTSTypeQueryExprName(pos) {
   }
 }
 
-function deserializeTSImportAttributeName(pos) {
-  switch (uint8[pos]) {
-    case 0:
-      return deserializeIdentifierName(pos + 8);
-    case 1:
-      return deserializeStringLiteral(pos + 8);
-    default:
-      throw new Error(`Unexpected discriminant ${uint8[pos]} for TSImportAttributeName`);
-  }
-}
-
 function deserializeTSMappedTypeModifierOperator(pos) {
   switch (uint8[pos]) {
     case 0:
@@ -5573,25 +5542,9 @@ function deserializeOptionTSTypeName(pos) {
   return deserializeTSTypeName(pos);
 }
 
-function deserializeBoxTSImportAttributes(pos) {
-  return deserializeTSImportAttributes(uint32[pos >> 2]);
-}
-
-function deserializeOptionBoxTSImportAttributes(pos) {
-  if (uint32[pos >> 2] === 0 && uint32[(pos + 4) >> 2] === 0) return null;
-  return deserializeBoxTSImportAttributes(pos);
-}
-
-function deserializeVecTSImportAttribute(pos) {
-  const arr = [],
-    pos32 = pos >> 2,
-    len = uint32[pos32 + 6];
-  pos = uint32[pos32];
-  for (let i = 0; i < len; i++) {
-    arr.push(deserializeTSImportAttribute(pos));
-    pos += 72;
-  }
-  return arr;
+function deserializeOptionObjectExpression(pos) {
+  if (uint8[pos + 40] === 2) return null;
+  return deserializeObjectExpression(pos);
 }
 
 function deserializeBoxTSExternalModuleReference(pos) {

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -1282,25 +1282,11 @@ export type TSTypeQueryExprName = TSImportType | TSTypeName;
 export interface TSImportType extends Span {
   type: 'TSImportType';
   isTypeOf: boolean;
-  parameter: TSType;
+  argument: TSType;
   qualifier: TSTypeName | null;
-  attributes: TSImportAttributes | null;
+  options: ObjectExpression | null;
   typeParameters: TSTypeParameterInstantiation | null;
 }
-
-export interface TSImportAttributes extends Span {
-  type: 'TSImportAttributes';
-  attributesKeyword: IdentifierName;
-  elements: Array<TSImportAttribute>;
-}
-
-export interface TSImportAttribute extends Span {
-  type: 'TSImportAttribute';
-  name: TSImportAttributeName;
-  value: Expression;
-}
-
-export type TSImportAttributeName = IdentifierName | StringLiteral;
 
 export interface TSFunctionType extends Span {
   type: 'TSFunctionType';

--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -22,7 +22,7 @@ use super::define_generator;
 /// Types to omit creating an `AstKind` for.
 ///
 /// Apart from this list every type with `#[ast(visit)]` attr gets an `AstKind`.
-const BLACK_LIST: [&str; 64] = [
+const BLACK_LIST: [&str; 61] = [
     "Span",
     "Expression",
     "ObjectPropertyKind",
@@ -71,9 +71,6 @@ const BLACK_LIST: [&str; 64] = [
     "TSModuleDeclarationName",
     "TSModuleDeclarationBody",
     "TSTypeQueryExprName",
-    "TSImportAttribute",
-    "TSImportAttributes",
-    "TSImportAttributeName",
     "TSFunctionType",
     "TSConstructorType",
     "TSNamespaceExportDeclaration",


### PR DESCRIPTION
TS-ESLint spec: https://github.com/typescript-eslint/typescript-eslint/blob/9aa0b6b49807599b1c2b704b778df74c91084a7c/packages/ast-spec/src/type/TSImportType/spec.ts#L8

ast-explorer: https://ast-explorer.dev/#eNoty8EKQiEQheFXGc6q4PYCQoteotVsRIy8eB1xhiLEd0+p7XfO35HhsPuX19BSNWyoE+xT4w8uUXMqy8Pf6UZXSkeVZifGQ4SxUX8nezrq6+CIsasUxhjnGcoMOxeaHMPh77FpWuv6ZW9RjcFlYHwB6tsulA==

I'm block by the fact that `parse_object_expression` return an expression and not an objectExpression

Feel free to close another PR