### PR TITLE
fix(estree/ast): fix lossy `StringLiteral.value`

### DIFF
--- a/crates/oxc_ast/src/ast/literal.rs
+++ b/crates/oxc_ast/src/ast/literal.rs
@@ -76,6 +76,7 @@ pub struct StringLiteral<'a> {
     /// The value of the string.
     ///
     /// Any escape sequences in the raw code are unescaped.
+    #[estree(via= StringLiteralValue)]
     pub value: Atom<'a>,
 
     /// The raw string as it appears in source code.

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1924,7 +1924,7 @@ impl ESTree for StringLiteral<'_> {
         state.serialize_field("type", &JsonSafeString("Literal"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("value", &self.value);
+        state.serialize_field("value", &crate::serialize::StringLiteralValue(self));
         state.serialize_field("raw", &self.raw);
         state.end();
     }

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -308,6 +308,21 @@ impl ESTree for RegExpFlagsConverter<'_> {
     }
 }
 
+#[ast_meta]
+#[estree(ts_type = "string", raw_deser = "'todo'")]
+pub struct StringLiteralValue<'a, 'b>(pub &'b StringLiteral<'a>);
+
+impl ESTree for StringLiteralValue<'_, '_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        if self.0.lossy {
+            let raw = self.0.raw.unwrap();
+            JsonSafeString(&raw[1..raw.len() - 1]).serialize(serializer);
+        } else {
+            self.0.value.serialize(serializer);
+        }
+    }
+}
+
 // --------------------
 // Various
 // --------------------

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -1065,7 +1065,7 @@ function deserializeStringLiteral(pos) {
     type: 'Literal',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    value: deserializeStr(pos + 8),
+    value: 'todo',
     raw: deserializeOptionStr(pos + 24),
   };
 }

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -1129,7 +1129,7 @@ function deserializeStringLiteral(pos) {
     type: 'Literal',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    value: deserializeStr(pos + 8),
+    value: 'todo',
     raw: deserializeOptionStr(pos + 24),
   };
 }

--- a/tasks/coverage/snapshots/estree_test262.snap
+++ b/tasks/coverage/snapshots/estree_test262.snap
@@ -2,9 +2,7 @@ commit: bc5c1417
 
 estree_test262 Summary:
 AST Parsed     : 44047/44047 (100.00%)
-Positive Passed: 44002/44047 (99.90%)
-Mismatch: tasks/coverage/test262/test/annexB/built-ins/RegExp/prototype/compile/pattern-string-u.js
-Mismatch: tasks/coverage/test262/test/annexB/built-ins/String/prototype/substr/surrogate-pairs.js
+Positive Passed: 44014/44047 (99.93%)
 Mismatch: tasks/coverage/test262/test/built-ins/Array/prototype/concat/Array.prototype.concat_spreadable-string-wrapper.js
 Mismatch: tasks/coverage/test262/test/built-ins/JSON/stringify/value-string-escape-unicode.js
 Mismatch: tasks/coverage/test262/test/built-ins/RegExp/dotall/with-dotall-unicode.js
@@ -12,10 +10,6 @@ Mismatch: tasks/coverage/test262/test/built-ins/RegExp/dotall/with-dotall.js
 Mismatch: tasks/coverage/test262/test/built-ins/RegExp/dotall/without-dotall-unicode.js
 Mismatch: tasks/coverage/test262/test/built-ins/RegExp/dotall/without-dotall.js
 Mismatch: tasks/coverage/test262/test/built-ins/RegExp/escape/escaped-surrogates.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/named-groups/non-unicode-property-names-invalid.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/named-groups/unicode-property-names-invalid.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/prototype/Symbol.replace/coerce-unicode.js
-Mismatch: tasks/coverage/test262/test/built-ins/RegExp/prototype/exec/u-captured-value.js
 Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/add-dotAll.js
 Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/changing-dotAll-flag-does-not-affect-dotAll-modifier.js
 Mismatch: tasks/coverage/test262/test/built-ins/RegExp/regexp-modifiers/nesting-add-dotAll-within-remove-dotAll.js
