### PR TITLE
refactor(ast): shorten generated code for `CloneIn`

### DIFF
--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -1,7 +1,7 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/derives/clone_in.rs`
 
-#![allow(unused_variables, clippy::default_trait_access)]
+#![allow(unused_variables, clippy::default_trait_access, clippy::inline_always)]
 
 use oxc_allocator::{Allocator, CloneIn};
 
@@ -1036,20 +1036,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for PropertyKey<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for PropertyKind {
     type Cloned = PropertyKind;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Init => PropertyKind::Init,
-            Self::Get => PropertyKind::Get,
-            Self::Set => PropertyKind::Set,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Init => PropertyKind::Init,
-            Self::Get => PropertyKind::Get,
-            Self::Set => PropertyKind::Set,
-        }
+        *self
     }
 }
 
@@ -2594,24 +2588,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for VariableDeclaration<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for VariableDeclarationKind {
     type Cloned = VariableDeclarationKind;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Var => VariableDeclarationKind::Var,
-            Self::Let => VariableDeclarationKind::Let,
-            Self::Const => VariableDeclarationKind::Const,
-            Self::Using => VariableDeclarationKind::Using,
-            Self::AwaitUsing => VariableDeclarationKind::AwaitUsing,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Var => VariableDeclarationKind::Var,
-            Self::Let => VariableDeclarationKind::Let,
-            Self::Const => VariableDeclarationKind::Const,
-            Self::Using => VariableDeclarationKind::Using,
-            Self::AwaitUsing => VariableDeclarationKind::AwaitUsing,
-        }
+        *self
     }
 }
 
@@ -3590,22 +3574,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for Function<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for FunctionType {
     type Cloned = FunctionType;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::FunctionDeclaration => FunctionType::FunctionDeclaration,
-            Self::FunctionExpression => FunctionType::FunctionExpression,
-            Self::TSDeclareFunction => FunctionType::TSDeclareFunction,
-            Self::TSEmptyBodyFunctionExpression => FunctionType::TSEmptyBodyFunctionExpression,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::FunctionDeclaration => FunctionType::FunctionDeclaration,
-            Self::FunctionExpression => FunctionType::FunctionExpression,
-            Self::TSDeclareFunction => FunctionType::TSDeclareFunction,
-            Self::TSEmptyBodyFunctionExpression => FunctionType::TSEmptyBodyFunctionExpression,
-        }
+        *self
     }
 }
 
@@ -3660,22 +3636,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for FormalParameter<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for FormalParameterKind {
     type Cloned = FormalParameterKind;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::FormalParameter => FormalParameterKind::FormalParameter,
-            Self::UniqueFormalParameters => FormalParameterKind::UniqueFormalParameters,
-            Self::ArrowFormalParameters => FormalParameterKind::ArrowFormalParameters,
-            Self::Signature => FormalParameterKind::Signature,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::FormalParameter => FormalParameterKind::FormalParameter,
-            Self::UniqueFormalParameters => FormalParameterKind::UniqueFormalParameters,
-            Self::ArrowFormalParameters => FormalParameterKind::ArrowFormalParameters,
-            Self::Signature => FormalParameterKind::Signature,
-        }
+        *self
     }
 }
 
@@ -3795,18 +3763,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for Class<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ClassType {
     type Cloned = ClassType;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::ClassDeclaration => ClassType::ClassDeclaration,
-            Self::ClassExpression => ClassType::ClassExpression,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::ClassDeclaration => ClassType::ClassDeclaration,
-            Self::ClassExpression => ClassType::ClassExpression,
-        }
+        *self
     }
 }
 
@@ -3909,18 +3873,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for MethodDefinition<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for MethodDefinitionType {
     type Cloned = MethodDefinitionType;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::MethodDefinition => MethodDefinitionType::MethodDefinition,
-            Self::TSAbstractMethodDefinition => MethodDefinitionType::TSAbstractMethodDefinition,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::MethodDefinition => MethodDefinitionType::MethodDefinition,
-            Self::TSAbstractMethodDefinition => MethodDefinitionType::TSAbstractMethodDefinition,
-        }
+        *self
     }
 }
 
@@ -3969,44 +3929,28 @@ impl<'new_alloc> CloneIn<'new_alloc> for PropertyDefinition<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for PropertyDefinitionType {
     type Cloned = PropertyDefinitionType;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::PropertyDefinition => PropertyDefinitionType::PropertyDefinition,
-            Self::TSAbstractPropertyDefinition => {
-                PropertyDefinitionType::TSAbstractPropertyDefinition
-            }
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::PropertyDefinition => PropertyDefinitionType::PropertyDefinition,
-            Self::TSAbstractPropertyDefinition => {
-                PropertyDefinitionType::TSAbstractPropertyDefinition
-            }
-        }
+        *self
     }
 }
 
 impl<'new_alloc> CloneIn<'new_alloc> for MethodDefinitionKind {
     type Cloned = MethodDefinitionKind;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Constructor => MethodDefinitionKind::Constructor,
-            Self::Method => MethodDefinitionKind::Method,
-            Self::Get => MethodDefinitionKind::Get,
-            Self::Set => MethodDefinitionKind::Set,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Constructor => MethodDefinitionKind::Constructor,
-            Self::Method => MethodDefinitionKind::Method,
-            Self::Get => MethodDefinitionKind::Get,
-            Self::Set => MethodDefinitionKind::Set,
-        }
+        *self
     }
 }
 
@@ -4103,18 +4047,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for ModuleDeclaration<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for AccessorPropertyType {
     type Cloned = AccessorPropertyType;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::AccessorProperty => AccessorPropertyType::AccessorProperty,
-            Self::TSAbstractAccessorProperty => AccessorPropertyType::TSAbstractAccessorProperty,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::AccessorProperty => AccessorPropertyType::AccessorProperty,
-            Self::TSAbstractAccessorProperty => AccessorPropertyType::TSAbstractAccessorProperty,
-        }
+        *self
     }
 }
 
@@ -4203,18 +4143,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for ImportDeclaration<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ImportPhase {
     type Cloned = ImportPhase;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Source => ImportPhase::Source,
-            Self::Defer => ImportPhase::Defer,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Source => ImportPhase::Source,
-            Self::Defer => ImportPhase::Defer,
-        }
+        *self
     }
 }
 
@@ -6200,20 +6136,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeOperator<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSTypeOperatorOperator {
     type Cloned = TSTypeOperatorOperator;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Keyof => TSTypeOperatorOperator::Keyof,
-            Self::Unique => TSTypeOperatorOperator::Unique,
-            Self::Readonly => TSTypeOperatorOperator::Readonly,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Keyof => TSTypeOperatorOperator::Keyof,
-            Self::Unique => TSTypeOperatorOperator::Unique,
-            Self::Readonly => TSTypeOperatorOperator::Readonly,
-        }
+        *self
     }
 }
 
@@ -6890,20 +6820,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSTypeAliasDeclaration<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSAccessibility {
     type Cloned = TSAccessibility;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Private => TSAccessibility::Private,
-            Self::Protected => TSAccessibility::Protected,
-            Self::Public => TSAccessibility::Public,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Private => TSAccessibility::Private,
-            Self::Protected => TSAccessibility::Protected,
-            Self::Public => TSAccessibility::Public,
-        }
+        *self
     }
 }
 
@@ -7096,20 +7020,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSCallSignatureDeclaration<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSMethodSignatureKind {
     type Cloned = TSMethodSignatureKind;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Method => TSMethodSignatureKind::Method,
-            Self::Get => TSMethodSignatureKind::Get,
-            Self::Set => TSMethodSignatureKind::Set,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Method => TSMethodSignatureKind::Method,
-            Self::Get => TSMethodSignatureKind::Get,
-            Self::Set => TSMethodSignatureKind::Set,
-        }
+        *self
     }
 }
 
@@ -7286,20 +7204,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSModuleDeclaration<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSModuleDeclarationKind {
     type Cloned = TSModuleDeclarationKind;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Global => TSModuleDeclarationKind::Global,
-            Self::Module => TSModuleDeclarationKind::Module,
-            Self::Namespace => TSModuleDeclarationKind::Namespace,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Global => TSModuleDeclarationKind::Global,
-            Self::Module => TSModuleDeclarationKind::Module,
-            Self::Namespace => TSModuleDeclarationKind::Namespace,
-        }
+        *self
     }
 }
 
@@ -7570,22 +7482,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSMappedType<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for TSMappedTypeModifierOperator {
     type Cloned = TSMappedTypeModifierOperator;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::True => TSMappedTypeModifierOperator::True,
-            Self::Plus => TSMappedTypeModifierOperator::Plus,
-            Self::Minus => TSMappedTypeModifierOperator::Minus,
-            Self::None => TSMappedTypeModifierOperator::None,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::True => TSMappedTypeModifierOperator::True,
-            Self::Plus => TSMappedTypeModifierOperator::Plus,
-            Self::Minus => TSMappedTypeModifierOperator::Minus,
-            Self::None => TSMappedTypeModifierOperator::None,
-        }
+        *self
     }
 }
 
@@ -7839,18 +7743,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInstantiationExpression<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for ImportOrExportKind {
     type Cloned = ImportOrExportKind;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Value => ImportOrExportKind::Value,
-            Self::Type => ImportOrExportKind::Type,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Value => ImportOrExportKind::Value,
-            Self::Type => ImportOrExportKind::Type,
-        }
+        *self
     }
 }
 
@@ -7909,64 +7809,42 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSDocUnknownType {
 impl<'new_alloc> CloneIn<'new_alloc> for CommentKind {
     type Cloned = CommentKind;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Line => CommentKind::Line,
-            Self::Block => CommentKind::Block,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Line => CommentKind::Line,
-            Self::Block => CommentKind::Block,
-        }
+        *self
     }
 }
 
 impl<'new_alloc> CloneIn<'new_alloc> for CommentPosition {
     type Cloned = CommentPosition;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Leading => CommentPosition::Leading,
-            Self::Trailing => CommentPosition::Trailing,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Leading => CommentPosition::Leading,
-            Self::Trailing => CommentPosition::Trailing,
-        }
+        *self
     }
 }
 
 impl<'new_alloc> CloneIn<'new_alloc> for CommentAnnotation {
     type Cloned = CommentAnnotation;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::None => CommentAnnotation::None,
-            Self::Jsdoc => CommentAnnotation::Jsdoc,
-            Self::Legal => CommentAnnotation::Legal,
-            Self::Pure => CommentAnnotation::Pure,
-            Self::NoSideEffects => CommentAnnotation::NoSideEffects,
-            Self::Webpack => CommentAnnotation::Webpack,
-            Self::Vite => CommentAnnotation::Vite,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::None => CommentAnnotation::None,
-            Self::Jsdoc => CommentAnnotation::Jsdoc,
-            Self::Legal => CommentAnnotation::Legal,
-            Self::Pure => CommentAnnotation::Pure,
-            Self::NoSideEffects => CommentAnnotation::NoSideEffects,
-            Self::Webpack => CommentAnnotation::Webpack,
-            Self::Vite => CommentAnnotation::Vite,
-        }
+        *self
     }
 }
 

--- a/crates/oxc_regular_expression/src/generated/derive_clone_in.rs
+++ b/crates/oxc_regular_expression/src/generated/derive_clone_in.rs
@@ -1,7 +1,7 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/derives/clone_in.rs`
 
