### PR TITLE
fix(estree/ast): fix `IdentifierName` and `IdentifierReference`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -209,7 +209,10 @@ pub use match_expression;
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "Identifier")]
+#[estree(
+    rename = "Identifier",
+    add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull)
+)]
 pub struct IdentifierName<'a> {
     pub span: Span,
     #[estree(json_safe)]
@@ -224,7 +227,10 @@ pub struct IdentifierName<'a> {
 #[ast(visit)]
 #[derive(Debug, Clone)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "Identifier")]
+#[estree(
+    rename = "Identifier",
+    add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull)
+)]
 pub struct IdentifierReference<'a> {
     pub span: Span,
     /// The name of the identifier being referenced.

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -87,6 +87,9 @@ impl ESTree for IdentifierName<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &JsonSafeString(self.name.as_str()));
+        state.serialize_ts_field("decorators", &crate::serialize::TsEmptyArray(self));
+        state.serialize_ts_field("optional", &crate::serialize::TsFalse(self));
+        state.serialize_ts_field("typeAnnotation", &crate::serialize::TsNull(self));
         state.end();
     }
 }
@@ -98,6 +101,9 @@ impl ESTree for IdentifierReference<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &JsonSafeString(self.name.as_str()));
+        state.serialize_ts_field("decorators", &crate::serialize::TsEmptyArray(self));
+        state.serialize_ts_field("optional", &crate::serialize::TsFalse(self));
+        state.serialize_ts_field("typeAnnotation", &crate::serialize::TsNull(self));
         state.end();
     }
 }

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -84,6 +84,17 @@ impl<T> ESTree for Null<'_, T> {
     }
 }
 
+#[ast_meta]
+#[estree(ts_type = "null", raw_deser = "null")]
+#[ts]
+pub struct TsNull<'b, T>(#[expect(dead_code)] pub &'b T);
+
+impl<T> ESTree for TsNull<'_, T> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        ().serialize(serializer);
+    }
+}
+
 /// Serialized as `true`.
 #[ast_meta]
 #[estree(ts_type = "true", raw_deser = "true")]
@@ -101,6 +112,17 @@ impl<T> ESTree for True<'_, T> {
 pub struct False<'b, T>(#[expect(dead_code)] pub &'b T);
 
 impl<T> ESTree for False<'_, T> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        false.serialize(serializer);
+    }
+}
+
+#[ast_meta]
+#[estree(ts_type = "false", raw_deser = "false")]
+#[ts]
+pub struct TsFalse<'b, T>(#[expect(dead_code)] pub &'b T);
+
+impl<T> ESTree for TsFalse<'_, T> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         false.serialize(serializer);
     }
@@ -125,6 +147,17 @@ pub struct Init<'b, T>(#[expect(dead_code)] pub &'b T);
 impl<T> ESTree for Init<'_, T> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         JsonSafeString("init").serialize(serializer);
+    }
+}
+
+#[ast_meta]
+#[estree(ts_type = "[]", raw_deser = "[]")]
+#[ts]
+pub struct TsEmptyArray<'b, T>(#[expect(dead_code)] pub &'b T);
+
+impl<T> ESTree for TsEmptyArray<'_, T> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        [(); 0].serialize(serializer);
     }
 }
 
@@ -538,6 +571,9 @@ impl ESTree for ClassImplements<'_, '_> {
     raw_deser = "
         const ident = DESER[Box<IdentifierReference>](POS);
         ident.type = 'JSXIdentifier';
+        delete ident.decorators;
+        delete ident.optional;
+        delete ident.typeAnnotation;
         ident
     "
 )]

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -3362,6 +3362,9 @@ function deserializeJSXElementName(pos) {
     case 1:
       const ident = deserializeBoxIdentifierReference(pos + 8);
       ident.type = 'JSXIdentifier';
+      delete ident.decorators;
+      delete ident.optional;
+      delete ident.typeAnnotation;
       return ident;
     case 2:
       return deserializeBoxJSXNamespacedName(pos + 8);
@@ -3380,6 +3383,9 @@ function deserializeJSXMemberExpressionObject(pos) {
     case 0:
       const ident = deserializeBoxIdentifierReference(pos + 8);
       ident.type = 'JSXIdentifier';
+      delete ident.decorators;
+      delete ident.optional;
+      delete ident.typeAnnotation;
       return ident;
     case 1:
       return deserializeBoxJSXMemberExpression(pos + 8);

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -53,6 +53,9 @@ function deserializeIdentifierName(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     name: deserializeStr(pos + 8),
+    decorators: [],
+    optional: false,
+    typeAnnotation: null,
   };
 }
 
@@ -62,6 +65,9 @@ function deserializeIdentifierReference(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     name: deserializeStr(pos + 8),
+    decorators: [],
+    optional: false,
+    typeAnnotation: null,
   };
 }
 
