### PR TITLE
fix(ast/estree): fix `BindingIdentifier`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -253,7 +253,10 @@ pub struct IdentifierReference<'a> {
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "Identifier")]
+#[estree(
+    rename = "Identifier",
+    add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull)
+)]
 pub struct BindingIdentifier<'a> {
     pub span: Span,
     /// The identifier name being bound.

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -115,6 +115,9 @@ impl ESTree for BindingIdentifier<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &JsonSafeString(self.name.as_str()));
+        state.serialize_ts_field("decorators", &crate::serialize::TsEmptyArray(self));
+        state.serialize_ts_field("optional", &crate::serialize::TsFalse(self));
+        state.serialize_ts_field("typeAnnotation", &crate::serialize::TsNull(self));
         state.end();
     }
 }

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -77,6 +77,9 @@ function deserializeBindingIdentifier(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     name: deserializeStr(pos + 8),
+    decorators: [],
+    optional: false,
+    typeAnnotation: null,
   };
 }
 

--- a/napi/parser/test/parse.test.ts
+++ b/napi/parser/test/parse.test.ts
@@ -62,6 +62,7 @@ describe('parse', () => {
                 start: 4,
                 end: 5,
                 name: 'x',
+                decorators: [],
                 typeAnnotation: null,
                 optional: false,
               },

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -70,6 +70,9 @@ export interface IdentifierReference extends Span {
 export interface BindingIdentifier extends Span {
   type: 'Identifier';
   name: string;
+  decorators?: [];
+  optional?: false;
+  typeAnnotation?: null;
 }
 
 export interface LabelIdentifier extends Span {

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -1,8 +1,8 @@
 commit: 15392346
 
 estree_typescript Summary:
-AST Parsed     : 10628/10725 (99.10%)
-Positive Passed: 128/10725 (1.19%)
+AST Parsed     : 10624/10725 (99.06%)
+Positive Passed: 698/10725 (6.51%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/2dArrays.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APILibCheck.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APISample_Watch.ts
@@ -21,13 +21,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration14.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration15.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration21.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration22.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration24.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration25.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration9.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/ClassDeclarationWithInvalidConstOnPropertyDeclaration.ts
 A class member cannot have the 'const' keyword.
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/ClassDeclarationWithInvalidConstOnPropertyDeclaration2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/DeclarationErrorsNoEmitOnError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment8.ts
@@ -45,7 +43,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractInterfaceIdenti
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractPropertyBasics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractPropertyInConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractPropertyNegative.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/acceptSymbolAsWeakType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/acceptableAlias1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessInstanceMemberFromStaticMethod01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessOverriddenBaseClassMember1.ts
@@ -97,7 +94,6 @@ Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports5.ts
@@ -178,7 +174,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyInferenceAnonymousFu
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyIsAssignableToObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyIsAssignableToVoid.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyMappedTypesError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyPlusAny1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/argsInScope.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arguments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsAsPropertyName.ts
@@ -193,8 +188,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsObjectIterator
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsSpreadRestIterables.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsUsedInClassFieldInitializerOrStaticInitializationBlock.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsUsedInObjectLiteralProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arithAssignTyping.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arithmeticOnInvalidTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arithmeticOnInvalidTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arityErrorRelatedSpanBindingPattern.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest1.ts
@@ -206,12 +199,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAugment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayBestCommonTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayBindingPatternOmittedExpressions.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayBufferIsViewNarrowsType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayCast.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayConcat2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayConcat3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayConcatMap.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayConstructors1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayDestructuringInSwitch1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayDestructuringInSwitch2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayEvery.ts
@@ -225,8 +216,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFrom.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/arrayFromAsync.ts
 `await` is only allowed within async functions and at the top levels of modules
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayIndexWithArrayFails.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteral1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteral2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralAndArrayConstructorEquivalence1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralContextualType.ts
@@ -433,7 +422,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseExpressionTypeParam
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseIndexSignatureResolution.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseTypeAfterDerivedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseTypeOrderChecking.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseTypePrivateMemberClash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseTypeWrappingInstantiationChain.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bestChoiceType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bestCommonTypeReturnStatement.ts
@@ -447,10 +435,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigint64ArraySubarray.t
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigintIndex.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigintWithLib.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigintWithoutLib.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/binaryArithmatic1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/binaryArithmatic2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/binaryArithmatic3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/binaryArithmatic4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/binaryArithmeticControlFlowGraphNotTooLarge.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bind1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bind2.ts
@@ -488,10 +472,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedSameNameFunc
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedVariablesUseBeforeDef.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bluebirdStaticThis.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bom-utf8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/booleanAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/booleanFilterAnyArray.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/booleanLiteralsContextuallyTypedFromUnion.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakInIterationOrSwitchStatement4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakNotInIterationOrSwitchStatement2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakTarget1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakTarget2.ts
@@ -501,16 +483,13 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakTarget5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakTarget6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/builtinIterator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bundledDtsLateExportRenaming.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/cacheResolutions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedContextualTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callConstructAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callExpressionWithTypeParameterConstrainedToOuterTypeParameter.ts
@@ -530,7 +509,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/callbackArgsDifferByOpt
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callbacksDontShareTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callsOnComplexSignatures.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cannotIndexGenericWritingError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/cannotInvokeNewOnIndexExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/captureSuperPropertyAccessInSuperCall01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/captureThisInSuperCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop1.ts
@@ -633,27 +611,21 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/classAccessorInitializa
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classAttributeInferenceTemplate.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classBlockScoping.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classCannotExtendVar.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclarationBlockScoping1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclarationBlockScoping2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclarationCheckUsedBeforeDefinitionInFunctionDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclarationCheckUsedBeforeDefinitionInItself.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclarationMergedInModuleWithContinuation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclarationShouldBeOutOfScopeInComputedNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclaredBeforeClassFactory.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionExtendingAbstractClass.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionInClassStaticDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionNames.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/classExpressionPropertyModifiers.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionTest1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionTest2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionWithDecorator1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionWithResolutionOfNamespaceOfSameName01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionWithStaticProperties1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionWithStaticProperties2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionWithStaticProperties3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionWithStaticPropertiesES61.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionWithStaticPropertiesES62.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionWithStaticPropertiesES63.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionWithStaticPropertiesES64.ts
@@ -683,7 +655,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFunctionMerging2.t
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/classHeritageWithTrailingSeparator.ts
 Expected `{` but found `EOF`
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementingInterfaceIndexer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass4.ts
@@ -693,13 +664,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass7.t
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsImportedInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsMethodWIthTupleArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsPrimitive.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classInConvertedLoopES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classIndexer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classIndexer2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classIndexer3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classIndexer4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classIndexer5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classInheritence.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerScoping.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerScoping2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping.ts
@@ -731,7 +700,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/classVarianceCircularit
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classVarianceResolveCircularity1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classVarianceResolveCircularity2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classWithDuplicateIdentifier.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classWithEmptyTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classWithMultipleBaseClasses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classWithOverloadImplementationOfWrongName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classWithOverloadImplementationOfWrongName2.ts
@@ -815,9 +783,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndParame
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndParameter1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndPropertyNameAsConstuctorParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndAliasInGlobal.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndAmbientClassInGlobal.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndAmbientVarInGlobal.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndClassInGlobal.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndEnumInGlobal.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndFunctionInGlobal.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInAccessors.ts
@@ -831,7 +796,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpression
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndNameResolution.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndPropertyNameAsConstuctorParameter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndVarInGlobal.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commaOperator1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commaOperatorInConditionalExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commaOperatorLeftSideUnused.ts
@@ -839,7 +803,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentBeforeStaticMeth
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentEmitAtEndOfFile1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentEmitOnParenthesizedAssertionInReturnStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentEmitOnParenthesizedAssertionInReturnStatement2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentEmitWithCommentOnLastLine.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentInEmptyParameterList1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentInMethodCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentInNamespaceDeclarationWithIdentifierPathName.ts
@@ -866,8 +829,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement6.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnBinaryOperator1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnBinaryOperator2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnBlock1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnClassAccessor1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnClassAccessor2.ts
@@ -914,7 +875,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsMultiModuleMultiFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsMultiModuleSingleFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnObjectLiteral1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnObjectLiteral2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnObjectLiteral3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnObjectLiteral4.ts
@@ -922,7 +882,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnObjectLiteral
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnPropertyOfObjectLiteral1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnRequireStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnReturnStatement1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnStaticMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsPropertySignature1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsTypeParameters.ts
@@ -932,11 +891,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsdoNotEmitCommen
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsemitComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonJsImportClassExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonSourceDir1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonSourceDir2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonSourceDir3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonSourceDir4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonSourceDir5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonSourceDir6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonSourceDirectory.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonSourceDirectory_dts.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonjsSafeImport.ts
@@ -974,23 +928,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertyNameWit
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedTypesKeyofNoIndexSignatureType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/computerPropertiesInES5ShouldBeTransformed.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/concatClassAndString.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/concatError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/concatTuples.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalAnyCheckTypePicksBothBranches.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalDoesntLeakUninstantiatedTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalEqualityOnLiteralObjects.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalEqualityTestingNullability.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpression1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressionNewLine9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressions2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalReturnExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeAnyUnion.ts
@@ -1018,7 +960,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/consistentAliasVsNonAli
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarationShadowedByVarDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarationShadowedByVarDeclaration2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarationShadowedByVarDeclaration3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-access.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-access2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-access3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-access4.ts
@@ -1074,7 +1015,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintReferencingTy
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintWithIndexedAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraints0.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintsThatReferenceOtherContstraints1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintsUsedInPrototypeProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorArgWithGenericCallSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorAsType.ts
@@ -1094,7 +1034,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorReturningAPr
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorReturnsInvalidType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorStaticParamName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorStaticParamNameErrors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorTypeWithTypeParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorWithCapturedSuper.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorWithParameterPropertiesAndPrivateFields.es2015.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorWithSuperAndPrologue.es5.ts
@@ -1227,7 +1166,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingOrOpe
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingOrOperator2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingOrOperator3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingRestParameters.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/continueInIterationStatement4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/continueInLoopsWithCapturedBlockScopedBindings1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/continueLabel.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/continueNotInIterationStatement2.ts
@@ -1257,7 +1195,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowDestructurin
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowDestructuringParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowDestructuringVariablesInTryCatch.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowFavorAssertedTypeThroughTypePredicate.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowFinallyNoCatchAssignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowForCatchAndFinally.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowForCompoundAssignmentToThisMember.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowForIndexSignatures.ts
@@ -1316,7 +1253,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileAliasUseBeforeD
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileAliasUseBeforeDeclaration2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileAmbientExternalModuleWithSingleExportedModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileCallSignatures.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileClassExtendsNull.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileClassWithIndexSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileClassWithStaticMethodReturningConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileConstructSignatures.ts
@@ -1337,7 +1273,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForFunctionType
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForInterfaceWithOptionalFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForInterfaceWithRestParams.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForTypeParameters.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForVarList.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileFunctions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileGenericClassWithGenericExtendedClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileGenericType.ts
@@ -1634,7 +1569,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitWithDefa
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitWithDefaultAsComputedName2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitWithInvalidPackageJsonTypings.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFileNoCrashOnExtraExportModifier.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFileOverwriteError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFileOverwriteErrorWithOut.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFilesGeneratingTypeReferences.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFilesWithTypeReferences1.ts
@@ -1667,8 +1601,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declareDottedModuleName
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declareExternalModuleWithExportAssignedFundule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declareFileExportAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declareFileExportAssignmentWithVarFromVariableStatement.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declareIdentifierAsBeginningOfStatementExpression01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declareModifierOnImport1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declareModifierOnTypeAlias.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declaredExternalModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declaredExternalModuleWithExportAssignment.ts
@@ -1736,21 +1668,15 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultValueInFunctionO
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultValueInFunctionTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deferredConditionalTypes.ts
 tasks/coverage/typescript/tests/cases/compiler/deferredConditionalTypes2.ts
-serde_json::from_str(oxc_json) error: number out of range at line 25 column 25
+serde_json::from_str(oxc_json) error: number out of range at line 28 column 25
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deferredLookupTypeResolution.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deferredLookupTypeResolution2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/deferredTypeReferenceWithinArrayWithinTuple.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/defineVariables_useDefineForClassFields.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/definiteAssignmentOfDestructuredVariable.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/definiteAssignmentWithErrorStillStripped.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deleteExpressionMustBeOptional.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deleteExpressionMustBeOptional_exactOptionalPropertyTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/deleteOperator1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/deleteOperatorInStrictMode.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deleteReadonly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deleteReadonlyInStrictNullChecks.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/dependencyViaImportAlias.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedBool.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedCompilerOptions1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedCompilerOptions2.ts
@@ -1804,7 +1730,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/detachedCommentAtStartO
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/detachedCommentAtStartOfLambdaFunction2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/didYouMeanStringLiteral.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/didYouMeanSuggestionErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/differentTypesWithSameName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminableUnionWithIntersectedMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantElementAccessCheck.ts
@@ -1854,7 +1779,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotEmitTripleSlashCom
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotInferUnrelatedTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotWidenAtObjectLiteralPropertyAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotemitTripleSlashComments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/doWhileLoop.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doWhileUnreachableCode.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2016Plus.ts
@@ -1869,7 +1793,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreEnumEmi
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreExportStarConflict.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreLabels.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreMappedTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst10.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst11.ts
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst12.ts
@@ -1882,15 +1805,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst18.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst19.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst2.ts
 Missing initializer in const declaration
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst3.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst4.ts
 Missing initializer in const declaration
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst5.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst6.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst9.ts
 tasks/coverage/typescript/tests/cases/compiler/dtsEmitTripleSlashAvoidUnnecessaryResolutionMode.ts
 Unexpected estree file content error: 2 != 3
 
@@ -1952,13 +1870,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateTypeParameters
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateTypeParameters3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateVarAndImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateVarAndImport2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateVariableDeclaration1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateVariablesByScope.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateVariablesWithAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateVarsAcrossFileBoundaries.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicImportEvaluateSpecifier.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicImportInDefaultExportExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicImportTrailingComma.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicImportWithNestedThis_es2015.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicImportWithNestedThis_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicImportsDeclaration.ts
@@ -1976,7 +1892,6 @@ Unexpected estree file content error: 1 != 2
 tasks/coverage/typescript/tests/cases/compiler/elidedJSImport2.ts
 Unexpected estree file content error: 1 != 3
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/elidingImportNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitAccessExpressionOfCastedObjectLiteralExpressionInArrowFunctionES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitAccessExpressionOfCastedObjectLiteralExpressionInArrowFunctionES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitBOM.ts
@@ -2012,16 +1927,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyArgumentsListComme
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyArrayDestructuringExpressionVisitedByTransformer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyDeclarationEmitIsModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyEnum.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyGenericParamList.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyIndexer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyModuleName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyObjectNotSubtypeOfIndexSignatureContainingObject1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyObjectNotSubtypeOfIndexSignatureContainingObject2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyOptionalBindingPatternInDeclarationSignature.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyThenWarning.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyThenWithoutWarning.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyTypeArgumentList.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyTypeArgumentListWithNew.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat3.ts
@@ -2083,7 +1994,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorForConflictingExpo
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorForUsingPropertyOfTypeAsType02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorForUsingPropertyOfTypeAsType03.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorForwardReferenceForwadingConstructor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorHandlingInInstanceOf.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorLocationForInterfaceExtension.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessageOnIntersectionsWithDiscriminants01.ts
@@ -2212,45 +2122,37 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBinding
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImportDts1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImportInEs5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImportWithExport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBinding.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBinding1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBinding1InEs5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBinding1WithExport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBindingDts.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBindingDts1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBindingWithExport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingInEs5.ts
+Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBindingWithExport.ts
+Expected `=` but found `,`
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingMergeErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingNoDefaultProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingWithExport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportEqualsDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportEqualsDeclaration2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportEqualsExportModuleCommonJsError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportEqualsExportModuleEs2015Error.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImportAmd.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImportDts.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImportInEs5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImportMergeErrors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImportNoNamedExports.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImportWithExport.ts
+Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImportWithExport.ts
+Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportAmd.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportDts.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportInEs5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportInExportAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportInIndirectExportAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportMergeErrors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportNoExportMember.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportNoNamedExports.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportWithExport.ts
+Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportWithExport.ts
+Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportWithTypesAndValues.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportWithoutFromClause.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportWithoutFromClauseAmd.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportWithoutFromClauseInEs5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportWithoutFromClauseNonInstantiatedModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportWithoutFromClauseWithExport.ts
+Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/es6ImportWithoutFromClauseWithExport.ts
+Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6MemberScoping.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6Module.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleClassDeclaration.ts
@@ -2334,7 +2236,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignClassAndMod
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignValueAndType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignedNamespaceIsVisibleInDeclarationEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignedTypeAsTypeAnnotation.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentFunction.ts
@@ -2344,7 +2245,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentInterna
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentMembersVisibleInAugmentation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentOfDeclaredExternalModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentOfGenericType1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentVariable.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithDeclareAndExportModifiers.ts
 Unexpected token
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithDeclareModifier.ts
@@ -2358,7 +2258,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithout
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithoutIdentifier1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportClassExtendingIntersection.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDeclarationForModuleOrEnumWithMemberOfSameName.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDeclarationWithModuleSpecifierNameOnNextLine1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDeclarationsInAmbientNamespaces.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDeclarationsInAmbientNamespaces2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDeclareClass1.ts
@@ -2496,13 +2395,13 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/externalModuleResolutio
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/externalModuleWithoutCompilerFlag1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extractInferenceImprovement.ts
 tasks/coverage/typescript/tests/cases/compiler/fakeInfinity1.ts
-serde_json::from_str(oxc_json) error: number out of range at line 29 column 27
+serde_json::from_str(oxc_json) error: number out of range at line 32 column 27
 
 tasks/coverage/typescript/tests/cases/compiler/fakeInfinity2.ts
-serde_json::from_str(oxc_json) error: number out of range at line 38 column 29
+serde_json::from_str(oxc_json) error: number out of range at line 41 column 29
 
 tasks/coverage/typescript/tests/cases/compiler/fakeInfinity3.ts
-serde_json::from_str(oxc_json) error: number out of range at line 38 column 29
+serde_json::from_str(oxc_json) error: number out of range at line 41 column 29
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fallFromLastCase1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fallFromLastCase2.ts
@@ -2536,14 +2435,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/flowAfterFinally1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/flowControlTypeGuardThenSwitch.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/flowInFinally1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forAwaitForUnion.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/forIn2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forInModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/forInStatement1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/forInStatement2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forInStatement3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/forInStatement5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/forInStatement6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/forInStatement7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forInStrictNullChecksNoError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forLoopEndingMultilineComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forLoopWithDestructuringDoesNotElideFollowingStatement.ts
@@ -2557,8 +2450,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/forwardRefInEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forwardRefInTypeDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/freshLiteralInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/freshLiteralTypesInIntersections.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/fromAsIdentifier1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/fromAsIdentifier2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/funClodule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/funcdecl.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionAndImportNameConflict.ts
@@ -2712,7 +2603,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericAndNonGenericOve
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArgumentCallSigAssignmentCompat.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArray0.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArray1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArrayAssignment1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArrayAssignmentCompatErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArrayExtenstions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArrayMethods1.ts
@@ -2741,8 +2631,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassPropertyInh
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassStaticMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassWithStaticFactory.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassWithStaticsUsingTypeArguments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClasses0.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClasses1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClasses2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClasses3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClasses4.ts
@@ -2825,7 +2713,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericOverloadSignatur
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericParameterAssignability1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericPrototypeProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericPrototypeProperty2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericPrototypeProperty3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericRecursiveImplicitConstructorErrors1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericRecursiveImplicitConstructorErrors2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericRecursiveImplicitConstructorErrors3.ts
@@ -2904,11 +2791,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/gettersAndSettersTypesA
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/global.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalFunctionAugmentationOverload.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalIsContextualKeyword.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalThis.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalThisCapture.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalThisDeclarationEmit.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalThisDeclarationEmit2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalThisDeclarationEmit3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/grammarAmbiguities1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/heterogeneousArrayAndOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/hidingCallSignatures.ts
@@ -3050,10 +2933,6 @@ Unexpected estree file content error: 1 != 3
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember7.ts
 tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember8.ts
 Unexpected estree file content error: 1 != 2
 
@@ -3063,7 +2942,6 @@ Unexpected estree file content error: 1 != 2
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNotElidedWhenNotFound.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importOnAliasedIdentifiers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importPropertyFromMappedType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importShadowsGlobalName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importShouldNotBeElidedInDeclarationEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importTypeGenericArrowTypeParenthesized.ts
 tasks/coverage/typescript/tests/cases/compiler/importTypeResolutionJSDocEOF.ts
@@ -3079,7 +2957,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/importWithTrailingSlash
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/import_reference-exported-alias.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/import_reference-to-type-alias.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/import_unneeded-require-when-referenecing-aliased-type-throug-array.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/import_var-referencing-an-imported-module-alias.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importedAliasedConditionalTypeInstantiation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importedAliasesInTypePositions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importedEnumMemberMergedWithExportedAliasIsError.ts
@@ -3106,13 +2983,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/incorrectNumberOfTypeAr
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/incorrectRecursiveMappedTypeConstraint.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/incrementOnNullAssertion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/incrementOnTypeParameter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/incrementalConfig.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/incrementalInvalid.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/incrementalOut.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/incrementalTsBuildInfoFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexAt.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexClassByNumber.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexIntoArraySubclass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexIntoEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexSignatureAndMappedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexSignatureInOtherFile.ts
@@ -3139,7 +3014,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexWithUndefinedAndNu
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexWithUndefinedAndNullStrictNullChecks.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/indexWithoutParamType.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexWithoutParamType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessAndNullableNarrowing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessCanBeHighOrder.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessConstraints.ts
@@ -3170,8 +3044,6 @@ Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexingTypesWithNever.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indirectDiscriminantAndExcessProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indirectGlobalSymbolPartOfObjectType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/indirectSelfReference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/indirectSelfReferenceGeneric.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indirectTypeParameterReferences.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indirectUniqueSymbolDeclarationEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferConditionalConstraintMappedMember.ts
@@ -3248,7 +3120,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingType
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypesNonGenericBase.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyGenerativeInheritance1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritFromGenericTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritSameNamePrivatePropertiesFromDifferentOrigins.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritSameNamePrivatePropertiesFromSameOrigin.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritSameNamePropertiesWithDifferentOptionality.ts
@@ -3278,8 +3149,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticFuncOv
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticFuncOverridingProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticFuncOverridingPropertyOfFuncType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticFunctionOverridingInstanceProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticMembersCompatible.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticMembersIncompatible.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticPropertyOverridingAccessor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticPropertyOverridingMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticPropertyOverridingProperty.ts
@@ -3301,7 +3170,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/initializerWithThisProp
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/initializersInAmbientEnums.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inlineConditionalHasSimilarAssignability.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inlineMappedTypeModifierDeclarationEmit.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inlineSourceMap.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inlineSourceMap2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inlineSources.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inlineSources2.ts
@@ -3318,7 +3186,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceAndStaticDeclar
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceOfAssignability.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceOfInExternalModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceSubtypeCheck1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceSubtypeCheck2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceofNarrowReadonlyArray.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceofOnInstantiationExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceofTypeAliasToGenericClass.ts
@@ -3449,7 +3316,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/intraBindingPatternRefe
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intrinsics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidConstraint1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidContinueInDownlevelAsync.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidSplice.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidStaticField.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidSymbolInTypeParameter1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidThisEmitInContextualObjectLiteral.ts
@@ -3463,7 +3329,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/invokingNonGenericMetho
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ipromise2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ipromise3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ipromise4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/isArray.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isDeclarationVisibleNodeKinds.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorTypes1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrors.ts
@@ -3485,7 +3350,6 @@ tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsAllowJs.ts
 Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsLiterals.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsRequiresDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsStrictBuiltinIteratorReturn.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesAmbientConstEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesConstEnum.ts
@@ -3494,16 +3358,13 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesDontElid
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesExportDeclarationType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesExportImportUninstantiatedNamespace.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesExternalModuleForced.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesGlobalNamespacesAndEnums.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesImportConstEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesImportConstEnumTypeOnly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesImportExportElision.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesNoEmitOnError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesNoExternalModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesNoExternalModuleMultiple.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesNonAmbientConstEnum.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesOut.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesPlainFile-AMD.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesPlainFile-CommonJS.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesPlainFile-ES6.ts
@@ -3518,8 +3379,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesSourceMa
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesSpecifiedModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesUnspecifiedModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesWithDeclarationFile.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModules_resolveJsonModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModules_resolveJsonModule_strict_outDir_commonJs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/iterableTReturnTNext.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/iteratorExtraParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/iteratorsAndStrictNullChecks.ts
@@ -3672,7 +3531,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxElementType.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxElementTypeLiteral.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxElementTypeLiteralWithGeneric.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxElementsAsIdentifierNames.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxEmitAttributeWithPreserve.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxEmptyExpressionNotCountedAsChild.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxEmptyExpressionNotCountedAsChild2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxExcessPropsAndAssignability.tsx
@@ -3744,10 +3602,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundConstraintType
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundDestructuringImplicitAnyError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundFunctionMemberAssignmentDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/letAndVarRedeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/letAsIdentifier.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/letAsIdentifier2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/letAsIdentifierInStrictMode.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/letConstInCaseClauses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/letConstMatchingParameterNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-access.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-es5-1.ts
@@ -3755,12 +3610,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-es5.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-invalidContexts.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-scopes-duplicates.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-scopes-duplicates2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-scopes-duplicates3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-scopes-duplicates4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-scopes-duplicates5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-scopes-duplicates6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-scopes-duplicates7.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-scopes.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-scopes2.ts
@@ -3802,7 +3651,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/literalIntersectionYiel
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/literalTypeNameAssertionNotTriggered.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/literalWideningWithCompoundLikeAssignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/literals-negative.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/literals1.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/literalsInComputedProperties1.ts
 An enum member cannot have a numeric name.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/localAliasExportAssignment.ts
@@ -3813,7 +3661,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/localTypeParameterInfer
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/localVariablesReturnedFromCatchBlocks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/m7Bugs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/manyConstExports.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/mapConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mapConstructorOnReadonlyTuple.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mapGroupBy.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mapOnTupleTypes01.ts
@@ -3859,7 +3706,6 @@ Unexpected estree file content error: 2 != 4
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/maximum10SpellingSuggestions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/memberAccessMustUseModuleInstances.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/memberAccessOnConstructorType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/memberOverride.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/memberScope.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/memberVariableDeclarations1.ts
@@ -3902,7 +3748,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/methodContainingLocalFu
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/methodInAmbientClass1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/methodSignatureDeclarationEmit1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/methodSignatureHandledDeclarationKindForSymbol.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/mismatchedClassConstructorVariable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mismatchedExplicitTypeParameterAndArgumentType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mismatchedGenericArguments1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingCommaInTemplateStringsArray.ts
@@ -3912,7 +3757,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingFunctionImplemen
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingImportAfterModuleImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingMemberErrorHasShortPath.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingPropertiesOfClassExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingRequiredDeclare.d.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingReturnStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingReturnStatement1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingSelf.ts
@@ -3932,7 +3776,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixingApparentTypeOverr
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixingFunctionAndAmbientModule1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixingStaticAndInstanceOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/modFunctionCrash.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/modKeyword.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/modifierParenCast.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/modifiersInObjectLiterals.ts
 'public' modifier cannot be used here.
@@ -4024,7 +3867,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleImportedForTypeArgumentPosition.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleInTypePosition1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleLocalImportNotIncorrectlyRedirected.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleMemberMissingErrorIsRelative.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleMemberWithoutTypeAnnotation1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleMemberWithoutTypeAnnotation2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleMerge.ts
@@ -4036,7 +3878,6 @@ tasks/coverage/typescript/tests/cases/compiler/moduleNoneDynamicImport.ts
 Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleNoneErrors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleNoneOutFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleOuterQualification.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePreserve1.ts
 tasks/coverage/typescript/tests/cases/compiler/modulePreserve2.ts
@@ -4060,7 +3901,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleProperty2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleRedifinitionErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleReopenedTypeOtherBlock.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleReopenedTypeSameBlock.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionAsTypeReferenceDirective.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionAsTypeReferenceDirectiveAmbient.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionAsTypeReferenceDirectiveScoped.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionNoResolve.ts
@@ -4108,7 +3948,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuf
 tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one_jsModule.ts
 Unexpected estree file content error: 1 != 3
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one_jsonModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_threeLastIsBlank1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_threeLastIsBlank2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_threeLastIsBlank3.ts
@@ -4145,7 +3984,6 @@ Unexpected estree file content error: 1 != 2
 tasks/coverage/typescript/tests/cases/compiler/moduleResolution_relativeImportJsFile_noImplicitAny.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleSameValueDuplicateExportedBindings1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleSameValueDuplicateExportedBindings2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleScopingBug.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt.ts
@@ -4181,7 +4019,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiModuleClodule1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiModuleFundule1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiSignatureTypeInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multipleBaseInterfaesWithIncompatibleProperties.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/multipleClassPropertyModifiers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multipleExportAssignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multipleExportAssignmentsInAmbientDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multipleExports.ts
@@ -4261,25 +4098,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingUnionToNeverAs
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingUnionToUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingUnionWithBang.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingWithNonNullExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nativeToBoxedTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nearbyIdenticalGenericLambdasAssignable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/negativeZero.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings11.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings13.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings14.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings15.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings16.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedCallbackErrorNotFlattened.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedExcessPropertyChecking.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedFreshLiteral.ts
@@ -4290,7 +4116,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedHomomorphicMapped
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedIndexer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedInfinitelyExpandedRecursiveTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedLoopTypeGuards.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedLoopWithOnlyInnerLetCaptured.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedLoops.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedModulePrivateAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedObjectRest.ts
@@ -4314,21 +4139,18 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/newLineInTypeofInstanti
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/newMap.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/newNamesInGlobalAugmentations1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/newNonReferenceType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/newOnInstanceSymbol.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noAsConstNameLookup.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noBundledEmitFromNodeModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCheckDoesNotReportError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCheckNoEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCheckRequiresEmitDeclarationOnly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCircularDefinitionOnExportOfPrivateInMergedNamespace.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndClassInGlobal.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInAccessors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInLambda.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndVarInGlobal.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionInFunctionAndVarInGlobal.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noConstraintInReturnType1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashOnImportShadowing.ts
@@ -4336,12 +4158,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashOnMixin.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashOnNoLib.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashOnThisTypeUsage.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashUMDMergedWithGlobalValue.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashWithVerbatimModuleSyntaxAndImportsNotUsedAsValues.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noDefaultLib.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noEmitAndComposite.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noEmitAndCompositeListFilesOnly.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noEmitAndIncremental.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noEmitAndIncrementalListFilesOnly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noEmitHelpers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noEmitHelpers2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noEmitOnError.ts
@@ -4444,9 +4261,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfName
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDirDeclDirNestedDirs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDirDeclDirRootDir.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDirRootDir.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution6.ts
@@ -4456,7 +4271,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonArrayRestArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonConflictingRecursiveBaseTypeMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonContextuallyTypedLogicalOr.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonExportedElementsOfMergedModules.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonGenericClassExtendingGenericClassWithAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonIdenticalTypeConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonInferrableTypePropagation1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonInferrableTypePropagation2.ts
@@ -4478,14 +4292,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonexistentPropertyOnUn
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonexistentPropertyUnavailableOnPromisedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nongenericConditionalNotPartiallyComputed.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nongenericPartialInstantiationsRelatedInBothDirections.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonnullAssertionPropegatesContextualType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonstrictTemplateWithNotOctalPrintsAsIs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/normalizedIntersectionTooComplex.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nounusedTypeParameterConstraint.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/null.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nullableFunctionError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/numberAssignableToEnumInsideUnion.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/numberOnLeftSideOfInExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/numberToString.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/numberVsBigIntOperations.ts
 Missing initializer in const declaration
@@ -4505,7 +4317,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericUnderscoredSepar
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectAssignLikeNonUnionResult.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectBindingPatternContextuallyTypesArgument.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectBindingPattern_restElementWithPropertyName.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectCreate-errors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectCreate.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectCreate2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectCreationOfElementAccessExpression.ts
@@ -4524,7 +4335,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteral1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteral2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralArraySpecialization.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralComputedNameNoDeclarationError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralDeclarationGeneration1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralEnumPropertyNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralExcessProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralFreshnessWithSpread.ts
@@ -4579,13 +4389,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalPropertiesTest.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalSetterParam.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalTupleElementsAndUndefined.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsCompositeWithIncrementalFalse.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsInlineSourceMapMapRoot.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsInlineSourceMapSourceRoot.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsInlineSourceMapSourcemap.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsOutAndNoModuleGen.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsSourcemapInlineSources.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsSourcemapInlineSourcesMapRoot.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsSourcemapInlineSourcesSourceRoot.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsStrictPropertyInitializationStrict.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsStrictPropertyInitializationStrictNullChecks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsTsBuildInfoFileWithoutIncrementalAndComposite.ts
@@ -4593,13 +4397,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/orderMattersForSignatur
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/out-flag.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/out-flag2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/out-flag3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/outModuleConcatAmd.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/outModuleConcatCommonjs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/outModuleConcatCommonjsDeclarationOnly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/outModuleConcatES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/outModuleConcatSystem.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/outModuleConcatUmd.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/outModuleConcatUnspecifiedModuleKind.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/outModuleConcatUnspecifiedModuleKindDeclarationOnly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/outModuleTripleSlashRefs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overEagerReturnTypeSpecialization.ts
@@ -4703,8 +4504,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/partiallyAmbientFundule
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/partiallyDiscriminantedUnions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution1_amd.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution1_node.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution2_classic.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution2_node.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution3_classic.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution3_node.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution4_classic.ts
@@ -4742,13 +4541,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleR
 tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution_withExtension_MapedToNodeModules.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution_withExtension_failedLookup.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingInheritedBaseUrl.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingWithoutBaseUrl1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingWithoutBaseUrl2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathsValidation1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathsValidation2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathsValidation3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/performanceComparisonOfStructurallyIdenticalInterfacesWithGenericSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pickOfLargeObjectUnionWorks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pinnedComments1.ts
@@ -4757,7 +4552,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/potentiallyUncalledDeco
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/predicateSemantics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/prefixIncrementAsOperandOfPlusExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/prefixUnaryOperatorsOnExportedVariables.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/prefixedNumberLiteralAssignToNumberLiteralType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/preserveConstEnums.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/preserveUnusedImports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/prespecializedGenericMembers1.ts
@@ -4766,7 +4560,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/primaryExpressionMods.t
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveConstraints1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveConstraints2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveMembers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveTypeAsClassName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveTypeAsInterfaceName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveTypeAsInterfaceNameGeneric.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveTypeAsmoduleName.ts
@@ -4860,10 +4653,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertiesAndIndexers.t
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertiesAndIndexers2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertiesAndIndexersForNumericNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccess1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccess2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccess3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccess6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccess7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccessExpressionInnerComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccessOfReadonlyIndexSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccessOnObjectLiteral.ts
@@ -4883,7 +4672,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/protectedMembersThisPar
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/protoAsIndexInIndexExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/protoAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/protoInIndexer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/prototypeInstantiatedWithBaseConstraint.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/prototypeOnConstructorFunctions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/prototypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/publicGetterProtectedSetterFromThisParameter.ts
@@ -4898,8 +4686,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedAccessorName2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedFunctionName1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedFunctionName2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedModuleNameMustBeAmbient.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedPropertyName1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedPropertyName2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedPropertyName3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/raiseErrorOnParameterProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ramdaToolsNoInfinite.ts
@@ -4908,7 +4694,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/randomSemicolons1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportGlobalDeclaration1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportGlobalDeclaration2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportGlobalDeclaration3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportGlobalDeclaration4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportUndefined1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportUndefined2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityCheckWithEmptyDefault.ts
@@ -4958,7 +4743,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseCheck5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseCheck6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseConstructorCreation1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseConstructorCreation2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseConstructorCreation3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveClassBaseType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveClassInstantiationsWithDefaultConstructors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveClassReferenceTest.ts
@@ -4975,10 +4759,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExcessProperty
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveFieldSetting.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveFunctionTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveFunctionTypes1.ts
@@ -5016,7 +4796,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeAliasWithS
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeComparison.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeComparison2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeIdentity.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeParameterConstraintReferenceLacksTypeArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeParameterReferenceError1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeParameterReferenceError2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeRelations.ts
@@ -5029,15 +4808,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/redeclareParameterInCat
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/redefineArray.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reducibleIndexedAccessTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportDefaultIsCallable.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportNameAliasedAndHoisted.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportWrittenCorrectlyInDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportedMissingAlias.ts
@@ -5061,7 +4832,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/relatedViaDiscriminated
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/relatedViaDiscriminatedTypeNoError2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/relationComplexityError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/relationalOperatorComparable.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/relativeNamesInClassicResolution.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/renamingDestructuredPropertyInFunctionType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/renamingDestructuredPropertyInFunctionType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/renamingDestructuredPropertyInFunctionType3.ts
@@ -5073,37 +4843,20 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireEmitSemicolon.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfAnEmptyFile1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileNonRelative.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileNonRelativeWithoutExtension.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileNonRelativeWithoutExtensionResolvesToTs.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithAlwaysStrictWithoutErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithAmd.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithComputedPropertyName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithEmptyObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithEmptyObjectWithErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithErrors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleEmitNone.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleEmitUndefined.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitAmd.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitAmdOutFile.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitEs2015.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitEsNext.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitNone.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitSystem.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitUmd.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithModuleNodeResolutionEmitUndefined.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithNoContent.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithSourceMap.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithTraillingComma.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutAllowJs.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutEsModuleInterop.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutExtension.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutExtensionResolvesToTs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutOutDir.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutResolveJsonModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutResolveJsonModuleAndPathMapping.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFile_PathMapping.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requiredInitializedParameter1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requiredInitializedParameter2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requiredInitializedParameter3.ts
@@ -5249,26 +5002,19 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/simpleRecursionWithBase
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/simpleRecursionWithBaseCase3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/simpleRecursionWithBaseCase4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/simplifyingConditionalWithInteriorConditionalIsRelated.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/singletonLabeledTuple.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sliceResultCast.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/slightlyIndirectedDeepObjectLiteralElaborations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-Comment1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-Comments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-Comments2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-FileWithComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-InterfacePrecedingVariableDeclaration1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-LineBreaks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-SemiColon1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-SingleSpace1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-StringLiteralWithNewLine.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapForFunctionInInternalModuleWithCommentPrecedingStatement01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapForFunctionWithCommentPrecedingStatement01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapPercentEncoded.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapSample.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationClass.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationClassWithDefaultConstructor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationClassWithDefaultConstructorAndCapturedThisStatement.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationClassWithDefaultConstructorAndExtendsClause.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationClasses.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDecorators.ts
 Unexpected token
@@ -5315,26 +5061,18 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDest
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementObjectBindingPattern2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementObjectBindingPattern3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementObjectBindingPattern4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDo.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationEnums.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationExportAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationExportAssignmentCommonjs.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationFor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationForIn.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationFunctionExpressions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationFunctionPropertyAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationFunctions.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationIfElse.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationLabeled.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationLambdaSpanningMultipleLines.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationStatements.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationSwitch.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationTryCatchFinally.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationVarInDownLevelGenerator.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationVariables.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationWhile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationWithComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapWithCaseSensitiveFileNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapWithCaseSensitiveFileNamesAndOutDir.ts
@@ -5363,7 +5101,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionJSXAt
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionLeadingUnderscores01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spliceTuples.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadBooleanRespectsFreshness.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadExpressionContainingObjectExpressionContextualType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadExpressionContextualType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadExpressionContextualTypeWithNamespace.ts
@@ -5402,7 +5139,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInterfaceAssignme
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMemberAccessOffDerivedType1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMemberExportAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMemberWithStringAndNumberNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMethodReferencingTypeArgument1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMethodWithTypeParameterExtendsClauseDeclFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMethodsReferencingClassTypeParameters.ts
@@ -5441,8 +5177,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictOptionalPropertie
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictOptionalProperties2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictSubtypeAndNarrowing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictTypeofUnionNarrowing.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringHasStringValuedNumericIndexer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringIncludes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringIndexerAndConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringIndexerAndConstructor1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringIndexerAssignments1.ts
@@ -5470,7 +5204,6 @@ Unexpected estree file content error: 1 != 2
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/subclassUint8Array.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/subclassWithPolymorphicThisIsAssignable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/substituteReturnTypeSatisfiesConstraint.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypeForIndexedAccessType1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypeForIndexedAccessType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypeForNonGenericIndexedAccessType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypeNoMergeOfAssignableType.ts
@@ -5534,7 +5267,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchFallThroughs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/symbolLinkDeclarationEmitModuleNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/symbolLinkDeclarationEmitModuleNamesImportRef.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/symbolLinkDeclarationEmitModuleNamesRootDir.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/symbolMergeValueAndImportedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/symbolObserverMismatchingPolyfillsWorkTogether.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/symlinkedWorkspaceDependenciesNoDirectLinkGeneratesDeepNonrelativeName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/symlinkedWorkspaceDependenciesNoDirectLinkGeneratesNonrelativeName.ts
@@ -5574,7 +5306,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModuleExportDefau
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModuleNonTopLevelModuleMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModuleTargetES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModuleTrailingComments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModuleWithSuperClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemNamespaceAliasEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemObjectShorthandRename.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedPrimitiveNarrowing.ts
@@ -5616,7 +5347,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateLiteralsSourceM
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateStringsArrayTypeDefinedInES5Mode.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateStringsArrayTypeNotDefinedES5Mode.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateStringsArrayTypeRedefinedInES6Mode.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/ternaryExpressionSourceMap.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/testContainerList.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/testTypings.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisBinding.ts
@@ -5656,7 +5386,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisTypeAsConstraint.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisWhenTypeCheckFails.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/this_inside-enum-should-not-be-allowed.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/this_inside-object-literal-getters-and-setters.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/toStringOnPrimitives.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tooFewArgumentsInGenericFunctionTypedArgument.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tooManyTypeParameters1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/topFunctionTypeNotCallable.ts
@@ -5667,7 +5396,6 @@ Unexpected estree file content error: 1 != 2
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevelExports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevelLambda.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevelLambda2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevelLambda3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevelLambda4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/trackedSymbolsNoCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/trailingCommaInHeterogenousArrayLiteral1.ts
@@ -5687,7 +5415,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressio
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessPromiseCoercion.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/tryCatchFinally.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tryCatchFinallyControlFlow.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tryStatementInternalComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsconfigExtendsPackageJsonExportsWildcard.ts
@@ -5728,7 +5455,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/twiceNestedKeyofIndexIn
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasDeclarationEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasDeclarationEmit2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasDeclarationEmit3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasDeclareKeyword01.d.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasDoesntMakeModuleInstantiated.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasFunctionTypeSharedSymbol.ts
@@ -5750,10 +5476,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentsOnFunction
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentsShouldDisallowNonGenericOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAssertionToGenericFunctionType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAssignabilityErrorMessage.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeCheckExportsVariable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeCheckObjectCreationExpressionWithUndefinedCallResolutionData.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeCheckObjectLiteralMethodBody.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeCheckReturnExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeCheckTypeArgument.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeCheckingInsideFunctionExpressionInArray.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeComparisonCaching.ts
@@ -5800,7 +5524,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeNamedUndefined1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeNamedUndefined2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfEnumAndVarRedeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfOnTypeArg.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfOperator1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfPrototype.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfSuperCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfThisInStatics.ts
@@ -5812,7 +5535,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEq
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEquivalence3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEquivalence4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEquivalence5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterAsBaseClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterAsElementType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterAssignmentCompat1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterAssignmentWithConstraints.ts
@@ -5838,15 +5560,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWith
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterHasSelfAsConstraint.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterInConstraint1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterLeak.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterListWithTrailingComma1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterOrderReversal.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterWithInvalidConstraintType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersAndParametersInComputedNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersInStaticAccessors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersInStaticMethods.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersInStaticProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersShouldNotBeEqual.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersShouldNotBeEqual2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersShouldNotBeEqual3.ts
@@ -5866,8 +5585,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion_n
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesOptionalChaining1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesOptionalChaining2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesOptionalChaining3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectiveScopedPackageCustomTypeRoot.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectiveWithFailedFromTypeRoot.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectiveWithTypeAsFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives10.ts
@@ -5904,9 +5621,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typedArraysCrossAssigna
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typedArraysSubarray.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typedGenericPrototypeMember.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofAmbientExternalModules.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofEnum.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofExternalModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofImportInstantiationExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofInObjectLiteralType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofInterface.ts
@@ -5914,10 +5629,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofInternalModules.t
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofObjectInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofSimple.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofStrictNull.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofStripsFreshness.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofThisInMethodSignature.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofUndefined.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofUnknownSymbol.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofUsedBeforeBlockScoped.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/umdDependencyComment2.ts
@@ -5942,7 +5655,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedAsDiscriminant
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedAssignableToGenericMappedIntersection.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedInferentialTyping.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedSymbolReferencedInArrayLiteral1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedTypeArgument1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedTypeArgument2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedTypeAssignment1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedTypeAssignment2.ts
@@ -5955,7 +5667,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreThisInDerived
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreThisInDerivedClass02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unexportedInstanceClassVariables.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unicodeEscapesInNames01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unicodeStringLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionCallMixedTypeParameterPresence.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionErrorMessageOnMatchingDiscriminant.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionExcessPropertyCheckNoApparentPropTypeMismatchErrors.ts
@@ -5991,10 +5702,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownSymbolOffContext
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownSymbols1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownSymbols2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownTypeArgOnCall.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownTypeErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unmatchedParameterPositions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unmetTypeConstraintInImportCall.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unqualifiedCallToClassStatic1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unreachableDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unreachableFlowAfterFinally.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unreachableSwitchTypeofAny.ts
@@ -6025,7 +5734,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedGetterInClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedIdentifiersConsolidated1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImportDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImportWithSpread.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports12.ts
@@ -6097,9 +5805,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateMethodInCl
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateMethodInClass3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateMethodInClass4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateStaticMembers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateVariableInClass1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateVariableInClass2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateVariableInClass3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateVariableInClass4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateVariableInClass5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSemicolonInClass.ts
@@ -6109,7 +5814,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSingleParameterIn
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSingleParameterInFunctionDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSingleParameterInFunctionExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSingleParameterInMethodDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSwitchStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInFunction1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInFunction2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInFunction3.ts
@@ -6124,7 +5828,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInMe
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInMethod3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInMethod4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInMethod5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters3.ts
@@ -6159,9 +5862,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_js
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_propertyAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_superClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDefinitionInDeclarationFiles.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/useDefineForClassFieldsFlagDefault.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/useStrictLikePrologueString01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/useUnknownInCatchVariables01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/usingModuleWithExportImportInValuePosition.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/validUseOfThisInSuper.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/valueOfTypedArray.ts
@@ -6176,8 +5877,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/varNameConflictsWithImp
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/vararg.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/vardecl.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/variableDeclarationDeclarationEmitUniqueSymbolPartialStatement.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/variableDeclarationInStrictMode1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/variableDeclarationInnerCommentEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/variableDeclarator1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/variableDeclaratorResolvedDuringContextualTyping.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceAnnotationValidation.ts
@@ -6190,8 +5889,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceReferences.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceRepeatedlyPropegatesWithUnreliableFlag.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/verbatim-declarations-parameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/verbatimModuleSyntaxDefaultValue.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/verifyDefaultLib_dom.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/verifyDefaultLib_webworker.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/visSyntax.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/visibilityOfCrossModuleTypeUsage.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/visibilityOfTypeParameters.ts
@@ -6201,7 +5898,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidAsOperator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidFunctionAssignmentCompat.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidIsInitialized.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidOperator1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidReturnIndexUnionInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidReturnLambdaValue.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidUndefinedReduction.ts
@@ -6223,8 +5919,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/withStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/withStatementErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/withStatementInternalComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/withStatementNestedScope.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/wrappedIncovations1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/wrappedIncovations2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/wrappedRecursiveGenericType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/yieldExpression1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/yieldExpressionInFlowLoop.ts
@@ -6240,7 +5934,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/Symbols/ES5SymbolPro
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/Symbols/ES5SymbolProperty5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/Symbols/ES5SymbolProperty6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/Symbols/ES5SymbolProperty7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/Symbols/ES5SymbolType1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/additionalChecks/noPropertyAccessFromIndexSignature1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsExternal.ts
@@ -6264,10 +5957,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShort
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/asyncFunctionDeclarationParameterEvaluation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/arrowFunctionWithParameterNameAsync_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction10_es2017.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction1_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction2_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction3_es2017.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction4_es2017.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction5_es2017.ts
 Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunctionCapturesArguments_es2017.ts
@@ -6313,10 +6004,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncAlias
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/arrowFunctionWithParameterNameAsync_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction10_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction11_es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction1_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction2_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction3_es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction4_es5.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction5_es5.ts
 Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunctionCapturesArguments_es5.ts
@@ -6365,10 +6054,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDe
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncAliasReturnType_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/arrowFunctionWithParameterNameAsync_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction10_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction1_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction2_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction3_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction4_es6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction5_es6.ts
 Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunctionCapturesArguments_es6.ts
@@ -6421,9 +6108,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/asyncGenerators/asyn
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/awaitAndYieldInProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractAccessor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractAsIdentifier.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractAssignabilityConstructorFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractClinterfaceAssignability.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractConstructorAssignability.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractExtends.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractFactoryFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts
@@ -6440,7 +6125,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclara
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractOverrideWithAbstract.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractProperties.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractSingleLineDecl.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractSuperCalls.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractUsingAbstractMethod1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractUsingAbstractMethods2.ts
@@ -6458,29 +6142,21 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclara
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendingClass.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendingOptionalChain.ts
 Expected `{` but found `?.`
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsItself.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsItselfIndirectly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsItselfIndirectly2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsItselfIndirectly3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsShadowedConstructorFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsValidConstructorFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classIsSubtypeOfBaseType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/constructorFunctionTypeIsAssignableToBaseType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/constructorFunctionTypeIsAssignableToBaseType2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/derivedTypeDoesNotRequireExtendsClause.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classImplementsMergedClassInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classInsideBlock.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classWithPredefinedTypesAsNames.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classWithSemicolonClassElement1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classWithSemicolonClassElement2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/declaredClassMergedwithSelf.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/mergeClassInterfaceAndModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/mergedClassInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/mergedInheritedClassInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/modifierOnClassDeclarationMemberInFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classExpression1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classExpression2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classExpression3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classExpression4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classExpression5.ts
@@ -6514,7 +6190,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticB
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock24.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock25.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock27.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock28.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock5.ts
@@ -6527,7 +6202,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticB
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlockUseBeforeDef3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlockUseBeforeDef4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlockUseBeforeDef5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/classWithoutExplicitConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/derivedClassWithoutExplicitConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/derivedClassWithoutExplicitConstructor2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/derivedClassWithoutExplicitConstructor3.ts
@@ -6572,7 +6246,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/acce
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/privateClassPropertyAccessibleWithinClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/privateClassPropertyAccessibleWithinNestedClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAreNotAccessibleDestructuring.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/privateStaticMemberAccessibility.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/privateStaticNotAccessibleInClodule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/privateStaticNotAccessibleInClodule2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinClass.ts
@@ -6628,7 +6301,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inst
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers13.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers5.ts
@@ -6641,7 +6313,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/priv
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAccessorsAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAccessorsCallExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAccessorssDerivedClasses.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAmbientNoImplicitAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndIndexSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndObjectRestSpread.ts
@@ -6833,13 +6504,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemb
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticAndNonStaticPropertiesSameName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticAutoAccessors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticAutoAccessorsWithDecorators.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticMemberInitialization.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyAndFunctionWithSameName.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts
 Classes may not have a static property named prototype
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflictsInAmbientContext.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/strictPropertyInitialization.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/thisInInstanceMemberInitializer.ts
 tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/thisPropertyOverridesAccessors.ts
 Unexpected estree file content error: 1 != 2
 
@@ -7102,20 +6771,13 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumMerging.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumMergingErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumShadowedInfinityNaN.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2016/es2016IntlAPIs.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/assignSharedArrayBufferToArrayBuffer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useObjectValuesAndEntries1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useObjectValuesAndEntries2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useObjectValuesAndEntries3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useObjectValuesAndEntries4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useSharedArrayBuffer1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useSharedArrayBuffer2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useSharedArrayBuffer3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useSharedArrayBuffer4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useSharedArrayBuffer5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useSharedArrayBuffer6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2018/es2018IntlAPIs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2018/usePromiseFinally.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2018/useRegexpGroups.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2019/allowUnescapedParagraphAndLineSeparatorsInStringLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2019/globalThisAmbientModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2019/globalThisBlockscopedProperties.ts
@@ -7136,8 +6798,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/constructBigi
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/es2020IntlAPIs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/intlNumberFormatES2020.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/localesObjectArgument.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/modules/exportAsNamespace1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/modules/exportAsNamespace2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/modules/exportAsNamespace3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/modules/exportAsNamespace4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/modules/exportAsNamespace5.ts
@@ -7167,13 +6827,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2023/intlNumberFor
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2024/resizableArrayBuffer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2024/sharedMemory.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2024/transferableArrayBuffer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit14.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit5.ts
@@ -7243,23 +6901,16 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolPr
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType13.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType15.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType16.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType17.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType18.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType19.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType20.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType9.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/disallowLineTerminatorBeforeArrow.ts
 Line terminator not permitted before arrow
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunction.ts
@@ -7309,19 +6960,17 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/em
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionsAsIs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/emitArrowFunctionsAsIsES6.ts
 tasks/coverage/typescript/tests/cases/conformance/es6/binaryAndOctalIntegerLiteral/binaryIntegerLiteral.ts
-serde_json::from_str(oxc_json) error: number out of range at line 117 column 27
+serde_json::from_str(oxc_json) error: number out of range at line 129 column 27
 
 tasks/coverage/typescript/tests/cases/conformance/es6/binaryAndOctalIntegerLiteral/binaryIntegerLiteralES6.ts
-serde_json::from_str(oxc_json) error: number out of range at line 117 column 27
+serde_json::from_str(oxc_json) error: number out of range at line 129 column 27
 
 tasks/coverage/typescript/tests/cases/conformance/es6/binaryAndOctalIntegerLiteral/octalIntegerLiteral.ts
-serde_json::from_str(oxc_json) error: number out of range at line 87 column 27
+serde_json::from_str(oxc_json) error: number out of range at line 96 column 27
 
 tasks/coverage/typescript/tests/cases/conformance/es6/binaryAndOctalIntegerLiteral/octalIntegerLiteralES6.ts
-serde_json::from_str(oxc_json) error: number out of range at line 87 column 27
+serde_json::from_str(oxc_json) error: number out of range at line 96 column 27
 
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/classWithSemicolonClassElementES61.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/classWithSemicolonClassElementES62.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationOverloadInES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithConstructorInES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithExtensionAndTypeArgumentInES6.ts
@@ -7347,8 +6996,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/superCallBeforeThisAccessing7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/superCallBeforeThisAccessing8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/superCallFromClassThatHasNoBaseTypeButWithSameSymbolInterface.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classExpressions/classExpressionES61.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classExpressions/classExpressionES62.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classExpressions/classExpressionES63.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classExpressions/typeArgumentInferenceWithClassExpression1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classExpressions/typeArgumentInferenceWithClassExpression2.ts
@@ -7710,7 +7357,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of54.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of55.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of56.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of57.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of58.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of7.ts
@@ -7824,7 +7470,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/arraySpre
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/arraySpreadInCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray4.ts
@@ -8043,21 +7688,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedE
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedEscapes/unicodeExtendedEscapesInTemplates16.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedEscapes/unicodeExtendedEscapesInTemplates18.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedEscapes/unicodeExtendedEscapesInTemplates20.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/variableDeclarations/VariableDeclaration10_es6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/variableDeclarations/VariableDeclaration11_es6.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/variableDeclarations/VariableDeclaration12_es6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/variableDeclarations/VariableDeclaration2_es6.ts
 Missing initializer in const declaration
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/variableDeclarations/VariableDeclaration3_es6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/variableDeclarations/VariableDeclaration4_es6.ts
 Missing initializer in const declaration
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/variableDeclarations/VariableDeclaration5_es6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/variableDeclarations/VariableDeclaration6_es6.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/variableDeclarations/VariableDeclaration7_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/variableDeclarations/VariableDeclaration8_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/variableDeclarations/VariableDeclaration9_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression10_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression11_es6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression12_es6.ts
@@ -8159,7 +7797,6 @@ Unexpected estree file content error: 1 != 2
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCanBeAssigned1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsReference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/emitCompoundExponentiationAssignmentWithIndexingOnLHS1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/emitCompoundExponentiationAssignmentWithIndexingOnLHS2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/emitCompoundExponentiationAssignmentWithIndexingOnLHS3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/emitCompoundExponentiationAssignmentWithIndexingOnLHS4.ts
@@ -8178,7 +7815,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOp
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperatorInTemplateString2ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperatorInTemplateString3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperatorInTemplateString3ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithAnyAndNumber.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithEnumUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithInvalidOperands.ts
@@ -8286,7 +7922,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classEx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-arguments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-contextualTypes.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-contextualTypes.ts
@@ -8336,7 +7971,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOp
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndInvalidOperands.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndValidOperator.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithAnyAndNumber.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithEnumUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithInvalidOperands.ts
@@ -8356,7 +7990,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOp
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedConstructorSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnOptionalProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipPrimitiveType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNumberOperand.ts
@@ -8371,12 +8004,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOp
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnOptionalProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTwoOperandsAreAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithValidOperands.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithInvalidOperands.es2015.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithInvalidOperands.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithInvalidStaticToString.ts
@@ -8384,7 +8014,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOp
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithLHSIsTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithRHSHasSymbolHasInstance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithRHSIsSubtypeOfFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalAndOperator/logicalAndOperatorStrictMode.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalAndOperator/logicalAndOperatorWithEveryType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalAndOperator/logicalAndOperatorWithTypeParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrExpressionIsContextuallyTyped.ts
@@ -8466,7 +8095,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishC
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator5.ts
@@ -8480,7 +8108,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishC
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperatorInParameterInitializer.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperatorInParameterInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator_es2020.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator_not_strict.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/objectLiterals/objectLiteralErrors.ts
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/objectLiterals/objectLiteralGettersAndSetters.ts
@@ -8544,8 +8171,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuar
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardNarrowsToLiteralType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardNarrowsToLiteralTypeUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardNesting.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormExpr1AndExpr2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormExpr1OrExpr2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormFunctionEquality.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormInstanceOf.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormInstanceOfOnInterface.ts
@@ -8557,10 +8182,8 @@ Expected a semicolon or an implicit semicolon after a statement, but found none
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormThisMemberErrors.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfBoolean.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfEqualEqualHasNoEffect.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfIsOrderIndependent.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfNotEqualHasNoEffect.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfNumber.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfOther.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfPrimitiveSubtype.ts
@@ -8654,7 +8277,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/valuesAn
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/valuesAndReferences/assignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/amdImportAsPrimaryExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/amdImportNotAsPrimaryExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/asiPreventsParsingAsAmbientExternalModule01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/asiPreventsParsingAsAmbientExternalModule02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/circularReference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/commonJSImportAsPrimaryExpression.ts
@@ -8723,7 +8345,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/glob
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/importImportOnlyModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/importNonExternalModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/importTsBeforeDTs.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/importsImplicitlyReadonly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithExtensions.ts
 tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension3.ts
 Unexpected estree file content error: 1 != 2
@@ -8790,20 +8411,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/type
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/cjsImportInES2015.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/computedPropertyName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/enums.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportDeclaration_moduleSpecifier-isolatedModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportDeclaration_moduleSpecifier.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportDeclaration_value.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportDefault.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace11.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace9.ts
@@ -8940,11 +8555,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarati
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/twoInterfacesDifferentRootModule2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/twoMergedInterfacesWithDifferingOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/twoMergedInterfacesWithDifferingOverloads2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/asiPreventsParsingAsInterface01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/asiPreventsParsingAsInterface02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/asiPreventsParsingAsInterface03.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/asiPreventsParsingAsInterface04.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/asiPreventsParsingAsInterface05.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/derivedInterfaceDoesNotHideBaseSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/derivedInterfaceIncompatibleWithBaseIndexer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendingOptionalChain.ts
@@ -9038,10 +8650,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/impo
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/importDeclarations/shadowedInternalModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleBody/moduleWithStatementsOfEveryKind.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/InvalidNonInstantiatedModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/asiPreventsParsingAsNamespace01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/asiPreventsParsingAsNamespace02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/asiPreventsParsingAsNamespace03.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/asiPreventsParsingAsNamespace04.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/asiPreventsParsingAsNamespace05.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/instantiatedModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/invalidInstantiatedModule.ts
@@ -9291,7 +8900,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxCorrectlyPars
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDefaultAttributesResolution1.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDefaultAttributesResolution2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDefaultAttributesResolution3.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName1.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName3.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName4.tsx
@@ -9497,7 +9105,6 @@ Unexpected estree file content error: 2 != 3
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/typesVersions.ambientModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/typesVersions.emptyTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/typesVersions.justIndex.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/typesVersions.multiFile.ts
 tasks/coverage/typescript/tests/cases/conformance/moduleResolution/untypedModuleImport.ts
 Unexpected estree file content error: 3 != 4
 
@@ -9681,7 +9288,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override1.t
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override14.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override15.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override16.ts
@@ -9726,21 +9332,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/A
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserGetAccessorWithTypeParameters1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserSetAccessorWithTypeAnnotation1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserSetAccessorWithTypeParameters1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression11.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression13.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression14.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression15.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrayLiteralExpressions/parserArrayLiteralExpression9.ts
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression10.ts
 Unexpected estree file content error: 1 != 2
 
@@ -9792,17 +9383,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/C
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration20.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration21.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration22.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration23.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration24.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration25.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration26.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration7.d.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclarationIndexSignature1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName3.ts
@@ -9810,9 +9395,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/C
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName5.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName6.ts
 Computed property names are not allowed in enums.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration10.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration11.ts
@@ -9859,10 +9442,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/E
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ParameterLists/parserErrorRecovery_ParameterList6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/VariableLists/parserErrorRecovery_VariableList1.ts
 Identifier expected. 'return' is a reserved word that cannot be used here.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/VariableLists/parserVariableStatement1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/VariableLists/parserVariableStatement2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/VariableLists/parserVariableStatement3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/VariableLists/parserVariableStatement4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserCommaInTypeMemberList1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserCommaInTypeMemberList2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserErrantSemicolonInClass1.ts
@@ -9898,19 +9477,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/G
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserCastVersusArrowFunction1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericClass1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericClass2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInInterfaceDeclaration1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInVariableDeclaration1.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGreaterThanTokenAmbiguity11.ts
 Cannot assign to this expression
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGreaterThanTokenAmbiguity15.ts
@@ -9919,7 +9488,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
 Cannot assign to this expression
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGreaterThanTokenAmbiguity20.ts
 Cannot assign to this expression
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserObjectCreation1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexMemberDeclarations/parserIndexMemberDeclaration3.ts
@@ -9970,10 +9538,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/M
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberFunctionDeclarations/parserMemberFunctionDeclaration4.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberFunctionDeclarations/parserMemberFunctionDeclarationAmbiguities1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberVariableDeclarations/parserMemberVariableDeclaration3.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberVariableDeclarations/parserMemberVariableDeclaration4.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberVariableDeclarations/parserMemberVariableDeclaration5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature11.ts
@@ -10004,7 +9570,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/M
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ObjectLiterals/parserObjectLiterals1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ObjectTypes/parserObjectType1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ObjectTypes/parserObjectType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ObjectTypes/parserObjectType3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ObjectTypes/parserObjectType4.ts
@@ -10057,27 +9622,20 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/R
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509698.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser536727.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser553699.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser579071.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser596700.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser618973.ts
 'export' modifier cannot be used here.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser630933.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser642331.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser642331_1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser643728.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser645086_3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser645086_4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser645484.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parserNotHexLiteral1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parserTernaryAndCommaOperators1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parseRegularExpressionMixedWithComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpression4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpression6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity2.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity3.ts
 Unexpected flag a in regular expression literal
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakInIterationOrSwitchStatement4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakNotInIterationOrSwitchStatement2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakTarget1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakTarget2.ts
@@ -10085,7 +9643,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/S
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakTarget4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakTarget5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakTarget6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ContinueStatements/parser_continueInIterationStatement4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ContinueStatements/parser_continueLabel.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ContinueStatements/parser_continueNotInIterationStatement2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ContinueStatements/parser_continueNotInIterationStatement4.ts
@@ -10105,36 +9662,23 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
 A 'return' statement can only be used within a function body.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ReturnStatements/parserReturnStatement3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ReturnStatements/parserReturnStatement4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement1.d.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement14.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement15.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement16.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement17.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement18.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement19.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserForInStatement1.d.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserForInStatement8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserForStatement2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserForStatement5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserForStatement9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserLabeledStatement1.d.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserReturnStatement1.d.ts
 A 'return' statement can only be used within a function body.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserTryStatement1.d.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserVariableStatement1.d.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserVariableStatement2.d.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserWithStatement2.ts
 A 'return' statement can only be used within a function body.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression1.ts
@@ -10146,42 +9690,24 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/S
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/TupleTypes/TupleType1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/TupleTypes/TupleType2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/TupleTypes/TupleType3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/TupleTypes/TupleType5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration1.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration10.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration4.d.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration4.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration5.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parser10.1.1-8gs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parser15.4.4.14-9-2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserArgumentList1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserAstSpans1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserEmptyStatement1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserExportAsFunctionIdentifier.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserImportDeclaration1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserInExpression1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserKeywordsAsIdentifierName1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserNoASIOnCallAfterFunctionExpression1.ts
@@ -10212,9 +9738,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/p
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserUnicode3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserUnicodeWhitespaceCharacter1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserUsingConstructorAsIdentifier.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parservoidInQualifiedName0.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parservoidInQualifiedName2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName13.ts
@@ -10228,22 +9751,16 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/C
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName20.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName21.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName22.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName23.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName24.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName25.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName26.ts
 Computed property names are not allowed in enums.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName28.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName29.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName31.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName32.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName34.ts
 Computed property names are not allowed in enums.
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName35.ts
 Expected `]` but found `,`
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName36.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName37.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName38.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName39.ts
@@ -10253,27 +9770,17 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/C
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName5.ts
 'public' modifier cannot be used here.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement1.d.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement14.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement15.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement16.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement17.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement18.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement19.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement22.ts
 The left-hand side of a `for...of` statement may not be `async`
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement23.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement24.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement25.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolIndexer1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolIndexer2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolIndexer3.ts
@@ -10281,9 +9788,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/S
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty9.ts
@@ -10402,7 +9906,6 @@ Unexpected estree file content error: 1 != 2
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scanner10.1.1-8gs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerClass2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerEnum1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerImportDeclaration1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerNonAsciiHorizontalWhitespace.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerS7.2_A1.5_T2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerS7.3_A1.1_T2.ts
@@ -10435,11 +9938,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableS
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.14.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.15.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsDeclarationEmit.1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsDeclarationEmit.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsInForAwaitOf.ts
@@ -10506,63 +10007,26 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-inSta
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES3For-ofTypeCheck1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES3For-ofTypeCheck2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES3For-ofTypeCheck4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES3For-ofTypeCheck6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of11.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of12.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of13.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of14.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of15.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of16.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of17.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of18.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of19.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of2.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of20.ts
 Missing initializer in const declaration
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of21.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of22.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of23.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of24.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of25.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of26.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of27.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of28.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of29.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of30.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of31.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of33.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of34.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of35.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of36.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of37.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck11.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck13.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck14.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5for-of32.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/forStatements/forStatements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/forStatements/forStatementsMultipleInvalidDecl.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/forStatements/forStatementsMultipleValidDecl.ts
@@ -10584,11 +10048,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/throwStat
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/throwStatements/throwStatements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/tryStatements/catchClauseWithTypeAnnotation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/tryStatements/tryStatements.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/withStatements/withStatements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/anyAsConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/anyAsFunctionCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/anyAsGenericFunctionCall.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/anyPropertyAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/assignAnyToEveryType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/assignEveryTypeToAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/narrowExceptionVariableInCatchClause.ts
@@ -10857,41 +10319,26 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLite
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/propertySignatures/propertyNameWithoutTypeAnnotation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/propertySignatures/propertyNamesOfReservedWords.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/propertySignatures/stringNamedPropertyAccess.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/assignFromBooleanInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/assignFromBooleanInterface2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/boolInsteadOfBoolean.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/booleanPropertyAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/extendBooleanInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/invalidBooleanAssignments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/validBooleanAssignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/enum/invalidEnumAssignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/enum/validEnumAssignments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/null/directReferenceToNull.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/null/validNullAssignments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/assignFromNumberInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/assignFromNumberInterface2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/extendNumberInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/invalidNumberAssignments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/numberPropertyAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/validNumberAssignments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/assignFromStringInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/assignFromStringInterface2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/extendStringInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/invalidStringAssignments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/stringPropertyAccess.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/stringPropertyAccessWithError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/validStringAssignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/stringLiteral/stringLiteralType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/directReferenceToUndefined.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/invalidUndefinedAssignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/invalidUndefinedValues.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/validUndefinedAssignments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/validUndefinedValues.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/void/invalidAssignmentsToVoid.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/void/invalidVoidAssignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/void/invalidVoidValues.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/void/validVoidAssignments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/void/validVoidValues.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/genericObjectRest.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/genericRestArity.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/genericRestArityStrict.ts
@@ -10931,7 +10378,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingType
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofANonExportedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofAnExportedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofClass2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofClassWithPrivates.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofModuleWithoutExports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofThis.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofThisWithImplicitThis.ts
@@ -10980,7 +10426,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInUnionTypes01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInUnionTypes02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInUnionTypes03.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInUnionTypes04.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInVariableDeclarations01.ts
 Missing initializer in const declaration
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignability01.ts
@@ -11031,8 +10476,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/arityAnd
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/castingTuple.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/contextualTypeTupleEnd.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/emptyTuples/emptyTuplesTypeAssertion01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/emptyTuples/emptyTuplesTypeAssertion02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/indexerWithTuple.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/namedTupleMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts
@@ -11057,12 +10500,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/variadic
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/variadicTuples3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/asiPreventsParsingAsTypeAlias01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/asiPreventsParsingAsTypeAlias02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/builtinIteratorReturn.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/circularTypeAliasForUnionWithClass.ts
@@ -11070,7 +10510,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/ci
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/classDoesNotDependOnBaseTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/directDependenceBetweenTypeAliases.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/genericTypeAliases.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/interfaceDoesNotDependOnBaseTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/intrinsicKeyword.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/intrinsicTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/typeAliases.ts
@@ -11181,7 +10620,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationsh
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/genericCallWithObjectTypeArgsAndInitializers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/intersectionIncludingPropFromGlobalAugmentation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/nullAssignableToEveryType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/nullAssignedToUndefined.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/numberAssignableToEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/optionalPropertyAssignableToStringIndexSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability.ts
@@ -11205,14 +10643,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationsh
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/independentPropertyVariance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/optionalProperties01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/optionalProperties02.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/switchCaseWithIntersectionTypes01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/switchCaseWithUnionTypes01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/typeAssertionsWithIntersectionTypes01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/typeAssertionsWithUnionTypes01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/weakTypesAndLiterals01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/instanceOf/narrowingConstrainedTypeVariable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/instanceOf/narrowingGenericTypeFromInstanceof01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/arrayLiteralsWithRecursiveGenerics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/infiniteExpansionThroughInstantiation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/infiniteExpansionThroughInstantiation2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/infiniteExpansionThroughTypeInference.ts
@@ -11221,7 +10656,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationsh
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedProperty2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedPropertyCheckedNominally.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/recursiveTypeInGenericConstraint.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/recursiveTypeReferences1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/recursiveTypesUsedAsFunctionParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/enumIsNotASubtypeOfAnythingButNumber.ts


### PR DESCRIPTION
spec: https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/ast-spec/src/expression/Identifier/spec.ts

I'm not sure whether this can be fixed on struct side `BindingIdentifier` instead of field side `Class.id`. `BindingIdentifier` is used inside flatten `BindingPatternKind` enum, so changing it might be complicated.

There are probably many instances like this, so I'm just trying to see the pattern first.