### PR TITLE
perf(linter): Return early in loop in `promise/no-nesting`

### DIFF
--- a/crates/oxc_linter/src/rules/promise/no_nesting.rs
+++ b/crates/oxc_linter/src/rules/promise/no_nesting.rs
@@ -126,31 +126,31 @@ fn can_safely_unnest(
     closest: &CallExpression,
     ctx: &LintContext,
 ) -> bool {
-    let mut safe_to_unnest: bool = true;
-
     if let Some(cb_span) = cb_call_expr.arguments.first().map(GetSpan::span) {
-        closest.arguments.iter().for_each(|new_expr| {
+        for new_expr in &closest.arguments {
             if let Some(arg_expr) = new_expr.as_expression() {
                 match arg_expr {
                     Expression::ArrowFunctionExpression(arrow_expr) => {
                         let scope = arrow_expr.scope_id();
                         if uses_closest_cb_vars(scope, cb_span, ctx) {
-                            safe_to_unnest = false;
+                            return false; // Not safe to unnest.
                         }
                     }
                     Expression::FunctionExpression(func_expr) => {
                         let scope = func_expr.scope_id();
                         if uses_closest_cb_vars(scope, cb_span, ctx) {
-                            safe_to_unnest = false;
+                            return false; // Not safe to unnest.
                         }
                     }
                     _ => {}
                 }
             };
-        });
+        }
     };
 
-    safe_to_unnest
+    // Didn't return false early, so it is safe to unnest the child callback as the child doesn't reference
+    // variables bound in the closest parent callback.
+    true
 }
 
 /// Check for references in cb_span to variables defined in the closest parent cb scope

--- a/crates/oxc_linter/src/rules/promise/no_nesting.rs
+++ b/crates/oxc_linter/src/rules/promise/no_nesting.rs
@@ -128,23 +128,24 @@ fn can_safely_unnest(
 ) -> bool {
     if let Some(cb_span) = cb_call_expr.arguments.first().map(GetSpan::span) {
         for new_expr in &closest.arguments {
-            if let Some(arg_expr) = new_expr.as_expression() {
-                match arg_expr {
-                    Expression::ArrowFunctionExpression(arrow_expr) => {
-                        let scope = arrow_expr.scope_id();
-                        if uses_closest_cb_vars(scope, cb_span, ctx) {
-                            return false; // Not safe to unnest.
-                        }
-                    }
-                    Expression::FunctionExpression(func_expr) => {
-                        let scope = func_expr.scope_id();
-                        if uses_closest_cb_vars(scope, cb_span, ctx) {
-                            return false; // Not safe to unnest.
-                        }
-                    }
-                    _ => {}
-                }
+            let Some(arg_expr) = new_expr.as_expression() else {
+                continue;
             };
+            match arg_expr {
+                Expression::ArrowFunctionExpression(arrow_expr) => {
+                    let scope = arrow_expr.scope_id();
+                    if uses_closest_cb_vars(scope, cb_span, ctx) {
+                        return false; // Not safe to unnest.
+                    }
+                }
+                Expression::FunctionExpression(func_expr) => {
+                    let scope = func_expr.scope_id();
+                    if uses_closest_cb_vars(scope, cb_span, ctx) {
+                        return false; // Not safe to unnest.
+                    }
+                }
+                _ => {}
+            }
         }
     };
 


### PR DESCRIPTION
This rule currently does unnecessary work by iterating through the all of the args of a parent promise callback even when not necessary. 

The iteration is there to check if there is a reference to any of the given args. After the first reference is found there is no need to continue iterating through the rest of the args.

This PR makes that loop return early as soon as the first reference to an arg is found.