### PR TITLE
fix(linter/react): `exhaustive-deps` report longest dependency

### DIFF
--- a/crates/oxc_linter/src/snapshots/react_exhaustive_deps.snap
+++ b/crates/oxc_linter/src/snapshots/react_exhaustive_deps.snap
@@ -514,10 +514,19 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Extract the expression to a separate variable so it can be statically checked.
 
-  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: props
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.foo
    ╭─[exhaustive_deps.tsx:6:14]
  5 │             console.log(props.bar);
  6 │           }, [props, props.foo]);
+   ·              ──────────────────
+ 7 │         }
+   ╰────
+  help: Either include it or remove the dependency array.
+
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.foo
+   ╭─[exhaustive_deps.tsx:6:14]
+ 5 │             console.log(props.bar);
+ 6 │           }, [props.foo, props]);
    ·              ──────────────────
  7 │         }
    ╰────
@@ -559,7 +568,7 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Either include it or remove the dependency array.
 
-  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: local
+  ⚠ eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: local.id
    ╭─[exhaustive_deps.tsx:5:14]
  4 │             console.log(local);
  5 │           }, [local.id, local]);


### PR DESCRIPTION
Where a hook has multiple overlapping dependencies, `react/exhaustive-deps` rule reports that overlap. e.g.:

```js
function Foo(props) {
    useCallback(() => {
        console.log(props.foo);
    }, [props, props.foo]);
    return <div />;
}
```

```
eslint-plugin-react(exhaustive-deps): React Hook useCallback has unnecessary dependency: props.foo
```

[eslint-plugin-react-hooks](https://www.npmjs.com/package/eslint-plugin-react-hooks) always reports the longest dependency (`props.foo` in above case). Whereas Oxlint would report either `props` or `props.foo` randomly - because the dependencies are stored in an `FxHashSet` which does not have a defined iteration order.

This PR fixes that so it always reports the longer dependency, aligning with the ESLint plugin.