### PR TITLE
test(transformer/using): failing test for class name

### DIFF
--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 578ac4df
 
-Passed: 139/225
+Passed: 139/226
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -16,7 +16,6 @@ Passed: 139/225
 * babel-plugin-transform-arrow-functions
 * babel-preset-typescript
 * babel-plugin-transform-react-jsx-source
-* babel-plugin-proposal-explicit-resource-management
 * regexp
 
 
@@ -318,6 +317,11 @@ x Output mismatch
 x Output mismatch
 
 * refresh/react-refresh/supports-typescript-namespace-syntax/input.tsx
+x Output mismatch
+
+
+# babel-plugin-proposal-explicit-resource-management (1/2)
+* export-class-name/input.js
 x Output mismatch
 
 

--- a/tasks/transform_conformance/tests/babel-plugin-proposal-explicit-resource-management/test/fixtures/export-class-name/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-proposal-explicit-resource-management/test/fixtures/export-class-name/input.js
@@ -1,0 +1,9 @@
+using x = foo();
+
+export class C {
+  static getSelf() { return C; }
+}
+const K = C;
+C = 123;
+
+assert(K.getSelf() === K);

--- a/tasks/transform_conformance/tests/babel-plugin-proposal-explicit-resource-management/test/fixtures/export-class-name/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-proposal-explicit-resource-management/test/fixtures/export-class-name/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["proposal-explicit-resource-management"]
+}

--- a/tasks/transform_conformance/tests/babel-plugin-proposal-explicit-resource-management/test/fixtures/export-class-name/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-proposal-explicit-resource-management/test/fixtures/export-class-name/output.js
@@ -1,0 +1,17 @@
+export { C };
+try {
+  var _usingCtx = babelHelpers.usingCtx();
+  var x = _usingCtx.u(foo());
+  var C = class C {
+    static getSelf() {
+      return C;
+    }
+  };
+  var K = C;
+  C = 123;
+  assert(K.getSelf() === K);
+} catch (_) {
+  _usingCtx.e = _;
+} finally {
+  _usingCtx.d();
+}


### PR DESCRIPTION
Add a failing test for `using` transform where exported class has a reference to itself within the class body, and the external class binding is mutated.

This is something of an edge case, but it'd be ideal to handle it correctly.

Babel has the same bug: https://github.com/babel/babel/issues/17172
