### PR TITLE
perf(allocator/vec2): replace `self.reserve(1)` calls with `self.grow_one()` for better efficiency

### DIFF
--- a/crates/oxc_allocator/src/vec2/mod.rs
+++ b/crates/oxc_allocator/src/vec2/mod.rs
@@ -1237,7 +1237,7 @@ impl<'bump, T: 'bump> Vec<'bump, T> {
 
         // space for the new element
         if len == self.buf.cap() {
-            self.reserve(1);
+            self.buf.grow_one();
         }
 
         unsafe {
@@ -1565,7 +1565,7 @@ impl<'bump, T: 'bump> Vec<'bump, T> {
         // This will panic or abort if we would allocate > isize::MAX bytes
         // or if the length increment would overflow for zero-sized types.
         if self.len == self.buf.cap() {
-            self.reserve(1);
+            self.buf.grow_one();
         }
         unsafe {
             let end = self.buf.ptr().add(self.len);

--- a/crates/oxc_allocator/src/vec2/raw_vec.rs
+++ b/crates/oxc_allocator/src/vec2/raw_vec.rs
@@ -437,7 +437,10 @@ impl<'a, T> RawVec<'a, T> {
 
     /// A specialized version of `self.reserve(len, 1)` which requires the
     /// caller to ensure `len == self.capacity()`.
-    #[inline(never)]
+    //
+    // Unlike standard library implementation marked as `#[inline(never)]`, we need to
+    // mark as `#[inline]` because this function is common case in the oxc_parser.
+    #[inline]
     pub fn grow_one(&mut self) {
         if let Err(err) = self.grow_amortized(self.cap, 1) {
             handle_error(err);


### PR DESCRIPTION
The places calling `self.reserve(1)` already checked `len == self.buf.cap()`, in order to avoid checking again in `reserve`, we should call `grow_one` instead which is a shortcut of `grow_amortized(len, 1)`.