### PR TITLE
refactor(transformer): construct new AST instead of calling `ast.clone_in()`

### DIFF
--- a/crates/oxc_transformer/src/common/duplicate.rs
+++ b/crates/oxc_transformer/src/common/duplicate.rs
@@ -130,7 +130,7 @@ impl<'a> TransformCtx<'a> {
                 let references = create_array(|| {
                     ctx.ast.expression_template_literal(
                         lit.span,
-                        lit.quasis.clone_in(ctx.ast.allocator),
+                        ctx.ast.vec_from_iter(lit.quasis.iter().cloned()),
                         ctx.ast.vec(),
                     )
                 });

--- a/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/oxc_transformer/src/es2016/exponentiation_operator.rs
@@ -415,7 +415,7 @@ impl<'a> ExponentiationOperator<'a, '_> {
         // obj.#prop = Math.pow(obj.#prop, right)
         //                          ^^^^^
         // ```
-        let field = field_expr.field.clone_in(ctx.ast.allocator);
+        let field = field_expr.field.clone();
 
         // Complete 2nd member expression
         // ```

--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -31,7 +31,7 @@ use std::mem;
 
 use serde::Deserialize;
 
-use oxc_allocator::{CloneIn, GetAddress, Vec as ArenaVec};
+use oxc_allocator::{GetAddress, Vec as ArenaVec};
 use oxc_ast::{NONE, ast::*};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_ecmascript::{
@@ -979,7 +979,9 @@ impl<'a> ObjectRestSpread<'a, '_> {
             }
             // `let { [`a`], ... rest }`
             PropertyKey::TemplateLiteral(lit) if lit.is_no_substitution_template() => {
-                let expr = Expression::TemplateLiteral(lit.clone_in(ctx.ast.allocator));
+                let quasis = ctx.ast.vec1(lit.quasis[0].clone());
+                let expressions = ctx.ast.vec();
+                let expr = ctx.ast.expression_template_literal(lit.span, quasis, expressions);
                 Some(ArrayExpressionElement::from(expr))
             }
             PropertyKey::PrivateIdentifier(_) => {


### PR DESCRIPTION
We should always avoid calling `.clone_in` because it will lose scoping information and it is not an efficient way. `clone_in` will traverse ast and calling `clone_in` for its all fields recursively