### PR TITLE
test(editor): add end-to-end tests for linter output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,6 +1780,7 @@ dependencies = [
  "futures",
  "globset",
  "ignore",
+ "insta",
  "log",
  "oxc_allocator",
  "oxc_data_structures",

--- a/crates/oxc_language_server/Cargo.toml
+++ b/crates/oxc_language_server/Cargo.toml
@@ -42,3 +42,6 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt-multi-thread", "io-std", "macros"] }
 tower-lsp = { workspace = true, features = ["proposed"] }
+
+[dev-dependencies]
+insta = { workspace = true }

--- a/crates/oxc_language_server/fixtures/linter/hello_world.js
+++ b/crates/oxc_language_server/fixtures/linter/hello_world.js
@@ -1,0 +1,1 @@
+console.log("Hello, world!");

--- a/crates/oxc_language_server/src/linter/mod.rs
+++ b/crates/oxc_language_server/src/linter/mod.rs
@@ -5,6 +5,9 @@ pub mod error_with_position;
 mod isolated_lint_handler;
 pub mod server_linter;
 
+#[cfg(test)]
+mod tester;
+
 #[expect(clippy::cast_possible_truncation)]
 pub fn offset_to_position(offset: usize, source_text: &str) -> Position {
     // TODO(perf): share a single instance of `Rope`

--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -28,3 +28,30 @@ impl ServerLinter {
             .run_single(&uri.to_file_path().unwrap(), content)
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::linter::tester::Tester;
+    use oxc_linter::{LintFilter, LintFilterKind};
+
+    #[test]
+    fn test_no_errors() {
+        Tester::new()
+            .with_snapshot_suffix("no_errors")
+            .test_and_snapshot_single_file("fixtures/linter/hello_world.js");
+    }
+
+    #[test]
+    fn test_no_console() {
+        let config_store = ConfigStoreBuilder::default()
+            .with_filter(LintFilter::deny(LintFilterKind::parse("no-console".into()).unwrap()))
+            .build()
+            .unwrap();
+        let linter = Linter::new(LintOptions::default(), config_store).with_fix(FixKind::SafeFix);
+
+        Tester::new_with_linter(linter)
+            .with_snapshot_suffix("deny_no_console")
+            .test_and_snapshot_single_file("fixtures/linter/hello_world.js");
+    }
+}

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_hello_world.js@deny_no_console.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_hello_world.js@deny_no_console.snap
@@ -1,0 +1,13 @@
+---
+source: crates/oxc_language_server/src/linter/tester.rs
+---
+code: "eslint(no-console)"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console"
+message: "eslint(no-console): Unexpected console statement.\nhelp: Delete this console statement."
+range: Range { start: Position { line: 0, character: 0 }, end: Position { line: 0, character: 11 } }
+related_information[0].message: ""
+related_information[0].location.uri: "file://<variable>/fixtures/linter/hello_world.js"
+related_information[0].location.range: Range { start: Position { line: 0, character: 0 }, end: Position { line: 0, character: 11 } }
+severity: Some(Error)
+source: Some("oxc")
+tags: None

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_hello_world.js@no_errors.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_hello_world.js@no_errors.snap
@@ -1,0 +1,4 @@
+---
+source: crates/oxc_language_server/src/linter/tester.rs
+---
+No diagnostic reports

--- a/crates/oxc_language_server/src/linter/tester.rs
+++ b/crates/oxc_language_server/src/linter/tester.rs
@@ -1,0 +1,126 @@
+use oxc_linter::Linter;
+use tower_lsp::lsp_types::Url;
+
+use super::{error_with_position::DiagnosticReport, server_linter::ServerLinter};
+
+const CURRENT_DIR: &str = env!("CARGO_MANIFEST_DIR");
+
+/// Given a file path relative to the crate root directory, return the URI of the file.
+pub fn get_file_uri(relative_file_path: &str) -> Url {
+    let absolute_file_path = PathBuf::from(CURRENT_DIR).join(relative_file_path);
+    let file_path = format!("file://{}", absolute_file_path.display());
+    Url::parse(&file_path).unwrap()
+}
+
+use std::path::PathBuf;
+
+use cow_utils::CowUtils;
+use tower_lsp::lsp_types::{CodeDescription, NumberOrString};
+
+fn get_snapshot_from_report(report: &DiagnosticReport) -> String {
+    let code = match &report.diagnostic.code {
+        Some(NumberOrString::Number(code)) => code.to_string(),
+        Some(NumberOrString::String(code)) => code.to_string(),
+        None => "None".to_string(),
+    };
+    let code_description_href = match &report.diagnostic.code_description {
+        Some(CodeDescription { href }) => href.to_string(),
+        None => "None".to_string(),
+    };
+    let message = report.diagnostic.message.clone();
+    let range = report.diagnostic.range;
+    let related_information = match &report.diagnostic.related_information {
+        Some(infos) => {
+            infos
+                .iter()
+                .enumerate()
+                .map(|(i, info)| {
+                    let mut result = String::new();
+                    result.push_str(&format!(
+                        "related_information[{}].message: {:?}",
+                        i, info.message
+                    ));
+                    result.push_str(&format!(
+                        "\nrelated_information[{}].location.uri: {:?}",
+                        i,
+                        // replace everything between `file://` and crate dir with `<variable>`, to avoid
+                        // the absolute path causing snapshot test failures
+                        info.location
+                            .uri
+                            .to_string()
+                            .cow_replace(&format!("{CURRENT_DIR}/"), "<variable>/")
+                    ));
+                    result.push_str(&format!(
+                        "\nrelated_information[{}].location.range: {:?}",
+                        i, info.location.range
+                    ));
+                    result
+                })
+                .collect::<Vec<_>>()
+                .join("\n")
+        }
+        None => "related_information: None".to_string(),
+    };
+    let severity = report.diagnostic.severity;
+    let source = report.diagnostic.source.clone();
+    let tags = report.diagnostic.tags.clone();
+    format!(
+        r"
+code: {code:?}
+code_description.href: {code_description_href:?}
+message: {message:?}
+range: {range:?}
+{related_information}
+severity: {severity:?}
+source: {source:?}
+tags: {tags:?}
+            "
+    )
+}
+
+/// Testing struct for the [linter server][crate::linter::server_linter::ServerLinter].
+pub struct Tester<'t> {
+    server_linter: ServerLinter,
+    snapshot_suffix: Option<&'t str>,
+}
+
+impl Tester<'_> {
+    pub fn new() -> Self {
+        Self { snapshot_suffix: None, server_linter: ServerLinter::new() }
+    }
+
+    pub fn new_with_linter(linter: Linter) -> Self {
+        Self { snapshot_suffix: None, server_linter: ServerLinter::new_with_linter(linter) }
+    }
+
+    pub fn with_snapshot_suffix(mut self, suffix: &'static str) -> Self {
+        self.snapshot_suffix = Some(suffix);
+        self
+    }
+
+    /// Given a relative file path (relative to `oxc_language_server` crate root), run the linter
+    /// and return the resulting diagnostics in a custom snapshot format.
+    #[expect(clippy::disallowed_methods)]
+    pub fn test_and_snapshot_single_file(&self, relative_file_path: &str) {
+        let uri = get_file_uri(relative_file_path);
+        let content = std::fs::read_to_string(uri.to_file_path().unwrap())
+            .expect("could not read fixture file");
+        let reports = self.server_linter.run_single(&uri, Some(content)).unwrap();
+        let snapshot = if reports.is_empty() {
+            "No diagnostic reports".to_string()
+        } else {
+            reports.iter().map(get_snapshot_from_report).collect::<Vec<_>>().join("\n")
+        };
+
+        let snapshot_name = relative_file_path.replace('/', "_");
+        let mut settings = insta::Settings::clone_current();
+        settings.set_prepend_module_to_snapshot(false);
+        settings.set_omit_expression(true);
+        if let Some(suffix) = self.snapshot_suffix {
+            settings.set_snapshot_suffix(suffix);
+        }
+        settings.bind(|| {
+            insta::assert_snapshot!(snapshot_name, snapshot);
+        });
+    }
+}


### PR DESCRIPTION
I'm working on laying some foundations for making our editor integrations a little bit more robust and easier to test. This adds a new `Tester` struct, similar to the one used in the `oxc_linter` crate which allows us to easily run the linter on a given file and assert against a snapshot of the diagnostic reports.

This should allow us to start adding more tests to ensure that our editor integrations don't regress on basic functionality for the linter.

For the snapshot format, I chose to use some custom formatting since it allows us to customize the results much better and make them more concise and easy to read.