### PR TITLE
fix(linter/no_case_declarations): fix span of error for `await using`

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_case_declarations.rs
@@ -64,15 +64,18 @@ impl Rule for NoCaseDeclarations {
                     }
                     Statement::VariableDeclaration(var) if var.kind.is_lexical() => {
                         let start = var.span.start;
-                        let end = match var.kind {
+                        let len = match var.kind {
                             VariableDeclarationKind::Const | VariableDeclarationKind::Using => 5,
                             VariableDeclarationKind::Let => 3,
+                            #[expect(clippy::cast_possible_truncation)]
                             VariableDeclarationKind::AwaitUsing => {
-                                var.declarations[0].span.start - start
+                                ctx.source_range(Span::new(start, var.declarations[0].span.start))
+                                    .trim_end()
+                                    .len() as u32
                             }
                             VariableDeclarationKind::Var => unreachable!(),
                         };
-                        let end = start + end;
+                        let end = start + len;
                         ctx.diagnostic(no_case_declarations_diagnostic(Span::new(start, end)));
                     }
                     _ => {}

--- a/crates/oxc_linter/src/snapshots/eslint_no_case_declarations.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_case_declarations.snap
@@ -58,5 +58,5 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint(no-case-declarations): Unexpected lexical declaration in case block.
    ╭─[no_case_declarations.tsx:1:23]
  1 │ switch (a) { default: await using x = {}; break; }
-   ·                       ────────────
+   ·                       ───────────
    ╰────


### PR DESCRIPTION
Follow-on after #9751. Make the span in error for `await using` more accurate.