### PR TITLE
docs(linter): Add correctness examples to `typescript-prefer-as-const`

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/prefer_as_const.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_as_const.rs
@@ -51,7 +51,6 @@ declare_oxc_lint!(
     /// let foo = 'bar' as const;
     /// let foo: 'bar' = 'bar' as const;
     /// let bar = 'bar' as string;
-    /// let foo = <string>'bar';
     /// let foo = { bar: 'baz' };
     /// ```
     PreferAsConst,

--- a/crates/oxc_linter/src/rules/typescript/prefer_as_const.rs
+++ b/crates/oxc_linter/src/rules/typescript/prefer_as_const.rs
@@ -23,20 +23,36 @@ pub struct PreferAsConst;
 
 declare_oxc_lint!(
     /// ### What it does
-    /// Enforce the use of as const over literal type.
+    ///
+    /// Enforce the use of `as const` over literal type.
+    ///
     /// ### Why is this bad?
-    /// There are two common ways to tell TypeScript that a literal value should be interpreted as its literal type (e.g. 2) rather than general primitive type (e.g. number);
     ///
-    /// as const: telling TypeScript to infer the literal type automatically
-    /// as with the literal type: explicitly telling the literal type to TypeScript
+    /// There are two common ways to tell TypeScript that a literal value should be interpreted as
+    /// its literal type (e.g. `2`) rather than general primitive type (e.g. `number`);
     ///
-    /// as const is generally preferred, as it doesn't require re-typing the literal value.
-    /// This rule reports when an as with an explicit literal type can be replaced with an as const.
+    /// `as const`: telling TypeScript to infer the literal type automatically
+    /// `as` with the literal type: explicitly telling the literal type to TypeScript
     ///
-    /// ### Example
+    /// `as const` is generally preferred, as it doesn't require re-typing the literal value.
+    /// This rule reports when an `as` with an explicit literal type can be replaced with an `as const`.
+    ///
+    /// ### Examples
+    ///
+    /// Examples of **incorrect** code for this rule:
     /// ```ts
     /// let bar: 2 = 2;
     /// let foo = { bar: 'baz' as 'baz' };
+    /// ```
+    ///
+    /// Examples of **correct** code for this rule:
+    /// ```ts
+    /// let foo = 'bar';
+    /// let foo = 'bar' as const;
+    /// let foo: 'bar' = 'bar' as const;
+    /// let bar = 'bar' as string;
+    /// let foo = <string>'bar';
+    /// let foo = { bar: 'baz' };
     /// ```
     PreferAsConst,
     typescript,


### PR DESCRIPTION
Adds correctness examples to docs in line with #6050
