### PR TITLE
chore(syntax,napi/playground): enable to list all supported es targets

### DIFF
--- a/crates/oxc_syntax/src/es_target.rs
+++ b/crates/oxc_syntax/src/es_target.rs
@@ -66,3 +66,22 @@ impl fmt::Display for ESTarget {
         write!(f, "{s}",)
     }
 }
+
+/// List all supported ECMAScript targets.
+pub fn list_all_es_target() -> Vec<ESTarget> {
+    vec![
+        ESTarget::ES5,
+        ESTarget::ES2015,
+        ESTarget::ES2016,
+        ESTarget::ES2017,
+        ESTarget::ES2018,
+        ESTarget::ES2019,
+        ESTarget::ES2020,
+        ESTarget::ES2021,
+        ESTarget::ES2022,
+        ESTarget::ES2023,
+        ESTarget::ES2024,
+        ESTarget::ES2025,
+        ESTarget::ESNext,
+    ]
+}

--- a/napi/playground/index.d.ts
+++ b/napi/playground/index.d.ts
@@ -15,6 +15,7 @@ export declare class Oxc {
   constructor()
   getDiagnostics(): Array<OxcError>
   getComments(): Array<Comment>
+  static getSupportedEsTargets(): Array<string>
   /**
    * # Errors
    * Serde serialization error

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -22,7 +22,7 @@ use oxc::{
         dot::{DebugDot, DebugDotContext},
     },
     span::{SourceType, Span},
-    syntax::reference::Reference,
+    syntax::{es_target::list_all_es_target, reference::Reference},
     transformer::{TransformOptions, Transformer},
 };
 use oxc_index::Idx;
@@ -68,6 +68,11 @@ impl Oxc {
     #[napi]
     pub fn get_comments(&self) -> Vec<Comment> {
         self.comments.clone()
+    }
+
+    #[napi]
+    pub fn get_supported_es_targets() -> Vec<String> {
+        list_all_es_target().into_iter().map(|s| format!("{s}")).collect()
     }
 
     /// # Errors


### PR DESCRIPTION
Maybe the playground [https://playground.oxc.rs/](https://playground.oxc.rs/) should list out all supported es targets.

![image](https://github.com/user-attachments/assets/a92f177b-0ad6-444a-9146-500aa9162f94)

Just as the ts playground did.

![image](https://github.com/user-attachments/assets/71e40655-be19-4018-b9af-24fd07cec02a)

