### PR TITLE
fix(napi/playground): fix wrapper proxy

### DIFF
--- a/napi/playground/patch.mjs
+++ b/napi/playground/patch.mjs
@@ -19,10 +19,11 @@ export function Oxc() {
       if (p === 'ast') {
         return jsonParseAst(oxc.astJson);
       }
-      if (typeof oxc[p] === 'function') {
-        return oxc[p].bind(oxc);
+      const value = oxc[p];
+      if (typeof value === 'function') {
+        return value.bind(oxc);
       }
-      return Reflect.get(...arguments);
+      return value;
     }
   })
 }

--- a/napi/playground/playground.wasi-browser.js
+++ b/napi/playground/playground.wasi-browser.js
@@ -63,10 +63,11 @@ export function Oxc() {
       if (p === 'ast') {
         return jsonParseAst(oxc.astJson);
       }
-      if (typeof oxc[p] === 'function') {
-        return oxc[p].bind(oxc);
+      const value = oxc[p];
+      if (typeof value === 'function') {
+        return value.bind(oxc);
       }
-      return Reflect.get(...arguments);
+      return value;
     }
   })
 }


### PR DESCRIPTION
- Closes https://github.com/oxc-project/playground/issues/80

I'm not quite sure why `Reflect.get` fails, but this should fix the issue. I confirmed all tabs are now working.