### PR TITLE
fix(ast/extree): fix `Class.implements`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1899,6 +1899,7 @@ pub struct Class<'a> {
     /// //                   ^^^
     /// ```
     #[ts]
+    #[estree(via = ClassImplements)]
     pub implements: Option<Vec<'a, TSClassImplements<'a>>>,
     pub body: Box<'a, ClassBody<'a>>,
     /// Whether the class is abstract

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1450,7 +1450,7 @@ impl ESTree for Class<'_> {
         state.serialize_ts_field("decorators", &self.decorators);
         state.serialize_ts_field("typeParameters", &self.type_parameters);
         state.serialize_ts_field("superTypeArguments", &self.super_type_arguments);
-        state.serialize_ts_field("implements", &self.implements);
+        state.serialize_ts_field("implements", &crate::serialize::ClassImplements(self));
         state.serialize_ts_field("abstract", &self.r#abstract);
         state.serialize_ts_field("declare", &self.declare);
         state.end();

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -505,6 +505,26 @@ impl ESTree for ExportAllDeclarationWithClause<'_, '_> {
     }
 }
 
+#[ast_meta]
+#[estree(
+    ts_type = "Array<TSClassImplements>",
+    raw_deser = "
+        const classImplements = DESER[Option<Vec<TSClassImplements>>](POS_OFFSET.implements);
+        classImplements === null ? [] : classImplements
+    "
+)]
+pub struct ClassImplements<'a, 'b>(pub &'b Class<'a>);
+
+impl ESTree for ClassImplements<'_, '_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        if let Some(implements) = &self.0.implements {
+            implements.serialize(serializer);
+        } else {
+            [(); 0].serialize(serializer);
+        }
+    }
+}
+
 // --------------------
 // JSX
 // --------------------

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -844,6 +844,7 @@ function deserializeYieldExpression(pos) {
 }
 
 function deserializeClass(pos) {
+  const classImplements = deserializeOptionVecTSClassImplements(pos + 112);
   return {
     type: deserializeClassType(pos + 8),
     start: deserializeU32(pos),
@@ -854,7 +855,7 @@ function deserializeClass(pos) {
     decorators: deserializeVecDecorator(pos + 16),
     typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 80),
     superTypeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 104),
-    implements: deserializeOptionVecTSClassImplements(pos + 112),
+    implements: classImplements === null ? [] : classImplements,
     abstract: deserializeBool(pos + 152),
     declare: deserializeBool(pos + 153),
   };

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -602,7 +602,7 @@ export interface Class extends Span {
   decorators: Array<Decorator>;
   typeParameters: TSTypeParameterDeclaration | null;
   superTypeArguments: TSTypeParameterInstantiation | null;
-  implements: Array<TSClassImplements> | null;
+  implements: Array<TSClassImplements>;
   abstract: boolean;
   declare: boolean;
 }


### PR DESCRIPTION
spec: https://github.com/typescript-eslint/typescript-eslint/blob/3efd99e954d1749225d65b774cfb3650a54ff083/packages/ast-spec/src/base/ClassBase.ts#L50

No effect on conformance yet since basic `Identifier` mismatches.