### PR TITLE
fix(transformer/decorator): do not lose `WeakMap` when decorator and class properties transforms combined

### DIFF
--- a/crates/oxc_transformer/src/common/statement_injector.rs
+++ b/crates/oxc_transformer/src/common/statement_injector.rs
@@ -158,7 +158,6 @@ impl<'a> StatementInjectorStore<'a> {
     ///
     /// Use this if you convert one statement to another, and other code may have attached
     /// insertions to the original statement.
-    #[expect(dead_code)]
     #[inline]
     pub fn move_insertions<A1: GetAddress, A2: GetAddress>(
         &self,

--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -279,6 +279,7 @@ impl<'a> LegacyDecorator<'a, '_> {
         if class_or_constructor_parameter_is_decorated {
             return Some(self.transform_class_declaration_with_class_decorators(
                 class,
+                stmt_address,
                 has_private_in_expression_in_decorator,
                 ctx,
             ));
@@ -300,6 +301,7 @@ impl<'a> LegacyDecorator<'a, '_> {
     fn transform_class_declaration_with_class_decorators(
         &self,
         class: &mut Class<'a>,
+        stmt_address: Address,
         has_private_in_expression_in_decorator: bool,
         ctx: &mut TraverseCtx<'a>,
     ) -> (BoundIdentifier<'a>, Statement<'a>) {
@@ -448,6 +450,8 @@ impl<'a> LegacyDecorator<'a, '_> {
         );
         let statement = Statement::from(var_declaration);
 
+        // Move any insertions attached to the old statement to the new one
+        self.ctx.statement_injector.move_insertions(&stmt_address, &statement);
         self.ctx.statement_injector.insert_many_after(&statement, decoration_stmts);
 
         (class_binding, statement)

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 578ac4df
 
-Passed: 138/227
+Passed: 138/229
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -362,7 +362,7 @@ after transform: SymbolId(4): ScopeId(1)
 rebuilt        : SymbolId(5): ScopeId(4)
 
 
-# legacy-decorators (2/66)
+# legacy-decorators (2/68)
 * oxc/metadata/bound-type-reference/input.ts
 Symbol reference IDs mismatch for "BoundTypeReference":
 after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6)]
@@ -384,6 +384,31 @@ rebuilt        : SymbolId(2): Span { start: 6, end: 13 }
 Unresolved reference IDs mismatch for "UnboundTypeReference":
 after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
 rebuilt        : [ReferenceId(4), ReferenceId(5)]
+
+* oxc/with-class-private-properties/input.ts
+Symbol span mismatch for "C":
+after transform: SymbolId(0): Span { start: 11, end: 12 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol span mismatch for "C":
+after transform: SymbolId(3): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(1): Span { start: 11, end: 12 }
+Symbol span mismatch for "D":
+after transform: SymbolId(1): Span { start: 87, end: 88 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol span mismatch for "D":
+after transform: SymbolId(4): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(3): Span { start: 87, end: 88 }
+Symbol span mismatch for "E":
+after transform: SymbolId(2): Span { start: 171, end: 172 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
+Symbol span mismatch for "E":
+after transform: SymbolId(5): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(5): Span { start: 171, end: 172 }
+
+* oxc/with-class-private-properties-unnamed-default-export/input.ts
+Symbol flags mismatch for "_default":
+after transform: SymbolId(0): SymbolFlags(Class)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 
 * typescript/accessor/decoratorOnClassAccessor1/input.ts
 Scope children mismatch:

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties-unnamed-default-export/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties-unnamed-default-export/input.ts
@@ -1,0 +1,7 @@
+@dec
+export default class {
+  #prop = 0;
+  meth() {
+    return this.#prop;
+  }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties-unnamed-default-export/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties-unnamed-default-export/output.js
@@ -1,0 +1,8 @@
+let _default = class {
+  #prop = 0;
+  meth() {
+    return this.#prop;
+  }
+};
+_default = babelHelpers.decorate([dec], _default);
+export default _default;

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties/input.ts
@@ -1,0 +1,23 @@
+@dec
+class C {
+  #prop = 0;
+  meth() {
+    return this.#prop;
+  }
+}
+
+@dec
+export class D {
+  #prop = 0;
+  meth() {
+    return this.#prop;
+  }
+}
+
+@dec
+export default class E {
+  #prop = 0;
+  meth() {
+    return this.#prop;
+  }
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties/output.js
@@ -1,0 +1,25 @@
+let C = class C {
+  #prop = 0;
+  meth() {
+    return this.#prop;
+  }
+};
+C = babelHelpers.decorate([dec], C);
+
+let D = class D {
+  #prop = 0;
+  meth() {
+    return this.#prop;
+  }
+};
+D = babelHelpers.decorate([dec], D);
+
+export { D };
+let E = class E {
+  #prop = 0;
+  meth() {
+    return this.#prop;
+  }
+};
+E = babelHelpers.decorate([dec], E);
+export default E;


### PR DESCRIPTION
Closes #9171.

Prevent injected statements attached to the `Class` statement getting lost when `class C {}` is replaced with `let C = class C {};` by moving them to be attached to the new `let C` statement.

---

I'm actually unclear why we have to transform `class C {}` to `let C = class C {};` anyway. `class C {}` already creates a binding `C` which behaves like a `let` binding, so it can be reassigned.

Input:

```js
@dec
export class C {}
```

Current output:

```js
let C = class C {};
C = babelHelpers.decorate([dec], C);
export { C };
```

Could just be:

```js
export class C {}
C = babelHelpers.decorate([dec], C);
```

[ESBuild does this](https://esbuild.github.io/try/#dAAwLjI0LjAALS10YXJnZXQ9ZXMyMDIwAEBkZWMoKQpjbGFzcyBGb28gewogICNiYXIgPSAiYmFyIjsKICB0ZXN0KCkgeyByZXR1cm4gdGhpcy4jYmFyOyB9Cn0K) - it keeps the class declaration.
