### PR TITLE
refactor(ast)!: reorder fields of `TemplateElement`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -446,11 +446,10 @@ pub struct TaggedTemplateExpression<'a> {
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(field_order(span, value, tail))]
 pub struct TemplateElement<'a> {
     pub span: Span,
-    pub tail: bool,
     pub value: TemplateElementValue<'a>,
+    pub tail: bool,
 }
 
 /// See [template-strings-cooked-vs-raw](https://exploringjs.com/js/book/ch_template-literals.html#template-strings-cooked-vs-raw)

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -103,8 +103,8 @@ const _: () = {
     assert!(size_of::<TemplateElement>() == 48);
     assert!(align_of::<TemplateElement>() == 8);
     assert!(offset_of!(TemplateElement, span) == 0);
-    assert!(offset_of!(TemplateElement, tail) == 8);
-    assert!(offset_of!(TemplateElement, value) == 16);
+    assert!(offset_of!(TemplateElement, value) == 8);
+    assert!(offset_of!(TemplateElement, tail) == 40);
 
     assert!(size_of::<TemplateElementValue>() == 32);
     assert!(align_of::<TemplateElementValue>() == 8);
@@ -1508,8 +1508,8 @@ const _: () = {
     assert!(size_of::<TemplateElement>() == 28);
     assert!(align_of::<TemplateElement>() == 4);
     assert!(offset_of!(TemplateElement, span) == 0);
-    assert!(offset_of!(TemplateElement, tail) == 8);
-    assert!(offset_of!(TemplateElement, value) == 12);
+    assert!(offset_of!(TemplateElement, value) == 8);
+    assert!(offset_of!(TemplateElement, tail) == 24);
 
     assert!(size_of::<TemplateElementValue>() == 16);
     assert!(align_of::<TemplateElementValue>() == 4);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -1863,16 +1863,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `tail`
     /// * `value`
+    /// * `tail`
     #[inline]
     pub fn template_element(
         self,
         span: Span,
-        tail: bool,
         value: TemplateElementValue<'a>,
+        tail: bool,
     ) -> TemplateElement<'a> {
-        TemplateElement { span, tail, value }
+        TemplateElement { span, value, tail }
     }
 
     /// Build a [`TemplateElement`], and store it in the memory arena.
@@ -1881,16 +1881,16 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
-    /// * `tail`
     /// * `value`
+    /// * `tail`
     #[inline]
     pub fn alloc_template_element(
         self,
         span: Span,
-        tail: bool,
         value: TemplateElementValue<'a>,
+        tail: bool,
     ) -> Box<'a, TemplateElement<'a>> {
-        Box::new_in(self.template_element(span, tail, value), self.allocator)
+        Box::new_in(self.template_element(span, value, tail), self.allocator)
     }
 
     /// Build a [`MemberExpression::ComputedMemberExpression`].

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -552,8 +552,8 @@ impl<'new_alloc> CloneIn<'new_alloc> for TemplateElement<'_> {
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         TemplateElement {
             span: CloneIn::clone_in(&self.span, allocator),
-            tail: CloneIn::clone_in(&self.tail, allocator),
             value: CloneIn::clone_in(&self.value, allocator),
+            tail: CloneIn::clone_in(&self.tail, allocator),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -289,8 +289,8 @@ impl ContentEq for TaggedTemplateExpression<'_> {
 
 impl ContentEq for TemplateElement<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.tail, &other.tail)
-            && ContentEq::content_eq(&self.value, &other.value)
+        ContentEq::content_eq(&self.value, &other.value)
+            && ContentEq::content_eq(&self.tail, &other.tail)
     }
 }
 

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -305,8 +305,8 @@ impl<'a> PeepholeOptimizations {
                         iter::repeat_with(|| {
                             ctx.ast.template_element(
                                 e.span(),
-                                false,
                                 TemplateElementValue { raw: "".into(), cooked: Some("".into()) },
+                                false,
                             )
                         })
                         .take(expressions.len() + 1),
@@ -331,8 +331,8 @@ impl<'a> PeepholeOptimizations {
                 iter::repeat_with(|| {
                     ctx.ast.template_element(
                         temp_lit.span,
-                        false,
                         TemplateElementValue { raw: "".into(), cooked: Some("".into()) },
+                        false,
                     )
                 })
                 .take(expressions.len() + 1),

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -738,12 +738,12 @@ impl<'a> PeepholeOptimizations {
                     let cooked = s.clone().into_in(ctx.ast.allocator);
                     ctx.ast.template_element(
                         SPAN,
-                        false,
                         TemplateElementValue {
                             raw: Self::escape_string_for_template_literal(&s)
                                 .into_in(ctx.ast.allocator),
                             cooked: Some(cooked),
                         },
+                        false,
                     )
                 }));
                 if let Some(last_quasi) = quasis.last_mut() {

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -546,8 +546,8 @@ impl<'a> ParserImpl<'a> {
         let tail = matches!(cur_kind, Kind::TemplateTail | Kind::NoSubstitutionTemplate);
         self.ast.template_element(
             span,
-            tail,
             TemplateElementValue { raw, cooked: cooked.map(Atom::from) },
+            tail,
         )
     }
 

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -152,8 +152,8 @@ function deserializeTemplateElement(pos) {
     type: 'TemplateElement',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    value: deserializeTemplateElementValue(pos + 16),
-    tail: deserializeBool(pos + 8),
+    value: deserializeTemplateElementValue(pos + 8),
+    tail: deserializeBool(pos + 40),
   };
 }
 

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -153,8 +153,8 @@ function deserializeTemplateElement(pos) {
     type: 'TemplateElement',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    value: deserializeTemplateElementValue(pos + 16),
-    tail: deserializeBool(pos + 8),
+    value: deserializeTemplateElementValue(pos + 8),
+    tail: deserializeBool(pos + 40),
   };
 }
 


### PR DESCRIPTION
Re-order the fields of `TemplateElement`, moving `tail` to last. This means fields are in same order as ESTree, withou having to manually re-order them.

The field order makes no real difference here, since `tail` field is not visited, so I figure might as well align with ESTree.