### PR TITLE
perf(cfg, codegen, linter, syntax): use `NonMaxU32` from `oxc_data_structures`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,12 +1374,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nonmax"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "610a5acd306ec67f907abe5567859a3c693fb9886eb1f012ab8f2a47bef3db51"
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,7 +1632,7 @@ version = "0.60.0"
 dependencies = [
  "bitflags 2.9.0",
  "itertools",
- "nonmax",
+ "oxc_data_structures",
  "oxc_index",
  "oxc_syntax",
  "petgraph",
@@ -1653,7 +1647,6 @@ dependencies = [
  "bitflags 2.9.0",
  "cow-utils",
  "insta",
- "nonmax",
  "oxc_allocator",
  "oxc_ast",
  "oxc_data_structures",
@@ -1815,12 +1808,12 @@ dependencies = [
  "lazy_static",
  "markdown",
  "memchr",
- "nonmax",
  "oxc_allocator",
  "oxc_ast",
  "oxc_ast_visit",
  "oxc_cfg",
  "oxc_codegen",
+ "oxc_data_structures",
  "oxc_diagnostics",
  "oxc_ecmascript",
  "oxc_index",
@@ -2122,7 +2115,6 @@ version = "0.60.0"
 dependencies = [
  "bitflags 2.9.0",
  "cow-utils",
- "nonmax",
  "oxc_allocator",
  "oxc_ast_macros",
  "oxc_data_structures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -195,7 +195,6 @@ markdown = "1.0.0-alpha.22"
 memchr = "2.7.4"
 miette = { package = "oxc-miette", version = "2.2.1", features = ["fancy-no-syscall"] }
 mimalloc-safe = "0.1.49"
-nonmax = "0.5.5"
 num-bigint = "0.4.6"
 num-traits = "0.2.19"
 papaya = "0.2.0"

--- a/crates/oxc_cfg/Cargo.toml
+++ b/crates/oxc_cfg/Cargo.toml
@@ -21,11 +21,11 @@ test = false
 doctest = false
 
 [dependencies]
+oxc_data_structures = { workspace = true, features = ["nonmax"] }
 oxc_index = { workspace = true }
 oxc_syntax = { workspace = true }
 
 bitflags = { workspace = true }
 itertools = { workspace = true }
-nonmax = { workspace = true }
 petgraph = { workspace = true }
 rustc-hash = { workspace = true }

--- a/crates/oxc_cfg/src/lib.rs
+++ b/crates/oxc_cfg/src/lib.rs
@@ -1,17 +1,18 @@
-mod block;
-mod builder;
-pub mod dot;
-pub mod visit;
-
 use std::fmt;
 
 use itertools::Itertools;
-use nonmax::NonMaxU32;
-use oxc_index::{Idx, IndexVec};
 use petgraph::{
     Direction,
     visit::{Control, DfsEvent, EdgeRef},
 };
+
+use oxc_data_structures::nonmax::NonMaxU32;
+use oxc_index::{Idx, IndexVec};
+
+mod block;
+mod builder;
+pub mod dot;
+pub mod visit;
 
 pub mod graph {
     pub use petgraph::*;

--- a/crates/oxc_codegen/Cargo.toml
+++ b/crates/oxc_codegen/Cargo.toml
@@ -22,7 +22,7 @@ doctest = false
 [dependencies]
 oxc_allocator = { workspace = true }
 oxc_ast = { workspace = true }
-oxc_data_structures = { workspace = true, features = ["code_buffer", "stack"] }
+oxc_data_structures = { workspace = true, features = ["code_buffer", "nonmax", "stack"] }
 oxc_index = { workspace = true }
 oxc_semantic = { workspace = true }
 oxc_sourcemap = { workspace = true }
@@ -31,7 +31,6 @@ oxc_syntax = { workspace = true }
 
 bitflags = { workspace = true }
 cow-utils = { workspace = true }
-nonmax = { workspace = true }
 rustc-hash = { workspace = true }
 ryu-js = { workspace = true }
 

--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -1,6 +1,6 @@
 use std::{path::Path, sync::Arc};
 
-use nonmax::NonMaxU32;
+use oxc_data_structures::nonmax::NonMaxU32;
 use oxc_index::{Idx, IndexVec};
 use oxc_span::Span;
 use oxc_syntax::identifier::{LS, PS};

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -25,6 +25,7 @@ oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_cfg = { workspace = true }
 oxc_codegen = { workspace = true }
+oxc_data_structures = { workspace = true, features = ["nonmax"] }
 oxc_diagnostics = { workspace = true }
 oxc_ecmascript = { workspace = true }
 oxc_index = { workspace = true, features = ["serde"] }
@@ -50,7 +51,6 @@ json-strip-comments = { workspace = true }
 language-tags = { workspace = true }
 lazy_static = { workspace = true }
 memchr = { workspace = true }
-nonmax = { workspace = true }
 phf = { workspace = true, features = ["macros"] }
 rayon = { workspace = true }
 regex = { workspace = true }

--- a/crates/oxc_linter/src/config/overrides.rs
+++ b/crates/oxc_linter/src/config/overrides.rs
@@ -4,10 +4,10 @@ use std::{
     path::Path,
 };
 
-use nonmax::NonMaxU32;
 use schemars::{JsonSchema, r#gen, schema::Schema};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
+use oxc_data_structures::nonmax::NonMaxU32;
 use oxc_index::{Idx, IndexVec};
 
 use crate::{LintPlugins, OxlintEnv, OxlintGlobals, config::OxlintRules};

--- a/crates/oxc_linter/src/snapshots/react_exhaustive_deps.snap
+++ b/crates/oxc_linter/src/snapshots/react_exhaustive_deps.snap
@@ -307,7 +307,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'history.foo', and 'history.foo.bar'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'history.foo.bar', and 'history.foo'
    ╭─[exhaustive_deps.tsx:7:14]
  6 │             ];
  7 │           }, []);
@@ -532,7 +532,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has missing dependencies: 'props.foo', and 'props.bar'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has missing dependencies: 'props.bar', and 'props.foo'
    ╭─[exhaustive_deps.tsx:6:14]
  5 │             console.log(props.bar);
  6 │           }, []);
@@ -728,7 +728,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'props.foo', and 'props.bar'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'props.bar', and 'props.foo'
    ╭─[exhaustive_deps.tsx:5:14]
  4 │             console.log(props.bar);
  5 │           }, []);
