### PR TITLE
fix(linter): import and fix tests for typescript::no_unnecessary_parameter_property_assignment

### DIFF
--- a/apps/oxlint/src/snapshots/_--ignore-path fixtures__linter__.customignore --no-ignore fixtures__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-path fixtures__linter__.customignore --no-ignore fixtures__linter__nan.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Use the isNaN function to compare with NaN.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--ignore-pattern _____.js --ignore-pattern _____.vue fixtures__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--ignore-pattern _____.js --ignore-pattern _____.vue fixtures__linter@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --ignore-pattern **/*.js --ignore-pattern **/*.vue fixtures/linter
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 99 rules using 1 threads.
+Finished in <variable>ms on 0 files with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--import-plugin -A all -D no-cycle fixtures__flow__@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--import-plugin -A all -D no-cycle fixtures__flow__@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --import-plugin -A all -D no-cycle fixtures/flow/
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 2 files with 101 rules using 1 threads.
+Finished in <variable>ms on 2 files with 102 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--import-plugin fixtures__flow__index.mjs@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--import-plugin fixtures__flow__index.mjs@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --import-plugin fixtures/flow/index.mjs
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 102 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_--vitest-plugin -c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
@@ -23,7 +23,7 @@ working directory:
   help: Remove the appending `.skip`
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 111 rules using 1 threads.
+Finished in <variable>ms on 1 file with 112 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-D correctness fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-D correctness fixtures__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Delete this code.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-W correctness -A no-debugger fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W correctness -A no-debugger fixtures__linter__debugger.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -W correctness -A no-debugger fixtures/linter/debugger.js
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 98 rules using 1 threads.
+Finished in <variable>ms on 1 file with 99 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__eslintrc_env__eslintrc_no_env.json fixtures__eslintrc_env__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__eslintrc_env__eslintrc_no_env.json fixtures__eslintrc_env__test.js@oxlint.snap
@@ -13,7 +13,7 @@ working directory:
    `----
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 100 rules using 1 threads.
+Finished in <variable>ms on 1 file with 101 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__no_undef__eslintrc.json fixtures__no_undef__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-W no-undef -c fixtures__no_undef__eslintrc.json fixtures__no_undef__test.js@oxlint.snap
@@ -13,7 +13,7 @@ working directory:
    `----
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 100 rules using 1 threads.
+Finished in <variable>ms on 1 file with 101 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__config_ignore_patterns__ignore_extension__eslintrc.json fixtures__config_ignore_patterns__ignore_extension@oxlint.snap
@@ -12,7 +12,7 @@ working directory:
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_env__eslintrc_env_browser.json fixtures__eslintrc_env__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_env__eslintrc_env_browser.json fixtures__eslintrc_env__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/eslintrc_env/eslintrc_env_browser.json fixtures/eslintrc_
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 100 rules using 1 threads.
+Finished in <variable>ms on 1 file with 101 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_off__eslintrc.json fixtures__eslintrc_off__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_off__eslintrc.json fixtures__eslintrc_off__test.js@oxlint.snap
@@ -12,7 +12,7 @@ working directory:
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__eslintrc_vitest_replace__eslintrc.json fixtures__eslintrc_vitest_replace__foo.test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/eslintrc_vitest_replace/eslintrc.json fixtures/eslintrc_v
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__linter__eslintrc.json fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__linter__eslintrc.json fixtures__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Delete this code.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__no_console_off__eslintrc.json fixtures__no_console_off__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__no_console_off__eslintrc.json fixtures__no_console_off__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/no_console_off/eslintrc.json fixtures/no_console_off/test
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__no_empty_allow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_allow_empty_catch__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__no_empty_allow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_allow_empty_catch__test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -c fixtures/no_empty_allow_empty_catch/eslintrc.json -W no-empty fixt
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 100 rules using 1 threads.
+Finished in <variable>ms on 1 file with 101 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__no_empty_disallow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_disallow_empty_catch__test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__no_empty_disallow_empty_catch__eslintrc.json -W no-empty fixtures__no_empty_disallow_empty_catch__test.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Remove this block or add a comment inside it
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 100 rules using 1 threads.
+Finished in <variable>ms on 1 file with 101 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.js -c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.ts -c fixtures__overrides__.oxlintrc.json fixtures__overrides__other.jsx@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.js -c fixtures__overrides__.oxlintrc.json fixtures__overrides__test.ts -c fixtures__overrides__.oxlintrc.json fixtures__overrides__other.jsx@oxlint.snap
@@ -15,7 +15,7 @@ working directory:
   help: Replace var with let or const
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 102 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------
@@ -42,7 +42,7 @@ working directory:
   help: Delete this console statement.
 
 Found 1 warning and 1 error.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 102 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------
