### PR TITLE
refactor(traverse): add `TraverseCtx::insert_scope_below_statements`

### DIFF
--- a/crates/oxc_transformer/src/proposals/explicit_resource_management.rs
+++ b/crates/oxc_transformer/src/proposals/explicit_resource_management.rs
@@ -418,8 +418,7 @@ impl<'a> Traverse<'a> for ExplicitResourceManagement<'a, '_> {
             },
         );
 
-        let block_scope_id =
-            ctx.scoping.insert_scope_below_statements(&inner_block, ScopeFlags::empty());
+        let block_scope_id = ctx.insert_scope_below_statements(&inner_block, ScopeFlags::empty());
         program_body.push(ctx.ast.statement_block_with_scope_id(SPAN, inner_block, block_scope_id));
 
         std::mem::swap(&mut program.body, &mut program_body);

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -1,4 +1,4 @@
-use oxc_allocator::{Allocator, Box};
+use oxc_allocator::{Allocator, Box, Vec as ArenaVec};
 use oxc_ast::{
     AstBuilder,
     ast::{Expression, IdentifierReference, Statement},
@@ -277,6 +277,23 @@ impl<'a> TraverseCtx<'a> {
         flags: ScopeFlags,
     ) -> ScopeId {
         self.scoping.insert_scope_below_expression(expr, flags)
+    }
+
+    /// Insert a scope into scope tree below a `Vec` of statements.
+    ///
+    /// Statements must be in current scope.
+    /// New scope is created as child of current scope.
+    /// All child scopes of the statement are reassigned to be children of the new scope.
+    ///
+    /// `flags` provided are amended to inherit from parent scope's flags.
+    ///
+    /// This is a shortcut for `ctx.scoping.insert_scope_below_statements`.
+    pub fn insert_scope_below_statements(
+        &mut self,
+        stmts: &ArenaVec<Statement>,
+        flags: ScopeFlags,
+    ) -> ScopeId {
+        self.scoping.insert_scope_below_statements(stmts, flags)
     }
 
     /// Remove scope for an expression from the scope chain.


### PR DESCRIPTION
Follow-on after #9748. Our convention is to add aliases for all methods on `TraverseScoping` to `TraverseCtx` too, to make usage shorter.

Add an alias for `insert_scope_below_statements`, added in #9748.