### PR TITLE
refactor(ast): `AstBuilder::move_*` methods use `TakeIn`

### DIFF
--- a/crates/oxc_ast/src/ast_builder_impl.rs
+++ b/crates/oxc_ast/src/ast_builder_impl.rs
@@ -1,8 +1,8 @@
 #![warn(missing_docs)]
 
-use std::{borrow::Cow, mem};
+use std::borrow::Cow;
 
-use oxc_allocator::{Allocator, Box, FromIn, IntoIn, String, Vec};
+use oxc_allocator::{Allocator, Box, FromIn, IntoIn, String, TakeIn, Vec};
 use oxc_span::{Atom, SPAN, Span};
 use oxc_syntax::{number::NumberBase, operator::UnaryOperator, scope::ScopeId};
 
@@ -101,121 +101,82 @@ impl<'a> AstBuilder<'a> {
         }
     }
 
-    /// Moves the expression out by replacing it with an [`Expression::NullLiteral`].
+    /// Replace [`Expression`] with a dummy node, and return the original.
     #[inline]
     pub fn move_expression(self, expr: &mut Expression<'a>) -> Expression<'a> {
-        let null_expr = self.expression_null_literal(SPAN);
-        mem::replace(expr, null_expr)
+        expr.take_in(self.allocator)
     }
 
-    /// Moves the statement out by replacing it with a [`Statement::EmptyStatement`].
+    /// Replace [`Statement`] with a dummy node, and return the original.
     #[inline]
     pub fn move_statement(self, stmt: &mut Statement<'a>) -> Statement<'a> {
-        let empty_stmt = self.empty_statement(SPAN);
-        mem::replace(stmt, Statement::EmptyStatement(self.alloc(empty_stmt)))
+        stmt.take_in(self.allocator)
     }
 
-    /// Moves the assignment target out by replacing it with a dummy
-    /// [`AssignmentTarget::AssignmentTargetIdentifier`] with no name and an empty [`Span`].
+    /// Replace [`AssignmentTarget`] with a dummy node, and return the original.
     #[inline]
     pub fn move_assignment_target(self, target: &mut AssignmentTarget<'a>) -> AssignmentTarget<'a> {
-        let dummy =
-            self.simple_assignment_target_assignment_target_identifier(SPAN, Atom::from(""));
-        mem::replace(target, dummy.into())
+        target.take_in(self.allocator)
     }
 
-    /// Moves the property key out by replacing it with a [`PropertyKey::NullLiteral`].
+    /// Replace [`PropertyKey`] with a dummy node, and return the original.
+    #[inline]
     pub fn move_property_key(self, key: &mut PropertyKey<'a>) -> PropertyKey<'a> {
-        let null_expr = PropertyKey::from(self.expression_null_literal(SPAN));
-        mem::replace(key, null_expr)
+        key.take_in(self.allocator)
     }
 
-    /// Move a declaration out by replacing it with an empty [`Declaration::VariableDeclaration`].
+    /// Replace [`Declaration`] with a dummy node, and return the original.
     #[inline]
     pub fn move_declaration(self, decl: &mut Declaration<'a>) -> Declaration<'a> {
-        let empty_decl =
-            self.declaration_variable(SPAN, VariableDeclarationKind::Var, self.vec(), false);
-        mem::replace(decl, empty_decl)
+        decl.take_in(self.allocator)
     }
 
-    /// Move a variable declaration out by replacing it with an empty [`VariableDeclaration`].
+    /// Replace [`VariableDeclaration`] with a dummy node, and return the original.
     #[inline]
     pub fn move_variable_declaration(
         self,
         decl: &mut VariableDeclaration<'a>,
     ) -> VariableDeclaration<'a> {
-        let empty_decl =
-            self.variable_declaration(SPAN, VariableDeclarationKind::Var, self.vec(), false);
-        mem::replace(decl, empty_decl)
+        decl.take_in(self.allocator)
     }
 
-    /// Move a formal parameters out by replacing it with an empty [`FormalParameters`].
+    /// Replace [`FormalParameters`] with a dummy node, and return the original.
     #[inline]
     pub fn move_formal_parameters(self, params: &mut FormalParameters<'a>) -> FormalParameters<'a> {
-        let empty_params = self.formal_parameters(SPAN, params.kind, self.vec(), NONE);
-        mem::replace(params, empty_params)
+        params.take_in(self.allocator)
     }
 
-    /// Move a function body out by replacing it with an empty [`FunctionBody`].
+    /// Replace [`FunctionBody`] with a dummy node, and return the original.
     #[inline]
     pub fn move_function_body(self, body: &mut FunctionBody<'a>) -> FunctionBody<'a> {
-        let empty_body = self.function_body(SPAN, self.vec(), self.vec());
-        mem::replace(body, empty_body)
+        body.take_in(self.allocator)
     }
 
-    /// Move a function out by replacing it with an empty [`Function`].
+    /// Replace [`Function`] with a dummy node, and return the original.
     #[inline]
     pub fn move_function(self, function: &mut Function<'a>) -> Function<'a> {
-        let params =
-            self.formal_parameters(SPAN, FormalParameterKind::FormalParameter, self.vec(), NONE);
-        let empty_function = self.function(
-            SPAN,
-            FunctionType::FunctionDeclaration,
-            None,
-            false,
-            false,
-            false,
-            NONE,
-            NONE,
-            params,
-            NONE,
-            NONE,
-        );
-        mem::replace(function, empty_function)
+        function.take_in(self.allocator)
     }
 
-    /// Move a class out by replacing it with an empty [`Class`].
+    /// Replace [`Class`] with a dummy node, and return the original.
+    #[inline]
     pub fn move_class(self, class: &mut Class<'a>) -> Class<'a> {
-        let empty_class = self.class(
-            SPAN,
-            ClassType::ClassDeclaration,
-            self.vec(),
-            None,
-            NONE,
-            None,
-            NONE,
-            None,
-            self.class_body(SPAN, self.vec()),
-            false,
-            false,
-        );
-        mem::replace(class, empty_class)
+        class.take_in(self.allocator)
     }
 
-    /// Move an array element out by replacing it with an [`ArrayExpressionElement::Elision`].
+    /// Replace [`ArrayExpressionElement`] with a dummy node, and return the original.
+    #[inline]
     pub fn move_array_expression_element(
         self,
         element: &mut ArrayExpressionElement<'a>,
     ) -> ArrayExpressionElement<'a> {
-        let elision = self.array_expression_element_elision(SPAN);
-        mem::replace(element, elision)
+        element.take_in(self.allocator)
     }
 
-    /// Take the contents of a arena-allocated [`Vec`], leaving an empty [`Vec`] in its place.
-    /// This is akin to [`std::mem::take`].
+    /// Replace [`Vec`] with an empty [`Vec`], and return the original.
     #[inline]
     pub fn move_vec<T>(self, vec: &mut Vec<'a, T>) -> Vec<'a, T> {
-        mem::replace(vec, self.vec())
+        vec.take_in(self.allocator)
     }
 
     /* ---------- Constructors ---------- */


### PR DESCRIPTION
`AstBuilder::move_*` methods use `TakeIn::take_in` (added in #9969) to replace nodes with dummy nodes.

`take_in` will always generate a dummy in whatever way minimizes the size and number of allocations required.

It would be possible to replace all the `move_*` methods with a single `AstBuilder::take` method which is generic over `T: TakeIn` (#9970). But have opted not to do that, because it's useful to be able to see in calling code what type of node is being replaced.

Some nodes are quite expensive to create a dummy for (e.g. `Declaration` and `Function` require allocating 56 bytes into arena, `ArrowFunctionExpression` allocates 128 bytes in 2 separate allocations), so it's useful to see where we're doing that, so we can try to replace them with cheaper operations e.g. replacing an `Expression` or `Statement` instead (only 8 bytes). We also want to avoid inadvertently adding further expensive `take_in` calls, which a blanket `AstBuilder::take` method would make it easy to do.
