### PR TITLE
refactor(isolated_declarations): remove unused `self` params

### DIFF
--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -14,8 +14,7 @@ use crate::{
 };
 
 impl<'a> IsolatedDeclarations<'a> {
-    #[expect(clippy::unused_self)]
-    pub(crate) fn is_literal_key(&self, key: &PropertyKey<'a>) -> bool {
+    pub(crate) fn is_literal_key(key: &PropertyKey<'a>) -> bool {
         match key {
             PropertyKey::StringLiteral(_)
             | PropertyKey::NumericLiteral(_)
@@ -55,7 +54,7 @@ impl<'a> IsolatedDeclarations<'a> {
     }
 
     pub(crate) fn report_property_key(&self, key: &PropertyKey<'a>) -> bool {
-        if !self.is_literal_key(key) && !Self::is_global_symbol(key) {
+        if !Self::is_literal_key(key) && !Self::is_global_symbol(key) {
             self.error(computed_property_name(key.span()));
             true
         } else {
@@ -63,9 +62,7 @@ impl<'a> IsolatedDeclarations<'a> {
         }
     }
 
-    #[expect(clippy::unused_self)]
     pub(crate) fn transform_accessibility(
-        &self,
         accessibility: Option<TSAccessibility>,
     ) -> Option<TSAccessibility> {
         if accessibility.is_none() || accessibility.is_some_and(|a| a == TSAccessibility::Public) {
@@ -126,7 +123,7 @@ impl<'a> IsolatedDeclarations<'a> {
             property.definite,
             property.readonly,
             type_annotations,
-            self.transform_accessibility(property.accessibility),
+            Self::transform_accessibility(property.accessibility),
         )
     }
 
@@ -163,7 +160,7 @@ impl<'a> IsolatedDeclarations<'a> {
             definition.r#static,
             definition.r#override,
             definition.optional,
-            self.transform_accessibility(definition.accessibility),
+            Self::transform_accessibility(definition.accessibility),
         )
     }
 
@@ -218,7 +215,7 @@ impl<'a> IsolatedDeclarations<'a> {
             false,
             param.readonly,
             type_annotation,
-            self.transform_accessibility(param.accessibility),
+            Self::transform_accessibility(param.accessibility),
         ))
     }
 
@@ -239,7 +236,7 @@ impl<'a> IsolatedDeclarations<'a> {
                     method.key.clone_in(self.ast.allocator),
                     method.r#static,
                     method.r#override,
-                    self.transform_accessibility(method.accessibility),
+                    Self::transform_accessibility(method.accessibility),
                 )
             }
             MethodDefinitionKind::Get | MethodDefinitionKind::Constructor => {
@@ -305,7 +302,7 @@ impl<'a> IsolatedDeclarations<'a> {
             if let ClassElement::MethodDefinition(method) = element {
                 if (method.key.is_private_identifier()
                     || method.accessibility.is_some_and(TSAccessibility::is_private))
-                    || (method.computed && !self.is_literal_key(&method.key))
+                    || (method.computed && !Self::is_literal_key(&method.key))
                 {
                     continue;
                 }

--- a/crates/oxc_isolated_declarations/src/declaration.rs
+++ b/crates/oxc_isolated_declarations/src/declaration.rs
@@ -232,7 +232,7 @@ impl<'a> IsolatedDeclarations<'a> {
             PropertyKey::StaticMemberExpression(expr) => {
                 !expr.get_first_object().is_identifier_reference()
             }
-            key => !self.is_literal_key(key),
+            key => !Self::is_literal_key(key),
         };
 
         if is_not_allowed {

--- a/crates/oxc_isolated_declarations/src/enum.rs
+++ b/crates/oxc_isolated_declarations/src/enum.rs
@@ -104,9 +104,7 @@ impl<'a> IsolatedDeclarations<'a> {
         self.evaluate(expr, enum_name, prev_members)
     }
 
-    #[expect(clippy::unused_self)]
     fn evaluate_ref(
-        &self,
         expr: &Expression<'a>,
         enum_name: &str,
         prev_members: &FxHashMap<Atom<'a>, ConstantValue>,
@@ -150,7 +148,7 @@ impl<'a> IsolatedDeclarations<'a> {
             | Expression::ComputedMemberExpression(_)
             | Expression::StaticMemberExpression(_)
             | Expression::PrivateFieldExpression(_) => {
-                self.evaluate_ref(expr, enum_name, prev_members)
+                Self::evaluate_ref(expr, enum_name, prev_members)
             }
             Expression::BinaryExpression(expr) => {
                 self.eval_binary_expression(expr, enum_name, prev_members)


### PR DESCRIPTION
Pure refactor / code clean up. Remove `&self` from method params where it's not used.
