### PR TITLE
perf(mangler, minifier): initialize a Vec with a specific value using `Vec::from_iter_in` combined with `repeat_with`

### DIFF
--- a/crates/oxc_mangler/src/lib.rs
+++ b/crates/oxc_mangler/src/lib.rs
@@ -1,4 +1,4 @@
-use std::iter;
+use std::iter::{self, repeat_with};
 
 use fixedbitset::FixedBitSet;
 use itertools::Itertools;
@@ -373,10 +373,10 @@ impl Mangler {
         allocator: &'a Allocator,
     ) -> Vec<'a, SlotFrequency<'a>> {
         let root_scope_id = scoping.root_scope_id();
-        let mut frequencies = Vec::with_capacity_in(total_number_of_slots, allocator);
-        for _ in 0..total_number_of_slots {
-            frequencies.push(SlotFrequency::new(allocator));
-        }
+        let mut frequencies = Vec::from_iter_in(
+            repeat_with(|| SlotFrequency::new(allocator)).take(total_number_of_slots),
+            allocator,
+        );
 
         for (symbol_id, slot) in slots.iter().copied().enumerate() {
             let symbol_id = SymbolId::from_usize(symbol_id);

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1,3 +1,5 @@
+use std::iter::repeat_with;
+
 use oxc_allocator::{CloneIn, Vec};
 use oxc_ast::{NONE, ast::*};
 use oxc_ecmascript::constant_evaluation::DetermineValueType;
@@ -744,8 +746,8 @@ impl<'a> PeepholeOptimizations {
                         if n.value.fract() == 0.0 {
                             let n_int = n.value as usize;
                             if (1..=6).contains(&n_int) {
-                                let elisions = std::iter::from_fn(|| {
-                                    Some(ArrayExpressionElement::Elision(ctx.ast.elision(n.span)))
+                                let elisions = repeat_with(|| {
+                                    ArrayExpressionElement::Elision(ctx.ast.elision(n.span))
                                 })
                                 .take(n_int);
                                 return Some(ctx.ast.expression_array(


### PR DESCRIPTION
https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=a7c0cc8b2427a67e50259253a85d0cbd

Replace `std::iter::from_fn` with `repeat_with` because it accepts a function that expects to return an `Option<T>`, but we always return a `Some`, and it doesn't satisfy the `TrustedLen` trait.