### PR TITLE
refactor(transformer/using): remove unused call to `enter_block_statement`

### DIFF
--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -214,10 +214,6 @@ impl<'a> Traverse<'a> for TransformerImpl<'a, '_> {
         }
     }
 
-    fn enter_block_statement(&mut self, node: &mut BlockStatement<'a>, ctx: &mut TraverseCtx<'a>) {
-        self.explicit_resource_management.enter_block_statement(node, ctx);
-    }
-
     fn enter_big_int_literal(&mut self, node: &mut BigIntLiteral<'a>, ctx: &mut TraverseCtx<'a>) {
         self.x2_es2020.enter_big_int_literal(node, ctx);
     }


### PR DESCRIPTION
`ExplicitResourceManagement` has no `enter_block_statement` method.