### PR TITLE
refactor(linter): use delete instead of delete_range to shorten calls

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
@@ -162,7 +162,7 @@ fn lint_empty_constructor<'a>(
     }
 
     ctx.diagnostic_with_fix(no_empty_constructor(constructor.span), |fixer| {
-        fixer.delete_range(constructor.span)
+        fixer.delete(constructor)
     });
 }
 
@@ -184,7 +184,7 @@ fn lint_redundant_super_call<'a>(
     {
         ctx.diagnostic_with_fix(
             no_redundant_super_call(constructor.key.span(), super_call.span()),
-            |fixer| fixer.delete_range(constructor.span),
+            |fixer| fixer.delete(constructor),
         );
     }
 }

--- a/crates/oxc_linter/src/rules/import/no_empty_named_blocks.rs
+++ b/crates/oxc_linter/src/rules/import/no_empty_named_blocks.rs
@@ -55,7 +55,7 @@ impl Rule for NoEmptyNamedBlocks {
         if specifiers.is_empty() {
             // for "import {} from 'mod'"
             ctx.diagnostic_with_fix(no_empty_named_blocks_diagnostic(import_decl.span), |fixer| {
-                fixer.delete_range(import_decl.span)
+                fixer.delete(import_decl)
             });
         }
 

--- a/crates/oxc_linter/src/rules/jest/prefer_todo.rs
+++ b/crates/oxc_linter/src/rules/jest/prefer_todo.rs
@@ -90,7 +90,7 @@ fn run<'a>(possible_jest_node: &PossibleJestNode<'a, '_>, ctx: &LintContext<'a>)
                         return fixer.replace(span, "todo");
                     }
                 }
-                fixer.delete_range(call_expr.span)
+                fixer.delete(call_expr)
             });
         }
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_redundant_roles.rs
@@ -73,7 +73,7 @@ impl Rule for NoRedundantRoles {
                     if exceptions.is_some_and(|set| set.contains(role)) {
                         ctx.diagnostic_with_fix(
                             no_redundant_roles_diagnostic(attr.span, &component, role),
-                            |fixer| fixer.delete_range(attr.span),
+                            |fixer| fixer.delete(attr),
                         );
                     }
                 }

--- a/crates/oxc_linter/src/rules/jsx_a11y/scope.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/scope.rs
@@ -77,7 +77,7 @@ impl Rule for Scope {
         }
 
         ctx.diagnostic_with_fix(scope_diagnostic(scope_attribute.span), |fixer| {
-            fixer.delete_range(scope_attribute.span)
+            fixer.delete(scope_attribute)
         });
     }
 }

--- a/crates/oxc_linter/src/rules/react/jsx_props_no_spread_multi.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_props_no_spread_multi.rs
@@ -120,7 +120,7 @@ impl Rule for JsxPropsNoSpreadMulti {
                                 vec![*left_span, *right_span],
                                 member_prop_name,
                             ),
-                            |fixer| fixer.delete_range(*left_span),
+                            |fixer| fixer.delete(left_span),
                         );
                     }
                 },

--- a/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
+++ b/crates/oxc_linter/src/rules/unicorn/switch_case_braces.rs
@@ -83,7 +83,7 @@ impl Rule for SwitchCaseBraces {
                                     case_block.span,
                                     Diagnostic::EmptyClause,
                                 ),
-                                |fixer| fixer.delete_range(case_block.span),
+                                |fixer| fixer.delete(case_block),
                             );
                         }
 

--- a/crates/oxc_span/src/span.rs
+++ b/crates/oxc_span/src/span.rs
@@ -1,7 +1,7 @@
 use std::{
     fmt::{self, Debug},
     hash::{Hash, Hasher},
-    ops::{Index, IndexMut, Range},
+    ops::{Deref, Index, IndexMut, Range},
 };
 
 use miette::{LabeledSpan, SourceOffset, SourceSpan};
@@ -552,6 +552,12 @@ impl Serialize for Span {
         map.serialize_entry("start", &self.start)?;
         map.serialize_entry("end", &self.end)?;
         map.end()
+    }
+}
+
+impl<T: GetSpan> GetSpan for oxc_allocator::Box<'_, T> {
+    fn span(&self) -> Span {
+        self.deref().span()
     }
 }
 


### PR DESCRIPTION
Some of these shorter calls are only possible because of the also added `impl GetSpan for oxc_allocator::Box`. I decided to put this impl block into `oxc_span/src/span.rs`, because it feels a bit wrong to add it to the similar impl blocks in `oxc_allocator/src/boxed.rs`, because that would make oxc_allocator depend on oxc_span.