@@ -737,7 +737,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'b', 'f', 'd', and 'e'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'd', 'f', 'b', and 'e'
    ╭─[exhaustive_deps.tsx:5:14]
  4 │             console.log(b, e, d, c, a, g, f);
  5 │           }, [c, a, g]);
@@ -746,7 +746,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'b', 'f', 'd', and 'e'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'd', 'f', 'b', and 'e'
    ╭─[exhaustive_deps.tsx:5:14]
  4 │             console.log(b, e, d, c, a, g, f);
  5 │           }, [a, c, g]);
@@ -755,7 +755,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'b', 'a', 'g', 'f', 'd', 'c', and 'e'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'd', 'f', 'b', 'c', 'g', 'e', and 'a'
    ╭─[exhaustive_deps.tsx:5:14]
  4 │             console.log(b, e, d, c, a, g, f);
  5 │           }, []);
@@ -926,7 +926,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'props.color', and 'props.someOtherRefs.current.innerHTML'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'props.someOtherRefs.current.innerHTML', and 'props.color'
     ╭─[exhaustive_deps.tsx:9:14]
   8 │             fetch(props.color);
   9 │           }, []);
@@ -934,15 +934,6 @@ source: crates/oxc_linter/src/tester.rs
  10 │         }
     ╰────
   help: Either include it or remove the dependency array.