@@ -61,7 +61,7 @@ working directory:
   help: Replace var with let or const
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 102 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__overrides__directories-config.json fixtures__overrides@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__overrides__directories-config.json fixtures__overrides@oxlint.snap
@@ -35,7 +35,7 @@ working directory:
   help: Delete this code.
 
 Found 2 warnings and 2 errors.
-Finished in <variable>ms on 7 files with 98 rules using 1 threads.
+Finished in <variable>ms on 7 files with 99 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json fixtures__typescript_eslint__test.ts@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__typescript_eslint__eslintrc.json fixtures__typescript_eslint__test.ts@oxlint.snap
@@ -31,7 +31,7 @@ working directory:
    `----
 
 Found 2 warnings and 1 error.
-Finished in <variable>ms on 1 file with 60 rules using 1 threads.
+Finished in <variable>ms on 1 file with 61 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__astro__debugger.astro@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__astro__debugger.astro@oxlint.snap
@@ -43,7 +43,7 @@ working directory:
   help: Delete this code.
 
 Found 4 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter@oxlint.snap
@@ -28,7 +28,7 @@ working directory:
   help: Use the isNaN function to compare with NaN.
 
 Found 3 warnings and 0 errors.
-Finished in <variable>ms on 3 files with 99 rules using 1 threads.
+Finished in <variable>ms on 3 files with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js fixtures__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js fixtures__linter__nan.js@oxlint.snap
@@ -21,7 +21,7 @@ working directory:
   help: Use the isNaN function to compare with NaN.
 
 Found 2 warnings and 0 errors.
-Finished in <variable>ms on 2 files with 99 rules using 1 threads.
+Finished in <variable>ms on 2 files with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory:
   help: Delete this code.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__svelte__debugger.svelte@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__svelte__debugger.svelte@oxlint.snap
@@ -16,7 +16,7 @@ working directory:
   help: Delete this code.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__vue__debugger.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__vue__debugger.vue@oxlint.snap
@@ -25,7 +25,7 @@ working directory:
   help: Delete this code.
 
 Found 2 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_fixtures__vue__empty.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__vue__empty.vue@oxlint.snap
@@ -6,7 +6,7 @@ arguments: fixtures/vue/empty.vue
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/_foo.asdf@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_foo.asdf@oxlint.snap
@@ -6,7 +6,7 @@ arguments: foo.asdf
 working directory: 
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 0 files with 99 rules using 1 threads.
+Finished in <variable>ms on 0 files with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__ignore_directory_-c eslintrc.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__ignore_directory_-c eslintrc.json@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/config_ignore_patterns/ignore_directory
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__with_oxlintrc_-c .__test__eslintrc.json --ignore-pattern _.ts .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__config_ignore_patterns__with_oxlintrc_-c .__test__eslintrc.json --ignore-pattern _.ts .@oxlint.snap
@@ -12,7 +12,7 @@ working directory: fixtures/config_ignore_patterns/with_oxlintrc
   help: Delete this file or add some code to it.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--config extends_rules_config.json console.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--config extends_rules_config.json console.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/extends_config
   help: Delete this console statement.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 100 rules using 1 threads.
+Finished in <variable>ms on 1 file with 101 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--config relative_paths__extends_extends_config.json console.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--config relative_paths__extends_extends_config.json console.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/extends_config
   help: Delete this console statement.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 101 rules using 1 threads.
+Finished in <variable>ms on 1 file with 102 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--disable-nested-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--disable-nested-config@oxlint.snap
@@ -31,7 +31,7 @@ working directory: fixtures/extends_config
   help: Delete this code.
 
 Found 3 warnings and 0 errors.
-Finished in <variable>ms on 4 files with 99 rules using 1 threads.
+Finished in <variable>ms on 4 files with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__linter_debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__linter_debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/linter
   help: Delete this code.
 
 Found 1 warning and 0 errors.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_--config oxlint-no-console.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_--config oxlint-no-console.json@oxlint.snap
@@ -37,7 +37,7 @@ working directory: fixtures/nested_config
   help: Delete this console statement.
 
 Found 0 warnings and 4 errors.
-Finished in <variable>ms on 7 files with 99 rules using 1 threads.
+Finished in <variable>ms on 7 files with 100 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_--experimental-nested-config --config oxlint-no-console.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_--experimental-nested-config --config oxlint-no-console.json@oxlint.snap
@@ -37,7 +37,7 @@ working directory: fixtures/nested_config
   help: Delete this console statement.
 
 Found 0 warnings and 4 errors.
-Finished in <variable>ms on 7 files with 99 rules using 1 threads.
+Finished in <variable>ms on 7 files with 100 rules using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_--experimental-nested-config -A no-console --config oxlint-no-console.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_--experimental-nested-config -A no-console --config oxlint-no-console.json@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --experimental-nested-config -A no-console --config oxlint-no-console
 working directory: fixtures/nested_config
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 7 files with 98 rules using 1 threads.
+Finished in <variable>ms on 7 files with 99 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_-A no-console --config oxlint-no-console.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_-A no-console --config oxlint-no-console.json@oxlint.snap
@@ -6,7 +6,7 @@ arguments: -A no-console --config oxlint-no-console.json
 working directory: fixtures/nested_config
 ----------
 Found 0 warnings and 0 errors.
-Finished in <variable>ms on 7 files with 98 rules using 1 threads.
+Finished in <variable>ms on 7 files with 99 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__overrides_env_globals_-c .oxlintrc.json .@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__overrides_env_globals_-c .oxlintrc.json .@oxlint.snap
@@ -51,7 +51,7 @@ working directory: fixtures/overrides_env_globals
    `----
 
 Found 5 warnings and 0 errors.
