### PR TITLE
perf(parser): do not call `ParserImpl::end_span` twice for `StringLiteral`s

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -398,7 +398,7 @@ impl<'a> ParserImpl<'a> {
         let raw = Atom::from(unsafe {
             self.source_text.get_unchecked(span.start as usize..span.end as usize)
         });
-        Ok(self.ast.string_literal(self.end_span(span), value, Some(raw)))
+        Ok(self.ast.string_literal(span, value, Some(raw)))
     }
 
     /// Section [Array Expression](https://tc39.es/ecma262/#prod-ArrayLiteral)


### PR DESCRIPTION
Calling `end_span` twice is unnecessary.

Skipping a couple of operations is not going to win us much perf, but hey...
