### PR TITLE
feat(minifier): support `keep_names` option

### DIFF
--- a/crates/oxc_minifier/src/compressor.rs
+++ b/crates/oxc_minifier/src/compressor.rs
@@ -31,7 +31,8 @@ impl<'a> Compressor<'a> {
         let normalize_options =
             NormalizeOptions { convert_while_to_fors: true, convert_const_to_let: true };
         Normalize::new(normalize_options, self.options).build(program, &mut ctx);
-        PeepholeOptimizations::new(self.options.target).run_in_loop(program, &mut ctx);
+        PeepholeOptimizations::new(self.options.target, self.options.keep_names)
+            .run_in_loop(program, &mut ctx);
         LatePeepholeOptimizations::new(self.options.target).build(program, &mut ctx);
     }
 

--- a/crates/oxc_minifier/src/lib.rs
+++ b/crates/oxc_minifier/src/lib.rs
@@ -18,7 +18,9 @@ use oxc_semantic::{Scoping, SemanticBuilder, Stats};
 
 pub use oxc_mangler::MangleOptions;
 
-pub use crate::{compressor::Compressor, options::CompressOptions};
+pub use crate::{
+    compressor::Compressor, options::CompressOptions, options::CompressOptionsKeepNames,
+};
 
 #[derive(Debug, Clone, Copy)]
 pub struct MinifierOptions {

--- a/crates/oxc_minifier/src/options.rs
+++ b/crates/oxc_minifier/src/options.rs
@@ -12,6 +12,9 @@ pub struct CompressOptions {
     /// Default `ESTarget::ESNext`
     pub target: ESTarget,
 
+    /// Keep function / class names.
+    pub keep_names: CompressOptionsKeepNames,
+
     /// Remove `debugger;` statements.
     ///
     /// Default `true`
@@ -32,10 +35,55 @@ impl Default for CompressOptions {
 
 impl CompressOptions {
     pub fn smallest() -> Self {
-        Self { target: ESTarget::ESNext, drop_debugger: true, drop_console: true }
+        Self {
+            target: ESTarget::ESNext,
+            keep_names: CompressOptionsKeepNames::all_false(),
+            drop_debugger: true,
+            drop_console: true,
+        }
     }
 
     pub fn safest() -> Self {
-        Self { target: ESTarget::ESNext, drop_debugger: false, drop_console: false }
+        Self {
+            target: ESTarget::ESNext,
+            keep_names: CompressOptionsKeepNames::all_true(),
+            drop_debugger: false,
+            drop_console: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CompressOptionsKeepNames {
+    /// Keep function names so that `Function.prototype.name` is preserved.
+    ///
+    /// This does not guarantee that the `undefined` name is preserved.
+    ///
+    /// Default `false`
+    pub function: bool,
+
+    /// Keep class names so that `Class.prototype.name` is preserved.
+    ///
+    /// This does not guarantee that the `undefined` name is preserved.
+    ///
+    /// Default `false`
+    pub class: bool,
+}
+
+impl CompressOptionsKeepNames {
+    pub fn all_false() -> Self {
+        Self { function: false, class: false }
+    }
+
+    pub fn all_true() -> Self {
+        Self { function: true, class: true }
+    }
+
+    pub fn function_only() -> Self {
+        Self { function: true, class: false }
+    }
+
+    pub fn class_only() -> Self {
+        Self { function: false, class: true }
     }
 }

--- a/crates/oxc_minifier/src/peephole/minimize_conditional_expression.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditional_expression.rs
@@ -423,10 +423,11 @@ impl<'a> PeepholeOptimizations {
         if !matches!(consequent.left, AssignmentTarget::AssignmentTargetIdentifier(_)) {
             return None;
         }
-        // TODO: need this condition when `keep_fnames` is introduced
-        // if consequent.right.is_anonymous_function_definition() {
-        //     return None;
-        // }
+        // NOTE: if the right hand side is an anonymous function, applying this compression will
+        // set the `name` property of that function.
+        // Since codes relying on the fact that function's name is undefined should be rare,
+        // we do this compression even if `keep_names` is enabled.
+
         if consequent.operator != AssignmentOperator::Assign
             || consequent.operator != alternate.operator
             || consequent.left.content_ne(&alternate.left)

--- a/crates/oxc_minifier/tests/peephole/mod.rs
+++ b/crates/oxc_minifier/tests/peephole/mod.rs
@@ -4,7 +4,7 @@ mod esbuild;
 use oxc_minifier::CompressOptions;
 
 fn test(source_text: &str, expected: &str) {
-    let options = CompressOptions::safest();
+    let options = CompressOptions { drop_debugger: false, ..CompressOptions::default() };
     crate::test(source_text, expected, options);
 }
 

--- a/napi/minify/index.d.ts
+++ b/napi/minify/index.d.ts
@@ -23,6 +23,8 @@ export interface CompressOptions {
    * @default 'esnext'
    */
   target?: 'esnext' | 'es2015' | 'es2016' | 'es2017' | 'es2018' | 'es2019' | 'es2020' | 'es2021' | 'es2022' | 'es2023' | 'es2024'
+  /** Keep function / class names. */
+  keepNames?: CompressOptionsKeepNames
   /**
    * Pass true to discard calls to `console.*`.
    *
@@ -35,6 +37,25 @@ export interface CompressOptions {
    * @default true
    */
   dropDebugger?: boolean
+}
+
+export interface CompressOptionsKeepNames {
+  /**
+   * Keep function names so that `Function.prototype.name` is preserved.
+   *
+   * This does not guarantee that the `undefined` name is preserved.
+   *
+   * @default false
+   */
+  function: boolean
+  /**
+   * Keep class names so that `Class.prototype.name` is preserved.
+   *
+   * This does not guarantee that the `undefined` name is preserved.
+   *
+   * @default false
+   */
+  class: boolean
 }
 
 export interface MangleOptions {

--- a/napi/minify/src/options.rs
+++ b/napi/minify/src/options.rs
@@ -23,6 +23,9 @@ pub struct CompressOptions {
     )]
     pub target: Option<String>,
 
+    /// Keep function / class names.
+    pub keep_names: Option<CompressOptionsKeepNames>,
+
     /// Pass true to discard calls to `console.*`.
     ///
     /// @default false
@@ -36,7 +39,7 @@ pub struct CompressOptions {
 
 impl Default for CompressOptions {
     fn default() -> Self {
-        Self { target: None, drop_console: None, drop_debugger: Some(true) }
+        Self { target: None, keep_names: None, drop_console: None, drop_debugger: Some(true) }
     }
 }
 
@@ -51,9 +54,33 @@ impl TryFrom<&CompressOptions> for oxc_minifier::CompressOptions {
                 .map(|s| ESTarget::from_str(s))
                 .transpose()?
                 .unwrap_or(default.target),
+            keep_names: o.keep_names.as_ref().map(Into::into).unwrap_or_default(),
             drop_console: o.drop_console.unwrap_or(default.drop_console),
             drop_debugger: o.drop_debugger.unwrap_or(default.drop_debugger),
         })
+    }
+}
+
+#[napi(object)]
+pub struct CompressOptionsKeepNames {
+    /// Keep function names so that `Function.prototype.name` is preserved.
+    ///
+    /// This does not guarantee that the `undefined` name is preserved.
+    ///
+    /// @default false
+    pub function: bool,
+
+    /// Keep class names so that `Class.prototype.name` is preserved.
+    ///
+    /// This does not guarantee that the `undefined` name is preserved.
+    ///
+    /// @default false
+    pub class: bool,
+}
+
+impl From<&CompressOptionsKeepNames> for oxc_minifier::CompressOptionsKeepNames {
+    fn from(o: &CompressOptionsKeepNames) -> Self {
+        oxc_minifier::CompressOptionsKeepNames { function: o.function, class: o.class }
     }
 }
 

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -266,10 +266,10 @@ impl Oxc {
                     CompressOptions {
                         drop_console: compress_options.drop_console,
                         drop_debugger: compress_options.drop_debugger,
-                        ..CompressOptions::safest()
+                        ..CompressOptions::default()
                     }
                 } else {
-                    CompressOptions::safest()
+                    CompressOptions::default()
                 }),
             };
             Minifier::new(options).build(&allocator, &mut program).scoping


### PR DESCRIPTION
Added support for `keep_names: { function: true, class: true }`.
Setting `.name` is makes it difficult to treeshake later on (https://github.com/evanw/esbuild/issues/3965), so it is better to avoid if possible.

This PR only adds support for the compressor. I'll add support for the mangler later on (probably first add required information to the semantics).

refs #9711
