### PR TITLE
fix(linter): correct fixer for spread in function arguments

### DIFF
--- a/crates/oxc_linter/src/snapshots/unicorn_no_useless_spread.snap
+++ b/crates/oxc_linter/src/snapshots/unicorn_no_useless_spread.snap
@@ -20,16 +20,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ foo(...[a])
    ·     ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:9]
  1 │ new Foo(...[a])
    ·         ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:16]
@@ -50,16 +48,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ foo(...[a,])
    ·     ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:9]
  1 │ new Foo(...[a,])
    ·         ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:16]
@@ -80,16 +76,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ foo(...[a,],)
    ·     ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:9]
  1 │ new Foo(...[a,],)
    ·         ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:16]
@@ -110,16 +104,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ foo(...(( [a] )))
    ·     ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:9]
  1 │ new Foo(...(( [a] )))
    ·         ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:16]
@@ -140,16 +132,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ foo(...[])
    ·     ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:9]
  1 │ new Foo(...[])
    ·         ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:16]
@@ -163,16 +153,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ foo(...[,])
    ·     ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:9]
  1 │ new Foo(...[,])
    ·         ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:16]
@@ -186,16 +174,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ foo(...[,,])
    ·     ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:9]
  1 │ new Foo(...[,,])
    ·         ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:16]
@@ -209,16 +195,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ foo(...[a, , b,])
    ·     ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:9]
  1 │ new Foo(...[a, , b,])
    ·         ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:16]
@@ -232,24 +216,21 @@ source: crates/oxc_linter/src/tester.rs
  1 │ foo(...[a, , b,],)
    ·     ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:9]
  1 │ new Foo(...[a, , b,],)
    ·         ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:5]
  1 │ foo(...[,, ,(( a )), ,,(0, b), ,,])
    ·     ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:19]
@@ -270,16 +251,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ foo(a, ...[a, b])
    ·        ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:12]
  1 │ new Foo(a, ...[a, b])
    ·            ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:16]
@@ -300,16 +279,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ foo(...[a, b], b,)
    ·     ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:9]
  1 │ new Foo(...[a, b], b,)
    ·         ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:19]
@@ -330,16 +307,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ foo(a, ...[a, b], b,)
    ·        ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:12]
  1 │ new Foo(a, ...[a, b], b,)
    ·            ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new object unnecessarily.
    ╭─[no_useless_spread.tsx:1:8]
@@ -374,16 +349,14 @@ source: crates/oxc_linter/src/tester.rs
  1 │ Promise.all(...[...iterable])
    ·             ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:9]
  1 │ new Map(...[...iterable])
    ·         ───
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): `Map` accepts an iterable, so it's unnecessary to convert the iterable to an array.
    ╭─[no_useless_spread.tsx:1:22]
@@ -707,8 +680,7 @@ source: crates/oxc_linter/src/tester.rs
    ·                                      ───
  4 │         }
    ╰────
-  help: This function accepts a rest parameter, it's unnecessary to create a new array and then spread it. Instead, supply the arguments directly.
-        For example, replace `foo(...[1, 2, 3])` with `foo(1, 2, 3)`.
+  help: Pass arguments directly instead of spreading an array.
 
   ⚠ eslint-plugin-unicorn(no-useless-spread): Using a spread operator here creates a new array unnecessarily.
    ╭─[no_useless_spread.tsx:1:2]


### PR DESCRIPTION
closes #8115 