-#![allow(unused_variables, clippy::default_trait_access)]
+#![allow(unused_variables, clippy::default_trait_access, clippy::inline_always)]
 
 use oxc_allocator::{Allocator, CloneIn};
 
@@ -150,22 +150,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for BoundaryAssertion {
 impl<'new_alloc> CloneIn<'new_alloc> for BoundaryAssertionKind {
     type Cloned = BoundaryAssertionKind;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Start => BoundaryAssertionKind::Start,
-            Self::End => BoundaryAssertionKind::End,
-            Self::Boundary => BoundaryAssertionKind::Boundary,
-            Self::NegativeBoundary => BoundaryAssertionKind::NegativeBoundary,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Start => BoundaryAssertionKind::Start,
-            Self::End => BoundaryAssertionKind::End,
-            Self::Boundary => BoundaryAssertionKind::Boundary,
-            Self::NegativeBoundary => BoundaryAssertionKind::NegativeBoundary,
-        }
+        *self
     }
 }
 
@@ -192,22 +184,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for LookAroundAssertion<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for LookAroundAssertionKind {
     type Cloned = LookAroundAssertionKind;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Lookahead => LookAroundAssertionKind::Lookahead,
-            Self::NegativeLookahead => LookAroundAssertionKind::NegativeLookahead,
-            Self::Lookbehind => LookAroundAssertionKind::Lookbehind,
-            Self::NegativeLookbehind => LookAroundAssertionKind::NegativeLookbehind,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Lookahead => LookAroundAssertionKind::Lookahead,
-            Self::NegativeLookahead => LookAroundAssertionKind::NegativeLookahead,
-            Self::Lookbehind => LookAroundAssertionKind::Lookbehind,
-            Self::NegativeLookbehind => LookAroundAssertionKind::NegativeLookbehind,
-        }
+        *self
     }
 }
 
