### PR TITLE
fix(parser-wasm): use web build output for d.ts

### DIFF
--- a/npm/parser-wasm/package.json
+++ b/npm/parser-wasm/package.json
@@ -20,7 +20,7 @@
   },
   "main": "./node/oxc_parser_wasm.js",
   "browser": "./web/oxc_parser_wasm.js",
-  "types": "./node/oxc_parser_wasm.d.ts",
+  "types": "./web/oxc_parser_wasm.d.ts",
   "files": [
     "node",
     "web"


### PR DESCRIPTION
Web build output has extra `export function initSync` and `export default function __wbg_init`, but those types are not visible when importing `@oxc-parser/wasm`. This can potentially confuses node users, but I think it's okay since node output allows just directly using `parseSync` without init-ing anything.