-Finished in <variable>ms on 3 files with 99 rules using 1 threads.
+Finished in <variable>ms on 3 files with 100 rules using 1 threads.
 ----------
 CLI result: LintSucceeded
 ----------

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_parameter_property_assignment.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_parameter_property_assignment.rs
@@ -52,7 +52,7 @@ declare_oxc_lint!(
     /// ```
     NoUnnecessaryParameterPropertyAssignment,
     typescript,
-    nursery, // TODO: import tests from typescript-eslint, fix them and change back to correctness
+    correctness,
     pending,
 );
 
@@ -98,7 +98,7 @@ impl Rule for NoUnnecessaryParameterPropertyAssignment {
             else {
                 continue;
             };
-            let Some(this_property_name) = get_this_property_name(&assignment.left) else {
+            let Some(this_property_name) = get_property_name(&assignment.left) else {
                 continue;
             };
 
@@ -127,7 +127,7 @@ impl<'a> Visit<'a> for AssignmentVisitor<'a, '_> {
         &mut self,
         assignment_expr: &oxc_ast::ast::AssignmentExpression<'a>,
     ) {
-        let Some(this_property_name) = get_this_property_name(&assignment_expr.left) else {
+        let Some(this_property_name) = get_property_name(&assignment_expr.left) else {
             return;
         };
         // assigning to a property of this
@@ -230,7 +230,7 @@ fn is_unnecessary_assignment_operator(operator: AssignmentOperator) -> bool {
     )
 }
 
-fn get_this_property_name<'a>(assignment_target: &AssignmentTarget<'a>) -> Option<Atom<'a>> {
+fn get_property_name<'a>(assignment_target: &AssignmentTarget<'a>) -> Option<Atom<'a>> {
     match assignment_target {
         AssignmentTarget::StaticMemberExpression(expr)
             if matches!(&expr.object, Expression::ThisExpression(_)) =>

--- a/crates/oxc_linter/src/snapshots/typescript_no_unnecessary_parameter_property_assignment.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_unnecessary_parameter_property_assignment.snap
@@ -54,3 +54,165 @@ source: crates/oxc_linter/src/tester.rs
  6 │             } else {
    ╰────
   help: Remove the unnecessary assignment
+
+  ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
+   ╭─[no_unnecessary_parameter_property_assignment.tsx:4:13]
+ 3 │           constructor(public foo: string) {
+ 4 │             this.foo = foo;
+   ·             ──────────────
+ 5 │           }
+   ╰────
+  help: Remove the unnecessary assignment
+
+  ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
+   ╭─[no_unnecessary_parameter_property_assignment.tsx:4:13]
+ 3 │           constructor(public foo = '') {
+ 4 │             this.foo = foo;
+   ·             ──────────────
+ 5 │           }
+   ╰────
+  help: Remove the unnecessary assignment
+
+  ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
+   ╭─[no_unnecessary_parameter_property_assignment.tsx:4:13]
+ 3 │           constructor(public foo = '') {
+ 4 │             this.foo = foo;
+   ·             ──────────────
+ 5 │             this.foo += 'foo';
+   ╰────
+  help: Remove the unnecessary assignment
+
+  ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
+   ╭─[no_unnecessary_parameter_property_assignment.tsx:4:13]
+ 3 │           constructor(public foo: string) {
+ 4 │             this.foo ||= foo;
+   ·             ────────────────
+ 5 │           }
+   ╰────
+  help: Remove the unnecessary assignment
+
+  ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
+   ╭─[no_unnecessary_parameter_property_assignment.tsx:4:13]
+ 3 │           constructor(public foo: string) {
+ 4 │             this.foo ??= foo;
+   ·             ────────────────
+ 5 │           }
+   ╰────
+  help: Remove the unnecessary assignment
+
+  ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
+   ╭─[no_unnecessary_parameter_property_assignment.tsx:4:13]
+ 3 │           constructor(public foo: string) {
+ 4 │             this.foo &&= foo;
+   ·             ────────────────
+ 5 │           }
+   ╰────
+  help: Remove the unnecessary assignment
+
+  ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
+   ╭─[no_unnecessary_parameter_property_assignment.tsx:5:15]
+ 4 │             function bar() {
+ 5 │               this.foo = foo;
+   ·               ──────────────
+ 6 │             }
+   ╰────
+  help: Remove the unnecessary assignment
+
+  ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
+   ╭─[no_unnecessary_parameter_property_assignment.tsx:7:13]
+ 6 │             }
+ 7 │             this.foo = foo;
+   ·             ──────────────
+ 8 │           }
+   ╰────
+  help: Remove the unnecessary assignment
+
+  ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
+   ╭─[no_unnecessary_parameter_property_assignment.tsx:5:15]
+ 4 │             this.bar = () => {
+ 5 │               this.foo = foo;
+   ·               ──────────────
+ 6 │             };
+   ╰────
+  help: Remove the unnecessary assignment
+
+  ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
+   ╭─[no_unnecessary_parameter_property_assignment.tsx:7:13]
+ 6 │             };
+ 7 │             this.foo = foo;
+   ·             ──────────────
+ 8 │           }
+   ╰────
+  help: Remove the unnecessary assignment
+
+  ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
+    ╭─[no_unnecessary_parameter_property_assignment.tsx:9:13]
+  8 │             }
+  9 │             this.foo = foo;
+    ·             ──────────────
+ 10 │           }
+    ╰────
+  help: Remove the unnecessary assignment
+
+  ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
+   ╭─[no_unnecessary_parameter_property_assignment.tsx:6:17]
+ 5 │               constructor(private foo: string) {
+ 6 │                 this.foo = foo;
+   ·                 ──────────────
+ 7 │               }
+   ╰────
+  help: Remove the unnecessary assignment
+
+  ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
+   ╭─[no_unnecessary_parameter_property_assignment.tsx:4:13]
+ 3 │           constructor(private foo: string) {
+ 4 │             this.foo = foo;
+   ·             ──────────────
+ 5 │           }
+   ╰────
+  help: Remove the unnecessary assignment
+
+  ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
+   ╭─[no_unnecessary_parameter_property_assignment.tsx:4:13]
+ 3 │           constructor(private foo: string) {
+ 4 │             this.foo = foo;
+   ·             ──────────────
+ 5 │           }
+   ╰────
+  help: Remove the unnecessary assignment
+
+  ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
+   ╭─[no_unnecessary_parameter_property_assignment.tsx:4:13]
+ 3 │           constructor(private foo: string) {
+ 4 │             this.foo = foo;
+   ·             ──────────────
+ 5 │           }
+   ╰────
+  help: Remove the unnecessary assignment
+
+  ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
+   ╭─[no_unnecessary_parameter_property_assignment.tsx:8:15]
+ 7 │             constructor(private foo: string) {
+ 8 │               this.foo = foo;
+   ·               ──────────────
+ 9 │             }
+   ╰────
+  help: Remove the unnecessary assignment
+
+  ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
+   ╭─[no_unnecessary_parameter_property_assignment.tsx:5:15]
+ 4 │             {
+ 5 │               this.foo = foo;
+   ·               ──────────────
+ 6 │             }
+   ╰────
+  help: Remove the unnecessary assignment
+
+  ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
+   ╭─[no_unnecessary_parameter_property_assignment.tsx:5:15]
+ 4 │             (() => {
+ 5 │               this.foo = foo;
+   ·               ──────────────
+ 6 │             })();
+   ╰────
+  help: Remove the unnecessary assignment

