### PR TITLE
fix(tasks/coverage/estree): test acorn-jsx parse error

### DIFF
--- a/tasks/coverage/snapshots/estree_acorn_jsx.snap
+++ b/tasks/coverage/snapshots/estree_acorn_jsx.snap
@@ -3,6 +3,16 @@ commit: b6d96c07
 estree_acorn_jsx Summary:
 AST Parsed     : 39/39 (100.00%)
 Positive Passed: 35/39 (89.74%)
+Negative Passed: 0/9 (0.00%)
+Expect to Parse: tasks/coverage/acorn-test262/test-acorn-jsx/fail/000.jsx
+Unterminated regular expressionExpect to Parse: tasks/coverage/acorn-test262/test-acorn-jsx/fail/001.jsx
+Unexpected tokenExpect to Parse: tasks/coverage/acorn-test262/test-acorn-jsx/fail/002.jsx
+Unexpected tokenExpect to Parse: tasks/coverage/acorn-test262/test-acorn-jsx/fail/006.jsx
+Unexpected tokenMismatch: tasks/coverage/acorn-test262/test-acorn-jsx/fail/036.jsx
+Expect to Parse: tasks/coverage/acorn-test262/test-acorn-jsx/fail/037.jsx
+Unexpected tokenExpect to Parse: tasks/coverage/acorn-test262/test-acorn-jsx/fail/038.jsx
+Unexpected tokenMismatch: tasks/coverage/acorn-test262/test-acorn-jsx/fail/039.jsx
+Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/fail/040.jsx
 Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/010.jsx
 Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/013.jsx
 Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/020.jsx

--- a/tasks/coverage/snapshots/estree_acorn_jsx.snap
+++ b/tasks/coverage/snapshots/estree_acorn_jsx.snap
@@ -3,16 +3,10 @@ commit: b6d96c07
 estree_acorn_jsx Summary:
 AST Parsed     : 39/39 (100.00%)
 Positive Passed: 35/39 (89.74%)
-Negative Passed: 0/9 (0.00%)
-Expect to Parse: tasks/coverage/acorn-test262/test-acorn-jsx/fail/000.jsx
-Unterminated regular expressionExpect to Parse: tasks/coverage/acorn-test262/test-acorn-jsx/fail/001.jsx
-Unexpected tokenExpect to Parse: tasks/coverage/acorn-test262/test-acorn-jsx/fail/002.jsx
-Unexpected tokenExpect to Parse: tasks/coverage/acorn-test262/test-acorn-jsx/fail/006.jsx
-Unexpected tokenMismatch: tasks/coverage/acorn-test262/test-acorn-jsx/fail/036.jsx
-Expect to Parse: tasks/coverage/acorn-test262/test-acorn-jsx/fail/037.jsx
-Unexpected tokenExpect to Parse: tasks/coverage/acorn-test262/test-acorn-jsx/fail/038.jsx
-Unexpected tokenMismatch: tasks/coverage/acorn-test262/test-acorn-jsx/fail/039.jsx
-Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/fail/040.jsx
+Negative Passed: 6/9 (66.67%)
+Expect Syntax Error: tasks/coverage/acorn-test262/test-acorn-jsx/fail/036.jsx
+Expect Syntax Error: tasks/coverage/acorn-test262/test-acorn-jsx/fail/039.jsx
+Expect Syntax Error: tasks/coverage/acorn-test262/test-acorn-jsx/fail/040.jsx
 Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/010.jsx
 Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/013.jsx
 Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/020.jsx

--- a/tasks/coverage/src/tools/estree.rs
+++ b/tasks/coverage/src/tools/estree.rs
@@ -196,7 +196,7 @@ pub struct AcornJsxSuite<T: Case> {
 impl<T: Case> AcornJsxSuite<T> {
     pub fn new() -> Self {
         Self {
-            path: Path::new("acorn-test262/test-acorn-jsx/pass").to_path_buf(),
+            path: Path::new("acorn-test262/test-acorn-jsx").to_path_buf(),
             test_cases: vec![],
         }
     }
@@ -250,6 +250,10 @@ impl Case for AcornJsxCase {
 
     fn skip_test_case(&self) -> bool {
         false
+    }
+
+    fn should_fail(&self) -> bool {
+        self.path.parent().unwrap().file_name().unwrap() == "fail"
     }
 
     fn run(&mut self) {

--- a/tasks/coverage/src/tools/estree.rs
+++ b/tasks/coverage/src/tools/estree.rs
@@ -195,10 +195,7 @@ pub struct AcornJsxSuite<T: Case> {
 
 impl<T: Case> AcornJsxSuite<T> {
     pub fn new() -> Self {
-        Self {
-            path: Path::new("acorn-test262/test-acorn-jsx").to_path_buf(),
-            test_cases: vec![],
-        }
+        Self { path: Path::new("acorn-test262/test-acorn-jsx").to_path_buf(), test_cases: vec![] }
     }
 }
 
@@ -263,7 +260,13 @@ impl Case for AcornJsxCase {
         let ret = Parser::new(&allocator, source_text, source_type).parse();
         let mut program = ret.program;
 
-        if ret.panicked || !ret.errors.is_empty() {
+        let is_parse_error = ret.panicked || !ret.errors.is_empty();
+        if self.should_fail() {
+            self.result =
+                if is_parse_error { TestResult::Passed } else { TestResult::IncorrectlyPassed };
+            return;
+        }
+        if is_parse_error {
             let error =
                 ret.errors.first().map_or_else(|| "Panicked".to_string(), OxcDiagnostic::to_string);
             self.result = TestResult::ParseError(error, ret.panicked);


### PR DESCRIPTION
- Follow up https://github.com/oxc-project/oxc/pull/9745

I added failure cases from https://github.com/oxc-project/acorn-test262/tree/main/test-acorn-jsx/fail in coverage runner.