### PR TITLE
docs(linter): Improve docs for `eslint-valid-typeof`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
@@ -47,8 +47,8 @@ declare_oxc_lint!(
     /// ```js
     /// typeof foo === "strnig"
     /// typeof foo == "undefimed"
-    /// typeof bar != "nunber"
-    /// typeof bar !== "fucntion"
+    /// typeof bar != "nunber"     // spellchecker:disable-line
+    /// typeof bar !== "fucntion"     // spellchecker:disable-line
     /// ```
     ///
     /// Examples of **correct** code for this rule:

--- a/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
@@ -81,12 +81,10 @@ declare_oxc_lint!(
     ///
     /// With `requireStringLiterals` set to `true` the following are examples of correct code:
     /// ```js
-    /// typeof foo === undefined
-    /// typeof bar == Object
-    /// typeof baz === "strnig"
-    /// typeof qux === "some invalid type"
-    /// typeof baz === anotherVariable
-    /// typeof foo == 5
+    /// typeof foo === "undefined"
+    /// typeof bar == "object"
+    /// typeof baz === "string"
+    /// typeof bar === typeof qux
     /// ```
     ValidTypeof,
     eslint,

--- a/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
@@ -31,24 +31,62 @@ pub struct ValidTypeof {
 }
 declare_oxc_lint!(
     /// ### What it does
-    /// Enforce comparing `typeof` expressions against valid strings
+    ///
+    /// Enforce comparing `typeof` expressions against valid strings.
     ///
     /// ### Why is this bad?
-    /// It is usually a typing mistake to compare the result of a `typeof`
-    /// operator to other string literals.
     ///
-    /// ### Example
+    /// For a vast majority of use cases, the result of the `typeof` operator is one of the
+    /// following string literals: `"undefined"`, `"object"`, `"boolean"`, `"number"`, `"string"`,
+    /// `"function"`, `"symbol"`, and `"bigint"`. It is usually a typing mistake to compare the
+    /// result of a `typeof` operator to other string literals.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```js
-    /// // requireStringLiterals: false
-    /// // incorrect:
     /// typeof foo === "strnig"
-    /// // correct:
-    /// typeof foo === "string"
-    /// typeof foo === baz
+    /// typeof foo == "undefimed"
+    /// typeof bar != "nunber"
+    /// typeof bar !== "fucntion"
+    /// ```
     ///
-    /// // requireStringLiterals: true
-    /// // incorrect:
+    /// Examples of **correct** code for this rule:
+    /// ```js
+    /// typeof foo === "string"
+    /// typeof bar == "undefined"
     /// typeof foo === baz
+    /// typeof bar === typeof qux
+    /// ```js
+    ///
+    /// ### Options
+    ///
+    /// #### requireStringLiterals
+    ///
+    /// `{ type: boolean, default: false }`
+    ///
+    /// The `requireStringLiterals` option when set to `true`, allows the comparison of `typeof`
+    /// expressions with only string literals or other `typeof` expressions, and disallows
+    /// comparisons to any other value. Default is `false`.
+    ///
+    /// With `requireStringLiterals` set to `true` the following are examples of incorrect code:
+    /// ```js
+    /// typeof foo === undefined
+    /// typeof bar == Object
+    /// typeof baz === "strnig"
+    /// typeof qux === "some invalid type"
+    /// typeof baz === anotherVariable
+    /// typeof foo == 5
+    /// ```
+    ///
+    /// With `requireStringLiterals` set to `true` the following are examples of correct code:
+    /// ```js
+    /// typeof foo === undefined
+    /// typeof bar == Object
+    /// typeof baz === "strnig"
+    /// typeof qux === "some invalid type"
+    /// typeof baz === anotherVariable
+    /// typeof foo == 5
     /// ```
     ValidTypeof,
     eslint,


### PR DESCRIPTION
Adds correctness examples and document options in line with #6050 