### PR TITLE
feat(allocator): remove drop operations from Vec2

### DIFF
--- a/crates/oxc_allocator/src/vec2/mod.rs
+++ b/crates/oxc_allocator/src/vec2/mod.rs
@@ -870,7 +870,7 @@ impl<'bump, T: 'bump> Vec<'bump, T> {
         unsafe {
             let ptr = self.as_ptr();
             let len = self.len();
-            mem::forget(self);
+            // Don't need `mem::forget(self)` here, because `Vec` does not implement `Drop`.
             slice::from_raw_parts(ptr, len)
         }
     }
@@ -895,7 +895,7 @@ impl<'bump, T: 'bump> Vec<'bump, T> {
     pub fn into_bump_slice_mut(mut self) -> &'bump mut [T] {
         let ptr = self.as_mut_ptr();
         let len = self.len();
-        mem::forget(self);
+        // Don't need `mem::forget(self)` here, because `Vec` does not implement `Drop`.
 
         unsafe { slice::from_raw_parts_mut(ptr, len) }
     }
@@ -2244,7 +2244,7 @@ impl<'bump, T: 'bump> IntoIterator for Vec<'bump, T> {
             } else {
                 begin.add(self.len()) as *const T
             };
-            mem::forget(self);
+            // Don't need `mem::forget(self)` here, because `Vec` does not implement `Drop`.
             IntoIter { phantom: PhantomData, ptr: begin, end }
         }
     }
@@ -2450,18 +2450,6 @@ impl<'bump, T: 'bump> BorrowMut<[T]> for Vec<'bump, T> {
     #[inline]
     fn borrow_mut(&mut self) -> &mut [T] {
         &mut self[..]
-    }
-}
-
-impl<'bump, T> Drop for Vec<'bump, T> {
-    fn drop(&mut self) {
-        unsafe {
-            // use drop for [T]
-            // use a raw slice to refer to the elements of the vector as weakest necessary type;
-            // could avoid questions of validity in certain cases
-            ptr::drop_in_place(ptr::slice_from_raw_parts_mut(self.as_mut_ptr(), self.len))
-        }
-        // RawVec handles deallocation
     }
 }
 

--- a/crates/oxc_allocator/src/vec2/raw_vec.rs
+++ b/crates/oxc_allocator/src/vec2/raw_vec.rs
@@ -702,15 +702,6 @@ impl<'a, T> RawVec<'a, T> {
     }
 }
 
-impl<'a, T> Drop for RawVec<'a, T> {
-    /// Frees the memory owned by the RawVec *without* trying to Drop its contents.
-    fn drop(&mut self) {
-        unsafe {
-            self.dealloc_buffer();
-        }
-    }
-}
-
 // We need to guarantee the following:
 // * We don't ever allocate `> isize::MAX` byte-size objects
 // * We don't overflow `usize::MAX` and actually allocate too little


### PR DESCRIPTION
Just like #6623. Since we have control over the `Vec` implementation, we can remove the `drop` operations and eventually revert the changes made in #6623 directly.