### PR TITLE
feat(data_structures)!: put all parts behind features

### DIFF
--- a/crates/oxc_ast/Cargo.toml
+++ b/crates/oxc_ast/Cargo.toml
@@ -21,7 +21,7 @@ doctest = false
 [dependencies]
 oxc_allocator = { workspace = true }
 oxc_ast_macros = { workspace = true }
-oxc_data_structures = { workspace = true }
+oxc_data_structures = { workspace = true, features = ["inline_string"] }
 oxc_estree = { workspace = true }
 oxc_regular_expression = { workspace = true }
 oxc_span = { workspace = true }

--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -22,7 +22,7 @@ doctest = false
 [dependencies]
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
-oxc_data_structures = { workspace = true }
+oxc_data_structures = { workspace = true, features = ["code_buffer", "stack"] }
 oxc_index = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_sourcemap = { workspace = true }

--- a/crates/oxc_data_structures/Cargo.toml
+++ b/crates/oxc_data_structures/Cargo.toml
@@ -21,5 +21,13 @@ test = true
 doctest = false
 
 [dependencies]
-assert-unchecked = { workspace = true }
-ropey = { workspace = true }
+assert-unchecked = { workspace = true, optional = true }
+ropey = { workspace = true, optional = true }
+
+[features]
+default = []
+all = ["code_buffer", "inline_string", "rope", "stack"]
+code_buffer = ["dep:assert-unchecked"]
+inline_string = []
+rope = ["dep:ropey"]
+stack = ["dep:assert-unchecked"]

--- a/crates/oxc_data_structures/src/lib.rs
+++ b/crates/oxc_data_structures/src/lib.rs
@@ -2,7 +2,11 @@
 
 #![warn(missing_docs)]
 
+#[cfg(feature = "code_buffer")]
 pub mod code_buffer;
+#[cfg(feature = "inline_string")]
 pub mod inline_string;
+#[cfg(feature = "rope")]
 pub mod rope;
+#[cfg(feature = "stack")]
 pub mod stack;

--- a/crates/oxc_estree/Cargo.toml
+++ b/crates/oxc_estree/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 doctest = false
 
 [dependencies]
-oxc_data_structures = { workspace = true, optional = true }
+oxc_data_structures = { workspace = true, features = ["code_buffer"], optional = true }
 
 itoa = { workspace = true, optional = true }
 ryu-js = { workspace = true, optional = true }

--- a/crates/oxc_language_server/Cargo.toml
+++ b/crates/oxc_language_server/Cargo.toml
@@ -23,7 +23,7 @@ doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }
-oxc_data_structures = { workspace = true }
+oxc_data_structures = { workspace = true, features = ["rope"] }
 oxc_diagnostics = { workspace = true }
 oxc_linter = { workspace = true }
 oxc_parser = { workspace = true }

--- a/crates/oxc_mangler/Cargo.toml
+++ b/crates/oxc_mangler/Cargo.toml
@@ -23,7 +23,7 @@ doctest = false
 [dependencies]
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
-oxc_data_structures = { workspace = true }
+oxc_data_structures = { workspace = true, features = ["inline_string"] }
 oxc_index = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }

--- a/crates/oxc_minifier/Cargo.toml
+++ b/crates/oxc_minifier/Cargo.toml
@@ -25,7 +25,7 @@ oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_codegen = { workspace = true }
-oxc_data_structures = { workspace = true }
+oxc_data_structures = { workspace = true, features = ["stack"] }
 oxc_ecmascript = { workspace = true }
 oxc_mangler = { workspace = true }
 oxc_parser = { workspace = true }

--- a/crates/oxc_semantic/Cargo.toml
+++ b/crates/oxc_semantic/Cargo.toml
@@ -23,7 +23,7 @@ oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_cfg = { workspace = true }
-oxc_data_structures = { workspace = true }
+oxc_data_structures = { workspace = true, features = ["stack"] }
 oxc_diagnostics = { workspace = true }
 oxc_ecmascript = { workspace = true }
 oxc_index = { workspace = true }

--- a/crates/oxc_transformer/Cargo.toml
+++ b/crates/oxc_transformer/Cargo.toml
@@ -25,7 +25,7 @@ oxc-browserslist = { workspace = true }
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
-oxc_data_structures = { workspace = true }
+oxc_data_structures = { workspace = true, features = ["rope", "stack"] }
 oxc_diagnostics = { workspace = true }
 oxc_ecmascript = { workspace = true }
 oxc_parser = { workspace = true }

--- a/crates/oxc_traverse/Cargo.toml
+++ b/crates/oxc_traverse/Cargo.toml
@@ -26,7 +26,7 @@ doctest = true
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
-oxc_data_structures = { workspace = true }
+oxc_data_structures = { workspace = true, features = ["stack"] }
 oxc_ecmascript = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_span = { workspace = true }


### PR DESCRIPTION
Put all parts of `oxc_data_structures` crate behind features.

`oxc_data_structures` is intended to be a "kitchen sink" crate where any data structures which are shared between multiple crates can go. We want to avoid having tons of little crates `oxc_rope`, `oxc_stack` etc. But this means it'll inevitably grow over time, and that will impact compile times.

Feature-gating each part of the crate should prevent compile times suffering as `oxc_data_structures` grows.

The immediate benefit is it removes the `ropey` dependency from `oxc_ast` and various other crates.
