### PR TITLE
fix(linter): Add missing fail cases in eslint/no-self-compare

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
@@ -81,6 +81,8 @@ fn test() {
         ("x == x", None),
         ("x != x", None),
         ("x > x", None),
+        ("x > (x)", None),
+        ("(x) > x", None),
         ("x < x", None),
         ("x >= x", None),
         ("x <= x", None),

--- a/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
@@ -48,7 +48,11 @@ impl Rule for NoSelfCompare {
             return;
         }
 
-        if binary_expr.left.content_eq(&binary_expr.right) {
+        if binary_expr
+            .left
+            .without_parentheses()
+            .content_eq(&binary_expr.right.without_parentheses())
+        {
             ctx.diagnostic(no_self_compare_diagnostic(
                 binary_expr.left.span(),
                 binary_expr.right.span(),
@@ -81,11 +85,12 @@ fn test() {
         ("x == x", None),
         ("x != x", None),
         ("x > x", None),
-        ("x > (x)", None),
-        ("(x) > x", None),
         ("x < x", None),
         ("x >= x", None),
         ("x <= x", None),
+        ("x > (x)", None),
+        ("(x) == x", None),
+        ("(x) >= ((x))", None),
         ("foo.bar().baz.qux >= foo.bar ().baz .qux", None),
         ("class C { #field; foo() { this.#field === this.#field; } }", None),
     ];

--- a/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_self_compare.rs
@@ -51,7 +51,7 @@ impl Rule for NoSelfCompare {
         if binary_expr
             .left
             .without_parentheses()
-            .content_eq(&binary_expr.right.without_parentheses())
+            .content_eq(binary_expr.right.without_parentheses())
         {
             ctx.diagnostic(no_self_compare_diagnostic(
                 binary_expr.left.span(),

--- a/crates/oxc_linter/src/snapshots/eslint_no_self_compare.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_self_compare.snap
@@ -94,6 +94,27 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
    ╭─[no_self_compare.tsx:1:1]
+ 1 │ x > (x)
+   · ─   ───
+   ╰────
+  help: If you are testing for NaN, you can use Number.isNaN function.
+
+  ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
+   ╭─[no_self_compare.tsx:1:1]
+ 1 │ (x) == x
+   · ───    ─
+   ╰────
+  help: If you are testing for NaN, you can use Number.isNaN function.
+
+  ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
+   ╭─[no_self_compare.tsx:1:1]
+ 1 │ (x) >= ((x))
+   · ───    ─────
+   ╰────
+  help: If you are testing for NaN, you can use Number.isNaN function.
+
+  ⚠ eslint(no-self-compare): Both sides of this comparison are exactly the same
+   ╭─[no_self_compare.tsx:1:1]
  1 │ foo.bar().baz.qux >= foo.bar ().baz .qux
    · ─────────────────    ───────────────────
    ╰────


### PR DESCRIPTION
Handles parentheses wrapping the LHS and RHS of the binary operation so that the following missing test cases pass:

```js
x > (x)

(x) == x

(x) >= ((x))
```

Eslint playground for these fail cases above can be found [here](https://eslint.org/play/#eyJ0ZXh0IjoiLyplc2xpbnQgbm8tc2VsZi1jb21wYXJlOiBcImVycm9yXCIqL1xuXG5pZiAoeCA+ICh4KSkge31cblxuaWYgKCh4KSA9PSB4KSB7fVxuXG5pZiAoKHgpID49ICgoeCkpKSB7fSIsIm9wdGlvbnMiOnsicnVsZXMiOnt9LCJsYW5ndWFnZU9wdGlvbnMiOnsicGFyc2VyT3B0aW9ucyI6eyJlY21hRmVhdHVyZXMiOnt9fX19fQ==).