### PR TITLE
fix(ast/estree): fix `Function.this_param`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1658,7 +1658,7 @@ pub struct BindingRestElement<'a> {
     add_fields(expression = False),
     field_order(
         r#type, span, id, expression, generator, r#async, params, body,
-        declare, type_parameters, this_param, return_type,
+        declare, type_parameters, return_type,
     ),
 )]
 pub struct Function<'a> {
@@ -1695,10 +1695,12 @@ pub struct Function<'a> {
     /// });
     /// ```
     #[ts]
+    #[estree(skip)]
     pub this_param: Option<Box<'a, TSThisParameter<'a>>>,
     /// Function parameters.
     ///
     /// Does not include `this` parameters used by some TypeScript functions.
+    #[estree(via = FunctionFormalParameters)]
     pub params: Box<'a, FormalParameters<'a>>,
     /// The TypeScript return type annotation.
     #[ts]

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -31,6 +31,10 @@ use super::{inherit_variants, js::*, literal::*};
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[estree(
+    rename = "Identifier",
+    add_fields(decorators = TsEmptyArray, optional = TsFalse, name = This)
+)]
 pub struct TSThisParameter<'a> {
     pub span: Span,
     #[estree(skip)]

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1345,11 +1345,10 @@ impl ESTree for Function<'_> {
         state.serialize_field("expression", &crate::serialize::False(self));
         state.serialize_field("generator", &self.generator);
         state.serialize_field("async", &self.r#async);
-        state.serialize_field("params", &self.params);
+        state.serialize_field("params", &crate::serialize::FunctionFormalParameters(self));
         state.serialize_field("body", &self.body);
         state.serialize_ts_field("declare", &self.declare);
         state.serialize_ts_field("typeParameters", &self.type_parameters);
-        state.serialize_ts_field("thisParam", &self.this_param);
         state.serialize_ts_field("returnType", &self.return_type);
         state.end();
     }
@@ -2278,10 +2277,13 @@ impl ESTree for JSXText<'_> {
 impl ESTree for TSThisParameter<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", &JsonSafeString("TSThisParameter"));
+        state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.serialize_field("name", &crate::serialize::This(self));
+        state.serialize_ts_field("decorators", &crate::serialize::TsEmptyArray(self));
+        state.serialize_ts_field("optional", &crate::serialize::TsFalse(self));
         state.end();
     }
 }

