### PR TITLE
docs(allocator/vec): fix link in doc comment for `Vec2`

### DIFF
--- a/crates/oxc_allocator/src/vec2/mod.rs
+++ b/crates/oxc_allocator/src/vec2/mod.rs
@@ -1827,7 +1827,7 @@ impl<'bump, T: 'bump + Copy> Vec<'bump, T> {
     /// ```
     ///
     /// [`extend_from_slice`]: #method.extend_from_slice
-    /// [`extend_from_slices`]: #method.extend_from_slices
+    /// [`extend_from_slices_copy`]: #method.extend_from_slices_copy
     pub fn extend_from_slice_copy(&mut self, other: &[T]) {
         // Reserve space in the Vec for the values to be added
         self.reserve(other.len());


### PR DESCRIPTION
Fix a doc comment on a method of `vec2::Vec` (the implementation copied from `bumpalo` in #9646).