### PR TITLE
test(ast/estree): fix final newlines in TS-ESLint test cases

### DIFF
--- a/.github/actions/clone-submodules/action.yml
+++ b/.github/actions/clone-submodules/action.yml
@@ -38,4 +38,4 @@ runs:
         show-progress: false
         repository: oxc-project/acorn-test262
         path: tasks/coverage/acorn-test262
-        ref: eb5e9976435fafd45e2859a4b668a77ec75ce625 # Latest main at 17/3/25
+        ref: b4592303caa442d3592f5c1c361dc703cec841b2 # Latest main at 24/3/25

--- a/justfile
+++ b/justfile
@@ -40,7 +40,7 @@ submodules:
   just clone-submodule tasks/coverage/babel https://github.com/babel/babel.git 578ac4df1c8a05f01350553950dbfbbeaac013c2
   just clone-submodule tasks/coverage/typescript https://github.com/microsoft/TypeScript.git 15392346d05045742e653eab5c87538ff2a3c863
   just clone-submodule tasks/prettier_conformance/prettier https://github.com/prettier/prettier.git 7584432401a47a26943dd7a9ca9a8e032ead7285
-  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 eb5e9976435fafd45e2859a4b668a77ec75ce625
+  just clone-submodule tasks/coverage/acorn-test262 https://github.com/oxc-project/acorn-test262 b4592303caa442d3592f5c1c361dc703cec841b2
   just update-transformer-fixtures
 
 # Install git pre-commit to format files

--- a/tasks/coverage/snapshots/estree_acorn_jsx.snap
+++ b/tasks/coverage/snapshots/estree_acorn_jsx.snap
@@ -1,4 +1,4 @@
-commit: eb5e9976
+commit: b4592303
 
 estree_acorn_jsx Summary:
 AST Parsed     : 39/39 (100.00%)

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -2,8 +2,7 @@ commit: 15392346
 
 estree_typescript Summary:
 AST Parsed     : 10623/10725 (99.05%)
