### PR TITLE
fix(linter): no-single-promise-in-promise-methods: do not fix Promise.all when chained

### DIFF
--- a/crates/oxc_linter/src/rules/unicorn/no_single_promise_in_promise_methods.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_single_promise_in_promise_methods.rs
@@ -86,27 +86,31 @@ impl Rule for NoSinglePromiseInPromiseMethods {
             return;
         }
 
-        let info = call_expr
+        let (span, method_name) = call_expr
             .callee
             .get_member_expr()
             .expect("callee is a member expression")
             .static_property_info()
             .expect("callee is a static property");
 
-        let diagnostic = no_single_promise_in_promise_methods_diagnostic(info.0, info.1);
+        let diagnostic = no_single_promise_in_promise_methods_diagnostic(span, method_name);
+
+        let is_directly_in_await = ctx
+            .nodes()
+            // get first non-parenthesis parent node
+            .ancestor_kinds(node.id())
+            .skip(1) // first node is the call expr
+            .find(|kind| !is_ignorable_kind(kind))
+            // check if it's an `await ...` expression
+            .is_some_and(|kind| matches!(kind, AstKind::AwaitExpression(_)));
+
+        if !is_directly_in_await && method_name == "all" {
+            return ctx.diagnostic(diagnostic);
+        }
+
         if is_fixable(node.id(), ctx) {
             ctx.diagnostic_with_fix(diagnostic, |fixer| {
                 let elem_text = fixer.source_range(first.span());
-
-                let is_directly_in_await = ctx
-                    .nodes()
-                    // get first non-parenthesis parent node
-                    .ancestors(node.id())
-                    .skip(1) // first node is the call expr
-                    .find(|parent| !is_ignorable_kind(&parent.kind()))
-                    // check if it's an `await ...` expression
-                    .is_some_and(|parent| matches!(parent.kind(), AstKind::AwaitExpression(_)));
-
                 let call_span = call_expr.span;
 
                 if is_directly_in_await {
@@ -177,6 +181,7 @@ fn test() {
         "new Promise.all([promise])",
         "globalThis.Promise.all([promise])",
         "Promise.allSettled([promise])",
+        "Promise.all('one').then(something);",
     ];
 
     let fail = vec![
@@ -246,10 +251,11 @@ fn test() {
         "Promise.all([x] satisfies any[]).then()",
         "Promise.all([x as const]).then()",
         "Promise.all([x!]).then()",
+        "Promise.all(['one']).then(something);",
     ];
 
     let fix = vec![
-        ("Promise.all([null]).then()", "Promise.resolve(null).then()", None),
+        ("Promise.all([null]).then()", "Promise.all([null]).then()", None),
         ("await Promise.all([x]);", "await x;", None),
         ("await Promise.all([x as Promise<number>]);", "await x as Promise<number>;", None),
         ("while(true) { await Promise.all([x]); }", "while(true) { await x; }", None),
@@ -259,6 +265,11 @@ fn test() {
         (
             "function foo () { return Promise.all([x]); }",
             "function foo () { return Promise.all([x]); }",
+            None,
+        ),
+        (
+            "Promise.all(['one']).then((result) => result[0]);",
+            "Promise.all(['one']).then((result) => result[0]);",
             None,
         ),
     ];

--- a/crates/oxc_linter/src/snapshots/unicorn_no_single_promise_in_promise_methods.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_single_promise_in_promise_methods.snap
@@ -405,3 +405,10 @@ source: crates/oxc_linter/src/tester.rs
    ·         ───
    ╰────
   help: Either use the value directly, or switch to `Promise.resolve(…)`.
+
+  ⚠ eslint-plugin-unicorn(no-single-promise-in-promise-methods): Wrapping single-element array with `Promise.all()` is unnecessary.
+   ╭─[no_single_promise_in_promise_methods.tsx:1:9]
+ 1 │ Promise.all(['one']).then(something);
+   ·         ───
+   ╰────
+  help: Either use the value directly, or switch to `Promise.resolve(…)`.


### PR DESCRIPTION
closes https://github.com/oxc-project/oxc/issues/9689

aligns with the original rule behavior to not try and fix complex `Promise.all`: https://github.com/sindresorhus/eslint-plugin-unicorn/blob/0f6048c4f66ea65caf24be40d88631daf0d0d234/rules/no-single-promise-in-promise-methods.js#L143-L145