### PR TITLE
feat(allocator/vec2): add specialized `grow_one` method

### DIFF
--- a/crates/oxc_allocator/src/vec2/raw_vec.rs
+++ b/crates/oxc_allocator/src/vec2/raw_vec.rs
@@ -435,6 +435,15 @@ impl<'a, T> RawVec<'a, T> {
         }
     }
 
+    /// A specialized version of `self.reserve(len, 1)` which requires the
+    /// caller to ensure `len == self.capacity()`.
+    #[inline(never)]
+    pub fn grow_one(&mut self) {
+        if let Err(err) = self.grow_amortized(self.cap, 1) {
+            handle_error(err);
+        }
+    }
+
     /*
     /// Attempts to ensure that the buffer contains at least enough space to hold
     /// `len + additional` elements. If it doesn't already have


### PR DESCRIPTION
A specialized version of `self.reserve(len, 1)` which requires the caller to ensure `len == self.capacity()`.