### PR TITLE
perf(lexer): pad `Token` to 16 bytes

### DIFF
--- a/crates/oxc_parser/src/lexer/token.rs
+++ b/crates/oxc_parser/src/lexer/token.rs
@@ -39,6 +39,7 @@ pub struct Token {
     // Padding to fill to 16 bytes.
     // This makes copying a `Token` 1 x xmmword load & store, rather than 1 x dword + 1 x qword
     // and `Token::default()` is 1 x xmmword store, rather than 1 x dword + 1 x qword.
+    _padding: u8,
     _padding2: u16,
 }
 


### PR DESCRIPTION
#9918 caused a small regression on lexer and parser benchmarks because it introduced an uninitialized padding byte into `Token`.

Add another dummy `u8` to fill the uninitialized hole.