@@ -258,34 +242,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for Character {
 impl<'new_alloc> CloneIn<'new_alloc> for CharacterKind {
     type Cloned = CharacterKind;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::ControlLetter => CharacterKind::ControlLetter,
-            Self::HexadecimalEscape => CharacterKind::HexadecimalEscape,
-            Self::Identifier => CharacterKind::Identifier,
-            Self::Null => CharacterKind::Null,
-            Self::Octal1 => CharacterKind::Octal1,
-            Self::Octal2 => CharacterKind::Octal2,
-            Self::Octal3 => CharacterKind::Octal3,
-            Self::SingleEscape => CharacterKind::SingleEscape,
-            Self::Symbol => CharacterKind::Symbol,
-            Self::UnicodeEscape => CharacterKind::UnicodeEscape,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::ControlLetter => CharacterKind::ControlLetter,
-            Self::HexadecimalEscape => CharacterKind::HexadecimalEscape,
-            Self::Identifier => CharacterKind::Identifier,
-            Self::Null => CharacterKind::Null,
-            Self::Octal1 => CharacterKind::Octal1,
-            Self::Octal2 => CharacterKind::Octal2,
-            Self::Octal3 => CharacterKind::Octal3,
-            Self::SingleEscape => CharacterKind::SingleEscape,
-            Self::Symbol => CharacterKind::Symbol,
-            Self::UnicodeEscape => CharacterKind::UnicodeEscape,
-        }
+        *self
     }
 }
 