-
-  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: ref1.
-    ╭─[exhaustive_deps.tsx:9:15]
-  8 │             fetch(props.color);
-  9 │           }, [ref1.current, ref2.current, props.someOtherRefs, props.color]);
-    ·               ────────────
- 10 │         }
-    ╰────
-  help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
   ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: ref2.
     ╭─[exhaustive_deps.tsx:9:29]
@@ -956,8 +947,8 @@ source: crates/oxc_linter/src/tester.rs
   ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: ref1.
     ╭─[exhaustive_deps.tsx:9:15]
   8 │             fetch(props.color);
-  9 │           }, [ref1?.current, ref2?.current, props.someOtherRefs, props.color]);
-    ·               ─────────────
+  9 │           }, [ref1.current, ref2.current, props.someOtherRefs, props.color]);
+    ·               ────────────
  10 │         }
     ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
@@ -971,21 +962,21 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: ref1.
+    ╭─[exhaustive_deps.tsx:9:15]
+  8 │             fetch(props.color);
+  9 │           }, [ref1?.current, ref2?.current, props.someOtherRefs, props.color]);
+    ·               ─────────────
+ 10 │         }
+    ╰────
+  help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
+
   ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: ref.
    ╭─[exhaustive_deps.tsx:5:15]
  4 │             console.log(ref.current);
  5 │           }, [ref.current]);
    ·               ───────────
  6 │         }
-   ╰────
-  help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
-
-  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: ref1.
-   ╭─[exhaustive_deps.tsx:7:15]
- 6 │             ref2.current.scrollTop = 0;
- 7 │           }, [ref1.current, ref2.current, activeTab]);
-   ·               ────────────
- 8 │         }
    ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
@@ -998,10 +989,10 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: ref1.
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: ref1.
    ╭─[exhaustive_deps.tsx:7:15]
- 6 │             ref2.current.scrollTop = initY;
- 7 │           }, [ref1.current, ref2.current, activeTab, initY]);
+ 6 │             ref2.current.scrollTop = 0;
+ 7 │           }, [ref1.current, ref2.current, activeTab]);
    ·               ────────────
  8 │         }
    ╰────
@@ -1012,6 +1003,15 @@ source: crates/oxc_linter/src/tester.rs
  6 │             ref2.current.scrollTop = initY;
  7 │           }, [ref1.current, ref2.current, activeTab, initY]);
    ·                             ────────────
+ 8 │         }
+   ╰────
+  help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
+
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: ref1.
+   ╭─[exhaustive_deps.tsx:7:15]
+ 6 │             ref2.current.scrollTop = initY;
+ 7 │           }, [ref1.current, ref2.current, activeTab, initY]);
+   ·               ────────────
  8 │         }
    ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
@@ -1070,7 +1070,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'props.foo', and 'props.foo.onChange'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'props.foo.onChange', and 'props.foo'
    ╭─[exhaustive_deps.tsx:6:14]
  5 │             }
  6 │           }, []);
@@ -1079,7 +1079,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'props.foo', 'props.foo.onChange', and 'props'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'props.foo.onChange', 'props', and 'props.foo'
    ╭─[exhaustive_deps.tsx:7:14]
  6 │             }
  7 │           }, []);
@@ -1097,7 +1097,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'props.isEditMode', 'skillsCount', and 'props'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'props', 'skillsCount', and 'props.isEditMode'
    ╭─[exhaustive_deps.tsx:7:14]
  6 │             }
  7 │           }, []);
@@ -1124,7 +1124,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'value3', 'asyncValue', 'value', 'value2', and 'value4'
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has missing dependencies: 'value2', 'value3', 'asyncValue', 'value4', and 'value'
     ╭─[exhaustive_deps.tsx:19:14]
  18 │             });
  19 │           }, []);
