### PR TITLE
ci(benchmarks): enable decorator transform in transformer benchmark

### DIFF
--- a/tasks/benchmark/benches/transformer.rs
+++ b/tasks/benchmark/benches/transformer.rs
@@ -24,6 +24,8 @@ fn bench_transformer(criterion: &mut Criterion) {
         // Even the plugins are unfinished, we still want to enable all of them
         // to track the performance changes during the development.
         transform_options.env = EnvOptions::enable_all(/* include_unfinished_plugins */ true);
+        transform_options.decorator.legacy = true;
+        transform_options.decorator.emit_decorator_metadata = true;
 
         group.bench_function(id, |b| {
             b.iter_with_setup_wrapper(|runner| {


### PR DESCRIPTION
Enable the decorator transform in transformer benchmarks, so we can see how expensive it is, and optimize it.