### PR TITLE
fix(napi/playground): fix the issue that missing `reset` the data before re-running the compilation process

### DIFF
--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -75,7 +75,7 @@ impl Oxc {
     #[napi]
     #[allow(clippy::allow_attributes, clippy::needless_pass_by_value)]
     pub fn run(&mut self, source_text: String, options: OxcOptions) -> napi::Result<()> {
-        self.diagnostics = vec![];
+        self.reset();
 
         let OxcOptions {
             run: run_options,
@@ -297,6 +297,22 @@ impl Oxc {
                 };
             }
         }
+    }
+
+    fn reset(&mut self) {
+        self.ast = ();
+        self.ast_json = String::new();
+        self.ir = String::new();
+        self.control_flow_graph = String::new();
+        self.symbols_json = String::new();
+        self.scope_text = String::new();
+        self.codegen_text = String::new();
+        self.codegen_sourcemap_text = None;
+        self.formatted_text = String::new();
+        self.prettier_formatted_text = String::new();
+        self.prettier_ir_text = String::new();
+        self.comments = vec![];
+        self.diagnostics = vec![];
     }
 
     fn get_scope_text(program: &Program<'_>, scoping: &Scoping) -> String {

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -301,10 +301,6 @@ impl Oxc {
         }
     }
 
-    fn reset(&self) {
-
-    }
-
     fn get_scope_text(program: &Program<'_>, scoping: &Scoping) -> String {
         struct ScopesTextWriter<'s> {
             scoping: &'s Scoping,

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -75,7 +75,9 @@ impl Oxc {
     #[napi]
     #[allow(clippy::allow_attributes, clippy::needless_pass_by_value)]
     pub fn run(&mut self, source_text: String, options: OxcOptions) -> napi::Result<()> {
-        self.reset();
+        self.diagnostics = vec![];
+        self.scope_text = String::new();
+        self.symbols_json = String::new();
 
         let OxcOptions {
             run: run_options,
@@ -299,20 +301,8 @@ impl Oxc {
         }
     }
 
-    fn reset(&mut self) {
-        self.ast = ();
-        self.ast_json = String::new();
-        self.ir = String::new();
-        self.control_flow_graph = String::new();
-        self.symbols_json = String::new();
-        self.scope_text = String::new();
-        self.codegen_text = String::new();
-        self.codegen_sourcemap_text = None;
-        self.formatted_text = String::new();
-        self.prettier_formatted_text = String::new();
-        self.prettier_ir_text = String::new();
-        self.comments = vec![];
-        self.diagnostics = vec![];
+    fn reset(&self) {
+
     }
 
     fn get_scope_text(program: &Program<'_>, scoping: &Scoping) -> String {


### PR DESCRIPTION
This PR is aimed to fix a slight issue, it didn't reset all the related data before re-running the wasm compilation process.

The repro steps:
1. Visit https://playground.oxc.rs
2. Select `Symol` or `Scope` tab on the right side of the page.
3. Check bettwen the `D.TS` and `TSX` boxes.
4. The contents under the `Symbol` and `Scope` tabs will not change as the checkboxes' changes.

![gif](https://github.com/user-attachments/assets/8304a38d-af6c-4460-86a8-3c98dc4a8d35)

And the 3rd step can trigger as this way:
Edit the json, make the `run.symbol` or `run.scope` as `false`.

![gif1](https://github.com/user-attachments/assets/c6012c81-dd4c-41cb-8ef7-06b58efb25ac)