@@ -1232,20 +1232,20 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: MutableStore.
-    ╭─[exhaustive_deps.tsx:10:17]
-  9 │               console.log(MutableStore.hello.world, props.foo, x, y, z, global.stuff);
- 10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
-    ·                 ────────────────────────
- 11 │           }
-    ╰────
-  help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
-
   ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: z.
     ╭─[exhaustive_deps.tsx:10:60]
   9 │               console.log(MutableStore.hello.world, props.foo, x, y, z, global.stuff);
  10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
     ·                                                            ─
+ 11 │           }
+    ╰────
+  help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
+
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: MutableStore.
+    ╭─[exhaustive_deps.tsx:10:17]
+  9 │               console.log(MutableStore.hello.world, props.foo, x, y, z, global.stuff);
+ 10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
+    ·                 ────────────────────────
  11 │           }
     ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
@@ -1268,20 +1268,20 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: MutableStore.
-    ╭─[exhaustive_deps.tsx:10:17]
-  9 │               // nothing
- 10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
-    ·                 ────────────────────────
- 11 │           }
-    ╰────
-  help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
-
   ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: z.
     ╭─[exhaustive_deps.tsx:10:60]
   9 │               // nothing
  10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
     ·                                                            ─
+ 11 │           }
+    ╰────
+  help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
+
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has an unnecessary dependency: MutableStore.
+    ╭─[exhaustive_deps.tsx:10:17]
+  9 │               // nothing
+ 10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
+    ·                 ────────────────────────
  11 │           }
     ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
@@ -1303,21 +1303,21 @@ source: crates/oxc_linter/src/tester.rs
  11 │           }
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
-
-  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: MutableStore.
-    ╭─[exhaustive_deps.tsx:10:17]
-  9 │               // nothing
- 10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
-    ·                 ────────────────────────
- 11 │           }
-    ╰────
-  help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
   ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: z.
     ╭─[exhaustive_deps.tsx:10:60]
   9 │               // nothing
  10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
     ·                                                            ─
+ 11 │           }
+    ╰────
+  help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
+
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: MutableStore.
+    ╭─[exhaustive_deps.tsx:10:17]
+  9 │               // nothing
+ 10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
+    ·                 ────────────────────────
  11 │           }
     ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
@@ -1331,15 +1331,6 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: MutableStore.hello.world
-    ╭─[exhaustive_deps.tsx:10:16]
-  9 │               // nothing
- 10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
-    ·                ────────────────────────────────────────────────────────────
- 11 │           }
-    ╰────
-  help: Either include it or remove the dependency array.
-
   ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: z
     ╭─[exhaustive_deps.tsx:10:16]
   9 │               // nothing
@@ -1349,16 +1340,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: global.stuff
-    ╭─[exhaustive_deps.tsx:10:16]
-  9 │               // nothing
- 10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
-    ·                ────────────────────────────────────────────────────────────
- 11 │           }
-    ╰────
-  help: Either include it or remove the dependency array.
-
-  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: y
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.foo
     ╭─[exhaustive_deps.tsx:10:16]
   9 │               // nothing
  10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
@@ -1376,7 +1358,25 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.foo
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: MutableStore.hello.world
+    ╭─[exhaustive_deps.tsx:10:16]
+  9 │               // nothing
+ 10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
+    ·                ────────────────────────────────────────────────────────────
+ 11 │           }
+    ╰────
+  help: Either include it or remove the dependency array.
+
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: y
+    ╭─[exhaustive_deps.tsx:10:16]
+  9 │               // nothing
+ 10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
+    ·                ────────────────────────────────────────────────────────────
+ 11 │           }
+    ╰────
+  help: Either include it or remove the dependency array.
+
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: global.stuff
     ╭─[exhaustive_deps.tsx:10:16]
   9 │               // nothing
  10 │             }, [MutableStore.hello.world, props.foo, x, y, z, global.stuff]);
@@ -1394,20 +1394,20 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Try memoizing this variable with `useRef` or `useCallback`.
 
