### PR TITLE
fix(ast/estree): fix `JSXOpeningElement` field order

### DIFF
--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -62,6 +62,7 @@ pub struct JSXElement<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[estree(field_order(span, attributes, name, self_closing, type_parameters))]
 pub struct JSXOpeningElement<'a> {
     /// Node location in source code
     pub span: Span,

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1986,9 +1986,9 @@ impl ESTree for JSXOpeningElement<'_> {
         state.serialize_field("type", &JsonSafeString("JSXOpeningElement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("selfClosing", &self.self_closing);
-        state.serialize_field("name", &self.name);
         state.serialize_field("attributes", &self.attributes);
+        state.serialize_field("name", &self.name);
+        state.serialize_field("selfClosing", &self.self_closing);
         state.serialize_ts_field("typeParameters", &self.type_parameters);
         state.end();
     }

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -1132,9 +1132,9 @@ function deserializeJSXOpeningElement(pos) {
     type: 'JSXOpeningElement',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    selfClosing: deserializeBool(pos + 8),
-    name: deserializeJSXElementName(pos + 16),
     attributes: deserializeVecJSXAttributeItem(pos + 32),
+    name: deserializeJSXElementName(pos + 16),
+    selfClosing: deserializeBool(pos + 8),
   };
 }
 

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -1184,9 +1184,9 @@ function deserializeJSXOpeningElement(pos) {
     type: 'JSXOpeningElement',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    selfClosing: deserializeBool(pos + 8),
-    name: deserializeJSXElementName(pos + 16),
     attributes: deserializeVecJSXAttributeItem(pos + 32),
+    name: deserializeJSXElementName(pos + 16),
+    selfClosing: deserializeBool(pos + 8),
     typeParameters: deserializeOptionBoxTSTypeParameterInstantiation(pos + 64),
   };
 }

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -817,9 +817,9 @@ export interface JSXElement extends Span {
 
 export interface JSXOpeningElement extends Span {
   type: 'JSXOpeningElement';
-  selfClosing: boolean;
-  name: JSXElementName;
   attributes: Array<JSXAttributeItem>;
+  name: JSXElementName;
+  selfClosing: boolean;
   typeParameters: TSTypeParameterInstantiation | null;
 }
 

--- a/tasks/coverage/snapshots/estree_acorn_jsx.snap
+++ b/tasks/coverage/snapshots/estree_acorn_jsx.snap
@@ -2,43 +2,9 @@ commit: b6d96c07
 
 estree_acorn_jsx Summary:
 AST Parsed     : 39/39 (100.00%)
-Positive Passed: 0/39 (0.00%)
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/003.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/004.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/005.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/007.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/008.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/009.jsx
+Positive Passed: 34/39 (87.18%)
 Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/010.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/011.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/012.jsx
 Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/013.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/014.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/015.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/016.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/017.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/018.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/019.jsx
 Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/020.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/021.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/022.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/023.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/024.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/025.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/026.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/027.jsx
 Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/028.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/029.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/030.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/031.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/032.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/033.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/034.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/035.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/041.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/042.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/043.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/044.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/045.jsx
 Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/046.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/047.jsx


### PR DESCRIPTION
Remaining failure looks like this:

```diff
== tasks/coverage/acorn-test262-diff/acorn-jsx/010.diff ==
@@ -71,7 +71,7 @@
                 "type": "Literal",
                 "start": 19,
                 "end": 26,
-                "value": "&",
+                "value": "&amp;",
                 "raw": "\"&amp;\""
               }
             },
== tasks/coverage/acorn-test262-diff/acorn-jsx/013.diff ==
@@ -30,7 +30,7 @@
                 "type": "Literal",
                 "start": 16,
                 "end": 31,
-                "value": "&&",
+                "value": "&#x0026;&#38;",
                 "raw": "\"&#x0026;&#38;\""
               }
             }
== tasks/coverage/acorn-test262-diff/acorn-jsx/020.diff ==
@@ -90,7 +90,7 @@
                     "type": "JSXText",
                     "start": 31,
                     "end": 53,
-                    "value": "monkeys /> gorillas",
+                    "value": "monkeys /&gt; gorillas",
                     "raw": "monkeys /&gt; gorillas"
                   }
                 ]
== tasks/coverage/acorn-test262-diff/acorn-jsx/028.diff ==
@@ -14,9 +14,7 @@
         "openingFragment": {
           "type": "JSXOpeningFragment",
           "start": 0,
-          "end": 2,
-          "attributes": [],
-          "selfClosing": false
+          "end": 2
         },
         "closingFragment": {
           "type": "JSXClosingFragment",
== tasks/coverage/acorn-test262-diff/acorn-jsx/046.diff ==
@@ -40,7 +40,7 @@
             "type": "JSXText",
             "start": 3,
             "end": 10,
-            "value": "foo>",
+            "value": "foo&gt;",
             "raw": "foo&gt;"
           }
         ]
```