### PR TITLE
feat(linter)!: enable `--experimental-nested-config` by default and add `--disable-nested-config` option

### DIFF
--- a/apps/oxlint/src/command/lint.rs
+++ b/apps/oxlint/src/command/lint.rs
@@ -42,9 +42,9 @@ pub struct LintCommand {
     #[bpaf(external)]
     pub misc_options: MiscOptions,
 
-    /// Enables automatic loading of nested configuration files (experimental feature)
+    /// Disables the automatic loading of nested configuration files.
     #[bpaf(switch, hide_usage)]
-    pub experimental_nested_config: bool,
+    pub disable_nested_config: bool,
 
     /// Single file, single path or list of paths
     #[bpaf(positional("PATH"), many, guard(validate_paths, PATHS_ERROR_MESSAGE))]
@@ -519,10 +519,10 @@ mod lint_options {
     }
 
     #[test]
-    fn experimental_nested_config() {
-        let options = get_lint_options("--experimental-nested-config");
-        assert!(options.experimental_nested_config);
+    fn disable_nested_config() {
+        let options = get_lint_options("--disable-nested-config");
+        assert!(options.disable_nested_config);
         let options = get_lint_options(".");
-        assert!(!options.experimental_nested_config);
+        assert!(!options.disable_nested_config);
     }
 }

--- a/apps/oxlint/src/snapshots/fixtures__auto_config_detection_debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__auto_config_detection_debugger.js@oxlint.snap
@@ -14,7 +14,7 @@ working directory: fixtures/auto_config_detection
   help: Delete this code.
 
 Found 0 warnings and 1 error.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--disable-nested-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--disable-nested-config@oxlint.snap
@@ -1,0 +1,37 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --disable-nested-config
+working directory: fixtures/extends_config
+----------
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html\eslint(no-unused-vars)]8;;\: Variable 'x' is declared but never used. Unused variables should start with a '_'.
+   ,-[overrides/test.ts:1:7]
+ 1 | const x: any = 3;
+   :       |
+   :       `-- 'x' is declared here
+   `----
+  help: Consider removing this declaration.
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html\eslint(no-unused-vars)]8;;\: Function 'component' is declared but never used.
+   ,-[overrides/test.tsx:1:10]
+ 1 | function component(): any {
+   :          ^^^^|^^^^
+   :              `-- 'component' is declared here
+ 2 |   return <a>click here</a>;
+   `----
+  help: Consider removing this declaration.
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[overrides_same_directory/config/test.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Delete this code.
+
+Found 3 warnings and 0 errors.
+Finished in <variable>ms on 4 files with 99 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_overrides@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_overrides@oxlint.snap
@@ -6,25 +6,31 @@ arguments: overrides
 working directory: fixtures/extends_config
 ----------
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html\eslint(no-unused-vars)]8;;\: Variable 'x' is declared but never used. Unused variables should start with a '_'.
-   ,-[overrides/test.ts:1:7]
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-explicit-any.html\typescript-eslint(no-explicit-any)]8;;\: Unexpected any. Specify a different type.
+   ,-[overrides/test.ts:1:10]
  1 | const x: any = 3;
-   :       |
-   :       `-- 'x' is declared here
+   :          ^^^
    `----
