### PR TITLE
perf(minify): use mimalloc-safe to replace mimalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "codspeed"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,12 +1258,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
-name = "libmimalloc-sys"
-version = "0.1.39"
+name = "libmimalloc-sys2"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
+checksum = "f104fa362f5881c5d5f346112b0d5f1b71942f8852c86cf64564ddc4d4333ffa"
 dependencies = [
- "cc",
+ "cmake",
  "libc",
 ]
 
@@ -1327,12 +1336,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
-name = "mimalloc"
-version = "0.1.43"
+name = "mimalloc-safe"
+version = "0.1.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
+checksum = "e345544894689290c7393b5b6a19733694f5b0b287f210d7ee2ca5648e058437"
 dependencies = [
- "libmimalloc-sys",
+ "libmimalloc-sys2",
 ]
 
 [[package]]
@@ -1946,6 +1955,7 @@ dependencies = [
 name = "oxc_minify_napi"
 version = "0.30.3"
 dependencies = [
+ "mimalloc-safe",
  "napi",
  "napi-build",
  "napi-derive",
@@ -2304,7 +2314,7 @@ dependencies = [
  "ignore",
  "insta",
  "jemallocator",
- "mimalloc",
+ "mimalloc-safe",
  "oxc-miette",
  "oxc_diagnostics",
  "oxc_linter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,7 +197,7 @@ log = "0.4.25"
 markdown = "1.0.0-alpha.22"
 memchr = "2.7.4"
 miette = { package = "oxc-miette", version = "2.1.2", features = ["fancy-no-syscall"] }
-mimalloc = "0.1.43"
+mimalloc-safe = "0.1.49"
 nonmax = "0.5.5"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"

--- a/apps/oxlint/Cargo.toml
+++ b/apps/oxlint/Cargo.toml
@@ -28,7 +28,7 @@ doctest = false
 jemallocator = { workspace = true, optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-mimalloc = { workspace = true, optional = true }
+mimalloc-safe = { workspace = true, optional = true }
 
 [dependencies]
 oxc_diagnostics = { workspace = true }
@@ -52,4 +52,4 @@ regex = { workspace = true }
 
 [features]
 default = []
-allocator = ["dep:jemallocator", "dep:mimalloc"]
+allocator = ["dep:jemallocator", "dep:mimalloc-safe"]

--- a/apps/oxlint/src/main.rs
+++ b/apps/oxlint/src/main.rs
@@ -5,7 +5,7 @@ static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
 
 #[cfg(all(feature = "allocator", not(miri), target_os = "windows"))]
 #[global_allocator]
-static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+static GLOBAL: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
 
 use oxlint::cli::{CliRunResult, LintRunner, Runner};
 use std::io::BufWriter;

--- a/napi/minify/Cargo.toml
+++ b/napi/minify/Cargo.toml
@@ -33,6 +33,12 @@ oxc_syntax = { workspace = true }
 napi = { workspace = true }
 napi-derive = { workspace = true }
 
+[target.'cfg(all(not(target_os = "linux"), not(target_os = "freebsd"), not(target_arch = "arm"), not(target_family = "wasm")))'.dependencies]
+mimalloc-safe = { workspace = true, features = ["skip_collect_on_exit"] }
+
+[target.'cfg(any(all(target_os = "linux", not(target_arch = "arm")), target_os = "freebsd"))'.dependencies]
+mimalloc-safe = { workspace = true, features = ["skip_collect_on_exit", "local_dynamic_tls"] }
+
 [package.metadata.cargo-shear]
 ignored = ["napi"]
 

--- a/napi/minify/src/lib.rs
+++ b/napi/minify/src/lib.rs
@@ -15,6 +15,10 @@ use oxc_span::SourceType;
 
 use crate::options::{MinifyOptions, MinifyResult};
 
+#[cfg(all(not(target_arch = "arm"), not(target_family = "wasm")))]
+#[global_allocator]
+static ALLOC: mimalloc_safe::MiMalloc = mimalloc_safe::MiMalloc;
+
 /// Minify synchronously.
 #[napi]
 pub fn minify(


### PR DESCRIPTION
This is maintained by us, and it's upgraded to mimalloc 2.2.2. This pr also adds mimalloc to `oxc-minify`