### PR TITLE
test(transformer/using): alter test to demonstrate semantic mismatch

### DIFF
--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 578ac4df
 
-Passed: 139/226
+Passed: 138/226
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -320,9 +320,20 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-proposal-explicit-resource-management (1/2)
+# babel-plugin-proposal-explicit-resource-management (0/2)
 * export-class-name/input.js
 x Output mismatch
+
+* for-of-no-block/input.js
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(7)]
+rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7)]
+Scope children mismatch:
+after transform: ScopeId(4): []
+rebuilt        : ScopeId(3): [ScopeId(4)]
+Scope parent mismatch:
+after transform: ScopeId(3): Some(ScopeId(1))
+rebuilt        : ScopeId(4): Some(ScopeId(3))
 
 
 # legacy-decorators (2/66)

--- a/tasks/transform_conformance/tests/babel-plugin-proposal-explicit-resource-management/test/fixtures/for-of-no-block/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-proposal-explicit-resource-management/test/fixtures/for-of-no-block/input.js
@@ -1,2 +1,3 @@
-for (using x of it)
-    doSomethingWith(x);
+// The arrow functions in this test case are to make sure that scopes are re-parented correctly
+for (using x of (() => it)())
+  doSomethingWith(x, () => {});

--- a/tasks/transform_conformance/tests/babel-plugin-proposal-explicit-resource-management/test/fixtures/for-of-no-block/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-proposal-explicit-resource-management/test/fixtures/for-of-no-block/output.js
@@ -1,8 +1,8 @@
-for (const _x of it)
+for (const _x of (() => it)())
   try {
     var _usingCtx = babelHelpers.usingCtx();
     const x = _usingCtx.u(_x);
-    doSomethingWith(x);
+    doSomethingWith(x, () => {});
   } catch (_) {
     _usingCtx.e = _;
   } finally {


### PR DESCRIPTION
Where a `for (using x of ...)` statement has a single statement as its body, `enter_for_of_statement` wraps that statement in a `BlockStatement`. This introduces a new scope. We are missing logic to re-parent any scopes within that statement to be children of the new block scope.

This PR alters one of the tests to demonstrate this problem.
