### PR TITLE
refactor(transformer/decorator): rename `enter_statement` to `exit_statement`

### DIFF
--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -82,7 +82,7 @@ impl<'a, 'ctx> LegacyDecorator<'a, 'ctx> {
 impl<'a> Traverse<'a> for LegacyDecorator<'a, '_> {
     // `#[inline]` because this is a hot path
     #[inline]
-    fn enter_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
+    fn exit_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
         match stmt {
             Statement::ClassDeclaration(_) => self.transform_class(stmt, ctx),
             Statement::ExportNamedDeclaration(_) => {

--- a/crates/oxc_transformer/src/decorator/mod.rs
+++ b/crates/oxc_transformer/src/decorator/mod.rs
@@ -26,9 +26,9 @@ impl<'a, 'ctx> Decorator<'a, 'ctx> {
 }
 
 impl<'a> Traverse<'a> for Decorator<'a, '_> {
-    fn enter_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
+    fn exit_statement(&mut self, stmt: &mut Statement<'a>, ctx: &mut TraverseCtx<'a>) {
         if self.options.legacy {
-            self.legacy_decorator.enter_statement(stmt, ctx);
+            self.legacy_decorator.exit_statement(stmt, ctx);
         }
     }
 

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -553,7 +553,7 @@ impl<'a> Traverse<'a> for TransformerImpl<'a, '_> {
         if let Some(typescript) = self.x0_typescript.as_mut() {
             typescript.exit_statement(stmt, ctx);
         }
-        self.decorator.enter_statement(stmt, ctx);
+        self.decorator.exit_statement(stmt, ctx);
         self.x2_es2018.exit_statement(stmt, ctx);
         self.x2_es2017.exit_statement(stmt, ctx);
     }


### PR DESCRIPTION
This was confusing the hell out of me while investigating #9171. "But the decorators transform runs first, this should be fine" I thought. But no... Because `Decorator::enter_statement` is running as part of `exit_statement`!

Rename `enter_statement` to `exit_statement` to clear up this confusion.
