### PR TITLE
feat(mangler): support `keep_names` option

### DIFF
--- a/crates/oxc_minifier/examples/mangler.rs
+++ b/crates/oxc_minifier/examples/mangler.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 
 use oxc_allocator::Allocator;
 use oxc_codegen::CodeGenerator;
-use oxc_mangler::{MangleOptions, Mangler};
+use oxc_mangler::{MangleOptions, MangleOptionsKeepNames, Mangler};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 use pico_args::Arguments;
@@ -15,6 +15,7 @@ use pico_args::Arguments;
 fn main() -> std::io::Result<()> {
     let mut args = Arguments::from_env();
 
+    let keep_names = args.contains("--keep-names");
     let debug = args.contains("--debug");
     let twice = args.contains("--twice");
     let name = args.free_from_str().unwrap_or_else(|_| "test.js".to_string());
@@ -23,11 +24,16 @@ fn main() -> std::io::Result<()> {
     let source_text = std::fs::read_to_string(path)?;
     let source_type = SourceType::from_path(path).unwrap();
 
-    let printed = mangler(&source_text, source_type, debug);
+    let options = MangleOptions {
+        top_level: source_type.is_module(),
+        keep_names: MangleOptionsKeepNames { function: keep_names, class: keep_names },
+        debug,
+    };
+    let printed = mangler(&source_text, source_type, options);
     println!("{printed}");
 
     if twice {
-        let printed2 = mangler(&printed, source_type, debug);
+        let printed2 = mangler(&printed, source_type, options);
         println!("{printed2}");
         println!("same = {}", printed == printed2);
     }
@@ -35,11 +41,9 @@ fn main() -> std::io::Result<()> {
     Ok(())
 }
 
-fn mangler(source_text: &str, source_type: SourceType, debug: bool) -> String {
+fn mangler(source_text: &str, source_type: SourceType, options: MangleOptions) -> String {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
-    let symbol_table = Mangler::new()
-        .with_options(MangleOptions { debug, top_level: source_type.is_module() })
-        .build(&ret.program);
+    let symbol_table = Mangler::new().with_options(options).build(&ret.program);
     CodeGenerator::new().with_scoping(Some(symbol_table)).build(&ret.program).code
 }

--- a/crates/oxc_minifier/src/lib.rs
+++ b/crates/oxc_minifier/src/lib.rs
@@ -16,7 +16,7 @@ use oxc_ast::ast::Program;
 use oxc_mangler::Mangler;
 use oxc_semantic::{Scoping, SemanticBuilder, Stats};
 
-pub use oxc_mangler::MangleOptions;
+pub use oxc_mangler::{MangleOptions, MangleOptionsKeepNames};
 
 pub use crate::{
     compressor::Compressor, options::CompressOptions, options::CompressOptionsKeepNames,

--- a/crates/oxc_minifier/tests/mangler/mod.rs
+++ b/crates/oxc_minifier/tests/mangler/mod.rs
@@ -2,24 +2,24 @@ use std::fmt::Write;
 
 use oxc_allocator::Allocator;
 use oxc_codegen::CodeGenerator;
-use oxc_mangler::{MangleOptions, Mangler};
+use oxc_mangler::{MangleOptions, MangleOptionsKeepNames, Mangler};
 use oxc_parser::Parser;
 use oxc_span::SourceType;
 
-fn mangle(source_text: &str, top_level: bool) -> String {
+fn mangle(source_text: &str, options: MangleOptions) -> String {
     let allocator = Allocator::default();
     let source_type = SourceType::mjs();
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     let program = ret.program;
-    let symbol_table =
-        Mangler::new().with_options(MangleOptions { debug: false, top_level }).build(&program);
+    let symbol_table = Mangler::new().with_options(options).build(&program);
     CodeGenerator::new().with_scoping(Some(symbol_table)).build(&program).code
 }
 
 #[test]
 fn direct_eval() {
     let source_text = "function foo() { let NO_MANGLE; eval('') }";
-    let mangled = mangle(source_text, false);
+    let options = MangleOptions::default();
+    let mangled = mangle(source_text, options);
     assert_eq!(mangled, "function foo() {\n\tlet NO_MANGLE;\n\teval(\"\");\n}\n");
 }
 
@@ -61,14 +61,31 @@ fn mangler() {
         "export const foo = 1; foo",
         "const foo = 1; foo; export { foo }",
     ];
+    let keep_name_cases = [
+        "function _() { function foo() { var x } }",
+        "function _() { var foo = function() { var x } }",
+        "function _() { var foo = () => { var x } }",
+        "function _() { class Foo { foo() { var x } } }",
+        "function _() { var Foo = class { foo() { var x } } }",
+    ];
 
     let mut snapshot = String::new();
     cases.into_iter().fold(&mut snapshot, |w, case| {
-        write!(w, "{case}\n{}\n", mangle(case, false)).unwrap();
+        let options = MangleOptions::default();
+        write!(w, "{case}\n{}\n", mangle(case, options)).unwrap();
         w
     });
     top_level_cases.into_iter().fold(&mut snapshot, |w, case| {
-        write!(w, "{case}\n{}\n", mangle(case, true)).unwrap();
+        let options = MangleOptions { top_level: true, ..MangleOptions::default() };
+        write!(w, "{case}\n{}\n", mangle(case, options)).unwrap();
+        w
+    });
+    keep_name_cases.into_iter().fold(&mut snapshot, |w, case| {
+        let options = MangleOptions {
+            keep_names: MangleOptionsKeepNames::all_true(),
+            ..MangleOptions::default()
+        };
+        write!(w, "{case}\n{}\n", mangle(case, options)).unwrap();
         w
     });
 

--- a/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
+++ b/crates/oxc_minifier/tests/mangler/snapshots/mangler.snap
@@ -235,3 +235,42 @@ const foo = 1; foo; export { foo }
 const e = 1;
 e;
 export { e as foo };
+
+function _() { function foo() { var x } }
+function _() {
+	function foo() {
+		var e;
+	}
+}
+
+function _() { var foo = function() { var x } }
+function _() {
+	var foo = function() {
+		var e;
+	};
+}
+
+function _() { var foo = () => { var x } }
+function _() {
+	var foo = () => {
+		var e;
+	};
+}
+
+function _() { class Foo { foo() { var x } } }
+function _() {
+	class Foo {
+		foo() {
+			var e;
+		}
+	}
+}
+
+function _() { var Foo = class { foo() { var x } } }
+function _() {
+	var Foo = class {
+		foo() {
+			var e;
+		}
+	};
+}

--- a/napi/minify/index.d.ts
+++ b/napi/minify/index.d.ts
@@ -65,8 +65,29 @@ export interface MangleOptions {
    * @default false
    */
   toplevel?: boolean
+  /**
+   * Preserve `name` property for functions and classes.
+   *
+   * @default false
+   */
+  keepNames?: boolean | MangleOptionsKeepNames
   /** Debug mangled names. */
   debug?: boolean
+}
+
+export interface MangleOptionsKeepNames {
+  /**
+   * Preserve `name` property for functions.
+   *
+   * @default false
+   */
+  function: boolean
+  /**
+   * Preserve `name` property for classes.
+   *
+   * @default false
+   */
+  class: boolean
 }
 
 /** Minify synchronously. */

--- a/napi/minify/src/options.rs
+++ b/napi/minify/src/options.rs
@@ -92,6 +92,11 @@ pub struct MangleOptions {
     /// @default false
     pub toplevel: Option<bool>,
 
+    /// Preserve `name` property for functions and classes.
+    ///
+    /// @default false
+    pub keep_names: Option<Either<bool, MangleOptionsKeepNames>>,
+
     /// Debug mangled names.
     pub debug: Option<bool>,
 }
@@ -101,8 +106,33 @@ impl From<&MangleOptions> for oxc_minifier::MangleOptions {
         let default = oxc_minifier::MangleOptions::default();
         Self {
             top_level: o.toplevel.unwrap_or(default.top_level),
+            keep_names: match &o.keep_names {
+                Some(Either::A(false)) => oxc_minifier::MangleOptionsKeepNames::all_false(),
+                Some(Either::A(true)) => oxc_minifier::MangleOptionsKeepNames::all_true(),
+                Some(Either::B(o)) => oxc_minifier::MangleOptionsKeepNames::from(o),
+                None => default.keep_names,
+            },
             debug: o.debug.unwrap_or(default.debug),
         }
+    }
+}
+
+#[napi(object)]
+pub struct MangleOptionsKeepNames {
+    /// Preserve `name` property for functions.
+    ///
+    /// @default false
+    pub function: bool,
+
+    /// Preserve `name` property for classes.
+    ///
+    /// @default false
+    pub class: bool,
+}
+
+impl From<&MangleOptionsKeepNames> for oxc_minifier::MangleOptionsKeepNames {
+    fn from(o: &MangleOptionsKeepNames) -> Self {
+        oxc_minifier::MangleOptionsKeepNames { function: o.function, class: o.class }
     }
 }
 


### PR DESCRIPTION
Same with #9873, but built on top of #9897.

close #9873
close #9711
