### PR TITLE
fix(parser)!: rename `type_parameters` to `type_arguments` where needed 

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -437,7 +437,7 @@ pub struct TaggedTemplateExpression<'a> {
     pub tag: Expression<'a>,
     pub quasi: TemplateLiteral<'a>,
     #[ts]
-    pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
+    pub type_arguments: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
 }
 
 /// `Hello, ` in `` `Hello, ${name}` ``
@@ -567,7 +567,7 @@ pub struct PrivateFieldExpression<'a> {
 /// //               ^ optional
 ///
 /// const z = foo<number, string>(1, 2)
-/// //            ^^^^^^^^^^^^^^ type_parameters
+/// //            ^^^^^^^^^^^^^^ type_arguments
 /// ```
 #[ast(visit)]
 #[derive(Debug)]
@@ -576,7 +576,7 @@ pub struct CallExpression<'a> {
     pub span: Span,
     pub callee: Expression<'a>,
     #[ts]
-    pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
+    pub type_arguments: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
     pub arguments: Vec<'a, Argument<'a>>,
     pub optional: bool, // for optional chaining
     /// `true` if the call expression is marked with a `/* @__PURE__ */` comment
@@ -595,7 +595,7 @@ pub struct CallExpression<'a> {
 /// //              ↓↓↓         ↓↓↓↓
 /// const foo = new Foo<number>(1, 2)
 /// //                 ↑↑↑↑↑↑↑↑
-/// //                 type_parameters
+/// //                 type_arguments
 /// ```
 #[ast(visit)]
 #[derive(Debug)]
@@ -605,7 +605,7 @@ pub struct NewExpression<'a> {
     pub callee: Expression<'a>,
     pub arguments: Vec<'a, Argument<'a>>,
     #[ts]
-    pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
+    pub type_arguments: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
     /// `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[builder(default)]
     #[estree(skip)]
@@ -1211,6 +1211,7 @@ pub struct EmptyStatement {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+// #[estree(add_fields(directive = Null),)]
 pub struct ExpressionStatement<'a> {
     pub span: Span,
     pub expression: Expression<'a>,
@@ -1850,7 +1851,7 @@ pub struct YieldExpression<'a> {
 #[rustfmt::skip]
 #[estree(field_order(
     r#type, span, id, super_class, body,
-    decorators, type_parameters, super_type_parameters, implements, r#abstract, declare,
+    decorators, type_parameters, super_type_arguments, implements, r#abstract, declare,
 ))]
 pub struct Class<'a> {
     pub span: Span,
@@ -1888,7 +1889,7 @@ pub struct Class<'a> {
     /// //                       ^
     /// ```
     #[ts]
-    pub super_type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
+    pub super_type_arguments: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
     /// Interface implementation clause for TypeScript classes.
     ///
     /// ## Example

--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -57,12 +57,12 @@ pub struct JSXElement<'a> {
 ///
 /// // element with self-closing tag (self_closing = true)
 /// <Component<T> />
-/// //         ^ type_parameters
+/// //         ^ type_arguments
 /// ```
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(field_order(span, attributes, name, self_closing, type_parameters))]
+#[estree(field_order(span, attributes, name, self_closing, type_arguments))]
 pub struct JSXOpeningElement<'a> {
     /// Node location in source code
     pub span: Span,
@@ -80,7 +80,7 @@ pub struct JSXOpeningElement<'a> {
     pub attributes: Vec<'a, JSXAttributeItem<'a>>,
     /// Type parameters for generic JSX elements.
     #[ts]
-    pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
+    pub type_arguments: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
 }
 
 /// JSX Closing Element

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -718,7 +718,7 @@ pub struct TSBigIntKeyword {
 pub struct TSTypeReference<'a> {
     pub span: Span,
     pub type_name: TSTypeName<'a>,
-    pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
+    pub type_arguments: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
 }
 
 /// TypeName:
@@ -850,7 +850,7 @@ pub enum TSAccessibility {
 /// ```ts
 /// //                   ___ expression
 /// class Foo implements Bar, Baz<number, string> {}
-/// //            type_parameters ^^^^^^^^^^^^^^
+/// //            type_arguments ^^^^^^^^^^^^^^
 /// ```
 #[ast(visit)]
 #[derive(Debug)]
@@ -858,7 +858,7 @@ pub enum TSAccessibility {
 pub struct TSClassImplements<'a> {
     pub span: Span,
     pub expression: TSTypeName<'a>,
-    pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
+    pub type_arguments: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
 }
 
 /// TypeScriptInterface Declaration
@@ -1042,7 +1042,7 @@ pub struct TSIndexSignatureName<'a> {
 pub struct TSInterfaceHeritage<'a> {
     pub span: Span,
     pub expression: Expression<'a>,
-    pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
+    pub type_arguments: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
 }
 
 /// TypeScript Type Predicate
@@ -1254,7 +1254,7 @@ pub struct TSInferType<'a> {
 pub struct TSTypeQuery<'a> {
     pub span: Span,
     pub expr_name: TSTypeQueryExprName<'a>,
