### PR TITLE
feat(allocator)!: remove `Vec::into_boxed_slice` method

### DIFF
--- a/crates/oxc_allocator/src/boxed.rs
+++ b/crates/oxc_allocator/src/boxed.rs
@@ -102,28 +102,6 @@ impl<T> Box<'_, T> {
 }
 
 impl<T: ?Sized> Box<'_, T> {
-    /// Create a [`Box`] from a raw pointer to a value.
-    ///
-    /// The [`Box`] takes ownership of the data pointed to by `ptr`.
-    ///
-    /// # SAFETY
-    /// Data pointed to by `ptr` must live as long as `'alloc`.
-    /// This requirement is met if the pointer was obtained from other data in the arena.
-    ///
-    /// Data pointed to by `ptr` must *only* be used for this `Box`. i.e. it must be unique,
-    /// with no other aliases. You must not, for example, create 2 `Box`es from the same pointer.
-    ///
-    /// `ptr` must have been created from a `*mut T` or `&mut T` (not a `*const T` / `&T`).
-    //
-    // `#[inline(always)]` because this is a no-op
-    #[expect(clippy::inline_always)]
-    #[inline(always)]
-    pub(crate) const unsafe fn from_non_null(ptr: NonNull<T>) -> Self {
-        const { Self::ASSERT_T_IS_NOT_DROP };
-
-        Self(ptr, PhantomData)
-    }
-
     /// Consume a [`Box`] and return a [`NonNull`] pointer to its contents.
     //
     // `#[inline(always)]` because this is a no-op


### PR DESCRIPTION
related: https://github.com/oxc-project/oxc/pull/9656#discussion_r1992578706

This method blocks us from replacing the allocator-api2's `Vec` with our own `Vec`(now called `Vec2`) in #9656, considering no use cases for this method, just remove it instead. After our own `Vec` is feature-complete, we can consider making https://github.com/oxc-project/oxc/blob/b32469a458b36097162e45c8ab20327d46867c7f/crates/oxc_allocator/src/vec2/mod.rs#L1686-L1719 this work.