### PR TITLE
fix(codegen): add sequence expression end source map

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2072,6 +2072,7 @@ impl GenExpr for SequenceExpression<'_> {
         p.wrap(precedence >= self.precedence(), |p| {
             p.print_expressions(&self.expressions, Precedence::Lowest, ctx.and_forbid_call(false));
         });
+        p.add_source_mapping_end(self.span);
     }
 }
 


### PR DESCRIPTION
I'm not entirely sure if there's any right or wrong for mapping the span end, but this one slightly affects stacktrace of module runner transformed code, which outputs call expressions of the form `(0, __vite_ssr_exports__.foo)(arg)`.

- playground example https://playground.oxc.rs/#eNo9kMFqwzAMhl8l6NRCKF1hl4zd1p4GG2uPgeA6SjFzpCAr3UrIu89OlpwsWdL369cAFgpoerLqmDLFoJttNpSUZUcRll1QY78vYiy+u9Zp9podXlLVMgX2uNNU2pRQVZfj+VJVJWxLGksqaWbF5s0+n8DbKYMcGIoBpKf0hAep+YVCpcccvCNd4mC5wzV5tFf2SxZFKTQsLRSN8QHHHDojASURjff884XaC330GlyNp397y3gnGHvv+GkEKcy/EZHEJ0SMV4WZqUZuGDcDDIf903P04KJ7o1i/ofVGTMJH0rKN5RpvOBlEMlePZ+7FYmu6Va115Bq36MVzqrA/xdXT0B3lyiG6n4Hj+Ae1jZXH
