### PR TITLE
refactor(napi): disable unused browser fs

### DIFF
--- a/napi/minify/minify.wasi-browser.js
+++ b/napi/minify/minify.wasi-browser.js
@@ -4,17 +4,11 @@ import {
   WASI as __WASI,
   createOnMessage as __wasmCreateOnMessageForFsProxy,
 } from '@napi-rs/wasm-runtime'
-import { memfs } from '@napi-rs/wasm-runtime/fs'
-import __wasmUrl from './minify.wasm32-wasi.wasm?url'
 
-export const { fs: __fs, vol: __volume } = memfs()
+import __wasmUrl from './minify.wasm32-wasi.wasm?url'
 
 const __wasi = new __WASI({
   version: 'preview1',
-  fs: __fs,
-  preopens: {
-    '/': '/',
-  },
 })
 
 const __emnapiContext = __emnapiGetDefaultContext()
@@ -39,7 +33,6 @@ const {
     const worker = new Worker(new URL('./wasi-worker-browser.mjs', import.meta.url), {
       type: 'module',
     })
-    worker.addEventListener('message', __wasmCreateOnMessageForFsProxy(__fs))
 
     return worker
   },

--- a/napi/minify/package.json
+++ b/napi/minify/package.json
@@ -57,7 +57,7 @@
     ],
     "wasm": {
       "browser": {
-        "fs": true
+        "fs": false
       }
     }
   }

--- a/napi/minify/wasi-worker-browser.mjs
+++ b/napi/minify/wasi-worker-browser.mjs
@@ -1,15 +1,8 @@
-import { instantiateNapiModuleSync, MessageHandler, WASI, createFsProxy } from '@napi-rs/wasm-runtime'
-import { memfsExported as __memfsExported } from '@napi-rs/wasm-runtime/fs'
-
-const fs = createFsProxy(__memfsExported)
+import { instantiateNapiModuleSync, MessageHandler, WASI } from '@napi-rs/wasm-runtime'
 
 const handler = new MessageHandler({
   onLoad({ wasmModule, wasmMemory }) {
     const wasi = new WASI({
-      fs,
-      preopens: {
-        '/': '/',
-      },
       print: function () {
         // eslint-disable-next-line no-console
         console.log.apply(console, arguments)

--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -73,7 +73,7 @@
     ],
     "wasm": {
       "browser": {
-        "fs": true
+        "fs": false
       }
     },
     "dtsHeaderFile": "header.js"

--- a/napi/parser/parser.wasi-browser.js
+++ b/napi/parser/parser.wasi-browser.js
@@ -4,17 +4,11 @@ import {
   WASI as __WASI,
   createOnMessage as __wasmCreateOnMessageForFsProxy,
 } from '@napi-rs/wasm-runtime'
-import { memfs } from '@napi-rs/wasm-runtime/fs'
-import __wasmUrl from './parser.wasm32-wasi.wasm?url'
 
-export const { fs: __fs, vol: __volume } = memfs()
+import __wasmUrl from './parser.wasm32-wasi.wasm?url'
 
 const __wasi = new __WASI({
   version: 'preview1',
-  fs: __fs,
-  preopens: {
-    '/': '/',
-  },
 })
 
 const __emnapiContext = __emnapiGetDefaultContext()
@@ -39,7 +33,6 @@ const {
     const worker = new Worker(new URL('./wasi-worker-browser.mjs', import.meta.url), {
       type: 'module',
     })
-    worker.addEventListener('message', __wasmCreateOnMessageForFsProxy(__fs))
 
     return worker
   },

--- a/napi/parser/wasi-worker-browser.mjs
+++ b/napi/parser/wasi-worker-browser.mjs
@@ -1,15 +1,8 @@
-import { instantiateNapiModuleSync, MessageHandler, WASI, createFsProxy } from '@napi-rs/wasm-runtime'
-import { memfsExported as __memfsExported } from '@napi-rs/wasm-runtime/fs'
-
-const fs = createFsProxy(__memfsExported)
+import { instantiateNapiModuleSync, MessageHandler, WASI } from '@napi-rs/wasm-runtime'
 
 const handler = new MessageHandler({
   onLoad({ wasmModule, wasmMemory }) {
     const wasi = new WASI({
-      fs,
-      preopens: {
-        '/': '/',
-      },
       print: function () {
         // eslint-disable-next-line no-console
         console.log.apply(console, arguments)

--- a/napi/transform/package.json
+++ b/napi/transform/package.json
@@ -57,7 +57,7 @@
     ],
     "wasm": {
       "browser": {
-        "fs": true
+        "fs": false
       }
     }
   }

--- a/napi/transform/transform.wasi-browser.js
+++ b/napi/transform/transform.wasi-browser.js
@@ -4,17 +4,11 @@ import {
   WASI as __WASI,
   createOnMessage as __wasmCreateOnMessageForFsProxy,
 } from '@napi-rs/wasm-runtime'
-import { memfs } from '@napi-rs/wasm-runtime/fs'
-import __wasmUrl from './transform.wasm32-wasi.wasm?url'
 
-export const { fs: __fs, vol: __volume } = memfs()
+import __wasmUrl from './transform.wasm32-wasi.wasm?url'
 
 const __wasi = new __WASI({
   version: 'preview1',
-  fs: __fs,
-  preopens: {
-    '/': '/',
-  },
 })
 
 const __emnapiContext = __emnapiGetDefaultContext()
@@ -39,7 +33,6 @@ const {
     const worker = new Worker(new URL('./wasi-worker-browser.mjs', import.meta.url), {
       type: 'module',
     })
-    worker.addEventListener('message', __wasmCreateOnMessageForFsProxy(__fs))
 
     return worker
   },

--- a/napi/transform/wasi-worker-browser.mjs
+++ b/napi/transform/wasi-worker-browser.mjs
@@ -1,15 +1,8 @@
-import { instantiateNapiModuleSync, MessageHandler, WASI, createFsProxy } from '@napi-rs/wasm-runtime'
-import { memfsExported as __memfsExported } from '@napi-rs/wasm-runtime/fs'
-
-const fs = createFsProxy(__memfsExported)
+import { instantiateNapiModuleSync, MessageHandler, WASI } from '@napi-rs/wasm-runtime'
 
 const handler = new MessageHandler({
   onLoad({ wasmModule, wasmMemory }) {
     const wasi = new WASI({
-      fs,
-      preopens: {
-        '/': '/',
-      },
       print: function () {
         // eslint-disable-next-line no-console
         console.log.apply(console, arguments)


### PR DESCRIPTION
I don't think file access is needed for napi packages. I've already disabled this on napi/playground.