### PR TITLE
perf(ast/estree): speed up raw deser for `JSXElement`

### DIFF
--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -570,11 +570,7 @@ impl ESTree for ClassImplements<'_, '_> {
     ts_type = "JSXIdentifier",
     raw_deser = "
         const ident = DESER[Box<IdentifierReference>](POS);
-        ident.type = 'JSXIdentifier';
-        delete ident.decorators;
-        delete ident.optional;
-        delete ident.typeAnnotation;
-        ident
+        {type: 'JSXIdentifier', start: ident.start, end: ident.end, name: ident.name}
     "
 )]
 pub struct JSXElementIdentifierReference<'a, 'b>(pub &'b IdentifierReference<'a>);

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -3361,11 +3361,7 @@ function deserializeJSXElementName(pos) {
       return deserializeBoxJSXIdentifier(pos + 8);
     case 1:
       const ident = deserializeBoxIdentifierReference(pos + 8);
-      ident.type = 'JSXIdentifier';
-      delete ident.decorators;
-      delete ident.optional;
-      delete ident.typeAnnotation;
-      return ident;
+      return { type: 'JSXIdentifier', start: ident.start, end: ident.end, name: ident.name };
     case 2:
       return deserializeBoxJSXNamespacedName(pos + 8);
     case 3:
@@ -3382,11 +3378,7 @@ function deserializeJSXMemberExpressionObject(pos) {
   switch (uint8[pos]) {
     case 0:
       const ident = deserializeBoxIdentifierReference(pos + 8);
-      ident.type = 'JSXIdentifier';
-      delete ident.decorators;
-      delete ident.optional;
-      delete ident.typeAnnotation;
-      return ident;
+      return { type: 'JSXIdentifier', start: ident.start, end: ident.end, name: ident.name };
     case 1:
       return deserializeBoxJSXMemberExpression(pos + 8);
     case 2:

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -3422,11 +3422,7 @@ function deserializeJSXElementName(pos) {
       return deserializeBoxJSXIdentifier(pos + 8);
     case 1:
       const ident = deserializeBoxIdentifierReference(pos + 8);
-      ident.type = 'JSXIdentifier';
-      delete ident.decorators;
-      delete ident.optional;
-      delete ident.typeAnnotation;
-      return ident;
+      return { type: 'JSXIdentifier', start: ident.start, end: ident.end, name: ident.name };
     case 2:
       return deserializeBoxJSXNamespacedName(pos + 8);
     case 3:
@@ -3443,11 +3439,7 @@ function deserializeJSXMemberExpressionObject(pos) {
   switch (uint8[pos]) {
     case 0:
       const ident = deserializeBoxIdentifierReference(pos + 8);
-      ident.type = 'JSXIdentifier';
-      delete ident.decorators;
-      delete ident.optional;
-      delete ident.typeAnnotation;
-      return ident;
+      return { type: 'JSXIdentifier', start: ident.start, end: ident.end, name: ident.name };
     case 1:
       return deserializeBoxJSXMemberExpression(pos + 8);
     case 2:


### PR DESCRIPTION
Follow-on after #9863. Speed up the raw deserializer code for `JSXElement` that PR introduced. Using `delete` in JS is usually a deoptimization. Better to create a new object.