### PR TITLE
refactor(allocator/vec): disable lint warnings in `vec2` files

### DIFF
--- a/crates/oxc_allocator/src/vec2/mod.rs
+++ b/crates/oxc_allocator/src/vec2/mod.rs
@@ -90,6 +90,24 @@
 //! [`IndexMut`]: https://doc.rust-lang.org/std/ops/trait.IndexMut.html
 //! [`vec!`]: ../../macro.vec.html
 
+#![expect(
+    clippy::semicolon_if_nothing_returned,
+    clippy::needless_pass_by_ref_mut,
+    clippy::needless_for_each,
+    clippy::needless_lifetimes,
+    clippy::cloned_instead_of_copied,
+    clippy::checked_conversions,
+    clippy::legacy_numeric_constants,
+    clippy::cast_sign_loss,
+    clippy::cast_possible_wrap,
+    clippy::swap_ptr_to_ref,
+    clippy::ref_as_ptr,
+    clippy::ptr_as_ptr,
+    clippy::ptr_cast_constness,
+    unsafe_op_in_unsafe_fn,
+    clippy::undocumented_unsafe_blocks
+)]
+
 use super::raw_vec::RawVec;
 use crate::Bump;
 use crate::collections::CollectionAllocErr;

--- a/crates/oxc_allocator/src/vec2/raw_vec.rs
+++ b/crates/oxc_allocator/src/vec2/raw_vec.rs
@@ -10,6 +10,16 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+#![allow(
+    unused_mut,
+    unused_unsafe,
+    clippy::allow_attributes,
+    clippy::uninlined_format_args,
+    clippy::enum_glob_use,
+    clippy::equatable_if_let,
+    clippy::needless_pass_by_value,
+    clippy::inline_always
+)]
 #![allow(unstable_name_collisions)]
 #![allow(dead_code)]
 


### PR DESCRIPTION
Disable lint warnings for `vec2::Vec` (the implementation copied from `bumpalo` in #9646).