### PR TITLE
feat(linter): Add suggested fix to `typescript/no_unnecessary_parameter_property_assignment` and fix false positive

### DIFF
--- a/crates/oxc_linter/src/snapshots/typescript_no_unnecessary_parameter_property_assignment.snap
+++ b/crates/oxc_linter/src/snapshots/typescript_no_unnecessary_parameter_property_assignment.snap
@@ -137,15 +137,6 @@ source: crates/oxc_linter/src/tester.rs
   help: Remove the unnecessary assignment
 
   ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
-   ╭─[no_unnecessary_parameter_property_assignment.tsx:5:15]
- 4 │             function bar() {
- 5 │               this.foo = foo;
-   ·               ──────────────
- 6 │             }
-   ╰────
-  help: Remove the unnecessary assignment
-
-  ⚠ typescript-eslint(no-unnecessary-parameter-property-assignment): Assignment of parameter property is unnecessary
    ╭─[no_unnecessary_parameter_property_assignment.tsx:7:13]
  6 │             }
  7 │             this.foo = foo;


### PR DESCRIPTION
Hey, I just added a suggested fix to the lint rule as continuation of my work in #9720 and #9618.
The original typescript-eslint rule isn't capable of fixing its reported issue, but the fix should be pretty safe.
I decided to configure it as `suggestion` and not as 100% safe `fix`.
Also found one false positive while implementing the fix suggestion, fixed it and added a corresponding passing test.