### PR TITLE
fix(transformer): fix `TSInstantiationExpression` not being removed

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -28,6 +28,7 @@ impl<'a> Expression<'a> {
                 | Self::TSSatisfiesExpression(_)
                 | Self::TSTypeAssertion(_)
                 | Self::TSNonNullExpression(_)
+                | Self::TSInstantiationExpression(_)
         )
     }
 

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -2361,24 +2361,24 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), Sc
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(8)]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-binary-operator/input.ts
-semantic error: Unresolved reference IDs mismatch for "b":
-after transform: [ReferenceId(1)]
-rebuilt        : [ReferenceId(2)]
+semantic error: Unresolved references mismatch:
+after transform: ["a", "b", "c"]
+rebuilt        : ["a", "c"]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-binary-operator-babel-7/input.ts
-semantic error: Unresolved reference IDs mismatch for "b":
-after transform: [ReferenceId(1)]
-rebuilt        : [ReferenceId(2)]
+semantic error: Unresolved references mismatch:
+after transform: ["a", "b", "c"]
+rebuilt        : ["a", "c"]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-optional-chain/input.ts
-semantic error: Unresolved reference IDs mismatch for "c":
-after transform: [ReferenceId(1), ReferenceId(3)]
-rebuilt        : [ReferenceId(4)]
+semantic error: Unresolved references mismatch:
+after transform: ["a", "c"]
+rebuilt        : ["a"]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-optional-chain-babel-7/input.ts
-semantic error: Unresolved reference IDs mismatch for "c":
-after transform: [ReferenceId(1), ReferenceId(3)]
-rebuilt        : [ReferenceId(4)]
+semantic error: Unresolved references mismatch:
+after transform: ["a", "c"]
+rebuilt        : ["a"]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/new/input.ts
 semantic error: Unresolved references mismatch:

--- a/tasks/coverage/snapshots/transformer_babel.snap
+++ b/tasks/coverage/snapshots/transformer_babel.snap
@@ -2,14 +2,6 @@ commit: 578ac4df
 
 transformer_babel Summary:
 AST Parsed     : 2322/2322 (100.00%)
-Positive Passed: 2312/2322 (99.57%)
+Positive Passed: 2320/2322 (99.91%)
 Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-private-properties/await-in-private-property-in-async/input.js
 Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-properties/await-in-class-property-in-async/input.js
-Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression/input.ts
-Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-asi/input.ts
-Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-asi-babel-7/input.ts
-Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-babel-7/input.ts
-Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-binary-operator/input.ts
-Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-binary-operator-babel-7/input.ts
-Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-optional-chain/input.ts
-Mismatch: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/instantiation-expression-optional-chain-babel-7/input.ts

--- a/tasks/coverage/snapshots/transformer_typescript.snap
+++ b/tasks/coverage/snapshots/transformer_typescript.snap
@@ -2,9 +2,7 @@ commit: 15392346
 
 transformer_typescript Summary:
 AST Parsed     : 6531/6531 (100.00%)
-Positive Passed: 6526/6531 (99.92%)
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitUsingTypeAlias2.ts
+Positive Passed: 6528/6531 (99.95%)
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-staticPrivateAccessor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-decoratorExpression.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxAndJsxFragPragmaOverridesCompilerOptions.tsx

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -2605,7 +2605,9 @@ after transform: ["T", "f"]
 rebuilt        : ["f"]
 
 * type-arguments/expr/input.ts
-x Output mismatch
+Unresolved references mismatch:
+after transform: ["T", "f"]
+rebuilt        : ["f"]
 
 * type-arguments/new/input.ts
 Unresolved references mismatch:


### PR DESCRIPTION
fixes https://github.com/rolldown/rolldown/issues/3833

```
Foo<Bar>
   ^^^^^ was not removed
```