### PR TITLE
feat(linter): add import/no-empty-named-blocks rule

### DIFF
--- a/crates/oxc_linter/src/rules.rs
+++ b/crates/oxc_linter/src/rules.rs
@@ -10,6 +10,7 @@ mod import {
     pub mod exports_last;
     pub mod no_absolute_path;
     pub mod no_anonymous_default_export;
+    pub mod no_empty_named_blocks;
     pub mod no_mutable_exports;
     // pub mod no_deprecated;
     // pub mod no_unused_modules;
@@ -701,6 +702,7 @@ oxc_macros::declare_all_lint_rules! {
     import::export,
     import::exports_last,
     import::first,
+    import::no_empty_named_blocks,
     import::no_anonymous_default_export,
     import::no_absolute_path,
     import::no_mutable_exports,

--- a/crates/oxc_linter/src/rules/import/no_empty_named_blocks.rs
+++ b/crates/oxc_linter/src/rules/import/no_empty_named_blocks.rs
@@ -1,0 +1,90 @@
+use oxc_ast::AstKind;
+use oxc_diagnostics::OxcDiagnostic;
+use oxc_macros::declare_oxc_lint;
+use oxc_span::Span;
+
+use crate::{AstNode, context::LintContext, rule::Rule};
+
+fn no_empty_named_blocks_diagnostic(span: Span) -> OxcDiagnostic {
+    // See <https://oxc.rs/docs/contribute/linter/adding-rules.html#diagnostics> for details
+    OxcDiagnostic::warn("Unexpected empty named import block.").with_label(span)
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct NoEmptyNamedBlocks;
+
+declare_oxc_lint!(
+    /// ### What it does
+    ///
+    /// Enforces that named import blocks are not empty
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Empty named imports serve no practical purpose and
+    /// often result from accidental deletions or tool-generated code.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
+    /// ```js
+    /// import {} from 'mod'
+    /// import Default, {} from 'mod'
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// import { mod } from 'mod'
+    /// import Default, { mod } from 'mod'
+    /// ```
+    NoEmptyNamedBlocks,
+    import,
+    suspicious,
+    pending
+);
+
+impl Rule for NoEmptyNamedBlocks {
+    fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
+        let AstKind::ImportDeclaration(import_decl) = node.kind() else {
+            return;
+        };
+        let source_token_str = Span::new(import_decl.span.start, import_decl.source.span.end)
+            .source_text(ctx.source_text());
+        // find is there anything between '{' and '}'
+        if let Some(start) = source_token_str.find('{') {
+            if let Some(end) = source_token_str[start..].find('}') {
+                let between_braces = &source_token_str[start + 1..start + end];
+                if between_braces.trim().is_empty() {
+                    ctx.diagnostic(no_empty_named_blocks_diagnostic(import_decl.span));
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn test() {
+    use crate::tester::Tester;
+
+    let pass = vec![
+        "import 'mod'",
+        "import { mod } from 'mod'",
+        "import Default, { mod } from 'mod'",
+        "import { Named } from 'mod'",
+        "import type { Named } from 'mod'",
+        "import type Default, { Named } from 'mod'",
+        "import type * as Namespace from 'mod'",
+        "import * as Namespace from 'mod'",
+    ];
+
+    let fail = vec![
+        "import {} from 'mod'",
+        "import Default, {} from 'mod'",
+        "import{}from'mod'",
+        "import type {}from'mod'",
+        "import type {} from 'mod'",
+        "import type{}from 'mod'",
+    ];
+
+    Tester::new(NoEmptyNamedBlocks::NAME, NoEmptyNamedBlocks::PLUGIN, pass, fail)
+        .test_and_snapshot();
+}

--- a/crates/oxc_linter/src/snapshots/import_no_empty_named_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_empty_named_blocks.snap
@@ -19,6 +19,7 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import Default, {} from 'mod'
    · ─────────────────────────────
    ╰────
+  help: Delete this code.
 
   ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named import block.
    ╭─[no_empty_named_blocks.tsx:1:1]

--- a/crates/oxc_linter/src/snapshots/import_no_empty_named_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_empty_named_blocks.snap
@@ -6,6 +6,13 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import {} from 'mod'
    · ────────────────────
    ╰────
+  help: Delete this code.
+
+  ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named import block.
+   ╭─[no_empty_named_blocks.tsx:1:1]
+ 1 │ import {} from 'mod'
+   · ────────────────────
+   ╰────
 
   ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named import block.
    ╭─[no_empty_named_blocks.tsx:1:1]
@@ -18,6 +25,20 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import{}from'mod'
    · ─────────────────
    ╰────
+  help: Delete this code.
+
+  ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named import block.
+   ╭─[no_empty_named_blocks.tsx:1:1]
+ 1 │ import{}from'mod'
+   · ─────────────────
+   ╰────
+
+  ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named import block.
+   ╭─[no_empty_named_blocks.tsx:1:1]
+ 1 │ import type {}from'mod'
+   · ───────────────────────
+   ╰────
+  help: Delete this code.
 
   ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named import block.
    ╭─[no_empty_named_blocks.tsx:1:1]
@@ -30,6 +51,20 @@ source: crates/oxc_linter/src/tester.rs
  1 │ import type {} from 'mod'
    · ─────────────────────────
    ╰────
+  help: Delete this code.
+
+  ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named import block.
+   ╭─[no_empty_named_blocks.tsx:1:1]
+ 1 │ import type {} from 'mod'
+   · ─────────────────────────
+   ╰────
+
+  ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named import block.
+   ╭─[no_empty_named_blocks.tsx:1:1]
+ 1 │ import type{}from 'mod'
+   · ───────────────────────
+   ╰────
+  help: Delete this code.
 
   ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named import block.
    ╭─[no_empty_named_blocks.tsx:1:1]

--- a/crates/oxc_linter/src/snapshots/import_no_empty_named_blocks.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_empty_named_blocks.snap
@@ -1,0 +1,38 @@
+---
+source: crates/oxc_linter/src/tester.rs
+---
+  ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named import block.
+   ╭─[no_empty_named_blocks.tsx:1:1]
+ 1 │ import {} from 'mod'
+   · ────────────────────
+   ╰────
+
+  ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named import block.
+   ╭─[no_empty_named_blocks.tsx:1:1]
+ 1 │ import Default, {} from 'mod'
+   · ─────────────────────────────
+   ╰────
+
+  ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named import block.
+   ╭─[no_empty_named_blocks.tsx:1:1]
+ 1 │ import{}from'mod'
+   · ─────────────────
+   ╰────
+
+  ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named import block.
+   ╭─[no_empty_named_blocks.tsx:1:1]
+ 1 │ import type {}from'mod'
+   · ───────────────────────
+   ╰────
+
+  ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named import block.
+   ╭─[no_empty_named_blocks.tsx:1:1]
+ 1 │ import type {} from 'mod'
+   · ─────────────────────────
+   ╰────
+
+  ⚠ eslint-plugin-import(no-empty-named-blocks): Unexpected empty named import block.
+   ╭─[no_empty_named_blocks.tsx:1:1]
+ 1 │ import type{}from 'mod'
+   · ───────────────────────
+   ╰────


### PR DESCRIPTION
Relates to #1117 
Rule detail：https://github.com/import-js/eslint-plugin-import/blob/v2.31.0/docs/rules/no-empty-named-blocks.md