### PR TITLE
fix(linter): bump `oxc-miette` to fix nightly panic `Formatting argument out of range`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,9 +1520,9 @@ dependencies = [
 
 [[package]]
 name = "oxc-miette"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112f8458565c773a1f6555c14d6cd0255f56c85dd372932029e4baeb15308bbe"
+checksum = "b8c278d00ecc50ee84aba4768a7ab74eb325dff4dca8c0581495b850d53480ba"
 dependencies = [
  "cfg-if",
  "owo-colors",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,7 @@ lazy_static = "1.5.0"
 log = "0.4.25"
 markdown = "1.0.0-alpha.22"
 memchr = "2.7.4"
-miette = { package = "oxc-miette", version = "2.2.0", features = ["fancy-no-syscall"] }
+miette = { package = "oxc-miette", version = "2.2.1", features = ["fancy-no-syscall"] }
 mimalloc-safe = "0.1.49"
 nonmax = "0.5.5"
 num-bigint = "0.4.6"


### PR DESCRIPTION
closes #9738