@@ -3417,6 +3423,9 @@ function deserializeJSXElementName(pos) {
     case 1:
       const ident = deserializeBoxIdentifierReference(pos + 8);
       ident.type = 'JSXIdentifier';
+      delete ident.decorators;
+      delete ident.optional;
+      delete ident.typeAnnotation;
       return ident;
     case 2:
       return deserializeBoxJSXNamespacedName(pos + 8);
@@ -3435,6 +3444,9 @@ function deserializeJSXMemberExpressionObject(pos) {
     case 0:
       const ident = deserializeBoxIdentifierReference(pos + 8);
       ident.type = 'JSXIdentifier';
+      delete ident.decorators;
+      delete ident.optional;
+      delete ident.typeAnnotation;
       return ident;
     case 1:
       return deserializeBoxJSXMemberExpression(pos + 8);

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -54,11 +54,17 @@ export type Expression =
 export interface IdentifierName extends Span {
   type: 'Identifier';
   name: string;
+  decorators?: [];
+  optional?: false;
+  typeAnnotation?: null;
 }
 
 export interface IdentifierReference extends Span {
   type: 'Identifier';
   name: string;
+  decorators?: [];
+  optional?: false;
+  typeAnnotation?: null;
 }
 
 export interface BindingIdentifier extends Span {

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -2,7 +2,7 @@ commit: 15392346
 
 estree_typescript Summary:
 AST Parsed     : 10628/10725 (99.10%)
-Positive Passed: 73/10725 (0.68%)
+Positive Passed: 128/10725 (1.19%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/2dArrays.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APILibCheck.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APISample_Watch.ts
@@ -1309,7 +1309,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicGenericTypeInstan
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicGenericTypeInstantiationInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicModuleImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicTypeInstantiation.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/dataViewConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/debugger.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/debuggerEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileAccessors.ts
@@ -2500,10 +2499,10 @@ tasks/coverage/typescript/tests/cases/compiler/fakeInfinity1.ts
 serde_json::from_str(oxc_json) error: number out of range at line 29 column 27
 
 tasks/coverage/typescript/tests/cases/compiler/fakeInfinity2.ts
-serde_json::from_str(oxc_json) error: number out of range at line 35 column 29
+serde_json::from_str(oxc_json) error: number out of range at line 38 column 29
 
 tasks/coverage/typescript/tests/cases/compiler/fakeInfinity3.ts
-serde_json::from_str(oxc_json) error: number out of range at line 35 column 29
+serde_json::from_str(oxc_json) error: number out of range at line 38 column 29
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fallFromLastCase1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fallFromLastCase2.ts
@@ -3812,7 +3811,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/localClassesInLoop_ES6.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/localImportNameVsGlobalName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/localTypeParameterInferencePriority.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/localVariablesReturnedFromCatchBlocks.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/logicalNotExpression1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/m7Bugs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/manyConstExports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mapConstructor.ts
@@ -4173,7 +4171,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/module_augmentUninstant
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/module_augmentUninstantiatedModule2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduledecl.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiCallOverloads.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiExtendsSplitInterfaces1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiExtendsSplitInterfaces2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiImportExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiLineContextDiagnosticWithPretty.ts
@@ -4486,7 +4483,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonstrictTemplateWithNo
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/normalizedIntersectionTooComplex.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nounusedTypeParameterConstraint.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/null.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nullKeyword.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nullableFunctionError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/numberAssignableToEnumInsideUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/numberOnLeftSideOfInExpression.ts
@@ -4866,8 +4862,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertiesAndIndexersFo
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccess1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccess2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccess3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccess4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccess5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccess6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccess7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccessExpressionInnerComments.ts
@@ -5206,7 +5200,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencingSpreadIn
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencingTypeReferenceInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferentialFunctionType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/semicolonsInModuleDeclarations.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/separate1-1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/separate1-2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/setMethods.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/setterBeforeGetter.ts
@@ -5934,7 +5927,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/umdGlobalAugmentationNo
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/umdGlobalConflict.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/umdNamedAmdMode.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/umdNamespaceMergedWithGlobalAugmentationIsNotCircular.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unaryOperators1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unaryOperatorsInStrictMode.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unaryPlus.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/uncalledFunctionChecksInConditional.ts
@@ -7111,7 +7103,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumMergingErr
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumShadowedInfinityNaN.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2016/es2016IntlAPIs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/assignSharedArrayBufferToArrayBuffer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/es2017DateAPIs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useObjectValuesAndEntries1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useObjectValuesAndEntries2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useObjectValuesAndEntries3.ts
@@ -7176,7 +7167,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2023/intlNumberFor
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2024/resizableArrayBuffer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2024/sharedMemory.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2024/transferableArrayBuffer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es5/es5DateAPIs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit11.ts
@@ -7257,13 +7247,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolTy
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType13.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType14.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType15.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType16.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType17.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType18.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType19.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType20.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType4.ts
@@ -8083,9 +8071,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpr
 A 'yield' expression is only allowed in a generator body.
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression17_es6.ts
 A 'yield' expression is only allowed in a generator body.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression18_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression19_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression1_es6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression2_es6.ts
 A 'yield' expression is only allowed in a generator body.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression3_es6.ts
@@ -8094,7 +8080,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression7_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression8_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression9_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldStarExpression1_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldStarExpression4_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorInAmbientContext1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorInAmbientContext3.d.ts
@@ -9897,8 +9882,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/E
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Expressions/parserAssignmentExpression1.ts
 Cannot assign to this expression
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Expressions/parserConditionalExpression1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Expressions/parserInvocationOfMemberAccessOffOfObjectCreationExpression1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Expressions/parserObjectCreation2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration1.d.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration2.d.ts
@@ -9909,18 +9892,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/F
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Fuzz/parser768531.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguity1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguity2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguity3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserCastVersusArrowFunction1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserConstructorAmbiguity1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserConstructorAmbiguity2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserConstructorAmbiguity3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserConstructorAmbiguity4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericClass1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericClass2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint1.ts
@@ -10077,7 +10054,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/R
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509668.ts
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509677.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509693.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509698.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser536727.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser553699.ts
@@ -10095,16 +10071,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/R
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parserNotHexLiteral1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parserTernaryAndCommaOperators1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parseRegularExpressionMixedWithComments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpression2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpression3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpression4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpression5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpression6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity2.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity3.ts
 Unexpected flag a in regular expression literal
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakInIterationOrSwitchStatement4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakNotInIterationOrSwitchStatement2.ts
@@ -10134,7 +10105,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
 A 'return' statement can only be used within a function body.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ReturnStatements/parserReturnStatement3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ReturnStatements/parserReturnStatement4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserDoStatement1.d.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement1.d.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement11.ts
@@ -10148,43 +10118,23 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/S
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement19.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserExpressionStatement1.d.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserForInStatement1.d.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserForInStatement8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserForStatement2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserForStatement3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserForStatement5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserForStatement9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserIfStatement1.d.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserIfStatement2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserLabeledStatement1.d.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserReturnStatement1.d.ts
 A 'return' statement can only be used within a function body.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserSwitchStatement1.d.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserThrowStatement1.d.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserTryStatement1.d.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserVariableStatement1.d.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserVariableStatement2.d.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserWhileStatement1.d.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserWithStatement1.d.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserWithStatement2.ts
 A 'return' statement can only be used within a function body.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode13.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode14.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode15-negative.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode15.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode3-negative.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode6-negative.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression1.ts
@@ -10227,7 +10177,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/V
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parser10.1.1-8gs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parser15.4.4.14-9-2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserAdditiveExpression1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserArgumentList1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserAstSpans1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserEmptyStatement1.ts
@@ -10239,8 +10188,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/p
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserNotRegex1.ts
 A 'return' statement can only be used within a function body.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserNotRegex2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserObjectCreationArrayLiteral2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserObjectCreationArrayLiteral4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserOptionalTypeMembers1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserOverloadOnConstants1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserParenthesizedVariableAndFunctionInTernary.ts
@@ -10453,7 +10400,6 @@ tasks/coverage/typescript/tests/cases/conformance/salsa/varRequireFromTypescript
 Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scanner10.1.1-8gs.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerAdditiveExpression1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerClass2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerEnum1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerImportDeclaration1.ts
@@ -10493,7 +10439,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableS
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.15.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsDeclarationEmit.1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsDeclarationEmit.2.ts


### PR DESCRIPTION
Binding side is tricky https://github.com/oxc-project/oxc/pull/9822, so I went with chipping away these two first.