### PR TITLE
refactor(ast_tools): pass `Codegen` to `prepare` methods

### DIFF
--- a/tasks/ast_tools/src/codegen.rs
+++ b/tasks/ast_tools/src/codegen.rs
@@ -112,10 +112,10 @@ pub enum GeneratorOrDerive {
 
 impl GeneratorOrDerive {
     /// Execute `prepare` method on the [`Generator`] or [`Derive`].
-    pub fn prepare(self, schema: &mut Schema) {
+    pub fn prepare(self, schema: &mut Schema, codegen: &Codegen) {
         match self {
-            Self::Generator(generator) => generator.prepare(schema),
-            Self::Derive(derive) => derive.prepare(schema),
+            Self::Generator(generator) => generator.prepare(schema, codegen),
+            Self::Derive(derive) => derive.prepare(schema, codegen),
         }
     }
 

--- a/tasks/ast_tools/src/derives/mod.rs
+++ b/tasks/ast_tools/src/derives/mod.rs
@@ -132,7 +132,7 @@ pub trait Derive: Runner {
     ///
     /// Runs before any `generate` or `derive` method runs.
     #[expect(unused_variables)]
-    fn prepare(&self, schema: &mut Schema) {}
+    fn prepare(&self, schema: &mut Schema, codegen: &Codegen) {}
 
     /// Generate trait implementation for a type.
     fn derive(&self, type_def: StructOrEnum<'_>, schema: &Schema) -> TokenStream;

--- a/tasks/ast_tools/src/generators/assert_layouts.rs
+++ b/tasks/ast_tools/src/generators/assert_layouts.rs
@@ -34,7 +34,7 @@ define_generator!(AssertLayouts);
 
 impl Generator for AssertLayouts {
     /// Calculate layouts of all types.
-    fn prepare(&self, schema: &mut Schema) {
+    fn prepare(&self, schema: &mut Schema, _codegen: &Codegen) {
         for type_id in schema.types.indices() {
             calculate_layout(type_id, schema);
         }

--- a/tasks/ast_tools/src/generators/ast_kind.rs
+++ b/tasks/ast_tools/src/generators/ast_kind.rs
@@ -96,7 +96,7 @@ define_generator!(AstKindGenerator);
 
 impl Generator for AstKindGenerator {
     /// Set `has_kind` for structs and enums which are visited, and not on blacklist.
-    fn prepare(&self, schema: &mut Schema) {
+    fn prepare(&self, schema: &mut Schema, _codegen: &Codegen) {
         // Set `has_kind` to `true` for all visited types
         for type_def in &mut schema.types {
             match type_def {

--- a/tasks/ast_tools/src/generators/mod.rs
+++ b/tasks/ast_tools/src/generators/mod.rs
@@ -99,7 +99,7 @@ pub trait Generator: Runner {
     ///
     /// Runs before any `generate` or `derive` method runs.
     #[expect(unused_variables)]
-    fn prepare(&self, schema: &mut Schema) {}
+    fn prepare(&self, schema: &mut Schema, codegen: &Codegen) {}
 
     /// Generate single output.
     #[expect(unused_variables, clippy::unimplemented)]

--- a/tasks/ast_tools/src/generators/visit.rs
+++ b/tasks/ast_tools/src/generators/visit.rs
@@ -45,7 +45,7 @@ impl Generator for VisitGenerator {
 
     /// Create names for `visit_*` methods and `walk_*` functions for all `Vec`s
     /// whose inner type has a visitor.
-    fn prepare(&self, schema: &mut Schema) {
+    fn prepare(&self, schema: &mut Schema, _codegen: &Codegen) {
         for type_id in schema.types.indices() {
             let Some(vec_def) = schema.types[type_id].as_vec() else { continue };
 

--- a/tasks/ast_tools/src/main.rs
+++ b/tasks/ast_tools/src/main.rs
@@ -300,7 +300,7 @@ fn main() {
     // Run `prepare` actions
     let runners = get_runners();
     for runner in &runners {
-        runner.prepare(&mut schema);
+        runner.prepare(&mut schema, &codegen);
     }
 
     // Run generators


### PR DESCRIPTION
Pure refactor. In `oxc_ast_tools`, pass `&Codegen` to `prepare` method of `Derive`s and `Generator`s. This is preparation for changes to come to `ESTree` generator.