### PR TITLE
feat(allocator): add `no_std` support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
           cache-key: warm
       - run: cargo ck
       - run: cargo test --all-features
+      - run: cargo test -p oxc_allocator --no-default-features --features serialize
       - run: git diff --exit-code # Must commit everything
 
   test-windows:
@@ -132,7 +133,6 @@ jobs:
           rustup target add wasm32-unknown-unknown
           cargo check -p oxc_wasm --target wasm32-unknown-unknown
       - uses: ./.github/actions/pnpm
-
       - run: just build-wasm debug
       - working-directory: npm/oxc-wasm
         run: pnpm run check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ oxc_resolver = "5"
 oxc_sourcemap = "3"
 
 #
-allocator-api2 = "0.2.21"
+allocator-api2 = { version = "0.2.21", default-features = false, features = ["alloc"] }
 assert-unchecked = "0.1.2"
 base64 = "0.22.1"
 bitflags = "2.8.0"
@@ -218,7 +218,7 @@ self_cell = "1.1.0"
 seq-macro = "0.3.5"
 serde-wasm-bindgen = "0.6.5"
 sha1 = "0.10.6"
-simdutf8 = { version = "0.1.5", features = ["aarch64_neon"] }
+simdutf8 = { version = "0.1.5", default-features = false, features = ["aarch64_neon"] }
 similar = "2.7.0"
 similar-asserts = "1.6.1"
 smallvec = "1.14.0"

--- a/crates/oxc_allocator/Cargo.toml
+++ b/crates/oxc_allocator/Cargo.toml
@@ -19,8 +19,6 @@ workspace = true
 doctest = false
 
 [dependencies]
-oxc_estree = { workspace = true, optional = true }
-
 allocator-api2 = { workspace = true }
 assert-unchecked = { workspace = true }
 bumpalo = { workspace = true, features = ["allocator-api2", "collections"] }
@@ -33,7 +31,10 @@ serde = { workspace = true, optional = true }
 [dev-dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
+oxc_estree = { workspace = true }
 
 [features]
+default = ["std"]
+std = ["simdutf8/std"]
 from_raw_parts = []
 serialize = ["dep:serde", "oxc_estree/serialize"]

--- a/crates/oxc_allocator/src/address.rs
+++ b/crates/oxc_allocator/src/address.rs
@@ -1,5 +1,3 @@
-use std::ptr;
-
 use crate::Box;
 
 /// Memory address of an AST node in arena.
@@ -40,7 +38,7 @@ impl<T> GetAddress for Box<'_, T> {
     /// so this address acts as a unique identifier for the duration of the arena's existence.
     #[inline]
     fn address(&self) -> Address {
-        Address::from_ptr(ptr::addr_of!(**self))
+        Address::from_ptr(&raw const (**self))
     }
 }
 

