### PR TITLE
fix(parser): error when `}` and `>` appear in `JSXText`

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2578,8 +2578,9 @@ impl Gen for JSXText<'_> {
 
 impl Gen for JSXSpreadChild<'_> {
     fn r#gen(&self, p: &mut Codegen, _ctx: Context) {
-        p.print_str("...");
+        p.print_str("{...");
         p.print_expression(&self.expression);
+        p.print_ascii_byte(b'}');
     }
 }
 
@@ -2588,7 +2589,7 @@ impl Gen for JSXChild<'_> {
         match self {
             Self::Fragment(fragment) => fragment.print(p, ctx),
             Self::Element(el) => el.print(p, ctx),
-            Self::Spread(spread) => p.print_expression(&spread.expression),
+            Self::Spread(spread) => spread.print(p, ctx),
             Self::ExpressionContainer(expr_container) => expr_container.print(p, ctx),
             Self::Text(text) => text.print(p, ctx),
         }

--- a/crates/oxc_linter/src/rules/eslint/no_unused_expressions.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_expressions.rs
@@ -292,7 +292,7 @@ fn test() {
             "
 			      namespace Foo {
 			        'use strict';
-			
+
 			        export class Foo {}
 			        export class Bar {}
 			      }
@@ -303,7 +303,7 @@ fn test() {
             "
 			      function foo() {
 			        'use strict';
-			
+
 			        return null;
 			      }
 			    ",
@@ -383,7 +383,7 @@ fn test() {
         ("<></>", Some(serde_json::json!([{ "enforceForJSX": true }]))), // { "parserOptions": { "ecmaFeatures": { "jsx": true } } },
         ("class C { static { 'use strict'; } }", None),                  // { "ecmaVersion": 2022 },
         (
-            "class C { static { 
+            "class C { static {
 			'foo'
 			'bar'
 			 } }",
@@ -479,7 +479,7 @@ fn test() {
 			namespace Foo {
 			  export class Foo {}
 			  export class Bar {}
-			
+
 			  'use strict';
 			}
 			      ",
@@ -489,7 +489,7 @@ fn test() {
             "
 			function foo() {
 			  const foo = true;
-			
+
 			  'use strict';
 			}
 			      ",
@@ -519,13 +519,13 @@ fn test() {
 			      ",
             None,
         ),
-        (
-            "
-			declare const foo: number | undefined;
-			<any>foo;
-			      ",
-            None,
-        ),
+        // (
+        // "
+        // declare const foo: number | undefined;
+        // <any>foo;
+        // ",
+        // None,
+        // ),
         (
             "
 			declare const foo: number | undefined;

--- a/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
+++ b/crates/oxc_linter/src/rules/react/no_unescaped_entities.rs
@@ -76,13 +76,11 @@ impl Rule for NoUnescapedEntities {
 }
 
 // NOTE: If we add substantially more characters, we should consider using a hash set instead.
-pub const CHARS: [char; 4] = ['>', '"', '\'', '}'];
+pub const CHARS: [char; 2] = ['"', '\''];
 
 pub const DEFAULTS: Map<char, &'static [&'static str]> = phf_map! {
-    '>' => &["&gt;"],
     '"' => &["&quot;", "&ldquo;", "&#34;", "&rdquo;"],
     '\'' => &["&apos;", "&lsquo;", "&#39;", "&rsquo;"],
-    '}' => &["&#125;"],
 };
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/array_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/array_type.rs
@@ -1011,10 +1011,10 @@ fn test() {
             "let x: Array<undefined> = [undefined] as undefined[];",
             Some(serde_json::json!([{"default":"array-simple"}])),
         ),
-        (
-            "let y: string[] = <Array<string>>['2'];",
-            Some(serde_json::json!([{"default":"array-simple"}])),
-        ),
+        // (
+        // "let y: string[] = <Array<string>>['2'];",
+        // Some(serde_json::json!([{"default":"array-simple"}])),
+        // ),
         ("let z: Array = [3, '4'];", Some(serde_json::json!([{"default":"array-simple"}]))),
         (
             "let ya = [[1, '2']] as [number, string][];",
@@ -1062,7 +1062,7 @@ fn test() {
             "let x: Array<undefined> = [undefined] as undefined[];",
             Some(serde_json::json!([{"default":"array"}])),
         ),
-        ("let y: string[] = <Array<string>>['2'];", Some(serde_json::json!([{"default":"array"}]))),
+        // ("let y: string[] = <Array<string>>['2'];", Some(serde_json::json!([{"default":"array"}]))),
         ("let z: Array = [3, '4'];", Some(serde_json::json!([{"default":"array"}]))),
         ("type Arr<T> = Array<T>;", Some(serde_json::json!([{"default":"array"}]))),
         // ("
@@ -1706,5 +1706,8 @@ fn test() {
         ),
     ];
 
-    Tester::new(ArrayType::NAME, ArrayType::PLUGIN, pass, fail).expect_fix(fix).test_and_snapshot();
+    Tester::new(ArrayType::NAME, ArrayType::PLUGIN, pass, fail)
+        .change_rule_path_extension("ts")
+        .expect_fix(fix)
+        .test_and_snapshot();
 }

--- a/crates/oxc_linter/src/snapshots/eslint_no_unused_expressions.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unused_expressions.snap
@@ -241,7 +241,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-unused-expressions): Disallow unused expressions
    ╭─[no_unused_expressions.tsx:2:4]
- 1 │ class C { static { 
+ 1 │ class C { static {
  2 │             'foo'
    ·             ─────
  3 │             'bar'
@@ -378,7 +378,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-unused-expressions): Disallow unused expressions
    ╭─[no_unused_expressions.tsx:6:6]
- 5 │             
+ 5 │ 
  6 │               'use strict';
    ·               ─────────────
  7 │             }
@@ -387,7 +387,7 @@ source: crates/oxc_linter/src/tester.rs
 
   ⚠ eslint(no-unused-expressions): Disallow unused expressions
    ╭─[no_unused_expressions.tsx:5:6]
- 4 │             
+ 4 │ 
  5 │               'use strict';
    ·               ─────────────
  6 │             }
@@ -441,12 +441,6 @@ source: crates/oxc_linter/src/tester.rs
  4 │                   
    ╰────
   help: Consider removing this expression
-
-  × Expected `<` but found `EOF`
-   ╭─[no_unused_expressions.tsx:4:10]
- 3 │             <any>foo;
- 4 │                   
-   ╰────
 
   ⚠ eslint(no-unused-expressions): Disallow unused expressions
    ╭─[no_unused_expressions.tsx:3:4]

--- a/crates/oxc_linter/src/snapshots/react_no_unescaped_entities.snap
+++ b/crates/oxc_linter/src/snapshots/react_no_unescaped_entities.snap
@@ -1,19 +1,19 @@
 ---
 source: crates/oxc_linter/src/tester.rs
 ---
-  ⚠ eslint-plugin-react(no-unescaped-entities): `>` can be escaped with &gt;
+  × Unexpected token. Did you mean `{'>'}` or `&gt;`?
    ╭─[no_unescaped_entities.tsx:3:24]
  2 │             render: function() {
  3 │               return <>> babel-eslint</>;
-   ·                        ─
+   ·                        ▲
  4 │             }
    ╰────
 
-  ⚠ eslint-plugin-react(no-unescaped-entities): `>` can be escaped with &gt;
+  × Unexpected token. Did you mean `{'>'}` or `&gt;`?
    ╭─[no_unescaped_entities.tsx:5:47]
  4 │               so is second
  5 │               and here are some bad entities: ></>
-   ·                                               ─
+   ·                                               ▲
  6 │             }
    ╰────
 
@@ -25,11 +25,11 @@ source: crates/oxc_linter/src/tester.rs
  5 │             }
    ╰────
 
-  ⚠ eslint-plugin-react(no-unescaped-entities): `}` can be escaped with &#125;
+  × Unexpected token. Did you mean `{'}'}` or `&rbrace;`?
    ╭─[no_unescaped_entities.tsx:4:60]
  3 │             render: function() {
  4 │               return <>{"Unbalanced braces - babel-eslint"}}</>;
-   ·                                                            ─
+   ·                                                            ▲
  5 │             }
    ╰────
 

