### PR TITLE
refactor(minifier, transformer): replace `vec_from_iter` with `vec_from_array` for array

### DIFF
--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -382,7 +382,7 @@ impl<'a, 'b> PeepholeOptimizations {
         expr.test.evaluate_value_to_boolean(&ctx).map(|v| {
             if expr.test.may_have_side_effects(&ctx) {
                 // "(a, true) ? b : c" => "a, b"
-                let exprs = ctx.ast.vec_from_iter([
+                let exprs = ctx.ast.vec_from_array([
                     {
                         let mut test = ctx.ast.move_expression(&mut expr.test);
                         self.remove_unused_expression(&mut test, ctx);
@@ -408,7 +408,7 @@ impl<'a, 'b> PeepholeOptimizations {
                 if should_keep_as_sequence_expr {
                     ctx.ast.expression_sequence(
                         expr.span,
-                        ctx.ast.vec_from_iter([
+                        ctx.ast.vec_from_array([
                             ctx.ast.expression_numeric_literal(
                                 expr.span,
                                 0.0,

--- a/crates/oxc_transformer/src/decorator/legacy/metadata.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/metadata.rs
@@ -562,7 +562,7 @@ impl<'a> LegacyDecoratorMetadata<'a, '_> {
         value: Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Decorator<'a> {
-        let arguments = ctx.ast.vec_from_iter([
+        let arguments = ctx.ast.vec_from_array([
             Argument::from(ctx.ast.expression_string_literal(SPAN, key, None)),
             Argument::from(value),
         ]);

--- a/crates/oxc_transformer/src/es2017/async_to_generator.rs
+++ b/crates/oxc_transformer/src/es2017/async_to_generator.rs
@@ -278,7 +278,7 @@ impl<'a, 'ctx> AsyncGeneratorExecutor<'a, 'ctx> {
                 Atom::new_const("arguments"),
                 ReferenceFlags::Read,
             ));
-            (callee, ctx.ast.vec_from_iter([this_argument, arguments_argument]))
+            (callee, ctx.ast.vec_from_array([this_argument, arguments_argument]))
         } else {
             // callee()
             (callee, ctx.ast.vec())


### PR DESCRIPTION
`vec_from_array` is more efficient than `vec_from_iter`. We should always use `vec_from_array` where possible.