### PR TITLE
refactor(allocator/vec): add comment about lifetime bound on `CloneIn` for `Vec`

### DIFF
--- a/crates/oxc_allocator/src/clone_in.rs
+++ b/crates/oxc_allocator/src/clone_in.rs
@@ -55,9 +55,12 @@ where
     }
 }
 
-impl<'new_alloc, T, C: 'new_alloc> CloneIn<'new_alloc> for Vec<'_, T>
+impl<'new_alloc, T, C> CloneIn<'new_alloc> for Vec<'_, T>
 where
     T: CloneIn<'new_alloc, Cloned = C>,
+    // TODO: This lifetime bound possibly shouldn't be required.
+    // https://github.com/oxc-project/oxc/pull/9656#issuecomment-2719762898
+    C: 'new_alloc,
 {
     type Cloned = Vec<'new_alloc, C>;
 


### PR DESCRIPTION
Follow-on after #9656. We think probably this change to lifetime bound of `CloneIn` for `Vec` is unnecessary, but that question is unresolved. Make a comment about it.