### PR TITLE
fix(ast/estree): fix TS type def for `TSThisParameter`

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -33,7 +33,8 @@ use super::{inherit_variants, js::*, literal::*};
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(
     rename = "Identifier",
-    add_fields(decorators = TsEmptyArray, optional = TsFalse, name = This)
+    add_fields(name = This, decorators = EmptyArray, optional = False),
+    field_order(span, name, type_annotation, decorators, optional),
 )]
 pub struct TSThisParameter<'a> {
     pub span: Span,

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -2280,10 +2280,10 @@ impl ESTree for TSThisParameter<'_> {
         state.serialize_field("type", &JsonSafeString("Identifier"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("typeAnnotation", &self.type_annotation);
         state.serialize_field("name", &crate::serialize::This(self));
-        state.serialize_ts_field("decorators", &crate::serialize::TsEmptyArray(self));
-        state.serialize_ts_field("optional", &crate::serialize::TsFalse(self));
+        state.serialize_field("typeAnnotation", &self.type_annotation);
+        state.serialize_field("decorators", &crate::serialize::EmptyArray(self));
+        state.serialize_field("optional", &crate::serialize::False(self));
         state.end();
     }
 }

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -161,6 +161,17 @@ impl<T> ESTree for This<'_, T> {
     }
 }
 
+/// Serialized as `[]`.
+#[ast_meta]
+#[estree(ts_type = "[]", raw_deser = "[]")]
+pub struct EmptyArray<'b, T>(#[expect(dead_code)] pub &'b T);
+
+impl<T> ESTree for EmptyArray<'_, T> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        [(); 0].serialize(serializer);
+    }
+}
+
 #[ast_meta]
 #[estree(ts_type = "[]", raw_deser = "[]")]
 #[ts]

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -1266,8 +1266,10 @@ function deserializeTSThisParameter(pos) {
     type: 'Identifier',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 16),
     name: 'this',
+    typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 16),
+    decorators: [],
+    optional: false,
   };
 }
 

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -1333,8 +1333,8 @@ function deserializeTSThisParameter(pos) {
     type: 'Identifier',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 16),
     name: 'this',
+    typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 16),
     decorators: [],
     optional: false,
   };

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -918,10 +918,10 @@ export interface JSXText extends Span {
 
 export interface TSThisParameter extends Span {
   type: 'Identifier';
-  typeAnnotation: TSTypeAnnotation | null;
   name: 'this';
-  decorators?: [];
-  optional?: false;
+  typeAnnotation: TSTypeAnnotation | null;
+  decorators: [];
+  optional: false;
 }
 
 export interface TSEnumDeclaration extends Span {


### PR DESCRIPTION
Follow-on after #9913.

`TSThisParameter` is a TS-only type, so its fields aren't optional the way the TS fields of JS types are.

Fix the type def by using JS versions of added fields (`False` instead of `TsFalse` etc).

Also re-order the fields, so that `name` is first. We want the object shape to be the same (same field order) for all types which are `Identifier`s in the ESTree AST.
