### PR TITLE
refactor(ast/estree): expose `INCLUDE_TS_FIELDS` constant on `Serializer`

### DIFF
--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -684,8 +684,10 @@ impl ESTree for FunctionFormalParameters<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut seq = serializer.serialize_sequence();
 
-        if let Some(this_param) = &self.0.this_param {
-            seq.serialize_ts_element(this_param);
+        if S::INCLUDE_TS_FIELDS {
+            if let Some(this_param) = &self.0.this_param {
+                seq.serialize_element(this_param);
+            }
         }
 
         for item in &self.0.params.items {

--- a/crates/oxc_estree/src/serialize/mod.rs
+++ b/crates/oxc_estree/src/serialize/mod.rs
@@ -30,6 +30,9 @@ pub trait ESTree {
 // Internal methods we don't want to expose outside this crate are in [`SerializerPrivate`] trait.
 #[expect(private_bounds)]
 pub trait Serializer: SerializerPrivate {
+    /// `true` if output should contain TS fields
+    const INCLUDE_TS_FIELDS: bool;
+
     /// Type of struct serializer this serializer uses.
     type StructSerializer: StructSerializer;
     /// Type of sequence serializer this serializer uses.
@@ -99,6 +102,9 @@ impl<C: Config, F: Formatter> Default for ESTreeSerializer<C, F> {
 }
 
 impl<'s, C: Config, F: Formatter> Serializer for &'s mut ESTreeSerializer<C, F> {
+    /// `true` if output should contain TS fields
+    const INCLUDE_TS_FIELDS: bool = C::INCLUDE_TS_FIELDS;
+
     type StructSerializer = ESTreeStructSerializer<'s, C, F>;
     type SequenceSerializer = ESTreeSequenceSerializer<'s, C, F>;
 

--- a/crates/oxc_estree/src/serialize/sequences.rs
+++ b/crates/oxc_estree/src/serialize/sequences.rs
@@ -4,7 +4,6 @@ use super::{Config, ESTree, ESTreeSerializer, Formatter, Serializer, SerializerP
 pub trait SequenceSerializer {
     /// Serialize sequence entry.
     fn serialize_element<T: ESTree + ?Sized>(&mut self, value: &T);
-    fn serialize_ts_element<T: ESTree + ?Sized>(&mut self, value: &T);
 
     /// Finish serializing sequence.
     fn end(self);
@@ -42,12 +41,6 @@ impl<C: Config, F: Formatter> SequenceSerializer for ESTreeSequenceSerializer<'_
         }
 
         value.serialize(&mut *self.serializer);
-    }
-
-    fn serialize_ts_element<T: ESTree + ?Sized>(&mut self, value: &T) {
-        if C::INCLUDE_TS_FIELDS {
-            self.serialize_element(value);
-        }
     }
 
     /// Finish serializing sequence.

--- a/crates/oxc_estree/src/serialize/structs.rs
+++ b/crates/oxc_estree/src/serialize/structs.rs
@@ -145,6 +145,9 @@ pub(super) enum StructState {
 pub struct FlatStructSerializer<'p, P: StructSerializer>(pub &'p mut P);
 
 impl<'p, P: StructSerializer> Serializer for FlatStructSerializer<'p, P> {
+    /// `true` if output should contain TS fields
+    const INCLUDE_TS_FIELDS: bool = P::Config::INCLUDE_TS_FIELDS;
+
     type StructSerializer = Self;
     type SequenceSerializer = ESTreeSequenceSerializer<'p, P::Config, P::Formatter>;
 


### PR DESCRIPTION
Remove the `serialize_ts_element` method added in #9913, and instead expose an `INCLUDE_TS_FIELDS` constant on `Serializer` trait.

Before:

```rs
if let Some(this_param) = &self.0.this_param {
    seq.serialize_ts_element(this_param);
}
```

After:

```rs
if S::INCLUDE_TS_FIELDS {
    if let Some(this_param) = &self.0.this_param {
        seq.serialize_element(this_param);
    }
}
```

This has one slight advantage. Because `INCLUDE_TS_FIELDS` is a constant, compiler will easily be able to prove that the code inside `if S::INCLUDE_TS_FIELDS { ... }` is dead code in the JS-only AST serializer, and remove it.

In this specific case, the TS-only logic is trivial, so compiler would probably see it could be optimized out anyway. But we may encounter other cases where more complex TS-only code is required, and compiler might not be able to prove that it's dead code in those cases.
