### PR TITLE
refactor(ast/estree): shorten raw deser code

### DIFF
--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -414,7 +414,7 @@ impl ESTree for ImportDeclarationSpecifiers<'_, '_> {
     ts_type = "FunctionBody | Expression",
     raw_deser = "
         let body = DESER[Box<FunctionBody>](POS_OFFSET.body);
-        DESER[bool](POS_OFFSET.expression) ? body.body[0].expression : body
+        THIS.expression ? body.body[0].expression : body
     "
 )]
 pub struct ArrowFunctionExpressionBody<'a>(pub &'a ArrowFunctionExpression<'a>);
@@ -436,14 +436,14 @@ impl ESTree for ArrowFunctionExpressionBody<'_> {
     ts_type = "IdentifierReference | AssignmentTargetWithDefault",
     raw_deser = "
         const init = DESER[Option<Expression>](POS_OFFSET.init),
-            binding = DESER[IdentifierReference](POS_OFFSET.binding),
+            keyCopy = {...THIS.key},
             value = init === null
-                ? binding
+                ? keyCopy
                 : {
                     type: 'AssignmentPattern',
-                    start: DESER[u32](POS_OFFSET.span.start),
-                    end: DESER[u32](POS_OFFSET.span.end),
-                    left: binding,
+                    start: THIS.start,
+                    end: THIS.end,
+                    left: keyCopy,
                     right: init,
                 };
         value
@@ -581,10 +581,7 @@ impl ESTree for ClassImplements<'_, '_> {
 }
 
 #[ast_meta]