--- a/crates/oxc_linter/src/snapshots/typescript_array_type.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_array_type.snap
@@ -2,446 +2,441 @@
 source: crates/oxc_linter/src/tester.rs
 ---
   ⚠ typescript-eslint(array-type): Array type using 'Array<number>' is forbidden. Use 'number[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: Array<number> = [];
    ·        ─────────────
    ╰────
   help: Replace `Array<number>` with `number[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: Array<string | number> = [];
    ·        ──────────────────────
    ╰────
   help: Replace `Array<string | number>` with `(string | number)[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<number>' is forbidden. Use 'readonly number[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: ReadonlyArray<number> = [];
    ·        ─────────────────────
    ╰────
   help: Replace `ReadonlyArray<number>` with `readonly number[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<T>' is forbidden. Use 'readonly T[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: ReadonlyArray<string | number> = [];
    ·        ──────────────────────────────
    ╰────
   help: Replace `ReadonlyArray<string | number>` with `readonly (string | number)[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<number>' is forbidden. Use 'number[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: Array<number> = [];
    ·        ─────────────
    ╰────
   help: Replace `Array<number>` with `number[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: Array<string | number> = [];
    ·        ──────────────────────
    ╰────
   help: Replace `Array<string | number>` with `(string | number)[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<number>' is forbidden. Use 'readonly number[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: ReadonlyArray<number> = [];
    ·        ─────────────────────
    ╰────
   help: Replace `ReadonlyArray<number>` with `readonly number[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<T>' is forbidden. Use 'readonly T[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: ReadonlyArray<string | number> = [];
    ·        ──────────────────────────────
    ╰────
   help: Replace `ReadonlyArray<string | number>` with `readonly (string | number)[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<number>' is forbidden. Use 'number[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: Array<number> = [];
    ·        ─────────────
    ╰────
   help: Replace `Array<number>` with `number[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: Array<string | number> = [];
    ·        ──────────────────────
    ╰────
   help: Replace `Array<string | number>` with `(string | number)[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<number>' is forbidden for simple types. Use 'readonly number[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: ReadonlyArray<number> = [];
    ·        ─────────────────────
    ╰────
   help: Replace `ReadonlyArray<number>` with `readonly number[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'readonly T[]' is forbidden for non-simple types. Use 'ReadonlyArray<T>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: readonly (string | number)[] = [];
    ·        ────────────────────────────
    ╰────
   help: Replace `readonly (string | number)[]` with `ReadonlyArray<string | number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<number>' is forbidden. Use 'number[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: Array<number> = [];
    ·        ─────────────
    ╰────
   help: Replace `Array<number>` with `number[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: Array<string | number> = [];
    ·        ──────────────────────
    ╰────
   help: Replace `Array<string | number>` with `(string | number)[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'readonly number[]' is forbidden. Use 'ReadonlyArray<number>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: readonly number[] = [];
    ·        ─────────────────
    ╰────
   help: Replace `readonly number[]` with `ReadonlyArray<number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'readonly T[]' is forbidden. Use 'ReadonlyArray<T>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: readonly (string | number)[] = [];
    ·        ────────────────────────────
    ╰────
   help: Replace `readonly (string | number)[]` with `ReadonlyArray<string | number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<number>' is forbidden for simple types. Use 'number[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: Array<number> = [];
    ·        ─────────────
    ╰────
   help: Replace `Array<number>` with `number[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: (string | number)[] = [];
    ·        ───────────────────
    ╰────
   help: Replace `(string | number)[]` with `Array<string | number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<number>' is forbidden for simple types. Use 'readonly number[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: ReadonlyArray<number> = [];
    ·        ─────────────────────
    ╰────
   help: Replace `ReadonlyArray<number>` with `readonly number[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'readonly T[]' is forbidden for non-simple types. Use 'ReadonlyArray<T>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: readonly (string | number)[] = [];
    ·        ────────────────────────────
    ╰────
   help: Replace `readonly (string | number)[]` with `ReadonlyArray<string | number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<number>' is forbidden for simple types. Use 'number[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: Array<number> = [];
    ·        ─────────────
    ╰────
   help: Replace `Array<number>` with `number[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: (string | number)[] = [];
    ·        ───────────────────
    ╰────
   help: Replace `(string | number)[]` with `Array<string | number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<number>' is forbidden. Use 'readonly number[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: ReadonlyArray<number> = [];
    ·        ─────────────────────
    ╰────
   help: Replace `ReadonlyArray<number>` with `readonly number[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<T>' is forbidden. Use 'readonly T[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: ReadonlyArray<string | number> = [];
    ·        ──────────────────────────────
    ╰────
   help: Replace `ReadonlyArray<string | number>` with `readonly (string | number)[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<number>' is forbidden for simple types. Use 'number[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: Array<number> = [];
    ·        ─────────────
    ╰────
   help: Replace `Array<number>` with `number[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: (string | number)[] = [];
    ·        ───────────────────
    ╰────
   help: Replace `(string | number)[]` with `Array<string | number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<number>' is forbidden for simple types. Use 'readonly number[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: ReadonlyArray<number> = [];
    ·        ─────────────────────
    ╰────
   help: Replace `ReadonlyArray<number>` with `readonly number[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'readonly T[]' is forbidden for non-simple types. Use 'ReadonlyArray<T>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: readonly (string | number)[] = [];
    ·        ────────────────────────────
    ╰────
   help: Replace `readonly (string | number)[]` with `ReadonlyArray<string | number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<number>' is forbidden for simple types. Use 'number[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: Array<number> = [];
    ·        ─────────────
    ╰────
   help: Replace `Array<number>` with `number[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: (string | number)[] = [];
    ·        ───────────────────
    ╰────
   help: Replace `(string | number)[]` with `Array<string | number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'readonly number[]' is forbidden. Use 'ReadonlyArray<number>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: readonly number[] = [];
    ·        ─────────────────
    ╰────
   help: Replace `readonly number[]` with `ReadonlyArray<number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'readonly T[]' is forbidden. Use 'ReadonlyArray<T>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: readonly (string | number)[] = [];
    ·        ────────────────────────────
    ╰────
   help: Replace `readonly (string | number)[]` with `ReadonlyArray<string | number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'number[]' is forbidden. Use 'Array<number>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: number[] = [];
    ·        ────────
    ╰────
   help: Replace `number[]` with `Array<number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: (string | number)[] = [];
    ·        ───────────────────
    ╰────
   help: Replace `(string | number)[]` with `Array<string | number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'readonly number[]' is forbidden. Use 'ReadonlyArray<number>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: readonly number[] = [];
    ·        ─────────────────
    ╰────
   help: Replace `readonly number[]` with `ReadonlyArray<number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'readonly T[]' is forbidden. Use 'ReadonlyArray<T>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: readonly (string | number)[] = [];
    ·        ────────────────────────────
    ╰────
   help: Replace `readonly (string | number)[]` with `ReadonlyArray<string | number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'number[]' is forbidden. Use 'Array<number>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: number[] = [];
    ·        ────────
    ╰────
   help: Replace `number[]` with `Array<number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: (string | number)[] = [];
    ·        ───────────────────
    ╰────
   help: Replace `(string | number)[]` with `Array<string | number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<number>' is forbidden. Use 'readonly number[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: ReadonlyArray<number> = [];
    ·        ─────────────────────
    ╰────
   help: Replace `ReadonlyArray<number>` with `readonly number[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<T>' is forbidden. Use 'readonly T[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: ReadonlyArray<string | number> = [];
    ·        ──────────────────────────────
    ╰────
   help: Replace `ReadonlyArray<string | number>` with `readonly (string | number)[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'number[]' is forbidden. Use 'Array<number>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: number[] = [];
    ·        ────────
    ╰────
   help: Replace `number[]` with `Array<number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: (string | number)[] = [];
    ·        ───────────────────
    ╰────
   help: Replace `(string | number)[]` with `Array<string | number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<number>' is forbidden for simple types. Use 'readonly number[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: ReadonlyArray<number> = [];
    ·        ─────────────────────
    ╰────
   help: Replace `ReadonlyArray<number>` with `readonly number[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'readonly T[]' is forbidden for non-simple types. Use 'ReadonlyArray<T>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: readonly (string | number)[] = [];
    ·        ────────────────────────────
    ╰────
   help: Replace `readonly (string | number)[]` with `ReadonlyArray<string | number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'number[]' is forbidden. Use 'Array<number>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: number[] = [];
    ·        ────────
    ╰────
   help: Replace `number[]` with `Array<number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: (string | number)[] = [];
    ·        ───────────────────
    ╰────
   help: Replace `(string | number)[]` with `Array<string | number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'readonly number[]' is forbidden. Use 'ReadonlyArray<number>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: readonly number[] = [];
    ·        ─────────────────
    ╰────
   help: Replace `readonly number[]` with `ReadonlyArray<number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'readonly T[]' is forbidden. Use 'ReadonlyArray<T>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: readonly (string | number)[] = [];
    ·        ────────────────────────────
    ╰────
   help: Replace `readonly (string | number)[]` with `ReadonlyArray<string | number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'bigint[]' is forbidden. Use 'Array<bigint>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: bigint[] = [];
    ·        ────────
    ╰────
   help: Replace `bigint[]` with `Array<bigint>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: (string | bigint)[] = [];
    ·        ───────────────────
    ╰────
   help: Replace `(string | bigint)[]` with `Array<string | bigint>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<bigint>' is forbidden for simple types. Use 'readonly bigint[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: ReadonlyArray<bigint> = [];
    ·        ─────────────────────
    ╰────
   help: Replace `ReadonlyArray<bigint>` with `readonly bigint[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: (string | bigint)[] = [];
    ·        ───────────────────
    ╰────
   help: Replace `(string | bigint)[]` with `Array<string | bigint>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'readonly bigint[]' is forbidden. Use 'ReadonlyArray<bigint>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: readonly bigint[] = [];
    ·        ─────────────────
    ╰────
   help: Replace `readonly bigint[]` with `ReadonlyArray<bigint>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'readonly T[]' is forbidden. Use 'ReadonlyArray<T>' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let a: readonly (string | bigint)[] = [];
    ·        ────────────────────────────
    ╰────
   help: Replace `readonly (string | bigint)[]` with `ReadonlyArray<string | bigint>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<Bar>' is forbidden. Use 'Bar[]' instead.
-   ╭─[array_type.tsx:1:15]
+   ╭─[array_type.ts:1:15]
  1 │ let a: { foo: Array<Bar> }[] = [];
    ·               ──────────
    ╰────
   help: Replace `Array<Bar>` with `Bar[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Bar[]' is forbidden. Use 'Array<Bar>' instead.
-   ╭─[array_type.tsx:1:21]
+   ╭─[array_type.ts:1:21]
  1 │ let a: Array<{ foo: Bar[] }> = [];
    ·                     ─────
    ╰────
   help: Replace `Bar[]` with `Array<Bar>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<Bar>' is forbidden. Use 'Bar[]' instead.
-   ╭─[array_type.tsx:1:17]
+   ╭─[array_type.ts:1:17]
  1 │ function foo(a: Array<Bar>): Array<Bar> {}
    ·                 ──────────
    ╰────
   help: Replace `Array<Bar>` with `Bar[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<Bar>' is forbidden. Use 'Bar[]' instead.
-   ╭─[array_type.tsx:1:30]
+   ╭─[array_type.ts:1:30]
  1 │ function foo(a: Array<Bar>): Array<Bar> {}
    ·                              ──────────
    ╰────
   help: Replace `Array<Bar>` with `Bar[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<undefined>' is forbidden for simple types. Use 'undefined[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let x: Array<undefined> = [undefined] as undefined[];
    ·        ────────────────
    ╰────
   help: Replace `Array<undefined>` with `undefined[]`.
 
-  × Expected `<` but found `EOF`
-   ╭─[array_type.tsx:1:40]
- 1 │ let y: string[] = <Array<string>>['2'];
-   ╰────
-
   ⚠ typescript-eslint(array-type): Array type using 'Array<any>' is forbidden for simple types. Use 'any[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let z: Array = [3, '4'];
    ·        ─────
    ╰────
   help: Replace `Array` with `any[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
-   ╭─[array_type.tsx:1:24]
+   ╭─[array_type.ts:1:24]
  1 │ let ya = [[1, '2']] as [number, string][];
    ·                        ──────────────────
    ╰────
   help: Replace `[number, string][]` with `Array<[number, string]>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.
-   ╭─[array_type.tsx:1:15]
+   ╭─[array_type.ts:1:15]
  1 │ type Arr<T> = Array<T>;
    ·               ────────
    ╰────
   help: Replace `Array<T>` with `T[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden for simple types. Use 'T[]' instead.
-   ╭─[array_type.tsx:3:14]
+   ╭─[array_type.ts:3:14]
  2 │         interface ArrayClass<T> {
  3 │         foo: Array<T>;
    ·              ────────
@@ -450,7 +445,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `Array<T>` with `T[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
-   ╭─[array_type.tsx:2:35]
+   ╭─[array_type.ts:2:35]
  1 │ 
  2 │         function barFunction(bar: ArrayClass<String>[]) {
    ·                                   ────────────────────
@@ -459,54 +454,49 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `ArrayClass<String>[]` with `Array<ArrayClass<String>>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
-   ╭─[array_type.tsx:1:13]
+   ╭─[array_type.ts:1:13]
  1 │ let barVar: ((c: number) => number)[];
    ·             ─────────────────────────
    ╰────
   help: Replace `((c: number) => number)[]` with `Array<(c: number) => number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
-   ╭─[array_type.tsx:1:17]
+   ╭─[array_type.ts:1:17]
  1 │ type barUnion = (string | number | boolean)[];
    ·                 ─────────────────────────────
    ╰────
   help: Replace `(string | number | boolean)[]` with `Array<string | number | boolean>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden for non-simple types. Use 'Array<T>' instead.
-   ╭─[array_type.tsx:1:24]
+   ╭─[array_type.ts:1:24]
  1 │ type barIntersection = (string & number)[];
    ·                        ───────────────────
    ╰────
   help: Replace `(string & number)[]` with `Array<string & number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<undefined>' is forbidden. Use 'undefined[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let x: Array<undefined> = [undefined] as undefined[];
    ·        ────────────────
    ╰────
   help: Replace `Array<undefined>` with `undefined[]`.
 
-  × Expected `<` but found `EOF`
-   ╭─[array_type.tsx:1:40]
- 1 │ let y: string[] = <Array<string>>['2'];
-   ╰────
-
   ⚠ typescript-eslint(array-type): Array type using 'Array<any>' is forbidden. Use 'any[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let z: Array = [3, '4'];
    ·        ─────
    ╰────
   help: Replace `Array` with `any[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
-   ╭─[array_type.tsx:1:15]
+   ╭─[array_type.ts:1:15]
  1 │ type Arr<T> = Array<T>;
    ·               ────────
    ╰────
   help: Replace `Array<T>` with `T[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
-   ╭─[array_type.tsx:3:14]
+   ╭─[array_type.ts:3:14]
  2 │         interface ArrayClass<T> {
  3 │         foo: Array<T>;
    ·              ────────
@@ -515,7 +505,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `Array<T>` with `T[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
-   ╭─[array_type.tsx:2:35]
+   ╭─[array_type.ts:2:35]
  1 │ 
  2 │         function fooFunction(foo: Array<ArrayClass<string>>) {
    ·                                   ─────────────────────────
@@ -524,75 +514,77 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `Array<ArrayClass<string>>` with `ArrayClass<string>[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
-   ╭─[array_type.tsx:1:13]
+   ╭─[array_type.ts:1:13]
  1 │ let fooVar: Array<(c: number) => number>;
    ·             ────────────────────────────
    ╰────
   help: Replace `Array<(c: number) => number>` with `((c: number) => number)[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
-   ╭─[array_type.tsx:1:17]
+   ╭─[array_type.ts:1:17]
  1 │ type fooUnion = Array<string | number | boolean>;
    ·                 ────────────────────────────────
    ╰────
   help: Replace `Array<string | number | boolean>` with `(string | number | boolean)[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
-   ╭─[array_type.tsx:1:24]
+   ╭─[array_type.ts:1:24]
  1 │ type fooIntersection = Array<string & number>;
    ·                        ──────────────────────
    ╰────
   help: Replace `Array<string & number>` with `(string & number)[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<any>' is forbidden. Use 'any[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let x: Array;
    ·        ─────
    ╰────
   help: Replace `Array` with `any[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<any>' is forbidden. Use 'any[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let x: Array<>;
    ·        ───────
    ╰────
   help: Replace `Array<>` with `any[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<any>' is forbidden for simple types. Use 'any[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let x: Array;
    ·        ─────
    ╰────
   help: Replace `Array` with `any[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<any>' is forbidden for simple types. Use 'any[]' instead.
-   ╭─[array_type.tsx:1:8]
+   ╭─[array_type.ts:1:8]
  1 │ let x: Array<>;
    ·        ───────
    ╰────
   help: Replace `Array<>` with `any[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'number[]' is forbidden. Use 'Array<number>' instead.
-   ╭─[array_type.tsx:1:31]
+   ╭─[array_type.ts:1:31]
  1 │ let x: Array<number> = [1] as number[];
    ·                               ────────
    ╰────
   help: Replace `number[]` with `Array<number>`.
 
-  × Expected `<` but found `EOF`
-   ╭─[array_type.tsx:1:40]
+  ⚠ typescript-eslint(array-type): Array type using 'string[]' is forbidden. Use 'Array<string>' instead.
+   ╭─[array_type.ts:1:8]
  1 │ let y: string[] = <Array<string>>['2'];
+   ·        ────────
    ╰────
+  help: Replace `string[]` with `Array<string>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
-   ╭─[array_type.tsx:1:24]
+   ╭─[array_type.ts:1:24]
  1 │ let ya = [[1, '2']] as [number, string][];
    ·                        ──────────────────
    ╰────
   help: Replace `[number, string][]` with `Array<[number, string]>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
-   ╭─[array_type.tsx:4:14]
+   ╭─[array_type.ts:4:14]
  3 │         foo: Array<T>;
  4 │         bar: T[];
    ·              ───
@@ -601,7 +593,7 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `T[]` with `Array<T>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
-   ╭─[array_type.tsx:2:35]
+   ╭─[array_type.ts:2:35]
  1 │ 
  2 │         function barFunction(bar: ArrayClass<String>[]) {
    ·                                   ────────────────────
@@ -610,28 +602,28 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `ArrayClass<String>[]` with `Array<ArrayClass<String>>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
-   ╭─[array_type.tsx:1:13]
+   ╭─[array_type.ts:1:13]
  1 │ let barVar: ((c: number) => number)[];
    ·             ─────────────────────────
    ╰────
   help: Replace `((c: number) => number)[]` with `Array<(c: number) => number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
-   ╭─[array_type.tsx:1:17]
+   ╭─[array_type.ts:1:17]
  1 │ type barUnion = (string | number | boolean)[];
    ·                 ─────────────────────────────
    ╰────
   help: Replace `(string | number | boolean)[]` with `Array<string | number | boolean>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'T[]' is forbidden. Use 'Array<T>' instead.
-   ╭─[array_type.tsx:1:24]
+   ╭─[array_type.ts:1:24]
  1 │ type barIntersection = (string & number)[];
    ·                        ───────────────────
    ╰────
   help: Replace `(string & number)[]` with `Array<string & number>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'string[]' is forbidden. Use 'Array<string>' instead.
-   ╭─[array_type.tsx:3:24]
+   ╭─[array_type.ts:3:24]
  2 │         interface FooInterface {
  3 │         '.bar': { baz: string[] };
    ·                        ────────
@@ -640,21 +632,21 @@ source: crates/oxc_linter/src/tester.rs
   help: Replace `string[]` with `Array<string>`.
 
   ⚠ typescript-eslint(array-type): Array type using 'Array<T>' is forbidden. Use 'T[]' instead.
-   ╭─[array_type.tsx:1:12]
+   ╭─[array_type.ts:1:12]
  1 │ const foo: Array<new (...args: any[]) => void> = [];
    ·            ───────────────────────────────────
    ╰────
   help: Replace `Array<new (...args: any[]) => void>` with `(new (...args: any[]) => void)[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'ReadonlyArray<T>' is forbidden. Use 'readonly T[]' instead.
-   ╭─[array_type.tsx:1:12]
+   ╭─[array_type.ts:1:12]
  1 │ const foo: ReadonlyArray<new (...args: any[]) => void> = [];
    ·            ───────────────────────────────────────────
    ╰────
   help: Replace `ReadonlyArray<new (...args: any[]) => void>` with `readonly (new (...args: any[]) => void)[]`.
 
   ⚠ typescript-eslint(array-type): Array type using 'string[]' is forbidden. Use 'Array<string>' instead.
-   ╭─[array_type.tsx:1:16]
+   ╭─[array_type.ts:1:16]
  1 │ let a: Promise<string[]> = Promise.resolve([]);
    ·                ────────
    ╰────

--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -91,6 +91,12 @@ pub fn unexpected_end(span: Span) -> OxcDiagnostic {
 }
 
 #[cold]
+pub fn unexpected_jsx_end(span: Span, a: char, b: &str) -> OxcDiagnostic {
+    OxcDiagnostic::error(format!("Unexpected token. Did you mean `{{'{a}'}}` or `&{b};`?"))
+        .with_label(span)
+}
+
+#[cold]
 pub fn unterminated_reg_exp(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Unterminated regular expression").with_label(span)
 }

--- a/crates/oxc_parser/src/lexer/jsx.rs
+++ b/crates/oxc_parser/src/lexer/jsx.rs
@@ -1,5 +1,6 @@
-use memchr::{memchr, memchr2};
+use memchr::memchr;
 
+use oxc_span::Span;
 use oxc_syntax::identifier::is_identifier_part;
 
 use crate::diagnostics;
@@ -11,6 +12,9 @@ use super::{
 
 static NOT_ASCII_JSX_ID_CONTINUE_TABLE: SafeByteMatchTable =
     safe_byte_match_table!(|b| !(b.is_ascii_alphanumeric() || matches!(b, b'_' | b'$' | b'-')));
+
+static JSX_CHILD_END_TABLE: SafeByteMatchTable =
+    safe_byte_match_table!(|b| b == b'{' || b == b'}' || b == b'>' || b == b'<');
 
 /// `JSXDoubleStringCharacters` ::
 ///   `JSXDoubleStringCharacter` `JSXDoubleStringCharactersopt`
@@ -72,18 +76,23 @@ impl Lexer<'_> {
                 Kind::LCurly
             }
             Some(_) => {
-                // The tokens `{`, `<`, `>` and `}` cannot appear in JSX text.
-                // The TypeScript compiler raises the error "Unexpected token. Did you mean `{'>'}` or `&gt;`?".
-                // Where as the Babel compiler does not raise any errors.
-                // The following check omits `>` and `}` so that more Babel tests can be passed.
-                let len = memchr2(b'{', b'<', self.remaining().as_bytes());
-                if let Some(len) = len {
-                    // SAFETY: `memchr2` guarantees `len` will be offset from current position
-                    // of a `{` or `<` byte. So must be a valid UTF-8 boundary, and within bounds of source.
-                    let end = unsafe { self.source.position().add(len) };
-                    self.source.set_position(end);
-                } else {
-                    self.source.advance_to_end();
+                let start = self.source.position();
+                let next_byte = byte_search! {
+                    lexer: self,
+                    table: JSX_CHILD_END_TABLE,
+                    start: start,
+                    handle_eof: {
+                        return Kind::Undetermined;
+                    },
+                };
+                if matches!(next_byte, b'}' | b'>') {
+                    let start = self.offset();
+                    self.error(diagnostics::unexpected_jsx_end(
+                        Span::new(start, start),
+                        next_byte as char,
+                        if next_byte == b'}' { "rbrace" } else { "gt" },
+                    ));
+                    return Kind::Undetermined;
                 }
                 Kind::JSXText
             }

--- a/tasks/coverage/snapshots/estree_acorn_jsx.snap
+++ b/tasks/coverage/snapshots/estree_acorn_jsx.snap
@@ -3,10 +3,7 @@ commit: eb5e9976
 estree_acorn_jsx Summary:
 AST Parsed     : 39/39 (100.00%)
 Positive Passed: 35/39 (89.74%)
-Negative Passed: 6/9 (66.67%)
-Expect Syntax Error: tasks/coverage/acorn-test262/test-acorn-jsx/fail/036.jsx
-Expect Syntax Error: tasks/coverage/acorn-test262/test-acorn-jsx/fail/039.jsx
-Expect Syntax Error: tasks/coverage/acorn-test262/test-acorn-jsx/fail/040.jsx
+Negative Passed: 9/9 (100.00%)
 Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/010.jsx
 Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/013.jsx
 Mismatch: tasks/coverage/acorn-test262/test-acorn-jsx/pass/020.jsx

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -3,7 +3,7 @@ commit: 578ac4df
 parser_babel Summary:
 AST Parsed     : 2303/2322 (99.18%)
 Positive Passed: 2282/2322 (98.28%)
-Negative Passed: 1548/1673 (92.53%)
+Negative Passed: 1549/1673 (92.59%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/annex-b/enabled/3.1-sloppy-labeled-functions-if-body/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/invalid-fn-decl-labeled-inside-if/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/invalid-fn-decl-labeled-inside-loop/input.js
@@ -99,7 +99,6 @@ Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/ty
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/static-blocks/invalid-static-block-with-modifier-static/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/static-blocks/invalid-static-blocks-with-modifer-declare-01/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/static-blocks/invalid-static-blocks-with-modifier-readonly-01/input.ts
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/tsx/invalid-gt-arrow-like/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/call-optional-chain-invalid/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/empty-function/input.ts
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/type-arguments/empty-function-babel-7/input.ts
@@ -294,21 +293,25 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022
    ╰────
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-ts-type-param-no-flow/input.js
 
-  × Expected `<` but found `EOF`
-   ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-ts-type-param-no-flow/input.js:2:1]
+  × Unexpected token. Did you mean `{'>'}` or `&gt;`?
+   ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-ts-type-param-no-flow/input.js:1:10]
  1 │ <div>() => {}
+   ·          ▲
    ╰────
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-ts-type-param-no-flow-babel-7/input.js
 
-  × Expected `<` but found `EOF`
-   ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-ts-type-param-no-flow-babel-7/input.js:2:1]
+  × Unexpected token. Did you mean `{'>'}` or `&gt;`?
+   ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-ts-type-param-no-flow-babel-7/input.js:1:10]
  1 │ <div>() => {}
+   ·          ▲
    ╰────
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/generic-tsx-babel-7/input.ts
 
-  × Expected `<` but found `EOF`
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/arrow-function/generic-tsx-babel-7/input.ts:3:1]
+  × Unexpected token. Did you mean `{'>'}` or `&gt;`?
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/arrow-function/generic-tsx-babel-7/input.ts:2:15]
+ 1 │ // Same as `generic`. Verify that JSX doesn't change things.
  2 │ <T>(a: T): T => a;
+   ·               ▲
    ╰────
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/class/constructor-with-modifier-names/input.ts
 
@@ -11392,14 +11395,16 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·             ─
    ╰────
 
-  × Expected `<` but found `EOF`
-   ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-type-param/input.js:2:1]
+  × Unexpected token. Did you mean `{'>'}` or `&gt;`?
+   ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-type-param/input.js:1:10]
  1 │ <div>() => {}
+   ·          ▲
    ╰────
 
-  × Expected `<` but found `EOF`
-   ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/unclosed-jsx-element/input.js:2:1]
+  × Unexpected token. Did you mean `{'>'}` or `&gt;`?
+   ╭─[babel/packages/babel-parser/test/fixtures/jsx/errors/unclosed-jsx-element/input.js:1:10]
  1 │ <div>() => {}
+   ·          ▲
    ╰────
 
   × Unexpected token
@@ -11533,11 +11538,12 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·              ─
    ╰────
 
-  × Unexpected token
-   ╭─[babel/packages/babel-parser/test/fixtures/typescript/arrow-function/generic-tsx/input.ts:4:3]
+  × Unexpected token. Did you mean `{'>'}` or `&gt;`?
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/arrow-function/generic-tsx/input.ts:2:15]
+ 1 │ // Generics without trailing comma are disallowed in JSX
+ 2 │ <T>(a: T): T => a;
+   ·               ▲
  3 │ 
- 4 │ <T,>(a: T): T => a;
-   ·   ─
    ╰────
 
   × Keywords cannot contain escape characters
@@ -12805,6 +12811,12 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  4 │   );
    ╰────
 
+  × Unexpected token. Did you mean `{'>'}` or `&gt;`?
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/tsx/invalid-gt-arrow-like/input.ts:1:8]
+ 1 │ <T>() => {}</T>;
+   ·        ▲
+   ╰────
+
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/type-alias/declare-new-line/input.ts:1:8]
  1 │ declare type
@@ -13024,57 +13036,21 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
     ╰────
   help: Remove the duplicate modifier.
 
-  × TS(1273): 'public' modifier cannot be used on a type parameter.
-    ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/variance-annotations-with-jsx/input.tsx:98:10]
- 97 │ 
- 98 │ type T20<public T> = T;  // Error
-    ·          ──────
- 99 │ type T21<in out in T> = T;  // Error
-    ╰────
+  × Unexpected token. Did you mean `{'>'}` or `&gt;`?
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/variance-annotations-with-jsx/input.tsx:2:11]
+ 1 │ // valid JSX
+ 2 │ <in T>() => {}</in>;
+   ·           ▲
+ 3 │ 
+   ╰────
 
-  × TS(1030): in' modifier already seen.
-     ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/variance-annotations-with-jsx/input.tsx:99:17]
-  98 │ type T20<public T> = T;  // Error
-  99 │ type T21<in out in T> = T;  // Error
-     ·                 ──
- 100 │ type T22<in out out T> = T;  // Error
-     ╰────
-  help: Remove the duplicate modifier.
-
-  × TS(1030): out' modifier already seen.
-     ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/variance-annotations-with-jsx/input.tsx:100:17]
-  99 │ type T21<in out in T> = T;  // Error
- 100 │ type T22<in out out T> = T;  // Error
-     ·                 ───
- 101 │ type T23<out in T> = T;  // Error
-     ╰────
-  help: Remove the duplicate modifier.
-
-  × TS(1273): 'public' modifier cannot be used on a type parameter.
-    ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/variance-annotations-with-jsx-babel-7/input.tsx:98:10]
- 97 │ 
- 98 │ type T20<public T> = T;  // Error
-    ·          ──────
- 99 │ type T21<in out in T> = T;  // Error
-    ╰────
-
-  × TS(1030): in' modifier already seen.
-     ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/variance-annotations-with-jsx-babel-7/input.tsx:99:17]
-  98 │ type T20<public T> = T;  // Error
-  99 │ type T21<in out in T> = T;  // Error
-     ·                 ──
- 100 │ type T22<in out out T> = T;  // Error
-     ╰────
-  help: Remove the duplicate modifier.
-
-  × TS(1030): out' modifier already seen.
-     ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/variance-annotations-with-jsx-babel-7/input.tsx:100:17]
-  99 │ type T21<in out in T> = T;  // Error
- 100 │ type T22<in out out T> = T;  // Error
-     ·                 ───
- 101 │ type T23<out in T> = T;  // Error
-     ╰────
-  help: Remove the duplicate modifier.
+  × Unexpected token. Did you mean `{'>'}` or `&gt;`?
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/types/variance-annotations-with-jsx-babel-7/input.tsx:2:11]
+ 1 │ // valid JSX
+ 2 │ <in T>() => {}</in>;
+   ·           ▲
+ 3 │ 
+   ╰────
 
   × Expected `]` but found `EOF`
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/types-arrow-function/invalid-incomplete-array-like/input.ts:2:1]

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: 15392346
 parser_typescript Summary:
 AST Parsed     : 6522/6531 (99.86%)
 Positive Passed: 6511/6531 (99.69%)
-Negative Passed: 1285/5754 (22.33%)
+Negative Passed: 1287/5754 (22.37%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration24.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment7.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment8.ts
@@ -3498,7 +3498,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/inlin
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxFactoryLocalTypeGlobalFallback.tsx
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxFactoryWithFragmentIsError.tsx
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxCheckJsxNoTypeArgumentsAllowed.tsx
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxParsingError2.tsx
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxParsingError3.tsx
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxSpreadOverwritesAttributeStrict.tsx
@@ -3538,7 +3537,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEl
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution8.tsx
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution9.tsx
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEmit3.tsx
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericArrowFunctionParsing.tsx
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxIntrinsicAttributeErrors.tsx
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxNamespacedTagName2.tsx
@@ -7857,10 +7855,11 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╰────
   help: Try insert a semicolon here
 
-  × Expected `<` but found `EOF`
-    ╭─[typescript/tests/cases/compiler/errorSpanForUnclosedJsxTag.tsx:11:23]
+  × Unexpected token
+    ╭─[typescript/tests/cases/compiler/errorSpanForUnclosedJsxTag.tsx:11:18]
  10 │ 
  11 │ let y = <   Baz >Hello
+    ·                  ─────
     ╰────
 
   × 'with' statements are not allowed
@@ -10883,16 +10882,18 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·    ─
    ╰────
 
-  × Expected `<` but found `EOF`
-   ╭─[typescript/tests/cases/compiler/parseUnaryExpressionNoTypeAssertionInJsx1.ts:2:24]
+  × Unexpected token
+   ╭─[typescript/tests/cases/compiler/parseUnaryExpressionNoTypeAssertionInJsx1.ts:2:21]
  1 │ const x = "oops";
  2 │ const y = + <number> x;
+   ·                     ───
    ╰────
 
-  × Expected `<` but found `EOF`
-   ╭─[typescript/tests/cases/compiler/parseUnaryExpressionNoTypeAssertionInJsx2.ts:2:18]
+  × Unexpected token
+   ╭─[typescript/tests/cases/compiler/parseUnaryExpressionNoTypeAssertionInJsx2.ts:2:15]
  1 │ const x = "oops";
  2 │ const y = + <> x;
+   ·               ───
    ╰────
 
   × Unexpected token
@@ -20481,6 +20482,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  8 │ </div>
    ╰────
 
+  × Unexpected token. Did you mean `{'>'}` or `&gt;`?
+    ╭─[typescript/tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx:40:41]
+ 39 │ 
+ 40 │ <LeftRight left=<a /> right=<b>monkeys /> gorillas</b> />;
+    ·                                         ▲
+ 41 │ 
+    ╰────
+
   × Unexpected token
    ╭─[typescript/tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx:3:2]
  2 │ 
@@ -20565,6 +20574,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
     ·        ╰── `>` expected
  10 │ 
     ╰────
+
+  × Unexpected token. Did you mean `{'>'}` or `&gt;`?
+   ╭─[typescript/tests/cases/conformance/jsx/tsxGenericArrowFunctionParsing.tsx:8:17]
+ 7 │ // This is an element
+ 8 │ var x1 = <T>() => {}</T>;
+   ·                 ▲
+ 9 │ x1.isElement;
+   ╰────
 
   × Expected `,` but found `;`
     ╭─[typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponents1.tsx:41:16]

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -236,10 +236,10 @@ after transform: ["T", "foo"]
 rebuilt        : ["foo"]
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-ts-type-param-no-flow/input.js
-semantic error: Expected `<` but found `EOF`
+semantic error: Unexpected token. Did you mean `{'>'}` or `&gt;`?
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/jsx/errors/_no-plugin-ts-type-param-no-flow-babel-7/input.js
-semantic error: Expected `<` but found `EOF`
+semantic error: Unexpected token. Did you mean `{'>'}` or `&gt;`?
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/arrow-function-with-newline/input.ts
 semantic error: Unresolved references mismatch:
@@ -272,7 +272,7 @@ after transform: ["T"]
 rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/arrow-function/generic-tsx-babel-7/input.ts
-semantic error: Expected `<` but found `EOF`
+semantic error: Unexpected token. Did you mean `{'>'}` or `&gt;`?
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/assert-predicate/arrow-function/input.ts
 semantic error: Unresolved references mismatch:


### PR DESCRIPTION
closes #9770
