### PR TITLE
test(allocator): fix tests

### DIFF
--- a/crates/oxc_allocator/Cargo.toml
+++ b/crates/oxc_allocator/Cargo.toml
@@ -31,6 +31,7 @@ simdutf8 = { workspace = true }
 serde = { workspace = true, optional = true }
 
 [dev-dependencies]
+oxc_estree = { workspace = true, features = ["serialize"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 


### PR DESCRIPTION
Fix `cargo test -p oxc_allocator`. Previously it would fail due to missing `oxc_estree` dependency.