### PR TITLE
docs(linter): fix typo in `oxc/bad-min-max-func`

### DIFF
--- a/crates/oxc_linter/src/rules/oxc/bad_min_max_func.rs
+++ b/crates/oxc_linter/src/rules/oxc/bad_min_max_func.rs
@@ -42,7 +42,7 @@ declare_oxc_lint!(
     ///
     /// ```javascript
     /// Math.max(0, Math.min(100, x));
-    /// Math.min(0, Math.max(1000, z));
+    /// Math.min(1000, Math.max(0, z));
     /// ```
     ///
     BadMinMaxFunc,


### PR DESCRIPTION
I think there's a typo in this rule's explanation. A correct clamp should have the upper bound in the min call, and the lower bound in the max call.

I initially opened a PR directly on the .md file but it turns out to be generated from source https://github.com/oxc-project/oxc-project.github.io/pull/317