--- a/crates/oxc_allocator/src/allocator.rs
+++ b/crates/oxc_allocator/src/allocator.rs
@@ -262,7 +262,7 @@ impl Allocator {
     #[expect(clippy::inline_always)]
     #[inline(always)]
     pub fn alloc<T>(&self, val: T) -> &mut T {
-        const { assert!(!std::mem::needs_drop::<T>(), "Cannot allocate Drop type in arena") };
+        const { assert!(!core::mem::needs_drop::<T>(), "Cannot allocate Drop type in arena") };
 
         self.bump.alloc(val)
     }

--- a/crates/oxc_allocator/src/allocator_api2.rs
+++ b/crates/oxc_allocator/src/allocator_api2.rs
@@ -2,7 +2,7 @@
 // All have same safety preconditions of `bumpalo` methods of the same name.
 #![expect(clippy::inline_always, clippy::undocumented_unsafe_blocks)]
 
-use std::{alloc::Layout, ptr::NonNull};
+use core::{alloc::Layout, ptr::NonNull};
 
 use allocator_api2::alloc::{AllocError, Allocator};
 

--- a/crates/oxc_allocator/src/clone_in.rs
+++ b/crates/oxc_allocator/src/clone_in.rs
@@ -1,4 +1,4 @@
-use std::cell::Cell;
+use core::cell::Cell;
 
 use crate::{Allocator, Box, Vec};
 

--- a/crates/oxc_allocator/src/convert.rs
+++ b/crates/oxc_allocator/src/convert.rs
@@ -1,5 +1,7 @@
 #![expect(clippy::inline_always)]
 
+use alloc::string::String;
+
 use crate::{Allocator, Box};
 
 /// This trait works similarly to the standard library [`From`] trait.

--- a/crates/oxc_allocator/src/from_raw_parts.rs
+++ b/crates/oxc_allocator/src/from_raw_parts.rs
@@ -1,6 +1,6 @@
 //! Define additional [`Allocator::from_raw_parts`] method, used only by raw transfer.
 
-use std::{
+use core::{
     alloc::Layout,
     cell::Cell,
     ptr::{self, NonNull},

--- a/crates/oxc_allocator/src/hash_map.rs
+++ b/crates/oxc_allocator/src/hash_map.rs
@@ -7,7 +7,7 @@
 // All methods which just delegate to `hashbrown::HashMap` methods marked `#[inline(always)]`
 #![expect(clippy::inline_always)]
 
-use std::{
+use core::{
     hash::Hash,
     mem::ManuallyDrop,
     ops::{Deref, DerefMut},
@@ -63,11 +63,11 @@ impl<'alloc, K, V> HashMap<'alloc, K, V> {
     /// Must be referenced in all methods which create a `HashMap`.
     const ASSERT_K_AND_V_ARE_NOT_DROP: () = {
         assert!(
-            !std::mem::needs_drop::<K>(),
+            !core::mem::needs_drop::<K>(),
             "Cannot create a HashMap<K, V> where K is a Drop type"
         );
         assert!(
-            !std::mem::needs_drop::<V>(),
+            !core::mem::needs_drop::<V>(),
             "Cannot create a HashMap<K, V> where V is a Drop type"
         );
     };

--- a/crates/oxc_allocator/src/lib.rs
+++ b/crates/oxc_allocator/src/lib.rs
@@ -11,8 +11,11 @@
 //! * [`HashMap`]
 //!
 //! See [`Allocator`] docs for information on efficient use of [`Allocator`].
-
+#![warn(clippy::alloc_instead_of_core, clippy::std_instead_of_alloc, clippy::std_instead_of_core)]
+#![cfg_attr(not(feature = "std"), no_std)]
 #![warn(missing_docs)]
+
+extern crate alloc;
 
 mod address;
 mod allocator;

--- a/crates/oxc_allocator/src/string.rs
+++ b/crates/oxc_allocator/src/string.rs
@@ -5,7 +5,7 @@
 // All methods which just delegate to `bumpalo::collections::String` methods marked `#[inline(always)]`
 #![expect(clippy::inline_always)]
 
-use std::{
+use core::{
     fmt::{self, Debug, Display},
     hash::{Hash, Hasher},
     mem::ManuallyDrop,
@@ -336,8 +336,8 @@ macro_rules! impl_eq {
 
 impl_eq! { String<'alloc>, str }
 impl_eq! { String<'alloc>, &'a str }
-impl_eq! { std::borrow::Cow<'a, str>, String<'alloc> }
-impl_eq! { std::string::String, String<'alloc> }
+impl_eq! { alloc::borrow::Cow<'a, str>, String<'alloc> }
+impl_eq! { alloc::string::String, String<'alloc> }
 
 impl Display for String<'_> {
     #[inline]
@@ -381,7 +381,7 @@ mod test {
     #[test]
     fn string_from_array_len_3() {
         let hello = "hello";
-        let world = std::string::String::from("world");
+        let world = alloc::string::String::from("world");
         let allocator = Allocator::default();
         let string = String::from_strs_array_in([hello, &world, "!"], &allocator);
         assert_eq!(string, "helloworld!");

--- a/crates/oxc_allocator/src/vec.rs
+++ b/crates/oxc_allocator/src/vec.rs
@@ -5,8 +5,7 @@
 // All methods which just delegate to `allocator_api2::vec::Vec` methods marked `#[inline(always)]`
 #![expect(clippy::inline_always)]
 
-use std::{
-    self,
+use core::{
     fmt::{self, Debug},
     hash::{Hash, Hasher},
     mem::ManuallyDrop,
@@ -17,7 +16,7 @@ use std::{
 
 use allocator_api2::vec::Vec as InnerVec;
 use bumpalo::Bump;
-#[cfg(any(feature = "serialize", test))]
+#[cfg(all(feature = "serialize", test))]
 use oxc_estree::{ESTree, Serializer as ESTreeSerializer};
 #[cfg(any(feature = "serialize", test))]
 use serde::{Serialize, Serializer as SerdeSerializer};
@@ -48,7 +47,7 @@ impl<'alloc, T> Vec<'alloc, T> {
     /// Const assertion that `T` is not `Drop`.
     /// Must be referenced in all methods which create a `Vec`.
     const ASSERT_T_IS_NOT_DROP: () =
-        assert!(!std::mem::needs_drop::<T>(), "Cannot create a Vec<T> where T is a Drop type");
+        assert!(!core::mem::needs_drop::<T>(), "Cannot create a Vec<T> where T is a Drop type");
 
     /// Constructs a new, empty `Vec<T>`.
     ///
@@ -233,7 +232,7 @@ impl<'alloc, T> IntoIterator for Vec<'alloc, T> {
 }
 
 impl<'i, T> IntoIterator for &'i Vec<'_, T> {
-    type IntoIter = std::slice::Iter<'i, T>;
+    type IntoIter = core::slice::Iter<'i, T>;
     type Item = &'i T;
 
     #[inline(always)]
@@ -243,7 +242,7 @@ impl<'i, T> IntoIterator for &'i Vec<'_, T> {
 }
 
 impl<'i, T> IntoIterator for &'i mut Vec<'_, T> {
-    type IntoIter = std::slice::IterMut<'i, T>;
+    type IntoIter = core::slice::IterMut<'i, T>;
     type Item = &'i mut T;
 
     #[inline(always)]
@@ -304,6 +303,8 @@ impl<T: Debug> Debug for Vec<'_, T> {
 
 #[cfg(test)]
 mod test {
+    use alloc::format;
+
     use super::Vec;
     use crate::{Allocator, Box};
 

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -60,7 +60,7 @@ schemars = { workspace = true, features = ["indexmap2"] }
 self_cell = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
-simdutf8 = { workspace = true }
+simdutf8 = { workspace = true, features = ["std"] }
 smallvec = { workspace = true }
 
 [dev-dependencies]


### PR DESCRIPTION
Add `no_std` support for `oxc_allocator` for downstream crates that need `no_std`.