@@ -31,9 +25,6 @@ Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/padStart/normal
 Mismatch: tasks/coverage/test262/test/built-ins/String/prototype/toWellFormed/returns-well-formed-string.js
 Mismatch: tasks/coverage/test262/test/built-ins/StringIteratorPrototype/next/next-iteration-surrogate-pairs.js
 Mismatch: tasks/coverage/test262/test/intl402/NumberFormat/prototype/format/format-non-finite-numbers.js
-Mismatch: tasks/coverage/test262/test/intl402/Segmenter/prototype/segment/containing/breakable-input.js
-Mismatch: tasks/coverage/test262/test/intl402/Segmenter/prototype/segment/containing/unbreakable-input.js
-Mismatch: tasks/coverage/test262/test/intl402/Segmenter/prototype/segment/containing/zero-index.js
 Mismatch: tasks/coverage/test262/test/language/expressions/assignment/fn-name-lhs-cover.js
 Mismatch: tasks/coverage/test262/test/language/expressions/assignment/target-cover-id.js
 Mismatch: tasks/coverage/test262/test/language/expressions/postfix-decrement/target-cover-id.js
@@ -41,10 +32,7 @@ Mismatch: tasks/coverage/test262/test/language/expressions/postfix-increment/tar
 Mismatch: tasks/coverage/test262/test/language/expressions/prefix-decrement/target-cover-id.js
 Mismatch: tasks/coverage/test262/test/language/expressions/prefix-increment/target-cover-id.js
 Mismatch: tasks/coverage/test262/test/language/literals/regexp/named-groups/invalid-lone-surrogate-groupname.js
-Mismatch: tasks/coverage/test262/test/language/literals/regexp/u-astral.js
-Mismatch: tasks/coverage/test262/test/language/literals/regexp/u-surrogate-pairs-atom-char-class.js
 Mismatch: tasks/coverage/test262/test/language/literals/regexp/u-surrogate-pairs-atom-escape-decimal.js
 Mismatch: tasks/coverage/test262/test/language/statements/for-in/head-lhs-cover.js
 Mismatch: tasks/coverage/test262/test/language/statements/for-of/head-lhs-async-parens.js
 Mismatch: tasks/coverage/test262/test/language/statements/for-of/head-lhs-cover.js
-Mismatch: tasks/coverage/test262/test/language/statements/for-of/string-astral-truncated.js

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -6676,10 +6676,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedE
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedEscapes/unicodeExtendedEscapesInStrings08.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedEscapes/unicodeExtendedEscapesInStrings09.ts
 tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedEscapes/unicodeExtendedEscapesInStrings10.ts
-serde_json::from_str(estree_json) error: unexpected end of hex escape at line 30 column 29
+serde_json::from_str(oxc_json) error: invalid escape at line 30 column 28
 
 tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedEscapes/unicodeExtendedEscapesInStrings11.ts
-serde_json::from_str(estree_json) error: lone leading surrogate in hex escape at line 30 column 28
+serde_json::from_str(oxc_json) error: invalid escape at line 30 column 28
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedEscapes/unicodeExtendedEscapesInStrings13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/unicodeExtendedEscapes/unicodeExtendedEscapesInStrings15.ts


### PR DESCRIPTION
I attempted fixing this but realizing https://github.com/oxc-project/oxc/pull/9965#discussion_r2008700191 and it might be out of my reach :sweat: Please feel free to take over.

In terms of test262 conformance, there was no edge case like https://github.com/oxc-project/oxc/pull/9965#discussion_r2008700191. So, remaining surrogate related mismatch is a following form. This difference is actually not visible in js world since the difference of acorn output is due to how `JSON.stringify` automatically normalizes string.

```diff
@@ -139,7 +139,7 @@
                 "type": "Literal",
                 "start": 408,
                 "end": 416,
-                "value": "\udf06",
+                "value": "\uDF06",
                 "raw": "\"\\uDF06\""
               }
             ],
@@ -299,7 +299,7 @@
                 "type": "Literal",
                 "start": 593,
                 "end": 619,
-                "value": "\ud834𝌆\ud834",
+                "value": "\uD834\uD834\uDF06\uD834",
                 "raw": "\"\\uD834\\uD834\\uDF06\\uD834\""
               }
```

```js
> console.log(JSON.stringify("\uD834\uD834\uDF06\uD834"))
"\ud834𝌆\ud834"
```