-Positive Passed: 2083/10725 (19.42%)
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/APILibCheck.ts
+Positive Passed: 3363/10725 (31.36%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APISample_Watch.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APISample_WatchWithDefaults.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APISample_WatchWithOwnWatchHost.ts
@@ -31,15 +30,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorAccidentalCallD
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/accessorBodyInTypeContext.ts
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorDeclarationEmitVisibilityErrors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorDeclarationOrder.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorInferredReturnTypeErrorInReturnStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorWithRestParam.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/addMoreCallSignaturesToBaseSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/addMoreOverloadsToBaseSignature.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasAssignments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasBug.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasInstantiationExpressionGenericIntersectionNoCrash1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasInstantiationExpressionGenericIntersectionNoCrash2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasOfGenericFunctionWithRestBehavedSameAsUnaliased.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasOnMergedModuleInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInAccessorsOfClass.ts
@@ -62,20 +56,12 @@ Unexpected estree file content error: 2 != 4
 tasks/coverage/typescript/tests/cases/compiler/allowJscheckJsTypeParameterNoCrash.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImports6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowSyntheticDefaultImportsCanPaintCrossModuleDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/alwaysStrictModule3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/alwaysStrictModule4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/alwaysStrictModule5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/alwaysStrictModule6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientClassDeclarationWithExtends.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientClassDeclaredBeforeBase.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientClassMergesOverloadsWithInterface.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientClassOverloadForFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientConstLiterals.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientEnum1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientEnumElementInitializer1.ts
@@ -97,7 +83,6 @@ Unexpected estree file content error: 1 != 2
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambientStatement1.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/ambientWithStatements.ts
 A 'return' statement can only be used within a function body.
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/ambiguousCallsWhereReturnTypesAgree.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdDeclarationEmitNoExtraDeclare.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdDependencyComment1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdDependencyComment2.ts
@@ -112,24 +97,15 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdModuleBundleNoDuplic
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdModuleConstEnumUsage.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdModuleName1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonClassDeclarationEmitIsAnon.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonymousClassDeclarationDoesntPrintWithReadonly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonymousClassExpression2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyAndUnknownHaveFalsyComponents.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyAsReturnTypeForNewOnCall.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyDeclare.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyIndexedAccessArrayNoException.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyIsAssignableToObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyIsAssignableToVoid.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyMappedTypesError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/argsInScope.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arguments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsAsPropertyName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsAsPropertyName2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsObjectIterator02_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsObjectIterator02_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsObjectIterator03_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsObjectIterator03_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsSpreadRestIterables.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsUsedInClassFieldInitializerOrStaticInitializationBlock.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsUsedInObjectLiteralProperty.ts
@@ -144,7 +120,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAugment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayBestCommonTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayBindingPatternOmittedExpressions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayCast.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayConcat2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayConcat3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayConcatMap.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayDestructuringInSwitch1.ts
@@ -153,21 +128,17 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayEvery.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFakeFlatNoCrashInferenceDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFilter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFind.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFlatMap.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFrom.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/arrayFromAsync.ts
 `await` is only allowed within async functions and at the top levels of modules
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayIndexWithArrayFails.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralAndArrayConstructorEquivalence1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralContextualType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralInNonVarArgParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralTypeInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayOfExportedClass.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayOfSubtypeIsAssignableToReadonlyArray.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/arraySigChecking.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arraySlice.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayToLocaleStringES2015.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayToLocaleStringES2020.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayToLocaleStringES5.ts
@@ -175,22 +146,17 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayTypeInSignatureOfI
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayconcat.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionErrorSpan.ts
 Line terminator not permitted before arrow
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionInConstructorArgument1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionParsingGenericInObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionWithObjectLiteralBody5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionWithObjectLiteralBody6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/asiAbstract.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asiAmbientFunctionDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/asiArith.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asiBreak.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asiContinue.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asiInES6Classes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/asiPublicPrivateProtected.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/asiReturn.ts
 A 'return' statement can only be used within a function body.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assertionFunctionWildcardImport1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assertionFunctionWildcardImport2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assertionFunctionsCanNarrowByDiscriminant.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assign1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignLambdaToNominalSubtypeOfFunction.ts
@@ -200,15 +166,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignToFn.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/assignToInvalidLHS.ts
 Cannot assign to this expression
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignToObjectTypeWithPrototypeProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assigningFromObjectToAnythingElse.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompat1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatBug2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatBug3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatBug5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatForEnums.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatFunctionsWithOptionalArgs.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatInterfaceWithStringIndexSignature.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatOnNew.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability11.ts
@@ -247,8 +210,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability41.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability42.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability43.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability44.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability45.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability46.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability6.ts
@@ -262,7 +223,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentIndexedToPrim
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentNestedInLiterals.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentNonObjectTypeConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentRestElementWithErrorSourceType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentStricterConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentToAnyArrayRestParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentToExpandingArrayType.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/assignmentToInstantiationExpression.ts
@@ -273,9 +233,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/assignmentToPare
 Cannot assign to this expression
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentToReferenceTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncArrowInClassES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncAwaitWithCapturedBlockScopeVar.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionContextuallyTypedReturns.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionNoReturnType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionReturnExpressionErrorSpans.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionReturnType.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionReturnType.ts
@@ -297,7 +255,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals4_1.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals6_1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentedTypeBracketNamedPropertyAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentedTypesClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentedTypesClass2.ts
@@ -321,11 +278,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/autoTypeAssignedUsingDe
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/autolift3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/autolift4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/autonumberingInEnums.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/avoid.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/avoidCycleWithVoidExpressionReturnedFromArrow.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/avoidListingPropertiesForTypesWithOnlyCallOrConstructSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/avoidNarrowingUsingConstVariableFromBindingElementWithLiteralInitializer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/awaitCallExpressionInSyncFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/awaitInClassInAsyncFunction.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/awaitInNonAsyncFunction.ts
 `await` is only allowed within async functions and at the top levels of modules
@@ -338,44 +293,31 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/awaitedTypeJQuery.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/awaitedTypeStrictNull.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/badExternalModuleReference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/badInferenceLowerPriorityThanGoodInference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/badOverloadError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bangInModuleName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseCheck.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseConstraintOfDecorator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseExpressionTypeParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseTypeAfterDerivedType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseTypeOrderChecking.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseTypeWrappingInstantiationChain.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bestChoiceType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bestCommonTypeReturnStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bestCommonTypeWithContextualTyping.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bestCommonTypeWithOptionalProperties.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/betterErrorForAccidentalCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/betterErrorForUnionCall.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigIntWithTargetES2016.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigIntWithTargetLessThanES2016.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigint64ArraySubarray.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigintIndex.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigintWithLib.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigintWithoutLib.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/binaryArithmeticControlFlowGraphNotTooLarge.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/bind1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bind2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bindingPatternCannotBeOnlyInferenceSource.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bindingPatternContextualTypeDoesNotCauseWidening.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/bindingPatternInParameter01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bindingPatternOmittedExpressionNesting.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/binopAssignmentShouldHaveType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/bitwiseCompoundAssignmentOperators.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingCaptureThisInFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingUsedBeforeDef.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingsInDownlevelGenerator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingsReassignedInLoop1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingsReassignedInLoop2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingsReassignedInLoop3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingsReassignedInLoop5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingsReassignedInLoop6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedClassDeclarationAcrossFiles.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedEnumVariablesUseBeforeDef.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedEnumVariablesUseBeforeDef_isolatedModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedEnumVariablesUseBeforeDef_preserve.ts
@@ -394,23 +336,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakTarget4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakTarget5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakTarget6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/builtinIterator.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/bundledDtsLateExportRenaming.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedContextualTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callOfConditionalTypeWithConcreteBranches.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/callOnClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callOnInstance.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/callOverloads2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/callOverloads3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/callOverloads4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/callOverloads5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/callSignatureFunctionOverload.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callSignaturesShouldBeResolvedBeforeSpecialization.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callbacksDontShareTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callsOnComplexSignatures.tsx
@@ -419,7 +352,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/captureThisInSuperCall.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop13.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop14.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop1_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop2_ES6.ts
@@ -442,21 +374,15 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedShorthandProper
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/caseInsensitiveFileSystemWithCapsImportTypeDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/castExpressionParentheses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/castFunctionExpressionShouldBeParenthesized.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/castOfAwait.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/castParentheses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/castTest.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/catch.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cf.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedAssignment1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedAssignment2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedAssignment3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedAssignmentChecking.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedCallsWithTypeParameterConstrainedToOtherTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedCallsWithTypeParameterConstrainedToOtherTypeParameter2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedImportAlias.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedSpecializationToObjectTypeLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkDestructuringShorthandAssigment2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkForObjectTooStrict.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkInfiniteExpansionTermination.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkInfiniteExpansionTermination2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkInterfaceBases.ts
@@ -466,7 +392,6 @@ Unexpected estree file content error: 1 != 2
 tasks/coverage/typescript/tests/cases/compiler/checkJsdocTypeTagOnExportAssignment2.ts
 Unexpected estree file content error: 1 != 4
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkMergedGlobalUMDSymbol.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkSuperCallBeforeThisAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkSuperCallBeforeThisAccessing1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkSuperCallBeforeThisAccessing2.ts
@@ -490,9 +415,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularContextualRetur
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularGetAccessor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularInferredTypeOfVariable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularInlineMappedGenericTupleTypeNoCrash.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularInstantiationExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularMappedTypeConstraint.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularModuleImports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularObjectLiteralAccessors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularOptionalityRemoval.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularReferenceInReturnType.ts
@@ -505,11 +428,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularlyReferentialIn
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularlySimplifyingConditionalTypesNoCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classAccessorInitializationInferenceWithElementAccess1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classAttributeInferenceTemplate.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classCannotExtendVar.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclarationShouldBeOutOfScopeInComputedNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclaredBeforeClassFactory.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionAssignment.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionExtendingAbstractClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionNames.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/classExpressionPropertyModifiers.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
@@ -526,28 +446,18 @@ tasks/coverage/typescript/tests/cases/compiler/classExtendingAny.ts
 Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsAcrossFiles.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsClauseClassNotReferringConstructor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsInterface.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsInterfaceInExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsInterfaceInModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsInterfaceThatExtendsClassWithPrivates1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsInterface_not.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsNull.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsNull2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFieldSuperAccessible.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFieldSuperNotAccessible.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFunctionMerging.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/classHeritageWithTrailingSeparator.ts
 Expected `{` but found `EOF`
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementingInterfaceIndexer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsClass7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsImportedInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsMethodWIthTupleArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsPrimitive.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classIndexer4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classIndexer5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerScoping.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerScoping2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping3.ts
@@ -556,30 +466,22 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerW
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMergedWithInterfaceMultipleBasesNoError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classNameReferencesInStaticElements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classNonUniqueSymbolMethodHasSymbolIndexer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classOrder1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classOrder2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classOrderBug.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classOverloadForFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classPropInitializationInferenceWithElementAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classReferencedInContextualParameterWithinItsOwnBaseExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classSideInheritance2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classSideInheritance3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classStaticInitializersUsePropertiesBeforeDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classStaticPropertyAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classStaticPropertyTypeGuard.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classTypeParametersInStatics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classUsedBeforeInitializedVariables.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classVarianceCircularity.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classVarianceResolveCircularity1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classVarianceResolveCircularity2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classWithDuplicateIdentifier.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classWithMultipleBaseClasses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classdecl.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/clinterfaces.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleAcrossModuleDefinitions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleAndTypeParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleGenericOnSelfMember.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleStaticMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleTest1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleWithPriorInstantiatedModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleWithPriorUninstantiatedModule.ts
@@ -612,7 +514,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequire
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndInternalModuleAlias.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionExportsRequireAndUninstantiatedModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterArrowFunctions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterClassConstructor.ts
@@ -681,7 +582,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnParameter2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnParameter3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnParenthesizedExpressionOpenParen1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnSignature1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentOnSimpleArrowFunctionBody1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentWithUnreasonableIndentationLevel01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsAfterCaseClauses1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsAfterCaseClauses2.ts
@@ -720,19 +620,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsVarDecl.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsVariableStatement1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsdoNotEmitComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsemitComments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonJsImportClassExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonSourceDir1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonSourceDirectory.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonSourceDirectory_dts.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commonjsSafeImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/comparabilityTypeParametersRelatedByUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/comparableRelationBidirectional.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/compareTypeParameterConstrainedByLiteralToLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/comparisonOfPartialDeepAndIndexedAccessTerminatesWithoutError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/compilerOptionsDeclarationAndNoEmit.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/compilerOptionsOutAndNoEmit.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/compilerOptionsOutDirAndNoEmit.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/compilerOptionsOutFileAndNoEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/complexClassRelationships.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/complexNarrowingWithAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/complexRecursiveCollections.ts
@@ -742,7 +635,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/complicatedIndexesOfInt
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/complicatedPrivacy.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/compositeContextualSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/compositeGenericFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/compositeWithNodeModulesSourceFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedEnumMemberSyntacticallyString.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedEnumMemberSyntacticallyString2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedEnumTypeWidening.ts
@@ -751,15 +643,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertiesInDes
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertiesInDestructuring2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertiesInDestructuring2_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertiesNarrowed.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertiesTransformedInOtherwiseNonTSClasses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertiesWithSetterAssignment.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertyNameAndTypeParameterConflict.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertyNameWithImportedKey.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedTypesKeyofNoIndexSignatureType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/computerPropertiesInES5ShouldBeTransformed.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/concatClassAndString.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/concatTuples.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalDoesntLeakUninstantiatedTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalEqualityOnLiteralObjects.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalEqualityTestingNullability.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpression1.ts
@@ -776,7 +664,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeRelaxing
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeSimplification.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeVarianceBigArrayConstraintsPerformance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypesASI.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypesSimplifyWhenTrivial.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conflictingDeclarationsImportFromNamespace1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conflictingDeclarationsImportFromNamespace2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conflictingMemberTypesInBases.ts
@@ -792,14 +679,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-acces
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-ambient.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-errors.ts
 Missing initializer in const declaration
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-es5.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-invalidContexts.ts
 Lexical declaration cannot appear in a single-statement context
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-scopes.ts
 Lexical declaration cannot appear in a single-statement context
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-scopes2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-useBeforeDefinition.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-useBeforeDefinition2.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-validContexts.ts
 Lexical declaration cannot appear in a single-statement context
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarations.ts
@@ -830,8 +714,6 @@ A class member cannot have the 'const' keyword.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constIndexedAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constWithNonNull.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constantEnumAssert.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/constantOverloadFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/constantOverloadFunctionNoSubtypeError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintCheckInGenericBaseTypeReference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintPropagationThroughReturnTypes.ts
@@ -839,21 +721,13 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintReferencingTy
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintWithIndexedAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraints0.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintsThatReferenceOtherContstraints1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorArgWithGenericCallSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorAsType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorInvocationWithTooFewTypeArgs.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorParametersInVariableDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorReturningAPrimitive.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorReturnsInvalidType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorStaticParamName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorWithParameterPropertiesAndPrivateFields.es2015.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorWithSuperAndPrologue.es5.ts
@@ -876,7 +750,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInAr
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInObjectFreeze.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstantiation1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstantiation2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstantiation3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstantiation4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstatiationContravariance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstatiationCovariance.ts
@@ -932,20 +805,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingArrayDestructuringWithDefaults.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingArrayOfLambdas.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingFunctionReturningFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingFunctionReturningFunction2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfAccessors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfArrayLiterals1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfConditionalExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfConditionalExpression2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfGenericFunctionTypedArguments1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfLambdaWithMultipleSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfObjectLiterals.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfObjectLiterals2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfOptionalMembers.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfTooShortOverloads.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingReturnStatementWithReturnTypeAnnotation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingWithFixedTypeParameters1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingWithGenericAndNonGenericSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingWithGenericSignature.ts
@@ -986,7 +853,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowArrays.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowAutoAccessor1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowBreakContinueWithLabel.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowCaching.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowCommaExpressionAssertionMultiple.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowCommaExpressionAssertionWithinTernary.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowCommaExpressionFunctionCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowDestructuringLoop.ts
@@ -1003,7 +869,6 @@ Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowInstanceofWithSymbolHasInstance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowLoopAnalysis.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowManyCallExpressionStatementsPerf.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowManyConsecutiveConditionsNoTimeout.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowNullTypeAndLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowOuterVariable.ts
@@ -1012,35 +877,27 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowPropertyInit
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowSelfReferentialLoop.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowUnionContainingTypeParameter1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowWithIncompleteTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/convertClassExpressionToFunctionFromObjectProperty1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/convertClassExpressionToFunctionFromObjectProperty2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/convertKeywords.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/convertKeywordsYes.ts
 Classes can't have a field named 'constructor'
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/copyrightWithNewLine1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/copyrightWithoutNewLine1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/correctOrderOfPromiseMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/correlatedUnions.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/couldNotSelectGenericOverload.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/covariance1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashDeclareGlobalTypeofExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashInEmitTokenWithComment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashInGetTextOfComputedPropertyName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashInResolveInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashInYieldStarInAsyncFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashInresolveReturnStatement.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashInsourcePropertyIsRelatableToTargetProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashIntypeCheckInvocationExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashIntypeCheckObjectCreationExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashOnMethodSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashRegressionTest.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/crossFileOverloadModifierConsistency.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/curiousNestedConditionalEvaluationResult.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/customAsyncIterator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/customEventDetail.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicGenericTypeInstantiation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicGenericTypeInstantiationInference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicModuleImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicTypeInstantiation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileAccessors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileAmbientExternalModuleWithSingleExportedModule.ts
@@ -1049,15 +906,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileClassWithStatic
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileConstructSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileConstructors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileEmitDeclarationOnly.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileEmitDeclarationOnlyError1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileEmitDeclarationOnlyError2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileEnumUsedAsValue.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileEnums.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileExportAssignmentImportInternalModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileExportAssignmentOfGenericInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForClassWithMultipleBaseClasses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForExportedImport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForFunctionTypeAsTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForInterfaceWithOptionalFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForInterfaceWithRestParams.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileFunctions.ts
@@ -1066,7 +920,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileGenericType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileGenericType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileImportChainInExportAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileImportModuleWithExportAssignment.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileImportedTypeUseInTypeArgPosition.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileMethods.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileModuleAssignmentInObjectLiteralProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileModuleContinuation.ts
@@ -1083,13 +936,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationP
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationTypeAlias.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationTypeLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationUnionType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorAccessors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorParameterOfFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorReturnTypeOfFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorTypeAlias.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorTypeLiteral.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorVariableDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofInAnonymousType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileWithClassNameConflictingWithClassReferredByExtendsClause.ts
@@ -1102,13 +950,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalMod
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declInput.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declInput3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationAssertionNodeNotReusedWhenTypeNotEquivalent1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAliasExportStar.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAliasFromIndirectFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAliasInlineing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAmdModuleDefault.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAmdModuleNameDirective.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAnyComputedPropertyInClass.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitArrayTypesFromGenericArrayUsage.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitArrowFunctionNoRenaming.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitBindingPatternWithReservedWord.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitBindingPatterns.ts
@@ -1130,7 +976,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassMem
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassMixinLocalClassDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassPrivateConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitClassPrivateConstructor2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitCommonJsModuleReferencedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitCommonSourceDirectoryDoesNotContainAllFiles.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedNameCausesImportToBePainted.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitComputedNameConstEnumAlias.ts
@@ -1176,7 +1021,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDuplicat
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitEnumReadonlyProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitEnumReferenceViaImportEquals.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExactOptionalPropertyTypesNodeNotReused.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpandoPropertyPrivateName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpandoWithGenericConstraint.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExportAliasVisibiilityMarking.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExportAssignedNamespaceNoTripleSlashTypesReference.ts
@@ -1191,8 +1035,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForDefau
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForGlobalishSpecifierSymlink.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForGlobalishSpecifierSymlink2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForModuleImportingModuleAugmentationRetainsImport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForTypesWhichNeedImportTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitFunctionDuplicateNamespace.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitGlobalThisPreserved.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitHasTypesRefOnNamespaceUse.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitHigherOrderRetainedGenerics.ts
@@ -1270,8 +1112,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPreserve
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrivateAsync.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrivateNameCausesError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrivatePromiseLikeInterface.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrivateReadonlyLiterals.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrivateSymbolCausesVarDeclarationEmit2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrivateSymbolCausesVarDeclarationToBeEmitted.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPromise.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPropertyNumericStringKey.ts
@@ -1310,7 +1150,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAlia
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasWithTypeParameters5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeAliasWithTypeParameters6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeParamMergedWithPrivate.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeParameterNameInOuterScope.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeParameterNameReusedInOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeParameterNameShadowedInternally.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeofDefaultExport.ts
@@ -1332,7 +1171,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitWithDefa
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitWithDefaultAsComputedName2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitWithInvalidPackageJsonTypings.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFileNoCrashOnExtraExportModifier.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFileOverwriteErrorWithOut.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFilesGeneratingTypeReferences.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFilesWithTypeReferences1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFilesWithTypeReferences2.ts
@@ -1358,7 +1196,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationsIndirectGen
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationsWithRecursiveInternalTypesProduceUniqueTypeParams.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/declareAlreadySeen.ts
 declare' modifier already seen.
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declareClassInterfaceImplementation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declareDottedExtend.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declareDottedModuleName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declareExternalModuleWithExportAssignedFundule.ts
@@ -1370,25 +1207,16 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declaredExternalModuleW
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataConditionalType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataElidedImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataElidedImportOnDeclare.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataForMethodWithNoReturnTypeAnnotation01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataGenericTypeVariable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataGenericTypeVariableDefault.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataGenericTypeVariableInScope.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataNoLibIsolatedModulesTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataOnInferredType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataPromise.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataRestParameterWithImportedType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataTypeOnlyExport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataTypeOnlyImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataWithConstructorType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataWithImportDeclarationNameCollision.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataWithImportDeclarationNameCollision2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataWithImportDeclarationNameCollision3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataWithImportDeclarationNameCollision4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataWithImportDeclarationNameCollision5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataWithImportDeclarationNameCollision6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataWithImportDeclarationNameCollision7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataWithImportDeclarationNameCollision8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorReferenceOnOtherProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorReferences.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorWithUnderscoreMethod.ts
@@ -1400,12 +1228,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/deepKeysIndexing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedAssignabilityErrorsCombined.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedAssignabilityIssue.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedCheck.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedConditionalTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedMappedTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedTemplateLiteralIntersection.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultArgsInOverloads.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultBestCommonTypesHaveDecls.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultDeclarationEmitDefaultImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultDeclarationEmitNamedCorrectly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultDeclarationEmitShadowedNamedCorrectly.ts
@@ -1433,15 +1259,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/deleteExpressionMustBeO
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deleteExpressionMustBeOptional_exactOptionalPropertyTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deleteReadonly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deleteReadonlyInStrictNullChecks.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedBool.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedCompilerOptions1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedCompilerOptions2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedCompilerOptions3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedCompilerOptions4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedCompilerOptions5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/deprecatedCompilerOptions6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/derivedClassConstructorWithExplicitReturns01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/derivedClasses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/derivedInterfaceCallSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/derivedTypeCallingBaseImplWithOptionalParams.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructureCatchClause.ts
@@ -1500,19 +1318,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminatedUnionError
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminatedUnionJsxElement.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminatedUnionWithIndexSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminatingUnionWithUnionPropertyAgainstUndefinedWithoutStrictNullChecks.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/dissallowSymbolAsWeakType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/distributiveConditionalTypeConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/distributiveConditionalTypeNeverIntersection1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessors1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsVisibility1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/divideAndConquerIntersections.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotElaborateAssignabilityToTypeParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotEmitDetachedComments.ts
@@ -1537,9 +1350,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/dottedModuleName2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/dottedNamesInSystem.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/dottedSymbolResolution1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doubleMixinConditionalTypeBaseClassWorks.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/doubleUnderStringLiteralAssignability.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreEnumEmit.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreExportStarConflict.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreLabels.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreMappedTypes.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst11.ts
@@ -1559,29 +1370,21 @@ Unexpected token
 tasks/coverage/typescript/tests/cases/compiler/dtsEmitTripleSlashAvoidUnnecessaryResolutionMode.ts
 Unexpected estree file content error: 2 != 3
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateAnonymousInners1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateAnonymousModuleClasses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateDefaultExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateErrorAssignability.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateErrorClassExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateErrorNameNotFound.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierBindingElementInParameterDeclaration1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierBindingElementInParameterDeclaration2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierComputedName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierDifferentModifiers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierDifferentSpelling.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierEnum.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierRelatedSpans1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierRelatedSpans2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierRelatedSpans3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierRelatedSpans4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierRelatedSpans5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierRelatedSpans6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierRelatedSpans7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierRelatedSpans_moduleAugmentation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierShouldNotShortCircuitBaseTypeBinding.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifiersAcrossContainerBoundaries.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifiersAcrossFileBoundaries.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateInterfaceMembers1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateLabel1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateLabel2.ts
@@ -1596,16 +1399,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateObjectLiteralP
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateObjectLiteralProperty_computedName3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateObjectLiteralProperty_computedNameNegative1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateOverloadInTypeAugmentation1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_globalMerge.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_packageIdIncludesSubModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_referenceTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_relativeImportWithinPackage.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_relativeImportWithinPackage_scoped.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_subModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicatePropertiesInStrictMode.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateStringNamedProperty1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateSymbolsExportMatching.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateTypeParameters1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateTypeParameters3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateVarAndImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateVarAndImport2.ts
@@ -1639,15 +1438,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitClassExpressionInDe
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitClassExpressionInDeclarationFile2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitClassMergedWithConstNamespaceNotElided.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitCommentsOnlyFile.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitDecoratorMetadata_isolatedModules.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitDecoratorMetadata_object.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitDecoratorMetadata_restArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitHelpersWithLocalCollisions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitMemberAccessExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitMethodCalledNew.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitOneLineVariableDeclarationRemoveCommentsFalse.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitPinnedCommentsOnTopOfFile.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitPostComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitPreComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSkipsThisWithRestParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSuperCallBeforeEmitParameterPropertyDeclaration1.ts
@@ -1657,10 +1453,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSuperCallBeforeEmit
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSuperCallBeforeEmitPropertyDeclarationAndParameterPropertyDeclaration1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSuperCallBeforeEmitPropertyDeclarationAndParameterPropertyDeclaration1ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitThisInObjectLiteralGetter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitThisInSuperMethodCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitTopOfFileTripleSlashCommentOnNotEmittedNodeIfRemoveCommentsIsFalse.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyAnonymousObjectNarrowing.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyArgumentsListComment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyArrayDestructuringExpressionVisitedByTransformer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyDeclarationEmitIsModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyEnum.ts
@@ -1731,14 +1525,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorForUsingPropertyOf
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorForUsingPropertyOfTypeAsType03.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorForwardReferenceForwadingConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorLocationForInterfaceExtension.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessageOnIntersectionsWithDiscriminants01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessageOnObjectLiteralType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessagesIntersectionTypes01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessagesIntersectionTypes02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessagesIntersectionTypes03.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessagesIntersectionTypes04.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorOnContextuallyTypedReturnType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorOnEnumReferenceInCondition.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorOnUnionVsObjectShouldDeeplyDisambiguate.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorOnUnionVsObjectShouldDeeplyDisambiguate2.ts
@@ -1747,7 +1539,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorWithSameNameType.t
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorWithTruncatedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorsInGenericTypeReference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorsOnImportedSymbol.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorsOnUnionsOfOverlappingObjects01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorsWithInvokablesInUnions01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es2015modulekind.ts
@@ -1762,7 +1553,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionDoStat
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionElementAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionForInStatements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionForOfStatements.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionHoisting.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionLongObjectLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionNestedLoops.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionNewExpressions.ts
@@ -1780,7 +1570,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-commonjs8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-importHelpersAsyncFunctions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-system.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-system2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-umd.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-umd2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-umd3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-umd4.ts
@@ -1804,18 +1593,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5ModuleWithoutModuleG
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5SetterparameterDestructuringNotElided.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5andes6module.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6-umd2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassSuperCodegenBug.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6DeclOrdering.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ExportAssignment.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ExportAssignment2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ExportAssignment3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ExportAssignment4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ExportClause.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ExportClauseInEs5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ExportClauseWithAssignmentInEs5.ts
@@ -1834,9 +1615,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBinding
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImport1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImport1InEs5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImport1WithExport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImportDts.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImportDts1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImportInEs5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImportWithExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBinding1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBinding1InEs5.ts
@@ -1845,29 +1624,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBinding
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBindingWithExport.ts
 Expected `=` but found `,`
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingMergeErrors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingNoDefaultProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportDefaultBindingWithExport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportEqualsDeclaration2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportEqualsExportModuleCommonJsError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportEqualsExportModuleEs2015Error.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImportAmd.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImportInEs5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImportMergeErrors.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpaceImportWithExport.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportAmd.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportDts.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportInEs5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportMergeErrors.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportWithExport.ts
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportWithTypesAndValues.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportWithoutFromClause.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/es6ImportWithoutFromClauseWithExport.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6MemberScoping.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6Module.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleClassDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleConst.ts
@@ -1885,27 +1649,19 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleWithModuleGenT
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ModuleWithModuleGenTargetCommonjs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6UseOfTopLevelRequire.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/esDecoratorsClassFieldsCrash.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInterop.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropDefaultImports.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropDefaultMemberMustBeSyntacticallyDefaultExport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropEnablesSyntheticDefaultImports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropImportDefaultWhenAllNamedAreDefaultAlias.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropImportNamespace.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropImportTSLibHasImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropNamedDefaultImports.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropPrettyErrorRelatedInformation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropTslibHelpers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropUsesExportStarWhenDefaultPlusNames.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropWithExportStar.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleIntersectionCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/esNextWeakRefs_IterableWeakMap.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/escapedIdentifiers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/escapedReservedCompilerNamedIdentifier.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/esmNoSynthesizedDefault.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/evalAfter0.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/evalOrArgumentsInDeclarationFunctions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/eventEmitterPatternWithRecordOfFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/evolvingArrayResolvedAssert.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/evolvingArrayTypeInAssert.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exactSpellingSuggestion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertiesInOverloads.ts
@@ -1922,7 +1678,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyErrorForF
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyErrorsSuppressed.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessivelyLargeTupleSpread.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exhaustiveSwitchCheckCircularity.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exhaustiveSwitchImplicitReturn.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exhaustiveSwitchWithWideningLiteralTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionBlockShadowing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionContextualTypes.ts
@@ -1937,14 +1692,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionSymbolPr
 tasks/coverage/typescript/tests/cases/compiler/expandoFunctionSymbolPropertyJs.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/experimentalDecoratorMetadataUnresolvedTypeObjectInEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/explicitAnyAfterSpreadNoImplicitAnyError.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/exportAlreadySeen.ts
 'export' modifier cannot be used here.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportArrayBindingPattern.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAsNamespace.d.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAsNamespaceConflict.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAsNamespace_augment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignClassAndModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignValueAndType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignedTypeAsTypeAnnotation.ts
@@ -1952,7 +1705,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentImportMergeNoCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentInterface.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentMembersVisibleInAugmentation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentOfDeclaredExternalModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentOfGenericType1.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithDeclareAndExportModifiers.ts
@@ -1968,7 +1720,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithout
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportClassExtendingIntersection.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDeclarationForModuleOrEnumWithMemberOfSameName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDeclarationsInAmbientNamespaces.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDeclarationsInAmbientNamespaces2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDeclareClass1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultAbstractClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportDefaultAlias_excludesEverything.ts
@@ -2015,13 +1766,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsClassNoRede
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsClassRedeclarationError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsCommonJs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsDefaultProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsOfModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsProperty2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsUmd.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportImportAndClodule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportImportCanSubstituteConstEnumForValue.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportImportMultipleFiles.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportImportNonInstantiatedModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportImportNonInstantiatedModule2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportInterfaceClassAndValue.ts
@@ -2031,7 +1780,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportObjectRest.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportPrivateType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportRedeclarationTypeAliases.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSameNameFuncVar.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierForAGlobal.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierReferencingOuterDeclaration2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierReferencingOuterDeclaration4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues.ts
@@ -2058,34 +1806,21 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/expr.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/expressionWithJSDocTypeArguments.ts
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/expressionsForbiddenInParameterInitializers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/extBaseClass1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/extBaseClass2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendArray.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendBaseClassBeforeItsDeclared.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendConstructSignatureInInterface.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendFromAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendGenericArray.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendGenericArray2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendGlobalThis.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendGlobalThis2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendPrivateConstructorClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendedInterfaceGenericType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendedInterfacesWithDuplicateTypeParameters.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendedUnicodeEscapeSequenceIdentifiers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendedUnicodePlaneIdentifiers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendingClassFromAliasAndUsageInIndexer.ts
 tasks/coverage/typescript/tests/cases/compiler/extendsUntypedModule.ts
 Unexpected estree file content error: 1 != 3
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/externFunc.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/externModuleClobber.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/externSyntax.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/externalModuleAssignToVar.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/externalModuleExportingGenericClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/externalModuleImmutableBindings.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/externalModuleQualification.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/externalModuleReferenceDoubleUnderscore1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/externalModuleReferenceOfImportDeclarationWithExportModifier.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/externalModuleRefernceResolutionOrderInImportDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/externalModuleWithoutCompilerFlag1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extractInferenceImprovement.ts
@@ -2100,9 +1835,7 @@ serde_json::from_str(oxc_json) error: number out of range at line 41 column 29
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fallbackToBindingPatternForTypeInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fatArrowSelf.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/fatArrowfunctionAsType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fatarrowfunctions.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/fatarrowfunctionsInFunctionParameterDefaults.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fatarrowfunctionsInFunctions.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors1.ts
 A rest parameter cannot be optional
@@ -2113,24 +1846,15 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/fileWithNextLine1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fileWithNextLine2.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/fileWithNextLine3.ts
 A 'return' statement can only be used within a function body.
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/filesEmittingIntoSameOutput.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/filesEmittingIntoSameOutputWithOutOption.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/fillInMissingTypeArgsOnConstructCalls.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/findLast.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/firstMatchRegExpMatchArray.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/fixCrashAliasLookupForDefauledImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fixingTypeParametersRepeatedly2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fixingTypeParametersRepeatedly3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/flatArrayNoExcessiveStackDepth.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/flowControlTypeGuardThenSwitch.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/forAwaitForUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forLoopEndingMultilineComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forLoopWithDestructuringDoesNotElideFollowingStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forOfStringConstituents.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forOfTransformsExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/forStatementInnerComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forwardDeclaredCommonTypes01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/forwardRefInClassProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forwardRefInEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forwardRefInTypeDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/freshLiteralInference.ts
@@ -2140,22 +1864,15 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionAndInterfaceWit
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionArgShadowing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall11.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall14.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall15.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall16.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall17.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall18.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCallOnConstrainedTypeVariable.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionDeclarationWithArgumentOfTypeFunctionTypeArray.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionDeclarationWithResolutionOfTypeNamedArguments01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionDeclarationWithResolutionOfTypeOfSameName01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionExpressionAndLambdaMatchesFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionExpressionShadowedByParams.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionExpressionWithResolutionOfTypeNamedArguments01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionExpressionWithResolutionOfTypeOfSameName01.ts
@@ -2163,11 +1880,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionExpressionWithR
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionInIfStatementInModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionLikeInParameterInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionMergedWithModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloadAmbiguity1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads11.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads14.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads15.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads16.ts
@@ -2177,17 +1889,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads19.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads20.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads21.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads22.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads23.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads24.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads25.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads26.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads27.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads28.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads29.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads30.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads31.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads32.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads33.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads34.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads35.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads36.ts
@@ -2200,15 +1901,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads42.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads43.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads44.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads45.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloadsOnGenericArity1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloadsOnGenericArity2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloadsRecursiveGenericReturnType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionParameterArityMismatch.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionReturnTypeQuery.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionSignatureAssignmentCompat1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionSubtypingOfVarArgs.ts
@@ -2217,41 +1912,28 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionToFunctionWithP
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionTypeArgumentArityErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionTypeArgumentArrayAssignment.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionTypeArgumentAssignmentCompat.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithAnyReturnTypeAndNoReturnExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements15.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithSameNameAsField.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithThrowButNoReturn1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionsMissingReturnStatementsAndExpressionsStrictNullChecks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionsWithImplicitReturnTypeAssignableToUndefined.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/funduleOfFunctionWithoutReturnTypeAnnotation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/funduleUsedAcrossFileBoundary.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fuzzy.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorES6InAMDModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorES6_4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorReturnExpressionIsChecked.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericAndNonGenericInheritedSignature1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericAndNonGenericInheritedSignature2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArgumentCallSigAssignmentCompat.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArray0.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArray1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArrayAssignmentCompatErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArrayExtenstions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArrayMethods1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArrayPropertyAssignment.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArrayWithoutTypeAnnotation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericAssignmentCompatOfFunctionSignatures1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericAssignmentCompatWithInterfaces1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericBaseClassLiteralProperty2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallInferenceConditionalType1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallInferenceConditionalType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallInferenceWithGenericLocalFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallOnMemberReturningClosedOverObject.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallSpecializedToTypeArg.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallWithFixedArguments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallWithNonGenericArgs1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallWithObjectLiteralArguments1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallWithinOwnBodyCastTypeParameterIdentity.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallbacksAndClassHierarchy.ts
@@ -2259,11 +1941,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCapturingFunctio
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericChainedCalls.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassImplementingGenericInterfaceFromAnotherModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassPropertyInheritanceSpecialization.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassStaticMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassWithStaticFactory.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassWithStaticsUsingTypeArguments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClasses2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClasses3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClasses4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassesInModule2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassesRedeclaration.ts
@@ -2275,18 +1955,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraintDeclar
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraintSatisfaction1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstructInvocationWithNoTypeArg.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericDefaults.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericDefaultsErrors.ts
 tasks/coverage/typescript/tests/cases/compiler/genericDefaultsJs.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericDerivedTypeWithSpecializedBase.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericDerivedTypeWithSpecializedBase2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionCallSignatureReturnTypeMismatch.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionInference1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionInference2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctions2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctions3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionsAndConditionalInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionsNotContextSensitive.ts
@@ -2304,16 +1980,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInstanceOf.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInterfaceFunctionTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInterfaceImplementation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInterfaceTypeCall.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInterfacesWithoutTypeArguments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericIsNeverEmptyObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericLambaArgWithoutTypeArguments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericMappedTypeAsClause.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericMemberFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericMergedDeclarationUsingTypeParameter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericMergedDeclarationUsingTypeParameter2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericMethodOverspecialization.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericNumberIndex.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericObjectCreationWithoutTypeArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericObjectLitReturnType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericObjectSpreadResultInSwitch.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericOverloadSignatures.ts
@@ -2325,13 +1996,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericRestArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericRestTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericReturnTypeFromGetter1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericSignatureIdentity.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericSignatureInheritance.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericSignatureInheritance2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericSpecializationToTypeLiteral1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericSpecializations1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericSpecializations2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericSpecializations3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericStaticAnyTypeFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTemplateOverloadResolution.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTupleWithSimplifiableElements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeArgumentInference1.ts
@@ -2339,18 +2006,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions3.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeAssertions5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeParameterEquivalence2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeReferencesRequireTypeArgs.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeUsedWithoutTypeArguments1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeUsedWithoutTypeArguments3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeWithCallableMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeWithMultipleBases1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeWithMultipleBases2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeWithMultipleBases3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeWithNonGenericBaseMisMatch.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericUnboundedTypeParamAssignability.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithCallSignatureReturningSpecialization.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithCallSignatures1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithIndexerOfTypeParameterType2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithOpenTypeParameters1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics0.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics1NoError.ts
@@ -2363,20 +2026,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericsAndHigherOrderFunctions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericsWithDuplicateTypeParameters1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericsWithoutTypeParameters1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/getAndSetAsMemberNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/getParameterNameAtPosition.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/getSetEnumerable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/getsetReturnTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/getterErrorMessageNotDuplicated.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/getterMissingReturnError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/getterSetterNonAccessor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/getterSetterSubtypeAssignment.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/getterThatThrowsShouldNotNeedReturn.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/gettersAndSetters.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/gettersAndSettersAccessibility.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/gettersAndSettersErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/gettersAndSettersTypesAgree.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/global.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalIsContextualKeyword.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalThisCapture.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/grammarAmbiguities1.ts
@@ -2387,12 +2044,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/homomorphicMappedTypeWi
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/hugeDeclarationOutputGetsTruncatedWithError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/i3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/icomparable.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/idInProp.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/identicalGenericConditionalsWithInferRelated.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/identicalTypesNoDifferByCheckOrder.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/identityAndDivergentNormalizedTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/identityRelationNeverTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/ifElseWithStatements1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ifStatementInternalComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ignoredJsxAttributes.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/illegalGenericWrapping1.ts
@@ -2404,9 +2059,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementGenericWithMis
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementInterfaceAnyMemberWithVoid.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementPublicPropertyAsPrivate.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementsInClassExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementsIncorrectlyNoAssertion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyAmbients.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyAnyReturningFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareFunctionExprWithoutFormalType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareFunctionWithoutFormalType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareFunctionWithoutFormalType2.ts
@@ -2436,30 +2089,20 @@ tasks/coverage/typescript/tests/cases/compiler/impliedNodeFormatEmit4.ts
 Unexpected estree file content error: 3 != 10
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/impliedNodeFormatInterop1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAliasAnExternalModuleInsideAnInternalModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAliasFromNamespace.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAliasInModuleAugmentation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAnImport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAndVariableDeclarationConflict1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAndVariableDeclarationConflict3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAndVariableDeclarationConflict4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importAsBaseClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDecl.ts
 tasks/coverage/typescript/tests/cases/compiler/importDeclFromTypeNodeInJsSource.ts
 Unexpected estree file content error: 2 != 3
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclRefereingExternalModuleWithNoResolve.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclWithDeclareModifier.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclWithDeclareModifierInAmbientContext.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclWithExportModifier.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclWithExportModifierAndExportAssignment.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclWithExportModifierInAmbientContext.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclarationNotCheckedAsValueWhenTargetNonValue.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclarationUsedAsTypeQuery.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importElisionEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importElisionExportNonExportAndDefault.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importEqualsError45874.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importExportInternalComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersAmd.ts
@@ -2474,9 +2117,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersInIsolated
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersInTsx.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersNoEmitHelpersExportDefault.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersNoHelpers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersNoHelpersForAsyncGenerators.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersNoHelpersForPrivateFields.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersNoModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersOutFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersSystem.ts
 tasks/coverage/typescript/tests/cases/compiler/importHelpersVerbatimModuleSyntax.ts
@@ -2488,8 +2128,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersWithImport
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersWithImportOrExportDefaultNoTslib.3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importHelpersWithLocalCollisions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importInTypePosition.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember1.ts
 tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember10.ts
 Unexpected estree file content error: 1 != 2
 
@@ -2499,8 +2137,6 @@ Unexpected estree file content error: 1 != 2
 tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember12.ts
 Unexpected estree file content error: 1 != 3
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember3.ts
 tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember8.ts
 Unexpected estree file content error: 1 != 2
 
@@ -2511,7 +2147,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNotElidedWhenNotF
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importOnAliasedIdentifiers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importPropertyFromMappedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importShouldNotBeElidedInDeclarationEmit.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importTypeGenericArrowTypeParenthesized.ts
 tasks/coverage/typescript/tests/cases/compiler/importTypeResolutionJSDocEOF.ts
 Unexpected estree file content error: 1 != 2
 
@@ -2522,8 +2157,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/importUsedInExtendsList
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importUsedInGenericImportResolves.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importWithTrailingSlash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importWithTrailingSlash_noResolve.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/import_reference-exported-alias.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/import_reference-to-type-alias.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/import_unneeded-require-when-referenecing-aliased-type-throug-array.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importedAliasesInTypePositions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importedEnumMemberMergedWithExportedAliasIsError.ts
@@ -2534,23 +2167,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/importsInAmbientModules
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inDoesNotOperateOnPrimitiveTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inKeywordAndIntersection.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inKeywordAndUnknown.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inKeywordNarrowingWithNoUncheckedIndexedAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inKeywordTypeguard.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inOperator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inOperatorWithFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/incompatibleAssignmentOfIdenticallyNamedTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/incompatibleExports1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/incompatibleExports2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/incompatibleGenericTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/incompatibleTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/incorrectNumberOfTypeArgumentsDuringErrorReporting.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/incorrectRecursiveMappedTypeConstraint.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/incrementOnNullAssertion.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/incrementOnTypeParameter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/incrementalInvalid.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/incrementalOut.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/incrementalTsBuildInfoFile.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexAt.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexClassByNumber.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexIntoEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexSignatureAndMappedType.ts
@@ -2574,8 +2198,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexSignaturesInferent
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/indexTypeCheck.ts
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexTypeNoSubstitutionTemplateLiteral.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexWithUndefinedAndNull.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexWithUndefinedAndNullStrictNullChecks.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/indexWithoutParamType.ts
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessAndNullableNarrowing.ts
@@ -2614,14 +2236,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferFromGenericFunctio
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferFromGenericFunctionReturnTypes3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferFromNestedSameShapeTuple.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferObjectTypeFromStringLiteralToKeyof.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferParameterWithMethodCallInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferPropertyWithContextSensitiveReturnStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferRestArgumentsMappedTuple.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferSecondaryParameter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferSetterParamType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferStringLiteralUnionForBindingElement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferTInParentheses.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferTupleFromBindingPattern.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferTypeArgumentsInSignatureWithRestParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferTypeConstraintInstantiationCircularity.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferTypeParameterConstraints.ts
@@ -2635,7 +2254,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceErasedSignatur
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceExactOptionalProperties1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceExactOptionalProperties2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceFromIncompleteSource.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceFromParameterlessLambda.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceLimit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceOfNullableObjectTypesWithCommonBase.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceOptionalProperties.ts
@@ -2653,7 +2271,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFu
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionTypeZip.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithObjectLiteralProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentiallyTypingAnEmptyArray.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferredFunctionReturnTypeIsEmptyType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferredNonidentifierTypesGetQuotes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferredRestTypeFixedOnce.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferredReturnTypeIncorrectReuse1.ts
@@ -2661,7 +2278,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferrenceInfiniteLoopW
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferringAnyFunctionType1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferringAnyFunctionType3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferringAnyFunctionType5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferringReturnTypeFromConstructSignatureGeneric.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/infiniteConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/infiniteExpandingTypeThroughInheritanceInstantiation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingBaseTypes1.ts
@@ -2679,22 +2295,13 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritSameNamePrivateP
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritSameNamePrivatePropertiesFromSameOrigin.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritSameNamePropertiesWithDifferentOptionality.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritSameNamePropertiesWithDifferentVisibility.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritance1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceGrandParentPrivateMemberCollision.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceGrandParentPrivateMemberCollisionWithPublicMember.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceGrandParentPublicMemberCollisionWithPrivateMember.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceOfGenericConstructorMethod1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritanceOfGenericConstructorMethod2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedConstructorPropertyContextualType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedConstructorWithRestParams.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedConstructorWithRestParams2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedFunctionAssignmentCompatibility.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedGenericCallSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedMembersAndIndexSignaturesFromDifferentBases.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedMembersAndIndexSignaturesFromDifferentBases2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedModuleMembersForClodule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedOverloadedSpecializedSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedStringIndexersFromDifferentBaseTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedStringIndexersFromDifferentBaseTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/initializePropertiesWithRenamedLet.ts
@@ -2704,16 +2311,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/initializersInAmbientEn
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inlineConditionalHasSimilarAssignability.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inlineMappedTypeModifierDeclarationEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inlineSourceMap2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inlineSources.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inlineSources2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inlinedAliasAssignableToConstraintSameAsAlias.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/innerAliases.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/innerAliases2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/innerBoundLambdaEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/innerExtern.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/innerFunc.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/innerOverloads.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/innerTypeCheckOfLambdaArgument.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceAndStaticDeclarations1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceOfAssignability.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceOfInExternalModules.ts
@@ -2725,7 +2325,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceofWithPrimitive
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceofWithStructurallyIdenticalTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiateContextualTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiateContextuallyTypedGenericThis.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiateCrossFileMerge.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiatedBaseTypeConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiatedReturnTypeContravariance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiatedTypeAliasDisplay.ts
@@ -2742,7 +2341,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceClassMerging.t
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceClassMerging2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceContextualType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceDeclaration1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceDeclaration2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceDeclaration3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceDeclaration5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceDeclaration6.ts
@@ -2757,13 +2355,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceInReopenedModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceInheritance.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceInheritance2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceMayNotBeExtendedWitACall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceMemberValidation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceMergedUnconstrainedNoErrorIrrespectiveOfOrder.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceNameAsIdentifier.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceOnly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfacePropertiesWithSameName1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfacePropertiesWithSameName2.ts
@@ -2784,7 +2378,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInside
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideLocalModuleWithoutExportAccessError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideTopLevelModuleWithExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasEnumInsideTopLevelModuleWithoutExport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideLocalModuleWithExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideLocalModuleWithoutExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideLocalModuleWithoutExportAccessError.ts
@@ -2795,7 +2388,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInitialize
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideLocalModuleWithoutExportAccessError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideTopLevelModuleWithExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideTopLevelModuleWithoutExport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInterfaceInsideLocalModuleWithExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInterfaceInsideLocalModuleWithoutExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasInterfaceInsideLocalModuleWithoutExportAccessError.ts
@@ -2807,7 +2399,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitiali
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideLocalModuleWithoutExportAccessError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideTopLevelModuleWithExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasUninitializedModuleInsideTopLevelModuleWithoutExport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasVar.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideLocalModuleWithExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideLocalModuleWithoutExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideLocalModuleWithoutExportAccessError.ts
@@ -2842,20 +2433,15 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionsOfLargeUni
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intraBindingPatternReferences.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intrinsics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidConstraint1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidSymbolInTypeParameter1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidThisEmitInContextualObjectLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidTripleSlashReference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidTypeNames.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidUseOfTypeAsNamespace.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/invariantGenericErrorElaboration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/invokingNonGenericMethodWithTypeArguments1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/invokingNonGenericMethodWithTypeArguments2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ipromise2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ipromise3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ipromise4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isDeclarationVisibleNodeKinds.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorTypes1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsAugmentation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsClasses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsClassesExpressions.ts
@@ -2867,7 +2453,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErro
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsObjects.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsReturnTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationLazySymbols.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationOutFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsAddUndefined2.ts
 tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsAllowJs.ts
 Unexpected estree file content error: 1 != 2
@@ -2876,7 +2461,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationsLit
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesAmbientConstEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesConstEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesDontElideReExportStar.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesExportDeclarationType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesExportImportUninstantiatedNamespace.ts
@@ -2885,18 +2469,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesImportCo
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesImportConstEnumTypeOnly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesImportExportElision.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesNoEmitOnError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesNoExternalModuleMultiple.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesNonAmbientConstEnum.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesPlainFile-AMD.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesPlainFile-CommonJS.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesPlainFile-ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesPlainFile-System.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesPlainFile-UMD.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesReExportAlias.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesReExportType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesRequiresPreserveConstEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesShadowGlobalTypeNotValue.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesSketchyAliasLocalMerge.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesSourceMap.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesSpecifiedModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesUnspecifiedModule.ts
@@ -3000,7 +2577,6 @@ Unexpected estree file content error: 1 != 2
 tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationWithOut.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationWithOutDeclarationFileNameSameAsInputJsFile.ts
 tasks/coverage/typescript/tests/cases/compiler/jsFileCompilationWithOutFileNameSameAsInputJsFile.ts
 Unexpected estree file content error: 1 != 2
 
@@ -3031,7 +2607,6 @@ tasks/coverage/typescript/tests/cases/compiler/jsdocReferenceGlobalTypeInCommonJ
 Unexpected estree file content error: 2 != 3
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsonFileImportChecksCallCorrectlyTwice.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxAttributeWithoutExpressionReact.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxCallElaborationCheckNoCrash1.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxCallbackWithDestructuring.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxChildWrongType.tsx
@@ -3063,7 +2638,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFragmentFactoryRefer
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFragmentWrongType.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxGenericComponentWithSpreadingResultOfGenericFunction.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxHasLiteralType.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxHash.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxImportForSideEffectsNonExtantNoError.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxImportInAttribute.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxImportSourceNonPragmaComment.tsx
@@ -3071,14 +2645,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxInExtendsClause.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxInferenceProducesLiteralAsExpected.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicDeclaredUsingTemplateLiteralTypeSignatures.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicElementsCompatability.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicElementsExtendsRecord.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicElementsTypeArgumentErrors.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicUnions.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxIssuesErrorWhenTagExpectsTooManyArguments.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxLibraryManagedAttributesUnusedGeneric.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxLocalNamespaceIndexSignatureNoCrash.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxMultilineAttributeStringValues.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxMultilineAttributeValuesReact.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceElementChildrenAttributeIgnoredWhenReactJsx.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceGlobalReexport.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceGlobalReexportMissingAliasTarget.tsx
@@ -3095,20 +2666,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxPropsAsIdentifierNam
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxSpreadFirstUnionNoErrors.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxViaImport.2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxViaImport.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/keepImportsInDts3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/keepImportsInDts4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/keyRemappingKeyofResult.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/keyofDoesntContainSymbols.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/keyofGenericExtendingClassDoubleLayer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/keyofIsLiteralContexualType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/keyofModuleObjectHasCorrectKeys.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/keyofObjectWithGlobalSymbolIncluded.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/keywordExpressionInternalComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/keywordField.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/keywordInJsxIdentifier.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/knockout.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/lambdaASIEmit.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/lambdaArgCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/lambdaExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/lambdaParamTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/lambdaParameterWithTupleArgsHasCorrectAssignability.ts
@@ -3119,21 +2684,15 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/lastPropertyInLiteralWi
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundConstraintTypeChecksCorrectly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundDestructuringImplicitAnyError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundFunctionMemberAssignmentDeclarations.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/letConstMatchingParameterNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-access.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-es5-1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-es5.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-invalidContexts.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-scopes-duplicates.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-scopes.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-scopes2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-useBeforeDefinition.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-useBeforeDefinition2.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/letDeclarations-validContexts.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/letDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/letInConstDeclarations_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/letInConstDeclarations_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/letInLetConstDeclOfForOfAndForIn_ES5.ts
@@ -3162,7 +2721,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/limitDeepInstantiations
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/listFailure.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/literalFreshnessPropagationOnNarrowing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/literalIntersectionYieldsLiteral.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/literalTypeNameAssertionNotTriggered.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/literalWideningWithCompoundLikeAssignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/literals-negative.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/literalsInComputedProperties1.ts
@@ -3172,7 +2730,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/localImportNameVsGlobal
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/localTypeParameterInferencePriority.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/m7Bugs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/manyConstExports.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/mapConstructorOnReadonlyTuple.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mapGroupBy.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mapOnTupleTypes01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mapOnTupleTypes02.ts
@@ -3218,7 +2775,6 @@ Unexpected estree file content error: 2 != 4
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/maximum10SpellingSuggestions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/memberAccessMustUseModuleInstances.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/memberOverride.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/memberScope.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/memberVariableDeclarations1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergeMultipleInterfacesReexported.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergeSymbolReexportInterface.ts
@@ -3226,8 +2782,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergeSymbolReexportedTy
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergeSymbolRexportFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergeWithImportedNamespace.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergeWithImportedType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedClassNamespaceRecordCast.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedClassWithNamespacePrototype.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarationExports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations2.ts
@@ -3252,12 +2806,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingCommaInTemplateS
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingDomElements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingFunctionImplementation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingImportAfterModuleImport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingPropertiesOfClassExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingReturnStatement.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingReturnStatement1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingSelf.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingSemicolonInModuleSpecifier.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingTypeArguments1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingTypeArguments3.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/misspelledNewMetaProperty.ts
 The only valid meta property for new is new.target
@@ -3267,7 +2816,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixinIntersectionIsVali
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixinOverMappedTypeNoCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixinPrivateAndProtected.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixingApparentTypeOverrides.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixingFunctionAndAmbientModule1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/modifierParenCast.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/modifiersInObjectLiterals.ts
 'public' modifier cannot be used here.
@@ -3285,11 +2833,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_Using
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_Worker.asynciterable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_Worker.iterable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAliasAsFunctionArgument.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAliasInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceSharingName4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceWithSameName.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAssignmentCompat1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAssignmentCompat3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationCollidingNamesInAugmentation1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDeclarationEmit1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDeclarationEmit2.ts
@@ -3335,7 +2880,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationsImpo
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleClassArrayCodeGenTest.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleCodeGenTest5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleCodegenTest4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleCrashBug1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleDeclarationExportStarShadowingGlobalIsNameable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleDuplicateIdentifiers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleElementsInWrongContext.ts
@@ -3358,8 +2902,6 @@ tasks/coverage/typescript/tests/cases/compiler/moduleNoneDynamicImport.ts
 Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleNoneErrors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleOuterQualification.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePreserve1.ts
 tasks/coverage/typescript/tests/cases/compiler/modulePreserve2.ts
 Unexpected estree file content error: 2 != 4
 
@@ -3377,11 +2919,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePrologueCommonjs.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePrologueES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePrologueSystem.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePrologueUmd.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleRedifinitionErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleReopenedTypeOtherBlock.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleReopenedTypeSameBlock.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionAsTypeReferenceDirectiveScoped.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionNoResolve.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionNoTsCJS.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionNoTsESM.ts
 tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithExtensions_notSupported.ts
@@ -3393,7 +2932,6 @@ Unexpected estree file content error: 1 != 2
 tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithExtensions_notSupported3.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithExtensions_unexpected.ts
 tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithExtensions_unexpected2.ts
 Unexpected estree file content error: 1 != 2
 
@@ -3406,11 +2944,6 @@ Unexpected estree file content error: 3 != 5
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithRequire.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithRequireAndImport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_empty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_notSpecified.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_oneBlank.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_oneNotFound.ts
 tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one_externalModule.ts
 Unexpected estree file content error: 3 != 5
 
@@ -3420,20 +2953,14 @@ Unexpected estree file content error: 3 != 5
 tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one_externalModule_withPaths.ts
 Unexpected estree file content error: 3 != 5
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one_externalTSModule.ts
 tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_one_jsModule.ts
 Unexpected estree file content error: 1 != 3
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_threeLastIsBlank1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_threeLastIsBlank2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_threeLastIsBlank3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSuffixes_threeLastIsBlank4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSymlinks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSymlinks_notInNodeModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSymlinks_preserveSymlinks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSymlinks_referenceTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithSymlinks_withOutDir.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_automaticTypeDirectiveNames.ts
 tasks/coverage/typescript/tests/cases/compiler/moduleResolution_classicPrefersTs.ts
 Unexpected estree file content error: 2 != 3
 
@@ -3443,17 +2970,12 @@ Unexpected estree file content error: 1 != 2
 tasks/coverage/typescript/tests/cases/compiler/moduleResolution_explicitNodeModulesImport_implicitAny.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_noLeadingDot.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_packageJson_notAtPackageRoot.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_packageJson_notAtPackageRoot_fakeScopedPackage.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_packageJson_scopedPackage.ts
 tasks/coverage/typescript/tests/cases/compiler/moduleResolution_packageJson_yesAtPackageRoot.ts
 Unexpected estree file content error: 2 != 3
 
 tasks/coverage/typescript/tests/cases/compiler/moduleResolution_packageJson_yesAtPackageRoot_fakeScopedPackage.ts
 Unexpected estree file content error: 2 != 3
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolution_packageJson_yesAtPackageRoot_mainFieldInSubDirectory.ts
 tasks/coverage/typescript/tests/cases/compiler/moduleResolution_relativeImportJsFile.ts
 Unexpected estree file content error: 1 != 2
 
@@ -3461,7 +2983,6 @@ tasks/coverage/typescript/tests/cases/compiler/moduleResolution_relativeImportJs
 Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleSameValueDuplicateExportedBindings2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleScopingBug.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt3.ts
@@ -3469,17 +2990,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImp
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleSharesNameWithImportDeclarationInsideIt6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleSymbolMerging.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleUnassignedVariable.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleVariableArrayIndexer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleVariables.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleVisibilityTest1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleVisibilityTest2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleVisibilityTest3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleVisibilityTest4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleWithTryStatement1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/module_augmentUninstantiatedModule2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduledecl.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiCallOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiExtendsSplitInterfaces2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiImportExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiLineContextDiagnosticWithPretty.ts
@@ -3495,45 +3009,32 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/multivar.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mutrec.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mutuallyRecursiveCallbacks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mutuallyRecursiveGenericBaseTypes1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/mutuallyRecursiveGenericBaseTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mutuallyRecursiveInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mutuallyRecursiveInterfaceDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nameCollisionsInPropertyAssignments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/namedFunctionExpressionAssignedToClassProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/namedFunctionExpressionCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/namedFunctionExpressionCallErrors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/namedFunctionExpressionInModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/namedImportNonExistentName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespaceDisambiguationInUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespaceMergedWithFunctionWithOverloadsUsage.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespaceMergedWithImportAliasNoCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespaceNotMergedWithFunctionDefaultExport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespacesWithTypeAliasOnlyExportsMerge.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nanEquality.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByBooleanComparison.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByEquality.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByInstanceof.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByParenthesizedSwitchExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowBySwitchDiscriminantUndefinedCase1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowCommaOperatorNestedWithinLHS.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowRefinedConstLikeParameterBIndingElementNameInInnerScope.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowSwitchOptionalChainContainmentEvolvingArrayNoCrash1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowTypeByInstanceof.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowUnknownByTypePredicate.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowUnknownByTypeofObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowedConstInMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowedImports.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowedImports_assumeInitialized.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingAssignmentReadonlyRespectsAssertion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingByDiscriminantInLoop.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingByTypeofInSwitch.ts
@@ -3549,21 +3050,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingOrderIndepende
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingPastLastAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingPastLastAssignmentInModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingRestGenericCall.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTruthyObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofDiscriminant.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofParenthesized1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofUndefined1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofUndefined2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingUnionToNeverAssigment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingUnionToUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingUnionWithBang.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingWithNonNullExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nearbyIdenticalGenericLambdasAssignable.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/negativeZero.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedBlockScopedBindings2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedCallbackErrorNotFlattened.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedExcessPropertyChecking.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedFreshLiteral.ts
@@ -3571,30 +3065,21 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedGenericConditiona
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedGenericSpreadInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedGenerics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedHomomorphicMappedTypesWithArrayConstraint1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedIndexer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedInfinitelyExpandedRecursiveTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedLoopTypeGuards.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedLoops.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedObjectRest.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedRecursiveArraysOrObjectsError01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedRecursiveLambda.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedSelf.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedSuperCallEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedThisContainer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedTypeVariableInfersLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/neverAsDiscriminantType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/newAbstractInstance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/newAbstractInstance2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/newFunctionImplicitAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/newLexicalEnvironmentForConvertedLoop.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/newLineFlagWithCRLF.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/newLineFlagWithLF.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/newLineInTypeofInstantiation.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/newMap.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/newNamesInGlobalAugmentations1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/newNonReferenceType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noAsConstNameLookup.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noBundledEmitFromNodeModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCheckDoesNotReportError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCheckNoEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCheckRequiresEmitDeclarationOnly.ts
@@ -3606,15 +3091,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressi
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionInFunctionAndVarInGlobal.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noConstraintInReturnType1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashOnImportShadowing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashOnMixin.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashOnNoLib.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashOnThisTypeUsage.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashUMDMergedWithGlobalValue.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noDefaultLib.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noEmitHelpers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noEmitOnError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noErrorTruncation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noErrorUsingImportExportModuleAugmentationInDeclarationFile1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noErrorUsingImportExportModuleAugmentationInDeclarationFile2.ts
@@ -3631,10 +3113,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyForIn.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyForwardReferencedInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyInBareInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyInCastExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyInContextuallyTypesFunctionParamter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyIndexing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyIndexingSuppressed.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyLoopCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyMissingGetAccessor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyMissingSetAccessor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyModule.ts
@@ -3652,10 +3132,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyUnionNorma
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyWithOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsExclusions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsInAsync2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsWithoutReturnExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitSymbolToString.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitThisBigThis.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitThisFunctions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitUseStrict_amd.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitUseStrict_commonjs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitUseStrict_es6.ts
@@ -3667,27 +3145,16 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/noIterationTypeErrorsIn
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noMappedGetSet.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noObjectKeysToKeyofT.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noRepeatedPropertyNames.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noSelfOnVars.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noStrictGenericChecks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noSubstitutionTemplateStringLiteralTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noSubtypeReduction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noSymbolForMergeCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUncheckedIndexAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUncheckedIndexedAccessCompoundAssignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUnusedLocals_destructuringAssignment.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUnusedLocals_potentialPredicateUnusedParam.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUnusedLocals_selfReference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUnusedLocals_selfReference_skipsBlockLocations.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUnusedLocals_typeParameterMergedWithParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUnusedLocals_writeOnly.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUnusedLocals_writeOnlyProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUnusedLocals_writeOnlyProperty_dynamicNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUsedBeforeDefinedErrorInAmbientContext1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUsedBeforeDefinedErrorInTypeContext.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeColonModuleResolution.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeColonModuleResolution2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeModuleReexportFromDottedPath.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextImportModeImplicitIndexResolution.ts
 tasks/coverage/typescript/tests/cases/compiler/nodeNextImportModeImplicitIndexResolution2.ts
 Unexpected estree file content error: 4 != 6
 
@@ -3695,19 +3162,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextModuleResolutio
 tasks/coverage/typescript/tests/cases/compiler/nodeNextModuleResolution2.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageImportMapRootDir.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDir.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDirDeclDir.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDirDeclDirComposite.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDirDeclDirCompositeNestedDirs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDirDeclDirNestedDirs.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDirDeclDirRootDir.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeNextPackageSelfNameWithOutDirRootDir.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonArrayRestArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonConflictingRecursiveBaseTypeMembers.ts
@@ -3728,27 +3186,19 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullableTypes1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullableWithNullableGenericIndexedAccessArg.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonObjectUnionNestedExcessPropertyCheck.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nondistributiveConditionalTypeInfer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonexistentPropertyOnUnion.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonexistentPropertyUnavailableOnPromisedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nongenericConditionalNotPartiallyComputed.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nongenericPartialInstantiationsRelatedInBothDirections.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonstrictTemplateWithNotOctalPrintsAsIs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/normalizedIntersectionTooComplex.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/null.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nullableFunctionError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/numberAssignableToEnumInsideUnion.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/numberToString.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/numberVsBigIntOperations.ts
 Missing initializer in const declaration
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericClassMembers1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericEnumMappedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexExpressions.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericMethodName1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericUnderscoredSeparator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectAssignLikeNonUnionResult.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectBindingPatternContextuallyTypesArgument.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectBindingPattern_restElementWithPropertyName.ts
@@ -3757,7 +3207,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectCreate2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectCreationOfElementAccessExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectFreeze.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectFreezeLiteralsDontWiden.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectFromEntries.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectGroupBy.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectIndexer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectInstantiationFromUnionSpread.ts
@@ -3791,7 +3240,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralThisWidene
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralWithGetAccessorInsideFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralWithNumericPropertyName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralsAgainstUnionsOfArrays01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectMembersOnTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectRestBindingContextualInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectRestSpread.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectSpreadWithinMethodWithinObjectWithSpread.ts
@@ -3803,11 +3251,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/operationsAvailableOnPr
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/operatorAddNullUndefined.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalAccessorsInInterface1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalChainWithInstantiationExpression2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalConstructorArgInSuper.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalFunctionArgAssignability.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParamArgsTest.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParamAssignmentCompat.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParamInOverride.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParameterInDestructuringWithInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParameterProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParameterRetainsNull.ts
@@ -3815,22 +3261,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParamterAndVari
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParamterAndVariableDeclaration2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalPropertiesInClasses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalPropertiesTest.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalSetterParam.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalTupleElementsAndUndefined.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsCompositeWithIncrementalFalse.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsOutAndNoModuleGen.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsStrictPropertyInitializationStrict.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsStrictPropertyInitializationStrictNullChecks.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsTsBuildInfoFileWithoutIncrementalAndComposite.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/out-flag.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/out-flag2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/out-flag3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/outModuleConcatCommonjs.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/outModuleConcatCommonjsDeclarationOnly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/outModuleConcatES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/outModuleConcatUmd.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/outModuleConcatUnspecifiedModuleKindDeclarationOnly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/outModuleTripleSlashRefs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overEagerReturnTypeSpecialization.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overload1.ts
@@ -3838,14 +3276,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/overload2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadAssignmentCompat.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadBindingAcrossDeclarationBoundaries.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadBindingAcrossDeclarationBoundaries2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadCallTest.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadCrash.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadEquivalenceWithStatics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadGenericFunctionWithRestArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadModifiersMustAgree.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstConstraintChecks1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstConstraintChecks3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstConstraintChecks4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInBaseWithBadImplementationInDerived.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInObjectLiteralImplementingAnInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInheritance1.ts
@@ -3853,25 +3287,19 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInherita
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInheritance3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInheritance4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstNoAnyImplementation2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstNoNonSpecializedSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstNoStringImplementation2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnGenericArity.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnGenericClassAndNonGenericClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOverNonCTLambdas.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOverNonCTObjectLit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionTest1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadRet.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadReturnTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadWithCallbacksWithDifferingOptionalityOnArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadedConstructorFixesInferencesAppropriately.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadedStaticMethodSpecialization.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadingOnConstants1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadresolutionWithConstraintCheckingDeferred.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsAndTypeArgumentArityErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsWithComputedNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsWithConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsWithProvisionalErrors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsWithinClasses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overrideBaseIntersectionMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overridingPrivateStaticMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overshifts.ts
@@ -3896,30 +3324,19 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseArrowFunctionWithF
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseCommaSeparatedNewlineNumber.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseCommaSeparatedNewlineString.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseEntityNameWithReservedWord.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseGenericArrowRatherThanLeftShift.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseInvalidNonNullableTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseInvalidNullableTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseObjectLiteralsWithoutTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseReplacementCharacter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseShortform.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseTypes.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/parserConstructorDeclaration12.ts
 Type parameters cannot appear on a constructor declaration
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/parserIsClassMemberStart.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/parsingClassRecoversWhenHittingUnexpectedSemicolon.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/partialDiscriminatedUnionMemberHasGoodError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/partialOfLargeAPIIsAbleToBeWorkedWith.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/partialTypeNarrowedToByTypeGuard.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/partiallyDiscriminantedUnions.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution1_amd.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution1_node.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution3_classic.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution3_node.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution5_node.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution7_classic.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution7_node.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution8_classic.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution8_node.ts
 tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution_rootImport_aliasWithRoot.ts
 Unexpected estree file content error: 2 != 3
 
@@ -3941,28 +3358,19 @@ Unexpected estree file content error: 2 != 3
 tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution_withExtension.ts
 Unexpected estree file content error: 2 != 3
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution_withExtensionInName.ts
 tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution_withExtension_MapedToNodeModules.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingInheritedBaseUrl.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingWithoutBaseUrl1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingWithoutBaseUrl2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/performanceComparisonOfStructurallyIdenticalInterfacesWithGenericSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pickOfLargeObjectUnionWorks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pinnedComments1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/potentiallyUnassignedVariableInCatch.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/potentiallyUncalledDecorators.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/predicateSemantics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/prefixIncrementAsOperandOfPlusExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/prefixUnaryOperatorsOnExportedVariables.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/preserveConstEnums.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/preserveUnusedImports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/prespecializedGenericMembers1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/primaryExpressionMods.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveConstraints1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveMembers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveTypeAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveUnionDetection.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCannotNameAccessorDeclFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCannotNameVarTypeDeclFile.ts
@@ -3974,27 +3382,20 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCheckExportAssig
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCheckExternalModuleExportAssignmentOfGenericClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCheckOnTypeParameterReferenceInConstructorParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCheckTypeOfFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCheckTypeOfInvisibleModuleError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCheckTypeOfInvisibleModuleNoError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyClass.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyClassExtendsClauseDeclFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyClassImplementsClauseDeclFile.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyFunc.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyFunctionCannotNameParameterTypeDeclFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyFunctionCannotNameReturnTypeDeclFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyFunctionParameterDeclFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyFunctionReturnTypeDeclFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyGetter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyGloClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyGloFunc.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyGloImportParseErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyGloInterface.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyGloVar.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyImport.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/privacyImportParseErrors.ts
 'export' modifier cannot be used here.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyInterface.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyInterfaceExtendsClauseDeclFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyLocalInternalReferenceImportWithExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyLocalInternalReferenceImportWithoutExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyTopLevelAmbientExternalModuleImportWithExport.ts
@@ -4010,17 +3411,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOf
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyVar.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyVarDeclFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateFieldAssignabilityFromUnknown.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateInstanceVisibility.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateInterfaceProperties.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateNameWeakMapCollision.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privatePropertyInUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privatePropertyUsingObjectType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateVisibility.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateVisibles.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseChaining.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseChaining1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseChaining2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseDefinitionTest.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseEmptyTupleNoException.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseIdentity.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseIdentity2.ts
@@ -4030,48 +3426,35 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseIdentityWithCons
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promisePermutations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promisePermutations2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promisePermutations3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseTry.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseTypeInference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseTypeStrictNull.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseVoidErrorCallback.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseWithResolvers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promises.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promisesWithConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propTypeValidatorInference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/propagateNonInferrableType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propagationOfPromiseInitialization.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertiesAndIndexers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertiesAndIndexers2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertiesAndIndexersForNumericNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccess1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccessExpressionInnerComments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccessOfReadonlyIndexSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccessOnObjectLiteral.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccessibility1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccessibility2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyIdentityWithPrivacyMismatch.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyNamesWithStringLiteral.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyOrdering.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyOrdering2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyOverridingPrototype.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyParameterWithQuestionMark.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertySignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/protectedAccessThroughContextualThis.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/protectedMembers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/protectedMembersThisParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/protoAsIndexInIndexExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/protoAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/prototypeOnConstructorFunctions.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/publicGetterProtectedSetterFromThisParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/publicMemberImplementedAsPrivateInDerivedClass.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/qualifiedModuleLocals.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/qualify.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/quickinfoTypeAtReturnPositionsInaccurate.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/raiseErrorOnParameterProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ramdaToolsNoInfinite.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ramdaToolsNoInfinite2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/randomSemicolons1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportGlobalDeclaration1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportGlobalDeclaration2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportUndefined1.ts
@@ -4089,11 +3472,6 @@ tasks/coverage/typescript/tests/cases/compiler/reactImportDropped.ts
 Unexpected estree file content error: 1 != 3
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactImportUnusedInNewJSXEmit.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactJsxReactResolvedNodeNext.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactJsxReactResolvedNodeNextEsm.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactNamespaceImportPresevation.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactNamespaceInvalidInput.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactNamespaceJSXEmit.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactNamespaceMissingDeclaration.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactReadonlyHOCAssignabilityReal.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactReduxLikeDeferredInferenceAllowsAssignment.ts
@@ -4106,23 +3484,16 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyInDeclarationFi
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyPropertySubtypeRelationDirected.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyTupleAndArrayElaboration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reassignStaticProp.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reboundBaseClassSymbol.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/rectype.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recur1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveArrayNotCircular.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseCheck.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseCheck2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseCheck3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseCheck4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseCheck5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseCheck6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseConstructorCreation1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseConstructorCreation2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveClassBaseType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveClassReferenceTest.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveCloduleReference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalCrash1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalCrash2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalCrash3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalCrash4.ts
@@ -4134,17 +3505,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignme
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveFieldSetting.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveGenericMethodCall.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveGenericSignatureInstantiation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveGenericTypeHierarchy.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveGenericUnionType1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveGenericUnionType2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveGetterAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveIdenticalAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveIdenticalOverloadResolution.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveInferenceBug.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveInheritance.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveInheritance2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveInheritance3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveInheritanceGeneric.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveLetConst.ts
@@ -4175,30 +3540,21 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/redeclarationOfVarWithG
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/redeclareParameterInCatchBlock.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reducibleIndexedAccessTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportDefaultIsCallable.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportMissingDefault1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportNameAliasedAndHoisted.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportWrittenCorrectlyInDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reexportedMissingAlias.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/referenceSatisfiesExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/referenceTypesPreferedToPathIfPossible.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/regExpWithOpenBracketInCharClass.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/regExpWithSlashInCharClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/regexMatchAll-esnext.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/regexMatchAll.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/regexpExecAndMatchTypeUsages.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/regularExpressionAnnexB.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/regularExpressionCharacterClassRangeOrder.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/regularExpressionExtendedUnicodeEscapes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/regularExpressionGroupNameSuggestions.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/regularExpressionScanning.ts
 Unexpected flag a in regular expression literal
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/regularExpressionUnicodePropertyValueExpressionSuggestions.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/regularExpressionWithNonBMPFlags.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/relatedViaDiscriminatedTypeNoError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/relatedViaDiscriminatedTypeNoError2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/relationComplexityError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/relationalOperatorComparable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/renamingDestructuredPropertyInFunctionType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/renamingDestructuredPropertyInFunctionType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/renamingDestructuredPropertyInFunctionType3.ts
@@ -4210,7 +3566,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireEmitSemicolon.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfAnEmptyFile1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileNonRelative.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileNonRelativeWithoutExtensionResolvesToTs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithAlwaysStrictWithoutErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithAmd.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithDeclaration.ts
@@ -4228,12 +3583,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/requiredInitializedPara
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requiredInitializedParameter2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requiredInitializedParameter3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requiredMappedTypeModifierTrumpsVariance.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reservedNameOnInterfaceImport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reservedNameOnModuleImport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reservedNameOnModuleImportWithInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reservedWords.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/resolutionCandidateFromPackageJsonField1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/resolutionCandidateFromPackageJsonField2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/resolveInterfaceNameWithSameLetDeclarationName1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/resolveInterfaceNameWithSameLetDeclarationName2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/resolveModuleNameWithSameLetDeclarationName1.ts
@@ -4242,7 +3592,6 @@ tasks/coverage/typescript/tests/cases/compiler/resolveNameWithNamspace.ts
 Unexpected estree file content error: 2 != 3
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/resolveTypeAliasWithSameLetDeclarationName1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/resolvingClassDeclarationWhenInBaseTypeResolution.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/restArgAssignmentCompat.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/restElementAssignable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/restElementWithNumberPropertyName.ts
@@ -4273,12 +3622,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnStatement1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypeInferenceNotTooBroad.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypePredicateIsInstantiateInContextOfTarget.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypeTypeArguments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnValueInSetter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reuseInnerModuleMember.ts
 tasks/coverage/typescript/tests/cases/compiler/reuseTypeAnnotationImportTypeInGlobalThisTypeArgument.ts
 Unexpected estree file content error: 2 != 4
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseInferenceInContextualInstantiation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedContravariantInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedIntersectionInference1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedIntersectionInference2.ts
@@ -4296,25 +3643,16 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeRecurs
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedUnionInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reversedRecusiveTypeInstantiation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/satisfiesEmit.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/scopeCheckClassProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/scopeCheckStaticInitializer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/scopingInCatchBlocks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfInLambdas.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfNameAndImportsEmitInclusion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfRef.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencingFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencingFile2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencingFile3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencingSpreadInLoop.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencingTypeReferenceInference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferentialFunctionType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/semicolonsInModuleDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/setMethods.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/setterBeforeGetter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/shadowPrivateMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/shadowedFunctionScopedVariablesByBlockScopedOnes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/shadowedReservedCompilerDeclarationsWithNoEmit.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/shadowingViaLocalValue.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/shadowingViaLocalValueOrBindingElement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/shebang.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/shebangBeforeReferences.ts
@@ -4334,7 +3672,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/sideEffectImports1.ts
 tasks/coverage/typescript/tests/cases/compiler/sideEffectImports2.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sideEffectImports3.ts
 tasks/coverage/typescript/tests/cases/compiler/sideEffectImports4.ts
 Unexpected estree file content error: 1 != 3
 
@@ -4345,22 +3682,15 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureCombiningRestP
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureCombiningRestParameters4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureCombiningRestParameters5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureInstantiationWithRecursiveConstraints.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureLengthMismatchCall.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureLengthMismatchInOverload.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureLengthMismatchWithOptionalParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureOverloadsWithComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/silentNeverPropagation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/simpleArrowFunctionParameterReferencedInObjectLiteral1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/simpleRecursionWithBaseCase1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/simpleRecursionWithBaseCase2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/simpleRecursionWithBaseCase3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/simpleRecursionWithBaseCase4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/simplifyingConditionalWithInteriorConditionalIsRelated.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/slightlyIndirectedDeepObjectLiteralElaborations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-Comment1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-Comments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-FileWithComments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-SemiColon1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-SingleSpace1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-StringLiteralWithNewLine.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapForFunctionInInternalModuleWithCommentPrecedingStatement01.ts
@@ -4431,11 +3761,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapWithNonCaseSen
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/specedNoStackBlown.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/specialIntersectionsInMappedTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializationError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializationOfExportedClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializationsShouldNotAffectEachOther.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializeVarArgs1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializedInheritedConstructors1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializedLambdaTypeArguments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializedOverloadWithRestParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializedSignatureOverloadReturnTypeWithIndexers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionGlobal1.ts
@@ -4444,14 +3772,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionGloba
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionGlobal4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionJSXAttribute.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionLeadingUnderscores01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/spliceTuples.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadExpressionContainingObjectExpressionContextualType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadExpressionContextualType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadExpressionContextualTypeWithNamespace.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadIdenticalTypesRemoved.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadIntersection.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadIntersectionJsx.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadInvalidArgumentType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadObjectNoCircular1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadObjectPermutations.ts
@@ -4461,7 +3786,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadOfParamsFromGener
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadParameterTupleType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadTupleAccessedByTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadTypeRemovesReadonly.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadsAndContextualTupleTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spuriousCircularityOnTypeImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spyComparisonChecking.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stackDepthLimitCastingType.ts
@@ -4469,24 +3793,17 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticAnonymousTypeNotR
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticFieldWithInterfaceContext.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticGetter1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticGetter2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticGetterAndSetter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInheritance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInitializersAndLegacyClassDecorators.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInterfaceAssignmentCompat.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMemberAccessOffDerivedType1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMemberExportAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMethodReferencingTypeArgument1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMethodWithTypeParameterExtendsClauseDeclFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMismatchBecauseOfPrototype.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMustPrecedePublic.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticOffOfInstance2.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/staticPrototypeProperty.ts
 Classes may not have a static property named prototype
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticVisibility.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/statics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stradac.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictFunctionTypes1.ts
@@ -4518,37 +3835,27 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringMappingAssignabil
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringMatchAll.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringPropCodeGen.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringRawType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringTrim.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stripMembersOptionality.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/structural1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/styleOptions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/styledComponentsInstantiaionLimitNotReached.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/subSubClassCanAccessProtectedConstructor.ts
 tasks/coverage/typescript/tests/cases/compiler/subclassThisTypeAssignable01.ts
 Unexpected estree file content error: 1 != 2
 
 tasks/coverage/typescript/tests/cases/compiler/subclassThisTypeAssignable02.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/subclassUint8Array.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/subclassWithPolymorphicThisIsAssignable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/substituteReturnTypeSatisfiesConstraint.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypeForIndexedAccessType2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypeForNonGenericIndexedAccessType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypeNoMergeOfAssignableType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypePassedToExtends.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypesCompareCorrectlyInRestrictiveInstances.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypesInIndexedAccessTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/subtypeReductionUnionConstraints.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/subtypeRelationForNever.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/subtypingTransitivity.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/super.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/super1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/super2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superAccessCastedCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallArgsMustMatch.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericType1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericTypeButWithIncorrectNumberOfTypeArguments1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericTypeButWithNoTypeArguments1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesNonGenericTypeButWithTypeArguments1.ts
@@ -4556,23 +3863,15 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatH
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallInNonStaticMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallInStaticMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallInsideObjectLiteralExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallOutsideConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallWithCommentEmit01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superHasMethodsFromMergedInterface.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superInCatchBlock1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superInObjectLiterals_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superInObjectLiterals_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superNewCall1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superWithGenerics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/super_inside-object-literal-getters-and-setters.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchAssignmentCompat.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchCaseCircularRefeference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchCaseInternalComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchCases.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchCasesExpressionTypeMismatch.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchComparableCompatForBrands.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchFallThroughs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/symbolLinkDeclarationEmitModuleNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/symbolLinkDeclarationEmitModuleNamesImportRef.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/symbolLinkDeclarationEmitModuleNamesRootDir.ts
@@ -4584,9 +3883,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/symlinkedWorkspaceDepen
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/syntheticDefaultExportsWithDynamicImports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemDefaultExportCommentValidity.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemDefaultImportCallable.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemExportAssignment.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemExportAssignment2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemExportAssignment3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemJsForInNoException.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule10.ts
@@ -4597,7 +3893,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule14.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule15.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule16.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule18.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule4.ts
@@ -4631,8 +3926,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplateWithoutDe
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplatesInDifferentScopes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplatesInModuleAndGlobal.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tailRecursiveConditionalTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetEs6DecoratorMetadataImportNotElided.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypeArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypeCastTest.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypeObjectLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypeObjectLiteralToAny.ts
@@ -4658,25 +3951,18 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/testTypings.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisBinding.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisBinding2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisConditionalOnMethodReturnOfGenericInstance.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisExpressionInCallExpressionWithTypeArguments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisExpressionOfGenericObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInAccessors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInClassBodyStaticESNext.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInConstructorParameter2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInFunctionCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInGenericStaticMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInInnerFunctions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInPropertyBoundDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInSuperCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInSuperCall1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInSuperCall2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInSuperCall3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInTupleTypeParameterConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInTypeQuery.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisIndexOnExistingReadonlyFieldIsNotNever.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisPredicateInObjectLiteral.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisShadowingErrorSpans.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisWhenTypeCheckFails.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/this_inside-enum-should-not-be-allowed.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/this_inside-object-literal-getters-and-setters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tooFewArgumentsInGenericFunctionTypedArgument.ts
@@ -4686,10 +3972,8 @@ tasks/coverage/typescript/tests/cases/compiler/topLevelBlockExpando.ts
 Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevelExports.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevelLambda.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevelLambda4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/trackedSymbolsNoCrash.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/trailingCommaInHeterogenousArrayLiteral1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/trailingCommasES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/transformArrowInBlockScopedLoopVarInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/transformNestedGeneratorsWithTry.ts
@@ -4707,7 +3991,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressio
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessPromiseCoercion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tryCatchFinallyControlFlow.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tryStatementInternalComments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsconfigExtendsPackageJsonExportsWildcard.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsconfigMapOptionsAreCaseInsensitive.ts
 tasks/coverage/typescript/tests/cases/compiler/tslibMissingHelper.ts
 Unexpected estree file content error: 3 != 4
@@ -4740,11 +4023,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxUnionMemberChecksFil
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxUnionSpread.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tupleTypeInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tupleTypeInference2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/tupleTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/twiceNestedKeyofIndexInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasDeclarationEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasDeclarationEmit2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasDeclarationEmit3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasFunctionTypeSharedSymbol.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAnnotationBestCommonTypeInArrayLiteral.ts
@@ -4752,20 +4033,15 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgInference2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgInference2WithError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgInferenceWithNull.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentConstraintResolution1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentDefaultUsesConstraintOnCircularDefault.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceOrdering.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceWithConstraintAsCommonRoot.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceWithRecursivelyReferencedTypeAliasToTypeLiteral01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceWithRecursivelyReferencedTypeAliasToTypeLiteral02.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentsInFunctionExpressions.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentsOnFunctionsWithNoTypeParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAssertionToGenericFunctionType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAssignabilityErrorMessage.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeCheckObjectCreationExpressionWithUndefinedCallResolutionData.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeCheckObjectLiteralMethodBody.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeCheckTypeArgument.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeCheckingInsideFunctionExpressionInArray.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeComparisonCaching.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeConstraintsWithConstructSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardConstructorClassAndNumber.ts
@@ -4781,21 +4057,15 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexed
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardOnContainerTypeNoHang.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeIdentityConsidersBrands.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInfer1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceCacheInvalidation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceFBoundedTypeParams.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceLiteralUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceReturnTypeCallback.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceTypePredicate.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceTypePredicate2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceWithExcessProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceWithExcessPropertiesJsx.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInterfaceDeclarationsInBlockStatements1.ts
@@ -4807,15 +4077,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeNamedUndefined1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeNamedUndefined2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfEnumAndVarRedeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfOnTypeArg.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfPrototype.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfThisInStatics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfYieldWithUnionInContextualReturnType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParamExtendsOtherTypeParam.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEquivalence.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEquivalence2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEquivalence3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEquivalence4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterArgumentEquivalence5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterAssignmentCompat1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterCompatibilityAccrossDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterConstrainedToOuterTypeParameter2.ts
@@ -4829,14 +4092,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWith
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterHasSelfAsConstraint.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterLeak.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterOrderReversal.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersInStaticAccessors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersInStaticMethods.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersShouldNotBeEqual.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersShouldNotBeEqual2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersShouldNotBeEqual3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePartameterConstraintInstantiatedWithDefaultWhenCheckingDefault.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicateAcceptingPartialOfRefinedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicateFreshLiteralWidening.ts
@@ -4847,13 +4106,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicateTopLevelTy
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicateWithThisParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesCanNarrowByDiscriminant.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion_noMatch.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesOptionalChaining1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesOptionalChaining2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesOptionalChaining3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectiveWithTypeAsFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives11.ts
@@ -4872,26 +4129,19 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeUsedAsTypeLiteralIn
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeUsedAsValueError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeUsedAsValueError2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeVal.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeValueConflict1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeValueConflict2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeVariableConstraintIntersections.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeVariableConstraintedToAliasNotAssignableToUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeVariableTypeGuards.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typecheckCommaExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typecheckIfCondition.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typedArrayConstructorOverloads.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typedArrays-es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typedArrays-es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typedArrays.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typedArraysCrossAssignability01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typedArraysSubarray.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typedGenericPrototypeMember.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofAmbientExternalModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofImportInstantiationExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofInObjectLiteralType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofInterface.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofInternalModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofObjectInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofSimple.ts
@@ -4906,14 +4156,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/umdGlobalAugmentationNo
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/umdGlobalConflict.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/umdNamedAmdMode.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/umdNamespaceMergedWithGlobalAugmentationIsNotCircular.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unaryOperatorsInStrictMode.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unaryPlus.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/uncalledFunctionChecksInConditional.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/uncalledFunctionChecksInConditional2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/uncalledFunctionChecksInConditionalPerf.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/uncaughtCompilerError1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/undeclaredBase.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/undeclaredMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undeclaredModuleError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undeclaredVarEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedArgumentInference.ts
@@ -4921,17 +4168,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedAsDiscriminant
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedAssignableToGenericMappedIntersection.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedSymbolReferencedInArrayLiteral1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedTypeArgument2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedTypeAssignment1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedTypeAssignment2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedTypeAssignment3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedTypeAssignment4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreEscapedNameInEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreMapFirst.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreTest1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreThisInDerivedClass01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreThisInDerivedClass02.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unexportedInstanceClassVariables.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unicodeEscapesInNames01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionCallMixedTypeParameterPresence.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionErrorMessageOnMatchingDiscriminant.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionExcessPropertyCheckNoApparentPropTypeMismatchErrors.ts
@@ -4962,14 +4204,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/uniqueSymbolAssignmentO
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/uniqueSymbolPropertyDeclarationEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownLikeUnionObjectFlagsNotPropagated.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownPropertiesAreAssignableToObjectUnion.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownSymbolInGenericReturnType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownSymbolOffContextualType1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownTypeArgOnCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unmatchedParameterPositions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unmetTypeConstraintInImportCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unreachableDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unresolvableSelfReferencingAwaitedUnion.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unresolvedTypeAssertionSymbol.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unspecializedConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts
 tasks/coverage/typescript/tests/cases/compiler/untypedModuleImport_withAugmentation2.ts
@@ -5001,28 +4240,19 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedMethodsInInterfac
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParameterProperty1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParameterProperty2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersWithUnderscore.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedPrivateStaticMembers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSemicolonInClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSetterInClass2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInInterface2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInLambda3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParametersCheckedByNoUnusedParameters.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParametersNotCheckedByNoUnusedLocals.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParametersWithUnderscore.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters_infer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesWithUnderscoreInBindingElement.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesWithUnderscoreInForOfLoop.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinModules1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unwitnessedTypeParameterVariance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_classDecorators.1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_classDecorators.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_destructuring.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_jsx.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_propertyAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_superClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDefinitionInDeclarationFiles.ts
@@ -5034,7 +4264,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/varArgConstructo
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/varArgParamTypeCheck.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/varArgsOnConstructorTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/varAsID.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/vararg.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/vardecl.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/variableDeclarationDeclarationEmitUniqueSymbolPartialStatement.ts
@@ -5049,15 +4278,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceReferences.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceRepeatedlyPropegatesWithUnreliableFlag.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/verbatim-declarations-parameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/verbatimModuleSyntaxDefaultValue.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/visSyntax.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/visibilityOfCrossModuleTypeUsage.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/visibilityOfTypeParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidArrayLit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidAsNonAmbiguousReturnType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidAsOperator.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidFunctionAssignmentCompat.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidIsInitialized.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidReturnIndexUnionInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidUndefinedReduction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/vueLikeDataAndPropsInference.ts
@@ -5065,22 +4290,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/vueLikeDataAndPropsInfe
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/weakType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/weakTypeAndPrimitiveNarrowing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/webworkerIterable.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/wellKnownSymbolExpando.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/whileStatementInnerComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/widenToAny1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/widenToAny2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/widenedTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/widenedTypes1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/wideningWithTopLevelTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/withExportDecl.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/withImportDecl.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/withStatement.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/withStatementErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/withStatementInternalComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/wrappedRecursiveGenericType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/yieldExpression1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/yieldExpressionInFlowLoop.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/yieldExpressionInnerCommentEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/yieldInForInInDownlevelGenerator.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/yieldStringLiteral.ts
 A 'yield' expression is only allowed in a generator body.
@@ -5095,9 +4312,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/additionalChecks/noP
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsExternal.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsPatterns.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsPatterns_merging1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsPatterns_merging3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsPatterns_tooManyAsterisks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientEnumDeclaration1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientEnumDeclaration2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientExternalModuleInsideNonAmbient.ts
@@ -5110,11 +4325,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShort
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand_merging.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand_reExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/asyncFunctionDeclarationParameterEvaluation.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction10_es2017.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction5_es2017.ts
 Cannot use `await` as an identifier in an async context
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunctionCapturesArguments_es2017.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunctionCapturesThis_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncAwaitIsolatedModules_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncAwait_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncMethodWithSuperConflict_es6.ts
@@ -5136,16 +4348,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/await_u
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/await_unaryExpression_es2017_2.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration12_es2017.ts
 Cannot use `await` as an identifier in an async context
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration13_es2017.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts
 Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration8_es2017.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction10_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction11_es5.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction5_es5.ts
 Cannot use `await` as an identifier in an async context
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunctionCapturesArguments_es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunctionCapturesThis_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncAwaitIsolatedModules_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncAwaitNestedClasses_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncAwait_es5.ts
@@ -5163,7 +4371,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallE
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitClassExpression_es5.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration12_es5.ts
 Cannot use `await` as an identifier in an async context
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration13_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration15_es5.ts
 tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration16_es5.ts
 Unexpected estree file content error: 1 != 2
@@ -5171,11 +4378,8 @@ Unexpected estree file content error: 1 != 2
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts
 Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration8_es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclarationCapturesArguments_es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction10_es6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction5_es6.ts
 Cannot use `await` as an identifier in an async context
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunctionCapturesThis_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncAwaitIsolatedModules_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncAwait_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncMethodWithSuper_es6.ts
@@ -5196,7 +4400,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/await_unar
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/await_unaryExpression_es6_2.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration12_es6.ts
 Cannot use `await` as an identifier in an async context
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration13_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration15_es6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts
 Cannot use `await` as an identifier in an async context
@@ -5206,22 +4409,13 @@ Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/asyncGenerators/asyncGeneratorGenericNonWrappedReturn.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/asyncGenerators/asyncGeneratorParameterEvaluation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/asyncGenerators/asyncGeneratorPromiseNextType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractAccessor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractClinterfaceAssignability.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractImportInstantiation.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInheritance2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInstantiations1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractMixedWithModifiers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractSuperCalls.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAndInterfaceMergeConflictingMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAndInterfaceWithSameName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classBody/classWithEmptyBody.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classDeclarationLoop.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classExtendingBuiltinType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classExtendingClassLikeType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classExtendingNonConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classExtendingNull.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classAppearsToHaveMembersOfObject.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendingOptionalChain.ts
 Expected `{` but found `?.`
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classIsSubtypeOfBaseType.ts
@@ -5233,54 +4427,29 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclara
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/mergedInheritedClassInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/modifierOnClassDeclarationMemberInFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classExpression3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classExpression4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classExpressionLoop.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classWithStaticFieldInParameterBindingPattern.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classWithStaticFieldInParameterBindingPattern.3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classWithStaticFieldInParameterBindingPattern.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classWithStaticFieldInParameterInitializer.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classWithStaticFieldInParameterInitializer.3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classWithStaticFieldInParameterInitializer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/extendClassExpressionFromModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/genericClassExpressionInFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/modifierOnClassExpressionMemberInFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock11.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock13.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock14.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock15.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock17.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock18.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock19.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock20.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock21.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock22.ts
 Cannot use `await` as an identifier in an async context
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock23.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock24.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock25.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock27.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock5.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock7.ts
 A 'yield' expression is only allowed in a generator body.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlockUseBeforeDef1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlockUseBeforeDef2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlockUseBeforeDef3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlockUseBeforeDef4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlockUseBeforeDef5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/derivedClassWithoutExplicitConstructor3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorParametersAccessibility.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorParametersAccessibility2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorParametersAccessibility3.ts
@@ -5313,15 +4482,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/acce
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/accessibility/protectedStaticNotAccessibleInClodule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/indexersInClassType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/instancePropertiesInheritedIntoClassType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/instancePropertyInClassType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/staticPropertyNotInClassType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/constructorFunctionTypes/classWithNoConstructorOrBaseClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/constructorFunctionTypes/classWithStaticMembers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassIncludesInheritedMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesPrivates.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesProtectedMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesProtectedMembers2.ts
@@ -5333,68 +4498,33 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inhe
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithAny.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithPrivateInstanceShadowingProtectedInstance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/superInStaticMembers1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/thisAndSuperInStaticMembers1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/thisAndSuperInStaticMembers2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/thisAndSuperInStaticMembers3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/thisAndSuperInStaticMembers4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers11.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers13.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInStaticMembers9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/instanceAndStaticMembers/typeOfThisInstanceMemberNarrowedWithLoopAntecedent.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAccessors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAccessorsAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAccessorsCallExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAccessorssDerivedClasses.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndAny.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndIndexSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndObjectRestSpread.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndPropertySignature.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameAndStaticInitializer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameBadAssignment.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameBadDeclaration.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameBadSuperUseDefineForClassFields.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameCircularReference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameClassExpressionLoop.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameComputedPropertyName1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameComputedPropertyName2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameComputedPropertyName3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameComputedPropertyName4.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameConstructorReserved.ts
 Classes can't have an element named '#constructor'
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameConstructorSignature.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameDeclarationMerging.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameDuplicateField.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameES5Ban.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameEmitHelpers.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameEnum.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameField.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldAccess.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldCallExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldClassExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldDerivedClasses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldDestructuredBinding.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldInitializer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldParenthesisLeftAssignment.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldUnaryMutation.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameFieldsESNext.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameInInExpressionUnused.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameInLhsReceiverExpression.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameInObjectLiteral-1.ts
 Unexpected token
@@ -5402,69 +4532,21 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/membe
 Unexpected token
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameInObjectLiteral-3.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameLateSuper.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameLateSuperUseDefineForClassFields.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameMethod.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameMethodAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameMethodAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameMethodAsync.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameMethodCallExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameMethodClassExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameMethodInStaticFieldInit.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameMethodsDerivedClasses.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameNestedClassAccessorsShadowing.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameNestedClassFieldShadowing.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameNestedClassMethodShadowing.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameNestedClassNameConflict.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameNestedMethodAccess.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameNotAccessibleOutsideDefiningClass.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameReadonly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameSetterExprReturnValue.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameSetterNoGetter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticAccessors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticAccessorsAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticAccessorsCallExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticAccessorssDerivedClasses.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticAndStaticInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticEmitHelpers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldAccess.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldCallExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldClassExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldDerivedClasses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldDestructuredBinding.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldInitializer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldNoInitializer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldUnaryMutation.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticMethodAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticMethodAsync.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticMethodCallExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticMethodClassExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticMethodInStaticFieldInit.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticsAndStaticMethods.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameUnused.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesAndDecorators.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesAndFields.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesAndGenericClasses-2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesAndMethods.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesAndStaticFields.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesAndStaticMethods.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesAndkeyof.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesAssertion.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesConstructorChain-1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesConstructorChain-2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesInGenericClasses.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesInNestedClasses-1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesInNestedClasses-2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesInterfaceExtendingClass.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesNoDelete.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUnique-1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUnique-2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUnique-3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUnique-4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUnique-5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNamesUseBeforeDef.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateWriteOnlyAccessorRead.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/typeFromPrivatePropertyAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/methodDeclarations/optionalMethodDeclarations.ts
@@ -5476,14 +4558,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinClasses
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesAnonymous.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinWithBaseDependingOnSelfNoCrash1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/abstractProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideMethod.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationES2022.ts
@@ -5516,20 +4592,13 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemb
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/ambientAccessors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/typeOfThisInAccessor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/derivedTypeAccessesHiddenBaseCallViaSuperPropertyAccess.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/optionalMethod.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/optionalProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/overrideInterfaceProperty.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyNamedConstructor.ts
 Classes can't have a field named 'constructor'
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyNamedPrototype.ts
 Classes may not have a static property named prototype
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesAccessors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesAccessors2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesAccessors3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesAccessors4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesAccessors5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyOverridesMethod.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/redeclaredProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/redefinedPararameterProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticAutoAccessors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticAutoAccessorsWithDecorators.ts
@@ -5541,8 +4610,6 @@ tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarat
 Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/twoAccessorsWithSameName.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/staticIndexSignature/staticIndexSignature7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum3.ts
@@ -5555,33 +4622,24 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/constEnums/importEli
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/controlFlow/assertionTypePredicates1.ts
 Expected `,` but found `is`
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowAliasing.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowAliasingCatchVariables.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowAssignmentExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowAssignmentPatternOrder.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowBinaryAndExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowBinaryOrExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowBindingElement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowBindingPatternOrder.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowCommaOperator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowComputedPropertyNames.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowConditionalExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowDeleteOperator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowDestructuringDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowDoWhileStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowElementAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowElementAccess2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowElementAccessNoCrash1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowForInStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowForInStatement2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowForOfStatement.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowForStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowGenericTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIIFE.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIfStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowInOperator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowInstanceofExtendsFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIteration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIterationErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIterationErrorsAsync.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowNoIntermediateErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowNullishCoalesce.ts
@@ -5590,10 +4648,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlF
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowOptionalChain3.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowStringIndex.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowSuperPropertyAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowTruthiness.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowTypeofObject.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowWhileStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowWithTemplateLiterals.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/dependentDestructuredVariables.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/dependentDestructuredVariablesFromNestedPatterns.ts
@@ -5611,7 +4666,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/libR
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/libReferenceDeclarationEmitBundle.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/libReferenceNoLib.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/libReferenceNoLibBundle.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/nullPropertyName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitIdentifierPredicates01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitIdentifierPredicatesWithPrivateName01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicates01.ts
@@ -5621,7 +4675,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/type
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typeReferenceRelatedFiles.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typeofImportTypeOnlyExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/1.0lib-noErrors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/constructableDecoratorOnClass01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor4.ts
@@ -5640,23 +4693,16 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/dec
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/decoratorOnClass3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod14.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod15.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod16.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod18.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod19.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodParameter3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorCallGeneric.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorInAmbientContext.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorMetadata-jsdoc.ts
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorMetadata.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorMetadataWithTypeOnlyImport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorMetadataWithTypeOnlyImport2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/legacyDecorators-contextualTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/missingDecoratorType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/directives/multiline.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/directives/ts-expect-error-nocheck.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/directives/ts-expect-error.ts
@@ -5676,10 +4722,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/import
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES6CJS.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES6System.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionAsyncES6UMD.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionCheckReturntype1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionDeclarationEmit1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionDeclarationEmit2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionDeclarationEmit3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionES5AMD.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionES5CJS.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionES5System.ts
@@ -5731,7 +4774,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es2018/async
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es2018/asyncGenerators/emitter.asyncGenerators.functionDeclarations.es2018.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es2018/asyncGenerators/emitter.asyncGenerators.functionExpressions.es2018.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es2018/asyncGenerators/emitter.asyncGenerators.objectLiteralMethods.es2018.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es2019/noCatchBinding/emitter.noCatchBinding.es2019.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es5/asyncGenerators/emitter.asyncGenerators.classMethods.es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es5/asyncGenerators/emitter.asyncGenerators.functionDeclarations.es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es5/asyncGenerators/emitter.asyncGenerators.functionExpressions.es5.ts
@@ -5755,17 +4797,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useObjectValu
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useObjectValuesAndEntries2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useObjectValuesAndEntries3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useObjectValuesAndEntries4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useSharedArrayBuffer6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2018/es2018IntlAPIs.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2018/usePromiseFinally.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2019/allowUnescapedParagraphAndLineSeparatorsInStringLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2019/globalThisAmbientModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2019/globalThisBlockscopedProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2019/globalThisGlobalExportAsGlobal.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2019/globalThisReadonlyProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2019/globalThisTypeIndexAccess.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2019/globalThisUnknown.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2019/globalThisUnknownNoImplicitAny.ts
 tasks/coverage/typescript/tests/cases/conformance/es2019/globalThisVarDeclaration.ts
 Unexpected estree file content error: 1 != 2
 
@@ -5777,16 +4814,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/bigintMissing
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/constructBigint.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/es2020IntlAPIs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/intlNumberFormatES2020.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/localesObjectArgument.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/modules/exportAsNamespace3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/modules/exportAsNamespace4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/modules/exportAsNamespace5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/modules/exportAsNamespace_exportAssignment.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/modules/exportAsNamespace_missingEmitHelpers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/modules/exportAsNamespace_nonExistent.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2021/es2021LocalesObjectArgument.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2021/intlDateTimeFormatRangeES2021.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2021/logicalAssignment/logicalAssignment1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2021/logicalAssignment/logicalAssignment10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2021/logicalAssignment/logicalAssignment2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2021/logicalAssignment/logicalAssignment3.ts
@@ -5800,13 +4830,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2022/arbitraryModu
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2022/arbitraryModuleNamespaceIdentifiers/arbitraryModuleNamespaceIdentifiers_importEmpty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2022/arbitraryModuleNamespaceIdentifiers/arbitraryModuleNamespaceIdentifiers_module.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2022/es2022IntlAPIs.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2022/es2022LocalesObjectArgument.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2022/es2024SharedMemory.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2023/intlNumberFormatES2023.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2023/intlNumberFormatES5UseGrouping.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2024/resizableArrayBuffer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2024/sharedMemory.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2024/transferableArrayBuffer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit6.ts
@@ -5844,7 +4872,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolPr
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty37.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty38.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty40.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty41.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty46.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty47.ts
@@ -5956,8 +4983,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/superCallBeforeThisAccessing6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/superCallBeforeThisAccessing7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/superCallBeforeThisAccessing8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/superCallFromClassThatHasNoBaseTypeButWithSameSymbolInterface.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classExpressions/classExpressionES63.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames10_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames10_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames11_ES5.ts
@@ -6134,7 +5159,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/de
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringVoid.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringVoidStrictNullChecks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringWithLiteralInitializers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringWithLiteralInitializers2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns01_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns01_ES5iterable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns01_ES6.ts
@@ -6268,7 +5292,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of9.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration12_es6.ts
 Cannot use `yield` as an identifier in a generator context
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration13_es6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration5_es6.ts
 Cannot use `yield` as an identifier in a generator context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration8_es6.ts
@@ -6301,22 +5324,17 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/defaultE
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportAndImport-es5-amd.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportAndImport-es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportBinding.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportSpellingSuggestion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportStar-amd.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportStar.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports1-amd.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports1-es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports2-amd.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports2-es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports3-amd.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports3-es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports4-amd.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports4-es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImports5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImportsWithContextualKeywordNames01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImportsWithContextualKeywordNames02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/exportsAndImportsWithUnderscores2.ts
@@ -6332,8 +5350,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/newTarget/invali
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/newTarget/invalidNewTarget.es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/newTarget/newTarget.es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/newTarget/newTarget.es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/newTarget/newTargetNarrowing.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/propertyAccess/propertyAccessNumericLiterals.es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/restParameters/emitRestParametersFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/restParameters/emitRestParametersFunctionES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/restParameters/emitRestParametersFunctionExpression.ts
@@ -6612,7 +5628,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck43.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck44.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck46.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck48.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck55.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck59.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck60.ts
@@ -6661,61 +5676,28 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es7/trailingC
 Unexpected trailing comma after rest element
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es7/trailingCommasInFunctionParametersAndArguments.ts
 A rest parameter must be last in a parameter list
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/accessors/esDecorators-classDeclaration-accessors-nonStatic.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/accessors/esDecorators-classDeclaration-accessors-nonStaticPrivate.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/accessors/esDecorators-classDeclaration-accessors-static.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/accessors/esDecorators-classDeclaration-accessors-staticPrivate.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classSuper/esDecorators-classDeclaration-classSuper.1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classSuper/esDecorators-classDeclaration-classSuper.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classSuper/esDecorators-classDeclaration-classSuper.3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classSuper/esDecorators-classDeclaration-classSuper.4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classSuper/esDecorators-classDeclaration-classSuper.5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classSuper/esDecorators-classDeclaration-classSuper.6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classSuper/esDecorators-classDeclaration-classSuper.7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classThisReference/esDecorators-classDeclaration-classThisReference.es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classThisReference/esDecorators-classDeclaration-classThisReference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-commentPreservation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-commonjs-classNamespaceMerge.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-commonjs.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-classDecorator.1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-classDecorator.2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-classDecorator.3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-nonStaticPrivateAutoAccessor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-nonStaticPrivateField.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-nonStaticPrivateGetter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-nonStaticPrivateMethod.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-nonStaticPrivateSetter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-staticComputedAutoAccessor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-staticComputedField.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-staticComputedGetter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-staticComputedMethod.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-staticComputedSetter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-staticPrivateAutoAccessor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-staticPrivateField.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-staticPrivateGetter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-staticPrivateMethod.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-staticPrivateSetter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-multipleDecorators.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-parameterProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-setFunctionName.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-simpleTransformation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-sourceMap.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-nonStatic.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-nonStaticAbstract.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-nonStaticAbstractAccessor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-nonStaticAccessor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-nonStaticAmbient.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-nonStaticPrivate.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-nonStaticPrivateAccessor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-static.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-staticAccessor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-staticAmbient.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-staticPrivate.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-staticPrivateAccessor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/methods/esDecorators-classDeclaration-methods-nonStatic.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/methods/esDecorators-classDeclaration-methods-nonStaticPrivate.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/methods/esDecorators-classDeclaration-methods-static.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/methods/esDecorators-classDeclaration-methods-staticPrivate.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/classSuper/esDecorators-classExpression-classSuper.1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/classSuper/esDecorators-classExpression-classSuper.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/classSuper/esDecorators-classExpression-classSuper.3.ts
@@ -6723,28 +5705,16 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classEx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/classSuper/esDecorators-classExpression-classSuper.5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/classSuper/esDecorators-classExpression-classSuper.6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-commentPreservation.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.11.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.14.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.15.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.16.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.17.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.6.ts
@@ -6758,12 +5728,6 @@ Expected a semicolon or an implicit semicolon after a statement, but found none
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-decoratorExpression.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-emitDecoratorMetadata.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-preservesThis.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-privateFieldAccess.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/metadata/esDecoratorsMetadata1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/metadata/esDecoratorsMetadata2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/metadata/esDecoratorsMetadata3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/metadata/esDecoratorsMetadata4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/metadata/esDecoratorsMetadata5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esnext/logicalAssignment/logicalAssignment11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiteralInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiterals.ts
@@ -6772,13 +5736,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLit
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiterals3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOpEmitParens.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOperator1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOperator2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOperator3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOperator4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOperatorASI.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOperatorAmbiguity.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOperatorContextualType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOperatorNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/assignmentGenericLookupTypeNarrowing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/assignmentLHSIsReference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/assignmentTypeNarrowing.ts
@@ -6832,8 +5794,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOp
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithValidOperands.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithInvalidOperands.es2015.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithInvalidStaticToString.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithLHSIsObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithRHSHasSymbolHasInstance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalAndOperator/logicalAndOperatorWithEveryType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalAndOperator/logicalAndOperatorWithTypeParameters.ts
@@ -6892,13 +5852,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/function
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/newWithSpread.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/newWithSpreadES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/newWithSpreadES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/overloadResolution.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/overloadResolutionClassConstructors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/overloadResolutionConstructors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/typeArgumentInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceErrors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceTransitiveConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithObjectLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts
@@ -6909,15 +5865,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/function
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functions/voidParamAssignmentCompatibility.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/identifiers/scopeResolutionIdentifiers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/newOperator/newOperatorConformance.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/newOperator/newOperatorErrorCases_noImplicitAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator9.ts
@@ -6953,8 +5903,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optional
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/taggedTemplateChain/taggedTemplateChain.ts
 Tagged template expressions are not permitted in an optional chain
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/propertyAccess/propertyAccess.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/propertyAccess/propertyAccessStringIndexSignature.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/propertyAccess/propertyAccessStringIndexSignatureNoImplicitAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/propertyAccess/propertyAccessWidening.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/superCalls/superCalls.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/superPropertyAccess/errorSuperPropertyAccess.ts
@@ -6962,26 +5910,20 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/superPro
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/thisKeyword/thisInInvalidContexts.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/thisKeyword/thisInInvalidContextsExternalModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/thisKeyword/thisInObjectLiterals.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/thisKeyword/typeOfThisGeneral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/thisKeyword/typeOfThisInConstructorParamList.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeAssertions/constAssertionOnEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeAssertions/constAssertions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeAssertions/duplicatePropertiesInTypeAssertions01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeAssertions/duplicatePropertiesInTypeAssertions02.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/TypeGuardWithArrayUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/TypeGuardWithEnumUnion.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/nullOrUndefinedTypeGuardIsOrderIndependent.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardEnums.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardFunctionOfFormThis.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardFunctionOfFormThisErrors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardInClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardIntersectionTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardNarrowsPrimitiveIntersection.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardNarrowsToLiteralType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardNarrowsToLiteralTypeUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardNesting.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormFunctionEquality.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormInstanceOf.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormInstanceOfOnInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormIsTypeOnInterfaces.ts
@@ -6990,24 +5932,17 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/t
 Expected a semicolon or an implicit semicolon after a statement, but found none
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormThisMemberErrors.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfBoolean.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfIsOrderIndependent.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfNumber.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfOther.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfPrimitiveSubtype.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfString.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFromPropNameInUnionType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardRedundancy.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardTautologicalConsistiency.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardTypeOfUndefined.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsDefeat.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInClassAccessors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInClassMethods.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInConditionalExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInDoStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInExternalModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInForStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInFunctionAndModuleBlock.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInGlobal.ts
@@ -7016,7 +5951,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuar
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInRightOperandOfAndAndOperator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInRightOperandOfOrOrOperator.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInWhileStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsObjectMethods.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsOnClassProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsWithAny.ts
@@ -7086,13 +6020,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/valuesAn
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/valuesAndReferences/assignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/amdImportAsPrimaryExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/amdImportNotAsPrimaryExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/circularReference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/commonJSImportAsPrimaryExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/commonJSImportNotAsPrimaryExpression.ts
 tasks/coverage/typescript/tests/cases/conformance/externalModules/commonJsImportBindingElementNarrowType.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/duplicateExportAssignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/es6/es6modulekind.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/es6/es6modulekindExportClassNameWithObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/es6/es6modulekindWithES2015Target.ts
@@ -7124,18 +6055,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/esne
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/esnext/esnextmodulekindWithES5Target9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/esnext/exnextmodulekindExportClassNameWithObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAmbientClassNameWithObject.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignDottedName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentAndDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentCircularModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentConstrainedGenericType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentGenericType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentMergedInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentOfExportNamespaceWithDefault.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentTopLevelClodule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentTopLevelEnumdule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentTopLevelFundule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentTopLevelIdentifier.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportClassNameWithObjectAMD.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportClassNameWithObjectCommonJS.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportClassNameWithObjectSystem.ts
@@ -7147,9 +6072,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/expo
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportNonVisibleType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportTypeMergedWithExportStarAsNamespace.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/globalAugmentationModuleResolution.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/importImportOnlyModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/importNonExternalModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/importTsBeforeDTs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithExtensions.ts
 tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension3.ts
 Unexpected estree file content error: 1 != 2
@@ -7164,26 +6086,19 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/mult
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/multipleExportDefault4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/multipleExportDefault5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/multipleExportDefault6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/nameDelimitedBySlashes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/nameWithFileExtension.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/nameWithRelativePaths.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/reexportClassDefinition.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/relativePathMustResolve.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/relativePathToDeclarationFile.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/rewriteRelativeImportExtensions/cjsErrors.ts
 tasks/coverage/typescript/tests/cases/conformance/externalModules/rewriteRelativeImportExtensions/emit.ts
 Unexpected estree file content error: 4 != 5
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/rewriteRelativeImportExtensions/emitModuleCommonJS.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/rewriteRelativeImportExtensions/nodeModulesTsFiles.ts
 tasks/coverage/typescript/tests/cases/conformance/externalModules/rewriteRelativeImportExtensions/nonTSExtensions.ts
 Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelAmbientModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelAwait.1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelAwait.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelAwait.3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.10.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelAwaitErrors.11.ts
@@ -7202,33 +6117,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/topL
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelAwaitNonModule.ts
 `await` is only allowed within async functions and at the top levels of modules
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelFileModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelFileModuleMissing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelModuleDeclarationAndFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeAndNamespaceExportMerge.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/allowsImportingTsExtension.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/ambient.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/chained.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/chained2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/circular1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/circular2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/circular3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/circular4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/cjsImportInES2015.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/computedPropertyName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/enums.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportDeclaration_moduleSpecifier-isolatedModules.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportDeclaration_moduleSpecifier.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportDeclaration_value.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportDefault.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportNamespace9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportSpecifiers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/extendsClause.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/filterNamespace_import.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/generic.ts
 tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/grammarErrors.ts
@@ -7240,40 +6134,24 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/type
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importClause_namespaceImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importDefaultNamedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importDefaultNamedType2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importDefaultNamedType3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importEquals1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importEquals2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importEquals3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importEqualsDeclaration.ts
 tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importSpecifiers_js.ts
 Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importsNotUsedAsValues_error.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/mergedWithLocalValue.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceImportTypeQuery.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceImportTypeQuery2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceImportTypeQuery3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceImportTypeQuery4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceMemberAccess.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/nestedNamespace.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/preserveValueImports.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/preserveValueImports_errors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/preserveValueImports_importsNotUsedAsValues.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/preserveValueImports_mixedImports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/preserveValueImports_module.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/renamed.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/typeQuery.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnlyMerge1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnlyMerge2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnlyMerge3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeValueMerge1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typesOnlyExternalModuleStillHasInstance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd-augmentation-1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd-augmentation-2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd-augmentation-3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd-augmentation-4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd5.ts
@@ -7281,12 +6159,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd6
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/valuesMergingAcrossModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxAmbientConstEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxCompat.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxConstEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxConstEnumUsage.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxDeclarationFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxInternalImportEquals.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxNoElisionCJS.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/verbatimModuleSyntaxNoElisionESM.ts
@@ -7314,16 +6190,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generator
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeFallback.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeFallback.4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeFallback.5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeIndirectReferenceToGlobalType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorReturnTypeInferenceNonStrict.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/generatorYieldContextualType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/restParameterInDownlevelGenerator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/generators/yieldStatementNoAsiAfterTransform.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/importAssertion/importAssertion2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/importAssertion/importAssertion3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/importAttributes/importAttributes2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/importAttributes/importAttributes3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/importAttributes/importAttributes7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/importAttributes/importAttributes8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/importAttributes/importAttributes9.ts
@@ -7355,7 +6226,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarati
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/twoMergedInterfacesWithDifferingOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/derivedInterfaceDoesNotHideBaseSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/derivedInterfaceIncompatibleWithBaseIndexer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendingOptionalChain.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersection.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceThatHidesBaseProperty.ts
@@ -7370,7 +6240,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interface
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithPropertyOfEveryType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithPropertyThatIsPrivateInBaseType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithPropertyThatIsPrivateInBaseType2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithSpecializedCallAndConstructSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithStringIndexerHidingBaseTypeIndexer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithStringIndexerHidingBaseTypeIndexer2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithStringIndexerHidingBaseTypeIndexer3.ts
@@ -7386,9 +6255,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/Decl
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/AmbientModuleAndNonAmbientClassWithSameNameAndCommonRoot.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/AmbientModuleAndNonAmbientFunctionWithTheSameNameAndCommonRoot.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithModuleMemberThatUsesClassTypeParameter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithModulesExportedGenericFunctionAndGenericClassStaticFunctionOfTheSameName.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithModulesExportedGenericFunctionAndNonGenericClassStaticFunctionOfTheSameName.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithModulesExportedStaticFunctionUsingClassPrivateStatics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithStaticFunctionAndExportedFunctionThatShareAName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithStaticFunctionAndNonExportedFunctionThatShareAName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithStaticVariableAndExportedVarThatShareAName.ts
@@ -7417,7 +6283,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/code
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/codeGeneration/nameCollision.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportClassWhichExtendsInterfaceWithInaccessibleType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportClassWithAccessibleTypesInTypeParameterConstraintsClassHeritageListMemberTypeAnnotations.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportClassWithInaccessibleTypeInIndexerTypeAnnotations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportClassWithInaccessibleTypeInTypeParameterConstraint.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportFunctionWithAccessibleTypesInParameterAndReturnTypeAnnotation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportFunctionWithInaccessibleTypesInParameterTypeAnnotation.ts
@@ -7433,7 +6298,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/expo
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ModuleWithExportedAndNonExportedClasses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ModuleWithExportedAndNonExportedEnums.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ModuleWithExportedAndNonExportedImportAlias.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ModuleWithExportedAndNonExportedVariables.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/importDeclarations/circularImportAlias.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/importDeclarations/exportImportAlias.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/importDeclarations/importAliasIdentifiers.ts
@@ -7566,11 +6430,7 @@ Unexpected estree file content error: 1 != 2
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocImportTypeReferenceToESModule.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocLinkTag9.ts
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/jsdocParseBackquotedParamName.ts
 Unexpected estree file content error: 1 != 2
@@ -7607,7 +6467,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/seeTag2.ts
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/syntaxErrors.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/thisPrototypeMethodCompoundAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/tsNoCheckForTypescript.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/tsNoCheckForTypescriptComments1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/tsNoCheckForTypescriptComments2.ts
@@ -7625,7 +6484,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildren
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty12.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty13.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty14.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty15.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty16.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty3.tsx
@@ -7673,7 +6531,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeReso
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution10.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution11.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution12.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution13.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution14.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution15.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution16.tsx
@@ -7703,22 +6560,13 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolu
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution11.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution12.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution13.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution14.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution15.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution16.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution17.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution18.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution19.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution3.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution4.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution5.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution6.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution7.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution8.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution9.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEmit1.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEmit2.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEmit3.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxExternalModuleEmit2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentPreserveEmit.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentReactEmit.tsx
@@ -7734,34 +6582,21 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttrib
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxInArrowFunction.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxIntrinsicAttributeErrors.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxNamespacedAttributeName1.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxNamespacedAttributeName2.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxNamespacedTagName1.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxNamespacedTagName2.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxNoJsx.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxOpeningClosingNames.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxParseTests1.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxParseTests2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxPreserveEmit1.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxPreserveEmit2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxPreserveEmit3.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefaultTypeParameter1.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefaultTypeParameter2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefaultTypeParameter3.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit1.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit2.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit5.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit6.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit7.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit8.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitEntities.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitNesting.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitWhitespace.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitWhitespace2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSfcReturnNull.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSfcReturnNullStrictNullChecks.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSfcReturnUndefinedStrictNullChecks.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution1.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution10.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution11.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution12.tsx
@@ -7780,7 +6615,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttribu
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution9.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadChildren.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadChildrenInvalidType.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadInvalidType.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload1.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload3.tsx
@@ -7806,8 +6640,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementT
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType5.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType6.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionTypeComponent1.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionTypeComponent2.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/allowImportingTsExtensions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/allowImportingTypesDtsExtension.ts
 tasks/coverage/typescript/tests/cases/conformance/moduleResolution/bundler/bundlerConditionsExcludesNode.ts
 Unexpected estree file content error: 3 != 5
@@ -7838,9 +6670,6 @@ Unexpected estree file content error: 2 != 4
 tasks/coverage/typescript/tests/cases/conformance/moduleResolution/extensionLoadingPriority.ts
 Unexpected estree file content error: 2 != 5
 
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/importFromDot.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/nestedPackageJsonRedirect.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/node10AlternateResult_noResolution.ts
 tasks/coverage/typescript/tests/cases/conformance/moduleResolution/node10Alternateresult_noTypes.ts
 Unexpected estree file content error: 2 != 3
 
@@ -7882,13 +6711,9 @@ Unexpected estree file content error: 2 != 4
 tasks/coverage/typescript/tests/cases/conformance/moduleResolution/resolvesWithoutExportsDiagnostic1.ts
 Unexpected estree file content error: 2 != 7
 
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/scopedPackages.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/scopedPackagesClassic.ts
 tasks/coverage/typescript/tests/cases/conformance/moduleResolution/selfNameModuleAugmentation.ts
 Unexpected estree file content error: 2 != 3
 
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/typesVersions.emptyTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/moduleResolution/typesVersions.justIndex.ts
 tasks/coverage/typescript/tests/cases/conformance/moduleResolution/untypedModuleImport.ts
 Unexpected estree file content error: 3 != 4
 
@@ -7999,16 +6824,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImpo
 tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportAttributes.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportAttributesModeDeclarationEmit1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportAttributesModeDeclarationEmit2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportAttributesModeDeclarationEmitErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportAttributesTypeModeDeclarationEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportHelpersCollisions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportHelpersCollisions2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportHelpersCollisions3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportMeta.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportModeDeclarationEmit1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportModeDeclarationEmit2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportModeDeclarationEmitErrors1.ts
 tasks/coverage/typescript/tests/cases/conformance/node/nodeModulesImportResolutionIntoExport.ts
 Unexpected estree file content error: 1 != 3
@@ -8067,34 +6888,17 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/nonjsExtensions/decl
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/nonjsExtensions/declarationFileForHtmlImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/nonjsExtensions/declarationFileForJsonImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/nonjsExtensions/declarationFileForTsJsImport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/nonjsExtensions/declarationFilesForNodeNativeModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override11.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override14.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override15.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override16.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override17.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override18.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override19.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override20.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override21.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override3.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/override/override5.ts
 override' modifier already seen.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/override/override7.ts
 override' modifier already seen.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/overrideDynamicName1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/overrideKeywordOrder.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/overrideLateBindableIndexSignature1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/overrideLateBindableName1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/overrideWithoutNoImplicitOverride1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript2021/numericSeparators/parser.numericSeparators.binary.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript2021/numericSeparators/parser.numericSeparators.decimal.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript2021/numericSeparators/parser.numericSeparators.hex.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript2021/numericSeparators/parser.numericSeparators.octal.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript3/Accessors/parserES3Accessors3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript3/Accessors/parserES3Accessors4.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors10.ts
@@ -8138,11 +6942,8 @@ Unexpected estree file content error: 1 != 2
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression9.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/AutomaticSemicolonInsertion/parserAutomaticSemicolonInsertion1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/CatchClauses/parserCatchClauseWithTypeAnnotation1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClass1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClass2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration17.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClassDeclaration25.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName3.ts
@@ -8172,15 +6973,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/E
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserEnumDeclaration6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserInterfaceKeywordInEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/EnumDeclarations/parserInterfaceKeywordInEnum1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic11.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic14.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/AccessibilityAfterStatic/parserAccessibilityAfterStatic7.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ExtendsOrImplementsClauses/parserErrorRecovery_ExtendsOrImplementsClause2.ts
 Expected `{` but found `EOF`
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ExtendsOrImplementsClauses/parserErrorRecovery_ExtendsOrImplementsClause5.ts
@@ -8196,7 +6988,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/E
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnPropertySignature2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnStatementInBlock1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnStatementInBlock3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnStatementInBlock4.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserStatementIsNotAMemberVariableDeclaration1.ts
 A 'return' statement can only be used within a function body.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ExportAssignments/parserExportAssignment1.ts
@@ -8215,8 +7006,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/G
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserCastVersusArrowFunction1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInInterfaceDeclaration1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGreaterThanTokenAmbiguity11.ts
 Cannot assign to this expression
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Generics/parserGreaterThanTokenAmbiguity15.ts
@@ -8268,8 +7057,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/M
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/MethodSignatures/parserMethodSignature9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModule1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration8.ts
@@ -8306,25 +7093,18 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/P
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RealWorld/parserindenter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509534.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509546.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509546_1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509546_2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509618.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509668.ts
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509677.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509698.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser536727.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser618973.ts
 'export' modifier cannot be used here.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser630933.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser642331.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser642331_1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser643728.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser645484.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parserNotHexLiteral1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parserTernaryAndCommaOperators1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpression4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity2.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity3.ts
@@ -8371,7 +7151,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/S
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Types/parserTypeQuery9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration1.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration10.ts
 Unexpected token
@@ -8382,11 +7161,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/p
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parser15.4.4.14-9-2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserArgumentList1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserAstSpans1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserEmptyStatement1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserExportAsFunctionIdentifier.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserInExpression1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserKeywordsAsIdentifierName1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserNoASIOnCallAfterFunctionExpression1.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserNotRegex1.ts
 A 'return' statement can only be used within a function body.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserNotRegex2.ts
@@ -8412,7 +7189,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/p
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserUnicode1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserUnicode2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserUnicode3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserUnicodeWhitespaceCharacter1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserUsingConstructorAsIdentifier.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName14.ts
@@ -8443,8 +7219,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/I
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement16.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement22.ts
 The left-hand side of a `for...of` statement may not be `async`
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement23.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement24.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement25.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty2.ts
@@ -8554,11 +7328,6 @@ Unexpected estree file content error: 1 != 3
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment29.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment30.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment31.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment32.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment33.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment36.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment38.ts
 tasks/coverage/typescript/tests/cases/conformance/salsa/varRequireFromTypescript.ts
 Unexpected estree file content error: 1 != 2
 
@@ -8577,7 +7346,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableS
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/recursiveInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.14.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.15.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.3.ts
@@ -8585,14 +7353,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableS
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsInForAwaitOf.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsInForAwaitOf.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsInForOf.1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsInForOf.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsInForOf.4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsTopLevelOfModule.1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsWithAsyncIteratorObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsWithImportHelpers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsWithIteratorObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.15.ts
@@ -8658,7 +7423,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-await
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-await-ofStatements/forAwaitPerIterationBindingDownlevel.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatementsArray.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatementsArrayErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatementsAsyncIdentifier.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring3.ts
@@ -8666,8 +7430,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-inSta
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of10.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of12.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of18.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of19.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of20.ts
 Missing initializer in const declaration
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of27.ts
@@ -8706,8 +7468,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/anyAsGener
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/assignAnyToEveryType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/assignEveryTypeToAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/narrowExceptionVariableInCatchClause.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/narrowFromAnyWithInstanceof.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/narrowFromAnyWithTypePredicate.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/conditionalTypes1.ts
@@ -8715,7 +7475,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/co
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/conditionalTypesExcessProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypes1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypes2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypesInvalidExtendsDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypesWithExtends1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypesWithExtends2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypesWithExtendsDependingOnTypeVariables.ts
@@ -8735,12 +7494,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualType
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedClassExpressionMethodDeclaration01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedClassExpressionMethodDeclaration02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedObjectLiteralMethodDeclaration01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceWithTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionWitoutTypeParameter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/forAwait/types.forAwait.es2018.1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/forAwait/types.forAwait.es2018.2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/forAwait/types.forAwait.es2018.3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeAmbient.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeAmbientMissing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeAmdBundleRewrite.ts
@@ -8891,7 +7646,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/gen
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/optionalMethods.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/never/neverInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/never/neverIntersectionNotCallable.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/never/neverType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/never/neverTypeErrors1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/never/neverTypeErrors2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/never/neverUnionIntersection.ts
@@ -8902,12 +7656,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/n
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAsProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAssignError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveConstraintOfIndexAccessType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveInFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveIndexingWithForIn.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveIndexingWithForInNoImplicitAny.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveIndexingWithForInSupressError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveNarrow.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignatureWithOptionalParameterAndInitializer.ts
@@ -9044,7 +7793,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadN
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadObjectOrFalsy.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadOverwritesProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadOverwritesPropertyStrict.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadTypeVariable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadUnion2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadUnion3.ts
@@ -9071,8 +7819,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignability03.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignability04.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignability05.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads03.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads04.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloads05.ts
@@ -9083,12 +7829,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/contextualThisType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/declarationFiles.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/fluentClasses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/fluentInterfaces.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/inferThisType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/looseThisTypeInFunctions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeAccessibility.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeAndConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeErrors2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInAccessors.ts
@@ -9097,7 +7841,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisT
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInClasses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInInterfaces.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInObjectLiterals.ts
@@ -9107,7 +7850,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisT
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInTypePredicate.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeOptionalCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeSyntacticContext.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/typeRelationships.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/unionThisTypeInFunctions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/castingTuple.ts
@@ -9119,20 +7861,13 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/na
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/partiallyNamedTuples.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/partiallyNamedTuples2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/partiallyNamedTuples3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/optionalTupleElements1.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts
 'readonly' type modifier is only permitted on array and tuple literal types.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/readonlyArraysAndTuples2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/restTupleElements1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/strictTupleLength.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/tupleLengthCheck.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/typeInferenceWithTupleType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/unionsOfTupleTypes1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/variadicTuples1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/variadicTuples2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/variadicTuples3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/builtinIteratorReturn.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/circularTypeAliasForUnionWithClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/circularTypeAliasForUnionWithInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/directDependenceBetweenTypeAliases.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/genericTypeAliases.ts
@@ -9176,9 +7911,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiersReverseMappedTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiersWithIntersection.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterDirectlyConstrainedToItself.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterIndirectlyConstrainedToItself.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterUsedAsConstraint.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParametersAvailableInNestedScope.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParametersAvailableInNestedScope3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSubtyping.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSupertype.ts
@@ -9262,7 +7994,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationsh
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/equalityWithEnumTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/equalityWithIntersectionTypes01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/equalityWithUnionTypes01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/equalityWithtNullishCoalescingAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/independentPropertyVariance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/optionalProperties01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/optionalProperties02.ts
@@ -9380,7 +8111,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationsh
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/discriminatedUnionInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallToOverloadedMethodWithOverloadedArguments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallTypeArgumentInference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithArrayLiteralArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithConstraintsTypeArgumentInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithConstraintsTypeArgumentInference2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithConstructorTypedArguments5.ts
@@ -9415,13 +8145,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationsh
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericFunctionParameters.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/indexSignatureTypeInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferences.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferencesJsx.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/keyofInferenceIntersectsResults.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/keyofInferenceLowerPriorityThanReturn.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/noInfer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/noInferRedeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference3.ts
@@ -9429,7 +8157,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationsh
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/widenedTypes/arrayLiteralWidened.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/widenedTypes/initializersWidened.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/widenedTypes/objectLiteralWidened.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/widenedTypes/strictNullChecksNoWidening.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/contextualTypeWithUnionTypeCallSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/contextualTypeWithUnionTypeIndexSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/contextualTypeWithUnionTypeMembers.ts
@@ -9449,9 +8176,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTyp
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeFromArrayLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeIndexSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeMembers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypePropertyAccessibility.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeReadonly.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeReduction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeReduction2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeWithIndexSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbols.ts
@@ -9465,9 +8190,4 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/unknown/unknow
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/witness/witness.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/typings/typingsLookup1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/typings/typingsLookup3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/typings/typingsLookup4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/typings/typingsLookupAmd.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/typings/typingsSuggestion1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/typings/typingsSuggestion2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/typings/typingsSuggestionBun1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/typings/typingsSuggestionBun2.ts


### PR DESCRIPTION
Bump `acorn-test262` dependency to include https://github.com/oxc-project/acorn-test262/pull/13. This fixes the mismatch between how our conformance tester and the `acorn-test262` test case generator were handling final newlines in source files.
