### PR TITLE
perf(regular_expression): make all fieldless enums `Copy`

### DIFF
--- a/crates/oxc_regular_expression/src/ast.rs
+++ b/crates/oxc_regular_expression/src/ast.rs
@@ -83,7 +83,7 @@ pub struct BoundaryAssertion {
 }
 
 #[ast]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[generate_derive(CloneIn, ContentEq, ESTree)]
 pub enum BoundaryAssertionKind {
     Start = 0,
@@ -104,7 +104,7 @@ pub struct LookAroundAssertion<'a> {
 }
 
 #[ast]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[generate_derive(CloneIn, ContentEq, ESTree)]
 pub enum LookAroundAssertionKind {
     Lookahead = 0,
@@ -217,7 +217,7 @@ pub struct CharacterClass<'a> {
 }
 
 #[ast]
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[generate_derive(CloneIn, ContentEq, ESTree)]
 pub enum CharacterClassContentsKind {
     Union = 0,

--- a/crates/oxc_regular_expression/src/parser/pattern_parser/pattern_parser_impl.rs
+++ b/crates/oxc_regular_expression/src/parser/pattern_parser/pattern_parser_impl.rs
@@ -761,7 +761,7 @@ impl<'a> PatternParser<'a> {
             let (kind, body) = self.parse_class_contents()?;
 
             if self.reader.eat(']') {
-                let strings = PatternParser::may_contain_strings_in_class_contents(&kind, &body);
+                let strings = PatternParser::may_contain_strings_in_class_contents(kind, &body);
 
                 // [SS:EE] CharacterClass :: [^ ClassContents ]
                 // It is a Syntax Error if MayContainStrings of the ClassContents is true.
@@ -1321,7 +1321,7 @@ impl<'a> PatternParser<'a> {
             let (kind, body) = self.parse_class_contents()?;
 
             if self.reader.eat(']') {
-                let strings = PatternParser::may_contain_strings_in_class_contents(&kind, &body);
+                let strings = PatternParser::may_contain_strings_in_class_contents(kind, &body);
 
                 // [SS:EE] NestedClass :: [^ ClassContents ]
                 // It is a Syntax Error if MayContainStrings of the ClassContents is true.
@@ -2307,7 +2307,7 @@ impl<'a> PatternParser<'a> {
     // ---
 
     fn may_contain_strings_in_class_contents(
-        kind: &ast::CharacterClassContentsKind,
+        kind: ast::CharacterClassContentsKind,
         body: &Vec<'a, ast::CharacterClassContents<'a>>,
     ) -> bool {
         let may_contain_strings = |item: &ast::CharacterClassContents<'a>| match item {


### PR DESCRIPTION
Fieldless enums should always be `Copy` because they're only 1 byte. There is no point in passing them by reference.
