### PR TITLE
ci(miri): run Miri on `oxc_data_structures` crate with all features enabled

### DIFF
--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -52,6 +52,6 @@ jobs:
       - name: Test with Miri
         run: |
           cargo miri test -p oxc_ast --all-features
-          cargo miri test -p oxc_data_structures
+          cargo miri test -p oxc_data_structures --all-features
           cargo miri test -p oxc_parser
           cargo miri test -p oxc_transformer


### PR DESCRIPTION
#9849 put all parts of `oxc_data_structures` behind features. I neglected to make Miri run on the crate with all those features activated, so it was skipping all the tests. Fix that.