-  help: Consider removing this declaration.
+  help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html\eslint(no-unused-vars)]8;;\: Function 'component' is declared but never used.
-   ,-[overrides/test.tsx:1:10]
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-explicit-any.html\typescript-eslint(no-explicit-any)]8;;\: Unexpected any. Specify a different type.
+   ,-[overrides/test.tsx:1:23]
  1 | function component(): any {
-   :          ^^^^|^^^^
-   :              `-- 'component' is declared here
+   :                       ^^^
  2 |   return <a>click here</a>;
    `----
-  help: Consider removing this declaration.
+  help: Use `unknown` instead, this will force you to explicitly, and safely, assert the type is correct.
 
-Found 2 warnings and 0 errors.
-Finished in <variable>ms on 2 files with 100 rules using 1 threads.
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/jsx_a11y/anchor-ambiguous-text.html\eslint-plugin-jsx-a11y(anchor-ambiguous-text)]8;;\: Unexpected ambagious anchor link text.
+   ,-[overrides/test.tsx:2:10]
+ 1 | function component(): any {
+ 2 |   return <a>click here</a>;
+   :          ^^^^^^^^^^^^^^^^^
+ 3 | }
+   `----
+
+Found 0 warnings and 3 errors.
+Finished in <variable>ms on 2 files using 1 threads.
 ----------
-CLI result: LintSucceeded
+CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_overrides_same_directory@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_overrides_same_directory@oxlint.snap
@@ -1,0 +1,20 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: overrides_same_directory
+working directory: fixtures/extends_config
+----------
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[overrides_same_directory/config/test.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Delete this code.
+
+Found 1 warning and 0 errors.
+Finished in <variable>ms on 1 file using 1 threads.
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_--config oxlint-no-console.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_--config oxlint-no-console.json@oxlint.snap
@@ -1,0 +1,43 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --config oxlint-no-console.json
+working directory: fixtures/nested_config
+----------
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: eslint(no-console): Unexpected console statement.
+   ,-[console.ts:1:1]
+ 1 | console.log("test");
+   : ^^^^^^^^^^^
+   `----
+  help: Delete this console statement.
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: eslint(no-console): Unexpected console statement.
+   ,-[package1-empty-config/console.ts:1:1]
+ 1 | console.log("test");
+   : ^^^^^^^^^^^
+   `----
+  help: Delete this console statement.
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: eslint(no-console): Unexpected console statement.
+   ,-[package2-no-config/console.ts:1:1]
+ 1 | console.log("test");
+   : ^^^^^^^^^^^
+   `----
+  help: Delete this console statement.
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: eslint(no-console): Unexpected console statement.
+   ,-[package3-deep-config/src/components/component.js:2:3]
+ 1 | export function Component() {
+ 2 |   console.log("hello");
+   :   ^^^^^^^^^^^
+ 3 | }
+   `----
+  help: Delete this console statement.
+
+Found 0 warnings and 4 errors.
+Finished in <variable>ms on 7 files with 99 rules using 1 threads.
+----------
+CLI result: LintFoundErrors
+----------

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_-A no-console --config oxlint-no-console.json@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_-A no-console --config oxlint-no-console.json@oxlint.snap
@@ -1,0 +1,12 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: -A no-console --config oxlint-no-console.json
+working directory: fixtures/nested_config
+----------
+Found 0 warnings and 0 errors.
+Finished in <variable>ms on 7 files with 98 rules using 1 threads.
+----------
+CLI result: LintSucceeded
+----------

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_-A no-console@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_-A no-console@oxlint.snap
@@ -1,0 +1,34 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: -A no-console
+working directory: fixtures/nested_config
+----------
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[debugger.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Delete this code.
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[package1-empty-config/debugger.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Delete this code.
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[package2-no-config/debugger.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Delete this code.
+
+Found 1 warning and 2 errors.
+Finished in <variable>ms on 7 files using 1 threads.
+----------
+CLI result: LintFoundErrors
+----------

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_@oxlint.snap
@@ -1,0 +1,57 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: 
+working directory: fixtures/nested_config
+----------
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: eslint(no-console): Unexpected console statement.
+   ,-[console.ts:1:1]
+ 1 | console.log("test");
+   : ^^^^^^^^^^^
+   `----
+  help: Delete this console statement.
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[debugger.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Delete this code.
+
+  ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[package1-empty-config/debugger.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Delete this code.
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: eslint(no-console): Unexpected console statement.
+   ,-[package2-no-config/console.ts:1:1]
+ 1 | console.log("test");
+   : ^^^^^^^^^^^
+   `----
+  help: Delete this console statement.
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
+   ,-[package2-no-config/debugger.js:1:1]
+ 1 | debugger;
+   : ^^^^^^^^^
+   `----
+  help: Delete this code.
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: eslint(no-console): Unexpected console statement.
+   ,-[package3-deep-config/src/components/component.js:2:3]
+ 1 | export function Component() {
+ 2 |   console.log("hello");
+   :   ^^^^^^^^^^^
+ 3 | }
+   `----
+  help: Delete this console statement.
+
+Found 1 warning and 5 errors.
+Finished in <variable>ms on 7 files using 1 threads.
+----------
+CLI result: LintFoundErrors
+----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=default test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=default test.js@oxlint.snap
@@ -33,7 +33,7 @@ working directory: fixtures/output_formatter_diagnostic
   help: Delete this code.
 
 Found 2 warnings and 1 error.
-Finished in <variable>ms on 1 file with 99 rules using 1 threads.
+Finished in <variable>ms on 1 file using 1 threads.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/tasks/website/src/linter/snapshots/cli.snap
+++ b/tasks/website/src/linter/snapshots/cli.snap
@@ -133,8 +133,8 @@ Arguments:
 ## Available options:
 - **`    --rules`** &mdash; 
   list all the rules that are currently registered
-- **`    --experimental-nested-config`** &mdash; 
-  Enables automatic loading of nested configuration files (experimental feature)
+- **`    --disable-nested-config`** &mdash; 
+  Disables the automatic loading of nested configuration files.
 - **`-h`**, **`--help`** &mdash; 
   Prints help information
 - **`-V`**, **`--version`** &mdash; 

--- a/tasks/website/src/linter/snapshots/cli_terminal.snap
+++ b/tasks/website/src/linter/snapshots/cli_terminal.snap
@@ -81,7 +81,6 @@ Available positional items:
 
 Available options:
         --rules               list all the rules that are currently registered
-        --experimental-nested-config  Enables automatic loading of nested configuration files
-                              (experimental feature)
+        --disable-nested-config  Disables the automatic loading of nested configuration files.
     -h, --help                Prints help information
     -V, --version             Prints version information


### PR DESCRIPTION
- closes https://github.com/oxc-project/oxc/issues/9755

- Makes the `--experimental-nested-config` behavior the default. 
- Includes a bug fix where nested configs didn't work properly with `--fix`.
- Adds a `--disable-nested-config` option to just read the config file from the current directory and skip looking for `.oxlintrc.json` files in directories.