### PR TITLE
perf(ast): re-order `VariableDeclarationKind` variants

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1170,8 +1170,8 @@ pub struct VariableDeclaration<'a> {
 #[generate_derive(CloneIn, ContentEq, ESTree)]
 pub enum VariableDeclarationKind {
     Var = 0,
-    Const = 1,
-    Let = 2,
+    Let = 1,
+    Const = 2,
     Using = 3,
     #[estree(rename = "await using")]
     AwaitUsing = 4,

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -1314,8 +1314,8 @@ impl<'alloc> CloneIn<'alloc> for VariableDeclarationKind {
     fn clone_in(&self, _: &'alloc Allocator) -> Self::Cloned {
         match self {
             Self::Var => VariableDeclarationKind::Var,
-            Self::Const => VariableDeclarationKind::Const,
             Self::Let => VariableDeclarationKind::Let,
+            Self::Const => VariableDeclarationKind::Const,
             Self::Using => VariableDeclarationKind::Using,
             Self::AwaitUsing => VariableDeclarationKind::AwaitUsing,
         }

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -913,8 +913,8 @@ impl ESTree for VariableDeclarationKind {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             Self::Var => JsonSafeString("var").serialize(serializer),
-            Self::Const => JsonSafeString("const").serialize(serializer),
             Self::Let => JsonSafeString("let").serialize(serializer),
+            Self::Const => JsonSafeString("const").serialize(serializer),
             Self::Using => JsonSafeString("using").serialize(serializer),
             Self::AwaitUsing => JsonSafeString("await using").serialize(serializer),
         }

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -2919,9 +2919,9 @@ function deserializeVariableDeclarationKind(pos) {
     case 0:
       return 'var';
     case 1:
-      return 'const';
-    case 2:
       return 'let';
+    case 2:
+      return 'const';
     case 3:
       return 'using';
     case 4:

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -2974,9 +2974,9 @@ function deserializeVariableDeclarationKind(pos) {
     case 0:
       return 'var';
     case 1:
-      return 'const';
-    case 2:
       return 'let';
+    case 2:
+      return 'const';
     case 3:
       return 'using';
     case 4:

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -368,7 +368,7 @@ export interface VariableDeclaration extends Span {
   declare: boolean;
 }
 
-export type VariableDeclarationKind = 'var' | 'const' | 'let' | 'using' | 'await using';
+export type VariableDeclarationKind = 'var' | 'let' | 'const' | 'using' | 'await using';
 
 export interface VariableDeclarator extends Span {
   type: 'VariableDeclarator';


### PR DESCRIPTION
Micro-optimization.

Re-order variants of `VariableDeclarationKind`. With this order:

* Checking if it's a lexical declaration is `discriminant != 0`
* Checking if it's const is `discriminant > 1`.

The latter is a couple of instructions shorter than it was before (`discriminant == 1 || discriminant > 2`).
