### PR TITLE
fix(ast/estree): Fix `FormalParameter`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1775,10 +1775,13 @@ pub struct FormalParameter<'a> {
     #[estree(flatten)]
     pub pattern: BindingPattern<'a>,
     #[ts]
+    #[estree(skip)]
     pub accessibility: Option<TSAccessibility>,
     #[ts]
+    #[estree(skip)]
     pub readonly: bool,
     #[ts]
+    #[estree(skip)]
     pub r#override: bool,
 }
 

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1382,9 +1382,6 @@ impl ESTree for FormalParameter<'_> {
         state.serialize_ts_field("typeAnnotation", &self.pattern.type_annotation);
         state.serialize_ts_field("optional", &self.pattern.optional);
         state.serialize_ts_field("decorators", &self.decorators);
-        state.serialize_ts_field("accessibility", &self.accessibility);
-        state.serialize_ts_field("readonly", &self.readonly);
-        state.serialize_ts_field("override", &self.r#override);
         state.end();
     }
 }

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -814,9 +814,6 @@ function deserializeFormalParameter(pos) {
     typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 56),
     optional: deserializeBool(pos + 64),
     decorators: deserializeVecDecorator(pos + 8),
-    accessibility: deserializeOptionTSAccessibility(pos + 72),
-    readonly: deserializeBool(pos + 73),
-    override: deserializeBool(pos + 74),
   };
 }
 

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -574,9 +574,6 @@ export interface FormalParameterRest extends Span {
 export type FormalParameter =
   & ({
     decorators?: Array<Decorator>;
-    accessibility?: TSAccessibility | null;
-    readonly?: boolean;
-    override?: boolean;
   })
   & BindingPattern;
 

--- a/tasks/coverage/snapshots/estree_test262.snap
+++ b/tasks/coverage/snapshots/estree_test262.snap
@@ -1,50 +1,5 @@
 commit: bc5c1417
 
 estree_test262 Summary:
-AST Parsed     : 44047/44047 (100.00%)
-Positive Passed: 44002/44047 (99.90%)
-Mismatch: tasks/coverage/test262/test/annexB/built-ins/RegExp/prototype/compile/pattern-string-u.js
-Mismatch: tasks/coverage/test262/test/annexB/built-ins/String/prototype/substr/surrogate-pairs.js
-Mismatch: tasks/coverage/test262/test/built-ins/Array/prototype/concat/Array.prototype.concat_spreadable-string-wrapper.js
-Mismatch: tasks/coverage/test262/test/built-ins/JSON/stringify/value-string-escape-unicode.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/dotall/with-dotall-unicode.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/dotall/with-dotall.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/dotall/without-dotall-unicode.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/dotall/without-dotall.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/escape/escaped-surrogates.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/named-groups/non-unicode-property-names-invalid.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/named-groups/unicode-property-names-invalid.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/prototype/Symbol.replace/coerce-unicode.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/prototype/exec/u-captured-value.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-dotAll.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/changing-dotAll-flag-does-not-affect-dotAll-modifier.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/nesting-add-dotAll-within-remove-dotAll.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/nesting-remove-dotAll-within-add-dotAll.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-dotAll.js
-Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/at/returns-code-unit.js
-Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/codePointAt/return-first-code-unit.js
-Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/codePointAt/return-single-code-unit.js
-Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/isWellFormed/returns-boolean.js
-Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/match/regexp-prototype-match-v-u-flag.js
-Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/padEnd/normal-operation.js
-Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/padStart/normal-operation.js
-Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/toWellFormed/returns-well-formed-string.js
-Mismatch: tasks/coverage/test262/test/built-ins/StringIteratorPrototype/next/next-iteration-surrogate-pairs.js
-Mismatch: tasks/coverage/test262/test/intl402/NumberFormat/prototype/format/format-non-finite-numbers.js
-Mismatch: tasks/coverage/test262/test/intl402/Segmenter/prototype/segment/containing/breakable-input.js
-Mismatch: tasks/coverage/test262/test/intl402/Segmenter/prototype/segment/containing/unbreakable-input.js
-Mismatch: tasks/coverage/test262/test/intl402/Segmenter/prototype/segment/containing/zero-index.js
-Mismatch: tasks/coverage/test262/test/language/expressions/assignment/fn-name-lhs-cover.js
-Mismatch: tasks/coverage/test262/test/language/expressions/assignment/target-cover-id.js
-Mismatch: tasks/coverage/test262/test/language/expressions/postfix-decrement/target-cover-id.js
-Mismatch: tasks/coverage/test262/test/language/expressions/postfix-increment/target-cover-id.js
-Mismatch: tasks/coverage/test262/test/language/expressions/prefix-decrement/target-cover-id.js
-Mismatch: tasks/coverage/test262/test/language/expressions/prefix-increment/target-cover-id.js
-Mismatch: tasks/coverage/test262/test/language/literals/regexp/named-groups/invalid-lone-surrogate-groupname.js
-Mismatch: tasks/coverage/test262/test/language/literals/regexp/u-astral.js
-Mismatch: tasks/coverage/test262/test/language/literals/regexp/u-surrogate-pairs-atom-char-class.js
-Mismatch: tasks/coverage/test262/test/language/literals/regexp/u-surrogate-pairs-atom-escape-decimal.js
-Mismatch: tasks/coverage/test262/test/language/statements/for-in/head-lhs-cover.js
-Mismatch: tasks/coverage/test262/test/language/statements/for-of/head-lhs-async-parens.js
-Mismatch: tasks/coverage/test262/test/language/statements/for-of/head-lhs-cover.js
-Mismatch: tasks/coverage/test262/test/language/statements/for-of/string-astral-truncated.js
+AST Parsed     : 0/0 (NaN%)
+Positive Passed: 0/0 (NaN%)

--- a/tasks/coverage/snapshots/estree_test262.snap
+++ b/tasks/coverage/snapshots/estree_test262.snap
@@ -1,5 +1,50 @@
 commit: bc5c1417
 
 estree_test262 Summary:
-AST Parsed     : 0/0 (NaN%)
-Positive Passed: 0/0 (NaN%)
+AST Parsed     : 44047/44047 (100.00%)
+Positive Passed: 44002/44047 (99.90%)
+Mismatch: tasks/coverage/test262/test/annexB/built-ins/RegExp/prototype/compile/pattern-string-u.js
+Mismatch: tasks/coverage/test262/test/annexB/built-ins/String/prototype/substr/surrogate-pairs.js
+Mismatch: tasks/coverage/test262/test/built-ins/Array/prototype/concat/Array.prototype.concat_spreadable-string-wrapper.js
+Mismatch: tasks/coverage/test262/test/built-ins/JSON/stringify/value-string-escape-unicode.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/dotall/with-dotall-unicode.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/dotall/with-dotall.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/dotall/without-dotall-unicode.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/dotall/without-dotall.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/escape/escaped-surrogates.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/named-groups/non-unicode-property-names-invalid.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/named-groups/unicode-property-names-invalid.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/prototype/Symbol.replace/coerce-unicode.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/prototype/exec/u-captured-value.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-dotAll.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/changing-dotAll-flag-does-not-affect-dotAll-modifier.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/nesting-add-dotAll-within-remove-dotAll.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/nesting-remove-dotAll-within-add-dotAll.js
+Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/remove-dotAll.js
+Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/at/returns-code-unit.js
+Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/codePointAt/return-first-code-unit.js
+Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/codePointAt/return-single-code-unit.js
+Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/isWellFormed/returns-boolean.js
+Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/match/regexp-prototype-match-v-u-flag.js
+Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/padEnd/normal-operation.js
+Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/padStart/normal-operation.js
+Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/toWellFormed/returns-well-formed-string.js
+Mismatch: tasks/coverage/test262/test/built-ins/StringIteratorPrototype/next/next-iteration-surrogate-pairs.js
+Mismatch: tasks/coverage/test262/test/intl402/NumberFormat/prototype/format/format-non-finite-numbers.js
+Mismatch: tasks/coverage/test262/test/intl402/Segmenter/prototype/segment/containing/breakable-input.js
+Mismatch: tasks/coverage/test262/test/intl402/Segmenter/prototype/segment/containing/unbreakable-input.js
+Mismatch: tasks/coverage/test262/test/intl402/Segmenter/prototype/segment/containing/zero-index.js
+Mismatch: tasks/coverage/test262/test/language/expressions/assignment/fn-name-lhs-cover.js
+Mismatch: tasks/coverage/test262/test/language/expressions/assignment/target-cover-id.js
+Mismatch: tasks/coverage/test262/test/language/expressions/postfix-decrement/target-cover-id.js
+Mismatch: tasks/coverage/test262/test/language/expressions/postfix-increment/target-cover-id.js
+Mismatch: tasks/coverage/test262/test/language/expressions/prefix-decrement/target-cover-id.js
+Mismatch: tasks/coverage/test262/test/language/expressions/prefix-increment/target-cover-id.js
+Mismatch: tasks/coverage/test262/test/language/literals/regexp/named-groups/invalid-lone-surrogate-groupname.js
+Mismatch: tasks/coverage/test262/test/language/literals/regexp/u-astral.js
+Mismatch: tasks/coverage/test262/test/language/literals/regexp/u-surrogate-pairs-atom-char-class.js
+Mismatch: tasks/coverage/test262/test/language/literals/regexp/u-surrogate-pairs-atom-escape-decimal.js
+Mismatch: tasks/coverage/test262/test/language/statements/for-in/head-lhs-cover.js
+Mismatch: tasks/coverage/test262/test/language/statements/for-of/head-lhs-async-parens.js
+Mismatch: tasks/coverage/test262/test/language/statements/for-of/head-lhs-cover.js
+Mismatch: tasks/coverage/test262/test/language/statements/for-of/string-astral-truncated.js

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -2,8 +2,7 @@ commit: 15392346
 
 estree_typescript Summary:
 AST Parsed     : 10623/10725 (99.05%)
-Positive Passed: 1332/10725 (12.42%)
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/2dArrays.ts
+Positive Passed: 1799/10725 (16.77%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APILibCheck.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APISample_Watch.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APISample_WatchWithDefaults.ts
@@ -24,7 +23,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/InterfaceDeclaration8.t
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/SystemModuleForStatementNoInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractClassInLocalScope.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractClassInLocalScopeIsAbstract.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractClassUnionInstantiation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractInterfaceIdentifierName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractPropertyBasics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractPropertyInConstructor.ts
@@ -36,12 +34,7 @@ Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorDeclarationEmitVisibilityErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorDeclarationOrder.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorInferredReturnTypeErrorInReturnStatement.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorWithInitializer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorWithLineTerminator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorWithRestParam.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorsInAmbientContext.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessors_spec_section-4.5_error-cases.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessors_spec_section-4.5_inference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/addMoreCallSignaturesToBaseSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/addMoreCallSignaturesToBaseSignature2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/addMoreOverloadsToBaseSignature.ts
@@ -97,7 +90,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientExportDefaultErr
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientExternalModuleInAnotherExternalModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientExternalModuleWithInternalImportDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientExternalModuleWithoutInternalImportDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientFundule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientModuleWithTemplateLiterals.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientNameRestrictions.ts
@@ -108,8 +100,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientStatement1.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/ambientWithStatements.ts
 A 'return' statement can only be used within a function body.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambiguousCallsWhereReturnTypesAgree.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambiguousOverload.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambiguousOverloadResolution.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdDeclarationEmitNoExtraDeclare.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdDependencyComment1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdDependencyComment2.ts
@@ -130,9 +120,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonymousClassExpressio
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyAndUnknownHaveFalsyComponents.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyAsReturnTypeForNewOnCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyDeclare.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyIdenticalToItself.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyIndexedAccessArrayNoException.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyInferenceAnonymousFunctions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyIsAssignableToObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyIsAssignableToVoid.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyMappedTypesError.ts
@@ -140,9 +128,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/argsInScope.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arguments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsAsPropertyName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsAsPropertyName2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsBindsToFunctionScopeArgumentList.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsObjectIterator01_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsObjectIterator01_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsObjectIterator02_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsObjectIterator02_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsObjectIterator03_ES5.ts
@@ -150,7 +135,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsObjectIterator
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsSpreadRestIterables.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsUsedInClassFieldInitializerOrStaticInitializationBlock.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsUsedInObjectLiteralProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arithmeticOnInvalidTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arityErrorRelatedSpanBindingPattern.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest2.ts
@@ -172,8 +156,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFakeFlatNoCrashInf
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFilter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFind.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFlatMap.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFlatNoCrashInference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFlatNoCrashInferenceDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFrom.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/arrayFromAsync.ts
 `await` is only allowed within async functions and at the top levels of modules
@@ -185,7 +167,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralInNonVarArg
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralTypeInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayOfExportedClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayOfSubtypeIsAssignableToReadonlyArray.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayReferenceWithoutTypeArgs.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/arraySigChecking.ts
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arraySlice.ts
@@ -199,10 +180,6 @@ Line terminator not permitted before arrow
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionInConstructorArgument1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionParsingGenericInObject.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionWithObjectLiteralBody1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionWithObjectLiteralBody2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionWithObjectLiteralBody3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionWithObjectLiteralBody4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionWithObjectLiteralBody5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionWithObjectLiteralBody6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asiAbstract.ts
@@ -225,7 +202,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignToFn.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/assignToInvalidLHS.ts
 Cannot assign to this expression
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignToObjectTypeWithPrototypeProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignToPrototype1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assigningFromObjectToAnythingElse.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assigningFunctionToTupleIssuesError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompat1.ts
@@ -369,7 +345,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/awaitedTypeStrictNull.t
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/badExternalModuleReference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/badInferenceLowerPriorityThanGoodInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/badOverloadError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/badThisBinding.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bangInModuleName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseCheck.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseConstraintOfDecorator.ts
@@ -414,10 +389,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedEnumVariable
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedEnumVariablesUseBeforeDef_verbatimModuleSyntax.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedFunctionDeclarationInStrictModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedNamespaceDifferentFile.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedSameNameFunctionDeclarationES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedSameNameFunctionDeclarationES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedSameNameFunctionDeclarationStrictES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedSameNameFunctionDeclarationStrictES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedVariablesUseBeforeDef.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bluebirdStaticThis.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bom-utf8.ts
@@ -444,8 +415,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/callExpressionWithTypeP
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callOfConditionalTypeWithConcreteBranches.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callOnClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callOnInstance.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/callOverloadViaElementAccessExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/callOverloads1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callOverloads2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callOverloads3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callOverloads4.ts
@@ -459,8 +428,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/cannotIndexGenericWriti
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/captureSuperPropertyAccessInSuperCall01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/captureThisInSuperCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop10_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop14.ts
@@ -482,9 +449,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop8
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop9_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedParametersInInitializers1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedParametersInInitializers2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedShorthandPropertyAssignmentNoCheck.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedVarInLoop.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/caseInsensitiveFileSystemWithCapsImportTypeDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/castExpressionParentheses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/castFunctionExpressionShouldBeParenthesized.ts
@@ -523,7 +488,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkSuperCallBeforeThi
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkSuperCallBeforeThisAccessing6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkSuperCallBeforeThisAccessing7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkSuperCallBeforeThisAccessing8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkSwitchStatementIfCaseTypeIsString.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkTypePredicateForRedundantProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkerInitializationCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkingObjectWithThisInNamePositionNoCrash.ts
@@ -553,7 +517,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularlyReferentialIn
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularlySimplifyingConditionalTypesNoCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classAccessorInitializationInferenceWithElementAccess1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classAttributeInferenceTemplate.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classBlockScoping.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classCannotExtendVar.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclarationShouldBeOutOfScopeInComputedNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclaredBeforeClassFactory.ts
@@ -587,7 +550,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsNull2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFieldSuperAccessible.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFieldSuperNotAccessible.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFunctionMerging.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFunctionMerging2.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/classHeritageWithTrailingSeparator.ts
 Expected `{` but found `EOF`
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementingInterfaceIndexer.ts
@@ -629,8 +591,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/classVarianceResolveCir
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classVarianceResolveCircularity2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classWithDuplicateIdentifier.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classWithMultipleBaseClasses.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classWithOverloadImplementationOfWrongName.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classWithOverloadImplementationOfWrongName2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classdecl.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/clinterfaces.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleAcrossModuleDefinitions.ts
@@ -638,8 +598,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleAndTypeParameter
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleGenericOnSelfMember.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleStaticMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleTest1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleTest2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleWithDuplicateMember2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleWithPriorInstantiatedModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleWithPriorUninstantiatedModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/clodulesDerivedClasses.ts
@@ -660,12 +618,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionArgumentsFunct
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionArgumentsInType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionArgumentsInterfaceMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenEnumWithEnumMemberConflict.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithAccessorChildren.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithConstructorChildren.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithEnumMemberConflict.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithFunctionChildren.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithMemberInterfaceConflict.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithMethodChildren.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionCodeGenModuleWithModuleChildren.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndAmbientEnum.ts
@@ -686,13 +641,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterF
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterInType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterInterfaceMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterUnderscoreIUsage.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalFunctionInAccessors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalFunctionInProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalVarInAccessors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalVarInProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndNameResolution.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndParameter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndParameter1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndPropertyNameAsConstuctorParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndEnumInGlobal.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInAccessors.ts
@@ -736,8 +688,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement7.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnArrayElement9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnBlock1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnClassAccessor2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnDecoratedClassDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnElidedModule1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnExportEnumDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnIfStatement1.ts
@@ -785,7 +735,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnPropertyOfObj
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnRequireStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsPropertySignature1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsTypeParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsVarDecl.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsVariableStatement1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsdoNotEmitComments.ts
@@ -849,7 +798,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeVariance
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypesASI.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypesSimplifyWhenTrivial.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionallyDuplicateOverloadsCausedByOverloadResolution.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/configFileExtendsAsList.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conflictingDeclarationsImportFromNamespace1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conflictingDeclarationsImportFromNamespace2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conflictingMemberTypesInBases.ts
@@ -906,7 +854,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/constantEnumAssert.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constantOverloadFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constantOverloadFunctionNoSubtypeError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintCheckInGenericBaseTypeReference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintErrors1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintPropagationThroughReturnTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintReferencingTypeParameterFromSameTypeParameterList.ts
@@ -927,12 +874,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads7.t
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorParametersInVariableDeclarations.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorParametersThatShadowExternalNamesInVariableDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorReturningAPrimitive.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorReturnsInvalidType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorStaticParamName.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorStaticParamNameErrors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorWithCapturedSuper.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorWithParameterPropertiesAndPrivateFields.es2015.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorWithSuperAndPrologue.es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorsWithSpecializedSignatures.ts
@@ -1004,11 +948,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping24.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping25.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping26.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping27.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping28.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping29.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping30.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping31.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping32.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping33.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping34.ts
@@ -1062,7 +1002,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParame
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedSymbolNamedProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingOrOperator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingOrOperator2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingOrOperator3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingRestParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/continueInLoopsWithCapturedBlockScopedBindings1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/continueLabel.ts
@@ -1105,7 +1044,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowManyCallExpr
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowManyConsecutiveConditionsNoTimeout.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowNullTypeAndLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowOuterVariable.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowPrivateClassField.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowPropertyDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowPropertyInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowSelfReferentialLoop.ts
@@ -1142,7 +1080,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicGenericTypeInstan
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicModuleImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicTypeInstantiation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileAccessors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileAliasUseBeforeDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileAmbientExternalModuleWithSingleExportedModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileCallSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileClassWithIndexSignature.ts
@@ -1157,12 +1094,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileEnums.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileExportAssignmentImportInternalModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileExportAssignmentOfGenericInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForClassWithMultipleBaseClasses.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForClassWithPrivateOverloadedFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForExportedImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForFunctionTypeAsTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForInterfaceWithOptionalFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForInterfaceWithRestParams.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForTypeParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileFunctions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileGenericClassWithGenericExtendedClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileGenericType.ts
@@ -1179,13 +1114,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileObjectLiteralWi
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileObjectLiteralWithOnlySetter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileOptionalInterfaceMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFilePrivateMethodOverloads.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFilePrivateStatic.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileRegressionTests.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileRestParametersOfFunctionAndFunctionType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationArrayType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationBuiltInType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationParenType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationStringLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationTupleType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationTypeAlias.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationTypeLiteral.ts
@@ -1286,7 +1219,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDestruct
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDetachedComment1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDetachedComment2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDistributiveConditionalWithInfer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDoesNotUseReexportedNamespaceAsLocal.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDuplicateParameterDestructuring.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitEnumReadonlyProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitEnumReferenceViaImportEquals.ts
@@ -1297,8 +1229,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExportAl
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExportAssignedNamespaceNoTripleSlashTypesReference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExportAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExportDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends6.ts
@@ -1494,7 +1424,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataGeneri
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataGenericTypeVariableDefault.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataGenericTypeVariableInScope.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataNoLibIsolatedModulesTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataNoStrictNull.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataOnInferredType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataPromise.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataRestParameterWithImportedType.ts
@@ -1511,9 +1440,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataWithIm
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataWithImportDeclarationNameCollision8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorReferenceOnOtherProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorReferences.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorWithNegativeLiteralTypeNoCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorWithUnderscoreMethod.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorsOnComputedProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deduplicateImportsInSystem.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deepComparisons.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deepElaborationsIntoArrowExpressions.ts
@@ -1541,12 +1468,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultNamedExportWithT
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultNamedExportWithType4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultOfAnyInStrictNullChecks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultParameterAddsUndefinedWithStrictNullChecks.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultParameterTrailingComments.ts
 tasks/coverage/typescript/tests/cases/compiler/defaultPropsEmptyCurlyBecomesAnyForJs.ts
 Unexpected estree file content error: 2 != 3
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultValueInConstructorOverload1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultValueInFunctionOverload1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultValueInFunctionTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deferredConditionalTypes.ts
 tasks/coverage/typescript/tests/cases/compiler/deferredConditionalTypes2.ts
@@ -1603,15 +1527,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringWithConstr
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringWithGenericParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringWithNewExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringWithNumberLiteral.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/detachedCommentAtStartOfConstructor1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/detachedCommentAtStartOfConstructor2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/detachedCommentAtStartOfFunctionBody1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/detachedCommentAtStartOfFunctionBody2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/detachedCommentAtStartOfLambdaFunction1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/detachedCommentAtStartOfLambdaFunction2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/didYouMeanStringLiteral.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/differentTypesWithSameName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminableUnionWithIntersectedMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantElementAccessCheck.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantNarrowingCouldBeCircular.ts
@@ -1681,9 +1602,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst14.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst15.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst16.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst17.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst18.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst19.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst2.ts
 Missing initializer in const declaration
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst4.ts
@@ -1695,11 +1614,8 @@ Unexpected estree file content error: 2 != 3
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateAnonymousInners1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateAnonymousModuleClasses.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateClassElements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateConstructSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateConstructSignature2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateConstructorOverloadSignature.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateConstructorOverloadSignature2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateDefaultExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateErrorAssignability.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateErrorClassExpression.ts
@@ -1761,7 +1677,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicNamesErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/elaboratedErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/elaboratedErrorsOnNullableTargets01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/elaborationForPossiblyCallableTypeStillReferencesArgumentAtTopLevel.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/elementAccessExpressionInternalComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/elidedEmbeddedStatementsReplacedWithSemicolon.ts
 tasks/coverage/typescript/tests/cases/compiler/elidedJSImport1.ts
@@ -2035,7 +1950,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInterop.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropDefaultImports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropDefaultMemberMustBeSyntacticallyDefaultExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropEnablesSyntheticDefaultImports.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropImportCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropImportDefaultWhenAllNamedAreDefaultAlias.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropImportNamespace.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropImportTSLibHasImport.ts
@@ -2198,7 +2112,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValuesInSystem.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarFromEmptyModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarNotElided.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportToString.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportTwoInterfacesWithSameName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportVisibility.ts
@@ -2251,8 +2164,6 @@ serde_json::from_str(oxc_json) error: number out of range at line 41 column 29
 tasks/coverage/typescript/tests/cases/compiler/fakeInfinity3.ts
 serde_json::from_str(oxc_json) error: number out of range at line 41 column 29
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/fallFromLastCase1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/fallFromLastCase2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fallbackToBindingPatternForTypeInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fatArrowSelf.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fatArrowfunctionAsType.ts
@@ -2274,7 +2185,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/fillInMissingTypeArgsOn
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/findLast.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/firstMatchRegExpMatchArray.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fixCrashAliasLookupForDefauledImport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/fixTypeParameterInSignatureWithRestParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fixingTypeParametersRepeatedly1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fixingTypeParametersRepeatedly2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fixingTypeParametersRepeatedly3.ts
@@ -2287,7 +2197,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/forLoopWithDestructurin
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forOfStringConstituents.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forOfTransformsExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forStatementInnerComments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/formatToPartsFractionalSecond.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forwardDeclaredCommonTypes01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forwardRefInClassProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forwardRefInEnum.ts
@@ -2311,7 +2220,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCallOnConstrainedTypeVariable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionDeclarationWithArgumentOfTypeFunctionTypeArray.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionDeclarationWithResolutionOfTypeNamedArguments01.ts
@@ -2325,9 +2233,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionInIfStatementIn
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionLikeInParameterInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionMergedWithModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloadAmbiguity1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloadImplementationOfWrongName.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloadImplementationOfWrongName2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads12.ts
@@ -2338,7 +2243,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads16.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads17.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads18.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads19.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads20.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads21.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads22.ts
@@ -2372,7 +2276,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloadsOnGenericArity1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloadsOnGenericArity2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloadsOutOfOrder.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloadsRecursiveGenericReturnType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionParameterArityMismatch.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionReturnTypeQuery.ts
@@ -2385,22 +2288,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionTypeArgumentAri
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionTypeArgumentArrayAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionTypeArgumentAssignmentCompat.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithAnyReturnTypeAndNoReturnExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements13.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements14.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements15.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements16.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithSameNameAsField.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithThrowButNoReturn1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionsMissingReturnStatementsAndExpressionsStrictNullChecks.ts
@@ -2409,11 +2299,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/funduleExportedClassIsU
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/funduleOfFunctionWithoutReturnTypeAnnotation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/funduleUsedAcrossFileBoundary.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fuzzy.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/generativeRecursionWithTypeOf.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorES6InAMDModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorES6_4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorReturnExpressionIsChecked.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorTransformFinalLabel.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericAndNonGenericInheritedSignature1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericAndNonGenericInheritedSignature2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericAndNonGenericOverload1.ts
@@ -2443,7 +2331,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallbacksAndClas
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCapturingFunctionNarrowing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericChainedCalls.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassImplementingGenericInterfaceFromAnotherModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassInheritsConstructorFromNonGenericClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassPropertyInheritanceSpecialization.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassStaticMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassWithStaticFactory.ts
@@ -2453,11 +2340,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClasses3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClasses4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassesInModule2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassesRedeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCloneReturnTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCloneReturnTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCombinators2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConditionalConstrainedToUnknownNotAssignableToConcreteObject.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraint1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraint2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraint3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraintDeclaration.ts
@@ -2467,7 +2351,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraintSatisf
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstructInvocationWithNoTypeArg.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstructSignatureInInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstructorFunction1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericContextualTypingSpecialization.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericDefaults.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericDefaultsErrors.ts
 tasks/coverage/typescript/tests/cases/compiler/genericDefaultsJs.ts
@@ -2479,10 +2362,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionCallSign
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionHasFreshTypeArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionInference1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionInference2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionSpecializations1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionTypedArgumentsAreFixed.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctions0.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctions1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctions2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctions3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionsAndConditionalInference.ts
@@ -2490,13 +2370,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionsNotCont
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionsWithOptionalParameters1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionsWithOptionalParameters2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionsWithOptionalParameters3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunduleInModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunduleInModule2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericImplements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericIndexTypeHasSensibleErrorMessage.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericIndexedAccessMethodIntersectionCanBeAccessed.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericIndexedAccessVarianceComparisonResultCorrect.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInference1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInference2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInferenceDefaultTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInferenceDefaultTypeParameterJsxReact.tsx
@@ -2518,21 +2395,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericNumberIndex.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericObjectCreationWithoutTypeArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericObjectLitReturnType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericObjectSpreadResultInSwitch.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericOfACloduleType1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericOfACloduleType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericOverloadSignatures.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericParameterAssignability1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericPrototypeProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericPrototypeProperty2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericRecursiveImplicitConstructorErrors1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericRecursiveImplicitConstructorErrors2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericRecursiveImplicitConstructorErrors3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericReduce.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericRestArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericRestTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericReturnTypeFromGetter1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericReversingTypeParameters.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericReversingTypeParameters2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericSignatureIdentity.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericSignatureInheritance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericSignatureInheritance2.ts
@@ -2544,12 +2414,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericStaticAnyTypeFun
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTemplateOverloadResolution.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTupleWithSimplifiableElements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeArgumentInference1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeParameterEquivalence2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeReferencesRequireTypeArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeUsedWithoutTypeArguments1.ts
@@ -2576,18 +2442,13 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics4NoError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericsAndHigherOrderFunctions.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericsManyTypeParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericsWithDuplicateTypeParameters1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericsWithoutTypeParameters1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/getAccessorWithImpliedReturnTypeAndFunctionClassMerge.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/getAndSetAsMemberNames.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/getAndSetNotIdenticalType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/getAndSetNotIdenticalType2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/getAndSetNotIdenticalType3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/getParameterNameAtPosition.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/getSetEnumerable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/getsetReturnTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/getterControlFlowStrictNull.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/getterErrorMessageNotDuplicated.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/getterMissingReturnError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/getterSetterNonAccessor.ts
@@ -2598,11 +2459,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/gettersAndSettersAccess
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/gettersAndSettersErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/gettersAndSettersTypesAgree.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/global.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalFunctionAugmentationOverload.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalIsContextualKeyword.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalThisCapture.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/grammarAmbiguities1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/heterogeneousArrayAndOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/hidingCallSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/hidingConstructSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/hidingIndexSignatures.ts
@@ -2635,7 +2494,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementsInClassExpres
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementsIncorrectlyNoAssertion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyAmbients.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyAnyReturningFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyCastedValue.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareFunctionExprWithoutFormalType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareFunctionWithoutFormalType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareFunctionWithoutFormalType2.ts
@@ -2648,10 +2506,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyFunctionInvo
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyFunctionOverloadWithImplicitAnyReturnType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyFunctionReturnNullOrUndefined.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyGenericTypeInference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyGenerics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyGetAndSetAccessorWithAnyReturnType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyInAmbientDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyInAmbientDeclaration2.d.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyInCatch.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyWidenToAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitConstParameters.ts
@@ -2716,12 +2571,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersSystem.ts
 tasks/coverage/typescript/tests/cases/compiler/importHelpersVerbatimModuleSyntax.ts
 Unexpected estree file content error: 2 != 3
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersWithExportStarAs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersWithImportOrExportDefault.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersWithImportOrExportDefaultNoTslib.1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersWithImportOrExportDefaultNoTslib.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersWithImportOrExportDefaultNoTslib.3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersWithImportStarAs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersWithLocalCollisions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importInTypePosition.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember.ts
@@ -2775,13 +2628,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/inKeywordNarrowingWithN
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inKeywordTypeguard.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inOperator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inOperatorWithFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inOperatorWithGeneric.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/incompatibleAssignmentOfIdenticallyNamedTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/incompatibleExports1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/incompatibleExports2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/incompatibleGenericTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/incompatibleTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/incorrectClassOverloadChain.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/incorrectNumberOfTypeArgumentsDuringErrorReporting.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/incorrectRecursiveMappedTypeConstraint.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/incrementOnNullAssertion.ts
@@ -2892,7 +2743,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingUsingA
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingUsingApparentType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingUsingApparentType3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionTypeNested.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionTypeSyntacticScenarios.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionTypeZip.ts
@@ -2932,20 +2782,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritance1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceGrandParentPrivateMemberCollision.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceGrandParentPrivateMemberCollisionWithPublicMember.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceGrandParentPublicMemberCollisionWithPrivateMember.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberAccessorOverridingAccessor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberAccessorOverridingMethod.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberAccessorOverridingProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberFuncOverridingAccessor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberFuncOverridingProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberPropertyOverridingAccessor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberPropertyOverridingMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceMemberPropertyOverridingProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceOfGenericConstructorMethod1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceOfGenericConstructorMethod2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticAccessorOverridingAccessor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticAccessorOverridingMethod.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticAccessorOverridingProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticFuncOverridingAccessor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticFuncOverridingAccessorOfFuncType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticFuncOverridingPropertyOfFuncType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceStaticPropertyOverridingAccessor.ts
@@ -3117,7 +2959,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidTripleSlashRefer
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidTypeNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidUseOfTypeAsNamespace.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/invariantGenericErrorElaboration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/invocationExpressionInFunctionParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/invokingNonGenericMethodWithTypeArguments1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/invokingNonGenericMethodWithTypeArguments2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ipromise2.ts
@@ -3138,7 +2979,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErro
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsReturnTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationLazySymbols.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationOutFile.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsAddUndefined.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsAddUndefined2.ts
 tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsAllowJs.ts
 Unexpected estree file content error: 1 != 2
@@ -3298,11 +3138,9 @@ tasks/coverage/typescript/tests/cases/compiler/jsdocImportTypeNodeNamespace.ts
 Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocInTypeScript.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocParameterParsingInvalidName.ts
 tasks/coverage/typescript/tests/cases/compiler/jsdocReferenceGlobalTypeInCommonJs.ts
 Unexpected estree file content error: 2 != 3
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/json.stringify.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsonFileImportChecksCallCorrectlyTwice.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxAttributeWithoutExpressionReact.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxCallElaborationCheckNoCrash1.tsx
@@ -3441,8 +3279,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/literals-negative.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/literalsInComputedProperties1.ts
 An enum member cannot have a numeric name.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/localAliasExportAssignment.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/localClassesInLoop.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/localClassesInLoop_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/localImportNameVsGlobalName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/localTypeParameterInferencePriority.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/m7Bugs.ts
@@ -3519,25 +3355,16 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclaration
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/metadataImportType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/metadataOfClassFromAlias.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/metadataOfClassFromAlias2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/metadataOfClassFromModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/metadataOfEventAlias.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/metadataOfStringLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/metadataOfUnion.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/metadataOfUnionWithNull.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/metadataReferencedWithinFilteredUnion.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/methodChainError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/methodContainingLocalFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/methodInAmbientClass1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/methodSignatureDeclarationEmit1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/methodSignatureHandledDeclarationKindForSymbol.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mismatchedExplicitTypeParameterAndArgumentType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mismatchedGenericArguments1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingCommaInTemplateStringsArray.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingDomElements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingFunctionImplementation.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingFunctionImplementation2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingImportAfterModuleImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingPropertiesOfClassExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingReturnStatement.ts
@@ -3550,14 +3377,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingTypeArguments3.t
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/misspelledNewMetaProperty.ts
 The only valid meta property for new is new.target
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixedExports.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixedStaticAndInstanceClassMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixedTypeEnumComparison.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixinIntersectionIsValidbaseType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixinOverMappedTypeNoCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixinPrivateAndProtected.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixingApparentTypeOverrides.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixingFunctionAndAmbientModule1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixingStaticAndInstanceOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/modFunctionCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/modifierParenCast.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/modifiersInObjectLiterals.ts
@@ -3573,7 +3398,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_Targe
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_TargetES6UsingES6Lib.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_UsingES5LibAndES6ArrayLib.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_UsingES5LibAndES6FeatureLibs.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_UsingES5LibES6ArrayLibES6WellknownSymbolLib.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_Worker.asynciterable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_Worker.iterable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAliasAsFunctionArgument.ts
@@ -3783,8 +3607,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiLineContextDiagnos
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiLineErrors.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/multiLinePropertyAccessAndArrowFunctionIndent1.ts
 A 'return' statement can only be used within a function body.
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiModuleClodule1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiModuleFundule1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiSignatureTypeInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multipleBaseInterfaesWithIncompatibleProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multipleExportAssignments.ts
@@ -3917,7 +3739,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashOnThisTypeUsage.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashUMDMergedWithGlobalValue.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noDefaultLib.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noEmitHelpers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noEmitHelpers2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noEmitOnError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noErrorTruncation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noErrorUsingImportExportModuleAugmentationInDeclarationFile1.ts
@@ -3932,10 +3753,8 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyDes
 Missing initializer in destructuring declaration
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyDestructuringVarDeclaration2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyForIn.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyForMethodParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyForwardReferencedInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyFunctionExpressionAssignment.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyFunctions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyInBareInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyInCastExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyInContextuallyTypesFunctionParamter.ts
@@ -3958,11 +3777,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyStringInde
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyUnionNormalizedObjectLiteral1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyWithOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsExclusions.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsInAsync1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsInAsync2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsWithProtectedBlocks1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsWithProtectedBlocks2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsWithProtectedBlocks3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsWithoutReturnExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitSymbolToString.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitThisBigThis.ts
@@ -3998,7 +3813,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUsedBeforeDefinedErro
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeColonModuleResolution.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeColonModuleResolution2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeModuleReexportFromDottedPath.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextEsmImportsOfPackagesWithExtensionlessMains.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextImportModeImplicitIndexResolution.ts
 tasks/coverage/typescript/tests/cases/compiler/nodeNextImportModeImplicitIndexResolution2.ts
 Unexpected estree file content error: 4 != 6
@@ -4029,11 +3843,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonIdenticalTypeConstra
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonInferrableTypePropagation1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonInferrableTypePropagation2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonInferrableTypePropagation3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonMergedDeclarationsAndOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonMergedOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullFullInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullMappedType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullParameterExtendingStringAssignableToString.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullReferenceMatching.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullableAndObjectIntersections.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullableReduction.ts
@@ -4122,16 +3934,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/omittedExpressionForOfL
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/operationsAvailableOnPromisedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/operatorAddNullUndefined.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalAccessorsInInterface1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalArgsWithDefaultValues.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalChainWithInstantiationExpression2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalConstructorArgInSuper.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalFunctionArgAssignability.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParamArgsTest.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParamAssignmentCompat.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParamInOverride.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParamReferencingOtherParams1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParamReferencingOtherParams2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParamReferencingOtherParams3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParamTypeComparison.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParameterInDestructuringWithInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParameterProperty.ts
@@ -4166,15 +3974,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadBindingAcrossDe
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadCallTest.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadEquivalenceWithStatics.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadErrorMatchesImplementationElaboaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadGenericFunctionWithRestArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadModifiersMustAgree.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstAsTypeAnnotation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstConstraintChecks1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstConstraintChecks2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstConstraintChecks3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstConstraintChecks4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstDuplicateOverloads1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInBaseWithBadImplementationInDerived.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInCallback1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInObjectLiteralImplementingAnInterface.ts
@@ -4187,7 +3992,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstNoAnyImp
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstNoNonSpecializedSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstNoStringImplementation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstNoStringImplementation2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstantsInvalidOverload1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnGenericArity.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnGenericClassAndNonGenericClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOverCTLambda.ts
@@ -4201,10 +4005,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadWithCallbacksWi
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadedConstructorFixesInferencesAppropriately.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadedStaticMethodSpecialization.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadingOnConstants1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadingOnConstants2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadingOnConstantsInImplementation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadresolutionWithConstraintCheckingDeferred.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsAndTypeArgumentArity.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsWithComputedNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsWithConstraints.ts
@@ -4223,9 +4024,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterPropertyInCons
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterPropertyInitializerInInitializers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterPropertyReferencingOtherParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterReferenceInInitializer1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterReferenceInInitializer2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterReferencesOtherParameter1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterReferencesOtherParameter2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/paramsOnlyHaveLiteralTypesWhenAppropriatelyContextualized.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/paramterDestrcuturingDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/parenthesisDoesNotBlockAliasSymbolCreation.ts
@@ -4256,12 +4054,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleR
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution1_node.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution3_classic.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution3_node.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution4_classic.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution4_node.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution5_classic.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution5_node.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution6_classic.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution6_node.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution7_classic.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution7_node.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution8_classic.ts
@@ -4307,13 +4100,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/preserveUnusedImports.t
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/prespecializedGenericMembers1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/primaryExpressionMods.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveConstraints1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveConstraints2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveTypeAsInterfaceName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveTypeAsInterfaceNameGeneric.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveTypeAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveUnionDetection.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyAccessorDeclFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCannotNameAccessorDeclFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCannotNameVarTypeDeclFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCheckAnonymousFunctionParameter.ts
@@ -4337,7 +4128,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyFunctionReturnTy
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyGetter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyGloClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyGloFunc.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyGloGetter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyGloImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyGloImportParseErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyGloInterface.ts
@@ -4369,7 +4159,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/privatePropertyInUnion.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privatePropertyUsingObjectType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateVisibility.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateVisibles.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseAllOnAny01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseChaining.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseChaining1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseChaining2.ts
@@ -4385,7 +4174,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/promisePermutations2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promisePermutations3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseTry.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseTypeInference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseTypeInferenceUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseTypeStrictNull.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseVoidErrorCallback.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseWithResolvers.ts
@@ -4394,7 +4182,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/promisesWithConstraints
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propTypeValidatorInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propagateNonInferrableType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propagationOfPromiseInitialization.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/properties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertiesAndIndexers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertiesAndIndexers2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertiesAndIndexersForNumericNames.ts
@@ -4430,8 +4217,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/randomSemicolons1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportGlobalDeclaration1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportGlobalDeclaration2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportUndefined1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportUndefined2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityCheckWithEmptyDefault.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks3.ts
@@ -4459,7 +4244,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactTagNameComponentWi
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactTagNameComponentWithPropsNoOOM2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactTransitiveImportHasValidDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyAssignmentInSubclassOfClassExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyFloat32ArrayAssignableWithFloat32Array.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyInDeclarationFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyPropertySubtypeRelationDirected.ts
@@ -4480,7 +4264,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseConstructo
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveClassBaseType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveClassReferenceTest.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveCloduleReference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveComplicatedClasses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalCrash1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalCrash2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalCrash3.ts
@@ -4494,7 +4277,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignme
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveFieldSetting.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveFunctionTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveFunctionTypes1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveGenericMethodCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveGenericSignatureInstantiation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveGenericTypeHierarchy.ts
@@ -4503,7 +4285,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveGenericUnionTy
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveGetterAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveIdenticalAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveIdenticalOverloadResolution.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveInference1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveInferenceBug.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveInheritance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveInheritance2.ts
@@ -4513,12 +4294,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveLetConst.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveMods.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveNamedLambdaCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveObjectLiteral.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveProperties.ts
 tasks/coverage/typescript/tests/cases/compiler/recursiveResolveDeclaredMembers.ts
 Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveResolveTypeMembers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveReturns.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveReverseMappedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveSpecializationOfExtendedTypeWithError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveSpecializationOfSignatures.ts
@@ -4538,7 +4317,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursivelyExpandingUni
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursivelySpecializedConstructorDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/redeclarationOfVarWithGenericType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/redeclareParameterInCatchBlock.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/redefineArray.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reducibleIndexedAccessTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportDefaultIsCallable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault1.ts
@@ -4593,7 +4371,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithou
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requiredInitializedParameter1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requiredInitializedParameter2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requiredInitializedParameter3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/requiredInitializedParameter4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requiredMappedTypeModifierTrumpsVariance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reservedNameOnInterfaceImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reservedNameOnModuleImport.ts
@@ -4638,7 +4415,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnInConstructor1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnInfiniteIntersection.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnStatement1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypeInferenceNotTooBroad.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypeParameterWithModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypePredicateIsInstantiateInContextOfTarget.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypeTypeArguments.ts
@@ -4673,7 +4449,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfInLambdas.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfNameAndImportsEmitInclusion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfRef.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencesInFunctionParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencingFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencingFile2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencingFile3.ts
@@ -4683,7 +4458,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferentialFunction
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/semicolonsInModuleDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/setMethods.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/setterBeforeGetter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/setterWithReturn.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/shadowPrivateMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/shadowedFunctionScopedVariablesByBlockScopedOnes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/shadowedReservedCompilerDeclarationsWithNoEmit.ts
@@ -4732,7 +4506,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/simplifyingConditionalW
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/slightlyIndirectedDeepObjectLiteralElaborations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-Comment1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-Comments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-Comments2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-FileWithComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-InterfacePrecedingVariableDeclaration1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-SemiColon1.ts
@@ -4791,7 +4564,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDest
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationEnums.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationExportAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationExportAssignmentCommonjs.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationFunctionExpressions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationFunctionPropertyAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationFunctions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationImport.ts
@@ -4851,7 +4623,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticGetterAndSetter.t
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticIndexSignatureAndNormalIndexSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInheritance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInitializersAndLegacyClassDecorators.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution5.ts
@@ -4861,15 +4632,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMemberExportAcces
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMethodReferencingTypeArgument1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMethodWithTypeParameterExtendsClauseDeclFile.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMethodsReferencingClassTypeParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMismatchBecauseOfPrototype.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMustPrecedePublic.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticOffOfInstance2.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/staticPrototypeProperty.ts
 Classes may not have a static property named prototype
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticPrototypePropertyOnClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticVisibility.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticVisibility2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/statics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stradac.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictFunctionTypes1.ts
@@ -4932,14 +4700,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/super2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superAccessCastedCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superAccessInFatArrow1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallArgsMustMatch.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallAssignResult.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericType1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericTypeButWithIncorrectNumberOfTypeArguments1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericTypeButWithNoTypeArguments1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesNonGenericTypeButWithTypeArguments1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatHasNoBaseType1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromFunction1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallInNonStaticMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallInStaticMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallInsideObjectLiteralExpression.ts
@@ -4948,14 +4714,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallWithCommentEmi
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superElementAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superHasMethodsFromMergedInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superInCatchBlock1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superInConstructorParam1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superInObjectLiterals_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superInObjectLiterals_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superNewCall1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superPropertyAccess.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superPropertyAccessInSuperCall01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superPropertyAccess_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superPropertyAccess_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superWithGenerics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/super_inside-object-literal-getters-and-setters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchAssignmentCompat.ts
@@ -5053,20 +4815,15 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/testContainerList.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/testTypings.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisBinding.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisBinding2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisCapture1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisConditionalOnMethodReturnOfGenericInstance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisExpressionInCallExpressionWithTypeArguments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisExpressionInIndexExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisExpressionOfGenericObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInAccessors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInArrowFunctionInStaticInitializer1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInClassBodyStaticESNext.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInConstructorParameter1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInConstructorParameter2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInFunctionCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInGenericStaticMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInInnerFunctions.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInLambda.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInPropertyBoundDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInSuperCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInSuperCall1.ts
@@ -5076,7 +4833,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInTupleTypeParamete
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInTypeQuery.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisIndexOnExistingReadonlyFieldIsNotNever.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisPredicateInObjectLiteral.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisReferencedInFunctionInsideArrowFunction1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisShadowingErrorSpans.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisWhenTypeCheckFails.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/this_inside-enum-should-not-be-allowed.ts
@@ -5090,7 +4846,6 @@ Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevelExports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevelLambda.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevelLambda2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevelLambda4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/trackedSymbolsNoCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/trailingCommaInHeterogenousArrayLiteral1.ts
@@ -5098,7 +4853,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/trailingCommasES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/transformArrowInBlockScopedLoopVarInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/transformNestedGeneratorsWithTry.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/transformParenthesizesConditionalSubexpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/transformsElideNullUndefinedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/transitiveTypeArgumentInference1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tripleSlashInCommentNotParsed.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tripleSlashReferenceAbsoluteWindowsPath.ts
@@ -5160,15 +4914,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgInference2WithEr
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgInferenceWithNull.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentConstraintResolution1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentDefaultUsesConstraintOnCircularDefault.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceApparentType1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceApparentType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceOrdering.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceWithConstraintAsCommonRoot.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceWithRecursivelyReferencedTypeAliasToTypeLiteral01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceWithRecursivelyReferencedTypeAliasToTypeLiteral02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentsInFunctionExpressions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentsOnFunctionsWithNoTypeParameters.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentsShouldDisallowNonGenericOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAssertionToGenericFunctionType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAssignabilityErrorMessage.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeCheckObjectCreationExpressionWithUndefinedCallResolutionData.ts
@@ -5223,7 +4974,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfPrototype.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfThisInStatics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfYieldWithUnionInContextualReturnType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParamExtendsOtherTypeParam.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterAndArgumentOfSameName1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEquivalence.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEquivalence2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEquivalence3.ts
@@ -5235,11 +4985,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterConstraine
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterConstrainedToOuterTypeParameter2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterConstraintInstantiation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterConstraints1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterDoesntBlockParameterLookup.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterEquality.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterExplicitlyExtendsAny.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterExtendingUnion1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterExtendingUnion2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterExtendsPrimitive.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments.ts
@@ -5250,7 +4997,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWith
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterHasSelfAsConstraint.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterLeak.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterOrderReversal.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersAndParametersInComputedNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersInStaticAccessors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersInStaticMethods.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersShouldNotBeEqual.ts
@@ -5338,7 +5084,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/undeclaredVarEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedArgumentInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedAsDiscriminantWithUnknown.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedAssignableToGenericMappedIntersection.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedInferentialTyping.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedSymbolReferencedInArrayLiteral1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedTypeArgument2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedTypeAssignment1.ts
@@ -5384,14 +5129,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownLikeUnionObjectF
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownPropertiesAreAssignableToObjectUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownSymbolInGenericReturnType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownSymbolOffContextualType1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownSymbols1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownSymbols2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownTypeArgOnCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unmatchedParameterPositions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unmetTypeConstraintInImportCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unreachableDeclarations.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unreachableSwitchTypeofAny.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unreachableSwitchTypeofUnknown.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unresolvableSelfReferencingAwaitedUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unresolvedTypeAssertionSymbol.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unspecializedConstraints.ts
@@ -5402,8 +5143,6 @@ Unexpected estree file content error: 2 != 3
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedDestructuring.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedDestructuringParameters.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedFunctionsinNamespaces3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedGetterInClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedIdentifiersConsolidated1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImportDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImportWithSpread.ts
@@ -5428,48 +5167,19 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsAndParamete
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsInMethod4.ts
 Missing initializer in const declaration
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsInRecursiveReturn.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsOnFunctionDeclarationWithinFunctionDeclaration1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsOnFunctionDeclarationWithinFunctionDeclaration2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsOnFunctionDeclarationWithinFunctionExpression1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsOnFunctionDeclarationWithinFunctionExpression2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsOnFunctionExpressionWithinFunctionDeclaration1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsOnFunctionExpressionWithinFunctionDeclaration2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsOnFunctionExpressionWithinFunctionExpression1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsOnFunctionExpressionWithinFunctionExpression2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsStartingWithUnderscore.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMethodsInInterface.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMultipleParameter1InContructor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMultipleParameter1InFunctionExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMultipleParameter2InContructor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMultipleParameter2InFunctionExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMultipleParameters1InFunctionDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMultipleParameters1InMethodDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMultipleParameters2InFunctionDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMultipleParameters2InMethodDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParameterProperty1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParameterProperty2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParameterUsedInTypeOf.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersInLambda1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersInLambda2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersWithUnderscore.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersinConstructor1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersinConstructor2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersinConstructor3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateStaticMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSemicolonInClass.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSetterInClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSetterInClass2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSingleParameterInContructor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSingleParameterInFunctionDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSingleParameterInFunctionExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSingleParameterInMethodDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInInterface1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInInterface2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInLambda3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters8.ts
@@ -5481,8 +5191,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters_in
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesWithUnderscoreInBindingElement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesWithUnderscoreInForOfLoop.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinModules1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinNamespaces2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinNamespaces3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unwitnessedTypeParameterVariance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_classDecorators.1.ts
@@ -5544,7 +5252,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/withImportDecl.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/withStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/withStatementErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/withStatementInternalComments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/withStatementNestedScope.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/wrappedRecursiveGenericType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/yieldExpression1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/yieldExpressionInFlowLoop.ts
@@ -5579,15 +5286,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShort
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand_merging.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand_reExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/asyncFunctionDeclarationParameterEvaluation.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/arrowFunctionWithParameterNameAsync_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction10_es2017.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction2_es2017.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction3_es2017.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction5_es2017.ts
 Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunctionCapturesArguments_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunctionCapturesThis_es2017.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncUnParenthesizedArrowFunction_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncAwaitIsolatedModules_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncAwait_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncMethodWithSuperConflict_es6.ts
@@ -5610,21 +5313,15 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/await_u
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration12_es2017.ts
 Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration13_es2017.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration2_es2017.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration3_es2017.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts
 Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration8_es2017.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/arrowFunctionWithParameterNameAsync_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction10_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction11_es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction2_es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction3_es5.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction5_es5.ts
 Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunctionCapturesArguments_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunctionCapturesThis_es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncUnParenthesizedArrowFunction_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncAwaitIsolatedModules_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncAwaitNestedClasses_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncAwait_es5.ts
@@ -5647,20 +5344,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDe
 tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration16_es5.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration2_es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration3_es5.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts
 Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration8_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclarationCapturesArguments_es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/arrowFunctionWithParameterNameAsync_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction10_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction2_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction3_es6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction5_es6.ts
 Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunctionCapturesThis_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncUnParenthesizedArrowFunction_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncAwaitIsolatedModules_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncAwait_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncMethodWithSuper_es6.ts
@@ -5683,8 +5374,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es6/fun
 Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration13_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration15_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration2_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration3_es6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts
 Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration8_es6.ts
@@ -5693,15 +5382,11 @@ Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/asyncGenerators/asyncGeneratorGenericNonWrappedReturn.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/asyncGenerators/asyncGeneratorParameterEvaluation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/asyncGenerators/asyncGeneratorPromiseNextType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/awaitAndYieldInProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractAccessor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractClinterfaceAssignability.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractFactoryFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractGeneric.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractImportInstantiation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInheritance2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInstantiations1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInstantiations2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMergedDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMixedWithModifiers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractProperties.ts
@@ -5716,7 +5401,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclara
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classExtendingNonConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classExtendingNull.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classAppearsToHaveMembersOfObject.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendingClass.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendingOptionalChain.ts
 Expected `{` but found `?.`
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classIsSubtypeOfBaseType.ts
@@ -5774,23 +5458,16 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticB
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlockUseBeforeDef3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlockUseBeforeDef4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlockUseBeforeDef5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/derivedClassWithoutExplicitConstructor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/derivedClassWithoutExplicitConstructor2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/derivedClassWithoutExplicitConstructor3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorOverloadsAccessibility.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorParametersAccessibility.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorParametersAccessibility2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorParametersAccessibility3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classWithTwoConstructorDefinitions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorDefaultValuesReferencingThis.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorImplementationWithDefaultValues.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorImplementationWithDefaultValues2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorOverloadsWithDefaultValues.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorOverloadsWithOptionalParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorParameterProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorParameterProperties2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/declarationEmitReadonly.ts
@@ -5809,11 +5486,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorD
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/superCalls/emitStatementsBeforeSuperCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/superCalls/emitStatementsBeforeSuperCallWithDefineFields.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/superCalls/superCallInConstructorWithNoBaseType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/superCalls/superPropertyInConstructorBeforeSuperCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/indexMemberDeclarations/staticIndexers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/classPropertyIsPublicByDefault.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/privateClassPropertyAccessibleWithinClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/privateClassPropertyAccessibleWithinNestedClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAreNotAccessibleDestructuring.ts
@@ -5821,20 +5494,15 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/acce
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/privateStaticNotAccessibleInClodule2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedClass.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedStaticNotAccessibleInClodule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/genericSetterInClassType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/indexersInClassType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/instancePropertiesInheritedIntoClassType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/instancePropertyInClassType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/staticPropertyNotInClassType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/constructorFunctionTypes/classWithBaseClassButNoConstructor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/constructorFunctionTypes/classWithConstructors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/constructorFunctionTypes/classWithNoConstructorOrBaseClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/constructorFunctionTypes/classWithStaticMembers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassFunctionOverridesBaseClassAccessor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassIncludesInheritedMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesIndexersWithAssignmentCompatibility.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesPrivates.ts
@@ -5850,16 +5518,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inhe
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithPrivateInstanceShadowingProtectedInstance.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithPrivateInstanceShadowingPublicInstance.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithPrivateStaticShadowingProtectedStatic.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithPrivateStaticShadowingPublicStatic.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/superInStaticMembers1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/thisAndSuperInStaticMembers1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/thisAndSuperInStaticMembers2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/thisAndSuperInStaticMembers3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/thisAndSuperInStaticMembers4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInInstanceMember.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInInstanceMember2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers11.ts
@@ -6032,22 +5695,13 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemb
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/instanceMemberWithComputedPropertyName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/instanceMemberWithComputedPropertyName2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/accessorWithES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/accessorWithMismatchedAccessibilityModifiers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/accessorsAreNotContextuallyTyped.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/ambientAccessors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/typeOfThisInAccessor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/derivedTypeAccessesHiddenBaseCallViaSuperPropertyAccess.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/instanceMemberAssignsToClassPrototype.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionOverloadMixingStaticAndInstance.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPrivateOverloads.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPublicOverloads.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPublicPrivateOverloads.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/staticMemberAssignsToConstructorFunctionMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/optionalMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/optionalProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/overrideInterfaceProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyAndAccessorWithSameName.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyAndFunctionWithSameName.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyNamedConstructor.ts
 Classes can't have a field named 'constructor'
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyNamedPrototype.ts
@@ -6070,7 +5724,6 @@ tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarat
 Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/twoAccessorsWithSameName.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/twoAccessorsWithSameName2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature3.ts
@@ -6112,7 +5765,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlF
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIIFE.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIfStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowInOperator.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowInstanceOfGuardPrimitives.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowInstanceofExtendsFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIteration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIterationErrors.ts
@@ -6161,17 +5813,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/type
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typesVersionsDeclarationEmit.multiFileBackReferenceToSelf.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typesVersionsDeclarationEmit.multiFileBackReferenceToUnmapped.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/1.0lib-noErrors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/constructableDecoratorOnClass01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/constructor/parameter/decoratorOnClassConstructorParameter1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/constructor/parameter/decoratorOnClassConstructorParameter5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratedBlockScopedClass1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratedBlockScopedClass2.ts
@@ -6183,40 +5828,25 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/dec
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratedClassFromExternalModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratorChecksFunctionBodies.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratorInstantiateModulesInFunctionBodies.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratorOnClass1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratorOnClass2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratorOnClass3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratorOnClass4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratorOnClass5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratorOnClass8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod14.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod15.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod16.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod18.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod19.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethodOverload2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodParameter1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodParameter2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodParameter3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty13.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorCallGeneric.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorInAmbientContext.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorMetadata-jsdoc.ts
@@ -6257,7 +5887,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/import
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionES6CJS.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionES6System.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionES6UMD.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionErrorInES2015.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInAMD1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInAMD2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionInAMD3.ts
@@ -6291,7 +5920,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/import
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionNoModuleKindSpecified.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionReturnPromiseOfAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionShouldNotGetParen.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionSpecifierNotStringTypeError.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionWithTypeArgument.ts
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es2015/asyncGenerators/emitter.asyncGenerators.classMethods.es2015.ts
@@ -6379,11 +6007,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2024/resizableArra
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2024/sharedMemory.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2024/transferableArrayBuffer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit13.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit7.ts
@@ -6419,12 +6043,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolPr
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty36.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty37.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty38.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty39.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty40.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty41.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty42.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty43.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty46.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty47.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty5.ts
@@ -6538,9 +6159,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/superCallBeforeThisAccessing8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/superCallFromClassThatHasNoBaseTypeButWithSameSymbolInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classExpressions/classExpressionES63.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classExpressions/typeArgumentInferenceWithClassExpression1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classExpressions/typeArgumentInferenceWithClassExpression2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classExpressions/typeArgumentInferenceWithClassExpression3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames10_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames10_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames11_ES5.ts
@@ -6551,8 +6169,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperti
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames13_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames16_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames16_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames17_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames17_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames18_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames18_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames19_ES5.ts
@@ -6575,8 +6191,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperti
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames28_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames29_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames29_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames2_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames2_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames30_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames30_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames31_ES5.ts
@@ -6595,8 +6209,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperti
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames38_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames39_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames39_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames3_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames3_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames40_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames40_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames41_ES5.ts
@@ -6653,10 +6265,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperti
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType8_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType9_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType9_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit1_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit1_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit2_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit2_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit3_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit3_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit4_ES5.ts
@@ -6665,17 +6273,13 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperti
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit5_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit6_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit6_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesOnOverloads_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesOnOverloads_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesSourceMap2_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesSourceMap2_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesWithStaticProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/accessor/decoratorOnClassAccessor1.es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass1.es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass2.es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass3.es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass4.es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass5.es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass6.es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass7.es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass8.es6.ts
@@ -6752,9 +6356,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/de
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringVoidStrictNullChecks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringWithLiteralInitializers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringWithLiteralInitializers2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyArrayBindingPatternParameter01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyArrayBindingPatternParameter02.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyArrayBindingPatternParameter03.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyArrayBindingPatternParameter04.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns01_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns01_ES5iterable.ts
@@ -6768,9 +6369,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/em
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns04_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns04_ES5iterable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns04_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyObjectBindingPatternParameter01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyObjectBindingPatternParameter02.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyObjectBindingPatternParameter03.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyObjectBindingPatternParameter04.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyVariableDeclarationBindingPatterns01_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyVariableDeclarationBindingPatterns01_ES5iterable.ts
@@ -6894,12 +6492,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration12_es6.ts
 Cannot use `yield` as an identifier in a generator context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration13_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration2_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration3_es6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration5_es6.ts
 Cannot use `yield` as an identifier in a generator context
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration6_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration7_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration8_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration9_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionPropertyAssignments/FunctionPropertyAssignments1_es6.ts
@@ -7232,9 +6826,6 @@ A 'yield' expression is only allowed in a generator body.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression8_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression9_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorNoImplicitReturns.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorOverloads5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck25.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck26.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck27.ts
@@ -7244,7 +6835,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck31.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck32.ts
 A 'yield' expression is only allowed in a generator body.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck39.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck40.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck41.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck42.ts
@@ -7336,7 +6926,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDe
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-staticPrivateMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-staticPrivateSetter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-multipleDecorators.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-outerThisReference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-parameterProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-setFunctionName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-simpleTransformation.ts
@@ -7451,7 +7040,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOp
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIntersectionType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts
@@ -7473,13 +7061,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOp
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedCallSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnOptionalProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithValidOperands.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithInvalidOperands.es2015.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithInvalidStaticToString.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithLHSIsObject.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithLHSIsTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithRHSHasSymbolHasInstance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithRHSIsSubtypeOfFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalAndOperator/logicalAndOperatorWithEveryType.ts
@@ -7633,7 +7219,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuar
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormFunctionEquality.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormInstanceOf.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormInstanceOfOnInterface.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormIsType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormIsTypeOnInterfaces.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormNotExpr.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormThisMember.ts
@@ -7781,7 +7366,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/expo
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentConstrainedGenericType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentGenericType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentMergedInterface.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentMergedModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentOfExportNamespaceWithDefault.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentTopLevelClodule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentTopLevelEnumdule.ts
@@ -7947,9 +7531,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/fixSignatureCaching.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/functionImplementationErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/functionImplementations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/functionNameConflicts.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/functionOverloadCompatibilityWithVoid01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/functionOverloadCompatibilityWithVoid02.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/functionOverloadCompatibilityWithVoid03.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/functionOverloadErrors.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/functions/functionOverloadErrorsSyntax.ts
 A rest parameter must be last in a parameter list
@@ -7957,7 +7538,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/functionPa
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/functionWithUseStrictAndSimpleParameterList_es2016.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/parameterInitializersBackwardReferencing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/parameterInitializersForwardReferencing.2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/parameterInitializersForwardReferencing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/parameterInitializersForwardReferencing1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/parameterInitializersForwardReferencing1_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/functions/strictBindCallApply1.ts
@@ -8009,7 +7589,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarati
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/twoInterfacesDifferentRootModule2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/twoMergedInterfacesWithDifferingOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/twoMergedInterfacesWithDifferingOverloads2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/asiPreventsParsingAsInterface02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/derivedInterfaceDoesNotHideBaseSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/derivedInterfaceIncompatibleWithBaseIndexer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendingOptionalChain.ts
@@ -8295,7 +7874,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildren
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty6.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty7.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty8.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty9.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxGenericTagHasCorrectInferences.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxIntersectionElementPropsType.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxSubtleSkipContextSensitiveBug.tsx
@@ -8742,7 +8320,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override16.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override17.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override18.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override19.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override20.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override21.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override3.ts
@@ -8762,20 +8339,15 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript202
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript2021/numericSeparators/parser.numericSeparators.decimal.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript2021/numericSeparators/parser.numericSeparators.hex.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript2021/numericSeparators/parser.numericSeparators.octal.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript3/Accessors/parserES3Accessors2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript3/Accessors/parserES3Accessors3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript3/Accessors/parserES3Accessors4.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors10.ts
 'public' modifier cannot be used here.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserSetAccessorWithTypeAnnotation1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserSetAccessorWithTypeParameters1.ts
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression10.ts
 Unexpected estree file content error: 1 != 2
 
@@ -8814,9 +8386,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/A
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/CatchClauses/parserCatchClauseWithTypeAnnotation1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClass1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClass2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration17.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration18.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration25.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclarationIndexSignature1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName2.ts
@@ -8856,8 +8426,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/E
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ArrowFunctions/ArrowFunction4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ArrowFunctions/parserX_ArrowFunction4.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ExtendsOrImplementsClauses/parserErrorRecovery_ExtendsOrImplementsClause2.ts
 Expected `{` but found `EOF`
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ExtendsOrImplementsClauses/parserErrorRecovery_ExtendsOrImplementsClause5.ts
@@ -8865,7 +8433,6 @@ Expected `{` but found `Identifier`
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ExtendsOrImplementsClauses/parserErrorRecovery_ExtendsOrImplementsClause6.ts
 Expected `{` but found `EOF`
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/IncompleteMemberVariables/parserErrorRecovery_IncompleteMemberVariable1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ParameterLists/parserErrorRecovery_ParameterList6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/VariableLists/parserErrorRecovery_VariableList1.ts
 Identifier expected. 'return' is a reserved word that cannot be used here.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserCommaInTypeMemberList1.ts
@@ -8933,17 +8500,9 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/InterfaceDeclarations/parserInterfaceDeclaration7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/InterfaceDeclarations/parserInterfaceDeclaration8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/InterfaceDeclarations/parserInterfaceDeclaration9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessor1.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration10.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration14.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration16.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration17.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration18.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberAccessorDeclarations/parserMemberAccessorDeclaration6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberFunctionDeclarations/parserMemberFunctionDeclaration4.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MemberVariableDeclarations/parserMemberVariableDeclaration4.ts
@@ -8978,13 +8537,6 @@ A rest parameter must be last in a parameter list
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList10.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList11.ts
 A rest parameter cannot be optional
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList14.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList15.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList16.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList17.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList3.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList9.ts
 A rest parameter cannot be optional
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertyAssignments/parserFunctionPropertyAssignment1.ts
@@ -9016,7 +8568,6 @@ Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509677.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509698.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser536727.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser553699.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser618973.ts
 'export' modifier cannot be used here.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser630933.ts
@@ -9068,8 +8619,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
 A 'return' statement can only be used within a function body.
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserWithStatement2.ts
 A 'return' statement can only be used within a function body.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression4.ts
@@ -9134,7 +8683,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/C
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName20.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName21.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName24.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName26.ts
 Computed property names are not allowed in enums.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName3.ts
@@ -9513,15 +9061,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/enumLi
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/enumLiteralTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/enumLiteralTypes3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypeWidening.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypes1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypes2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypes3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypesAndDestructuring.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypesAndTypeAssertions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypesWidenInParameterPosition.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/numericLiteralTypes1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/numericLiteralTypes2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/numericLiteralTypes3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/numericStringLiteralTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringEnumLiteralTypes1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringEnumLiteralTypes2.ts
@@ -9662,7 +9207,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/objectT
 A rest parameter must be last in a parameter list
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/specializedSignatureIsNotSubtypeOfNonSpecializedSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/specializedSignatureIsSubtypeOfNonSpecializedSignature.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/specializedSignatureWithOptional.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterAsTypeArgument.ts
@@ -9703,7 +9247,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/num
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/assignFromStringInterface2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/extendStringInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/invalidStringAssignments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/stringLiteral/stringLiteralType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/invalidUndefinedAssignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/invalidUndefinedValues.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/validUndefinedAssignments.ts
@@ -9748,10 +9291,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingType
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeQueryWithReservedWords.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofANonExportedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofAnExportedType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofClass2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofThis.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofThisWithImplicitThis.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeReferences/genericTypeReferenceWithoutTypeArgument.d.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeReferences/genericTypeReferenceWithoutTypeArgument.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeReferences/genericTypeReferenceWithoutTypeArgument2.ts
@@ -9808,7 +9349,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads03.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads04.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads05.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesTypePredicates01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesWithTemplateStrings01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesWithTemplateStrings02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesWithVariousOperators01.ts
@@ -9859,7 +9399,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/readonly
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/restTupleElements1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/strictTupleLength.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/tupleElementTypes1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/tupleElementTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/tupleElementTypes3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/tupleElementTypes4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/tupleLengthCheck.ts
@@ -9868,7 +9407,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/unionsOf
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/variadicTuples1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/variadicTuples2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/variadicTuples3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/wideningTuples6.ts
@@ -9902,7 +9440,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/typeParameterAsTypeParameterConstraintTransitively.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/typeParameterAsTypeParameterConstraintTransitively2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/wrappedAndRecursiveConstraints.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/wrappedAndRecursiveConstraints2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/wrappedAndRecursiveConstraints3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/wrappedAndRecursiveConstraints4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterAsBaseType.ts
@@ -9922,7 +9459,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterUsedAsConstraint.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParametersAvailableInNestedScope.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParametersAvailableInNestedScope2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParametersAvailableInNestedScope3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typesWithDuplicateTypeParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSubtyping.ts
@@ -10025,7 +9561,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationsh
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedProperty2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedPropertyCheckedNominally.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/recursiveTypeReferences1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/recursiveTypesUsedAsFunctionParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/enumIsNotASubtypeOfAnythingButNumber.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/nullIsSubtypeOfEverythingButUndefined.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/stringLiteralTypeIsSubtypeOfString.ts
@@ -10045,7 +9580,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationsh
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignaturesWithOptionalParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignaturesWithRestParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignaturesWithSpecializedSignatures.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithConstructSignatures4.ts
@@ -10144,7 +9678,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationsh
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithNonSymmetricSubtypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectLiteralArgs.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgs2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndConstraints2.ts


### PR DESCRIPTION
Align our AST's ESTree output with that of TS-ESLint's for the `FormalParameter` node.  Relates to #9705 

Skips the estree serialization of `accessibility` `readonly` and `overrides` fields.