### PR TITLE
refactor(ast): methods for fieldless enums take `self` not `&self` + remove unnecessary `matches!`

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -1065,29 +1065,30 @@ impl VariableDeclaration<'_> {
 
 impl VariableDeclarationKind {
     /// Returns `true` if declared using `var` (such as `var x`)
-    pub fn is_var(&self) -> bool {
-        matches!(self, Self::Var)
+    pub fn is_var(self) -> bool {
+        self == Self::Var
     }
 
     /// Returns `true` if declared using `const` (such as `const x`)
-    pub fn is_const(&self) -> bool {
-        matches!(self, Self::Const)
+    pub fn is_const(self) -> bool {
+        self == Self::Const
     }
 
     /// Returns `true` if declared using `let`, `const` or `using` (such as `let x` or `const x`)
-    pub fn is_lexical(&self) -> bool {
+    pub fn is_lexical(self) -> bool {
         matches!(self, Self::Const | Self::Let | Self::Using | Self::AwaitUsing)
     }
 
     /// Returns `true` if declared using `await using` (such as `await using x`)
-    pub fn is_await(&self) -> bool {
-        matches!(self, Self::AwaitUsing)
+    pub fn is_await(self) -> bool {
+        self == Self::AwaitUsing
     }
 
     /// Returns the code syntax for this [`VariableDeclarationKind`].
-    /// For example, [`Var`][`VariableDeclarationKind::Var`] would return `"var"` and
-    /// [`AwaitUsing`][`VariableDeclarationKind::AwaitUsing`] would return `"await using"`.
-    pub fn as_str(&self) -> &'static str {
+    ///
+    /// For example, [`Var`][`VariableDeclarationKind::Var`] returns `"var"`,
+    /// [`AwaitUsing`][`VariableDeclarationKind::AwaitUsing`] returns `"await using"`.
+    pub fn as_str(self) -> &'static str {
         match self {
             Self::Var => "var",
             Self::Const => "const",
@@ -1406,8 +1407,8 @@ impl FormalParameter<'_> {
 
 impl FormalParameterKind {
     /// `true` when part of a TypeScript method or function signature.
-    pub fn is_signature(&self) -> bool {
-        matches!(self, Self::Signature)
+    pub fn is_signature(self) -> bool {
+        self == Self::Signature
     }
 }
 
@@ -1652,36 +1653,36 @@ impl<'a> ClassElement<'a> {
 
 impl PropertyDefinitionType {
     /// `true` for abstract properties and methods.
-    pub fn is_abstract(&self) -> bool {
-        matches!(self, Self::TSAbstractPropertyDefinition)
+    pub fn is_abstract(self) -> bool {
+        self == Self::TSAbstractPropertyDefinition
     }
 }
 
 impl MethodDefinitionKind {
     /// `true` for constructors.
-    pub fn is_constructor(&self) -> bool {
-        matches!(self, Self::Constructor)
+    pub fn is_constructor(self) -> bool {
+        self == Self::Constructor
     }
 
     /// `true` for regular methods.
-    pub fn is_method(&self) -> bool {
-        matches!(self, Self::Method)
+    pub fn is_method(self) -> bool {
+        self == Self::Method
     }
 
     /// `true` for setter methods.
-    pub fn is_set(&self) -> bool {
-        matches!(self, Self::Set)
+    pub fn is_set(self) -> bool {
+        self == Self::Set
     }
 
     /// `true` for getter methods.
-    pub fn is_get(&self) -> bool {
-        matches!(self, Self::Get)
+    pub fn is_get(self) -> bool {
+        self == Self::Get
     }
 
     /// Returns `true` if this method is a getter or a setter.
     ///
     /// Analogous to [`PropertyKind::is_accessor`].
-    pub fn is_accessor(&self) -> bool {
+    pub fn is_accessor(self) -> bool {
         matches!(self, Self::Get | Self::Set)
     }
 
@@ -1700,8 +1701,8 @@ impl MethodDefinitionType {
     /// Returns `true` if this method definition is a TypeScript `abstract` method.
     ///
     /// See: [`MethodDefinitionType::TSAbstractMethodDefinition`]
-    pub fn is_abstract(&self) -> bool {
-        matches!(self, Self::TSAbstractMethodDefinition)
+    pub fn is_abstract(self) -> bool {
+        self == Self::TSAbstractMethodDefinition
     }
 }
 
@@ -1781,8 +1782,8 @@ impl AccessorPropertyType {
     /// Returns `true` if this accessor property is a TypeScript `abstract` accessor.
     ///
     /// See: [`AccessorPropertyType::TSAbstractAccessorProperty`]
-    pub fn is_abstract(&self) -> bool {
-        matches!(self, Self::TSAbstractAccessorProperty)
+    pub fn is_abstract(self) -> bool {
+        self == Self::TSAbstractAccessorProperty
     }
 }
 
@@ -1903,7 +1904,7 @@ impl ImportPhase {
     ///
     /// - [`Source`][`ImportPhase::Source`] => `"source"`
     /// - [`Defer`][`ImportPhase::Defer`] => `"defer"`
-    pub fn as_str(&self) -> &'static str {
+    pub fn as_str(self) -> &'static str {
         match self {
             Self::Source => "source",
             Self::Defer => "defer",

--- a/crates/oxc_transformer/src/es2022/class_properties/class_details.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class_details.rs
@@ -62,7 +62,7 @@ impl<'a> PrivateProp<'a> {
     }
 
     pub fn is_accessor(&self) -> bool {
-        self.is_accessor || self.method_kind.is_some_and(|kind| kind.is_accessor())
+        self.is_accessor || self.method_kind.is_some_and(MethodDefinitionKind::is_accessor)
     }
 
     pub fn set_binding2(&mut self, binding: BoundIdentifier<'a>) {


### PR DESCRIPTION
Small refactor. Fieldless enums are `Copy`, so it's pointless passing references to them (`&self`) into methods. Pass `self` instead.

Additionally, replace `matches!` with `==` where possible, for shorter code and faster compilation.
