### PR TITLE
test(editor): add tests for `offset_to_position`

### DIFF
--- a/crates/oxc_language_server/src/linter/mod.rs
+++ b/crates/oxc_language_server/src/linter/mod.rs
@@ -12,3 +12,49 @@ pub fn offset_to_position(offset: usize, source_text: &str) -> Position {
     let (line, column) = get_line_column(&rope, offset as u32, source_text);
     Position::new(line, column)
 }
+
+#[cfg(test)]
+mod test {
+    use crate::linter::offset_to_position;
+
+    #[test]
+    fn single_line() {
+        let source = "foo.bar!;";
+        assert_position(source, 0, (0, 0));
+        assert_position(source, 4, (0, 4));
+        assert_position(source, 9, (0, 9));
+    }
+
+    #[test]
+    fn multi_line() {
+        let source = "console.log(\n  foo.bar!\n);";
+        assert_position(source, 0, (0, 0));
+        assert_position(source, 12, (0, 12));
+        assert_position(source, 13, (1, 0));
+        assert_position(source, 23, (1, 10));
+        assert_position(source, 24, (2, 0));
+        assert_position(source, 26, (2, 2));
+    }
+
+    #[test]
+    fn multi_byte() {
+        let source = "let foo = \n  '👍';";
+        assert_position(source, 10, (0, 10));
+        assert_position(source, 11, (1, 0));
+        assert_position(source, 14, (1, 3));
+        assert_position(source, 18, (1, 5));
+        assert_position(source, 19, (1, 6));
+    }
+
+    #[test]
+    #[should_panic(expected = "out of bounds")]
+    fn out_of_bounds() {
+        offset_to_position(100, "foo");
+    }
+
+    fn assert_position(source: &str, offset: usize, expected: (u32, u32)) {
+        let position = offset_to_position(offset, source);
+        assert_eq!(position.line, expected.0);
+        assert_eq!(position.character, expected.1);
+    }
+}


### PR DESCRIPTION
Working on adding more comprehensive tests for the LSP code. This offset to position function is a core part of the range calculations, so we should start to have some tests for it.