### PR TITLE
refactor(minifier)!: rename `CompressOptions::all_true`/`all_false` to `smallest`/`safest`

### DIFF
--- a/crates/oxc_minifier/src/options.rs
+++ b/crates/oxc_minifier/src/options.rs
@@ -26,16 +26,16 @@ pub struct CompressOptions {
 #[expect(clippy::derivable_impls)]
 impl Default for CompressOptions {
     fn default() -> Self {
-        Self { drop_console: false, ..Self::all_true() }
+        Self { drop_console: false, ..Self::smallest() }
     }
 }
 
 impl CompressOptions {
-    pub fn all_true() -> Self {
+    pub fn smallest() -> Self {
         Self { target: ESTarget::ESNext, drop_debugger: true, drop_console: true }
     }
 
-    pub fn all_false() -> Self {
+    pub fn safest() -> Self {
         Self { target: ESTarget::ESNext, drop_debugger: false, drop_console: false }
     }
 }

--- a/crates/oxc_minifier/src/tester.rs
+++ b/crates/oxc_minifier/src/tester.rs
@@ -10,7 +10,7 @@ pub fn test_same(source_text: &str) {
 }
 
 pub fn test(source_text: &str, expected: &str) {
-    let result = run(source_text, Some(CompressOptions::all_true()));
+    let result = run(source_text, Some(CompressOptions::smallest()));
     let expected = run(expected, None);
     assert_eq!(result, expected, "\nfor source\n{source_text}\nexpect\n{expected}\ngot\n{result}");
 }

--- a/crates/oxc_minifier/tests/peephole/mod.rs
+++ b/crates/oxc_minifier/tests/peephole/mod.rs
@@ -4,7 +4,7 @@ mod esbuild;
 use oxc_minifier::CompressOptions;
 
 fn test(source_text: &str, expected: &str) {
-    let options = CompressOptions::all_false();
+    let options = CompressOptions::safest();
     crate::test(source_text, expected, options);
 }
 

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -266,10 +266,10 @@ impl Oxc {
                     CompressOptions {
                         drop_console: compress_options.drop_console,
                         drop_debugger: compress_options.drop_debugger,
-                        ..CompressOptions::all_false()
+                        ..CompressOptions::safest()
                     }
                 } else {
-                    CompressOptions::all_false()
+                    CompressOptions::safest()
                 }),
             };
             Minifier::new(options).build(&allocator, &mut program).scoping

--- a/tasks/benchmark/benches/minifier.rs
+++ b/tasks/benchmark/benches/minifier.rs
@@ -28,7 +28,7 @@ fn bench_minifier(criterion: &mut Criterion) {
                 let mut program = Parser::new(&allocator, source_text, source_type).parse().program;
                 let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
 
-                let options = CompressOptions::all_true();
+                let options = CompressOptions::smallest();
 
                 runner.run(|| {
                     Compressor::new(&allocator, options).build_with_scoping(scoping, &mut program);

--- a/tasks/coverage/src/driver.rs
+++ b/tasks/coverage/src/driver.rs
@@ -54,7 +54,7 @@ impl CompilerInterface for Driver {
     }
 
     fn compress_options(&self) -> Option<CompressOptions> {
-        self.compress.then(CompressOptions::all_true)
+        self.compress.then(CompressOptions::smallest)
     }
 
     fn codegen_options(&self) -> Option<CodegenOptions> {


### PR DESCRIPTION
With the `keep_names` option, `all_true` will not behave as you would expect. I think what is expected is `smallest` / `safest` than `all_true` / `all_false`.

Without this change, `all_true` will drop `console` calls but keep the function names as-is.