-  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: MutableStore.
-    ╭─[exhaustive_deps.tsx:10:17]
-  9 │               // nothing
- 10 │             }, [MutableStore?.hello?.world, props.foo, x, y, z, global?.stuff]);
-    ·                 ──────────────────────────
- 11 │           }
-    ╰────
-  help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
-
   ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: z.
     ╭─[exhaustive_deps.tsx:10:62]
   9 │               // nothing
  10 │             }, [MutableStore?.hello?.world, props.foo, x, y, z, global?.stuff]);
     ·                                                              ─
+ 11 │           }
+    ╰────
+  help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
+
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has an unnecessary dependency: MutableStore.
+    ╭─[exhaustive_deps.tsx:10:17]
+  9 │               // nothing
+ 10 │             }, [MutableStore?.hello?.world, props.foo, x, y, z, global?.stuff]);
+    ·                 ──────────────────────────
  11 │           }
     ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
@@ -1421,15 +1421,6 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Consider removing it from the dependency array. Outer scope values like aren't valid dependencies because mutating them doesn't re-render the component.
 
-  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: MutableStore.hello.world
-    ╭─[exhaustive_deps.tsx:10:16]
-  9 │               // nothing
- 10 │             }, [MutableStore?.hello?.world, props.foo, x, y, z, global?.stuff]);
-    ·                ───────────────────────────────────────────────────────────────
- 11 │           }
-    ╰────
-  help: Either include it or remove the dependency array.
-
   ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: z
     ╭─[exhaustive_deps.tsx:10:16]
   9 │               // nothing
@@ -1439,16 +1430,7 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: global.stuff
-    ╭─[exhaustive_deps.tsx:10:16]
-  9 │               // nothing
- 10 │             }, [MutableStore?.hello?.world, props.foo, x, y, z, global?.stuff]);
-    ·                ───────────────────────────────────────────────────────────────
- 11 │           }
-    ╰────
-  help: Either include it or remove the dependency array.
-
-  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: y
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.foo
     ╭─[exhaustive_deps.tsx:10:16]
   9 │               // nothing
  10 │             }, [MutableStore?.hello?.world, props.foo, x, y, z, global?.stuff]);
@@ -1466,7 +1448,25 @@ source: crates/oxc_linter/src/tester.rs
     ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.foo
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: MutableStore.hello.world
+    ╭─[exhaustive_deps.tsx:10:16]
+  9 │               // nothing
+ 10 │             }, [MutableStore?.hello?.world, props.foo, x, y, z, global?.stuff]);
+    ·                ───────────────────────────────────────────────────────────────
+ 11 │           }
+    ╰────
+  help: Either include it or remove the dependency array.
+
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: y
+    ╭─[exhaustive_deps.tsx:10:16]
+  9 │               // nothing
+ 10 │             }, [MutableStore?.hello?.world, props.foo, x, y, z, global?.stuff]);
+    ·                ───────────────────────────────────────────────────────────────
+ 11 │           }
+    ╰────
+  help: Either include it or remove the dependency array.
+
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: global.stuff
     ╭─[exhaustive_deps.tsx:10:16]
   9 │               // nothing
  10 │             }, [MutableStore?.hello?.world, props.foo, x, y, z, global?.stuff]);

--- a/crates/oxc_syntax/Cargo.toml
+++ b/crates/oxc_syntax/Cargo.toml
@@ -22,14 +22,13 @@ doctest = false
 [dependencies]
 oxc_allocator = { workspace = true }
 oxc_ast_macros = { workspace = true }
-oxc_data_structures = { workspace = true, features = ["assert_unchecked"] }
+oxc_data_structures = { workspace = true, features = ["assert_unchecked", "nonmax"] }
 oxc_estree = { workspace = true }
 oxc_index = { workspace = true }
 oxc_span = { workspace = true }
 
 bitflags = { workspace = true }
 cow-utils = { workspace = true }
-nonmax = { workspace = true }
 phf = { workspace = true, features = ["macros"] }
 rustc-hash = { workspace = true }
 unicode-id-start = { workspace = true }