-    pub type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
+    pub type_arguments: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
 }
 
 inherit_variants! {

--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -378,7 +378,7 @@ impl<'a> AstBuilder<'a> {
             extends.into_iter().map(|(expression, type_parameters, span)| TSInterfaceHeritage {
                 span,
                 expression,
-                type_parameters,
+                type_arguments: type_parameters,
             }),
             self.allocator,
         )

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -98,7 +98,7 @@ const _: () = {
     assert!(offset_of!(TaggedTemplateExpression, span) == 0);
     assert!(offset_of!(TaggedTemplateExpression, tag) == 8);
     assert!(offset_of!(TaggedTemplateExpression, quasi) == 24);
-    assert!(offset_of!(TaggedTemplateExpression, type_parameters) == 96);
+    assert!(offset_of!(TaggedTemplateExpression, type_arguments) == 96);
 
     assert!(size_of::<TemplateElement>() == 48);
     assert!(align_of::<TemplateElement>() == 8);
@@ -139,7 +139,7 @@ const _: () = {
     assert!(align_of::<CallExpression>() == 8);
     assert!(offset_of!(CallExpression, span) == 0);
     assert!(offset_of!(CallExpression, callee) == 8);
-    assert!(offset_of!(CallExpression, type_parameters) == 24);
+    assert!(offset_of!(CallExpression, type_arguments) == 24);
     assert!(offset_of!(CallExpression, arguments) == 32);
     assert!(offset_of!(CallExpression, optional) == 64);
     assert!(offset_of!(CallExpression, pure) == 65);
@@ -149,7 +149,7 @@ const _: () = {
     assert!(offset_of!(NewExpression, span) == 0);
     assert!(offset_of!(NewExpression, callee) == 8);
     assert!(offset_of!(NewExpression, arguments) == 24);
-    assert!(offset_of!(NewExpression, type_parameters) == 56);
+    assert!(offset_of!(NewExpression, type_arguments) == 56);
     assert!(offset_of!(NewExpression, pure) == 64);
 
     assert!(size_of::<MetaProperty>() == 56);
@@ -571,7 +571,7 @@ const _: () = {
     assert!(offset_of!(Class, id) == 48);
     assert!(offset_of!(Class, type_parameters) == 80);
     assert!(offset_of!(Class, super_class) == 88);
-    assert!(offset_of!(Class, super_type_parameters) == 104);
+    assert!(offset_of!(Class, super_type_arguments) == 104);
     assert!(offset_of!(Class, implements) == 112);
     assert!(offset_of!(Class, body) == 144);
     assert!(offset_of!(Class, r#abstract) == 152);
@@ -813,7 +813,7 @@ const _: () = {
     assert!(offset_of!(JSXOpeningElement, self_closing) == 8);
     assert!(offset_of!(JSXOpeningElement, name) == 16);
     assert!(offset_of!(JSXOpeningElement, attributes) == 32);
-    assert!(offset_of!(JSXOpeningElement, type_parameters) == 64);
+    assert!(offset_of!(JSXOpeningElement, type_arguments) == 64);
 
     assert!(size_of::<JSXClosingElement>() == 24);
     assert!(align_of::<JSXClosingElement>() == 8);
@@ -1073,7 +1073,7 @@ const _: () = {
     assert!(align_of::<TSTypeReference>() == 8);
     assert!(offset_of!(TSTypeReference, span) == 0);
     assert!(offset_of!(TSTypeReference, type_name) == 8);
-    assert!(offset_of!(TSTypeReference, type_parameters) == 24);
+    assert!(offset_of!(TSTypeReference, type_arguments) == 24);
 
     assert!(size_of::<TSTypeName>() == 16);
     assert!(align_of::<TSTypeName>() == 8);
@@ -1120,7 +1120,7 @@ const _: () = {
     assert!(align_of::<TSClassImplements>() == 8);
     assert!(offset_of!(TSClassImplements, span) == 0);
     assert!(offset_of!(TSClassImplements, expression) == 8);
-    assert!(offset_of!(TSClassImplements, type_parameters) == 24);
+    assert!(offset_of!(TSClassImplements, type_arguments) == 24);
 
     assert!(size_of::<TSInterfaceDeclaration>() == 96);
     assert!(align_of::<TSInterfaceDeclaration>() == 8);
@@ -1199,7 +1199,7 @@ const _: () = {
     assert!(align_of::<TSInterfaceHeritage>() == 8);
     assert!(offset_of!(TSInterfaceHeritage, span) == 0);
     assert!(offset_of!(TSInterfaceHeritage, expression) == 8);
-    assert!(offset_of!(TSInterfaceHeritage, type_parameters) == 24);
+    assert!(offset_of!(TSInterfaceHeritage, type_arguments) == 24);
 
     assert!(size_of::<TSTypePredicate>() == 40);
     assert!(align_of::<TSTypePredicate>() == 8);
@@ -1249,7 +1249,7 @@ const _: () = {
     assert!(align_of::<TSTypeQuery>() == 8);
     assert!(offset_of!(TSTypeQuery, span) == 0);
     assert!(offset_of!(TSTypeQuery, expr_name) == 8);
-    assert!(offset_of!(TSTypeQuery, type_parameters) == 24);
+    assert!(offset_of!(TSTypeQuery, type_arguments) == 24);
 
     assert!(size_of::<TSTypeQueryExprName>() == 16);
     assert!(align_of::<TSTypeQueryExprName>() == 8);
@@ -1503,7 +1503,7 @@ const _: () = {
     assert!(offset_of!(TaggedTemplateExpression, span) == 0);
     assert!(offset_of!(TaggedTemplateExpression, tag) == 8);
     assert!(offset_of!(TaggedTemplateExpression, quasi) == 16);
-    assert!(offset_of!(TaggedTemplateExpression, type_parameters) == 56);
+    assert!(offset_of!(TaggedTemplateExpression, type_arguments) == 56);
 
     assert!(size_of::<TemplateElement>() == 28);
     assert!(align_of::<TemplateElement>() == 4);
@@ -1544,7 +1544,7 @@ const _: () = {
     assert!(align_of::<CallExpression>() == 4);
     assert!(offset_of!(CallExpression, span) == 0);
     assert!(offset_of!(CallExpression, callee) == 8);
-    assert!(offset_of!(CallExpression, type_parameters) == 16);
+    assert!(offset_of!(CallExpression, type_arguments) == 16);
     assert!(offset_of!(CallExpression, arguments) == 20);
     assert!(offset_of!(CallExpression, optional) == 36);
     assert!(offset_of!(CallExpression, pure) == 37);
@@ -1554,7 +1554,7 @@ const _: () = {
     assert!(offset_of!(NewExpression, span) == 0);
     assert!(offset_of!(NewExpression, callee) == 8);
     assert!(offset_of!(NewExpression, arguments) == 16);
-    assert!(offset_of!(NewExpression, type_parameters) == 32);
+    assert!(offset_of!(NewExpression, type_arguments) == 32);
     assert!(offset_of!(NewExpression, pure) == 36);
 
     assert!(size_of::<MetaProperty>() == 40);
@@ -1976,7 +1976,7 @@ const _: () = {
     assert!(offset_of!(Class, id) == 28);
     assert!(offset_of!(Class, type_parameters) == 48);
     assert!(offset_of!(Class, super_class) == 52);
-    assert!(offset_of!(Class, super_type_parameters) == 60);
+    assert!(offset_of!(Class, super_type_arguments) == 60);
     assert!(offset_of!(Class, implements) == 64);
     assert!(offset_of!(Class, body) == 80);
     assert!(offset_of!(Class, r#abstract) == 84);
@@ -2218,7 +2218,7 @@ const _: () = {
     assert!(offset_of!(JSXOpeningElement, self_closing) == 8);
     assert!(offset_of!(JSXOpeningElement, name) == 12);
     assert!(offset_of!(JSXOpeningElement, attributes) == 20);
-    assert!(offset_of!(JSXOpeningElement, type_parameters) == 36);
+    assert!(offset_of!(JSXOpeningElement, type_arguments) == 36);
 
     assert!(size_of::<JSXClosingElement>() == 16);
     assert!(align_of::<JSXClosingElement>() == 4);
@@ -2478,7 +2478,7 @@ const _: () = {
     assert!(align_of::<TSTypeReference>() == 4);
     assert!(offset_of!(TSTypeReference, span) == 0);
     assert!(offset_of!(TSTypeReference, type_name) == 8);
-    assert!(offset_of!(TSTypeReference, type_parameters) == 16);
+    assert!(offset_of!(TSTypeReference, type_arguments) == 16);
 
     assert!(size_of::<TSTypeName>() == 8);
     assert!(align_of::<TSTypeName>() == 4);
@@ -2525,7 +2525,7 @@ const _: () = {
     assert!(align_of::<TSClassImplements>() == 4);
     assert!(offset_of!(TSClassImplements, span) == 0);
     assert!(offset_of!(TSClassImplements, expression) == 8);
-    assert!(offset_of!(TSClassImplements, type_parameters) == 16);
+    assert!(offset_of!(TSClassImplements, type_arguments) == 16);
 
     assert!(size_of::<TSInterfaceDeclaration>() == 60);
     assert!(align_of::<TSInterfaceDeclaration>() == 4);
@@ -2604,7 +2604,7 @@ const _: () = {
     assert!(align_of::<TSInterfaceHeritage>() == 4);
     assert!(offset_of!(TSInterfaceHeritage, span) == 0);
     assert!(offset_of!(TSInterfaceHeritage, expression) == 8);
-    assert!(offset_of!(TSInterfaceHeritage, type_parameters) == 16);
+    assert!(offset_of!(TSInterfaceHeritage, type_arguments) == 16);
 
     assert!(size_of::<TSTypePredicate>() == 28);
     assert!(align_of::<TSTypePredicate>() == 4);
@@ -2654,7 +2654,7 @@ const _: () = {
     assert!(align_of::<TSTypeQuery>() == 4);
     assert!(offset_of!(TSTypeQuery, span) == 0);
     assert!(offset_of!(TSTypeQuery, expr_name) == 8);
-    assert!(offset_of!(TSTypeQuery, type_parameters) == 16);
+    assert!(offset_of!(TSTypeQuery, type_arguments) == 16);
 
     assert!(size_of::<TSTypeQueryExprName>() == 8);
     assert!(align_of::<TSTypeQueryExprName>() == 4);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -530,7 +530,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
-    /// * `type_parameters`
+    /// * `type_arguments`
     /// * `arguments`
     /// * `optional`
     #[inline]
@@ -538,7 +538,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         callee: Expression<'a>,
-        type_parameters: T1,
+        type_arguments: T1,
         arguments: Vec<'a, Argument<'a>>,
         optional: bool,
     ) -> Expression<'a>
@@ -548,7 +548,7 @@ impl<'a> AstBuilder<'a> {
         Expression::CallExpression(self.alloc_call_expression(
             span,
             callee,
-            type_parameters,
+            type_arguments,
             arguments,
             optional,
         ))
@@ -561,7 +561,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
-    /// * `type_parameters`
+    /// * `type_arguments`
     /// * `arguments`
     /// * `optional`
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
@@ -570,7 +570,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         callee: Expression<'a>,
-        type_parameters: T1,
+        type_arguments: T1,
         arguments: Vec<'a, Argument<'a>>,
         optional: bool,
         pure: bool,
@@ -581,7 +581,7 @@ impl<'a> AstBuilder<'a> {
         Expression::CallExpression(self.alloc_call_expression_with_pure(
             span,
             callee,
-            type_parameters,
+            type_arguments,
             arguments,
             optional,
             pure,
@@ -611,7 +611,7 @@ impl<'a> AstBuilder<'a> {
     /// * `id`: Class identifier, AKA the name
     /// * `type_parameters`
     /// * `super_class`: Super class. When present, this will usually be an [`IdentifierReference`].
-    /// * `super_type_parameters`: Type parameters passed to super class.
+    /// * `super_type_arguments`: Type parameters passed to super class.
     /// * `implements`: Interface implementation clause for TypeScript classes.
     /// * `body`
     /// * `abstract`: Whether the class is abstract
@@ -625,7 +625,7 @@ impl<'a> AstBuilder<'a> {
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
         super_class: Option<Expression<'a>>,
-        super_type_parameters: T2,
+        super_type_arguments: T2,
         implements: Option<Vec<'a, TSClassImplements<'a>>>,
         body: T3,
         r#abstract: bool,
@@ -643,7 +643,7 @@ impl<'a> AstBuilder<'a> {
             id,
             type_parameters,
             super_class,
-            super_type_parameters,
+            super_type_arguments,
             implements,
             body,
             r#abstract,
@@ -662,7 +662,7 @@ impl<'a> AstBuilder<'a> {
     /// * `id`: Class identifier, AKA the name
     /// * `type_parameters`
     /// * `super_class`: Super class. When present, this will usually be an [`IdentifierReference`].
-    /// * `super_type_parameters`: Type parameters passed to super class.
+    /// * `super_type_arguments`: Type parameters passed to super class.
     /// * `implements`: Interface implementation clause for TypeScript classes.
     /// * `body`
     /// * `abstract`: Whether the class is abstract
@@ -677,7 +677,7 @@ impl<'a> AstBuilder<'a> {
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
         super_class: Option<Expression<'a>>,
-        super_type_parameters: T2,
+        super_type_arguments: T2,
         implements: Option<Vec<'a, TSClassImplements<'a>>>,
         body: T3,
         r#abstract: bool,
@@ -696,7 +696,7 @@ impl<'a> AstBuilder<'a> {
             id,
             type_parameters,
             super_class,
-            super_type_parameters,
+            super_type_arguments,
             implements,
             body,
             r#abstract,
@@ -887,14 +887,14 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
     /// * `arguments`
-    /// * `type_parameters`
+    /// * `type_arguments`
     #[inline]
     pub fn expression_new<T1>(
         self,
         span: Span,
         callee: Expression<'a>,
         arguments: Vec<'a, Argument<'a>>,
-        type_parameters: T1,
+        type_arguments: T1,
     ) -> Expression<'a>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
@@ -903,7 +903,7 @@ impl<'a> AstBuilder<'a> {
             span,
             callee,
             arguments,
-            type_parameters,
+            type_arguments,
         ))
     }
 
@@ -915,7 +915,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
     /// * `arguments`
-    /// * `type_parameters`
+    /// * `type_arguments`
     /// * `pure`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[inline]
     pub fn expression_new_with_pure<T1>(
@@ -923,7 +923,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         callee: Expression<'a>,
         arguments: Vec<'a, Argument<'a>>,
-        type_parameters: T1,
+        type_arguments: T1,
         pure: bool,
     ) -> Expression<'a>
     where
@@ -933,7 +933,7 @@ impl<'a> AstBuilder<'a> {
             span,
             callee,
             arguments,
-            type_parameters,
+            type_arguments,
             pure,
         ))
     }
@@ -996,14 +996,14 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `tag`
     /// * `quasi`
-    /// * `type_parameters`
+    /// * `type_arguments`
     #[inline]
     pub fn expression_tagged_template<T1>(
         self,
         span: Span,
         tag: Expression<'a>,
         quasi: TemplateLiteral<'a>,
-        type_parameters: T1,
+        type_arguments: T1,
     ) -> Expression<'a>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
@@ -1012,7 +1012,7 @@ impl<'a> AstBuilder<'a> {
             span,
             tag,
             quasi,
-            type_parameters,
+            type_arguments,
         ))
     }
 
@@ -1811,14 +1811,14 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `tag`
     /// * `quasi`
-    /// * `type_parameters`
+    /// * `type_arguments`
     #[inline]
     pub fn tagged_template_expression<T1>(
         self,
         span: Span,
         tag: Expression<'a>,
         quasi: TemplateLiteral<'a>,
-        type_parameters: T1,
+        type_arguments: T1,
     ) -> TaggedTemplateExpression<'a>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
@@ -1827,7 +1827,7 @@ impl<'a> AstBuilder<'a> {
             span,
             tag,
             quasi,
-            type_parameters: type_parameters.into_in(self.allocator),
+            type_arguments: type_arguments.into_in(self.allocator),
         }
     }
 
@@ -1839,20 +1839,20 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `tag`
     /// * `quasi`
-    /// * `type_parameters`
+    /// * `type_arguments`
     #[inline]
     pub fn alloc_tagged_template_expression<T1>(
         self,
         span: Span,
         tag: Expression<'a>,
         quasi: TemplateLiteral<'a>,
-        type_parameters: T1,
+        type_arguments: T1,
     ) -> Box<'a, TaggedTemplateExpression<'a>>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         Box::new_in(
-            self.tagged_template_expression(span, tag, quasi, type_parameters),
+            self.tagged_template_expression(span, tag, quasi, type_arguments),
             self.allocator,
         )
     }
@@ -2089,7 +2089,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
-    /// * `type_parameters`
+    /// * `type_arguments`
     /// * `arguments`
     /// * `optional`
     #[inline]
@@ -2097,7 +2097,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         callee: Expression<'a>,
-        type_parameters: T1,
+        type_arguments: T1,
         arguments: Vec<'a, Argument<'a>>,
         optional: bool,
     ) -> CallExpression<'a>
@@ -2107,7 +2107,7 @@ impl<'a> AstBuilder<'a> {
         CallExpression {
             span,
             callee,
-            type_parameters: type_parameters.into_in(self.allocator),
+            type_arguments: type_arguments.into_in(self.allocator),
             arguments,
             optional,
             pure: Default::default(),
@@ -2121,7 +2121,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
-    /// * `type_parameters`
+    /// * `type_arguments`
     /// * `arguments`
     /// * `optional`
     #[inline]
@@ -2129,7 +2129,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         callee: Expression<'a>,
-        type_parameters: T1,
+        type_arguments: T1,
         arguments: Vec<'a, Argument<'a>>,
         optional: bool,
     ) -> Box<'a, CallExpression<'a>>
@@ -2137,7 +2137,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         Box::new_in(
-            self.call_expression(span, callee, type_parameters, arguments, optional),
+            self.call_expression(span, callee, type_arguments, arguments, optional),
             self.allocator,
         )
     }
@@ -2149,7 +2149,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
-    /// * `type_parameters`
+    /// * `type_arguments`
     /// * `arguments`
     /// * `optional`
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
@@ -2158,7 +2158,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         callee: Expression<'a>,
-        type_parameters: T1,
+        type_arguments: T1,
         arguments: Vec<'a, Argument<'a>>,
         optional: bool,
         pure: bool,
@@ -2169,7 +2169,7 @@ impl<'a> AstBuilder<'a> {
         CallExpression {
             span,
             callee,
-            type_parameters: type_parameters.into_in(self.allocator),
+            type_arguments: type_arguments.into_in(self.allocator),
             arguments,
             optional,
             pure,
@@ -2183,7 +2183,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
-    /// * `type_parameters`
+    /// * `type_arguments`
     /// * `arguments`
     /// * `optional`
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
@@ -2192,7 +2192,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         callee: Expression<'a>,
-        type_parameters: T1,
+        type_arguments: T1,
         arguments: Vec<'a, Argument<'a>>,
         optional: bool,
         pure: bool,
@@ -2201,14 +2201,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         Box::new_in(
-            self.call_expression_with_pure(
-                span,
-                callee,
-                type_parameters,
-                arguments,
-                optional,
-                pure,
-            ),
+            self.call_expression_with_pure(span, callee, type_arguments, arguments, optional, pure),
             self.allocator,
         )
     }
@@ -2221,14 +2214,14 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
     /// * `arguments`
-    /// * `type_parameters`
+    /// * `type_arguments`
     #[inline]
     pub fn new_expression<T1>(
         self,
         span: Span,
         callee: Expression<'a>,
         arguments: Vec<'a, Argument<'a>>,
-        type_parameters: T1,
+        type_arguments: T1,
     ) -> NewExpression<'a>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
@@ -2237,7 +2230,7 @@ impl<'a> AstBuilder<'a> {
             span,
             callee,
             arguments,
-            type_parameters: type_parameters.into_in(self.allocator),
+            type_arguments: type_arguments.into_in(self.allocator),
             pure: Default::default(),
         }
     }
@@ -2250,19 +2243,19 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
     /// * `arguments`
-    /// * `type_parameters`
+    /// * `type_arguments`
     #[inline]
     pub fn alloc_new_expression<T1>(
         self,
         span: Span,
         callee: Expression<'a>,
         arguments: Vec<'a, Argument<'a>>,
-        type_parameters: T1,
+        type_arguments: T1,
     ) -> Box<'a, NewExpression<'a>>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
-        Box::new_in(self.new_expression(span, callee, arguments, type_parameters), self.allocator)
+        Box::new_in(self.new_expression(span, callee, arguments, type_arguments), self.allocator)
     }
 
     /// Build a [`NewExpression`] with `pure`.
@@ -2273,7 +2266,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
     /// * `arguments`
-    /// * `type_parameters`
+    /// * `type_arguments`
     /// * `pure`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[inline]
     pub fn new_expression_with_pure<T1>(
@@ -2281,7 +2274,7 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         callee: Expression<'a>,
         arguments: Vec<'a, Argument<'a>>,
-        type_parameters: T1,
+        type_arguments: T1,
         pure: bool,
     ) -> NewExpression<'a>
     where
@@ -2291,7 +2284,7 @@ impl<'a> AstBuilder<'a> {
             span,
             callee,
             arguments,
-            type_parameters: type_parameters.into_in(self.allocator),
+            type_arguments: type_arguments.into_in(self.allocator),
             pure,
         }
     }
@@ -2304,7 +2297,7 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
     /// * `arguments`
-    /// * `type_parameters`
+    /// * `type_arguments`
     /// * `pure`: `true` if the new expression is marked with a `/* @__PURE__ */` comment
     #[inline]
     pub fn alloc_new_expression_with_pure<T1>(
@@ -2312,14 +2305,14 @@ impl<'a> AstBuilder<'a> {
         span: Span,
         callee: Expression<'a>,
         arguments: Vec<'a, Argument<'a>>,
-        type_parameters: T1,
+        type_arguments: T1,
         pure: bool,
     ) -> Box<'a, NewExpression<'a>>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         Box::new_in(
-            self.new_expression_with_pure(span, callee, arguments, type_parameters, pure),
+            self.new_expression_with_pure(span, callee, arguments, type_arguments, pure),
             self.allocator,
         )
     }
@@ -3250,7 +3243,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
-    /// * `type_parameters`
+    /// * `type_arguments`
     /// * `arguments`
     /// * `optional`
     #[inline]
@@ -3258,7 +3251,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         callee: Expression<'a>,
-        type_parameters: T1,
+        type_arguments: T1,
         arguments: Vec<'a, Argument<'a>>,
         optional: bool,
     ) -> ChainElement<'a>
@@ -3268,7 +3261,7 @@ impl<'a> AstBuilder<'a> {
         ChainElement::CallExpression(self.alloc_call_expression(
             span,
             callee,
-            type_parameters,
+            type_arguments,
             arguments,
             optional,
         ))
@@ -3281,7 +3274,7 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `callee`
-    /// * `type_parameters`
+    /// * `type_arguments`
     /// * `arguments`
     /// * `optional`
     /// * `pure`: `true` if the call expression is marked with a `/* @__PURE__ */` comment
@@ -3290,7 +3283,7 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         callee: Expression<'a>,
-        type_parameters: T1,
+        type_arguments: T1,
         arguments: Vec<'a, Argument<'a>>,
         optional: bool,
         pure: bool,
@@ -3301,7 +3294,7 @@ impl<'a> AstBuilder<'a> {
         ChainElement::CallExpression(self.alloc_call_expression_with_pure(
             span,
             callee,
-            type_parameters,
+            type_arguments,
             arguments,
             optional,
             pure,
@@ -4056,7 +4049,7 @@ impl<'a> AstBuilder<'a> {
     /// * `id`: Class identifier, AKA the name
     /// * `type_parameters`
     /// * `super_class`: Super class. When present, this will usually be an [`IdentifierReference`].
-    /// * `super_type_parameters`: Type parameters passed to super class.
+    /// * `super_type_arguments`: Type parameters passed to super class.
     /// * `implements`: Interface implementation clause for TypeScript classes.
     /// * `body`
     /// * `abstract`: Whether the class is abstract
@@ -4070,7 +4063,7 @@ impl<'a> AstBuilder<'a> {
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
         super_class: Option<Expression<'a>>,
-        super_type_parameters: T2,
+        super_type_arguments: T2,
         implements: Option<Vec<'a, TSClassImplements<'a>>>,
         body: T3,
         r#abstract: bool,
@@ -4088,7 +4081,7 @@ impl<'a> AstBuilder<'a> {
             id,
             type_parameters,
             super_class,
-            super_type_parameters,
+            super_type_arguments,
             implements,
             body,
             r#abstract,
@@ -4107,7 +4100,7 @@ impl<'a> AstBuilder<'a> {
     /// * `id`: Class identifier, AKA the name
     /// * `type_parameters`
     /// * `super_class`: Super class. When present, this will usually be an [`IdentifierReference`].
-    /// * `super_type_parameters`: Type parameters passed to super class.
+    /// * `super_type_arguments`: Type parameters passed to super class.
     /// * `implements`: Interface implementation clause for TypeScript classes.
     /// * `body`
     /// * `abstract`: Whether the class is abstract
@@ -4122,7 +4115,7 @@ impl<'a> AstBuilder<'a> {
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
         super_class: Option<Expression<'a>>,
-        super_type_parameters: T2,
+        super_type_arguments: T2,
         implements: Option<Vec<'a, TSClassImplements<'a>>>,
         body: T3,
         r#abstract: bool,
@@ -4141,7 +4134,7 @@ impl<'a> AstBuilder<'a> {
             id,
             type_parameters,
             super_class,
-            super_type_parameters,
+            super_type_arguments,
             implements,
             body,
             r#abstract,
@@ -6438,7 +6431,7 @@ impl<'a> AstBuilder<'a> {
     /// * `id`: Class identifier, AKA the name
     /// * `type_parameters`
     /// * `super_class`: Super class. When present, this will usually be an [`IdentifierReference`].
-    /// * `super_type_parameters`: Type parameters passed to super class.
+    /// * `super_type_arguments`: Type parameters passed to super class.
     /// * `implements`: Interface implementation clause for TypeScript classes.
     /// * `body`
     /// * `abstract`: Whether the class is abstract
@@ -6452,7 +6445,7 @@ impl<'a> AstBuilder<'a> {
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
         super_class: Option<Expression<'a>>,
-        super_type_parameters: T2,
+        super_type_arguments: T2,
         implements: Option<Vec<'a, TSClassImplements<'a>>>,
         body: T3,
         r#abstract: bool,
@@ -6470,7 +6463,7 @@ impl<'a> AstBuilder<'a> {
             id,
             type_parameters: type_parameters.into_in(self.allocator),
             super_class,
-            super_type_parameters: super_type_parameters.into_in(self.allocator),
+            super_type_arguments: super_type_arguments.into_in(self.allocator),
             implements,
             body: body.into_in(self.allocator),
             r#abstract,
@@ -6490,7 +6483,7 @@ impl<'a> AstBuilder<'a> {
     /// * `id`: Class identifier, AKA the name
     /// * `type_parameters`
     /// * `super_class`: Super class. When present, this will usually be an [`IdentifierReference`].
-    /// * `super_type_parameters`: Type parameters passed to super class.
+    /// * `super_type_arguments`: Type parameters passed to super class.
     /// * `implements`: Interface implementation clause for TypeScript classes.
     /// * `body`
     /// * `abstract`: Whether the class is abstract
@@ -6504,7 +6497,7 @@ impl<'a> AstBuilder<'a> {
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
         super_class: Option<Expression<'a>>,
-        super_type_parameters: T2,
+        super_type_arguments: T2,
         implements: Option<Vec<'a, TSClassImplements<'a>>>,
         body: T3,
         r#abstract: bool,
@@ -6523,7 +6516,7 @@ impl<'a> AstBuilder<'a> {
                 id,
                 type_parameters,
                 super_class,
-                super_type_parameters,
+                super_type_arguments,
                 implements,
                 body,
                 r#abstract,
@@ -6544,7 +6537,7 @@ impl<'a> AstBuilder<'a> {
     /// * `id`: Class identifier, AKA the name
     /// * `type_parameters`
     /// * `super_class`: Super class. When present, this will usually be an [`IdentifierReference`].
-    /// * `super_type_parameters`: Type parameters passed to super class.
+    /// * `super_type_arguments`: Type parameters passed to super class.
     /// * `implements`: Interface implementation clause for TypeScript classes.
     /// * `body`
     /// * `abstract`: Whether the class is abstract
@@ -6559,7 +6552,7 @@ impl<'a> AstBuilder<'a> {
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
         super_class: Option<Expression<'a>>,
-        super_type_parameters: T2,
+        super_type_arguments: T2,
         implements: Option<Vec<'a, TSClassImplements<'a>>>,
         body: T3,
         r#abstract: bool,
@@ -6578,7 +6571,7 @@ impl<'a> AstBuilder<'a> {
             id,
             type_parameters: type_parameters.into_in(self.allocator),
             super_class,
-            super_type_parameters: super_type_parameters.into_in(self.allocator),
+            super_type_arguments: super_type_arguments.into_in(self.allocator),
             implements,
             body: body.into_in(self.allocator),
             r#abstract,
@@ -6598,7 +6591,7 @@ impl<'a> AstBuilder<'a> {
     /// * `id`: Class identifier, AKA the name
     /// * `type_parameters`
     /// * `super_class`: Super class. When present, this will usually be an [`IdentifierReference`].
-    /// * `super_type_parameters`: Type parameters passed to super class.
+    /// * `super_type_arguments`: Type parameters passed to super class.
     /// * `implements`: Interface implementation clause for TypeScript classes.
     /// * `body`
     /// * `abstract`: Whether the class is abstract
@@ -6613,7 +6606,7 @@ impl<'a> AstBuilder<'a> {
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
         super_class: Option<Expression<'a>>,
-        super_type_parameters: T2,
+        super_type_arguments: T2,
         implements: Option<Vec<'a, TSClassImplements<'a>>>,
         body: T3,
         r#abstract: bool,
@@ -6633,7 +6626,7 @@ impl<'a> AstBuilder<'a> {
                 id,
                 type_parameters,
                 super_class,
-                super_type_parameters,
+                super_type_arguments,
                 implements,
                 body,
                 r#abstract,
@@ -8164,7 +8157,7 @@ impl<'a> AstBuilder<'a> {
     /// * `id`: Class identifier, AKA the name
     /// * `type_parameters`
     /// * `super_class`: Super class. When present, this will usually be an [`IdentifierReference`].
-    /// * `super_type_parameters`: Type parameters passed to super class.
+    /// * `super_type_arguments`: Type parameters passed to super class.
     /// * `implements`: Interface implementation clause for TypeScript classes.
     /// * `body`
     /// * `abstract`: Whether the class is abstract
@@ -8178,7 +8171,7 @@ impl<'a> AstBuilder<'a> {
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
         super_class: Option<Expression<'a>>,
-        super_type_parameters: T2,
+        super_type_arguments: T2,
         implements: Option<Vec<'a, TSClassImplements<'a>>>,
         body: T3,
         r#abstract: bool,
@@ -8196,7 +8189,7 @@ impl<'a> AstBuilder<'a> {
             id,
             type_parameters,
             super_class,
-            super_type_parameters,
+            super_type_arguments,
             implements,
             body,
             r#abstract,
@@ -8215,7 +8208,7 @@ impl<'a> AstBuilder<'a> {
     /// * `id`: Class identifier, AKA the name
     /// * `type_parameters`
     /// * `super_class`: Super class. When present, this will usually be an [`IdentifierReference`].
-    /// * `super_type_parameters`: Type parameters passed to super class.
+    /// * `super_type_arguments`: Type parameters passed to super class.
     /// * `implements`: Interface implementation clause for TypeScript classes.
     /// * `body`
     /// * `abstract`: Whether the class is abstract
@@ -8230,7 +8223,7 @@ impl<'a> AstBuilder<'a> {
         id: Option<BindingIdentifier<'a>>,
         type_parameters: T1,
         super_class: Option<Expression<'a>>,
-        super_type_parameters: T2,
+        super_type_arguments: T2,
         implements: Option<Vec<'a, TSClassImplements<'a>>>,
         body: T3,
         r#abstract: bool,
@@ -8249,7 +8242,7 @@ impl<'a> AstBuilder<'a> {
             id,
             type_parameters,
             super_class,
-            super_type_parameters,
+            super_type_arguments,
             implements,
             body,
             r#abstract,
@@ -8702,7 +8695,7 @@ impl<'a> AstBuilder<'a> {
     /// * `self_closing`: Is this tag self-closing?
     /// * `name`: The possibly-namespaced tag name, e.g. `Foo` in `<Foo />`.
     /// * `attributes`: List of JSX attributes. In React-like applications, these become props.
-    /// * `type_parameters`: Type parameters for generic JSX elements.
+    /// * `type_arguments`: Type parameters for generic JSX elements.
     #[inline]
     pub fn jsx_opening_element<T1>(
         self,
@@ -8710,7 +8703,7 @@ impl<'a> AstBuilder<'a> {
         self_closing: bool,
         name: JSXElementName<'a>,
         attributes: Vec<'a, JSXAttributeItem<'a>>,
-        type_parameters: T1,
+        type_arguments: T1,
     ) -> JSXOpeningElement<'a>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
@@ -8720,7 +8713,7 @@ impl<'a> AstBuilder<'a> {
             self_closing,
             name,
             attributes,
-            type_parameters: type_parameters.into_in(self.allocator),
+            type_arguments: type_arguments.into_in(self.allocator),
         }
     }
 
@@ -8733,7 +8726,7 @@ impl<'a> AstBuilder<'a> {
     /// * `self_closing`: Is this tag self-closing?
     /// * `name`: The possibly-namespaced tag name, e.g. `Foo` in `<Foo />`.
     /// * `attributes`: List of JSX attributes. In React-like applications, these become props.
-    /// * `type_parameters`: Type parameters for generic JSX elements.
+    /// * `type_arguments`: Type parameters for generic JSX elements.
     #[inline]
     pub fn alloc_jsx_opening_element<T1>(
         self,
@@ -8741,13 +8734,13 @@ impl<'a> AstBuilder<'a> {
         self_closing: bool,
         name: JSXElementName<'a>,
         attributes: Vec<'a, JSXAttributeItem<'a>>,
-        type_parameters: T1,
+        type_arguments: T1,
     ) -> Box<'a, JSXOpeningElement<'a>>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         Box::new_in(
-            self.jsx_opening_element(span, self_closing, name, attributes, type_parameters),
+            self.jsx_opening_element(span, self_closing, name, attributes, type_arguments),
             self.allocator,
         )
     }
@@ -10610,18 +10603,18 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expr_name`
-    /// * `type_parameters`
+    /// * `type_arguments`
     #[inline]
     pub fn ts_type_type_query<T1>(
         self,
         span: Span,
         expr_name: TSTypeQueryExprName<'a>,
-        type_parameters: T1,
+        type_arguments: T1,
     ) -> TSType<'a>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
-        TSType::TSTypeQuery(self.alloc_ts_type_query(span, expr_name, type_parameters))
+        TSType::TSTypeQuery(self.alloc_ts_type_query(span, expr_name, type_arguments))
     }
 
     /// Build a [`TSType::TSTypeReference`].
@@ -10631,18 +10624,18 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `type_name`
-    /// * `type_parameters`
+    /// * `type_arguments`
     #[inline]
     pub fn ts_type_type_reference<T1>(
         self,
         span: Span,
         type_name: TSTypeName<'a>,
-        type_parameters: T1,
+        type_arguments: T1,
     ) -> TSType<'a>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
-        TSType::TSTypeReference(self.alloc_ts_type_reference(span, type_name, type_parameters))
+        TSType::TSTypeReference(self.alloc_ts_type_reference(span, type_name, type_arguments))
     }
 
     /// Build a [`TSType::TSUnionType`].
@@ -11506,22 +11499,18 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `type_name`
-    /// * `type_parameters`
+    /// * `type_arguments`
     #[inline]
     pub fn ts_type_reference<T1>(
         self,
         span: Span,
         type_name: TSTypeName<'a>,
-        type_parameters: T1,
+        type_arguments: T1,
     ) -> TSTypeReference<'a>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
-        TSTypeReference {
-            span,
-            type_name,
-            type_parameters: type_parameters.into_in(self.allocator),
-        }
+        TSTypeReference { span, type_name, type_arguments: type_arguments.into_in(self.allocator) }
     }
 
     /// Build a [`TSTypeReference`], and store it in the memory arena.
@@ -11531,18 +11520,18 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `type_name`
-    /// * `type_parameters`
+    /// * `type_arguments`
     #[inline]
     pub fn alloc_ts_type_reference<T1>(
         self,
         span: Span,
         type_name: TSTypeName<'a>,
-        type_parameters: T1,
+        type_arguments: T1,
     ) -> Box<'a, TSTypeReference<'a>>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
-        Box::new_in(self.ts_type_reference(span, type_name, type_parameters), self.allocator)
+        Box::new_in(self.ts_type_reference(span, type_name, type_arguments), self.allocator)
     }
 
     /// Build a [`TSTypeName::IdentifierReference`].
@@ -11896,13 +11885,13 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
-    /// * `type_parameters`
+    /// * `type_arguments`
     #[inline]
     pub fn ts_class_implements<T1>(
         self,
         span: Span,
         expression: TSTypeName<'a>,
-        type_parameters: T1,
+        type_arguments: T1,
     ) -> TSClassImplements<'a>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
@@ -11910,7 +11899,7 @@ impl<'a> AstBuilder<'a> {
         TSClassImplements {
             span,
             expression,
-            type_parameters: type_parameters.into_in(self.allocator),
+            type_arguments: type_arguments.into_in(self.allocator),
         }
     }
 
@@ -11921,18 +11910,18 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
-    /// * `type_parameters`
+    /// * `type_arguments`
     #[inline]
     pub fn alloc_ts_class_implements<T1>(
         self,
         span: Span,
         expression: TSTypeName<'a>,
-        type_parameters: T1,
+        type_arguments: T1,
     ) -> Box<'a, TSClassImplements<'a>>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
-        Box::new_in(self.ts_class_implements(span, expression, type_parameters), self.allocator)
+        Box::new_in(self.ts_class_implements(span, expression, type_arguments), self.allocator)
     }
 
     /// Build a [`TSInterfaceDeclaration`].
@@ -12943,13 +12932,13 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
-    /// * `type_parameters`
+    /// * `type_arguments`
     #[inline]
     pub fn ts_interface_heritage<T1>(
         self,
         span: Span,
         expression: Expression<'a>,
-        type_parameters: T1,
+        type_arguments: T1,
     ) -> TSInterfaceHeritage<'a>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
@@ -12957,7 +12946,7 @@ impl<'a> AstBuilder<'a> {
         TSInterfaceHeritage {
             span,
             expression,
-            type_parameters: type_parameters.into_in(self.allocator),
+            type_arguments: type_arguments.into_in(self.allocator),
         }
     }
 
@@ -12968,18 +12957,18 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
-    /// * `type_parameters`
+    /// * `type_arguments`
     #[inline]
     pub fn alloc_ts_interface_heritage<T1>(
         self,
         span: Span,
         expression: Expression<'a>,
-        type_parameters: T1,
+        type_arguments: T1,
     ) -> Box<'a, TSInterfaceHeritage<'a>>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
-        Box::new_in(self.ts_interface_heritage(span, expression, type_parameters), self.allocator)
+        Box::new_in(self.ts_interface_heritage(span, expression, type_arguments), self.allocator)
     }
 
     /// Build a [`TSTypePredicate`].
@@ -13389,18 +13378,18 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expr_name`
-    /// * `type_parameters`
+    /// * `type_arguments`
     #[inline]
     pub fn ts_type_query<T1>(
         self,
         span: Span,
         expr_name: TSTypeQueryExprName<'a>,
-        type_parameters: T1,
+        type_arguments: T1,
     ) -> TSTypeQuery<'a>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
-        TSTypeQuery { span, expr_name, type_parameters: type_parameters.into_in(self.allocator) }
+        TSTypeQuery { span, expr_name, type_arguments: type_arguments.into_in(self.allocator) }
     }
 
     /// Build a [`TSTypeQuery`], and store it in the memory arena.
@@ -13410,18 +13399,18 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expr_name`
-    /// * `type_parameters`
+    /// * `type_arguments`
     #[inline]
     pub fn alloc_ts_type_query<T1>(
         self,
         span: Span,
         expr_name: TSTypeQueryExprName<'a>,
-        type_parameters: T1,
+        type_arguments: T1,
     ) -> Box<'a, TSTypeQuery<'a>>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
-        Box::new_in(self.ts_type_query(span, expr_name, type_parameters), self.allocator)
+        Box::new_in(self.ts_type_query(span, expr_name, type_arguments), self.allocator)
     }
 
     /// Build a [`TSTypeQueryExprName::TSImportType`].

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -542,7 +542,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TaggedTemplateExpression<'_> {
             span: CloneIn::clone_in(&self.span, allocator),
             tag: CloneIn::clone_in(&self.tag, allocator),
             quasi: CloneIn::clone_in(&self.quasi, allocator),
-            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
+            type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
         }
     }
 }
@@ -627,7 +627,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for CallExpression<'_> {
         CallExpression {
             span: CloneIn::clone_in(&self.span, allocator),
             callee: CloneIn::clone_in(&self.callee, allocator),
-            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
+            type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
             arguments: CloneIn::clone_in(&self.arguments, allocator),
             optional: CloneIn::clone_in(&self.optional, allocator),
             pure: CloneIn::clone_in(&self.pure, allocator),
@@ -642,7 +642,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for NewExpression<'_> {
             span: CloneIn::clone_in(&self.span, allocator),
             callee: CloneIn::clone_in(&self.callee, allocator),
             arguments: CloneIn::clone_in(&self.arguments, allocator),
-            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
+            type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
             pure: CloneIn::clone_in(&self.pure, allocator),
         }
     }
@@ -1935,7 +1935,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for Class<'_> {
             id: CloneIn::clone_in(&self.id, allocator),
             type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
             super_class: CloneIn::clone_in(&self.super_class, allocator),
-            super_type_parameters: CloneIn::clone_in(&self.super_type_parameters, allocator),
+            super_type_arguments: CloneIn::clone_in(&self.super_type_arguments, allocator),
             implements: CloneIn::clone_in(&self.implements, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
             r#abstract: CloneIn::clone_in(&self.r#abstract, allocator),
@@ -2602,7 +2602,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXOpeningElement<'_> {
             self_closing: CloneIn::clone_in(&self.self_closing, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
             attributes: CloneIn::clone_in(&self.attributes, allocator),
-            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
+            type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
         }
     }
 }
@@ -3458,7 +3458,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeReference<'_> {
         TSTypeReference {
             span: CloneIn::clone_in(&self.span, allocator),
             type_name: CloneIn::clone_in(&self.type_name, allocator),
-            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
+            type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
         }
     }
 }
@@ -3552,7 +3552,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSClassImplements<'_> {
         TSClassImplements {
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
-            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
+            type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
         }
     }
 }
@@ -3704,7 +3704,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInterfaceHeritage<'_> {
         TSInterfaceHeritage {
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
-            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
+            type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
         }
     }
 }
@@ -3823,7 +3823,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeQuery<'_> {
         TSTypeQuery {
             span: CloneIn::clone_in(&self.span, allocator),
             expr_name: CloneIn::clone_in(&self.expr_name, allocator),
-            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
+            type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -283,7 +283,7 @@ impl ContentEq for TaggedTemplateExpression<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.tag, &other.tag)
             && ContentEq::content_eq(&self.quasi, &other.quasi)
-            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
+            && ContentEq::content_eq(&self.type_arguments, &other.type_arguments)
     }
 }
 
@@ -341,7 +341,7 @@ impl ContentEq for PrivateFieldExpression<'_> {
 impl ContentEq for CallExpression<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.callee, &other.callee)
-            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
+            && ContentEq::content_eq(&self.type_arguments, &other.type_arguments)
             && ContentEq::content_eq(&self.arguments, &other.arguments)
             && ContentEq::content_eq(&self.optional, &other.optional)
             && ContentEq::content_eq(&self.pure, &other.pure)
@@ -352,7 +352,7 @@ impl ContentEq for NewExpression<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.callee, &other.callee)
             && ContentEq::content_eq(&self.arguments, &other.arguments)
-            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
+            && ContentEq::content_eq(&self.type_arguments, &other.type_arguments)
             && ContentEq::content_eq(&self.pure, &other.pure)
     }
 }
@@ -1123,7 +1123,7 @@ impl ContentEq for Class<'_> {
             && ContentEq::content_eq(&self.id, &other.id)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
             && ContentEq::content_eq(&self.super_class, &other.super_class)
-            && ContentEq::content_eq(&self.super_type_parameters, &other.super_type_parameters)
+            && ContentEq::content_eq(&self.super_type_arguments, &other.super_type_arguments)
             && ContentEq::content_eq(&self.implements, &other.implements)
             && ContentEq::content_eq(&self.body, &other.body)
             && ContentEq::content_eq(&self.r#abstract, &other.r#abstract)
@@ -1506,7 +1506,7 @@ impl ContentEq for JSXOpeningElement<'_> {
         ContentEq::content_eq(&self.self_closing, &other.self_closing)
             && ContentEq::content_eq(&self.name, &other.name)
             && ContentEq::content_eq(&self.attributes, &other.attributes)
-            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
+            && ContentEq::content_eq(&self.type_arguments, &other.type_arguments)
     }
 }
 
@@ -2036,7 +2036,7 @@ impl ContentEq for TSBigIntKeyword {
 impl ContentEq for TSTypeReference<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.type_name, &other.type_name)
-            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
+            && ContentEq::content_eq(&self.type_arguments, &other.type_arguments)
     }
 }
 
@@ -2098,7 +2098,7 @@ impl ContentEq for TSAccessibility {
 impl ContentEq for TSClassImplements<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.expression, &other.expression)
-            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
+            && ContentEq::content_eq(&self.type_arguments, &other.type_arguments)
     }
 }
 
@@ -2201,7 +2201,7 @@ impl ContentEq for TSIndexSignatureName<'_> {
 impl ContentEq for TSInterfaceHeritage<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.expression, &other.expression)
-            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
+            && ContentEq::content_eq(&self.type_arguments, &other.type_arguments)
     }
 }
 
@@ -2280,7 +2280,7 @@ impl ContentEq for TSInferType<'_> {
 impl ContentEq for TSTypeQuery<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.expr_name, &other.expr_name)
-            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
+            && ContentEq::content_eq(&self.type_arguments, &other.type_arguments)
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -321,7 +321,7 @@ impl ESTree for TaggedTemplateExpression<'_> {
         state.serialize_field("end", &self.span.end);
         state.serialize_field("tag", &self.tag);
         state.serialize_field("quasi", &self.quasi);
-        state.serialize_ts_field("typeParameters", &self.type_parameters);
+        state.serialize_ts_field("typeArguments", &self.type_arguments);
         state.end();
     }
 }
@@ -408,7 +408,7 @@ impl ESTree for CallExpression<'_> {
         state.serialize_field("callee", &self.callee);
         state.serialize_field("arguments", &self.arguments);
         state.serialize_field("optional", &self.optional);
-        state.serialize_ts_field("typeParameters", &self.type_parameters);
+        state.serialize_ts_field("typeArguments", &self.type_arguments);
         state.end();
     }
 }
@@ -421,7 +421,7 @@ impl ESTree for NewExpression<'_> {
         state.serialize_field("end", &self.span.end);
         state.serialize_field("callee", &self.callee);
         state.serialize_field("arguments", &self.arguments);
-        state.serialize_ts_field("typeParameters", &self.type_parameters);
+        state.serialize_ts_field("typeArguments", &self.type_arguments);
         state.end();
     }
 }
@@ -1449,7 +1449,7 @@ impl ESTree for Class<'_> {
         state.serialize_field("body", &self.body);
         state.serialize_ts_field("decorators", &self.decorators);
         state.serialize_ts_field("typeParameters", &self.type_parameters);
-        state.serialize_ts_field("superTypeParameters", &self.super_type_parameters);
+        state.serialize_ts_field("superTypeArguments", &self.super_type_arguments);
         state.serialize_ts_field("implements", &self.implements);
         state.serialize_ts_field("abstract", &self.r#abstract);
         state.serialize_ts_field("declare", &self.declare);
@@ -1989,7 +1989,7 @@ impl ESTree for JSXOpeningElement<'_> {
         state.serialize_field("attributes", &self.attributes);
         state.serialize_field("name", &self.name);
         state.serialize_field("selfClosing", &self.self_closing);
-        state.serialize_ts_field("typeParameters", &self.type_parameters);
+        state.serialize_ts_field("typeArguments", &self.type_arguments);
         state.end();
     }
 }
@@ -2720,7 +2720,7 @@ impl ESTree for TSTypeReference<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeName", &self.type_name);
-        state.serialize_field("typeParameters", &self.type_parameters);
+        state.serialize_field("typeArguments", &self.type_arguments);
         state.end();
     }
 }
@@ -2815,7 +2815,7 @@ impl ESTree for TSClassImplements<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
-        state.serialize_field("typeParameters", &self.type_parameters);
+        state.serialize_field("typeArguments", &self.type_arguments);
         state.end();
     }
 }
@@ -2961,7 +2961,7 @@ impl ESTree for TSInterfaceHeritage<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
-        state.serialize_field("typeParameters", &self.type_parameters);
+        state.serialize_field("typeArguments", &self.type_arguments);
         state.end();
     }
 }
@@ -3073,7 +3073,7 @@ impl ESTree for TSTypeQuery<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("exprName", &self.expr_name);
-        state.serialize_field("typeParameters", &self.type_parameters);
+        state.serialize_field("typeArguments", &self.type_arguments);
         state.end();
     }
 }

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -1576,8 +1576,8 @@ pub mod walk {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.tag);
         visitor.visit_template_literal(&it.quasi);
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        if let Some(type_arguments) = &it.type_arguments {
+            visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
         visitor.leave_node(kind);
     }
@@ -1645,8 +1645,8 @@ pub mod walk {
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.callee);
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        if let Some(type_arguments) = &it.type_arguments {
+            visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
         visitor.visit_arguments(&it.arguments);
         visitor.leave_node(kind);
@@ -1659,8 +1659,8 @@ pub mod walk {
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.callee);
         visitor.visit_arguments(&it.arguments);
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        if let Some(type_arguments) = &it.type_arguments {
+            visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
         visitor.leave_node(kind);
     }
@@ -2563,8 +2563,8 @@ pub mod walk {
         if let Some(super_class) = &it.super_class {
             visitor.visit_expression(super_class);
         }
-        if let Some(super_type_parameters) = &it.super_type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(super_type_parameters);
+        if let Some(super_type_arguments) = &it.super_type_arguments {
+            visitor.visit_ts_type_parameter_instantiation(super_type_arguments);
         }
         if let Some(implements) = &it.implements {
             visitor.visit_ts_class_implementses(implements);
@@ -2964,8 +2964,8 @@ pub mod walk {
         visitor.visit_span(&it.span);
         visitor.visit_jsx_element_name(&it.name);
         visitor.visit_jsx_attribute_items(&it.attributes);
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        if let Some(type_arguments) = &it.type_arguments {
+            visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
         visitor.leave_node(kind);
     }
@@ -3529,8 +3529,8 @@ pub mod walk {
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
         visitor.visit_ts_type_name(&it.type_name);
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        if let Some(type_arguments) = &it.type_arguments {
+            visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
         visitor.leave_node(kind);
     }
@@ -3619,8 +3619,8 @@ pub mod walk {
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
         visitor.visit_ts_type_name(&it.expression);
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        if let Some(type_arguments) = &it.type_arguments {
+            visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
         visitor.leave_node(kind);
     }
@@ -3770,8 +3770,8 @@ pub mod walk {
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.expression);
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        if let Some(type_arguments) = &it.type_arguments {
+            visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
         visitor.leave_node(kind);
     }
@@ -3884,8 +3884,8 @@ pub mod walk {
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
         visitor.visit_ts_type_query_expr_name(&it.expr_name);
-        if let Some(type_parameters) = &it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        if let Some(type_arguments) = &it.type_arguments {
+            visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
         visitor.leave_node(kind);
     }

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -1586,8 +1586,8 @@ pub mod walk_mut {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.tag);
         visitor.visit_template_literal(&mut it.quasi);
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        if let Some(type_arguments) = &mut it.type_arguments {
+            visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
         visitor.leave_node(kind);
     }
@@ -1661,8 +1661,8 @@ pub mod walk_mut {
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.callee);
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        if let Some(type_arguments) = &mut it.type_arguments {
+            visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
         visitor.visit_arguments(&mut it.arguments);
         visitor.leave_node(kind);
@@ -1675,8 +1675,8 @@ pub mod walk_mut {
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.callee);
         visitor.visit_arguments(&mut it.arguments);
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        if let Some(type_arguments) = &mut it.type_arguments {
+            visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
         visitor.leave_node(kind);
     }
@@ -2649,8 +2649,8 @@ pub mod walk_mut {
         if let Some(super_class) = &mut it.super_class {
             visitor.visit_expression(super_class);
         }
-        if let Some(super_type_parameters) = &mut it.super_type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(super_type_parameters);
+        if let Some(super_type_arguments) = &mut it.super_type_arguments {
+            visitor.visit_ts_type_parameter_instantiation(super_type_arguments);
         }
         if let Some(implements) = &mut it.implements {
             visitor.visit_ts_class_implementses(implements);
@@ -3083,8 +3083,8 @@ pub mod walk_mut {
         visitor.visit_span(&mut it.span);
         visitor.visit_jsx_element_name(&mut it.name);
         visitor.visit_jsx_attribute_items(&mut it.attributes);
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        if let Some(type_arguments) = &mut it.type_arguments {
+            visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
         visitor.leave_node(kind);
     }
@@ -3717,8 +3717,8 @@ pub mod walk_mut {
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type_name(&mut it.type_name);
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        if let Some(type_arguments) = &mut it.type_arguments {
+            visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
         visitor.leave_node(kind);
     }
@@ -3816,8 +3816,8 @@ pub mod walk_mut {
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type_name(&mut it.expression);
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        if let Some(type_arguments) = &mut it.type_arguments {
+            visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
         visitor.leave_node(kind);
     }
@@ -3976,8 +3976,8 @@ pub mod walk_mut {
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.expression);
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        if let Some(type_arguments) = &mut it.type_arguments {
+            visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
         visitor.leave_node(kind);
     }
@@ -4093,8 +4093,8 @@ pub mod walk_mut {
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
         visitor.visit_ts_type_query_expr_name(&mut it.expr_name);
-        if let Some(type_parameters) = &mut it.type_parameters {
-            visitor.visit_ts_type_parameter_instantiation(type_parameters);
+        if let Some(type_arguments) = &mut it.type_arguments {
+            visitor.visit_ts_type_parameter_instantiation(type_arguments);
         }
         visitor.leave_node(kind);
     }

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1451,7 +1451,7 @@ impl GenExpr for CallExpression<'_> {
             if self.optional {
                 p.print_str("?.");
             }
-            if let Some(type_parameters) = &self.type_parameters {
+            if let Some(type_parameters) = &self.type_arguments {
                 type_parameters.print(p, ctx);
             }
             p.print_ascii_byte(b'(');
@@ -2156,7 +2156,7 @@ impl Gen for TaggedTemplateExpression<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         self.tag.print_expr(p, Precedence::Postfix, Context::empty());
-        if let Some(type_parameters) = &self.type_parameters {
+        if let Some(type_parameters) = &self.type_arguments {
             type_parameters.print(p, ctx);
         }
         self.quasi.print(p, ctx);
@@ -2337,7 +2337,7 @@ impl Gen for Class<'_> {
             if let Some(super_class) = self.super_class.as_ref() {
                 p.print_str(" extends ");
                 super_class.print_expr(p, Precedence::Postfix, Context::empty());
-                if let Some(super_type_parameters) = &self.super_type_parameters {
+                if let Some(super_type_parameters) = &self.super_type_arguments {
                     super_type_parameters.print(p, ctx);
                 }
             }
@@ -2983,7 +2983,7 @@ impl Gen for Decorator<'_> {
 impl Gen for TSClassImplements<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         self.expression.print(p, ctx);
-        if let Some(type_parameters) = self.type_parameters.as_ref() {
+        if let Some(type_parameters) = self.type_arguments.as_ref() {
             type_parameters.print(p, ctx);
         }
     }
@@ -3259,7 +3259,7 @@ impl Gen for TSTypePredicate<'_> {
 impl Gen for TSTypeReference<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         self.type_name.print(p, ctx);
-        if let Some(type_parameters) = &self.type_parameters {
+        if let Some(type_parameters) = &self.type_arguments {
             type_parameters.print(p, ctx);
         }
     }
@@ -3530,7 +3530,7 @@ impl Gen for TSTypeQuery<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         p.print_str("typeof ");
         self.expr_name.print(p, ctx);
-        if let Some(type_params) = &self.type_parameters {
+        if let Some(type_params) = &self.type_arguments {
             type_params.print(p, ctx);
         }
     }
@@ -3771,7 +3771,7 @@ impl Gen for TSInterfaceDeclaration<'_> {
 impl Gen for TSInterfaceHeritage<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         self.expression.print_expr(p, Precedence::Call, ctx);
-        if let Some(type_parameters) = &self.type_parameters {
+        if let Some(type_parameters) = &self.type_arguments {
             type_parameters.print(p, ctx);
         }
     }

--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -558,7 +558,7 @@ impl<'a> IsolatedDeclarations<'a> {
             decl.id.clone_in(self.ast.allocator),
             decl.type_parameters.clone_in(self.ast.allocator),
             decl.super_class.clone_in(self.ast.allocator),
-            decl.super_type_parameters.clone_in(self.ast.allocator),
+            decl.super_type_arguments.clone_in(self.ast.allocator),
             decl.implements.clone_in(self.ast.allocator),
             body,
             decl.r#abstract,

--- a/crates/oxc_isolated_declarations/src/scope.rs
+++ b/crates/oxc_isolated_declarations/src/scope.rs
@@ -118,7 +118,7 @@ impl<'a> Visit<'a> for ScopeTree<'a> {
             self.add_reference(ident.name, KindFlags::Value);
             // `typeof Type<Parameters>`
             //              ^^^^^^^^^^^
-            if let Some(type_parameters) = &ty.type_parameters {
+            if let Some(type_parameters) = &ty.type_arguments {
                 self.visit_ts_type_parameter_instantiation(type_parameters);
             }
         } else {

--- a/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_array_constructor.rs
@@ -57,14 +57,14 @@ impl Rule for NoArrayConstructor {
                 call_expr.span,
                 &call_expr.callee,
                 &call_expr.arguments,
-                &call_expr.type_parameters,
+                &call_expr.type_arguments,
                 call_expr.optional,
             ),
             AstKind::NewExpression(new_expr) => (
                 new_expr.span,
                 &new_expr.callee,
                 &new_expr.arguments,
-                &new_expr.type_parameters,
+                &new_expr.type_arguments,
                 false,
             ),
             _ => {

--- a/crates/oxc_linter/src/rules/eslint/no_object_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_object_constructor.rs
@@ -47,14 +47,11 @@ declare_oxc_lint!(
 impl Rule for NoObjectConstructor {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         let (span, callee, arguments, type_parameters) = match node.kind() {
-            AstKind::CallExpression(call_expr) => (
-                call_expr.span,
-                &call_expr.callee,
-                &call_expr.arguments,
-                &call_expr.type_parameters,
-            ),
+            AstKind::CallExpression(call_expr) => {
+                (call_expr.span, &call_expr.callee, &call_expr.arguments, &call_expr.type_arguments)
+            }
             AstKind::NewExpression(new_expr) => {
-                (new_expr.span, &new_expr.callee, &new_expr.arguments, &new_expr.type_parameters)
+                (new_expr.span, &new_expr.callee, &new_expr.arguments, &new_expr.type_arguments)
             }
             _ => {
                 return;

--- a/crates/oxc_linter/src/rules/eslint/no_unexpected_multiline.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unexpected_multiline.rs
@@ -117,7 +117,7 @@ impl Rule for NoUnexpectedMultiline {
                     return;
                 }
 
-                let start = if let Some(generics) = &call_expr.type_parameters {
+                let start = if let Some(generics) = &call_expr.type_arguments {
                     generics.span.end
                 } else {
                     call_expr.callee.span().end
@@ -153,7 +153,7 @@ impl Rule for NoUnexpectedMultiline {
                 }
             }
             AstKind::TaggedTemplateExpression(tagged_template_expr) => {
-                let start = if let Some(generics) = &tagged_template_expr.type_parameters {
+                let start = if let Some(generics) = &tagged_template_expr.type_arguments {
                     generics.span.end
                 } else {
                     tagged_template_expr.tag.span().end

--- a/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
+++ b/crates/oxc_linter/src/rules/jest/no_untyped_mock_factory.rs
@@ -124,7 +124,7 @@ impl NoUntypedMockFactory {
             return;
         };
 
-        if call_expr.type_parameters.is_some() || Self::has_return_type(factory_node) {
+        if call_expr.type_arguments.is_some() || Self::has_return_type(factory_node) {
             return;
         }
 

--- a/crates/oxc_linter/src/rules/typescript/array_type.rs
+++ b/crates/oxc_linter/src/rules/typescript/array_type.rs
@@ -250,7 +250,7 @@ fn check_and_report_error_reference(
         {
             check_and_report_error_array(default_config, readonly_config, ts_type_reference, ctx);
         } else if ident_ref_type_name.name.as_str() == "Promise" {
-            if let Some(type_params) = &ts_type_reference.type_parameters {
+            if let Some(type_params) = &ts_type_reference.type_arguments {
                 if type_params.params.len() == 1 {
                     if let Some(type_param) = type_params.params.first() {
                         if let TSType::TSArrayType(array_type) = &type_param {
@@ -314,7 +314,7 @@ fn check_and_report_error_array(
     }
     let readonly_prefix: &'static str = if is_readonly_array_type { "readonly " } else { "" };
     let class_name = if is_readonly_array_type { "ReadonlyArray" } else { "Array" };
-    let type_params = &ts_type_reference.type_parameters;
+    let type_params = &ts_type_reference.type_arguments;
 
     if type_params.is_none() || type_params.as_ref().unwrap().params.len() == 0 {
         let diagnostic = match config {
@@ -400,16 +400,16 @@ fn is_simple_type(ts_type: &TSType) -> bool {
         TSType::TSTypeReference(node) => {
             let type_name = TSTypeName::get_identifier_reference(&node.type_name);
             if type_name.name.as_str() == "Array" {
-                if node.type_parameters.is_none() {
+                if node.type_arguments.is_none() {
                     return true;
                 }
-                if node.type_parameters.as_ref().unwrap().params.len() == 1 {
+                if node.type_arguments.as_ref().unwrap().params.len() == 1 {
                     return is_simple_type(
-                        node.type_parameters.as_ref().unwrap().params.first().unwrap(),
+                        node.type_arguments.as_ref().unwrap().params.first().unwrap(),
                     );
                 }
             } else {
-                if node.type_parameters.is_some() {
+                if node.type_arguments.is_some() {
                     return false;
                 }
                 if let TSTypeName::IdentifierReference(_) = &node.type_name {

--- a/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_generic_constructors.rs
@@ -155,7 +155,7 @@ impl ConsistentGenericConstructors {
 
         if matches!(self.0.option, PreferGenericType::TypeAnnotation) {
             if type_annotation.is_none() {
-                if let Some(type_arguments) = &new_expression.type_parameters {
+                if let Some(type_arguments) = &new_expression.type_arguments {
                     ctx.diagnostic(consistent_generic_constructors_diagnostic_prefer_annotation(
                         type_arguments.span,
                     ));
@@ -166,7 +166,7 @@ impl ConsistentGenericConstructors {
 
         if let Some(type_arguments) = &type_annotation {
             if has_type_parameters(&type_arguments.type_annotation)
-                && new_expression.type_parameters.is_none()
+                && new_expression.type_arguments.is_none()
             {
                 ctx.diagnostic(consistent_generic_constructors_diagnostic_prefer_constructor(
                     type_arguments.span,
@@ -178,7 +178,7 @@ impl ConsistentGenericConstructors {
 
 fn has_type_parameters(ts_type: &TSType) -> bool {
     match ts_type {
-        TSType::TSTypeReference(type_ref) => type_ref.type_parameters.is_some(),
+        TSType::TSTypeReference(type_ref) => type_ref.type_arguments.is_some(),
         _ => false,
     }
 }

--- a/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_indexed_object_style.rs
@@ -217,13 +217,13 @@ impl Rule for ConsistentIndexedObjectStyle {
                     return;
                 }
 
-                let Some(params) = &tref.type_parameters else { return };
+                let Some(params) = &tref.type_arguments else { return };
                 if params.params.len() != 2 {
                     return;
                 }
 
                 if let Some(TSType::TSStringKeyword(first)) =
-                    &tref.type_parameters.as_ref().and_then(|params| params.params.first())
+                    &tref.type_arguments.as_ref().and_then(|params| params.params.first())
                 {
                     ctx.diagnostic_with_fix(
                         consistent_indexed_object_style_diagnostic(

--- a/crates/oxc_linter/src/rules/unicorn/consistent_date_clone.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_date_clone.rs
@@ -52,7 +52,7 @@ impl Rule for ConsistentDateClone {
 
         if !(expr.callee.is_specific_id("Date")
             && expr.arguments.len() == 1
-            && expr.type_parameters.is_none())
+            && expr.type_arguments.is_none())
         {
             return;
         }

--- a/crates/oxc_prettier/src/format/jsx.rs
+++ b/crates/oxc_prettier/src/format/jsx.rs
@@ -169,7 +169,7 @@ impl<'a> Format<'a> for JSXOpeningElement<'a> {
         parts.push(text!("<"));
         parts.push(self.name.format(p));
 
-        if let Some(type_parameters) = &self.type_parameters {
+        if let Some(type_parameters) = &self.type_arguments {
             parts.push(type_parameters.format(p));
         }
 

--- a/crates/oxc_prettier/src/format/print/assignment.rs
+++ b/crates/oxc_prettier/src/format/print/assignment.rs
@@ -340,7 +340,7 @@ fn is_poorly_breakable_member_or_call_chain<'a>(p: &Prettier<'a>, expr: &Express
             return false;
         }
 
-        if let Some(type_parameters) = &call_expression.type_parameters {
+        if let Some(type_parameters) = &call_expression.type_arguments {
             return is_complex_type_arguments(type_parameters);
         }
     }

--- a/crates/oxc_prettier/src/format/print/call_expression.rs
+++ b/crates/oxc_prettier/src/format/print/call_expression.rs
@@ -52,8 +52,8 @@ impl<'a> CallExpressionLike<'a, '_> {
 
     fn type_parameters(&self) -> Option<&oxc_allocator::Box<'a, TSTypeParameterInstantiation<'a>>> {
         match self {
-            CallExpressionLike::CallExpression(call) => call.type_parameters.as_ref(),
-            CallExpressionLike::NewExpression(new) => new.type_parameters.as_ref(),
+            CallExpressionLike::CallExpression(call) => call.type_arguments.as_ref(),
+            CallExpressionLike::NewExpression(new) => new.type_arguments.as_ref(),
             CallExpressionLike::V8Intrinsic(_) => None,
         }
     }

--- a/crates/oxc_prettier/src/format/print/class.rs
+++ b/crates/oxc_prettier/src/format/print/class.rs
@@ -29,7 +29,7 @@ pub fn print_class<'a>(p: &mut Prettier<'a>, class: &Class<'a>) -> Doc<'a> {
         extend_parts.push(text!("extends "));
         extend_parts.push(super_class.format(p));
 
-        if let Some(super_type_parameters) = &class.super_type_parameters {
+        if let Some(super_type_parameters) = &class.super_type_arguments {
             extend_parts.push(super_type_parameters.format(p));
         }
 

--- a/crates/oxc_prettier/src/format/print/template_literal.rs
+++ b/crates/oxc_prettier/src/format/print/template_literal.rs
@@ -72,7 +72,7 @@ pub fn print_tagged_template_literal<'a>(
     let mut parts = Vec::new_in(p.allocator);
 
     parts.push(tagged_template_literal.tag.format(p));
-    if let Some(type_parameters) = &tagged_template_literal.type_parameters {
+    if let Some(type_parameters) = &tagged_template_literal.type_arguments {
         parts.push(type_parameters.format(p));
     }
     parts.push(line_suffix_boundary!());

--- a/crates/oxc_prettier/src/format/typescript.rs
+++ b/crates/oxc_prettier/src/format/typescript.rs
@@ -473,7 +473,7 @@ impl<'a> Format<'a> for TSTypeQuery<'a> {
             }
         }
 
-        if let Some(type_parameters) = &self.type_parameters {
+        if let Some(type_parameters) = &self.type_arguments {
             parts.push(type_parameters.format(p));
         }
 
@@ -485,7 +485,7 @@ impl<'a> Format<'a> for TSTypeReference<'a> {
     fn format(&self, p: &mut Prettier<'a>) -> Doc<'a> {
         let mut parts = Vec::new_in(p.allocator);
         parts.push(self.type_name.format(p));
-        if let Some(params) = &self.type_parameters {
+        if let Some(params) = &self.type_arguments {
             parts.push(params.format(p));
         }
         array!(p, parts)
@@ -568,7 +568,7 @@ impl<'a> Format<'a> for TSInterfaceDeclaration<'a> {
                         }
 
                         extends_parts.push(extend.expression.format(p));
-                        if let Some(type_parameters) = &extend.type_parameters {
+                        if let Some(type_parameters) = &extend.type_arguments {
                             extends_parts.push(type_parameters.format(p));
                         }
                     }
@@ -897,7 +897,7 @@ impl<'a> Format<'a> for TSClassImplements<'a> {
 
         parts.push(self.expression.format(p));
 
-        if let Some(type_parameters) = &self.type_parameters {
+        if let Some(type_parameters) = &self.type_arguments {
             parts.push(type_parameters.format(p));
         }
 

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -687,7 +687,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         if let Some(super_class) = &class.super_class {
             self.visit_expression(super_class);
         }
-        if let Some(super_type_parameters) = &class.super_type_parameters {
+        if let Some(super_type_parameters) = &class.super_type_arguments {
             self.visit_ts_type_parameter_instantiation(super_type_parameters);
         }
         if let Some(implements) = &class.implements {

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -198,7 +198,7 @@ impl<'a> Traverse<'a> for TypeScriptAnnotations<'a, '_> {
     }
 
     fn enter_call_expression(&mut self, expr: &mut CallExpression<'a>, _ctx: &mut TraverseCtx<'a>) {
-        expr.type_parameters = None;
+        expr.type_arguments = None;
     }
 
     fn enter_chain_element(&mut self, element: &mut ChainElement<'a>, ctx: &mut TraverseCtx<'a>) {
@@ -218,7 +218,7 @@ impl<'a> Traverse<'a> for TypeScriptAnnotations<'a, '_> {
 
     fn enter_class(&mut self, class: &mut Class<'a>, _ctx: &mut TraverseCtx<'a>) {
         class.type_parameters = None;
-        class.super_type_parameters = None;
+        class.super_type_arguments = None;
         class.implements = None;
         class.r#abstract = false;
     }
@@ -315,7 +315,7 @@ impl<'a> Traverse<'a> for TypeScriptAnnotations<'a, '_> {
         elem: &mut JSXOpeningElement<'a>,
         _ctx: &mut TraverseCtx<'a>,
     ) {
-        elem.type_parameters = None;
+        elem.type_arguments = None;
     }
 
     fn enter_method_definition(
@@ -377,7 +377,7 @@ impl<'a> Traverse<'a> for TypeScriptAnnotations<'a, '_> {
     }
 
     fn enter_new_expression(&mut self, expr: &mut NewExpression<'a>, _ctx: &mut TraverseCtx<'a>) {
-        expr.type_parameters = None;
+        expr.type_arguments = None;
     }
 
     fn enter_property_definition(
@@ -538,7 +538,7 @@ impl<'a> Traverse<'a> for TypeScriptAnnotations<'a, '_> {
         expr: &mut TaggedTemplateExpression<'a>,
         _ctx: &mut TraverseCtx<'a>,
     ) {
-        expr.type_parameters = None;
+        expr.type_arguments = None;
     }
 
     fn enter_jsx_element(&mut self, _elem: &mut JSXElement<'a>, _ctx: &mut TraverseCtx<'a>) {

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -32,7 +32,7 @@ pub(crate) enum AncestorType {
     TemplateLiteralExpressions = 9,
     TaggedTemplateExpressionTag = 10,
     TaggedTemplateExpressionQuasi = 11,
-    TaggedTemplateExpressionTypeParameters = 12,
+    TaggedTemplateExpressionTypeArguments = 12,
     ComputedMemberExpressionObject = 13,
     ComputedMemberExpressionExpression = 14,
     StaticMemberExpressionObject = 15,
@@ -40,11 +40,11 @@ pub(crate) enum AncestorType {
     PrivateFieldExpressionObject = 17,
     PrivateFieldExpressionField = 18,
     CallExpressionCallee = 19,
-    CallExpressionTypeParameters = 20,
+    CallExpressionTypeArguments = 20,
     CallExpressionArguments = 21,
     NewExpressionCallee = 22,
     NewExpressionArguments = 23,
-    NewExpressionTypeParameters = 24,
+    NewExpressionTypeArguments = 24,
     MetaPropertyMeta = 25,
     MetaPropertyProperty = 26,
     SpreadElementArgument = 27,
@@ -149,7 +149,7 @@ pub(crate) enum AncestorType {
     ClassId = 126,
     ClassTypeParameters = 127,
     ClassSuperClass = 128,
-    ClassSuperTypeParameters = 129,
+    ClassSuperTypeArguments = 129,
     ClassImplements = 130,
     ClassBody = 131,
     ClassBodyBody = 132,
@@ -196,7 +196,7 @@ pub(crate) enum AncestorType {
     JSXElementChildren = 173,
     JSXOpeningElementName = 174,
     JSXOpeningElementAttributes = 175,
-    JSXOpeningElementTypeParameters = 176,
+    JSXOpeningElementTypeArguments = 176,
     JSXClosingElementName = 177,
     JSXFragmentOpeningFragment = 178,
     JSXFragmentClosingFragment = 179,
@@ -234,7 +234,7 @@ pub(crate) enum AncestorType {
     TSOptionalTypeTypeAnnotation = 211,
     TSRestTypeTypeAnnotation = 212,
     TSTypeReferenceTypeName = 213,
-    TSTypeReferenceTypeParameters = 214,
+    TSTypeReferenceTypeArguments = 214,
     TSQualifiedNameLeft = 215,
     TSQualifiedNameRight = 216,
     TSTypeParameterInstantiationParams = 217,
@@ -246,7 +246,7 @@ pub(crate) enum AncestorType {
     TSTypeAliasDeclarationTypeParameters = 223,
     TSTypeAliasDeclarationTypeAnnotation = 224,
     TSClassImplementsExpression = 225,
-    TSClassImplementsTypeParameters = 226,
+    TSClassImplementsTypeArguments = 226,
     TSInterfaceDeclarationId = 227,
     TSInterfaceDeclarationExtends = 228,
     TSInterfaceDeclarationTypeParameters = 229,
@@ -270,7 +270,7 @@ pub(crate) enum AncestorType {
     TSConstructSignatureDeclarationReturnType = 247,
     TSIndexSignatureNameTypeAnnotation = 248,
     TSInterfaceHeritageExpression = 249,
-    TSInterfaceHeritageTypeParameters = 250,
+    TSInterfaceHeritageTypeArguments = 250,
     TSTypePredicateParameterName = 251,
     TSTypePredicateTypeAnnotation = 252,
     TSModuleDeclarationId = 253,
@@ -280,7 +280,7 @@ pub(crate) enum AncestorType {
     TSTypeLiteralMembers = 257,
     TSInferTypeTypeParameter = 258,
     TSTypeQueryExprName = 259,
-    TSTypeQueryTypeParameters = 260,
+    TSTypeQueryTypeArguments = 260,
     TSImportTypeArgument = 261,
     TSImportTypeOptions = 262,
     TSImportTypeQualifier = 263,
@@ -360,8 +360,8 @@ pub enum Ancestor<'a, 't> {
         AncestorType::TaggedTemplateExpressionTag as u16,
     TaggedTemplateExpressionQuasi(TaggedTemplateExpressionWithoutQuasi<'a, 't>) =
         AncestorType::TaggedTemplateExpressionQuasi as u16,
-    TaggedTemplateExpressionTypeParameters(TaggedTemplateExpressionWithoutTypeParameters<'a, 't>) =
-        AncestorType::TaggedTemplateExpressionTypeParameters as u16,
+    TaggedTemplateExpressionTypeArguments(TaggedTemplateExpressionWithoutTypeArguments<'a, 't>) =
+        AncestorType::TaggedTemplateExpressionTypeArguments as u16,
     ComputedMemberExpressionObject(ComputedMemberExpressionWithoutObject<'a, 't>) =
         AncestorType::ComputedMemberExpressionObject as u16,
     ComputedMemberExpressionExpression(ComputedMemberExpressionWithoutExpression<'a, 't>) =
@@ -376,16 +376,16 @@ pub enum Ancestor<'a, 't> {
         AncestorType::PrivateFieldExpressionField as u16,
     CallExpressionCallee(CallExpressionWithoutCallee<'a, 't>) =
         AncestorType::CallExpressionCallee as u16,
-    CallExpressionTypeParameters(CallExpressionWithoutTypeParameters<'a, 't>) =
-        AncestorType::CallExpressionTypeParameters as u16,
+    CallExpressionTypeArguments(CallExpressionWithoutTypeArguments<'a, 't>) =
+        AncestorType::CallExpressionTypeArguments as u16,
     CallExpressionArguments(CallExpressionWithoutArguments<'a, 't>) =
         AncestorType::CallExpressionArguments as u16,
     NewExpressionCallee(NewExpressionWithoutCallee<'a, 't>) =
         AncestorType::NewExpressionCallee as u16,
     NewExpressionArguments(NewExpressionWithoutArguments<'a, 't>) =
         AncestorType::NewExpressionArguments as u16,
-    NewExpressionTypeParameters(NewExpressionWithoutTypeParameters<'a, 't>) =
-        AncestorType::NewExpressionTypeParameters as u16,
+    NewExpressionTypeArguments(NewExpressionWithoutTypeArguments<'a, 't>) =
+        AncestorType::NewExpressionTypeArguments as u16,
     MetaPropertyMeta(MetaPropertyWithoutMeta<'a, 't>) = AncestorType::MetaPropertyMeta as u16,
     MetaPropertyProperty(MetaPropertyWithoutProperty<'a, 't>) =
         AncestorType::MetaPropertyProperty as u16,
@@ -565,8 +565,8 @@ pub enum Ancestor<'a, 't> {
     ClassTypeParameters(ClassWithoutTypeParameters<'a, 't>) =
         AncestorType::ClassTypeParameters as u16,
     ClassSuperClass(ClassWithoutSuperClass<'a, 't>) = AncestorType::ClassSuperClass as u16,
-    ClassSuperTypeParameters(ClassWithoutSuperTypeParameters<'a, 't>) =
-        AncestorType::ClassSuperTypeParameters as u16,
+    ClassSuperTypeArguments(ClassWithoutSuperTypeArguments<'a, 't>) =
+        AncestorType::ClassSuperTypeArguments as u16,
     ClassImplements(ClassWithoutImplements<'a, 't>) = AncestorType::ClassImplements as u16,
     ClassBody(ClassWithoutBody<'a, 't>) = AncestorType::ClassBody as u16,
     ClassBodyBody(ClassBodyWithoutBody<'a, 't>) = AncestorType::ClassBodyBody as u16,
@@ -653,8 +653,8 @@ pub enum Ancestor<'a, 't> {
         AncestorType::JSXOpeningElementName as u16,
     JSXOpeningElementAttributes(JSXOpeningElementWithoutAttributes<'a, 't>) =
         AncestorType::JSXOpeningElementAttributes as u16,
-    JSXOpeningElementTypeParameters(JSXOpeningElementWithoutTypeParameters<'a, 't>) =
-        AncestorType::JSXOpeningElementTypeParameters as u16,
+    JSXOpeningElementTypeArguments(JSXOpeningElementWithoutTypeArguments<'a, 't>) =
+        AncestorType::JSXOpeningElementTypeArguments as u16,
     JSXClosingElementName(JSXClosingElementWithoutName<'a, 't>) =
         AncestorType::JSXClosingElementName as u16,
     JSXFragmentOpeningFragment(JSXFragmentWithoutOpeningFragment<'a, 't>) =
@@ -725,8 +725,8 @@ pub enum Ancestor<'a, 't> {
         AncestorType::TSRestTypeTypeAnnotation as u16,
     TSTypeReferenceTypeName(TSTypeReferenceWithoutTypeName<'a, 't>) =
         AncestorType::TSTypeReferenceTypeName as u16,
-    TSTypeReferenceTypeParameters(TSTypeReferenceWithoutTypeParameters<'a, 't>) =
-        AncestorType::TSTypeReferenceTypeParameters as u16,
+    TSTypeReferenceTypeArguments(TSTypeReferenceWithoutTypeArguments<'a, 't>) =
+        AncestorType::TSTypeReferenceTypeArguments as u16,
     TSQualifiedNameLeft(TSQualifiedNameWithoutLeft<'a, 't>) =
         AncestorType::TSQualifiedNameLeft as u16,
     TSQualifiedNameRight(TSQualifiedNameWithoutRight<'a, 't>) =
@@ -749,8 +749,8 @@ pub enum Ancestor<'a, 't> {
         AncestorType::TSTypeAliasDeclarationTypeAnnotation as u16,
     TSClassImplementsExpression(TSClassImplementsWithoutExpression<'a, 't>) =
         AncestorType::TSClassImplementsExpression as u16,
-    TSClassImplementsTypeParameters(TSClassImplementsWithoutTypeParameters<'a, 't>) =
-        AncestorType::TSClassImplementsTypeParameters as u16,
+    TSClassImplementsTypeArguments(TSClassImplementsWithoutTypeArguments<'a, 't>) =
+        AncestorType::TSClassImplementsTypeArguments as u16,
     TSInterfaceDeclarationId(TSInterfaceDeclarationWithoutId<'a, 't>) =
         AncestorType::TSInterfaceDeclarationId as u16,
     TSInterfaceDeclarationExtends(TSInterfaceDeclarationWithoutExtends<'a, 't>) =
@@ -800,8 +800,8 @@ pub enum Ancestor<'a, 't> {
         AncestorType::TSIndexSignatureNameTypeAnnotation as u16,
     TSInterfaceHeritageExpression(TSInterfaceHeritageWithoutExpression<'a, 't>) =
         AncestorType::TSInterfaceHeritageExpression as u16,
-    TSInterfaceHeritageTypeParameters(TSInterfaceHeritageWithoutTypeParameters<'a, 't>) =
-        AncestorType::TSInterfaceHeritageTypeParameters as u16,
+    TSInterfaceHeritageTypeArguments(TSInterfaceHeritageWithoutTypeArguments<'a, 't>) =
+        AncestorType::TSInterfaceHeritageTypeArguments as u16,
     TSTypePredicateParameterName(TSTypePredicateWithoutParameterName<'a, 't>) =
         AncestorType::TSTypePredicateParameterName as u16,
     TSTypePredicateTypeAnnotation(TSTypePredicateWithoutTypeAnnotation<'a, 't>) =
@@ -819,8 +819,8 @@ pub enum Ancestor<'a, 't> {
         AncestorType::TSInferTypeTypeParameter as u16,
     TSTypeQueryExprName(TSTypeQueryWithoutExprName<'a, 't>) =
         AncestorType::TSTypeQueryExprName as u16,
-    TSTypeQueryTypeParameters(TSTypeQueryWithoutTypeParameters<'a, 't>) =
-        AncestorType::TSTypeQueryTypeParameters as u16,
+    TSTypeQueryTypeArguments(TSTypeQueryWithoutTypeArguments<'a, 't>) =
+        AncestorType::TSTypeQueryTypeArguments as u16,
     TSImportTypeArgument(TSImportTypeWithoutArgument<'a, 't>) =
         AncestorType::TSImportTypeArgument as u16,
     TSImportTypeOptions(TSImportTypeWithoutOptions<'a, 't>) =
@@ -930,7 +930,7 @@ impl<'a, 't> Ancestor<'a, 't> {
             self,
             Self::TaggedTemplateExpressionTag(_)
                 | Self::TaggedTemplateExpressionQuasi(_)
-                | Self::TaggedTemplateExpressionTypeParameters(_)
+                | Self::TaggedTemplateExpressionTypeArguments(_)
         )
     }
 
@@ -960,7 +960,7 @@ impl<'a, 't> Ancestor<'a, 't> {
         matches!(
             self,
             Self::CallExpressionCallee(_)
-                | Self::CallExpressionTypeParameters(_)
+                | Self::CallExpressionTypeArguments(_)
                 | Self::CallExpressionArguments(_)
         )
     }
@@ -971,7 +971,7 @@ impl<'a, 't> Ancestor<'a, 't> {
             self,
             Self::NewExpressionCallee(_)
                 | Self::NewExpressionArguments(_)
-                | Self::NewExpressionTypeParameters(_)
+                | Self::NewExpressionTypeArguments(_)
         )
     }
 
@@ -1307,7 +1307,7 @@ impl<'a, 't> Ancestor<'a, 't> {
                 | Self::ClassId(_)
                 | Self::ClassTypeParameters(_)
                 | Self::ClassSuperClass(_)
-                | Self::ClassSuperTypeParameters(_)
+                | Self::ClassSuperTypeArguments(_)
                 | Self::ClassImplements(_)
                 | Self::ClassBody(_)
         )
@@ -1451,7 +1451,7 @@ impl<'a, 't> Ancestor<'a, 't> {
             self,
             Self::JSXOpeningElementName(_)
                 | Self::JSXOpeningElementAttributes(_)
-                | Self::JSXOpeningElementTypeParameters(_)
+                | Self::JSXOpeningElementTypeArguments(_)
         )
     }
 
@@ -1591,7 +1591,7 @@ impl<'a, 't> Ancestor<'a, 't> {
 
     #[inline]
     pub fn is_ts_type_reference(self) -> bool {
-        matches!(self, Self::TSTypeReferenceTypeName(_) | Self::TSTypeReferenceTypeParameters(_))
+        matches!(self, Self::TSTypeReferenceTypeName(_) | Self::TSTypeReferenceTypeArguments(_))
     }
 
     #[inline]
@@ -1633,7 +1633,7 @@ impl<'a, 't> Ancestor<'a, 't> {
     pub fn is_ts_class_implements(self) -> bool {
         matches!(
             self,
-            Self::TSClassImplementsExpression(_) | Self::TSClassImplementsTypeParameters(_)
+            Self::TSClassImplementsExpression(_) | Self::TSClassImplementsTypeArguments(_)
         )
     }
 
@@ -1708,7 +1708,7 @@ impl<'a, 't> Ancestor<'a, 't> {
     pub fn is_ts_interface_heritage(self) -> bool {
         matches!(
             self,
-            Self::TSInterfaceHeritageExpression(_) | Self::TSInterfaceHeritageTypeParameters(_)
+            Self::TSInterfaceHeritageExpression(_) | Self::TSInterfaceHeritageTypeArguments(_)
         )
     }
 
@@ -1742,7 +1742,7 @@ impl<'a, 't> Ancestor<'a, 't> {
 
     #[inline]
     pub fn is_ts_type_query(self) -> bool {
-        matches!(self, Self::TSTypeQueryExprName(_) | Self::TSTypeQueryTypeParameters(_))
+        matches!(self, Self::TSTypeQueryExprName(_) | Self::TSTypeQueryTypeArguments(_))
     }
 
     #[inline]
@@ -2233,7 +2233,7 @@ impl<'a, 't> GetAddress for Ancestor<'a, 't> {
             Self::TemplateLiteralExpressions(a) => a.address(),
             Self::TaggedTemplateExpressionTag(a) => a.address(),
             Self::TaggedTemplateExpressionQuasi(a) => a.address(),
-            Self::TaggedTemplateExpressionTypeParameters(a) => a.address(),
+            Self::TaggedTemplateExpressionTypeArguments(a) => a.address(),
             Self::ComputedMemberExpressionObject(a) => a.address(),
             Self::ComputedMemberExpressionExpression(a) => a.address(),
             Self::StaticMemberExpressionObject(a) => a.address(),
@@ -2241,11 +2241,11 @@ impl<'a, 't> GetAddress for Ancestor<'a, 't> {
             Self::PrivateFieldExpressionObject(a) => a.address(),
             Self::PrivateFieldExpressionField(a) => a.address(),
             Self::CallExpressionCallee(a) => a.address(),
-            Self::CallExpressionTypeParameters(a) => a.address(),
+            Self::CallExpressionTypeArguments(a) => a.address(),
             Self::CallExpressionArguments(a) => a.address(),
             Self::NewExpressionCallee(a) => a.address(),
             Self::NewExpressionArguments(a) => a.address(),
-            Self::NewExpressionTypeParameters(a) => a.address(),
+            Self::NewExpressionTypeArguments(a) => a.address(),
             Self::MetaPropertyMeta(a) => a.address(),
             Self::MetaPropertyProperty(a) => a.address(),
             Self::SpreadElementArgument(a) => a.address(),
@@ -2350,7 +2350,7 @@ impl<'a, 't> GetAddress for Ancestor<'a, 't> {
             Self::ClassId(a) => a.address(),
             Self::ClassTypeParameters(a) => a.address(),
             Self::ClassSuperClass(a) => a.address(),
-            Self::ClassSuperTypeParameters(a) => a.address(),
+            Self::ClassSuperTypeArguments(a) => a.address(),
             Self::ClassImplements(a) => a.address(),
             Self::ClassBody(a) => a.address(),
             Self::ClassBodyBody(a) => a.address(),
@@ -2397,7 +2397,7 @@ impl<'a, 't> GetAddress for Ancestor<'a, 't> {
             Self::JSXElementChildren(a) => a.address(),
             Self::JSXOpeningElementName(a) => a.address(),
             Self::JSXOpeningElementAttributes(a) => a.address(),
-            Self::JSXOpeningElementTypeParameters(a) => a.address(),
+            Self::JSXOpeningElementTypeArguments(a) => a.address(),
             Self::JSXClosingElementName(a) => a.address(),
             Self::JSXFragmentOpeningFragment(a) => a.address(),
             Self::JSXFragmentClosingFragment(a) => a.address(),
@@ -2435,7 +2435,7 @@ impl<'a, 't> GetAddress for Ancestor<'a, 't> {
             Self::TSOptionalTypeTypeAnnotation(a) => a.address(),
             Self::TSRestTypeTypeAnnotation(a) => a.address(),
             Self::TSTypeReferenceTypeName(a) => a.address(),
-            Self::TSTypeReferenceTypeParameters(a) => a.address(),
+            Self::TSTypeReferenceTypeArguments(a) => a.address(),
             Self::TSQualifiedNameLeft(a) => a.address(),
             Self::TSQualifiedNameRight(a) => a.address(),
             Self::TSTypeParameterInstantiationParams(a) => a.address(),
@@ -2447,7 +2447,7 @@ impl<'a, 't> GetAddress for Ancestor<'a, 't> {
             Self::TSTypeAliasDeclarationTypeParameters(a) => a.address(),
             Self::TSTypeAliasDeclarationTypeAnnotation(a) => a.address(),
             Self::TSClassImplementsExpression(a) => a.address(),
-            Self::TSClassImplementsTypeParameters(a) => a.address(),
+            Self::TSClassImplementsTypeArguments(a) => a.address(),
             Self::TSInterfaceDeclarationId(a) => a.address(),
             Self::TSInterfaceDeclarationExtends(a) => a.address(),
             Self::TSInterfaceDeclarationTypeParameters(a) => a.address(),
@@ -2471,7 +2471,7 @@ impl<'a, 't> GetAddress for Ancestor<'a, 't> {
             Self::TSConstructSignatureDeclarationReturnType(a) => a.address(),
             Self::TSIndexSignatureNameTypeAnnotation(a) => a.address(),
             Self::TSInterfaceHeritageExpression(a) => a.address(),
-            Self::TSInterfaceHeritageTypeParameters(a) => a.address(),
+            Self::TSInterfaceHeritageTypeArguments(a) => a.address(),
             Self::TSTypePredicateParameterName(a) => a.address(),
             Self::TSTypePredicateTypeAnnotation(a) => a.address(),
             Self::TSModuleDeclarationId(a) => a.address(),
@@ -2481,7 +2481,7 @@ impl<'a, 't> GetAddress for Ancestor<'a, 't> {
             Self::TSTypeLiteralMembers(a) => a.address(),
             Self::TSInferTypeTypeParameter(a) => a.address(),
             Self::TSTypeQueryExprName(a) => a.address(),
-            Self::TSTypeQueryTypeParameters(a) => a.address(),
+            Self::TSTypeQueryTypeArguments(a) => a.address(),
             Self::TSImportTypeArgument(a) => a.address(),
             Self::TSImportTypeOptions(a) => a.address(),
             Self::TSImportTypeQualifier(a) => a.address(),
@@ -2947,8 +2947,8 @@ pub(crate) const OFFSET_TAGGED_TEMPLATE_EXPRESSION_TAG: usize =
     offset_of!(TaggedTemplateExpression, tag);
 pub(crate) const OFFSET_TAGGED_TEMPLATE_EXPRESSION_QUASI: usize =
     offset_of!(TaggedTemplateExpression, quasi);
-pub(crate) const OFFSET_TAGGED_TEMPLATE_EXPRESSION_TYPE_PARAMETERS: usize =
-    offset_of!(TaggedTemplateExpression, type_parameters);
+pub(crate) const OFFSET_TAGGED_TEMPLATE_EXPRESSION_TYPE_ARGUMENTS: usize =
+    offset_of!(TaggedTemplateExpression, type_arguments);
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -2974,9 +2974,9 @@ impl<'a, 't> TaggedTemplateExpressionWithoutTag<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TAGGED_TEMPLATE_EXPRESSION_TYPE_PARAMETERS)
+            &*((self.0 as *const u8).add(OFFSET_TAGGED_TEMPLATE_EXPRESSION_TYPE_ARGUMENTS)
                 as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
@@ -3013,9 +3013,9 @@ impl<'a, 't> TaggedTemplateExpressionWithoutQuasi<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TAGGED_TEMPLATE_EXPRESSION_TYPE_PARAMETERS)
+            &*((self.0 as *const u8).add(OFFSET_TAGGED_TEMPLATE_EXPRESSION_TYPE_ARGUMENTS)
                 as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
@@ -3030,12 +3030,12 @@ impl<'a, 't> GetAddress for TaggedTemplateExpressionWithoutQuasi<'a, 't> {
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
-pub struct TaggedTemplateExpressionWithoutTypeParameters<'a, 't>(
+pub struct TaggedTemplateExpressionWithoutTypeArguments<'a, 't>(
     pub(crate) *const TaggedTemplateExpression<'a>,
     pub(crate) PhantomData<&'t ()>,
 );
 
-impl<'a, 't> TaggedTemplateExpressionWithoutTypeParameters<'a, 't> {
+impl<'a, 't> TaggedTemplateExpressionWithoutTypeArguments<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe {
@@ -3060,7 +3060,7 @@ impl<'a, 't> TaggedTemplateExpressionWithoutTypeParameters<'a, 't> {
     }
 }
 
-impl<'a, 't> GetAddress for TaggedTemplateExpressionWithoutTypeParameters<'a, 't> {
+impl<'a, 't> GetAddress for TaggedTemplateExpressionWithoutTypeArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)
@@ -3324,8 +3324,8 @@ impl<'a, 't> GetAddress for PrivateFieldExpressionWithoutField<'a, 't> {
 
 pub(crate) const OFFSET_CALL_EXPRESSION_SPAN: usize = offset_of!(CallExpression, span);
 pub(crate) const OFFSET_CALL_EXPRESSION_CALLEE: usize = offset_of!(CallExpression, callee);
-pub(crate) const OFFSET_CALL_EXPRESSION_TYPE_PARAMETERS: usize =
-    offset_of!(CallExpression, type_parameters);
+pub(crate) const OFFSET_CALL_EXPRESSION_TYPE_ARGUMENTS: usize =
+    offset_of!(CallExpression, type_arguments);
 pub(crate) const OFFSET_CALL_EXPRESSION_ARGUMENTS: usize = offset_of!(CallExpression, arguments);
 pub(crate) const OFFSET_CALL_EXPRESSION_OPTIONAL: usize = offset_of!(CallExpression, optional);
 pub(crate) const OFFSET_CALL_EXPRESSION_PURE: usize = offset_of!(CallExpression, pure);
@@ -3344,9 +3344,9 @@ impl<'a, 't> CallExpressionWithoutCallee<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_CALL_EXPRESSION_TYPE_PARAMETERS)
+            &*((self.0 as *const u8).add(OFFSET_CALL_EXPRESSION_TYPE_ARGUMENTS)
                 as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
@@ -3379,12 +3379,12 @@ impl<'a, 't> GetAddress for CallExpressionWithoutCallee<'a, 't> {
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
-pub struct CallExpressionWithoutTypeParameters<'a, 't>(
+pub struct CallExpressionWithoutTypeArguments<'a, 't>(
     pub(crate) *const CallExpression<'a>,
     pub(crate) PhantomData<&'t ()>,
 );
 
-impl<'a, 't> CallExpressionWithoutTypeParameters<'a, 't> {
+impl<'a, 't> CallExpressionWithoutTypeArguments<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_CALL_EXPRESSION_SPAN) as *const Span) }
@@ -3416,7 +3416,7 @@ impl<'a, 't> CallExpressionWithoutTypeParameters<'a, 't> {
     }
 }
 
-impl<'a, 't> GetAddress for CallExpressionWithoutTypeParameters<'a, 't> {
+impl<'a, 't> GetAddress for CallExpressionWithoutTypeArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)
@@ -3444,9 +3444,9 @@ impl<'a, 't> CallExpressionWithoutArguments<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_CALL_EXPRESSION_TYPE_PARAMETERS)
+            &*((self.0 as *const u8).add(OFFSET_CALL_EXPRESSION_TYPE_ARGUMENTS)
                 as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
@@ -3472,8 +3472,8 @@ impl<'a, 't> GetAddress for CallExpressionWithoutArguments<'a, 't> {
 pub(crate) const OFFSET_NEW_EXPRESSION_SPAN: usize = offset_of!(NewExpression, span);
 pub(crate) const OFFSET_NEW_EXPRESSION_CALLEE: usize = offset_of!(NewExpression, callee);
 pub(crate) const OFFSET_NEW_EXPRESSION_ARGUMENTS: usize = offset_of!(NewExpression, arguments);
-pub(crate) const OFFSET_NEW_EXPRESSION_TYPE_PARAMETERS: usize =
-    offset_of!(NewExpression, type_parameters);
+pub(crate) const OFFSET_NEW_EXPRESSION_TYPE_ARGUMENTS: usize =
+    offset_of!(NewExpression, type_arguments);
 pub(crate) const OFFSET_NEW_EXPRESSION_PURE: usize = offset_of!(NewExpression, pure);
 
 #[repr(transparent)]
@@ -3498,9 +3498,9 @@ impl<'a, 't> NewExpressionWithoutCallee<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_NEW_EXPRESSION_TYPE_PARAMETERS)
+            &*((self.0 as *const u8).add(OFFSET_NEW_EXPRESSION_TYPE_ARGUMENTS)
                 as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
@@ -3539,9 +3539,9 @@ impl<'a, 't> NewExpressionWithoutArguments<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_NEW_EXPRESSION_TYPE_PARAMETERS)
+            &*((self.0 as *const u8).add(OFFSET_NEW_EXPRESSION_TYPE_ARGUMENTS)
                 as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
@@ -3561,12 +3561,12 @@ impl<'a, 't> GetAddress for NewExpressionWithoutArguments<'a, 't> {
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
-pub struct NewExpressionWithoutTypeParameters<'a, 't>(
+pub struct NewExpressionWithoutTypeArguments<'a, 't>(
     pub(crate) *const NewExpression<'a>,
     pub(crate) PhantomData<&'t ()>,
 );
 
-impl<'a, 't> NewExpressionWithoutTypeParameters<'a, 't> {
+impl<'a, 't> NewExpressionWithoutTypeArguments<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_NEW_EXPRESSION_SPAN) as *const Span) }
@@ -3593,7 +3593,7 @@ impl<'a, 't> NewExpressionWithoutTypeParameters<'a, 't> {
     }
 }
 
-impl<'a, 't> GetAddress for NewExpressionWithoutTypeParameters<'a, 't> {
+impl<'a, 't> GetAddress for NewExpressionWithoutTypeArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)
@@ -7740,8 +7740,7 @@ pub(crate) const OFFSET_CLASS_DECORATORS: usize = offset_of!(Class, decorators);
 pub(crate) const OFFSET_CLASS_ID: usize = offset_of!(Class, id);
 pub(crate) const OFFSET_CLASS_TYPE_PARAMETERS: usize = offset_of!(Class, type_parameters);
 pub(crate) const OFFSET_CLASS_SUPER_CLASS: usize = offset_of!(Class, super_class);
-pub(crate) const OFFSET_CLASS_SUPER_TYPE_PARAMETERS: usize =
-    offset_of!(Class, super_type_parameters);
+pub(crate) const OFFSET_CLASS_SUPER_TYPE_ARGUMENTS: usize = offset_of!(Class, super_type_arguments);
 pub(crate) const OFFSET_CLASS_IMPLEMENTS: usize = offset_of!(Class, implements);
 pub(crate) const OFFSET_CLASS_BODY: usize = offset_of!(Class, body);
 pub(crate) const OFFSET_CLASS_ABSTRACT: usize = offset_of!(Class, r#abstract);
@@ -7789,9 +7788,9 @@ impl<'a, 't> ClassWithoutDecorators<'a, 't> {
     }
 
     #[inline]
-    pub fn super_type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn super_type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_CLASS_SUPER_TYPE_PARAMETERS)
+            &*((self.0 as *const u8).add(OFFSET_CLASS_SUPER_TYPE_ARGUMENTS)
                 as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
@@ -7872,9 +7871,9 @@ impl<'a, 't> ClassWithoutId<'a, 't> {
     }
 
     #[inline]
-    pub fn super_type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn super_type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_CLASS_SUPER_TYPE_PARAMETERS)
+            &*((self.0 as *const u8).add(OFFSET_CLASS_SUPER_TYPE_ARGUMENTS)
                 as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
@@ -7957,9 +7956,9 @@ impl<'a, 't> ClassWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn super_type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn super_type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_CLASS_SUPER_TYPE_PARAMETERS)
+            &*((self.0 as *const u8).add(OFFSET_CLASS_SUPER_TYPE_ARGUMENTS)
                 as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
@@ -8043,9 +8042,9 @@ impl<'a, 't> ClassWithoutSuperClass<'a, 't> {
     }
 
     #[inline]
-    pub fn super_type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn super_type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_CLASS_SUPER_TYPE_PARAMETERS)
+            &*((self.0 as *const u8).add(OFFSET_CLASS_SUPER_TYPE_ARGUMENTS)
                 as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
@@ -8090,12 +8089,12 @@ impl<'a, 't> GetAddress for ClassWithoutSuperClass<'a, 't> {
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
-pub struct ClassWithoutSuperTypeParameters<'a, 't>(
+pub struct ClassWithoutSuperTypeArguments<'a, 't>(
     pub(crate) *const Class<'a>,
     pub(crate) PhantomData<&'t ()>,
 );
 
-impl<'a, 't> ClassWithoutSuperTypeParameters<'a, 't> {
+impl<'a, 't> ClassWithoutSuperTypeArguments<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_CLASS_SPAN) as *const Span) }
@@ -8166,7 +8165,7 @@ impl<'a, 't> ClassWithoutSuperTypeParameters<'a, 't> {
     }
 }
 
-impl<'a, 't> GetAddress for ClassWithoutSuperTypeParameters<'a, 't> {
+impl<'a, 't> GetAddress for ClassWithoutSuperTypeArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)
@@ -8221,9 +8220,9 @@ impl<'a, 't> ClassWithoutImplements<'a, 't> {
     }
 
     #[inline]
-    pub fn super_type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn super_type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_CLASS_SUPER_TYPE_PARAMETERS)
+            &*((self.0 as *const u8).add(OFFSET_CLASS_SUPER_TYPE_ARGUMENTS)
                 as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
@@ -8303,9 +8302,9 @@ impl<'a, 't> ClassWithoutBody<'a, 't> {
     }
 
     #[inline]
-    pub fn super_type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn super_type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_CLASS_SUPER_TYPE_PARAMETERS)
+            &*((self.0 as *const u8).add(OFFSET_CLASS_SUPER_TYPE_ARGUMENTS)
                 as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
@@ -10600,8 +10599,8 @@ pub(crate) const OFFSET_JSX_OPENING_ELEMENT_SELF_CLOSING: usize =
 pub(crate) const OFFSET_JSX_OPENING_ELEMENT_NAME: usize = offset_of!(JSXOpeningElement, name);
 pub(crate) const OFFSET_JSX_OPENING_ELEMENT_ATTRIBUTES: usize =
     offset_of!(JSXOpeningElement, attributes);
-pub(crate) const OFFSET_JSX_OPENING_ELEMENT_TYPE_PARAMETERS: usize =
-    offset_of!(JSXOpeningElement, type_parameters);
+pub(crate) const OFFSET_JSX_OPENING_ELEMENT_TYPE_ARGUMENTS: usize =
+    offset_of!(JSXOpeningElement, type_arguments);
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -10632,9 +10631,9 @@ impl<'a, 't> JSXOpeningElementWithoutName<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_TYPE_PARAMETERS)
+            &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_TYPE_ARGUMENTS)
                 as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
@@ -10676,9 +10675,9 @@ impl<'a, 't> JSXOpeningElementWithoutAttributes<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_TYPE_PARAMETERS)
+            &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_TYPE_ARGUMENTS)
                 as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
@@ -10693,12 +10692,12 @@ impl<'a, 't> GetAddress for JSXOpeningElementWithoutAttributes<'a, 't> {
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
-pub struct JSXOpeningElementWithoutTypeParameters<'a, 't>(
+pub struct JSXOpeningElementWithoutTypeArguments<'a, 't>(
     pub(crate) *const JSXOpeningElement<'a>,
     pub(crate) PhantomData<&'t ()>,
 );
 
-impl<'a, 't> JSXOpeningElementWithoutTypeParameters<'a, 't> {
+impl<'a, 't> JSXOpeningElementWithoutTypeArguments<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_SPAN) as *const Span) }
@@ -10728,7 +10727,7 @@ impl<'a, 't> JSXOpeningElementWithoutTypeParameters<'a, 't> {
     }
 }
 
-impl<'a, 't> GetAddress for JSXOpeningElementWithoutTypeParameters<'a, 't> {
+impl<'a, 't> GetAddress for JSXOpeningElementWithoutTypeArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)
@@ -11956,8 +11955,8 @@ impl<'a, 't> GetAddress for TSRestTypeWithoutTypeAnnotation<'a, 't> {
 
 pub(crate) const OFFSET_TS_TYPE_REFERENCE_SPAN: usize = offset_of!(TSTypeReference, span);
 pub(crate) const OFFSET_TS_TYPE_REFERENCE_TYPE_NAME: usize = offset_of!(TSTypeReference, type_name);
-pub(crate) const OFFSET_TS_TYPE_REFERENCE_TYPE_PARAMETERS: usize =
-    offset_of!(TSTypeReference, type_parameters);
+pub(crate) const OFFSET_TS_TYPE_REFERENCE_TYPE_ARGUMENTS: usize =
+    offset_of!(TSTypeReference, type_arguments);
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -11973,9 +11972,9 @@ impl<'a, 't> TSTypeReferenceWithoutTypeName<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_TYPE_REFERENCE_TYPE_PARAMETERS)
+            &*((self.0 as *const u8).add(OFFSET_TS_TYPE_REFERENCE_TYPE_ARGUMENTS)
                 as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
@@ -11990,12 +11989,12 @@ impl<'a, 't> GetAddress for TSTypeReferenceWithoutTypeName<'a, 't> {
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
-pub struct TSTypeReferenceWithoutTypeParameters<'a, 't>(
+pub struct TSTypeReferenceWithoutTypeArguments<'a, 't>(
     pub(crate) *const TSTypeReference<'a>,
     pub(crate) PhantomData<&'t ()>,
 );
 
-impl<'a, 't> TSTypeReferenceWithoutTypeParameters<'a, 't> {
+impl<'a, 't> TSTypeReferenceWithoutTypeArguments<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_TS_TYPE_REFERENCE_SPAN) as *const Span) }
@@ -12010,7 +12009,7 @@ impl<'a, 't> TSTypeReferenceWithoutTypeParameters<'a, 't> {
     }
 }
 
-impl<'a, 't> GetAddress for TSTypeReferenceWithoutTypeParameters<'a, 't> {
+impl<'a, 't> GetAddress for TSTypeReferenceWithoutTypeArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)
@@ -12478,8 +12477,8 @@ impl<'a, 't> GetAddress for TSTypeAliasDeclarationWithoutTypeAnnotation<'a, 't> 
 pub(crate) const OFFSET_TS_CLASS_IMPLEMENTS_SPAN: usize = offset_of!(TSClassImplements, span);
 pub(crate) const OFFSET_TS_CLASS_IMPLEMENTS_EXPRESSION: usize =
     offset_of!(TSClassImplements, expression);
-pub(crate) const OFFSET_TS_CLASS_IMPLEMENTS_TYPE_PARAMETERS: usize =
-    offset_of!(TSClassImplements, type_parameters);
+pub(crate) const OFFSET_TS_CLASS_IMPLEMENTS_TYPE_ARGUMENTS: usize =
+    offset_of!(TSClassImplements, type_arguments);
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -12495,9 +12494,9 @@ impl<'a, 't> TSClassImplementsWithoutExpression<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_CLASS_IMPLEMENTS_TYPE_PARAMETERS)
+            &*((self.0 as *const u8).add(OFFSET_TS_CLASS_IMPLEMENTS_TYPE_ARGUMENTS)
                 as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
@@ -12512,12 +12511,12 @@ impl<'a, 't> GetAddress for TSClassImplementsWithoutExpression<'a, 't> {
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
-pub struct TSClassImplementsWithoutTypeParameters<'a, 't>(
+pub struct TSClassImplementsWithoutTypeArguments<'a, 't>(
     pub(crate) *const TSClassImplements<'a>,
     pub(crate) PhantomData<&'t ()>,
 );
 
-impl<'a, 't> TSClassImplementsWithoutTypeParameters<'a, 't> {
+impl<'a, 't> TSClassImplementsWithoutTypeArguments<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_TS_CLASS_IMPLEMENTS_SPAN) as *const Span) }
@@ -12532,7 +12531,7 @@ impl<'a, 't> TSClassImplementsWithoutTypeParameters<'a, 't> {
     }
 }
 
-impl<'a, 't> GetAddress for TSClassImplementsWithoutTypeParameters<'a, 't> {
+impl<'a, 't> GetAddress for TSClassImplementsWithoutTypeArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)
@@ -13822,8 +13821,8 @@ impl<'a, 't> GetAddress for TSIndexSignatureNameWithoutTypeAnnotation<'a, 't> {
 pub(crate) const OFFSET_TS_INTERFACE_HERITAGE_SPAN: usize = offset_of!(TSInterfaceHeritage, span);
 pub(crate) const OFFSET_TS_INTERFACE_HERITAGE_EXPRESSION: usize =
     offset_of!(TSInterfaceHeritage, expression);
-pub(crate) const OFFSET_TS_INTERFACE_HERITAGE_TYPE_PARAMETERS: usize =
-    offset_of!(TSInterfaceHeritage, type_parameters);
+pub(crate) const OFFSET_TS_INTERFACE_HERITAGE_TYPE_ARGUMENTS: usize =
+    offset_of!(TSInterfaceHeritage, type_arguments);
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -13839,9 +13838,9 @@ impl<'a, 't> TSInterfaceHeritageWithoutExpression<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_HERITAGE_TYPE_PARAMETERS)
+            &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_HERITAGE_TYPE_ARGUMENTS)
                 as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
@@ -13856,12 +13855,12 @@ impl<'a, 't> GetAddress for TSInterfaceHeritageWithoutExpression<'a, 't> {
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
-pub struct TSInterfaceHeritageWithoutTypeParameters<'a, 't>(
+pub struct TSInterfaceHeritageWithoutTypeArguments<'a, 't>(
     pub(crate) *const TSInterfaceHeritage<'a>,
     pub(crate) PhantomData<&'t ()>,
 );
 
-impl<'a, 't> TSInterfaceHeritageWithoutTypeParameters<'a, 't> {
+impl<'a, 't> TSInterfaceHeritageWithoutTypeArguments<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_HERITAGE_SPAN) as *const Span) }
@@ -13876,7 +13875,7 @@ impl<'a, 't> TSInterfaceHeritageWithoutTypeParameters<'a, 't> {
     }
 }
 
-impl<'a, 't> GetAddress for TSInterfaceHeritageWithoutTypeParameters<'a, 't> {
+impl<'a, 't> GetAddress for TSInterfaceHeritageWithoutTypeArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)
@@ -14184,8 +14183,8 @@ impl<'a, 't> GetAddress for TSInferTypeWithoutTypeParameter<'a, 't> {
 
 pub(crate) const OFFSET_TS_TYPE_QUERY_SPAN: usize = offset_of!(TSTypeQuery, span);
 pub(crate) const OFFSET_TS_TYPE_QUERY_EXPR_NAME: usize = offset_of!(TSTypeQuery, expr_name);
-pub(crate) const OFFSET_TS_TYPE_QUERY_TYPE_PARAMETERS: usize =
-    offset_of!(TSTypeQuery, type_parameters);
+pub(crate) const OFFSET_TS_TYPE_QUERY_TYPE_ARGUMENTS: usize =
+    offset_of!(TSTypeQuery, type_arguments);
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -14201,9 +14200,9 @@ impl<'a, 't> TSTypeQueryWithoutExprName<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
+    pub fn type_arguments(self) -> &'t Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_TYPE_QUERY_TYPE_PARAMETERS)
+            &*((self.0 as *const u8).add(OFFSET_TS_TYPE_QUERY_TYPE_ARGUMENTS)
                 as *const Option<Box<'a, TSTypeParameterInstantiation<'a>>>)
         }
     }
@@ -14218,12 +14217,12 @@ impl<'a, 't> GetAddress for TSTypeQueryWithoutExprName<'a, 't> {
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
-pub struct TSTypeQueryWithoutTypeParameters<'a, 't>(
+pub struct TSTypeQueryWithoutTypeArguments<'a, 't>(
     pub(crate) *const TSTypeQuery<'a>,
     pub(crate) PhantomData<&'t ()>,
 );
 
-impl<'a, 't> TSTypeQueryWithoutTypeParameters<'a, 't> {
+impl<'a, 't> TSTypeQueryWithoutTypeArguments<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_TS_TYPE_QUERY_SPAN) as *const Span) }
@@ -14238,7 +14237,7 @@ impl<'a, 't> TSTypeQueryWithoutTypeParameters<'a, 't> {
     }
 }
 
-impl<'a, 't> GetAddress for TSTypeQueryWithoutTypeParameters<'a, 't> {
+impl<'a, 't> GetAddress for TSTypeQueryWithoutTypeArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -502,10 +502,10 @@ unsafe fn walk_tagged_template_expression<'a, Tr: Traverse<'a>>(
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8)
-        .add(ancestor::OFFSET_TAGGED_TEMPLATE_EXPRESSION_TYPE_PARAMETERS)
+        .add(ancestor::OFFSET_TAGGED_TEMPLATE_EXPRESSION_TYPE_ARGUMENTS)
         as *mut Option<Box<TSTypeParameterInstantiation>>)
     {
-        ctx.retag_stack(AncestorType::TaggedTemplateExpressionTypeParameters);
+        ctx.retag_stack(AncestorType::TaggedTemplateExpressionTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
@@ -632,10 +632,10 @@ unsafe fn walk_call_expression<'a, Tr: Traverse<'a>>(
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8)
-        .add(ancestor::OFFSET_CALL_EXPRESSION_TYPE_PARAMETERS)
+        .add(ancestor::OFFSET_CALL_EXPRESSION_TYPE_ARGUMENTS)
         as *mut Option<Box<TSTypeParameterInstantiation>>)
     {
-        ctx.retag_stack(AncestorType::CallExpressionTypeParameters);
+        ctx.retag_stack(AncestorType::CallExpressionTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::CallExpressionArguments);
@@ -669,10 +669,10 @@ unsafe fn walk_new_expression<'a, Tr: Traverse<'a>>(
         walk_argument(traverser, item as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8)
-        .add(ancestor::OFFSET_NEW_EXPRESSION_TYPE_PARAMETERS)
+        .add(ancestor::OFFSET_NEW_EXPRESSION_TYPE_ARGUMENTS)
         as *mut Option<Box<TSTypeParameterInstantiation>>)
     {
-        ctx.retag_stack(AncestorType::NewExpressionTypeParameters);
+        ctx.retag_stack(AncestorType::NewExpressionTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
@@ -2502,10 +2502,10 @@ unsafe fn walk_class<'a, Tr: Traverse<'a>>(
         ctx.retag_stack(AncestorType::ClassSuperClass);
         walk_expression(traverser, field as *mut _, ctx);
     }
-    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_SUPER_TYPE_PARAMETERS)
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_SUPER_TYPE_ARGUMENTS)
         as *mut Option<Box<TSTypeParameterInstantiation>>)
     {
-        ctx.retag_stack(AncestorType::ClassSuperTypeParameters);
+        ctx.retag_stack(AncestorType::ClassSuperTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_CLASS_IMPLEMENTS)
@@ -3232,10 +3232,10 @@ unsafe fn walk_jsx_opening_element<'a, Tr: Traverse<'a>>(
         walk_jsx_attribute_item(traverser, item as *mut _, ctx);
     }
     if let Some(field) = &mut *((node as *mut u8)
-        .add(ancestor::OFFSET_JSX_OPENING_ELEMENT_TYPE_PARAMETERS)
+        .add(ancestor::OFFSET_JSX_OPENING_ELEMENT_TYPE_ARGUMENTS)
         as *mut Option<Box<TSTypeParameterInstantiation>>)
     {
-        ctx.retag_stack(AncestorType::JSXOpeningElementTypeParameters);
+        ctx.retag_stack(AncestorType::JSXOpeningElementTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
@@ -4393,10 +4393,10 @@ unsafe fn walk_ts_type_reference<'a, Tr: Traverse<'a>>(
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8)
-        .add(ancestor::OFFSET_TS_TYPE_REFERENCE_TYPE_PARAMETERS)
+        .add(ancestor::OFFSET_TS_TYPE_REFERENCE_TYPE_ARGUMENTS)
         as *mut Option<Box<TSTypeParameterInstantiation>>)
     {
-        ctx.retag_stack(AncestorType::TSTypeReferenceTypeParameters);
+        ctx.retag_stack(AncestorType::TSTypeReferenceTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
@@ -4567,10 +4567,10 @@ unsafe fn walk_ts_class_implements<'a, Tr: Traverse<'a>>(
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8)
-        .add(ancestor::OFFSET_TS_CLASS_IMPLEMENTS_TYPE_PARAMETERS)
+        .add(ancestor::OFFSET_TS_CLASS_IMPLEMENTS_TYPE_ARGUMENTS)
         as *mut Option<Box<TSTypeParameterInstantiation>>)
     {
-        ctx.retag_stack(AncestorType::TSClassImplementsTypeParameters);
+        ctx.retag_stack(AncestorType::TSClassImplementsTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
@@ -4889,10 +4889,10 @@ unsafe fn walk_ts_interface_heritage<'a, Tr: Traverse<'a>>(
         ctx,
     );
     if let Some(field) = &mut *((node as *mut u8)
-        .add(ancestor::OFFSET_TS_INTERFACE_HERITAGE_TYPE_PARAMETERS)
+        .add(ancestor::OFFSET_TS_INTERFACE_HERITAGE_TYPE_ARGUMENTS)
         as *mut Option<Box<TSTypeParameterInstantiation>>)
     {
-        ctx.retag_stack(AncestorType::TSInterfaceHeritageTypeParameters);
+        ctx.retag_stack(AncestorType::TSInterfaceHeritageTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);
@@ -5088,11 +5088,10 @@ unsafe fn walk_ts_type_query<'a, Tr: Traverse<'a>>(
         (node as *mut u8).add(ancestor::OFFSET_TS_TYPE_QUERY_EXPR_NAME) as *mut TSTypeQueryExprName,
         ctx,
     );
-    if let Some(field) = &mut *((node as *mut u8)
-        .add(ancestor::OFFSET_TS_TYPE_QUERY_TYPE_PARAMETERS)
+    if let Some(field) = &mut *((node as *mut u8).add(ancestor::OFFSET_TS_TYPE_QUERY_TYPE_ARGUMENTS)
         as *mut Option<Box<TSTypeParameterInstantiation>>)
     {
-        ctx.retag_stack(AncestorType::TSTypeQueryTypeParameters);
+        ctx.retag_stack(AncestorType::TSTypeQueryTypeArguments);
         walk_ts_type_parameter_instantiation(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.pop_stack(pop_token);

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -1533,7 +1533,7 @@ function deserializeTSTypeReference(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     typeName: deserializeTSTypeName(pos + 8),
-    typeParameters: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
+    typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
   };
 }
 
@@ -1597,7 +1597,7 @@ function deserializeTSClassImplements(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     expression: deserializeTSTypeName(pos + 8),
-    typeParameters: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
+    typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
   };
 }
 
@@ -1703,7 +1703,7 @@ function deserializeTSInterfaceHeritage(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     expression: deserializeExpression(pos + 8),
-    typeParameters: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
+    typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
   };
 }
 
@@ -1765,7 +1765,7 @@ function deserializeTSTypeQuery(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     exprName: deserializeTSTypeQueryExprName(pos + 8),
-    typeParameters: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
+    typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
   };
 }
 

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -144,7 +144,7 @@ function deserializeTaggedTemplateExpression(pos) {
     end: deserializeU32(pos + 4),
     tag: deserializeExpression(pos + 8),
     quasi: deserializeTemplateLiteral(pos + 24),
-    typeParameters: deserializeOptionBoxTSTypeParameterInstantiation(pos + 96),
+    typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 96),
   };
 }
 
@@ -209,7 +209,7 @@ function deserializeCallExpression(pos) {
     callee: deserializeExpression(pos + 8),
     arguments: deserializeVecArgument(pos + 32),
     optional: deserializeBool(pos + 64),
-    typeParameters: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
+    typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
   };
 }
 
@@ -220,7 +220,7 @@ function deserializeNewExpression(pos) {
     end: deserializeU32(pos + 4),
     callee: deserializeExpression(pos + 8),
     arguments: deserializeVecArgument(pos + 24),
-    typeParameters: deserializeOptionBoxTSTypeParameterInstantiation(pos + 56),
+    typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 56),
   };
 }
 
@@ -853,7 +853,7 @@ function deserializeClass(pos) {
     body: deserializeBoxClassBody(pos + 144),
     decorators: deserializeVecDecorator(pos + 16),
     typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 80),
-    superTypeParameters: deserializeOptionBoxTSTypeParameterInstantiation(pos + 104),
+    superTypeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 104),
     implements: deserializeOptionVecTSClassImplements(pos + 112),
     abstract: deserializeBool(pos + 152),
     declare: deserializeBool(pos + 153),
@@ -1187,7 +1187,7 @@ function deserializeJSXOpeningElement(pos) {
     attributes: deserializeVecJSXAttributeItem(pos + 32),
     name: deserializeJSXElementName(pos + 16),
     selfClosing: deserializeBool(pos + 8),
-    typeParameters: deserializeOptionBoxTSTypeParameterInstantiation(pos + 64),
+    typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 64),
   };
 }
 
@@ -1586,7 +1586,7 @@ function deserializeTSTypeReference(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     typeName: deserializeTSTypeName(pos + 8),
-    typeParameters: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
+    typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
   };
 }
 
@@ -1650,7 +1650,7 @@ function deserializeTSClassImplements(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     expression: deserializeTSTypeName(pos + 8),
-    typeParameters: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
+    typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
   };
 }
 
@@ -1756,7 +1756,7 @@ function deserializeTSInterfaceHeritage(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     expression: deserializeExpression(pos + 8),
-    typeParameters: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
+    typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
   };
 }
 
@@ -1818,7 +1818,7 @@ function deserializeTSTypeQuery(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     exprName: deserializeTSTypeQueryExprName(pos + 8),
-    typeParameters: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
+    typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 24),
   };
 }
 

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -113,7 +113,7 @@ export interface TaggedTemplateExpression extends Span {
   type: 'TaggedTemplateExpression';
   tag: Expression;
   quasi: TemplateLiteral;
-  typeParameters: TSTypeParameterInstantiation | null;
+  typeArguments: TSTypeParameterInstantiation | null;
 }
 
 export interface TemplateElement extends Span {
@@ -158,14 +158,14 @@ export interface CallExpression extends Span {
   callee: Expression;
   arguments: Array<Argument>;
   optional: boolean;
-  typeParameters: TSTypeParameterInstantiation | null;
+  typeArguments: TSTypeParameterInstantiation | null;
 }
 
 export interface NewExpression extends Span {
   type: 'NewExpression';
   callee: Expression;
   arguments: Array<Argument>;
-  typeParameters: TSTypeParameterInstantiation | null;
+  typeArguments: TSTypeParameterInstantiation | null;
 }
 
 export interface MetaProperty extends Span {
@@ -601,7 +601,7 @@ export interface Class extends Span {
   body: ClassBody;
   decorators: Array<Decorator>;
   typeParameters: TSTypeParameterDeclaration | null;
-  superTypeParameters: TSTypeParameterInstantiation | null;
+  superTypeArguments: TSTypeParameterInstantiation | null;
   implements: Array<TSClassImplements> | null;
   abstract: boolean;
   declare: boolean;
@@ -820,7 +820,7 @@ export interface JSXOpeningElement extends Span {
   attributes: Array<JSXAttributeItem>;
   name: JSXElementName;
   selfClosing: boolean;
-  typeParameters: TSTypeParameterInstantiation | null;
+  typeArguments: TSTypeParameterInstantiation | null;
 }
 
 export interface JSXClosingElement extends Span {
@@ -1110,7 +1110,7 @@ export interface TSBigIntKeyword extends Span {
 export interface TSTypeReference extends Span {
   type: 'TSTypeReference';
   typeName: TSTypeName;
-  typeParameters: TSTypeParameterInstantiation | null;
+  typeArguments: TSTypeParameterInstantiation | null;
 }
 
 export type TSTypeName = IdentifierReference | TSQualifiedName;
@@ -1154,7 +1154,7 @@ export type TSAccessibility = 'private' | 'protected' | 'public';
 export interface TSClassImplements extends Span {
   type: 'TSClassImplements';
   expression: TSTypeName;
-  typeParameters: TSTypeParameterInstantiation | null;
+  typeArguments: TSTypeParameterInstantiation | null;
 }
 
 export interface TSInterfaceDeclaration extends Span {
@@ -1233,7 +1233,7 @@ export interface TSIndexSignatureName extends Span {
 export interface TSInterfaceHeritage extends Span {
   type: 'TSInterfaceHeritage';
   expression: Expression;
-  typeParameters: TSTypeParameterInstantiation | null;
+  typeArguments: TSTypeParameterInstantiation | null;
 }
 
 export interface TSTypePredicate extends Span {
@@ -1277,7 +1277,7 @@ export interface TSInferType extends Span {
 export interface TSTypeQuery extends Span {
   type: 'TSTypeQuery';
   exprName: TSTypeQueryExprName;
-  typeParameters: TSTypeParameterInstantiation | null;
+  typeArguments: TSTypeParameterInstantiation | null;
 }
 
 export type TSTypeQueryExprName = TSImportType | TSTypeName;


### PR DESCRIPTION
Aligning with https://github.com/typescript-eslint/typescript-eslint/pull/5384