### PR TITLE
feat(mangler): support `keep_names` option

### DIFF
--- a/crates/oxc_minifier/examples/mangler.rs
+++ b/crates/oxc_minifier/examples/mangler.rs
@@ -15,6 +15,7 @@ use pico_args::Arguments;
 fn main() -> std::io::Result<()> {
     let mut args = Arguments::from_env();
 
+    let keep_names = args.contains("--keep-names");
     let debug = args.contains("--debug");
     let twice = args.contains("--twice");
     let name = args.free_from_str().unwrap_or_else(|_| "test.js".to_string());
@@ -23,11 +24,11 @@ fn main() -> std::io::Result<()> {
     let source_text = std::fs::read_to_string(path)?;
     let source_type = SourceType::from_path(path).unwrap();
 
-    let printed = mangler(&source_text, source_type, debug);
+    let printed = mangler(&source_text, source_type, keep_names, debug);
     println!("{printed}");
 
     if twice {
-        let printed2 = mangler(&printed, source_type, debug);
+        let printed2 = mangler(&printed, source_type, keep_names, debug);
         println!("{printed2}");
         println!("same = {}", printed == printed2);
     }
@@ -35,11 +36,15 @@ fn main() -> std::io::Result<()> {
     Ok(())
 }
 
-fn mangler(source_text: &str, source_type: SourceType, debug: bool) -> String {
+fn mangler(source_text: &str, source_type: SourceType, keep_names: bool, debug: bool) -> String {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     let symbol_table = Mangler::new()
-        .with_options(MangleOptions { debug, top_level: source_type.is_module() })
+        .with_options(MangleOptions {
+            keep_names: keep_names.into(),
+            debug,
+            top_level: source_type.is_module(),
+        })
         .build(&ret.program);
     CodeGenerator::new().with_scoping(Some(symbol_table)).build(&ret.program).code
 }

--- a/crates/oxc_minifier/src/lib.rs
+++ b/crates/oxc_minifier/src/lib.rs
@@ -16,7 +16,7 @@ use oxc_ast::ast::Program;
 use oxc_mangler::Mangler;
 use oxc_semantic::{Scoping, SemanticBuilder, Stats};
 
-pub use oxc_mangler::MangleOptions;
+pub use oxc_mangler::{MangleOptions, MangleOptionsKeepNames};
 
 pub use crate::{
     compressor::Compressor, options::CompressOptions, options::CompressOptionsKeepNames,

--- a/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
+++ b/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
@@ -235,3 +235,42 @@ const foo = 1; foo; export { foo }
 const e = 1;
 e;
 export { e as foo };
+
+function _() { function foo() { var x } }
+function _() {
+	function foo() {
+		var e;
+	}
+}
+
+function _() { var foo = function() { var x } }
+function _() {
+	var foo = function() {
+		var e;
+	};
+}
+
+function _() { var foo = () => { var x } }
+function _() {
+	var foo = () => {
+		var e;
+	};
+}
+
+function _() { class Foo { foo() { var x } } }
+function _() {
+	class Foo {
+		foo() {
+			var e;
+		}
+	}
+}
+
+function _() { var Foo = class { foo() { var x } } }
+function _() {
+	var Foo = class {
+		foo() {
+			var e;
+		}
+	};
+}

--- a/napi/minify/index.d.ts
+++ b/napi/minify/index.d.ts
@@ -65,8 +65,25 @@ export interface MangleOptions {
    * @default false
    */
   toplevel?: boolean
+  /** Keep function / class names */
+  keepNames?: MangleOptionsKeepNames
   /** Debug mangled names. */
   debug?: boolean
+}
+
+export interface MangleOptionsKeepNames {
+  /**
+   * Keep function names so that `Function.prototype.name` is preserved.
+   *
+   * @default false
+   */
+  function: boolean
+  /**
+   * Keep class names so that `Class.prototype.name` is preserved.
+   *
+   * @default false
+   */
+  class: boolean
 }
 
 /** Minify synchronously. */

--- a/napi/minify/src/options.rs
+++ b/napi/minify/src/options.rs
@@ -92,6 +92,9 @@ pub struct MangleOptions {
     /// @default false
     pub toplevel: Option<bool>,
 
+    /// Keep function / class names
+    pub keep_names: Option<MangleOptionsKeepNames>,
+
     /// Debug mangled names.
     pub debug: Option<bool>,
 }
@@ -101,8 +104,28 @@ impl From<&MangleOptions> for oxc_minifier::MangleOptions {
         let default = oxc_minifier::MangleOptions::default();
         Self {
             top_level: o.toplevel.unwrap_or(default.top_level),
+            keep_names: o.keep_names.as_ref().map(Into::into).unwrap_or_default(),
             debug: o.debug.unwrap_or(default.debug),
         }
+    }
+}
+
+#[napi(object)]
+pub struct MangleOptionsKeepNames {
+    /// Keep function names so that `Function.prototype.name` is preserved.
+    ///
+    /// @default false
+    pub function: bool,
+
+    /// Keep class names so that `Class.prototype.name` is preserved.
+    ///
+    /// @default false
+    pub class: bool,
+}
+
+impl From<&MangleOptionsKeepNames> for oxc_minifier::MangleOptionsKeepNames {
+    fn from(o: &MangleOptionsKeepNames) -> Self {
+        oxc_minifier::MangleOptionsKeepNames { function: o.function, class: o.class }
     }
 }
 


### PR DESCRIPTION
Adds support for keepNames in mangler.
The current implementration does not reuse the name kept. For example, for this input,
```js
function e() {}
function foo() {
  var bar = 1;
  console.log(bar)
}
```
the ideal output is
```js
function e() {}
function foo() {
  var e = 1;
  console.log(e)
}
```
(because `e` is not used inside `foo` and can be reused)
but the current output is
```js
function e() {}
function foo() {
  var t = 1;
  console.log(t)
}
```
. I guess this isn't a problem in most cases as you won't use many short names for functions / classes.

close #9711