@@ -310,26 +274,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for CharacterClassEscape {
 impl<'new_alloc> CloneIn<'new_alloc> for CharacterClassEscapeKind {
     type Cloned = CharacterClassEscapeKind;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::D => CharacterClassEscapeKind::D,
-            Self::NegativeD => CharacterClassEscapeKind::NegativeD,
-            Self::S => CharacterClassEscapeKind::S,
-            Self::NegativeS => CharacterClassEscapeKind::NegativeS,
-            Self::W => CharacterClassEscapeKind::W,
-            Self::NegativeW => CharacterClassEscapeKind::NegativeW,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::D => CharacterClassEscapeKind::D,
-            Self::NegativeD => CharacterClassEscapeKind::NegativeD,
-            Self::S => CharacterClassEscapeKind::S,
-            Self::NegativeS => CharacterClassEscapeKind::NegativeS,
-            Self::W => CharacterClassEscapeKind::W,
-            Self::NegativeW => CharacterClassEscapeKind::NegativeW,
-        }
+        *self
     }
 }
 
@@ -396,20 +348,14 @@ impl<'new_alloc> CloneIn<'new_alloc> for CharacterClass<'_> {
 impl<'new_alloc> CloneIn<'new_alloc> for CharacterClassContentsKind {
     type Cloned = CharacterClassContentsKind;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Union => CharacterClassContentsKind::Union,
-            Self::Intersection => CharacterClassContentsKind::Intersection,
-            Self::Subtraction => CharacterClassContentsKind::Subtraction,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Union => CharacterClassContentsKind::Union,
-            Self::Intersection => CharacterClassContentsKind::Intersection,
-            Self::Subtraction => CharacterClassContentsKind::Subtraction,
-        }
+        *self
     }
 }
 

