### PR TITLE
chore(linter): Add pending placeholder for `typescript-no-non-null-asserted-optional-chain`

### DIFF
--- a/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_non_null_asserted_optional_chain.rs
@@ -39,7 +39,8 @@ declare_oxc_lint!(
     /// ```
     NoNonNullAssertedOptionalChain,
     typescript,
-    correctness
+    correctness,
+    pending
 );
 
 impl Rule for NoNonNullAssertedOptionalChain {


### PR DESCRIPTION
A suggestion for a fix is possible as per the eslint rule details [here](https://typescript-eslint.io/rules/no-non-null-asserted-optional-chain/).

This PR just adds the pending status for the fix to this rule as a reminder that this is a todo.