--- a/crates/oxc_syntax/src/generated/assert_layouts.rs
+++ b/crates/oxc_syntax/src/generated/assert_layouts.rs
@@ -5,7 +5,7 @@
 
 use std::mem::{align_of, offset_of, size_of};
 
-use nonmax::NonMaxU32;
+use oxc_data_structures::nonmax::NonMaxU32;
 
 use crate::{module_record::*, number::*, operator::*, reference::*, scope::*, symbol::*};
 

--- a/crates/oxc_syntax/src/lib.rs
+++ b/crates/oxc_syntax/src/lib.rs
@@ -30,7 +30,7 @@ mod generated {
     mod derive_estree;
 }
 
-/// Dummy type to communicate the content of `nonmax::NonMaxU32` to `oxc_ast_tools`.
+/// Dummy type to communicate the content of `oxc_data_structures::nonmax::NonMaxU32` to `oxc_ast_tools`.
 #[ast(foreign = NonMaxU32)]
 #[expect(dead_code)]
 struct NonMaxU32Alias(NonZeroU32);

--- a/crates/oxc_syntax/src/node.rs
+++ b/crates/oxc_syntax/src/node.rs
@@ -1,9 +1,11 @@
 //! AST Node ID and flags.
+
 use bitflags::bitflags;
-use nonmax::NonMaxU32;
-use oxc_index::Idx;
 #[cfg(feature = "serialize")]
 use serde::{Serialize, Serializer};
+
+use oxc_data_structures::nonmax::NonMaxU32;
+use oxc_index::Idx;
 
 /// AST Node ID
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/crates/oxc_syntax/src/reference.rs
+++ b/crates/oxc_syntax/src/reference.rs
@@ -1,11 +1,12 @@
 #![expect(missing_docs)] // fixme
+
 use bitflags::bitflags;
-use nonmax::NonMaxU32;
-use oxc_index::Idx;
 #[cfg(feature = "serialize")]
 use serde::{Serialize, Serializer};
 
 use oxc_allocator::CloneIn;
+use oxc_data_structures::nonmax::NonMaxU32;
+use oxc_index::Idx;
 
 use crate::{node::NodeId, symbol::SymbolId};
 

--- a/crates/oxc_syntax/src/scope.rs
+++ b/crates/oxc_syntax/src/scope.rs
@@ -1,11 +1,12 @@
 #![expect(missing_docs)] // fixme
+
 use bitflags::bitflags;
-use nonmax::NonMaxU32;
-use oxc_index::Idx;
 #[cfg(feature = "serialize")]
 use serde::{Serialize, Serializer};
 
 use oxc_ast_macros::ast;
+use oxc_data_structures::nonmax::NonMaxU32;
+use oxc_index::Idx;
 
 #[ast]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -1,11 +1,12 @@
 #![expect(missing_docs)] // fixme
+
 use bitflags::bitflags;
-use nonmax::NonMaxU32;
-use oxc_index::Idx;
 #[cfg(feature = "serialize")]
 use serde::{Serialize, Serializer};
 
 use oxc_ast_macros::ast;
+use oxc_data_structures::nonmax::NonMaxU32;
+use oxc_index::Idx;
 
 #[ast]
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/tasks/ast_tools/src/generators/assert_layouts.rs
+++ b/tasks/ast_tools/src/generators/assert_layouts.rs
@@ -510,7 +510,7 @@ fn template(krate: &str, assertions_64: &TokenStream, assertions_32: &TokenStrea
             use crate::*;
         },
         "oxc_syntax" => quote! {
-            use nonmax::NonMaxU32;
+            use oxc_data_structures::nonmax::NonMaxU32;
 
             ///@@line_break
             use crate::{module_record::*, number::*, operator::*, reference::*, scope::*, symbol::*};


### PR DESCRIPTION
Replace [nonmax](https://crates.io/crates/nonmax) dependency with our own `NonMaxU32` type, introduced in #9883.