--- a/crates/oxc_syntax/src/generated/derive_clone_in.rs
+++ b/crates/oxc_syntax/src/generated/derive_clone_in.rs
@@ -1,7 +1,7 @@
 // Auto-generated code, DO NOT EDIT DIRECTLY!
 // To edit this generated file you have to edit `tasks/ast_tools/src/derives/clone_in.rs`
 
-#![allow(unused_variables, clippy::default_trait_access)]
+#![allow(unused_variables, clippy::default_trait_access, clippy::inline_always)]
 
 use oxc_allocator::{Allocator, CloneIn};
 
@@ -11,215 +11,97 @@ use crate::operator::*;
 impl<'new_alloc> CloneIn<'new_alloc> for NumberBase {
     type Cloned = NumberBase;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Float => NumberBase::Float,
-            Self::Decimal => NumberBase::Decimal,
-            Self::Binary => NumberBase::Binary,
-            Self::Octal => NumberBase::Octal,
-            Self::Hex => NumberBase::Hex,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Float => NumberBase::Float,
-            Self::Decimal => NumberBase::Decimal,
-            Self::Binary => NumberBase::Binary,
-            Self::Octal => NumberBase::Octal,
-            Self::Hex => NumberBase::Hex,
-        }
+        *self
     }
 }
 
 impl<'new_alloc> CloneIn<'new_alloc> for BigintBase {
     type Cloned = BigintBase;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Decimal => BigintBase::Decimal,
-            Self::Binary => BigintBase::Binary,
-            Self::Octal => BigintBase::Octal,
-            Self::Hex => BigintBase::Hex,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Decimal => BigintBase::Decimal,
-            Self::Binary => BigintBase::Binary,
-            Self::Octal => BigintBase::Octal,
-            Self::Hex => BigintBase::Hex,
-        }
+        *self
     }
 }
 
 impl<'new_alloc> CloneIn<'new_alloc> for AssignmentOperator {
     type Cloned = AssignmentOperator;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Assign => AssignmentOperator::Assign,
-            Self::Addition => AssignmentOperator::Addition,
-            Self::Subtraction => AssignmentOperator::Subtraction,
-            Self::Multiplication => AssignmentOperator::Multiplication,
-            Self::Division => AssignmentOperator::Division,
-            Self::Remainder => AssignmentOperator::Remainder,
-            Self::Exponential => AssignmentOperator::Exponential,
-            Self::ShiftLeft => AssignmentOperator::ShiftLeft,
-            Self::ShiftRight => AssignmentOperator::ShiftRight,
-            Self::ShiftRightZeroFill => AssignmentOperator::ShiftRightZeroFill,
-            Self::BitwiseOR => AssignmentOperator::BitwiseOR,
-            Self::BitwiseXOR => AssignmentOperator::BitwiseXOR,
-            Self::BitwiseAnd => AssignmentOperator::BitwiseAnd,
-            Self::LogicalOr => AssignmentOperator::LogicalOr,
-            Self::LogicalAnd => AssignmentOperator::LogicalAnd,
-            Self::LogicalNullish => AssignmentOperator::LogicalNullish,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Assign => AssignmentOperator::Assign,
-            Self::Addition => AssignmentOperator::Addition,
-            Self::Subtraction => AssignmentOperator::Subtraction,
-            Self::Multiplication => AssignmentOperator::Multiplication,
-            Self::Division => AssignmentOperator::Division,
-            Self::Remainder => AssignmentOperator::Remainder,
-            Self::Exponential => AssignmentOperator::Exponential,
-            Self::ShiftLeft => AssignmentOperator::ShiftLeft,
-            Self::ShiftRight => AssignmentOperator::ShiftRight,
-            Self::ShiftRightZeroFill => AssignmentOperator::ShiftRightZeroFill,
-            Self::BitwiseOR => AssignmentOperator::BitwiseOR,
-            Self::BitwiseXOR => AssignmentOperator::BitwiseXOR,
-            Self::BitwiseAnd => AssignmentOperator::BitwiseAnd,
-            Self::LogicalOr => AssignmentOperator::LogicalOr,
-            Self::LogicalAnd => AssignmentOperator::LogicalAnd,
-            Self::LogicalNullish => AssignmentOperator::LogicalNullish,
-        }
+        *self
     }
 }
 
 impl<'new_alloc> CloneIn<'new_alloc> for BinaryOperator {
     type Cloned = BinaryOperator;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Equality => BinaryOperator::Equality,
-            Self::Inequality => BinaryOperator::Inequality,
-            Self::StrictEquality => BinaryOperator::StrictEquality,
-            Self::StrictInequality => BinaryOperator::StrictInequality,
-            Self::LessThan => BinaryOperator::LessThan,
-            Self::LessEqualThan => BinaryOperator::LessEqualThan,
-            Self::GreaterThan => BinaryOperator::GreaterThan,
-            Self::GreaterEqualThan => BinaryOperator::GreaterEqualThan,
-            Self::Addition => BinaryOperator::Addition,
-            Self::Subtraction => BinaryOperator::Subtraction,
-            Self::Multiplication => BinaryOperator::Multiplication,
-            Self::Division => BinaryOperator::Division,
-            Self::Remainder => BinaryOperator::Remainder,
-            Self::Exponential => BinaryOperator::Exponential,
-            Self::ShiftLeft => BinaryOperator::ShiftLeft,
-            Self::ShiftRight => BinaryOperator::ShiftRight,
-            Self::ShiftRightZeroFill => BinaryOperator::ShiftRightZeroFill,
-            Self::BitwiseOR => BinaryOperator::BitwiseOR,
-            Self::BitwiseXOR => BinaryOperator::BitwiseXOR,
-            Self::BitwiseAnd => BinaryOperator::BitwiseAnd,
-            Self::In => BinaryOperator::In,
-            Self::Instanceof => BinaryOperator::Instanceof,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Equality => BinaryOperator::Equality,
-            Self::Inequality => BinaryOperator::Inequality,
-            Self::StrictEquality => BinaryOperator::StrictEquality,
-            Self::StrictInequality => BinaryOperator::StrictInequality,
-            Self::LessThan => BinaryOperator::LessThan,
-            Self::LessEqualThan => BinaryOperator::LessEqualThan,
-            Self::GreaterThan => BinaryOperator::GreaterThan,
-            Self::GreaterEqualThan => BinaryOperator::GreaterEqualThan,
-            Self::Addition => BinaryOperator::Addition,
-            Self::Subtraction => BinaryOperator::Subtraction,
-            Self::Multiplication => BinaryOperator::Multiplication,
-            Self::Division => BinaryOperator::Division,
-            Self::Remainder => BinaryOperator::Remainder,
-            Self::Exponential => BinaryOperator::Exponential,
-            Self::ShiftLeft => BinaryOperator::ShiftLeft,
-            Self::ShiftRight => BinaryOperator::ShiftRight,
-            Self::ShiftRightZeroFill => BinaryOperator::ShiftRightZeroFill,
-            Self::BitwiseOR => BinaryOperator::BitwiseOR,
-            Self::BitwiseXOR => BinaryOperator::BitwiseXOR,
-            Self::BitwiseAnd => BinaryOperator::BitwiseAnd,
-            Self::In => BinaryOperator::In,
-            Self::Instanceof => BinaryOperator::Instanceof,
-        }
+        *self
     }
 }
 
 impl<'new_alloc> CloneIn<'new_alloc> for LogicalOperator {
     type Cloned = LogicalOperator;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Or => LogicalOperator::Or,
-            Self::And => LogicalOperator::And,
-            Self::Coalesce => LogicalOperator::Coalesce,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Or => LogicalOperator::Or,
-            Self::And => LogicalOperator::And,
-            Self::Coalesce => LogicalOperator::Coalesce,
-        }
+        *self
     }
 }
 
 impl<'new_alloc> CloneIn<'new_alloc> for UnaryOperator {
     type Cloned = UnaryOperator;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::UnaryPlus => UnaryOperator::UnaryPlus,
-            Self::UnaryNegation => UnaryOperator::UnaryNegation,
-            Self::LogicalNot => UnaryOperator::LogicalNot,
-            Self::BitwiseNot => UnaryOperator::BitwiseNot,
-            Self::Typeof => UnaryOperator::Typeof,
-            Self::Void => UnaryOperator::Void,
-            Self::Delete => UnaryOperator::Delete,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::UnaryPlus => UnaryOperator::UnaryPlus,
-            Self::UnaryNegation => UnaryOperator::UnaryNegation,
-            Self::LogicalNot => UnaryOperator::LogicalNot,
-            Self::BitwiseNot => UnaryOperator::BitwiseNot,
-            Self::Typeof => UnaryOperator::Typeof,
-            Self::Void => UnaryOperator::Void,
-            Self::Delete => UnaryOperator::Delete,
-        }
+        *self
     }
 }
 
 impl<'new_alloc> CloneIn<'new_alloc> for UpdateOperator {
     type Cloned = UpdateOperator;
 
+    #[inline(always)]
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Increment => UpdateOperator::Increment,
-            Self::Decrement => UpdateOperator::Decrement,
-        }
+        *self
     }
 
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
-        match self {
-            Self::Increment => UpdateOperator::Increment,
-            Self::Decrement => UpdateOperator::Decrement,
-        }
+        *self
     }
 }

--- a/crates/oxc_syntax/src/reference.rs
+++ b/crates/oxc_syntax/src/reference.rs
@@ -27,6 +27,8 @@ impl<'alloc> CloneIn<'alloc> for ReferenceId {
         unreachable!();
     }
 
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, _: &'alloc Allocator) -> Self {
         *self
     }

--- a/crates/oxc_syntax/src/scope.rs
+++ b/crates/oxc_syntax/src/scope.rs
@@ -24,6 +24,8 @@ impl<'alloc> CloneIn<'alloc> for ScopeId {
         unreachable!();
     }
 
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, _: &'alloc Allocator) -> Self {
         *self
     }

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -24,6 +24,8 @@ impl<'alloc> CloneIn<'alloc> for SymbolId {
         unreachable!();
     }
 
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
     fn clone_in_with_semantic_ids(&self, _: &'alloc Allocator) -> Self {
         *self
     }


### PR DESCRIPTION
Shorten generated code for `CloneIn` for fieldless enums. All fieldless enums are `Copy`, so cloning them can just be `*self`, rather than a large match expression. This removes about 500 lines of code.

Add `#[inline(always)]` to these no-op `clone_in` methods.