--- a/crates/oxc_linter/src/snapshots/typescript_no_unnecessary_parameter_property_assignment.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_unnecessary_parameter_property_assignment.snap
@@ -66,6 +66,24 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
    ╭─[no_unnecessary_parameter_property_assignment.tsx:4:13]
+ 3 │           constructor(public foo?: string) {
+ 4 │             this.foo = foo!;
+   ·             ───────────────
+ 5 │           }
+   ╰────
+  help: Remove the unnecessary assignment
+
+  ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
+   ╭─[no_unnecessary_parameter_property_assignment.tsx:4:13]
+ 3 │           constructor(public foo?: string) {
+ 4 │             this.foo = foo as any;
+   ·             ─────────────────────
+ 5 │           }
+   ╰────
+  help: Remove the unnecessary assignment
+
+  ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
+   ╭─[no_unnecessary_parameter_property_assignment.tsx:4:13]
  3 │           constructor(public foo = '') {
  4 │             this.foo = foo;
    ·             ──────────────

--- a/crates/oxc_linter/src/snapshots/typescript_no_unnecessary_parameter_property_assignment.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_unnecessary_parameter_property_assignment.snap
@@ -128,6 +128,15 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the unnecessary assignment
 
   ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
+   ╭─[no_unnecessary_parameter_property_assignment.tsx:4:13]
+ 3 │           constructor(private foo: string) {
+ 4 │             this['foo'] = foo;
+   ·             ─────────────────
+ 5 │           }
+   ╰────
+  help: Remove the unnecessary assignment
+
+  ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
    ╭─[no_unnecessary_parameter_property_assignment.tsx:5:15]
  4 │             function bar() {
  5 │               this.foo = foo;

--- a/crates/oxc_linter/src/snapshots/typescript_no_unnecessary_parameter_property_assignment.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_unnecessary_parameter_property_assignment.snap
@@ -155,15 +155,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the unnecessary assignment
 
   ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
-   ╭─[no_unnecessary_parameter_property_assignment.tsx:5:15]
- 4 │             this.bar = () => {
- 5 │               this.foo = foo;
-   ·               ──────────────
- 6 │             };
-   ╰────
-  help: Remove the unnecessary assignment
-
-  ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
    ╭─[no_unnecessary_parameter_property_assignment.tsx:7:13]
  6 │             };
  7 │             this.foo = foo;


### PR DESCRIPTION
Followup to #9618.
PRs for oxc/no-redundant-constructor-init: #9299 #9364
typescript-eslint rule: [Docs](https://typescript-eslint.io/rules/no-unnecessary-parameter-property-assignment) [Source](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/src/rules/no-unnecessary-parameter-property-assignment.ts) [Tests](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/tests/rules/no-unnecessary-parameter-property-assignment.test.ts)


Changes of this PR:

- Imported tests from typescript-eslint
- Added one more passing test to the end
- Fixed all new test cases
- Changed rule category back to correctness

This is my first major change to OXC.
If there's anything wrong or not the OXC-way, I will happily improve on that. 