### PR TITLE
fix(ast/estree): fix TS type defs for `TSIndexSignature` and `TSIndexSignatureName`

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -962,7 +962,7 @@ pub enum TSSignature<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(add_fields(accessibility = TsNull))]
+#[estree(add_fields(accessibility = Null))]
 pub struct TSIndexSignature<'a> {
     pub span: Span,
     pub parameters: Vec<'a, TSIndexSignatureName<'a>>,
@@ -1036,7 +1036,7 @@ pub struct TSConstructSignatureDeclaration<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "Identifier", add_fields(decorators = TsEmptyArray, optional = TsFalse))]
+#[estree(rename = "Identifier", add_fields(decorators = EmptyArray, optional = False))]
 pub struct TSIndexSignatureName<'a> {
     pub span: Span,
     #[estree(json_safe)]

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -2897,7 +2897,7 @@ impl ESTree for TSIndexSignature<'_> {
         state.serialize_field("typeAnnotation", &self.type_annotation);
         state.serialize_field("readonly", &self.readonly);
         state.serialize_field("static", &self.r#static);
-        state.serialize_ts_field("accessibility", &crate::serialize::TsNull(self));
+        state.serialize_field("accessibility", &crate::serialize::Null(self));
         state.end();
     }
 }
@@ -2964,8 +2964,8 @@ impl ESTree for TSIndexSignatureName<'_> {
         state.serialize_field("end", &self.span.end);
         state.serialize_field("name", &JsonSafeString(self.name.as_str()));
         state.serialize_field("typeAnnotation", &self.type_annotation);
-        state.serialize_ts_field("decorators", &crate::serialize::TsEmptyArray(self));
-        state.serialize_ts_field("optional", &crate::serialize::TsFalse(self));
+        state.serialize_field("decorators", &crate::serialize::EmptyArray(self));
+        state.serialize_field("optional", &crate::serialize::False(self));
         state.end();
     }
 }

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -1654,6 +1654,7 @@ function deserializeTSIndexSignature(pos) {
     typeAnnotation: deserializeBoxTSTypeAnnotation(pos + 40),
     readonly: deserializeBool(pos + 48),
     static: deserializeBool(pos + 49),
+    accessibility: null,
   };
 }
 
@@ -1702,6 +1703,8 @@ function deserializeTSIndexSignatureName(pos) {
     end: deserializeU32(pos + 4),
     name: deserializeStr(pos + 8),
     typeAnnotation: deserializeBoxTSTypeAnnotation(pos + 24),
+    decorators: [],
+    optional: false,
   };
 }
 

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -1206,7 +1206,7 @@ export interface TSIndexSignature extends Span {
   typeAnnotation: TSTypeAnnotation;
   readonly: boolean;
   static: boolean;
-  accessibility?: null;
+  accessibility: null;
 }
 
 export interface TSCallSignatureDeclaration extends Span {
@@ -1241,8 +1241,8 @@ export interface TSIndexSignatureName extends Span {
   type: 'Identifier';
   name: string;
   typeAnnotation: TSTypeAnnotation;
-  decorators?: [];
-  optional?: false;
+  decorators: [];
+  optional: false;
 }
 
 export interface TSInterfaceHeritage extends Span {


### PR DESCRIPTION
Follow-on after #9968. These 2 types are TS-only, so none of the fields are optional. Correct TS type defs by replacing `TSNull` with `Null` etc in the extra field types.