--- a/crates/oxc_estree/src/serialize/sequences.rs
+++ b/crates/oxc_estree/src/serialize/sequences.rs
@@ -4,6 +4,7 @@ use super::{Config, ESTree, ESTreeSerializer, Formatter, Serializer, SerializerP
 pub trait SequenceSerializer {
     /// Serialize sequence entry.
     fn serialize_element<T: ESTree + ?Sized>(&mut self, value: &T);
+    fn serialize_ts_element<T: ESTree + ?Sized>(&mut self, value: &T);
 
     /// Finish serializing sequence.
     fn end(self);
@@ -41,6 +42,12 @@ impl<C: Config, F: Formatter> SequenceSerializer for ESTreeSequenceSerializer<'_
         }
 
         value.serialize(&mut *self.serializer);
+    }
+
+    fn serialize_ts_element<T: ESTree + ?Sized>(&mut self, value: &T) {
+        if C::INCLUDE_TS_FIELDS {
+            self.serialize_element(value);
+        }
     }
 
     /// Finish serializing sequence.

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -749,6 +749,7 @@ function deserializeBindingRestElement(pos) {
 }
 
 function deserializeFunction(pos) {
+  const params = deserializeBoxFormalParameters(pos + 72);
   return {
     type: deserializeFunctionType(pos + 8),
     start: deserializeU32(pos),
@@ -757,7 +758,7 @@ function deserializeFunction(pos) {
     expression: false,
     generator: deserializeBool(pos + 48),
     async: deserializeBool(pos + 49),
-    params: deserializeBoxFormalParameters(pos + 72),
+    params,
     body: deserializeOptionBoxFunctionBody(pos + 88),
   };
 }
@@ -1262,10 +1263,11 @@ function deserializeJSXText(pos) {
 
 function deserializeTSThisParameter(pos) {
   return {
-    type: 'TSThisParameter',
+    type: 'Identifier',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 16),
+    name: 'this',
   };
 }
 

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -768,6 +768,11 @@ function deserializeBindingRestElement(pos) {
 }
 
 function deserializeFunction(pos) {
+  const params = deserializeBoxFormalParameters(pos + 72);
+  const thisParam = deserializeOptionBoxTSThisParameter(pos + 64);
+  if (thisParam !== null) {
+    params.unshift(thisParam);
+  }
   return {
     type: deserializeFunctionType(pos + 8),
     start: deserializeU32(pos),
@@ -776,11 +781,10 @@ function deserializeFunction(pos) {
     expression: false,
     generator: deserializeBool(pos + 48),
     async: deserializeBool(pos + 49),
-    params: deserializeBoxFormalParameters(pos + 72),
+    params,
     body: deserializeOptionBoxFunctionBody(pos + 88),
     declare: deserializeBool(pos + 50),
     typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 56),
-    thisParam: deserializeOptionBoxTSThisParameter(pos + 64),
     returnType: deserializeOptionBoxTSTypeAnnotation(pos + 80),
   };
 }
@@ -1326,10 +1330,13 @@ function deserializeJSXText(pos) {
 
 function deserializeTSThisParameter(pos) {
   return {
-    type: 'TSThisParameter',
+    type: 'Identifier',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 16),
+    name: 'this',
+    decorators: [],
+    optional: false,
   };
 }
 

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -553,7 +553,6 @@ export interface Function extends Span {
   body: FunctionBody | null;
   declare?: boolean;
   typeParameters?: TSTypeParameterDeclaration | null;
-  thisParam?: TSThisParameter | null;
   returnType?: TSTypeAnnotation | null;
 }
 
@@ -918,8 +917,11 @@ export interface JSXText extends Span {
 }
 
 export interface TSThisParameter extends Span {
-  type: 'TSThisParameter';
+  type: 'Identifier';
   typeAnnotation: TSTypeAnnotation | null;
+  name: 'this';
+  decorators?: [];
+  optional?: false;
 }
 
 export interface TSEnumDeclaration extends Span {

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -1,8 +1,8 @@
 commit: 15392346
 
 estree_typescript Summary:
-AST Parsed     : 10624/10725 (99.06%)
-Positive Passed: 816/10725 (7.61%)
+AST Parsed     : 10623/10725 (99.05%)
+Positive Passed: 1332/10725 (12.42%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/2dArrays.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APILibCheck.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APISample_Watch.ts
@@ -14,38 +14,22 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/APISample_linter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APISample_parseConfig.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APISample_transform.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APISample_watcher.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration11.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration13.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration14.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration15.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration21.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration22.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration25.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration9.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/ClassDeclarationWithInvalidConstOnPropertyDeclaration.ts
 A class member cannot have the 'const' keyword.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/DeclarationErrorsNoEmitOnError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/FunctionDeclaration7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/InterfaceDeclaration8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/SystemModuleForStatementNoInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractClassInLocalScope.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractClassInLocalScopeIsAbstract.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractClassUnionInstantiation.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractIdentifierNameStrict.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractInterfaceIdentifierName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractPropertyBasics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractPropertyInConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractPropertyNegative.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessInstanceMemberFromStaticMethod01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessOverriddenBaseClassMember1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessStaticMemberFromInstanceMethod01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorAccidentalCallDiagnostic.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/accessorBodyInTypeContext.ts
 Unexpected token
@@ -55,7 +39,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorInferredReturnT
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorWithInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorWithLineTerminator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorWithRestParam.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorsEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorsInAmbientContext.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessors_spec_section-4.5_error-cases.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessors_spec_section-4.5_inference.ts
@@ -64,7 +47,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/addMoreCallSignaturesTo
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/addMoreOverloadsToBaseSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasAssignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasBug.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasDoesNotDuplicateSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasInstantiationExpressionGenericIntersectionNoCrash1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasInstantiationExpressionGenericIntersectionNoCrash2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasOfGenericFunctionWithRestBehavedSameAsUnaliased.ts
@@ -90,25 +72,15 @@ tasks/coverage/typescript/tests/cases/compiler/allowJscheckJsTypeParameterNoCras
 Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImportsCanPaintCrossModuleDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/alwaysStrict.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/alwaysStrictAlreadyUseStrict.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/alwaysStrictES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/alwaysStrictModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/alwaysStrictModule2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/alwaysStrictModule3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/alwaysStrictModule4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/alwaysStrictModule5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/alwaysStrictModule6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/alwaysStrictNoImplicitUseStrict.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientClassDeclarationWithExtends.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientClassDeclaredBeforeBase.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientClassMergesOverloadsWithInterface.ts
@@ -124,11 +96,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientEnumElementIniti
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientExportDefaultErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientExternalModuleInAnotherExternalModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientExternalModuleWithInternalImportDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientExternalModuleWithRelativeExternalImportDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientExternalModuleWithoutInternalImportDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientFundule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientGetters.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientModuleExports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientModuleWithTemplateLiterals.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientNameRestrictions.ts
@@ -157,7 +126,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdModuleName1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonClassDeclarationEmitIsAnon.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonymousClassDeclarationDoesntPrintWithReadonly.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonymousClassExpression1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonymousClassExpression2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyAndUnknownHaveFalsyComponents.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyAsReturnTypeForNewOnCall.ts
@@ -325,7 +293,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentRestElementWi
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentStricterConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentToAnyArrayRestParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentToExpandingArrayType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentToFunction.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/assignmentToInstantiationExpression.ts
 The left-hand side of an assignment expression must be a variable or a property access.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentToObject.ts
@@ -341,7 +308,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionReturnExpr
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionReturnType.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionReturnType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionTempVariableScoping.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionWithForStatementNoInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionsAcrossFiles.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionsAndStrictNullChecks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncIIFE.ts
@@ -389,7 +355,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/avoidCycleWithVoidExpre
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/avoidListingPropertiesForTypesWithOnlyCallOrConstructSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/awaitCallExpressionInSyncFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/awaitExpressionInnerCommentEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/awaitInClassInAsyncFunction.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/awaitInNonAsyncFunction.ts
 `await` is only allowed within async functions and at the top levels of modules
@@ -407,7 +372,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/badOverloadError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/badThisBinding.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bangInModuleName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseCheck.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseClassImprovedMismatchErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseConstraintOfDecorator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseExpressionTypeParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseIndexSignatureResolution.ts
@@ -441,7 +405,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingsInDo
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingsReassignedInLoop1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingsReassignedInLoop2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingsReassignedInLoop3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingsReassignedInLoop4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingsReassignedInLoop5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingsReassignedInLoop6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedClassDeclarationAcrossFiles.ts
@@ -449,12 +412,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedEnumVariable
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedEnumVariablesUseBeforeDef_isolatedModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedEnumVariablesUseBeforeDef_preserve.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedEnumVariablesUseBeforeDef_verbatimModuleSyntax.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedFunctionDeclarationES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedFunctionDeclarationES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedFunctionDeclarationInStrictClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedFunctionDeclarationInStrictModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedFunctionDeclarationStrictES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedFunctionDeclarationStrictES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedNamespaceDifferentFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedSameNameFunctionDeclarationES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedSameNameFunctionDeclarationES6.ts
@@ -465,7 +423,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/bluebirdStaticThis.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bom-utf8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/booleanFilterAnyArray.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/booleanLiteralsContextuallyTypedFromUnion.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakNotInIterationOrSwitchStatement2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakTarget1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakTarget2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakTarget3.ts
@@ -495,7 +452,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/callOverloads4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callOverloads5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callSignatureFunctionOverload.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callSignaturesShouldBeResolvedBeforeSpecialization.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/callWithWrongNumberOfTypeArguments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callbackArgsDifferByOptionality.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callbacksDontShareTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callsOnComplexSignatures.tsx
@@ -505,8 +461,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/captureThisInSuperCall.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop10_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop11.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop11_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop14.ts
@@ -589,7 +543,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularMappedTypeConst
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularModuleImports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularObjectLiteralAccessors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularOptionalityRemoval.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularReferenceInImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularReferenceInReturnType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularReferenceInReturnType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularResolvedSignature.ts
@@ -602,8 +555,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/classAccessorInitializa
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classAttributeInferenceTemplate.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classBlockScoping.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classCannotExtendVar.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclarationBlockScoping2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclarationCheckUsedBeforeDefinitionInFunctionDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclarationShouldBeOutOfScopeInComputedNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclaredBeforeClassFactory.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionAssignment.ts
@@ -633,8 +584,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsInterfaceTh
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsInterface_not.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsNull.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsNull2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsNull3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtensionNameOutput.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFieldSuperAccessible.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFieldSuperNotAccessible.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFunctionMerging.ts
@@ -642,11 +591,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFunctionMerging2.t
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/classHeritageWithTrailingSeparator.ts
 Expected `{` but found `EOF`
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementingInterfaceIndexer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsImportedInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsMethodWIthTupleArgs.ts
@@ -664,18 +608,15 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerW
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMergedWithInterfaceMultipleBasesNoError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMethodWithKeywordName1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classNameReferencesInStaticElements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classNonUniqueSymbolMethodHasSymbolIndexer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classOrder1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classOrder2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classOrderBug.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classOverloadForFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classOverloadForFunction2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classPropInitializationInferenceWithElementAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classPropertyErrorOnNameOnly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classReferencedInContextualParameterWithinItsOwnBaseExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classSideInheritance1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classSideInheritance2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classSideInheritance3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classStaticInitializersUsePropertiesBeforeDeclaration.ts
@@ -698,7 +639,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleGenericOnSelfMem
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleStaticMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleTest1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleTest2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleWithDuplicateMember1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleWithDuplicateMember2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleWithPriorInstantiatedModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleWithPriorUninstantiatedModule.ts
@@ -727,7 +667,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleW
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithMemberInterfaceConflict.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithMethodChildren.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithModuleChildren.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAlias.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientFunction.ts
@@ -736,11 +675,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequire
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientVar.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndFunctionInGlobalFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndInternalModuleAlias.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndUninstantiatedModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndVar.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterArrowFunctions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterClassConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterClassMethod.ts
@@ -750,37 +687,29 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterI
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterInterfaceMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterUnderscoreIUsage.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalFunctionInAccessors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalFunctionInConstructor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalFunctionInMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalFunctionInProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalVarInAccessors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalVarInConstructor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalVarInMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalVarInProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndNameResolution.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndParameter1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndPropertyNameAsConstuctorParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndEnumInGlobal.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndFunctionInGlobal.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInAccessors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInLambda.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarWithSuperExperssion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndNameResolution.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndPropertyNameAsConstuctorParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commaOperator1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commaOperatorInConditionalExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commaOperatorLeftSideUnused.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentBeforeStaticMethod1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentEmitAtEndOfFile1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentEmitOnParenthesizedAssertionInReturnStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentEmitOnParenthesizedAssertionInReturnStatement2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentInEmptyParameterList1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentInMethodCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentInNamespaceDeclarationWithIdentifierPathName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentLeadingCloseBrace.ts
@@ -807,9 +736,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement7.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnBlock1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnClassAccessor1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnClassAccessor2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnClassMethod1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnDecoratedClassDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnElidedModule1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnExportEnumDeclaration.ts
@@ -824,7 +751,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnParameter3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnParenthesizedExpressionOpenParen1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnSignature1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnSimpleArrowFunctionBody1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnStaticMember1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentWithUnreasonableIndentationLevel01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsAfterCaseClauses1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsAfterCaseClauses2.ts
@@ -857,7 +783,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnObjectLiteral
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnObjectLiteral5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnPropertyOfObjectLiteral1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnRequireStatement.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnReturnStatement1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsPropertySignature1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsTypeParameters.ts
@@ -920,7 +845,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeDoesntSp
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeGenericInSignatureTypeParameterConstraint.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeRelaxingConstraintAssignability.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeSimplification.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeSubclassExtendsTypeParam.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeVarianceBigArrayConstraintsPerformance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypesASI.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypesSimplifyWhenTrivial.ts
@@ -929,7 +853,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/configFileExtendsAsList
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conflictingDeclarationsImportFromNamespace1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conflictingDeclarationsImportFromNamespace2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conflictingMemberTypesInBases.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/conflictingTypeAnnotatedVar.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conflictingTypeParameterSymbolTransfer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/consistentAliasVsNonAliasRecordBehavior.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarationShadowedByVarDeclaration.ts
@@ -1143,7 +1066,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingOrOpe
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingRestParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/continueInLoopsWithCapturedBlockScopedBindings1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/continueLabel.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/continueNotInIterationStatement2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/continueNotInIterationStatement4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/continueStatementInternalComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/continueTarget1.ts
@@ -1158,7 +1080,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/contravariantOnlyInfere
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contravariantTypeAliasInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowAliasedDiscriminants.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowAnalysisOnBareThisKeyword.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowArrayErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowArrays.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowAutoAccessor1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowBreakContinueWithLabel.ts
@@ -1182,7 +1103,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowInstanceofWi
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowLoopAnalysis.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowManyCallExpressionStatementsPerf.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowManyConsecutiveConditionsNoTimeout.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowNoImplicitAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowNullTypeAndLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowOuterVariable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowPrivateClassField.ts
@@ -1221,8 +1141,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicGenericTypeInstan
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicGenericTypeInstantiationInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicModuleImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicTypeInstantiation.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/debugger.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/debuggerEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileAccessors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileAliasUseBeforeDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileAmbientExternalModuleWithSingleExportedModule.ts
@@ -1271,8 +1189,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationS
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationTupleType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationTypeAlias.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationTypeLiteral.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationTypeQuery.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationTypeReference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationUnionType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorParameterOfFunction.ts
@@ -1384,7 +1300,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExportDe
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends7.ts
@@ -1397,7 +1312,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForGloba
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForModuleImportingModuleAugmentationRetainsImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForTypesWhichNeedImportTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitFunctionDuplicateNamespace.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitFunctionKeywordProp.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitGlobalThisPreserved.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitHasTypesRefOnNamespaceUse.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitHigherOrderRetainedGenerics.ts
@@ -1653,7 +1567,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedCompilerOptio
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedCompilerOptions5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedCompilerOptions6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/derivedClassConstructorWithExplicitReturns01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/derivedClassOverridesPrivateFunction1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/derivedClasses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/derivedInterfaceCallSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/derivedTypeCallingBaseImplWithOptionalParams.ts
@@ -1797,7 +1710,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierComp
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierDifferentModifiers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierDifferentSpelling.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierEnum.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierInCatchBlock.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierRelatedSpans1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierRelatedSpans2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierRelatedSpans3.ts
@@ -1816,7 +1728,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateLabel3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateLabel4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateLocalVariable1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateLocalVariable2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateLocalVariable3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateLocalVariable4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateObjectLiteralProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateObjectLiteralProperty_computedName1.ts
@@ -1899,7 +1810,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyModuleName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyObjectNotSubtypeOfIndexSignatureContainingObject1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyObjectNotSubtypeOfIndexSignatureContainingObject2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyOptionalBindingPatternInDeclarationSignature.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyTypeArgumentList.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumAssignmentCompat3.ts
@@ -1973,7 +1883,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorOnContextuallyType
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorOnEnumReferenceInCondition.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorOnUnionVsObjectShouldDeeplyDisambiguate.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorOnUnionVsObjectShouldDeeplyDisambiguate2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorSupression1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorTypesAsTypeArguments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorWithSameNameType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorWithTruncatedType.ts
@@ -1986,8 +1895,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/es2015modulekind.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es2015modulekindWithES6Target.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es2017basicAsync.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es2018ObjectAssign.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-amd.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionArrayLiterals.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionBinaryExpressions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionCallExpressions.ts
@@ -1996,19 +1903,13 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionDoStat
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionElementAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionForInStatements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionForOfStatements.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionForStatements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionHoisting.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionIfStatements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionLongObjectLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionNestedLoops.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionNewExpressions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionObjectLiterals.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionPropertyAccess.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionReturnStatements.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionSwitchStatements.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionTryStatements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionWhileStatements.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionWithStatements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-commonjs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-commonjs2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-commonjs3.ts
@@ -2017,9 +1918,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-commonjs5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-commonjs6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-commonjs7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-commonjs8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-declaration-amd.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-importHelpersAsyncFunctions.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-souremap-amd.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-system.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-system2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-umd.ts
@@ -2045,15 +1944,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5ModuleWithModuleGenC
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5ModuleWithoutModuleGenTarget.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5SetterparameterDestructuringNotElided.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5andes6module.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6-amd.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6-declaration-amd.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6-sourcemap-amd.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6-umd.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6-umd2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassSuperCodegenBug.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest7.ts
@@ -2204,7 +2098,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignedNamespace
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignedTypeAsTypeAnnotation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentImportMergeNoCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentMembersVisibleInAugmentation.ts
@@ -2219,7 +2112,6 @@ Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithExports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithImportStatementPrivacyError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithPrivacyError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithoutAllowSyntheticDefaultImportsError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithoutIdentifier1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportClassExtendingIntersection.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDeclarationForModuleOrEnumWithMemberOfSameName.ts
@@ -2275,7 +2167,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsOfModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsProperty2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsUmd.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportImportAndClodule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportImportCanSubstituteConstEnumForValue.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportImportMultipleFiles.ts
@@ -2322,8 +2213,6 @@ Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/expressionsForbiddenInParameterInitializers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extBaseClass1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extBaseClass2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendAndImplementTheSameBaseType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendAndImplementTheSameBaseType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendArray.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendBaseClassBeforeItsDeclared.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendConstructSignatureInInterface.ts
@@ -2332,15 +2221,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendGenericArray.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendGenericArray2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendGlobalThis.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendGlobalThis2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendNonClassSymbol1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendNonClassSymbol2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendPrivateConstructorClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendedInterfaceGenericType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendedInterfacesWithDuplicateTypeParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendedUnicodeEscapeSequenceIdentifiers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendedUnicodePlaneIdentifiers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendingClassFromAliasAndUsageInIndexer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendingSetWithCheckJs.ts
 tasks/coverage/typescript/tests/cases/compiler/extendsUntypedModule.ts
 Unexpected estree file content error: 1 != 3
 
@@ -2393,11 +2279,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/fixingTypeParametersRep
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fixingTypeParametersRepeatedly2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fixingTypeParametersRepeatedly3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/flatArrayNoExcessiveStackDepth.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/flowAfterFinally1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/flowControlTypeGuardThenSwitch.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/flowInFinally1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forAwaitForUnion.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/forInStatement3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forInStrictNullChecksNoError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forLoopEndingMultilineComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forLoopWithDestructuringDoesNotElideFollowingStatement.ts
@@ -2411,16 +2294,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/forwardRefInEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forwardRefInTypeDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/freshLiteralInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/freshLiteralTypesInIntersections.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/funClodule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/funcdecl.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionAndImportNameConflict.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionAndInterfaceWithSeparateErrors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionAndPropertyNameConflict.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionArgShadowing.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionAssignabilityWithArrayLike01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionAssignment.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionAssignmentError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall12.ts
@@ -2430,10 +2307,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall15.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall16.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall17.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall18.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall8.ts
@@ -2443,8 +2317,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionDeclarationWith
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionDeclarationWithResolutionOfTypeNamedArguments01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionDeclarationWithResolutionOfTypeOfSameName01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionExpressionAndLambdaMatchesFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionExpressionInWithBlock.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionExpressionReturningItself.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionExpressionShadowedByParams.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionExpressionWithResolutionOfTypeNamedArguments01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionExpressionWithResolutionOfTypeOfSameName01.ts
@@ -2452,12 +2324,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionExpressionWithR
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionInIfStatementInModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionLikeInParameterInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionMergedWithModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOnlyHasThrow.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloadAmbiguity1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloadImplementationOfWrongName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloadImplementationOfWrongName2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads12.ts
@@ -2479,7 +2349,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads26.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads27.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads28.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads29.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads30.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads31.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads32.ts
@@ -2490,7 +2359,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads36.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads37.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads38.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads39.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads40.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads41.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads42.ts
@@ -2507,9 +2375,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloadsOnGene
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloadsOutOfOrder.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloadsRecursiveGenericReturnType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionParameterArityMismatch.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionReturn.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionReturnTypeQuery.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionReturningItself.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionSignatureAssignmentCompat1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionSubtypingOfVarArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionSubtypingOfVarArgs2.ts
@@ -2518,7 +2384,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionTypeArgumentArityErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionTypeArgumentArrayAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionTypeArgumentAssignmentCompat.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionVariableInReturnTypeAnnotation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithAnyReturnTypeAndNoReturnExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements10.ts
@@ -2536,26 +2401,17 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultPara
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithNoBestCommonType1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithNoBestCommonType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithSameNameAsField.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithThrowButNoReturn1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionsInClassExpressions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionsMissingReturnStatementsAndExpressionsStrictNullChecks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionsWithImplicitReturnTypeAssignableToUndefined.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/funduleExportedClassIsUsedBeforeDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/funduleOfFunctionWithoutReturnTypeAnnotation.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/funduleSplitAcrossFiles.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/funduleUsedAcrossFileBoundary.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fuzzy.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/generativeRecursionWithTypeOf.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorES6InAMDModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorES6_1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorES6_2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorES6_3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorES6_4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorES6_5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorES6_6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorReturnExpressionIsChecked.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorTransformFinalLabel.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericAndNonGenericInheritedSignature1.ts
@@ -2597,8 +2453,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClasses3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClasses4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassesInModule2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassesRedeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCloduleInModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCloduleInModule2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCloneReturnTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCloneReturnTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCombinators2.ts
@@ -2638,9 +2492,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionsWithOpt
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionsWithOptionalParameters3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunduleInModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunduleInModule2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericGetter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericGetter2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericGetter3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericImplements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericIndexTypeHasSensibleErrorMessage.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericIndexedAccessMethodIntersectionCanBeAccessed.ts
@@ -2699,7 +2550,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions3.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeParameterEquivalence2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeReferencesRequireTypeArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeUsedWithoutTypeArguments1.ts
@@ -2715,7 +2565,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithCallSignatur
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithCallSignatures1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithIndexerOfTypeParameterType1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithIndexerOfTypeParameterType2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithNoConstraintComparableWithCurlyCurly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithOpenTypeParameters1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics0.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics1.ts
@@ -2804,7 +2653,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyGetAndSetAcc
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyInAmbientDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyInAmbientDeclaration2.d.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyInCatch.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyNewExprLackConstructorSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyWidenToAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitConstParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitIndexSignatures.ts
@@ -2826,7 +2674,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAliasFromNamespac
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAliasInModuleAugmentation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAnImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAndVariableDeclarationConflict1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAndVariableDeclarationConflict2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAndVariableDeclarationConflict3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAndVariableDeclarationConflict4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAsBaseClass.ts
@@ -3089,7 +2936,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberAccess
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberAccessorOverridingProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberFuncOverridingAccessor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberFuncOverridingMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberFuncOverridingProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberPropertyOverridingAccessor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberPropertyOverridingMethod.ts
@@ -3101,12 +2947,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticAccess
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticAccessorOverridingProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticFuncOverridingAccessor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticFuncOverridingAccessorOfFuncType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticFuncOverridingMethod.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticFuncOverridingProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticFuncOverridingPropertyOfFuncType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticFunctionOverridingInstanceProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticPropertyOverridingAccessor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticPropertyOverridingMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticPropertyOverridingProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedConstructorPropertyContextualType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedConstructorWithRestParams.ts
@@ -3269,8 +3111,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionsOfLargeUni
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intraBindingPatternReferences.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intrinsics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidConstraint1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidContinueInDownlevelAsync.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidStaticField.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidSymbolInTypeParameter1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidThisEmitInContextualObjectLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidTripleSlashReference.ts
@@ -3304,7 +3144,6 @@ tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsAllowJs.ts
 Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsLiterals.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsStrictBuiltinIteratorReturn.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesAmbientConstEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesConstEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesDeclaration.ts
@@ -3332,7 +3171,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesSketchyA
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesSourceMap.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesSpecifiedModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesUnspecifiedModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesWithDeclarationFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/iterableTReturnTNext.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/iteratorExtraParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/iteratorsAndStrictNullChecks.ts
@@ -3415,7 +3253,6 @@ Unexpected estree file content error: 2 != 3
 tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationNoErrorWithoutDeclarationsWithJsFileReferenceWithOut.ts
 Unexpected estree file content error: 2 != 3
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationWithDeclarationEmitPathSameAsInput.ts
 tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationWithEnabledCompositeOption.ts
 Unexpected estree file content error: 1 != 2
 
@@ -3555,8 +3392,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/lastPropertyInLiteralWi
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundConstraintTypeChecksCorrectly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundDestructuringImplicitAnyError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundFunctionMemberAssignmentDeclarations.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/letAndVarRedeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/letAsIdentifier2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/letConstMatchingParameterNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-access.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-es5-1.ts
@@ -3583,7 +3418,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/letInVarDeclOfForIn_ES5
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/letInVarDeclOfForIn_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/letInVarDeclOfForOf_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/letInVarDeclOfForOf_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/letKeepNamesOfTopLevelItems.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/letShadowedByNameInNestedScope.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/libCompileChecks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/libTypeScriptOverrideSimple.ts
@@ -3611,7 +3445,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/localClassesInLoop.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/localClassesInLoop_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/localImportNameVsGlobalName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/localTypeParameterInferencePriority.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/localVariablesReturnedFromCatchBlocks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/m7Bugs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/manyConstExports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mapConstructorOnReadonlyTuple.ts
@@ -3674,7 +3507,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarationExport
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations7.ts
@@ -3707,7 +3539,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingDomElements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingFunctionImplementation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingFunctionImplementation2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingImportAfterModuleImport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingMemberErrorHasShortPath.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingPropertiesOfClassExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingReturnStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingReturnStatement1.ts
@@ -3791,7 +3622,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationInAmb
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationInAmbientModule5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationNoNewNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationOfAlias.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationWithNonExistentNamedImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationsBundledOutput1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationsImports1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationsImports2.ts
@@ -3842,7 +3672,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePrologueCommonjs.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePrologueES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePrologueSystem.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePrologueUmd.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleProperty2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleRedifinitionErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleReopenedTypeOtherBlock.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleReopenedTypeSameBlock.ts
@@ -3878,7 +3707,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuf
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_oneBlank.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_oneNotFound.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one_dirModuleWithIndex.ts
 tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one_externalModule.ts
 Unexpected estree file content error: 3 != 5
 
@@ -3982,7 +3810,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespaceMergedWithImpo
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespaceNotMergedWithFunctionDefaultExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespaces1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespacesDeclaration1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespacesDeclaration2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespacesWithTypeAliasOnlyExportsMerge.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nanEquality.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByBooleanComparison.ts
@@ -4039,10 +3866,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/nearbyIdenticalGenericL
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/negativeZero.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedCallbackErrorNotFlattened.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedExcessPropertyChecking.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedFreshLiteral.ts
@@ -4057,7 +3880,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedLoops.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedObjectRest.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedRecursiveArraysOrObjectsError01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedRecursiveLambda.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedRedeclarationInES6AMD.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedSelf.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedSuperCallEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedThisContainer.ts
@@ -4065,7 +3887,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedTypeVariableInfer
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/neverAsDiscriminantType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/newAbstractInstance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/newAbstractInstance2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/newArrays.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/newExpressionWithTypeParameterConstrainedToOuterTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/newFunctionImplicitAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/newLexicalEnvironmentForConvertedLoop.ts
@@ -4136,7 +3957,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyReferencin
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyUnionNormalizedObjectLiteral1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyWithOverloads.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnInConstructors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsExclusions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsInAsync1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsInAsync2.ts
@@ -4157,14 +3977,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/noInferUnionExcessPrope
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noIterationTypeErrorsInCFA.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noMappedGetSet.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noObjectKeysToKeyofT.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noReachabilityErrorsOnEmptyStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noRepeatedPropertyNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noSelfOnVars.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noStrictGenericChecks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noSubstitutionTemplateStringLiteralTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noSubtypeReduction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noSymbolForMergeCrash.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noTypeArgumentOnReturnType1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUncheckedIndexAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUncheckedIndexedAccessCompoundAssignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUnusedLocals_destructuringAssignment.ts
@@ -4372,7 +4190,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstNoString
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstantsInvalidOverload1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnGenericArity.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnGenericClassAndNonGenericClass.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOnDefaultConstructor1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOverCTLambda.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOverNonCTLambdas.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOverNonCTObjectLit.ts
@@ -4389,7 +4206,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadingOnConstantsI
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadresolutionWithConstraintCheckingDeferred.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsAndTypeArgumentArity.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsInDifferentContainersDisagreeOnAmbient.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsWithComputedNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsWithConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsWithProvisionalErrors.ts
@@ -4435,8 +4251,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/parsingClassRecoversWhe
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/partialDiscriminatedUnionMemberHasGoodError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/partialOfLargeAPIIsAbleToBeWorkedWith.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/partialTypeNarrowedToByTypeGuard.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/partiallyAmbientClodule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/partiallyAmbientFundule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/partiallyDiscriminantedUnions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution1_amd.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution1_node.ts
@@ -4491,7 +4305,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/prefixUnaryOperatorsOnE
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/preserveConstEnums.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/preserveUnusedImports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/prespecializedGenericMembers1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/prettyFileWithErrorsAndTabs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/primaryExpressionMods.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveConstraints1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveConstraints2.ts
@@ -4548,7 +4361,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOf
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOfInterfaceDeclFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyVar.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyVarDeclFile.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateAccessInSubclass1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateFieldAssignabilityFromUnknown.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateInstanceVisibility.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateInterfaceProperties.ts
@@ -4572,7 +4384,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/promisePermutations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promisePermutations2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promisePermutations3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseTry.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseTypeInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseTypeInferenceUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseTypeStrictNull.ts
@@ -4606,19 +4417,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/protectedMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/protectedMembersThisParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/protoAsIndexInIndexExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/protoAssignment.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/protoInIndexer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/prototypeOnConstructorFunctions.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/prototypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/publicGetterProtectedSetterFromThisParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/publicMemberImplementedAsPrivateInDerivedClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/qualifiedModuleLocals.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/qualify.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/quickinfoTypeAtReturnPositionsInaccurate.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedAccessorName1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedAccessorName2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedFunctionName1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedFunctionName2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/quotedPropertyName3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/raiseErrorOnParameterProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ramdaToolsNoInfinite.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ramdaToolsNoInfinite2.ts
@@ -4862,12 +4666,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedUnionInfer
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reversedRecusiveTypeInstantiation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/satisfiesEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/scopeCheckClassProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/scopeCheckExtendedClassInsidePublicMethod2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/scopeCheckExtendedClassInsideStaticMethod1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/scopeCheckInsidePublicMethod1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/scopeCheckInsideStaticMethod1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/scopeCheckStaticInitializer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/scopeTests.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/scopingInCatchBlocks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfInCallback.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfInLambdas.ts
@@ -4882,7 +4681,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencingSpreadIn
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencingTypeReferenceInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferentialFunctionType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/semicolonsInModuleDeclarations.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/separate1-2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/setMethods.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/setterBeforeGetter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/setterWithReturn.ts
@@ -4999,10 +4797,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationFunc
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationLabeled.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationLambdaSpanningMultipleLines.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationStatements.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationVarInDownLevelGenerator.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationWithComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapWithCaseSensitiveFileNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapWithCaseSensitiveFileNamesAndOutDir.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapWithMultipleFilesWithCopyright.ts
@@ -5048,9 +4843,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadsAndContextualTup
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spuriousCircularityOnTypeImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spyComparisonChecking.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stackDepthLimitCastingType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticAndMemberFunctions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticAnonymousTypeNotReferencingTypeParameter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticClassMemberError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticFieldWithInterfaceContext.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticGetter1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticGetter2.ts
@@ -5061,7 +4854,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInitializersAndLe
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInterfaceAssignmentCompat.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMemberAccessOffDerivedType1.ts
@@ -5072,9 +4864,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMethodWithTypePar
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMethodsReferencingClassTypeParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMismatchBecauseOfPrototype.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMustPrecedePublic.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticOffOfInstance1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticOffOfInstance2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticPropSuper.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/staticPrototypeProperty.ts
 Classes may not have a static property named prototype
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticPrototypePropertyOnClass.ts
@@ -5082,11 +4872,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticVisibility.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticVisibility2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/statics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stradac.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictBooleanMemberAssignability.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictFunctionTypes1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictFunctionTypesErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictModeEnumMemberNameReserved.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictModeInConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictModeReservedWord.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictModeReservedWord2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictModeReservedWordInClassDeclaration.ts
@@ -5115,7 +4903,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringMatchAll.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringPropCodeGen.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringRawType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringTrim.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/stripInternal1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stripMembersOptionality.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/structural1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/styleOptions.ts
@@ -5142,7 +4929,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/subtypingTransitivity.t
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/super.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/super1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/super2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superAccessCastedCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superAccessInFatArrow1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallArgsMustMatch.ts
@@ -5156,13 +4942,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatH
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromFunction1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallInNonStaticMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallInStaticMethod.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallInsideClassDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallInsideClassExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallInsideObjectLiteralExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallOutsideConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallWithCommentEmit01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallWithMissingBaseClass.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallsInConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superElementAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superHasMethodsFromMergedInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superInCatchBlock1.ts
@@ -5171,15 +4953,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/superInObjectLiterals_E
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superInObjectLiterals_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superNewCall1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superPropertyAccess.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superPropertyAccess1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superPropertyAccess2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superPropertyAccessInComputedPropertiesOfNestedType_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superPropertyAccessInComputedPropertiesOfNestedType_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superPropertyAccessInSuperCall01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superPropertyAccess_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superPropertyAccess_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superPropertyElementNoUnusedLexicalThisCapture.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superWithGenericSpecialization.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superWithGenerics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/super_inside-object-literal-getters-and-setters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchAssignmentCompat.ts
@@ -5291,11 +5067,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInFunctionCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInGenericStaticMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInInnerFunctions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInLambda.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInModuleFunction1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInOuterClassBody.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInPropertyBoundDeclarations.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInStaticMethod1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInStatics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInSuperCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInSuperCall1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInSuperCall2.ts
@@ -5306,7 +5078,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisIndexOnExistingRead
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisPredicateInObjectLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisReferencedInFunctionInsideArrowFunction1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisShadowingErrorSpans.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisTypeAsConstraint.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisWhenTypeCheckFails.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/this_inside-enum-should-not-be-allowed.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/this_inside-object-literal-getters-and-setters.ts
@@ -5449,7 +5220,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeNamedUndefined2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfEnumAndVarRedeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfOnTypeArg.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfPrototype.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfSuperCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfThisInStatics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfYieldWithUnionInContextualReturnType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParamExtendsOtherTypeParam.ts
@@ -5459,18 +5229,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEq
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEquivalence3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEquivalence4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEquivalence5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterAsElementType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterAssignmentCompat1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterAssignmentWithConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterCompatibilityAccrossDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterConstrainedToOuterTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterConstrainedToOuterTypeParameter2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterConstraintInstantiation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterConstraints1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterDiamond1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterDiamond2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterDiamond3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterDiamond4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterDoesntBlockParameterLookup.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterEquality.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterExplicitlyExtendsAny.ts
@@ -5486,7 +5250,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWith
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterHasSelfAsConstraint.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterLeak.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterOrderReversal.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterWithInvalidConstraintType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersAndParametersInComputedNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersInStaticAccessors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersInStaticMethods.ts
@@ -5627,7 +5390,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownTypeArgOnCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unmatchedParameterPositions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unmetTypeConstraintInImportCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unreachableDeclarations.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unreachableFlowAfterFinally.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unreachableSwitchTypeofAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unreachableSwitchTypeofUnknown.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unresolvableSelfReferencingAwaitedUnion.ts
@@ -5638,30 +5400,17 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/untypedFunctionCallsWit
 tasks/coverage/typescript/tests/cases/compiler/untypedModuleImport_withAugmentation2.ts
 Unexpected estree file content error: 2 != 3
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedClassesinModule1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedDestructuring.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedDestructuringParameters.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedFunctionsinNamespaces1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedFunctionsinNamespaces2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedFunctionsinNamespaces3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedFunctionsinNamespaces4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedFunctionsinNamespaces5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedFunctionsinNamespaces6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedGetterInClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedIdentifiersConsolidated1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImportDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImportWithSpread.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports_entireImportDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedInterfaceinNamespace1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedInterfaceinNamespace2.ts
@@ -5676,9 +5425,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndParamete
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndParametersOverloadSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndParametersTypeAliases.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndParametersTypeAliases2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsInMethod1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsInMethod2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsInMethod3.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsInMethod4.ts
 Missing initializer in const declaration
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsInRecursiveReturn.ts
@@ -5691,8 +5437,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsOnFunctionE
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsOnFunctionExpressionWithinFunctionExpression1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsOnFunctionExpressionWithinFunctionExpression2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsStartingWithUnderscore.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsinConstructor1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsinConstructor2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMethodsInInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMultipleParameter1InContructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMultipleParameter1InFunctionExpression.ts
@@ -5702,25 +5446,17 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMultipleParameter
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMultipleParameters1InMethodDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMultipleParameters2InFunctionDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMultipleParameters2InMethodDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParameterInCatchClause.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParameterProperty1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParameterProperty2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParameterUsedInTypeOf.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersInLambda1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersInLambda2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersThis.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersWithUnderscore.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersinConstructor1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersinConstructor2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersinConstructor3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateMembers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateMethodInClass1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateMethodInClass2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateMethodInClass3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateMethodInClass4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateStaticMembers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateVariableInClass4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateVariableInClass5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSemicolonInClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSetterInClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSetterInClass2.ts
@@ -5728,23 +5464,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSingleParameterIn
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSingleParameterInFunctionDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSingleParameterInFunctionExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSingleParameterInMethodDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInFunction1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInFunction2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInFunction3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInFunction4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInInterface1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInInterface2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInLambda1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInLambda2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInLambda3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInMethod1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInMethod2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInMethod3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInMethod4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInMethod5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters6.ts
@@ -5757,12 +5480,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParametersWit
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters_infer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesWithUnderscoreInBindingElement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesWithUnderscoreInForOfLoop.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinBlocks1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinBlocks2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinForLoop.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinForLoop2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinForLoop3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinForLoop4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinModules1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinNamespaces2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinNamespaces3.ts
@@ -5779,17 +5496,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/useStrictLikePrologueSt
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/usingModuleWithExportImportInValuePosition.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/validUseOfThisInSuper.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/valueOfTypedArray.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/varAndFunctionShareName.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/varArgConstructorMemberParameter.ts
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/varArgParamTypeCheck.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/varArgsOnConstructorTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/varAsID.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/varInFunctionInVarInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/vararg.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/vardecl.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/variableDeclarationDeclarationEmitUniqueSymbolPartialStatement.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/variableDeclarator1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/variableDeclaratorResolvedDuringContextualTyping.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceAnnotationValidation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceCallbacksAndIndexedAccesses.ts
@@ -5878,10 +5592,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncAw
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncAwait_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncMethodWithSuperConflict_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncMethodWithSuper_es2017.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncUseStrict_es2017.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpression/awaitBinaryExpression1_es2017.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpression/awaitBinaryExpression2_es2017.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpression/awaitBinaryExpression3_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpression/awaitBinaryExpression4_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpression/awaitBinaryExpression5_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression1_es2017.ts
@@ -5893,24 +5603,18 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCa
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression7_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression8_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitClassExpression_es2017.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitInheritedPromise_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/await_incorrectThisType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/await_unaryExpression_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/await_unaryExpression_es2017_1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/await_unaryExpression_es2017_2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration11_es2017.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration12_es2017.ts
 Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration13_es2017.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration14_es2017.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration1_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration2_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration3_es2017.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration4_es2017.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts
 Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration8_es2017.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncAliasReturnType_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/arrowFunctionWithParameterNameAsync_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction10_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction11_es5.ts
@@ -5924,14 +5628,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrow
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncAwaitIsolatedModules_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncAwaitNestedClasses_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncAwait_es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncImportedPromise_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncMethodWithSuper_es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncMultiFile_es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncQualifiedReturnType_es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncUseStrict_es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitBinaryExpression/awaitBinaryExpression1_es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitBinaryExpression/awaitBinaryExpression2_es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitBinaryExpression/awaitBinaryExpression3_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitBinaryExpression/awaitBinaryExpression4_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitBinaryExpression/awaitBinaryExpression5_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallExpression/awaitCallExpression1_es5.ts
@@ -5943,45 +5640,31 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallE
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallExpression/awaitCallExpression7_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallExpression/awaitCallExpression8_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitClassExpression_es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitUnion_es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration11_es5.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration12_es5.ts
 Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration13_es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration14_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration15_es5.ts
 tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration16_es5.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration1_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration2_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration3_es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration4_es5.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts
 Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration8_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclarationCapturesArguments_es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncAliasReturnType_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/arrowFunctionWithParameterNameAsync_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction10_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction2_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction3_es6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction5_es6.ts
 Cannot use `await` as an identifier in an async context
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunctionCapturesArguments_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunctionCapturesThis_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncUnParenthesizedArrowFunction_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncAwaitIsolatedModules_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncAwait_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncImportedPromise_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncMethodWithSuper_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncMultiFile_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncQualifiedReturnType_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncUseStrict_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncWithVarShadowing_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression1_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression2_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression3_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression4_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression5_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression1_es6.ts
@@ -5993,20 +5676,15 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallE
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression7_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression8_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitClassExpression_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitUnion_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/await_unaryExpression_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/await_unaryExpression_es6_1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/await_unaryExpression_es6_2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration11_es6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration12_es6.ts
 Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration13_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration14_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration15_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration1_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration2_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration3_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration4_es6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts
 Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration8_es6.ts
@@ -6017,26 +5695,17 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/asyncGenerators/asyn
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/asyncGenerators/asyncGeneratorPromiseNextType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/awaitAndYieldInProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractAccessor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractAsIdentifier.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractClinterfaceAssignability.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractExtends.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractFactoryFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractImportInstantiation.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInheritance1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInheritance2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInstantiations1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInstantiations2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMergedDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMethodInNonAbstractClass.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMethodWithImplementation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMixedWithModifiers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractOverloads.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractOverrideWithAbstract.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractSuperCalls.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractUsingAbstractMethod1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractUsingAbstractMethods2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAndInterfaceMerge.d.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAndInterfaceMergeConflictingMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAndInterfaceWithSameName.ts
@@ -6050,12 +5719,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclara
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendingClass.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendingOptionalChain.ts
 Expected `{` but found `?.`
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsValidConstructorFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classIsSubtypeOfBaseType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/constructorFunctionTypeIsAssignableToBaseType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/constructorFunctionTypeIsAssignableToBaseType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classImplementsMergedClassInterface.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classInsideBlock.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classWithPredefinedTypesAsNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/declaredClassMergedwithSelf.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/mergeClassInterfaceAndModule.ts
@@ -6065,7 +5732,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclara
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classExpression3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classExpression4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classExpression5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classExpressionLoop.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classWithStaticFieldInParameterBindingPattern.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classWithStaticFieldInParameterBindingPattern.3.ts
@@ -6114,7 +5780,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorD
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorOverloadsAccessibility.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorParametersAccessibility.ts
@@ -6157,13 +5822,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/acce
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedStaticClassPropertyAccessibleWithinSubclass.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedStaticClassPropertyAccessibleWithinSubclass2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedStaticNotAccessibleInClodule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/genericSetterInClassType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/indexersInClassType.ts
@@ -6193,7 +5853,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inhe
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithPrivateInstanceShadowingPublicInstance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithPrivateStaticShadowingProtectedStatic.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithPrivateStaticShadowingPublicStatic.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedGenericClassWithAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/superInStaticMembers1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/thisAndSuperInStaticMembers1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/thisAndSuperInStaticMembers2.ts
@@ -6227,7 +5886,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/priv
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameBadAssignment.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameBadDeclaration.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameBadSuper.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameBadSuperUseDefineForClassFields.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameCircularReference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameClassExpressionLoop.ts
@@ -6306,7 +5964,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/priv
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticMethodInStaticFieldInit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticsAndStaticMethods.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameUnused.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameWhenNotUseDefineForClassFieldsInEsNext.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesAndDecorators.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesAndFields.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesAndGenericClasses-2.ts
@@ -6328,7 +5985,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/priv
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUnique-4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUnique-5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUseBeforeDef.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateStaticNameShadowing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateWriteOnlyAccessorRead.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/typeFromPrivatePropertyAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/methodDeclarations/optionalMethodDeclarations.ts
@@ -6386,9 +6042,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemb
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPrivateOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPublicOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPublicPrivateOverloads.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/staticFactory1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/staticMemberAssignsToConstructorFunctionMembers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/typeOfThisInMemberFunctions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/optionalMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/optionalProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/overrideInterfaceProperty.ts
@@ -6406,10 +6060,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemb
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/redeclaredProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/redefinedPararameterProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticAndNonStaticPropertiesSameName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticAutoAccessors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticAutoAccessorsWithDecorators.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyAndFunctionWithSameName.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts
 Classes may not have a static property named prototype
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflictsInAmbientContext.ts
@@ -6435,7 +6087,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/constEnums/importElisionConstEnumMerge1.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/controlFlow/assertionTypePredicates1.ts
 Expected `,` but found `is`
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/constLocalsInFunctionExpressions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowAliasing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowAliasingCatchVariables.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowAssignmentExpression.ts
@@ -6538,7 +6189,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/dec
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratorOnClass4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratorOnClass5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratorOnClass8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratorOnClass9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod11.ts
@@ -6617,11 +6267,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/import
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInCJS3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInCJS4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInCJS5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInExportEqualsAMD.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInExportEqualsCJS.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInExportEqualsUMD.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInScriptContext1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInScriptContext2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInSystem1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInSystem2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInSystem3.ts
@@ -6647,7 +6292,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/import
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionReturnPromiseOfAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionShouldNotGetParen.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionSpecifierNotStringTypeError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionWithTypeArgument.ts
+Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionWithTypeArgument.ts
+Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es2015/asyncGenerators/emitter.asyncGenerators.classMethods.es2015.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es2015/asyncGenerators/emitter.asyncGenerators.functionDeclarations.es2015.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es2015/asyncGenerators/emitter.asyncGenerators.functionExpressions.es2015.ts
@@ -6736,7 +6382,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDe
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit13.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit14.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit5.ts
@@ -6762,8 +6407,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolPr
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty23.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty24.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty25.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty26.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty27.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty28.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty29.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty3.ts
@@ -6782,15 +6425,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolPr
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty41.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty42.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty43.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty44.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty45.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty46.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty47.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty48.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty49.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty50.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty51.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty52.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty53.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty54.ts
@@ -6799,10 +6437,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolPr
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty57.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty58.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty59.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty60.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty61.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType1.ts
@@ -6913,10 +6549,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperti
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames12_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames13_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames13_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames14_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames14_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames15_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames15_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames16_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames16_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames17_ES5.ts
@@ -6929,14 +6561,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperti
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames1_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames20_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames20_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames21_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames21_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames22_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames22_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames23_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames23_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames24_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames24_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames25_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames25_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames26_ES5.ts
@@ -6953,8 +6581,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperti
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames30_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames31_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames31_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames32_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames32_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames33_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames33_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames34_ES5.ts
@@ -7041,8 +6667,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperti
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit6_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesOnOverloads_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesOnOverloads_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesSourceMap1_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesSourceMap1_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesSourceMap2_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesSourceMap2_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesWithStaticProperty.ts
@@ -7267,28 +6891,19 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration11_es6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration12_es6.ts
 Cannot use `yield` as an identifier in a generator context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration13_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration1_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration2_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration3_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration4_es6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration5_es6.ts
 Cannot use `yield` as an identifier in a generator context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration6_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration7_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration8_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration9_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionExpressions/FunctionExpression1_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionExpressions/FunctionExpression2_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionPropertyAssignments/FunctionPropertyAssignments1_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionPropertyAssignments/FunctionPropertyAssignments5_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/memberFunctionDeclarations/MemberFunctionDeclaration1_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/memberFunctionDeclarations/MemberFunctionDeclaration2_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/memberFunctionDeclarations/MemberFunctionDeclaration3_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/memberFunctionDeclarations/MemberFunctionDeclaration7_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsAmd/anonymousDefaultExportsAmd.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsAmd/decoratedDefaultExportsGetExportedAmd.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsAmd/defaultExportsGetExportedAmd.ts
@@ -7335,7 +6950,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsA
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImportsWithContextualKeywordNames02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImportsWithUnderscores2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImportsWithUnderscores3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImportsWithUnderscores4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/importEmptyFromModuleNotExisted.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/multipleDefaultExports01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/multipleDefaultExports02.ts
@@ -7374,7 +6988,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/arrayLite
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/arraySpreadImportHelpers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/arraySpreadInCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray4.ts
@@ -7605,7 +7218,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression11_es6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression12_es6.ts
 A 'yield' expression is only allowed in a generator body.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression13_es6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression14_es6.ts
 A 'yield' expression is only allowed in a generator body.
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression15_es6.ts
@@ -7617,56 +7229,22 @@ A 'yield' expression is only allowed in a generator body.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression19_es6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression2_es6.ts
 A 'yield' expression is only allowed in a generator body.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression3_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression4_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression6_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression7_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression8_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression9_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldStarExpression4_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorInAmbientContext1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorInAmbientContext3.d.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorInAmbientContext5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorInAmbientContext6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorNoImplicitReturns.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck11.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck13.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck14.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck15.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck16.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck17.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck18.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck19.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck20.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck21.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck22.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck23.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck24.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck25.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck26.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck27.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck28.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck29.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck30.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck31.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck32.ts
 A 'yield' expression is only allowed in a generator body.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck33.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck34.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck35.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck36.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck37.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck38.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck39.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck40.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck41.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck42.ts
@@ -7674,28 +7252,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck44.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck45.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck46.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck47.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck48.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck49.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck50.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck51.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck52.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck53.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck54.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck55.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck56.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck57.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck58.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck59.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck60.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck61.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck62.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck63.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck9.ts
 tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/yieldExpressionInControlFlow.ts
 Unexpected estree file content error: 1 != 2
 
@@ -7913,7 +7477,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOp
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithValidOperands.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithInvalidOperands.es2015.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithInvalidOperands.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithInvalidStaticToString.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithLHSIsObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithLHSIsTypeParameter.ts
@@ -8022,8 +7585,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optional
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/callChainInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/callChainWithSuper.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/parentheses.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/superMethodCall.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/thisMethodCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/delete/deleteChain.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/elementAccessChain/elementAccessChain.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/elementAccessChain/elementAccessChain.ts
@@ -8046,12 +7607,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/property
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/superCalls/superCalls.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/superPropertyAccess/errorSuperPropertyAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/superPropertyAccess/superPropertyAccessNoError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/superPropertyAccess/superSymbolIndexedAccess1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/superPropertyAccess/superSymbolIndexedAccess2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/superPropertyAccess/superSymbolIndexedAccess3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/superPropertyAccess/superSymbolIndexedAccess4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/superPropertyAccess/superSymbolIndexedAccess5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/superPropertyAccess/superSymbolIndexedAccess6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/thisKeyword/thisInInvalidContexts.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/thisKeyword/thisInInvalidContextsExternalModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/thisKeyword/thisInObjectLiterals.ts
@@ -8220,7 +7775,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/esne
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/esnext/exnextmodulekindExportClassNameWithObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAmbientClassNameWithObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignDottedName.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignImportedIdentifier.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentAndDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentCircularModules.ts
@@ -8237,7 +7791,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/expo
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportClassNameWithObjectCommonJS.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportClassNameWithObjectSystem.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportClassNameWithObjectUMD.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportDeclaredModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportDefaultClassNameWithObject.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportNonInitializedVariablesInIfThenStatementNoCrash1.ts
 Missing initializer in const declaration
@@ -8410,12 +7963,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/parameterI
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/strictBindCallApply1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/strictBindCallApply2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorAssignability.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorExplicitReturnType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorImplicitAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnContextualType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeFallback.1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeFallback.2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeFallback.3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeFallback.4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeFallback.5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeIndirectReferenceToGlobalType.ts
@@ -8831,7 +8382,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolu
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEmit1.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEmit2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEmit3.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxExternalModuleEmit1.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxExternalModuleEmit2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentPreserveEmit.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentReactEmit.tsx
@@ -9184,7 +8734,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/nonjsExtensions/decl
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/nonjsExtensions/declarationFileForTsJsImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/nonjsExtensions/declarationFilesForNodeNativeModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override14.ts
@@ -9213,22 +8762,18 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript202
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript2021/numericSeparators/parser.numericSeparators.decimal.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript2021/numericSeparators/parser.numericSeparators.hex.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript2021/numericSeparators/parser.numericSeparators.octal.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript3/Accessors/parserES3Accessors1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript3/Accessors/parserES3Accessors2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript3/Accessors/parserES3Accessors3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript3/Accessors/parserES3Accessors4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors1.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors10.ts
 'public' modifier cannot be used here.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserGetAccessorWithTypeParameters1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserSetAccessorWithTypeAnnotation1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserSetAccessorWithTypeParameters1.ts
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression10.ts
@@ -9269,24 +8814,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/A
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/CatchClauses/parserCatchClauseWithTypeAnnotation1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClass1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClass2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration13.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration14.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration15.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration16.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration17.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration18.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration19.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration20.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration21.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration22.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration25.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclarationIndexSignature1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName4.ts
@@ -9294,14 +8826,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/C
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName6.ts
 Computed property names are not allowed in enums.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration10.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration11.ts
 Type parameters cannot appear on a constructor declaration
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration2.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration3.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration5.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration9.ts
 Type parameters cannot appear on a constructor declaration
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnum1.ts
@@ -9357,15 +8885,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/E
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Expressions/parserAssignmentExpression1.ts
 Cannot assign to this expression
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Expressions/parserConditionalExpression1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration1.d.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration2.d.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/FunctionDeclarations/parserFunctionDeclaration8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Fuzz/parser768531.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguity3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator1.ts
@@ -9415,25 +8934,18 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/I
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/InterfaceDeclarations/parserInterfaceDeclaration8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/InterfaceDeclarations/parserInterfaceDeclaration9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessor1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration1.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration10.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration14.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration16.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration17.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration18.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberFunctionDeclarations/parserMemberFunctionDeclaration3.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberFunctionDeclarations/parserMemberFunctionDeclaration4.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberFunctionDeclarations/parserMemberFunctionDeclarationAmbiguities1.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberVariableDeclarations/parserMemberVariableDeclaration4.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature1.ts
@@ -9491,9 +9003,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/P
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RealWorld/parserindenter.ts
@@ -9522,7 +9031,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/R
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity3.ts
 Unexpected flag a in regular expression literal
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakNotInIterationOrSwitchStatement2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakTarget1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakTarget2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakTarget3.ts
@@ -9530,7 +9038,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/S
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakTarget5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakTarget6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ContinueStatements/parser_continueLabel.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ContinueStatements/parser_continueNotInIterationStatement2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ContinueStatements/parser_continueNotInIterationStatement4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ContinueStatements/parser_continueTarget1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ContinueStatements/parser_continueTarget2.ts
@@ -9546,7 +9053,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
 A 'return' statement can only be used within a function body.
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ReturnStatements/parserReturnStatement2.ts
 A 'return' statement can only be used within a function body.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ReturnStatements/parserReturnStatement3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ReturnStatements/parserReturnStatement4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement12.ts
@@ -9565,18 +9071,13 @@ A 'return' statement can only be used within a function body.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolIndexer1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolIndexer2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolIndexer3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery9.ts
@@ -9584,7 +9085,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/V
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration10.ts
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration3.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration5.ts
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parser10.1.1-8gs.ts
@@ -9623,8 +9123,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/p
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserUnicode3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserUnicodeWhitespaceCharacter1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserUsingConstructorAsIdentifier.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName11.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName14.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName15.ts
@@ -9636,21 +9134,16 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/C
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName20.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName21.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName23.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName24.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName26.ts
 Computed property names are not allowed in enums.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName32.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName34.ts
 Computed property names are not allowed in enums.
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName35.ts
 Expected `]` but found `,`
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName37.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName38.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName39.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName40.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName41.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName5.ts
 'public' modifier cannot be used here.
@@ -9672,8 +9165,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/S
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolIndexer4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/pedantic/noUncheckedIndexedAccess.ts
@@ -9803,8 +9294,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableS
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/recursiveInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.14.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.15.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.2.ts
@@ -9932,7 +9421,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/switchSta
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/throwStatements/throwInEnclosingStatements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/throwStatements/throwStatements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/tryStatements/catchClauseWithTypeAnnotation.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/tryStatements/tryStatements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/anyAsConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/anyAsFunctionCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/anyAsGenericFunctionCall.ts
@@ -10096,7 +9584,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/augmen
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/augmentedTypeBracketAccessIndexSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/classWithPrivateProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/classWithProtectedProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/classWithPublicProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/duplicateNumericIndexers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/duplicatePropertyNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/duplicateStringIndexers.ts
@@ -10149,7 +9636,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/n
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveIndexingWithForInNoImplicitAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveIndexingWithForInSupressError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveNarrow.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveRhsSideOfInExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignatureWithOptionalParameterAndInitializer.ts
@@ -10386,7 +9872,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/widening
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/builtinIteratorReturn.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/circularTypeAliasForUnionWithClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/circularTypeAliasForUnionWithInterface.ts


### PR DESCRIPTION
`Function.this_param` is included in `Function.params` as an `Identifier` with `name: "this"`

https://ast-explorer.dev/#eNolykEKwzAMRNGrmFm10F7AB+lKG2MU6uAoJlICwfjuUchiNu9PR0XEnI6keSvN8EFzsLPxA1/WWuT27D7tkq2sEqaX/YvG0Mfb53X12klCIHBe0o839R8hOtRkrEYgGRgXircmAw==