### PR TITLE
fix(editor)!: enable nested configuration by default

### DIFF
--- a/editors/vscode/client/config.spec.ts
+++ b/editors/vscode/client/config.spec.ts
@@ -16,7 +16,7 @@ suite('Config', () => {
     strictEqual(config.runTrigger, 'onType');
     strictEqual(config.enable, true);
     strictEqual(config.trace, 'off');
-    strictEqual(config.configPath, '.oxlintrc.json');
+    strictEqual(config.configPath, '');
     strictEqual(config.binPath, '');
     deepStrictEqual(config.flags, {});
   });

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -97,8 +97,8 @@
         "oxc.configPath": {
           "type": "string",
           "scope": "window",
-          "default": ".oxlintrc.json",
-          "description": "Path to ESlint configuration."
+          "default": "",
+          "description": "Path to ESlint configuration. Keep it empty to enable nested configuration."
         },
         "oxc.path.server": {
           "type": "string",


### PR DESCRIPTION
closes #9924

The changes in https://github.com/oxc-project/oxc/blob/33c1c76955f155a03bd4a1b6b6c99c86fe6979b6/editors/vscode/client/Config.ts#L27 has no effect because the function is reading from the `package.json`