### PR TITLE
refactor(allocator/vec): comment out feature-gated methods

### DIFF
--- a/crates/oxc_allocator/src/vec2/mod.rs
+++ b/crates/oxc_allocator/src/vec2/mod.rs
@@ -106,8 +106,9 @@ use core::ops::{Index, IndexMut, RangeBounds};
 use core::ptr;
 use core::ptr::NonNull;
 use core::slice;
-#[cfg(feature = "std")]
-use std::io;
+
+// #[cfg(feature = "std")]
+// use std::io;
 
 unsafe fn arith_offset<T>(p: *const T, offset: isize) -> *const T {
     p.offset(offset)
@@ -1664,6 +1665,7 @@ impl<'bump, T: 'bump> Vec<'bump, T> {
     }
 }
 
+/*
 #[cfg(feature = "boxed")]
 impl<'bump, T> Vec<'bump, T> {
     /// Converts the vector into [`Box<[T]>`][owned slice].
@@ -1695,6 +1697,7 @@ impl<'bump, T> Vec<'bump, T> {
         }
     }
 }
+*/
 
 impl<'bump, T: 'bump + Clone> Vec<'bump, T> {
     /// Resizes the `Vec` in-place so that `len` is equal to `new_len`.
@@ -2287,12 +2290,14 @@ impl<'bump, T: 'bump> AsMut<[T]> for Vec<'bump, T> {
     }
 }
 
+/*
 #[cfg(feature = "boxed")]
 impl<'bump, T: 'bump> From<Vec<'bump, T>> for crate::boxed::Box<'bump, [T]> {
     fn from(v: Vec<'bump, T>) -> crate::boxed::Box<'bump, [T]> {
         v.into_boxed_slice()
     }
 }
+*/
 
 impl<'bump, T: 'bump> Borrow<[T]> for Vec<'bump, T> {
     #[inline]
@@ -2713,6 +2718,7 @@ where
     }
 }
 
+/*
 #[cfg(feature = "std")]
 impl<'bump> io::Write for Vec<'bump, u8> {
     #[inline]
@@ -2732,7 +2738,9 @@ impl<'bump> io::Write for Vec<'bump, u8> {
         Ok(())
     }
 }
+*/
 
+/*
 #[cfg(feature = "serde")]
 mod serialize {
     use super::*;
@@ -2755,3 +2763,4 @@ mod serialize {
         }
     }
 }
+*/

--- a/crates/oxc_allocator/src/vec2/raw_vec.rs
+++ b/crates/oxc_allocator/src/vec2/raw_vec.rs
@@ -154,6 +154,7 @@ impl<'a, T> RawVec<'a, T> {
         }
     }
 
+    /*
     /// Doubles the size of the type's backing allocation. This is common enough
     /// to want to do that it's easiest to just have a dedicated method. Slightly
     /// more efficient logic can be provided for this than the general case.
@@ -250,7 +251,9 @@ impl<'a, T> RawVec<'a, T> {
             self.cap = new_cap;
         }
     }
+    */
 
+    /*
     /// Attempts to double the size of the type's backing allocation in place. This is common
     /// enough to want to do that it's easiest to just have a dedicated method. Slightly
     /// more efficient logic can be provided for this than the general case.
@@ -297,6 +300,7 @@ impl<'a, T> RawVec<'a, T> {
             }
         }
     }
+    */
 
     /// The same as `reserve_exact`, but returns on errors instead of panicking or aborting.
     pub fn try_reserve_exact(
@@ -413,6 +417,7 @@ impl<'a, T> RawVec<'a, T> {
         self.infallible_reserve_internal(used_cap, needed_extra_cap, Amortized)
     }
 
+    /*
     /// Attempts to ensure that the buffer contains at least enough space to hold
     /// `used_cap + needed_extra_cap` elements. If it doesn't already have
     /// enough capacity, will reallocate in place enough space plus comfortable slack
@@ -468,6 +473,7 @@ impl<'a, T> RawVec<'a, T> {
             }
         }
     }
+    */
 
     /// Shrinks the allocation down to the specified amount. If the given amount
     /// is 0, actually completely deallocates.
@@ -529,6 +535,7 @@ impl<'a, T> RawVec<'a, T> {
     }
 }
 
+/*
 #[cfg(feature = "boxed")]
 impl<'a, T> RawVec<'a, T> {
     /// Converts the entire buffer into `Box<[T]>`.
@@ -551,6 +558,7 @@ impl<'a, T> RawVec<'a, T> {
         output
     }
 }
+*/
 
 enum Fallibility {
     Fallible,


### PR DESCRIPTION
Comment out methods which are feature-gated in `vec2::Vec` (the implementation copied from `bumpalo` in #9646).