### PR TITLE
perf(ast/estree): faster JSON serialization of empty arrays

### DIFF
--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -2,8 +2,8 @@ use cow_utils::CowUtils;
 
 use oxc_ast_macros::ast_meta;
 use oxc_estree::{
-    CompactJSSerializer, CompactTSSerializer, ESTree, JsonSafeString, PrettyJSSerializer,
-    PrettyTSSerializer, SequenceSerializer, Serializer, StructSerializer,
+    CompactJSSerializer, CompactTSSerializer, ESTree, EmptyArray, JsonSafeString,
+    PrettyJSSerializer, PrettyTSSerializer, SequenceSerializer, Serializer, StructSerializer,
 };
 
 use crate::ast::*;
@@ -157,7 +157,7 @@ pub struct TsEmptyArray<'b, T>(#[expect(dead_code)] pub &'b T);
 
 impl<T> ESTree for TsEmptyArray<'_, T> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        [(); 0].serialize(serializer);
+        EmptyArray.serialize(serializer);
     }
 }
 
@@ -378,7 +378,7 @@ impl ESTree for ImportDeclarationSpecifiers<'_, '_> {
         if let Some(specifiers) = &self.0.specifiers {
             specifiers.serialize(serializer);
         } else {
-            [(); 0].serialize(serializer);
+            EmptyArray.serialize(serializer);
         }
     }
 }
@@ -493,7 +493,7 @@ impl ESTree for ImportDeclarationWithClause<'_, '_> {
         if let Some(with_clause) = &self.0.with_clause {
             with_clause.with_entries.serialize(serializer);
         } else {
-            [(); 0].serialize(serializer);
+            EmptyArray.serialize(serializer);
         }
     }
 }
@@ -513,7 +513,7 @@ impl ESTree for ExportNamedDeclarationWithClause<'_, '_> {
         if let Some(with_clause) = &self.0.with_clause {
             with_clause.with_entries.serialize(serializer);
         } else {
-            [(); 0].serialize(serializer);
+            EmptyArray.serialize(serializer);
         }
     }
 }
@@ -533,7 +533,7 @@ impl ESTree for ExportAllDeclarationWithClause<'_, '_> {
         if let Some(with_clause) = &self.0.with_clause {
             with_clause.with_entries.serialize(serializer);
         } else {
-            [(); 0].serialize(serializer);
+            EmptyArray.serialize(serializer);
         }
     }
 }
@@ -553,7 +553,7 @@ impl ESTree for ClassImplements<'_, '_> {
         if let Some(implements) = &self.0.implements {
             implements.serialize(serializer);
         } else {
-            [(); 0].serialize(serializer);
+            EmptyArray.serialize(serializer);
         }
     }
 }
@@ -606,7 +606,7 @@ pub struct JSXOpeningFragmentAttributes<'b>(#[expect(dead_code)] pub &'b JSXOpen
 
 impl ESTree for JSXOpeningFragmentAttributes<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        [(); 0].serialize(serializer);
+        EmptyArray.serialize(serializer);
     }
 }
 

--- a/crates/oxc_estree/src/serialize/mod.rs
+++ b/crates/oxc_estree/src/serialize/mod.rs
@@ -8,6 +8,7 @@ mod config;
 mod formatter;
 mod primitives;
 mod sequences;
+mod special;
 mod strings;
 mod structs;
 use config::{Config, ConfigJS, ConfigTS};
@@ -16,6 +17,7 @@ use sequences::ESTreeSequenceSerializer;
 use structs::ESTreeStructSerializer;
 
 pub use sequences::SequenceSerializer;
+pub use special::EmptyArray;
 pub use strings::JsonSafeString;
 pub use structs::{FlatStructSerializer, StructSerializer};
 

--- a/crates/oxc_estree/src/serialize/special.rs
+++ b/crates/oxc_estree/src/serialize/special.rs
@@ -1,0 +1,12 @@
+use super::{ESTree, Serializer};
+
+/// Type that is output as `[]`.
+///
+/// Could alternatively serialize e.g. `[(); 0]`, but this is faster.
+pub struct EmptyArray;
+
+impl ESTree for EmptyArray {
+    fn serialize<S: Serializer>(&self, mut serializer: S) {
+        serializer.buffer_mut().print_str("[]");
+    }
+}


### PR DESCRIPTION
#9863 hurt performance of serializing AST to JSON by 8%. This may just have been that `Identifier`s are so common that adding more bulk to them is costly. But it might also be that serializing `[(); 0]` is expensive.

Introduce an `EmptyArray` object which is as fast as possible to serialize.

Let's see if it helps...