-#[estree(
-    ts_type = "boolean",
-    raw_deser = "DESER[TSModuleDeclarationKind](POS_OFFSET.kind) === 'global'"
-)]
+#[estree(ts_type = "boolean", raw_deser = "THIS.kind === 'global'")]
 pub struct TSModuleDeclarationGlobal<'a, 'b>(pub &'b TSModuleDeclaration<'a>);
 
 impl ESTree for TSModuleDeclarationGlobal<'_, '_> {
@@ -671,9 +668,7 @@ impl ESTree for ExpressionStatementDirective<'_, '_> {
         const params = DESER[Box<FormalParameters>](POS_OFFSET.params);
         /* IF_TS */
         const thisParam = DESER[Option<Box<TSThisParameter>>](POS_OFFSET.this_param)
-        if (thisParam !== null) {
-            params.unshift(thisParam);
-        }
+        if (thisParam !== null) params.unshift(thisParam);
         /* END_IF_TS */
         params
     "

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -361,25 +361,28 @@ function deserializeAssignmentTargetWithDefault(pos) {
 }
 
 function deserializeAssignmentTargetPropertyIdentifier(pos) {
+  const start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
+    key = deserializeIdentifierReference(pos + 8);
   const init = deserializeOptionExpression(pos + 40),
-    binding = deserializeIdentifierReference(pos + 8),
+    keyCopy = { ...key },
     value = init === null
-      ? binding
+      ? keyCopy
       : {
         type: 'AssignmentPattern',
-        start: deserializeU32(pos),
-        end: deserializeU32(pos + 4),
-        left: binding,
+        start: start,
+        end: end,
+        left: keyCopy,
         right: init,
       };
   return {
     type: 'Property',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
+    start,
+    end,
     method: false,
     shorthand: true,
     computed: false,
-    key: deserializeIdentifierReference(pos + 8),
+    key,
     value,
     kind: 'init',
   };
@@ -795,17 +798,18 @@ function deserializeFunctionBody(pos) {
 }
 
 function deserializeArrowFunctionExpression(pos) {
+  const expression = deserializeBool(pos + 8);
   let body = deserializeBoxFunctionBody(pos + 40);
   return {
     type: 'ArrowFunctionExpression',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     id: null,
-    expression: deserializeBool(pos + 8),
+    expression,
     generator: false,
     async: deserializeBool(pos + 9),
     params: deserializeBoxFormalParameters(pos + 24),
-    body: deserializeBool(pos + 8) ? body.body[0].expression : body,
+    body: expression ? body.body[0].expression : body,
   };
 }
 
@@ -1723,15 +1727,16 @@ function deserializeTSTypePredicate(pos) {
 }
 
 function deserializeTSModuleDeclaration(pos) {
+  const kind = deserializeTSModuleDeclarationKind(pos + 80);
   return {
     type: 'TSModuleDeclaration',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     id: deserializeTSModuleDeclarationName(pos + 8),
     body: deserializeOptionTSModuleDeclarationBody(pos + 64),
-    kind: deserializeTSModuleDeclarationKind(pos + 80),
+    kind,
     declare: deserializeBool(pos + 81),
-    global: deserializeTSModuleDeclarationKind(pos + 80) === 'global',
+    global: kind === 'global',
   };
 }
 

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -373,25 +373,28 @@ function deserializeAssignmentTargetWithDefault(pos) {
 }
 
 function deserializeAssignmentTargetPropertyIdentifier(pos) {
+  const start = deserializeU32(pos),
+    end = deserializeU32(pos + 4),
+    key = deserializeIdentifierReference(pos + 8);
   const init = deserializeOptionExpression(pos + 40),
-    binding = deserializeIdentifierReference(pos + 8),
+    keyCopy = { ...key },
     value = init === null
-      ? binding
+      ? keyCopy
       : {
         type: 'AssignmentPattern',
-        start: deserializeU32(pos),
-        end: deserializeU32(pos + 4),
-        left: binding,
+        start: start,
+        end: end,
+        left: keyCopy,
         right: init,
       };
   return {
     type: 'Property',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
+    start,
+    end,
     method: false,
     shorthand: true,
     computed: false,
-    key: deserializeIdentifierReference(pos + 8),
+    key,
     value,
     kind: 'init',
   };
@@ -770,9 +773,7 @@ function deserializeBindingRestElement(pos) {
 function deserializeFunction(pos) {
   const params = deserializeBoxFormalParameters(pos + 72);
   const thisParam = deserializeOptionBoxTSThisParameter(pos + 64);
-  if (thisParam !== null) {
-    params.unshift(thisParam);
-  }
+  if (thisParam !== null) params.unshift(thisParam);
   return {
     type: deserializeFunctionType(pos + 8),
     start: deserializeU32(pos),
@@ -831,17 +832,18 @@ function deserializeFunctionBody(pos) {
 }
 
 function deserializeArrowFunctionExpression(pos) {
+  const expression = deserializeBool(pos + 8);
   let body = deserializeBoxFunctionBody(pos + 40);
   return {
     type: 'ArrowFunctionExpression',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     id: null,
-    expression: deserializeBool(pos + 8),
+    expression,
     generator: false,
     async: deserializeBool(pos + 9),
     params: deserializeBoxFormalParameters(pos + 24),
-    body: deserializeBool(pos + 8) ? body.body[0].expression : body,
+    body: expression ? body.body[0].expression : body,
     typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 16),
     returnType: deserializeOptionBoxTSTypeAnnotation(pos + 32),
   };
@@ -1790,15 +1792,16 @@ function deserializeTSTypePredicate(pos) {
 }
 
 function deserializeTSModuleDeclaration(pos) {
+  const kind = deserializeTSModuleDeclarationKind(pos + 80);
   return {
     type: 'TSModuleDeclaration',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     id: deserializeTSModuleDeclarationName(pos + 8),
     body: deserializeOptionTSModuleDeclarationBody(pos + 64),
-    kind: deserializeTSModuleDeclarationKind(pos + 80),
+    kind,
     declare: deserializeBool(pos + 81),
-    global: deserializeTSModuleDeclarationKind(pos + 80) === 'global',
+    global: kind === 'global',
   };
 }
 


### PR DESCRIPTION
Shorten and simplify some `raw_deser` code, by using `THIS.prop` instead of `DESER[TypeOfProp](POS_OFFSET.prop)`.

As well as being shorter, this also results in more efficient deserializer code, as it avoids deserializing the same value twice.
