### PR TITLE
feat(transformer/module_runner_transform): remove duplicate `deps` and `dynamicDeps`

### DIFF
--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -815,8 +815,8 @@ pub fn module_runner_transform(
     ModuleRunnerTransformResult {
         code,
         map: map.map(Into::into),
-        deps,
-        dynamic_deps,
+        deps: deps.into_iter().collect::<Vec<String>>(),
+        dynamic_deps: dynamic_deps.into_iter().collect::<Vec<String>>(),
         errors: parser_ret.errors.into_iter().map(OxcError::from).collect(),
     }
 }


### PR DESCRIPTION
I found that the import source can be repeated, so it seems like removing the duplicate `deps` and `dynamicDeps` would be better, but I am not sure it is worth doing it. 
