### PR TITLE
refactor(semantic): remove dead code

### DIFF
--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -624,11 +624,10 @@ fn unexpected_initializer_in_for_loop_head(x0: &str, span1: Span) -> OxcDiagnost
         .with_label(span1)
 }
 
-pub fn check_for_statement_left<'a>(
+pub fn check_for_statement_left(
     left: &ForStatementLeft,
     is_for_in: bool,
-    _node: &AstNode<'a>,
-    ctx: &SemanticBuilder<'a>,
+    ctx: &SemanticBuilder<'_>,
 ) {
     let ForStatementLeft::VariableDeclaration(decl) = left else { return };
 
@@ -864,11 +863,7 @@ fn a_rest_parameter_cannot_have_an_initializer(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("A rest parameter cannot have an initializer").with_label(span)
 }
 
-pub fn check_formal_parameters<'a>(
-    params: &FormalParameters,
-    _node: &AstNode<'a>,
-    ctx: &SemanticBuilder<'a>,
-) {
+pub fn check_formal_parameters(params: &FormalParameters, ctx: &SemanticBuilder<'_>) {
     if let Some(rest) = &params.rest {
         if let BindingPatternKind::AssignmentPattern(pat) = &rest.argument.kind {
             ctx.error(a_rest_parameter_cannot_have_an_initializer(pat.span));
@@ -1000,11 +995,7 @@ fn delete_private_field(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
-pub fn check_unary_expression<'a>(
-    unary_expr: &'a UnaryExpression,
-    _node: &AstNode<'a>,
-    ctx: &SemanticBuilder<'a>,
-) {
+pub fn check_unary_expression(unary_expr: &UnaryExpression, ctx: &SemanticBuilder<'_>) {
     // https://tc39.es/ecma262/#sec-delete-operator-static-semantics-early-errors
     if unary_expr.operator == UnaryOperator::Delete {
         match unary_expr.argument.get_inner_expression() {

--- a/crates/oxc_semantic/src/checker/mod.rs
+++ b/crates/oxc_semantic/src/checker/mod.rs
@@ -53,12 +53,12 @@ pub fn check<'a>(node: &AstNode<'a>, ctx: &SemanticBuilder<'a>) {
         }
         AstKind::ForInStatement(stmt) => {
             js::check_function_declaration(&stmt.body, false, ctx);
-            js::check_for_statement_left(&stmt.left, true, node, ctx);
+            js::check_for_statement_left(&stmt.left, true, ctx);
             ts::check_for_statement_left(&stmt.left, true, ctx);
         }
         AstKind::ForOfStatement(stmt) => {
             js::check_function_declaration(&stmt.body, false, ctx);
-            js::check_for_statement_left(&stmt.left, false, node, ctx);
+            js::check_for_statement_left(&stmt.left, false, ctx);
             ts::check_for_statement_left(&stmt.left, false, ctx);
         }
         AstKind::WhileStatement(WhileStatement { body, .. })
@@ -88,7 +88,7 @@ pub fn check<'a>(node: &AstNode<'a>, ctx: &SemanticBuilder<'a>) {
         AstKind::Super(sup) => js::check_super(sup, node, ctx),
 
         AstKind::FormalParameters(params) => {
-            js::check_formal_parameters(params, node, ctx);
+            js::check_formal_parameters(params, ctx);
             ts::check_formal_parameters(params, ctx);
         }
         AstKind::ArrayPattern(pat) => {
@@ -102,7 +102,7 @@ pub fn check<'a>(node: &AstNode<'a>, ctx: &SemanticBuilder<'a>) {
         AstKind::LogicalExpression(expr) => js::check_logical_expression(expr, ctx),
         AstKind::MemberExpression(expr) => js::check_member_expression(expr, ctx),
         AstKind::ObjectExpression(expr) => js::check_object_expression(expr, ctx),
-        AstKind::UnaryExpression(expr) => js::check_unary_expression(expr, node, ctx),
+        AstKind::UnaryExpression(expr) => js::check_unary_expression(expr, ctx),
         AstKind::YieldExpression(expr) => js::check_yield_expression(expr, node, ctx),
         AstKind::VariableDeclaration(decl) => ts::check_variable_declaration(decl, ctx),
         AstKind::VariableDeclarator(decl) => ts::check_variable_declarator(decl, ctx),


### PR DESCRIPTION
Pure refactor. Remove unused `&AstNode<'a>` params passed to functions.