### PR TITLE
test(transformer/using): add failing test for scopes

### DIFF
--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 578ac4df
 
-Passed: 138/226
+Passed: 138/227
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -320,7 +320,7 @@ x Output mismatch
 x Output mismatch
 
 
-# babel-plugin-proposal-explicit-resource-management (0/2)
+# babel-plugin-proposal-explicit-resource-management (0/3)
 * export-class-name/input.js
 x Output mismatch
 
@@ -334,6 +334,20 @@ rebuilt        : ScopeId(3): [ScopeId(4)]
 Scope parent mismatch:
 after transform: ScopeId(3): Some(ScopeId(1))
 rebuilt        : ScopeId(4): Some(ScopeId(3))
+
+* function-with-scopes-in-params/input.js
+Scope children mismatch:
+after transform: ScopeId(1): [ScopeId(5), ScopeId(6), ScopeId(8)]
+rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(8)]
+Scope parent mismatch:
+after transform: ScopeId(2): Some(ScopeId(5))
+rebuilt        : ScopeId(2): Some(ScopeId(1))
+Scope parent mismatch:
+after transform: ScopeId(3): Some(ScopeId(5))
+rebuilt        : ScopeId(3): Some(ScopeId(1))
+Scope children mismatch:
+after transform: ScopeId(5): [ScopeId(2), ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(4): [ScopeId(5)]
 
 
 # legacy-decorators (2/66)

--- a/tasks/transform_conformance/tests/babel-plugin-proposal-explicit-resource-management/test/fixtures/function-with-scopes-in-params/input.js
+++ b/tasks/transform_conformance/tests/babel-plugin-proposal-explicit-resource-management/test/fixtures/function-with-scopes-in-params/input.js
@@ -1,0 +1,5 @@
+// The arrow functions in this test case are to make sure that scopes are re-parented correctly
+function f(a = () => {}, b = () => {}) {
+  using x = a(), y = b();
+  doSomethingWith(x, y, () => {});
+}

--- a/tasks/transform_conformance/tests/babel-plugin-proposal-explicit-resource-management/test/fixtures/function-with-scopes-in-params/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-proposal-explicit-resource-management/test/fixtures/function-with-scopes-in-params/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["proposal-explicit-resource-management"]
+}

--- a/tasks/transform_conformance/tests/babel-plugin-proposal-explicit-resource-management/test/fixtures/function-with-scopes-in-params/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-proposal-explicit-resource-management/test/fixtures/function-with-scopes-in-params/output.js
@@ -1,0 +1,11 @@
+function f(a = () => {}, b = () => {}) {
+  try {
+    var _usingCtx = babelHelpers.usingCtx();
+    const x = _usingCtx.u(a()), y = _usingCtx.u(b());
+    doSomethingWith(x, y, () => {});
+  } catch (_) {
+    _usingCtx.e = _;
+  } finally {
+    _usingCtx.d();
+  }
+}


### PR DESCRIPTION
Add a test case for explicit resource management (`using` declarations) which demonstrates a problem with scopes.

See: https://github.com/oxc-project/oxc/pull/9310#discussion_r1988348266
