### PR TITLE
perf(parser): record fatal errors centrally

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -51,13 +51,7 @@ jobs:
       fail-fast: true
       matrix:
         component:
-          - lexer
           - parser
-          - transformer
-          - isolated_declarations
-          - semantic
-          - minifier
-          - codegen
 
     steps:
       - name: Checkout Branch
@@ -82,80 +76,6 @@ jobs:
       - name: Run benchmark
         uses: CodSpeedHQ/action@0010eb0ca6e89b80c88e8edaaa07cfe5f3e6664d # v3.5.0
         timeout-minutes: 30
-        with:
-          token: ${{ secrets.CODSPEED_TOKEN }}
-          run: cargo codspeed run
-
-  # Build linter benchmark.
-  # Linter benchmarks are much slower than the rest, so we run each fixture in a separate job.
-  # But only build the linter benchmark once.
-  build-linter:
-    name: Build Linter Benchmark
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Branch
-        uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
-
-      - uses: oxc-project/setup-rust@cd82e1efec7fef815e2c23d296756f31c7cdc03d # v1.0.0
-        with:
-          cache-key: benchmark-linter
-          save-cache: ${{ github.ref_name == 'main' }}
-
-      - name: Build benchmark
-        env:
-          RUSTFLAGS: "-C debuginfo=1 -C strip=none -g --cfg codspeed"
-        run: |
-          cargo build --release -p oxc_benchmark --bench linter \
-            --no-default-features --features linter --features codspeed
-          mkdir -p target/codspeed/instrumentation/oxc_benchmark
-          mv target/release/deps/linter-* target/codspeed/instrumentation/oxc_benchmark
-          rm target/codspeed/instrumentation/oxc_benchmark/*.d
-
-      - name: Upload Binary
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          if-no-files-found: error
-          name: benchmark-linter
-          path: ./target/codspeed/instrumentation/oxc_benchmark
-          retention-days: 1
-
-  # Run linter benchmarks. Each fixture in a separate job.
-  benchmark-linter:
-    name: Benchmark linter
-    needs: build-linter
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: true
-      matrix:
-        fixture:
-          - 0
-          - 1
-
-    steps:
-      - name: Checkout Branch
-        uses: taiki-e/checkout-action@b13d20b7cda4e2f325ef19895128f7ff735c0b3d # v1.3.1
-
-      - name: Download Binary
-        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
-        with:
-          name: benchmark-linter
-          path: ./target/codspeed/instrumentation/oxc_benchmark
-
-      - name: Fix permission loss
-        run: |
-          ls ./target/codspeed/instrumentation/oxc_benchmark
-          chmod +x ./target/codspeed/instrumentation/oxc_benchmark/*
-
-      - name: Install codspeed
-        uses: taiki-e/install-action@a433d87f121760c7447ab86390794f9a2dce31cf # v2.49.33
-        with:
-          tool: cargo-codspeed
-
-      - name: Run benchmark
-        uses: CodSpeedHQ/action@0010eb0ca6e89b80c88e8edaaa07cfe5f3e6664d # v3.5.0
-        timeout-minutes: 30
-        env:
-          FIXTURE: ${{ matrix.fixture }}
         with:
           token: ${{ secrets.CODSPEED_TOKEN }}
           run: cargo codspeed run

--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -1,6 +1,5 @@
 use oxc_allocator::Box;
 use oxc_ast::{NONE, ast::*};
-use oxc_diagnostics::Result;
 use oxc_span::{GetSpan, Span};
 use oxc_syntax::precedence::Precedence;
 
@@ -20,12 +19,12 @@ impl<'a> ParserImpl<'a> {
     pub(super) fn try_parse_parenthesized_arrow_function_expression(
         &mut self,
         allow_return_type_in_arrow_function: bool,
-    ) -> Result<Option<Expression<'a>>> {
+    ) -> Option<Expression<'a>> {
         match self.is_parenthesized_arrow_function_expression() {
-            Tristate::False => Ok(None),
-            Tristate::True => self.parse_parenthesized_arrow_function_expression(
+            Tristate::False => None,
+            Tristate::True => Some(self.parse_parenthesized_arrow_function_expression(
                 /* allow_return_type_in_arrow_function */ true,
-            ),
+            )),
             Tristate::Maybe => self.parse_possible_parenthesized_arrow_function_expression(
                 allow_return_type_in_arrow_function,
             ),
@@ -35,23 +34,21 @@ impl<'a> ParserImpl<'a> {
     pub(super) fn try_parse_async_simple_arrow_function_expression(
         &mut self,
         allow_return_type_in_arrow_function: bool,
-    ) -> Result<Option<Expression<'a>>> {
+    ) -> Option<Expression<'a>> {
         if self.at(Kind::Async)
             && self.is_un_parenthesized_async_arrow_function_worker() == Tristate::True
         {
             let span = self.start_span();
             self.bump_any(); // bump `async`
-            let expr = self.parse_binary_expression_or_higher(Precedence::Comma)?;
-            return self
-                .parse_simple_arrow_function_expression(
-                    span,
-                    expr,
-                    /* async */ true,
-                    allow_return_type_in_arrow_function,
-                )
-                .map(Some);
+            let expr = self.parse_binary_expression_or_higher(Precedence::Comma);
+            return Some(self.parse_simple_arrow_function_expression(
+                span,
+                expr,
+                /* async */ true,
+                allow_return_type_in_arrow_function,
+            ));
         }
-        Ok(None)
+        None
     }
 
     fn is_parenthesized_arrow_function_expression(&mut self) -> Tristate {
@@ -217,7 +214,7 @@ impl<'a> ParserImpl<'a> {
         ident: Expression<'a>,
         r#async: bool,
         allow_return_type_in_arrow_function: bool,
-    ) -> Result<Expression<'a>> {
+    ) -> Expression<'a> {
         let has_await = self.ctx.has_await();
         self.ctx = self.ctx.union_await_if(r#async);
 
@@ -247,7 +244,7 @@ impl<'a> ParserImpl<'a> {
             self.error(diagnostics::lineterminator_before_arrow(self.cur_token().span()));
         }
 
-        self.expect(Kind::Arrow)?;
+        self.expect(Kind::Arrow);
 
         self.parse_arrow_function_expression_body(
             ArrowFunctionHead {
@@ -262,17 +259,17 @@ impl<'a> ParserImpl<'a> {
         )
     }
 
-    fn parse_parenthesized_arrow_function_head(&mut self) -> Result<ArrowFunctionHead<'a>> {
+    fn parse_parenthesized_arrow_function_head(&mut self) -> ArrowFunctionHead<'a> {
         let span = self.start_span();
         let r#async = self.eat(Kind::Async);
 
         let has_await = self.ctx.has_await();
         self.ctx = self.ctx.union_await_if(r#async);
 
-        let type_parameters = self.parse_ts_type_parameters()?;
+        let type_parameters = self.parse_ts_type_parameters();
 
         let (this_param, params) =
-            self.parse_formal_parameters(FormalParameterKind::ArrowFormalParameters)?;
+            self.parse_formal_parameters(FormalParameterKind::ArrowFormalParameters);
 
         if let Some(this_param) = this_param {
             // const x = (this: number) => {};
@@ -280,7 +277,7 @@ impl<'a> ParserImpl<'a> {
         }
 
         let has_return_colon = self.is_ts && self.at(Kind::Colon);
-        let return_type = self.parse_ts_return_type_annotation(Kind::Arrow, false)?;
+        let return_type = self.parse_ts_return_type_annotation(Kind::Arrow, false);
 
         self.ctx = self.ctx.and_await(has_await);
 
@@ -288,16 +285,9 @@ impl<'a> ParserImpl<'a> {
             self.error(diagnostics::lineterminator_before_arrow(self.cur_token().span()));
         }
 
-        self.expect(Kind::Arrow)?;
+        self.expect(Kind::Arrow);
 
-        Ok(ArrowFunctionHead {
-            type_parameters,
-            params,
-            return_type,
-            r#async,
-            span,
-            has_return_colon,
-        })
+        ArrowFunctionHead { type_parameters, params, return_type, r#async, span, has_return_colon }
     }
 
     /// [ConciseBody](https://tc39.es/ecma262/#prod-ConciseBody)
@@ -309,7 +299,7 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         arrow_function_head: ArrowFunctionHead<'a>,
         allow_return_type_in_arrow_function: bool,
-    ) -> Result<Expression<'a>> {
+    ) -> Expression<'a> {
         let ArrowFunctionHead { type_parameters, params, return_type, r#async, span, .. } =
             arrow_function_head;
         let has_await = self.ctx.has_await();
@@ -319,17 +309,17 @@ impl<'a> ParserImpl<'a> {
         let expression = !self.at(Kind::LCurly);
         let body = if expression {
             let expr = self
-                .parse_assignment_expression_or_higher_impl(allow_return_type_in_arrow_function)?;
+                .parse_assignment_expression_or_higher_impl(allow_return_type_in_arrow_function);
             let span = expr.span();
             let expr_stmt = self.ast.statement_expression(span, expr);
             self.ast.alloc_function_body(span, self.ast.vec(), self.ast.vec1(expr_stmt))
         } else {
-            self.parse_function_body()?
+            self.parse_function_body()
         };
 
         self.ctx = self.ctx.and_await(has_await).and_yield(has_yield);
 
-        Ok(self.ast.expression_arrow_function(
+        self.ast.expression_arrow_function(
             self.end_span(span),
             expression,
             r#async,
@@ -337,7 +327,7 @@ impl<'a> ParserImpl<'a> {
             params,
             return_type,
             body,
-        ))
+        )
     }
 
     /// Section [Arrow Function](https://tc39.es/ecma262/#sec-arrow-function-definitions)
@@ -346,33 +336,38 @@ impl<'a> ParserImpl<'a> {
     fn parse_parenthesized_arrow_function_expression(
         &mut self,
         allow_return_type_in_arrow_function: bool,
-    ) -> Result<Option<Expression<'a>>> {
-        let head = self.parse_parenthesized_arrow_function_head()?;
+    ) -> Expression<'a> {
+        let head = self.parse_parenthesized_arrow_function_head();
         self.parse_arrow_function_expression_body(head, allow_return_type_in_arrow_function)
-            .map(Some)
     }
 
     fn parse_possible_parenthesized_arrow_function_expression(
         &mut self,
         allow_return_type_in_arrow_function: bool,
-    ) -> Result<Option<Expression<'a>>> {
+    ) -> Option<Expression<'a>> {
         let pos = self.cur_token().start;
         if self.state.not_parenthesized_arrow.contains(&pos) {
-            return Ok(None);
+            return None;
+        }
+
+        if self.fatal_error.is_some() {
+            return None;
         }
 
         let checkpoint = self.checkpoint();
 
-        let Ok(head) = self.parse_parenthesized_arrow_function_head() else {
+        let head = self.parse_parenthesized_arrow_function_head();
+        if self.fatal_error.is_some() {
+            self.fatal_error = None;
             self.state.not_parenthesized_arrow.insert(pos);
             self.rewind(checkpoint);
-            return Ok(None);
-        };
+            return None;
+        }
 
         let has_return_colon = head.has_return_colon;
 
         let body =
-            self.parse_arrow_function_expression_body(head, allow_return_type_in_arrow_function)?;
+            self.parse_arrow_function_expression_body(head, allow_return_type_in_arrow_function);
 
         // Given:
         //     x ? y => ({ y }) : z => ({ z })
@@ -399,10 +394,10 @@ impl<'a> ParserImpl<'a> {
             if !self.at(Kind::Colon) {
                 self.state.not_parenthesized_arrow.insert(pos);
                 self.rewind(checkpoint);
-                return Ok(None);
+                return None;
             }
         }
 
-        Ok(Some(body))
+        Some(body)
     }
 }

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -1,6 +1,5 @@
 use oxc_allocator::{Box, Vec};
 use oxc_ast::ast::*;
-use oxc_diagnostics::Result;
 use oxc_ecmascript::PropName;
 use oxc_span::{GetSpan, Span};
 
@@ -22,12 +21,12 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         stmt_ctx: StatementContext,
         start_span: Span,
-    ) -> Result<Statement<'a>> {
+    ) -> Statement<'a> {
         let modifiers = self.parse_modifiers(
             /* allow_decorators */ true, /* permit_const_as_modifier */ false,
             /* stop_on_start_of_class_static_block */ true,
         );
-        let decl = self.parse_class_declaration(start_span, &modifiers)?;
+        let decl = self.parse_class_declaration(start_span, &modifiers);
 
         if stmt_ctx.is_single_statement() {
             self.error(diagnostics::class_declaration(Span::new(
@@ -36,7 +35,7 @@ impl<'a> ParserImpl<'a> {
             )));
         }
 
-        Ok(Statement::ClassDeclaration(decl))
+        Statement::ClassDeclaration(decl)
     }
 
     /// Section 15.7 Class Definitions
@@ -44,17 +43,17 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         start_span: Span,
         modifiers: &Modifiers<'a>,
-    ) -> Result<Box<'a, Class<'a>>> {
+    ) -> Box<'a, Class<'a>> {
         self.parse_class(start_span, ClassType::ClassDeclaration, modifiers)
     }
 
     /// Section [Class Definitions](https://tc39.es/ecma262/#prod-ClassExpression)
     /// `ClassExpression`[Yield, Await] :
     ///     class `BindingIdentifier`[?Yield, ?Await]opt `ClassTail`[?Yield, ?Await]
-    pub(crate) fn parse_class_expression(&mut self) -> Result<Expression<'a>> {
+    pub(crate) fn parse_class_expression(&mut self) -> Expression<'a> {
         let class =
-            self.parse_class(self.start_span(), ClassType::ClassExpression, &Modifiers::empty())?;
-        Ok(Expression::ClassExpression(class))
+            self.parse_class(self.start_span(), ClassType::ClassExpression, &Modifiers::empty());
+        Expression::ClassExpression(class)
     }
 
     fn parse_class(
@@ -62,20 +61,20 @@ impl<'a> ParserImpl<'a> {
         start_span: Span,
         r#type: ClassType,
         modifiers: &Modifiers<'a>,
-    ) -> Result<Box<'a, Class<'a>>> {
+    ) -> Box<'a, Class<'a>> {
         self.bump_any(); // advance `class`
 
         let decorators = self.consume_decorators();
         let start_span = decorators.iter().next().map_or(start_span, |d| d.span);
 
         let id = if self.cur_kind().is_binding_identifier() && !self.at(Kind::Implements) {
-            Some(self.parse_binding_identifier()?)
+            Some(self.parse_binding_identifier())
         } else {
             None
         };
 
-        let type_parameters = if self.is_ts { self.parse_ts_type_parameters()? } else { None };
-        let (extends, implements) = self.parse_heritage_clause()?;
+        let type_parameters = if self.is_ts { self.parse_ts_type_parameters() } else { None };
+        let (extends, implements) = self.parse_heritage_clause();
         let mut super_class = None;
         let mut super_type_parameters = None;
         if let Some(mut extends) = extends {
@@ -85,7 +84,7 @@ impl<'a> ParserImpl<'a> {
                 super_type_parameters = first_extends.1;
             }
         }
-        let body = self.parse_class_body()?;
+        let body = self.parse_class_body();
 
         self.verify_modifiers(
             modifiers,
@@ -93,7 +92,7 @@ impl<'a> ParserImpl<'a> {
             diagnostics::modifier_cannot_be_used_here,
         );
 
-        Ok(self.ast.alloc_class(
+        self.ast.alloc_class(
             self.end_span(start_span),
             r#type,
             decorators,
@@ -105,46 +104,46 @@ impl<'a> ParserImpl<'a> {
             body,
             modifiers.contains_abstract(),
             modifiers.contains_declare(),
-        ))
+        )
     }
 
     pub(crate) fn parse_heritage_clause(
         &mut self,
-    ) -> Result<(Option<Extends<'a>>, Option<Implements<'a>>)> {
+    ) -> (Option<Extends<'a>>, Option<Implements<'a>>) {
         let mut extends = None;
         let mut implements = None;
 
         loop {
             match self.cur_kind() {
                 Kind::Extends => {
-                    extends = Some(self.parse_extends_clause()?);
+                    extends = Some(self.parse_extends_clause());
                 }
                 Kind::Implements => {
-                    implements = Some(self.parse_ts_implements_clause()?);
+                    implements = Some(self.parse_ts_implements_clause());
                 }
                 _ => break,
             }
         }
 
-        Ok((extends, implements))
+        (extends, implements)
     }
 
     /// `ClassHeritage`
     /// extends `LeftHandSideExpression`[?Yield, ?Await]
-    fn parse_extends_clause(&mut self) -> Result<Extends<'a>> {
+    fn parse_extends_clause(&mut self) -> Extends<'a> {
         self.bump_any(); // bump `extends`
 
         let mut extends = self.ast.vec();
         loop {
             let span = self.start_span();
-            let mut extend = self.parse_lhs_expression_or_higher()?;
+            let mut extend = self.parse_lhs_expression_or_higher();
             let type_argument;
             if let Expression::TSInstantiationExpression(expr) = extend {
                 let expr = expr.unbox();
                 extend = expr.expression;
                 type_argument = Some(expr.type_parameters);
             } else {
-                type_argument = self.try_parse_type_arguments()?;
+                type_argument = self.try_parse_type_arguments();
             }
 
             extends.push((extend, type_argument, self.end_span(span)));
@@ -154,23 +153,23 @@ impl<'a> ParserImpl<'a> {
             }
         }
 
-        Ok(extends)
+        extends
     }
 
-    fn parse_class_body(&mut self) -> Result<Box<'a, ClassBody<'a>>> {
+    fn parse_class_body(&mut self) -> Box<'a, ClassBody<'a>> {
         let span = self.start_span();
         let class_elements =
-            self.parse_normal_list(Kind::LCurly, Kind::RCurly, Self::parse_class_element)?;
-        Ok(self.ast.alloc_class_body(self.end_span(span), class_elements))
+            self.parse_normal_list(Kind::LCurly, Kind::RCurly, Self::parse_class_element);
+        self.ast.alloc_class_body(self.end_span(span), class_elements)
     }
 
-    pub(crate) fn parse_class_element(&mut self) -> Result<Option<ClassElement<'a>>> {
+    pub(crate) fn parse_class_element(&mut self) -> Option<ClassElement<'a>> {
         // skip empty class element `;`
         while self.at(Kind::Semicolon) {
             self.bump_any();
         }
         if self.at(Kind::RCurly) {
-            return Ok(None);
+            return None;
         }
 
         let span = self.start_span();
@@ -195,7 +194,7 @@ impl<'a> ParserImpl<'a> {
             // static { block }
             if self.peek_at(Kind::LCurly) {
                 self.bump(Kind::Static);
-                return self.parse_class_static_block(span).map(Some);
+                return Some(self.parse_class_static_block(span));
             }
 
             // static ...
@@ -203,7 +202,7 @@ impl<'a> ParserImpl<'a> {
                 self.bump(Kind::Static);
                 r#static = true;
             } else {
-                key_name = Some(self.parse_class_element_name()?);
+                key_name = Some(self.parse_class_element_name());
             }
         }
 
@@ -215,14 +214,13 @@ impl<'a> ParserImpl<'a> {
                 self.bump(Kind::Async);
                 r#async = true;
             } else {
-                key_name = Some(self.parse_class_element_name()?);
+                key_name = Some(self.parse_class_element_name());
             }
         }
 
         if self.is_at_ts_index_signature_member() {
-            return self
-                .parse_index_signature_declaration(span, &modifiers)
-                .map(|sig| Some(ClassElement::TSIndexSignature(self.alloc(sig))));
+            let sig = self.parse_index_signature_declaration(span, &modifiers);
+            return Some(ClassElement::TSIndexSignature(self.alloc(sig)));
         }
 
         // * ...
@@ -237,22 +235,22 @@ impl<'a> ParserImpl<'a> {
                 Kind::Get if peeked_class_element => {
                     self.bump(Kind::Get);
                     kind = MethodDefinitionKind::Get;
-                    Some(self.parse_class_element_name()?)
+                    Some(self.parse_class_element_name())
                 }
                 Kind::Set if peeked_class_element => {
                     self.bump(Kind::Set);
                     kind = MethodDefinitionKind::Set;
-                    Some(self.parse_class_element_name()?)
+                    Some(self.parse_class_element_name())
                 }
-                kind if kind.is_class_element_name_start() => {
-                    Some(self.parse_class_element_name()?)
+                kind if kind.is_class_element_name_start() => Some(self.parse_class_element_name()),
+                _ => {
+                    return self.unexpected();
                 }
-                _ => return Err(self.unexpected()),
             }
         }
 
         let (key, computed) =
-            if let Some(result) = key_name { result } else { self.parse_class_element_name()? };
+            if let Some(result) = key_name { result } else { self.parse_class_element_name() };
 
         let (optional, optional_span) = if self.at(Kind::Question) {
             let span = self.start_span();
@@ -289,7 +287,7 @@ impl<'a> ParserImpl<'a> {
             if optional {
                 self.error(diagnostics::optional_accessor_property(optional_span));
             }
-            self.parse_class_accessor_property(
+            Some(self.parse_class_accessor_property(
                 span,
                 key,
                 computed,
@@ -297,8 +295,7 @@ impl<'a> ParserImpl<'a> {
                 r#abstract,
                 definite,
                 accessibility,
-            )
-            .map(Some)
+            ))
         } else if self.at(Kind::LParen) || self.at(Kind::LAngle) || r#async || generator {
             if !computed {
                 if let Some((name, span)) = key.prop_name() {
@@ -332,12 +329,12 @@ impl<'a> ParserImpl<'a> {
                 r#abstract,
                 accessibility,
                 optional,
-            )?;
-            Ok(Some(definition))
+            );
+            Some(definition)
         } else {
             // getter and setter has no ts type annotation
             if !kind.is_method() {
-                return Err(self.unexpected());
+                return self.unexpected();
             }
             if !computed {
                 if let Some((name, span)) = key.prop_name() {
@@ -361,16 +358,16 @@ impl<'a> ParserImpl<'a> {
                 accessibility,
                 optional,
                 definite,
-            )?;
-            Ok(Some(definition))
+            );
+            Some(definition)
         }
     }
 
-    fn parse_class_element_name(&mut self) -> Result<(PropertyKey<'a>, bool)> {
+    fn parse_class_element_name(&mut self) -> (PropertyKey<'a>, bool) {
         match self.cur_kind() {
             Kind::PrivateIdentifier => {
                 let private_ident = self.parse_private_identifier();
-                Ok((PropertyKey::PrivateIdentifier(self.alloc(private_ident)), false))
+                (PropertyKey::PrivateIdentifier(self.alloc(private_ident)), false)
             }
             _ => self.parse_property_name(),
         }
@@ -389,7 +386,7 @@ impl<'a> ParserImpl<'a> {
         r#abstract: bool,
         accessibility: Option<TSAccessibility>,
         optional: bool,
-    ) -> Result<ClassElement<'a>> {
+    ) -> ClassElement<'a> {
         let kind = if !r#static
             && !computed
             && key.prop_name().is_some_and(|(name, _)| name == "constructor")
@@ -401,7 +398,7 @@ impl<'a> ParserImpl<'a> {
 
         let decorators = self.consume_decorators();
 
-        let value = self.parse_method(r#async, generator)?;
+        let value = self.parse_method(r#async, generator);
 
         if kind == MethodDefinitionKind::Constructor {
             if let Some(this_param) = &value.this_param {
@@ -424,7 +421,7 @@ impl<'a> ParserImpl<'a> {
         } else {
             MethodDefinitionType::MethodDefinition
         };
-        Ok(self.ast.class_element_method_definition(
+        self.ast.class_element_method_definition(
             self.end_span(span),
             r#type,
             decorators,
@@ -436,7 +433,7 @@ impl<'a> ParserImpl<'a> {
             r#override,
             optional,
             accessibility,
-        ))
+        )
     }
 
     /// `FieldDefinition`[?Yield, ?Await] ;
@@ -453,18 +450,18 @@ impl<'a> ParserImpl<'a> {
         accessibility: Option<TSAccessibility>,
         optional: bool,
         definite: bool,
-    ) -> Result<ClassElement<'a>> {
-        let type_annotation = if self.is_ts { self.parse_ts_type_annotation()? } else { None };
+    ) -> ClassElement<'a> {
+        let type_annotation = if self.is_ts { self.parse_ts_type_annotation() } else { None };
         let decorators = self.consume_decorators();
-        let value = if self.eat(Kind::Eq) { Some(self.parse_expr()?) } else { None };
-        self.asi()?;
+        let value = if self.eat(Kind::Eq) { Some(self.parse_expr()) } else { None };
+        self.asi();
 
         let r#type = if r#abstract {
             PropertyDefinitionType::TSAbstractPropertyDefinition
         } else {
             PropertyDefinitionType::PropertyDefinition
         };
-        Ok(self.ast.class_element_property_definition(
+        self.ast.class_element_property_definition(
             self.end_span(span),
             r#type,
             decorators,
@@ -479,15 +476,15 @@ impl<'a> ParserImpl<'a> {
             readonly,
             type_annotation,
             accessibility,
-        ))
+        )
     }
 
     /// `ClassStaticBlockStatementList` :
     ///    `StatementList`[~Yield, +Await, ~Return]
-    fn parse_class_static_block(&mut self, span: Span) -> Result<ClassElement<'a>> {
+    fn parse_class_static_block(&mut self, span: Span) -> ClassElement<'a> {
         let block =
-            self.context(Context::Await, Context::Yield | Context::Return, Self::parse_block)?;
-        Ok(self.ast.class_element_static_block(self.end_span(span), block.unbox().body))
+            self.context(Context::Await, Context::Yield | Context::Return, Self::parse_block);
+        self.ast.class_element_static_block(self.end_span(span), block.unbox().body)
     }
 
     /// <https://github.com/tc39/proposal-decorators>
@@ -500,18 +497,17 @@ impl<'a> ParserImpl<'a> {
         r#abstract: bool,
         definite: bool,
         accessibility: Option<TSAccessibility>,
-    ) -> Result<ClassElement<'a>> {
-        let type_annotation = if self.is_ts { self.parse_ts_type_annotation()? } else { None };
-        let value =
-            self.eat(Kind::Eq).then(|| self.parse_assignment_expression_or_higher()).transpose()?;
-        self.asi()?;
+    ) -> ClassElement<'a> {
+        let type_annotation = if self.is_ts { self.parse_ts_type_annotation() } else { None };
+        let value = self.eat(Kind::Eq).then(|| self.parse_assignment_expression_or_higher());
+        self.asi();
         let r#type = if r#abstract {
             AccessorPropertyType::TSAbstractAccessorProperty
         } else {
             AccessorPropertyType::AccessorProperty
         };
         let decorators = self.consume_decorators();
-        Ok(self.ast.class_element_accessor_property(
+        self.ast.class_element_accessor_property(
             self.end_span(span),
             r#type,
             decorators,
@@ -522,6 +518,6 @@ impl<'a> ParserImpl<'a> {
             definite,
             type_annotation,
             accessibility,
-        ))
+        )
     }
 }

--- a/crates/oxc_parser/src/js/declaration.rs
+++ b/crates/oxc_parser/src/js/declaration.rs
@@ -1,6 +1,5 @@
 use oxc_allocator::Box;
 use oxc_ast::{NONE, ast::*};
-use oxc_diagnostics::Result;
 use oxc_span::{GetSpan, Span};
 
 use super::VariableDeclarationParent;
@@ -11,33 +10,33 @@ use crate::{
 };
 
 impl<'a> ParserImpl<'a> {
-    pub(crate) fn parse_let(&mut self, stmt_ctx: StatementContext) -> Result<Statement<'a>> {
+    pub(crate) fn parse_let(&mut self, stmt_ctx: StatementContext) -> Statement<'a> {
         let span = self.start_span();
         let peeked = self.peek_kind();
         // let = foo, let instanceof x, let + 1
         if peeked.is_assignment_operator() || peeked.is_binary_operator() {
-            let expr = self.parse_assignment_expression_or_higher()?;
+            let expr = self.parse_assignment_expression_or_higher();
             self.parse_expression_statement(span, expr)
         // let.a = 1, let()[a] = 1
         } else if matches!(peeked, Kind::Dot | Kind::LParen) {
-            let expr = self.parse_expr()?;
-            Ok(self.ast.statement_expression(self.end_span(span), expr))
+            let expr = self.parse_expr();
+            self.ast.statement_expression(self.end_span(span), expr)
         // single statement let declaration: while (0) let
         } else if (stmt_ctx.is_single_statement() && peeked != Kind::LBrack)
             || peeked == Kind::Semicolon
         {
-            let expr = self.parse_identifier_expression()?;
+            let expr = self.parse_identifier_expression();
             self.parse_expression_statement(span, expr)
         } else {
             self.parse_variable_statement(stmt_ctx)
         }
     }
 
-    pub(crate) fn parse_using_statement(&mut self) -> Result<Statement<'a>> {
-        let mut decl = self.parse_using_declaration(StatementContext::StatementList)?;
-        self.asi()?;
+    pub(crate) fn parse_using_statement(&mut self) -> Statement<'a> {
+        let mut decl = self.parse_using_declaration(StatementContext::StatementList);
+        self.asi();
         decl.span = self.end_span(decl.span);
-        Ok(Statement::VariableDeclaration(self.alloc(decl)))
+        Statement::VariableDeclaration(self.alloc(decl))
     }
 
     pub(crate) fn parse_variable_declaration(
@@ -45,18 +44,18 @@ impl<'a> ParserImpl<'a> {
         start_span: Span,
         decl_parent: VariableDeclarationParent,
         modifiers: &Modifiers<'a>,
-    ) -> Result<Box<'a, VariableDeclaration<'a>>> {
+    ) -> Box<'a, VariableDeclaration<'a>> {
         let kind = match self.cur_kind() {
             Kind::Var => VariableDeclarationKind::Var,
             Kind::Const => VariableDeclarationKind::Const,
             Kind::Let => VariableDeclarationKind::Let,
-            _ => return Err(self.unexpected()),
+            _ => return self.unexpected(),
         };
         self.bump_any();
 
         let mut declarations = self.ast.vec();
         loop {
-            let declaration = self.parse_variable_declarator(decl_parent, kind)?;
+            let declaration = self.parse_variable_declarator(decl_parent, kind);
             declarations.push(declaration);
             if !self.eat(Kind::Comma) {
                 break;
@@ -64,7 +63,7 @@ impl<'a> ParserImpl<'a> {
         }
 
         if matches!(decl_parent, VariableDeclarationParent::Statement) {
-            self.asi()?;
+            self.asi();
         }
 
         self.verify_modifiers(
@@ -73,22 +72,22 @@ impl<'a> ParserImpl<'a> {
             diagnostics::modifier_cannot_be_used_here,
         );
 
-        Ok(self.ast.alloc_variable_declaration(
+        self.ast.alloc_variable_declaration(
             self.end_span(start_span),
             kind,
             declarations,
             modifiers.contains_declare(),
-        ))
+        )
     }
 
     fn parse_variable_declarator(
         &mut self,
         decl_parent: VariableDeclarationParent,
         kind: VariableDeclarationKind,
-    ) -> Result<VariableDeclarator<'a>> {
+    ) -> VariableDeclarator<'a> {
         let span = self.start_span();
 
-        let mut binding_kind = self.parse_binding_pattern_kind()?;
+        let mut binding_kind = self.parse_binding_pattern_kind();
 
         let (id, definite) = if self.is_ts {
             // const x!: number = 1
@@ -102,7 +101,7 @@ impl<'a> ParserImpl<'a> {
                 definite = true;
             }
             let optional = self.eat(Kind::Question); // not allowed, but checked in checker/typescript.rs
-            let type_annotation = self.parse_ts_type_annotation()?;
+            let type_annotation = self.parse_ts_type_annotation();
             if let Some(type_annotation) = &type_annotation {
                 Self::extend_binding_pattern_span_end(type_annotation.span.end, &mut binding_kind);
             }
@@ -110,13 +109,12 @@ impl<'a> ParserImpl<'a> {
         } else {
             (self.ast.binding_pattern(binding_kind, NONE, false), false)
         };
-        let init =
-            self.eat(Kind::Eq).then(|| self.parse_assignment_expression_or_higher()).transpose()?;
+        let init = self.eat(Kind::Eq).then(|| self.parse_assignment_expression_or_higher());
         let decl = self.ast.variable_declarator(self.end_span(span), kind, id, init, definite);
         if decl_parent == VariableDeclarationParent::Statement {
             self.check_missing_initializer(&decl);
         }
-        Ok(decl)
+        decl
     }
 
     pub(crate) fn check_missing_initializer(&mut self, decl: &VariableDeclarator<'a>) {
@@ -136,12 +134,12 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_using_declaration(
         &mut self,
         statement_ctx: StatementContext,
-    ) -> Result<VariableDeclaration<'a>> {
+    ) -> VariableDeclaration<'a> {
         let span = self.start_span();
 
         let is_await = self.eat(Kind::Await);
 
-        self.expect(Kind::Using)?;
+        self.expect(Kind::Using);
 
         // `[no LineTerminator here]`
         if self.cur_token().is_on_new_line {
@@ -166,7 +164,7 @@ impl<'a> ParserImpl<'a> {
                 } else {
                     VariableDeclarationKind::Using
                 },
-            )?;
+            );
 
             match declaration.id.kind {
                 BindingPatternKind::BindingIdentifier(_) => {}
@@ -195,6 +193,6 @@ impl<'a> ParserImpl<'a> {
         } else {
             VariableDeclarationKind::Using
         };
-        Ok(self.ast.variable_declaration(self.end_span(span), kind, declarations, false))
+        self.ast.variable_declaration(self.end_span(span), kind, declarations, false)
     }
 }

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -1,7 +1,6 @@
 use cow_utils::CowUtils;
-use oxc_allocator::Box;
+use oxc_allocator::{Box, Dummy};
 use oxc_ast::ast::*;
-use oxc_diagnostics::Result;
 #[cfg(feature = "regular_expression")]
 use oxc_regular_expression::ast::Pattern;
 use oxc_span::{Atom, GetSpan, Span};
@@ -23,15 +22,15 @@ use crate::{
 };
 
 impl<'a> ParserImpl<'a> {
-    pub(crate) fn parse_paren_expression(&mut self) -> Result<Expression<'a>> {
-        self.expect(Kind::LParen)?;
-        let expression = self.parse_expr()?;
-        self.expect(Kind::RParen)?;
-        Ok(expression)
+    pub(crate) fn parse_paren_expression(&mut self) -> Expression<'a> {
+        self.expect(Kind::LParen);
+        let expression = self.parse_expr();
+        self.expect(Kind::RParen);
+        expression
     }
 
     /// Section [Expression](https://tc39.es/ecma262/#sec-ecmascript-language-expressions)
-    pub(crate) fn parse_expr(&mut self) -> Result<Expression<'a>> {
+    pub(crate) fn parse_expr(&mut self) -> Expression<'a> {
         let span = self.start_span();
 
         let has_decorator = self.ctx.has_decorator();
@@ -39,67 +38,68 @@ impl<'a> ParserImpl<'a> {
             self.ctx = self.ctx.and_decorator(false);
         }
 
-        let lhs = self.parse_assignment_expression_or_higher()?;
+        let lhs = self.parse_assignment_expression_or_higher();
         if !self.at(Kind::Comma) {
-            return Ok(lhs);
+            return lhs;
         }
 
-        let expr = self.parse_sequence_expression(span, lhs)?;
+        let expr = self.parse_sequence_expression(span, lhs);
 
         if has_decorator {
             self.ctx = self.ctx.and_decorator(true);
         }
 
-        Ok(expr)
+        expr
     }
 
     /// `PrimaryExpression`: Identifier Reference
-    pub(crate) fn parse_identifier_expression(&mut self) -> Result<Expression<'a>> {
-        let ident = self.parse_identifier_reference()?;
-        Ok(Expression::Identifier(self.alloc(ident)))
+    pub(crate) fn parse_identifier_expression(&mut self) -> Expression<'a> {
+        let ident = self.parse_identifier_reference();
+        Expression::Identifier(self.alloc(ident))
     }
 
-    pub(crate) fn parse_identifier_reference(&mut self) -> Result<IdentifierReference<'a>> {
+    pub(crate) fn parse_identifier_reference(&mut self) -> IdentifierReference<'a> {
         // allow `await` and `yield`, let semantic analysis report error
         if !self.cur_kind().is_identifier_reference(false, false) {
-            return Err(self.unexpected());
+            return self.unexpected();
         }
         let (span, name) = self.parse_identifier_kind(Kind::Ident);
         self.check_identifier(span, &name);
-        Ok(self.ast.identifier_reference(span, name))
+        self.ast.identifier_reference(span, name)
     }
 
     /// `BindingIdentifier` : Identifier
-    pub(crate) fn parse_binding_identifier(&mut self) -> Result<BindingIdentifier<'a>> {
+    pub(crate) fn parse_binding_identifier(&mut self) -> BindingIdentifier<'a> {
         let cur = self.cur_kind();
         if !cur.is_binding_identifier() {
-            let err = if cur.is_reserved_keyword() {
-                diagnostics::identifier_reserved_word(self.cur_token().span(), cur.to_str())
-            } else {
-                self.unexpected()
-            };
-            return Err(err);
+            if cur.is_reserved_keyword() {
+                return self.fatal_error(diagnostics::identifier_reserved_word(
+                    self.cur_token().span(),
+                    cur.to_str(),
+                ));
+            }
+            return self.unexpected();
         }
         let (span, name) = self.parse_identifier_kind(Kind::Ident);
         self.check_identifier(span, &name);
-        Ok(self.ast.binding_identifier(span, name))
+        self.ast.binding_identifier(span, name)
     }
 
-    pub(crate) fn parse_label_identifier(&mut self) -> Result<LabelIdentifier<'a>> {
+    pub(crate) fn parse_label_identifier(&mut self) -> LabelIdentifier<'a> {
         if !self.cur_kind().is_label_identifier(self.ctx.has_yield(), self.ctx.has_await()) {
-            return Err(self.unexpected());
+            return self.unexpected();
         }
         let (span, name) = self.parse_identifier_kind(Kind::Ident);
         self.check_identifier(span, &name);
-        Ok(self.ast.label_identifier(span, name))
+        self.ast.label_identifier(span, name)
     }
 
-    pub(crate) fn parse_identifier_name(&mut self) -> Result<IdentifierName<'a>> {
+    pub(crate) fn parse_identifier_name(&mut self) -> IdentifierName<'a> {
         if !self.cur_kind().is_identifier_name() {
-            return Err(self.unexpected());
+            return self.unexpected();
         }
         let (span, name) = self.parse_identifier_kind(Kind::Ident);
-        Ok(self.ast.identifier_name(span, name))
+        self.ast.identifier_name(span, name)
     }
 
     /// Parse keyword kind as identifier
@@ -153,11 +153,11 @@ impl<'a> ParserImpl<'a> {
     ///     `RegularExpressionLiteral`
     ///     `TemplateLiteral`[?Yield, ?Await, ~Tagged]
     ///     `CoverParenthesizedExpressionAndArrowParameterList`[?Yield, ?Await]
-    fn parse_primary_expression(&mut self) -> Result<Expression<'a>> {
+    fn parse_primary_expression(&mut self) -> Expression<'a> {
         let span = self.start_span();
 
         if self.at(Kind::At) {
-            self.eat_decorators()?;
+            self.eat_decorators();
         }
 
         // FunctionExpression, GeneratorExpression
@@ -172,23 +172,24 @@ impl<'a> ParserImpl<'a> {
             // ArrayLiteral
             Kind::LBrack => self.parse_array_expression(),
             // ObjectLiteral
-            Kind::LCurly => self.parse_object_expression().map(Expression::ObjectExpression),
+            Kind::LCurly => Expression::ObjectExpression(self.parse_object_expression()),
             // ClassExpression
             Kind::Class => self.parse_class_expression(),
             // This
-            Kind::This => Ok(self.parse_this_expression()),
+            Kind::This => self.parse_this_expression(),
             // TemplateLiteral
             Kind::NoSubstitutionTemplate | Kind::TemplateHead => {
                 self.parse_template_literal_expression(false)
             }
             Kind::Percent => self.parse_v8_intrinsic_expression(),
             Kind::New => self.parse_new_expression(),
-            Kind::Super => Ok(self.parse_super()),
+            Kind::Super => self.parse_super(),
             Kind::Import => self.parse_import_meta_or_call(),
             Kind::LParen => self.parse_parenthesized_expression(span),
-            Kind::Slash | Kind::SlashEq => self
-                .parse_literal_regexp()
-                .map(|literal| Expression::RegExpLiteral(self.alloc(literal))),
+            Kind::Slash | Kind::SlashEq => {
+                let lit = self.parse_literal_regexp();
+                Expression::RegExpLiteral(self.alloc(lit))
+            }
             // Literal, RegularExpressionLiteral
             kind if kind.is_literal() => self.parse_literal_expression(),
             // JSXElement, JSXFragment
@@ -197,8 +198,8 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
-    fn parse_parenthesized_expression(&mut self, span: Span) -> Result<Expression<'a>> {
-        self.expect(Kind::LParen)?;
+    fn parse_parenthesized_expression(&mut self, span: Span) -> Expression<'a> {
+        self.expect(Kind::LParen);
         let expr_span = self.start_span();
         let mut expressions = self.context(Context::In, Context::Decorator, |p| {
             p.parse_delimited_list(
@@ -207,15 +208,16 @@ impl<'a> ParserImpl<'a> {
                 /* trailing_separator */ false,
                 Self::parse_assignment_expression_or_higher,
             )
-        })?;
+        });
 
         if expressions.is_empty() {
-            self.expect(Kind::RParen)?;
-            return Err(diagnostics::empty_parenthesized_expression(self.end_span(span)));
+            self.expect(Kind::RParen);
+            return self
+                .fatal_error(diagnostics::empty_parenthesized_expression(self.end_span(span)));
         }
 
         let expr_span = self.end_span(expr_span);
-        self.expect(Kind::RParen)?;
+        self.expect(Kind::RParen);
 
         // ParenthesizedExpression is from acorn --preserveParens
         let expression = if expressions.len() == 1 {
@@ -224,11 +226,11 @@ impl<'a> ParserImpl<'a> {
             self.ast.expression_sequence(expr_span, expressions)
         };
 
-        Ok(if self.options.preserve_parens {
+        if self.options.preserve_parens {
             self.ast.expression_parenthesized(self.end_span(span), expression)
         } else {
             expression
-        })
+        }
     }
 
     /// Section 13.2.2 This Expression
@@ -240,40 +242,42 @@ impl<'a> ParserImpl<'a> {
 
     /// [Literal Expression](https://tc39.es/ecma262/#prod-Literal)
     /// parses string | true | false | null | number
-    pub(crate) fn parse_literal_expression(&mut self) -> Result<Expression<'a>> {
+    pub(crate) fn parse_literal_expression(&mut self) -> Expression<'a> {
         match self.cur_kind() {
-            Kind::Str => self
-                .parse_literal_string()
-                .map(|literal| Expression::StringLiteral(self.alloc(literal))),
-            Kind::True | Kind::False => self
-                .parse_literal_boolean()
-                .map(|literal| Expression::BooleanLiteral(self.alloc(literal))),
+            Kind::Str => {
+                let lit = self.parse_literal_string();
+                Expression::StringLiteral(self.alloc(lit))
+            }
+            Kind::True | Kind::False => {
+                let lit = self.parse_literal_boolean();
+                Expression::BooleanLiteral(self.alloc(lit))
+            }
             Kind::Null => {
-                let literal = self.parse_literal_null();
-                Ok(Expression::NullLiteral(self.alloc(literal)))
+                let lit = self.parse_literal_null();
+                Expression::NullLiteral(self.alloc(lit))
             }
             kind if kind.is_number() => {
                 if self.cur_src().ends_with('n') {
-                    self.parse_literal_bigint()
-                        .map(|literal| Expression::BigIntLiteral(self.alloc(literal)))
+                    let lit = self.parse_literal_bigint();
+                    Expression::BigIntLiteral(self.alloc(lit))
                 } else {
-                    self.parse_literal_number()
-                        .map(|literal| Expression::NumericLiteral(self.alloc(literal)))
+                    let lit = self.parse_literal_number();
+                    Expression::NumericLiteral(self.alloc(lit))
                 }
             }
-            _ => Err(self.unexpected()),
+            _ => self.unexpected(),
         }
     }
 
-    pub(crate) fn parse_literal_boolean(&mut self) -> Result<BooleanLiteral> {
+    pub(crate) fn parse_literal_boolean(&mut self) -> BooleanLiteral {
         let span = self.start_span();
         let value = match self.cur_kind() {
             Kind::True => true,
             Kind::False => false,
-            _ => return Err(self.unexpected()),
+            _ => return self.unexpected(),
         };
         self.bump_any();
-        Ok(self.ast.boolean_literal(self.end_span(span), value))
+        self.ast.boolean_literal(self.end_span(span), value)
     }
 
     pub(crate) fn parse_literal_null(&mut self) -> NullLiteral {
@@ -282,7 +286,7 @@ impl<'a> ParserImpl<'a> {
         self.ast.null_literal(self.end_span(span))
     }
 
-    pub(crate) fn parse_literal_number(&mut self) -> Result<NumericLiteral<'a>> {
+    pub(crate) fn parse_literal_number(&mut self) -> NumericLiteral<'a> {
         let span = self.start_span();
         let token = self.cur_token();
         let src = self.cur_src();
@@ -294,8 +298,12 @@ impl<'a> ParserImpl<'a> {
                 parse_float(src, token.has_separator())
             }
             _ => unreachable!(),
-        }
-        .map_err(|err| diagnostics::invalid_number(err, token.span()))?;
+        };
+        let value = value.unwrap_or_else(|err| {
+            self.set_fatal_error(diagnostics::invalid_number(err, token.span()));
+            0.0 // Dummy value
+        });
+
         let base = match token.kind {
             Kind::Decimal => NumberBase::Decimal,
             Kind::Float => NumberBase::Float,
@@ -309,34 +317,43 @@ impl<'a> ParserImpl<'a> {
                     NumberBase::Float
                 }
             }
-            _ => return Err(self.unexpected()),
+            _ => return self.unexpected(),
         };
         self.bump_any();
-        Ok(self.ast.numeric_literal(self.end_span(span), value, Some(Atom::from(src)), base))
+        self.ast.numeric_literal(self.end_span(span), value, Some(Atom::from(src)), base)
     }
 
-    pub(crate) fn parse_literal_bigint(&mut self) -> Result<BigIntLiteral<'a>> {
+    pub(crate) fn parse_literal_bigint(&mut self) -> BigIntLiteral<'a> {
         let span = self.start_span();
         let base = match self.cur_kind() {
             Kind::Decimal => BigintBase::Decimal,
             Kind::Binary => BigintBase::Binary,
             Kind::Octal => BigintBase::Octal,
             Kind::Hex => BigintBase::Hex,
-            _ => return Err(self.unexpected()),
+            _ => return self.unexpected(),
         };
         let token = self.cur_token();
         let raw = self.cur_src();
         let src = raw.strip_suffix('n').unwrap();
-        let _value = parse_big_int(src, token.kind, token.has_separator())
-            .map_err(|err| diagnostics::invalid_number(err, token.span()))?;
+        if let Err(err) = parse_big_int(src, token.kind, token.has_separator()) {
+            self.set_fatal_error(diagnostics::invalid_number(err, token.span()));
+        }
+
         self.bump_any();
-        Ok(self.ast.big_int_literal(self.end_span(span), raw, base))
+        self.ast.big_int_literal(self.end_span(span), raw, base)
     }
 
-    pub(crate) fn parse_literal_regexp(&mut self) -> Result<RegExpLiteral<'a>> {
+    pub(crate) fn parse_literal_regexp(&mut self) -> RegExpLiteral<'a> {
         let span = self.start_span();
         // split out pattern
-        let (pattern_end, flags, flags_error) = self.read_regex()?;
+        let (pattern_end, flags, flags_error) = match self.read_regex() {
+            Ok(res) => res,
+            Err(error) => {
+                self.set_fatal_error(error);
+                return Dummy::dummy(self.ast.allocator);
+            }
+        };
+
         let pattern_start = self.cur_token().start + 1; // +1 to exclude left `/`
         let pattern_text = &self.source_text[pattern_start as usize..pattern_end as usize];
         let flags_start = pattern_end + 1; // +1 to include right `/`
@@ -368,11 +385,11 @@ impl<'a> ParserImpl<'a> {
             RegExpPattern::Raw(pattern_text)
         };
 
-        Ok(self.ast.reg_exp_literal(
+        self.ast.reg_exp_literal(
             self.end_span(span),
             RegExp { pattern, flags },
             Some(Atom::from(raw)),
-        ))
+        )
     }
 
     #[cfg(feature = "regular_expression")]
@@ -400,9 +417,9 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
-    pub(crate) fn parse_literal_string(&mut self) -> Result<StringLiteral<'a>> {
+    pub(crate) fn parse_literal_string(&mut self) -> StringLiteral<'a> {
         if !self.at(Kind::Str) {
-            return Err(self.unexpected());
+            return self.unexpected();
         }
         let value = self.cur_string();
         let span = self.start_span();
@@ -416,7 +433,7 @@ impl<'a> ParserImpl<'a> {
         });
         let mut string_literal = self.ast.string_literal(span, value, Some(raw));
         string_literal.lossy = lossy;
-        Ok(string_literal)
+        string_literal
     }
 
     /// Section [Array Expression](https://tc39.es/ecma262/#prod-ArrayLiteral)
@@ -424,9 +441,9 @@ impl<'a> ParserImpl<'a> {
     ///     [ Elision opt ]
     ///     [ `ElementList`[?Yield, ?Await] ]
     ///     [ `ElementList`[?Yield, ?Await] , Elisionopt ]
-    pub(crate) fn parse_array_expression(&mut self) -> Result<Expression<'a>> {
+    pub(crate) fn parse_array_expression(&mut self) -> Expression<'a> {
         let span = self.start_span();
-        self.expect(Kind::LBrack)?;
+        self.expect(Kind::LBrack);
         let elements = self.context(Context::In, Context::empty(), |p| {
             p.parse_delimited_list(
                 Kind::RBrack,
@@ -434,21 +451,21 @@ impl<'a> ParserImpl<'a> {
                 /* trailing_separator */ false,
                 Self::parse_array_expression_element,
             )
-        })?;
+        });
         let trailing_comma = self.at(Kind::Comma).then(|| {
             let span = self.start_span();
             self.bump_any();
             self.end_span(span)
         });
-        self.expect(Kind::RBrack)?;
-        Ok(self.ast.expression_array(self.end_span(span), elements, trailing_comma))
+        self.expect(Kind::RBrack);
+        self.ast.expression_array(self.end_span(span), elements, trailing_comma)
     }
 
-    fn parse_array_expression_element(&mut self) -> Result<ArrayExpressionElement<'a>> {
+    fn parse_array_expression_element(&mut self) -> ArrayExpressionElement<'a> {
         match self.cur_kind() {
-            Kind::Comma => Ok(self.parse_elision()),
-            Kind::Dot3 => self.parse_spread_element().map(ArrayExpressionElement::SpreadElement),
-            _ => self.parse_assignment_expression_or_higher().map(ArrayExpressionElement::from),
+            Kind::Comma => self.parse_elision(),
+            Kind::Dot3 => ArrayExpressionElement::SpreadElement(self.parse_spread_element()),
+            _ => ArrayExpressionElement::from(self.parse_assignment_expression_or_higher()),
         }
     }
 
@@ -463,7 +480,7 @@ impl<'a> ParserImpl<'a> {
     /// `TemplateLiteral`[Yield, Await, Tagged] :
     ///     `NoSubstitutionTemplate`
     ///     `SubstitutionTemplate`[?Yield, ?Await, ?Tagged]
-    pub(crate) fn parse_template_literal(&mut self, tagged: bool) -> Result<TemplateLiteral<'a>> {
+    pub(crate) fn parse_template_literal(&mut self, tagged: bool) -> TemplateLiteral<'a> {
         let span = self.start_span();
         let mut expressions = self.ast.vec();
         let mut quasis = self.ast.vec();
@@ -474,12 +491,12 @@ impl<'a> ParserImpl<'a> {
             Kind::TemplateHead => {
                 quasis.push(self.parse_template_element(tagged));
                 // TemplateHead Expression[+In, ?Yield, ?Await]
-                let expr = self.context(Context::In, Context::empty(), Self::parse_expr)?;
+                let expr = self.context(Context::In, Context::empty(), Self::parse_expr);
                 expressions.push(expr);
                 self.re_lex_template_substitution_tail();
                 loop {
                     match self.cur_kind() {
-                        Kind::Eof => self.expect(Kind::TemplateTail)?,
+                        Kind::Eof => self.expect(Kind::TemplateTail),
                         Kind::TemplateTail => {
                             quasis.push(self.parse_template_element(tagged));
                             break;
@@ -490,7 +507,7 @@ impl<'a> ParserImpl<'a> {
                         _ => {
                             // TemplateMiddle Expression[+In, ?Yield, ?Await]
                             let expr =
-                                self.context(Context::In, Context::empty(), Self::parse_expr)?;
+                                self.context(Context::In, Context::empty(), Self::parse_expr);
                             expressions.push(expr);
                             self.re_lex_template_substitution_tail();
                         }
@@ -499,15 +516,12 @@ impl<'a> ParserImpl<'a> {
             }
             _ => unreachable!("parse_template_literal"),
         }
-        Ok(self.ast.template_literal(self.end_span(span), quasis, expressions))
+        self.ast.template_literal(self.end_span(span), quasis, expressions)
     }
 
-    pub(crate) fn parse_template_literal_expression(
-        &mut self,
-        tagged: bool,
-    ) -> Result<Expression<'a>> {
-        self.parse_template_literal(tagged)
-            .map(|template_literal| Expression::TemplateLiteral(self.alloc(template_literal)))
+    pub(crate) fn parse_template_literal_expression(&mut self, tagged: bool) -> Expression<'a> {
+        let template_lit = self.parse_template_literal(tagged);
+        Expression::TemplateLiteral(self.alloc(template_lit))
     }
 
     fn parse_tagged_template(
@@ -516,8 +530,8 @@ impl<'a> ParserImpl<'a> {
         lhs: Expression<'a>,
         in_optional_chain: bool,
         type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
-    ) -> Result<Expression<'a>> {
-        let quasi = self.parse_template_literal(true)?;
+    ) -> Expression<'a> {
+        let quasi = self.parse_template_literal(true);
         let span = self.end_span(span);
         // OptionalChain :
         //   ?. TemplateLiteral
@@ -527,7 +541,7 @@ impl<'a> ParserImpl<'a> {
         if in_optional_chain {
             self.error(diagnostics::optional_chain_tagged_template(quasi.span));
         }
-        Ok(self.ast.expression_tagged_template(span, lhs, quasi, type_parameters))
+        self.ast.expression_tagged_template(span, lhs, quasi, type_parameters)
     }
 
     pub(crate) fn parse_template_element(&mut self, tagged: bool) -> TemplateElement<'a> {
@@ -570,7 +584,7 @@ impl<'a> ParserImpl<'a> {
     }
 
     /// Section 13.3 ImportCall or ImportMeta
-    fn parse_import_meta_or_call(&mut self) -> Result<Expression<'a>> {
+    fn parse_import_meta_or_call(&mut self) -> Expression<'a> {
         let span = self.start_span();
         let meta = self.parse_keyword_identifier(Kind::Import);
         match self.cur_kind() {
@@ -582,7 +596,7 @@ impl<'a> ParserImpl<'a> {
                         let property = self.parse_keyword_identifier(Kind::Meta);
                         let span = self.end_span(span);
                         self.module_record_builder.visit_import_meta(span);
-                        Ok(self.ast.expression_meta_property(span, meta, property))
+                        self.ast.expression_meta_property(span, meta, property)
                     }
                     // `import.source(expr)`
                     Kind::Source => {
@@ -596,27 +610,27 @@ impl<'a> ParserImpl<'a> {
                     }
                     _ => {
                         self.bump_any();
-                        Err(diagnostics::import_meta(self.end_span(span)))
+                        self.fatal_error(diagnostics::import_meta(self.end_span(span)))
                     }
                 }
             }
             Kind::LParen => self.parse_import_expression(span, None),
-            _ => Err(self.unexpected()),
+            _ => self.unexpected(),
         }
     }
 
     /// V8 Runtime calls.
     /// See: [runtime.h](https://github.com/v8/v8/blob/5fe0aa3bc79c0a9d3ad546b79211f07105f09585/src/runtime/runtime.h#L43)
-    pub(crate) fn parse_v8_intrinsic_expression(&mut self) -> Result<Expression<'a>> {
+    pub(crate) fn parse_v8_intrinsic_expression(&mut self) -> Expression<'a> {
         if !self.options.allow_v8_intrinsics {
-            return Err(self.unexpected());
+            return self.unexpected();
         }
 
         let span = self.start_span();
-        self.expect(Kind::Percent)?;
-        let name = self.parse_identifier_name()?;
+        self.expect(Kind::Percent);
+        let name = self.parse_identifier_name();
 
-        self.expect(Kind::LParen)?;
+        self.expect(Kind::LParen);
         let arguments = self.context(Context::In, Context::Decorator, |p| {
             p.parse_delimited_list(
                 Kind::RParen,
@@ -624,28 +638,28 @@ impl<'a> ParserImpl<'a> {
                 /* trailing_separator */ true,
                 Self::parse_v8_intrinsic_argument,
             )
-        })?;
-        self.expect(Kind::RParen)?;
-        Ok(self.ast.expression_v_8_intrinsic(self.end_span(span), name, arguments))
+        });
+        self.expect(Kind::RParen);
+        self.ast.expression_v_8_intrinsic(self.end_span(span), name, arguments)
     }
 
-    fn parse_v8_intrinsic_argument(&mut self) -> Result<Argument<'a>> {
+    fn parse_v8_intrinsic_argument(&mut self) -> Argument<'a> {
         if self.at(Kind::Dot3) {
             self.error(diagnostics::v8_intrinsic_spread_elem(self.cur_token().span()));
-            self.parse_spread_element().map(Argument::SpreadElement)
+            Argument::SpreadElement(self.parse_spread_element())
         } else {
-            self.parse_assignment_expression_or_higher().map(Argument::from)
+            Argument::from(self.parse_assignment_expression_or_higher())
         }
     }
 
     /// Section 13.3 Left-Hand-Side Expression
-    pub(crate) fn parse_lhs_expression_or_higher(&mut self) -> Result<Expression<'a>> {
+    pub(crate) fn parse_lhs_expression_or_higher(&mut self) -> Expression<'a> {
         let span = self.start_span();
         let mut in_optional_chain = false;
-        let lhs = self.parse_member_expression_or_higher(&mut in_optional_chain)?;
-        let lhs = self.parse_call_expression_rest(span, lhs, &mut in_optional_chain)?;
+        let lhs = self.parse_member_expression_or_higher(&mut in_optional_chain);
+        let lhs = self.parse_call_expression_rest(span, lhs, &mut in_optional_chain);
         if !in_optional_chain {
-            return Ok(lhs);
+            return lhs;
         }
         // Add `ChainExpression` to `a?.c?.b<c>`;
         if let Expression::TSInstantiationExpression(mut expr) = lhs {
@@ -653,10 +667,10 @@ impl<'a> ParserImpl<'a> {
                 expr.expression.span(),
                 self.ast.move_expression(&mut expr.expression),
             );
-            Ok(Expression::TSInstantiationExpression(expr))
+            Expression::TSInstantiationExpression(expr)
         } else {
             let span = self.end_span(span);
-            Ok(self.map_to_chain_expression(span, lhs))
+            self.map_to_chain_expression(span, lhs)
         }
     }
 
@@ -680,9 +694,9 @@ impl<'a> ParserImpl<'a> {
     fn parse_member_expression_or_higher(
         &mut self,
         in_optional_chain: &mut bool,
-    ) -> Result<Expression<'a>> {
+    ) -> Expression<'a> {
         let span = self.start_span();
-        let lhs = self.parse_primary_expression()?;
+        let lhs = self.parse_primary_expression();
         self.parse_member_expression_rest(span, lhs, in_optional_chain)
     }
 
@@ -711,23 +725,23 @@ impl<'a> ParserImpl<'a> {
         lhs_span: Span,
         lhs: Expression<'a>,
         in_optional_chain: &mut bool,
-    ) -> Result<Expression<'a>> {
+    ) -> Expression<'a> {
         let mut lhs = lhs;
         loop {
             lhs = match self.cur_kind() {
-                Kind::Dot => self.parse_static_member_expression(lhs_span, lhs, false)?,
+                Kind::Dot => self.parse_static_member_expression(lhs_span, lhs, false),
                 Kind::QuestionDot => {
                     *in_optional_chain = true;
                     match self.peek_kind() {
                         Kind::LBrack if !self.ctx.has_decorator() => {
                             self.bump_any(); // bump `?.`
-                            self.parse_computed_member_expression(lhs_span, lhs, true)?
+                            self.parse_computed_member_expression(lhs_span, lhs, true)
                         }
                         Kind::PrivateIdentifier => {
-                            self.parse_static_member_expression(lhs_span, lhs, true)?
+                            self.parse_static_member_expression(lhs_span, lhs, true)
                         }
                         kind if kind.is_identifier_name() => {
-                            self.parse_static_member_expression(lhs_span, lhs, true)?
+                            self.parse_static_member_expression(lhs_span, lhs, true)
                         }
                         Kind::Bang
                         | Kind::LAngle
@@ -737,7 +751,9 @@ impl<'a> ParserImpl<'a> {
                         | Kind::TemplateHead
                         | Kind::LBrack => break,
                         _ => {
-                            return Err(diagnostics::unexpected_token(self.cur_token().span()));
+                            return self.fatal_error(diagnostics::unexpected_token(
+                                self.cur_token().span(),
+                            ));
                         }
                     }
                 }
@@ -745,7 +761,7 @@ impl<'a> ParserImpl<'a> {
                 // class C { @dec ["1"]() { } }
                 //                ^
                 Kind::LBrack if !self.ctx.has_decorator() => {
-                    self.parse_computed_member_expression(lhs_span, lhs, false)?
+                    self.parse_computed_member_expression(lhs_span, lhs, false)
                 }
                 Kind::Bang if !self.cur_token().is_on_new_line && self.is_ts => {
                     self.bump_any();
@@ -759,7 +775,7 @@ impl<'a> ParserImpl<'a> {
                         } else {
                             (lhs, None)
                         };
-                    self.parse_tagged_template(lhs_span, expr, *in_optional_chain, type_parameters)?
+                    self.parse_tagged_template(lhs_span, expr, *in_optional_chain, type_parameters)
                 }
                 Kind::LAngle | Kind::ShiftLeft => {
                     if let Some(Some(arguments)) =
@@ -777,7 +793,7 @@ impl<'a> ParserImpl<'a> {
                 _ => break,
             };
         }
-        Ok(lhs)
+        lhs
     }
 
     /// Section 13.3 `MemberExpression`
@@ -787,21 +803,21 @@ impl<'a> ParserImpl<'a> {
         lhs_span: Span,
         lhs: Expression<'a>,
         optional: bool,
-    ) -> Result<Expression<'a>> {
+    ) -> Expression<'a> {
         self.bump_any(); // advance `.` or `?.`
-        if self.cur_kind() == Kind::PrivateIdentifier {
+        let member_expr = if self.cur_kind() == Kind::PrivateIdentifier {
             let private_ident = self.parse_private_identifier();
-            Ok(self.ast.member_expression_private_field_expression(
+            self.ast.member_expression_private_field_expression(
                 self.end_span(lhs_span),
                 lhs,
                 private_ident,
                 optional,
-            ))
+            )
         } else {
-            let ident = self.parse_identifier_name()?;
-            Ok(self.ast.member_expression_static(self.end_span(lhs_span), lhs, ident, optional))
-        }
-        .map(Expression::from)
+            let ident = self.parse_identifier_name();
+            self.ast.member_expression_static(self.end_span(lhs_span), lhs, ident, optional)
+        };
+        Expression::from(member_expr)
     }
 
     /// Section 13.3 `MemberExpression`
@@ -812,34 +828,36 @@ impl<'a> ParserImpl<'a> {
         lhs_span: Span,
         lhs: Expression<'a>,
         optional: bool,
-    ) -> Result<Expression<'a>> {
+    ) -> Expression<'a> {
         self.bump_any(); // advance `[`
-        let property = self.context(Context::In, Context::empty(), Self::parse_expr)?;
-        self.expect(Kind::RBrack)?;
-        Ok(self
-            .ast
-            .member_expression_computed(self.end_span(lhs_span), lhs, property, optional)
-            .into())
+        let property = self.context(Context::In, Context::empty(), Self::parse_expr);
+        self.expect(Kind::RBrack);
+        Expression::from(self.ast.member_expression_computed(
+            self.end_span(lhs_span),
+            lhs,
+            property,
+            optional,
+        ))
     }
 
     /// [NewExpression](https://tc39.es/ecma262/#sec-new-operator)
-    fn parse_new_expression(&mut self) -> Result<Expression<'a>> {
+    fn parse_new_expression(&mut self) -> Expression<'a> {
         let span = self.start_span();
         let identifier = self.parse_keyword_identifier(Kind::New);
 
         if self.eat(Kind::Dot) {
             return if self.at(Kind::Target) {
                 let property = self.parse_keyword_identifier(Kind::Target);
-                Ok(self.ast.expression_meta_property(self.end_span(span), identifier, property))
+                self.ast.expression_meta_property(self.end_span(span), identifier, property)
             } else {
                 self.bump_any();
-                Err(diagnostics::new_target(self.end_span(span)))
+                self.fatal_error(diagnostics::new_target(self.end_span(span)))
             };
         }
         let rhs_span = self.start_span();
 
         let mut optional = false;
-        let mut callee = self.parse_member_expression_or_higher(&mut optional)?;
+        let mut callee = self.parse_member_expression_or_higher(&mut optional);
 
         let mut type_parameter = None;
         if let Expression::TSInstantiationExpression(instantiation_expr) = callee {
@@ -859,8 +877,8 @@ impl<'a> ParserImpl<'a> {
                     /* trailing_separator */ true,
                     Self::parse_call_argument,
                 )
-            })?;
-            self.expect(Kind::RParen)?;
+            });
+            self.expect(Kind::RParen);
             call_arguments
         } else {
             self.ast.vec()
@@ -876,7 +894,7 @@ impl<'a> ParserImpl<'a> {
             self.error(diagnostics::new_optional_chain(span));
         }
 
-        Ok(self.ast.expression_new(span, callee, arguments, type_parameter))
+        self.ast.expression_new(span, callee, arguments, type_parameter)
     }
 
     /// Section 13.3 Call Expression
@@ -885,11 +903,11 @@ impl<'a> ParserImpl<'a> {
         lhs_span: Span,
         lhs: Expression<'a>,
         in_optional_chain: &mut bool,
-    ) -> Result<Expression<'a>> {
+    ) -> Expression<'a> {
         let mut lhs = lhs;
         loop {
             let mut type_arguments = None;
-            lhs = self.parse_member_expression_rest(lhs_span, lhs, in_optional_chain)?;
+            lhs = self.parse_member_expression_rest(lhs_span, lhs, in_optional_chain);
             let optional_call = self.eat(Kind::QuestionDot);
             *in_optional_chain = if optional_call { true } else { *in_optional_chain };
 
@@ -898,8 +916,7 @@ impl<'a> ParserImpl<'a> {
                     type_arguments = Some(args);
                 }
                 if self.cur_kind().is_template_start_of_tagged_template() {
-                    lhs =
-                        self.parse_tagged_template(lhs_span, lhs, optional_call, type_arguments)?;
+                    lhs = self.parse_tagged_template(lhs_span, lhs, optional_call, type_arguments);
                     continue;
                 }
             }
@@ -912,13 +929,13 @@ impl<'a> ParserImpl<'a> {
                 }
 
                 lhs =
-                    self.parse_call_arguments(lhs_span, lhs, optional_call, type_arguments.take())?;
+                    self.parse_call_arguments(lhs_span, lhs, optional_call, type_arguments.take());
                 continue;
             }
             break;
         }
 
-        Ok(lhs)
+        lhs
     }
 
     fn parse_call_arguments(
@@ -927,10 +944,10 @@ impl<'a> ParserImpl<'a> {
         lhs: Expression<'a>,
         optional: bool,
         type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
-    ) -> Result<Expression<'a>> {
+    ) -> Expression<'a> {
         // ArgumentList[Yield, Await] :
         //   AssignmentExpression[+In, ?Yield, ?Await]
-        self.expect(Kind::LParen)?;
+        self.expect(Kind::LParen);
         let call_arguments = self.context(Context::In, Context::Decorator, |p| {
             p.parse_delimited_list(
                 Kind::RParen,
@@ -938,40 +955,35 @@ impl<'a> ParserImpl<'a> {
                 /* trailing_separator */ true,
                 Self::parse_call_argument,
             )
-        })?;
-        self.expect(Kind::RParen)?;
-        Ok(self.ast.expression_call(
+        });
+        self.expect(Kind::RParen);
+        self.ast.expression_call(
             self.end_span(lhs_span),
             lhs,
             type_parameters,
             call_arguments,
             optional,
-        ))
+        )
     }
 
-    fn parse_call_argument(&mut self) -> Result<Argument<'a>> {
+    fn parse_call_argument(&mut self) -> Argument<'a> {
         if self.at(Kind::Dot3) {
-            self.parse_spread_element().map(Argument::SpreadElement)
+            Argument::SpreadElement(self.parse_spread_element())
         } else {
-            self.parse_assignment_expression_or_higher().map(Argument::from)
+            Argument::from(self.parse_assignment_expression_or_higher())
         }
     }
 
     /// Section 13.4 Update Expression
-    fn parse_update_expression(&mut self, lhs_span: Span) -> Result<Expression<'a>> {
+    fn parse_update_expression(&mut self, lhs_span: Span) -> Expression<'a> {
         let kind = self.cur_kind();
         // ++ -- prefix update expressions
         if kind.is_update_operator() {
             let operator = map_update_operator(kind);
             self.bump_any();
-            let argument = self.parse_unary_expression_or_higher(lhs_span)?;
-            let argument = SimpleAssignmentTarget::cover(argument, self)?;
-            return Ok(self.ast.expression_update(
-                self.end_span(lhs_span),
-                operator,
-                true,
-                argument,
-            ));
+            let argument = self.parse_unary_expression_or_higher(lhs_span);
+            let argument = SimpleAssignmentTarget::cover(argument, self);
+            return self.ast.expression_update(self.end_span(lhs_span), operator, true, argument);
         }
 
         if self.source_type.is_jsx()
@@ -982,22 +994,19 @@ impl<'a> ParserImpl<'a> {
         }
 
         let span = self.start_span();
-        let lhs = self.parse_lhs_expression_or_higher()?;
+        let lhs = self.parse_lhs_expression_or_higher();
         // ++ -- postfix update expressions
         if self.cur_kind().is_update_operator() && !self.cur_token().is_on_new_line {
             let operator = map_update_operator(self.cur_kind());
             self.bump_any();
-            let lhs = SimpleAssignmentTarget::cover(lhs, self)?;
-            return Ok(self.ast.expression_update(self.end_span(span), operator, false, lhs));
+            let lhs = SimpleAssignmentTarget::cover(lhs, self);
+            return self.ast.expression_update(self.end_span(span), operator, false, lhs);
         }
-        Ok(lhs)
+        lhs
     }
 
     /// Section 13.5 Unary Expression
-    pub(crate) fn parse_unary_expression_or_higher(
-        &mut self,
-        lhs_span: Span,
-    ) -> Result<Expression<'a>> {
+    pub(crate) fn parse_unary_expression_or_higher(&mut self, lhs_span: Span) -> Expression<'a> {
         // ++ -- prefix update expressions
         if self.is_update_expression() {
             return self.parse_update_expression(lhs_span);
@@ -1005,10 +1014,7 @@ impl<'a> ParserImpl<'a> {
         self.parse_simple_unary_expression(lhs_span)
     }
 
-    pub(crate) fn parse_simple_unary_expression(
-        &mut self,
-        lhs_span: Span,
-    ) -> Result<Expression<'a>> {
+    pub(crate) fn parse_simple_unary_expression(&mut self, lhs_span: Span) -> Expression<'a> {
         match self.cur_kind() {
             kind if kind.is_unary_operator() => self.parse_unary_expression(),
             Kind::LAngle => {
@@ -1018,42 +1024,42 @@ impl<'a> ParserImpl<'a> {
                 if self.is_ts {
                     return self.parse_ts_type_assertion();
                 }
-                Err(self.unexpected())
+                self.unexpected()
             }
             Kind::Await if self.is_await_expression() => self.parse_await_expression(lhs_span),
             _ => self.parse_update_expression(lhs_span),
         }
     }
 
-    fn parse_unary_expression(&mut self) -> Result<Expression<'a>> {
+    fn parse_unary_expression(&mut self) -> Expression<'a> {
         let span = self.start_span();
         let operator = map_unary_operator(self.cur_kind());
         self.bump_any();
         let has_pure_comment = self.lexer.trivia_builder.previous_token_has_pure_comment();
-        let mut argument = self.parse_simple_unary_expression(span)?;
+        let mut argument = self.parse_simple_unary_expression(span);
         if has_pure_comment {
             Self::set_pure_on_call_or_new_expr(&mut argument);
         }
-        Ok(self.ast.expression_unary(self.end_span(span), operator, argument))
+        self.ast.expression_unary(self.end_span(span), operator, argument)
     }
 
     pub(crate) fn parse_binary_expression_or_higher(
         &mut self,
         lhs_precedence: Precedence,
-    ) -> Result<Expression<'a>> {
+    ) -> Expression<'a> {
         let lhs_span = self.start_span();
 
         let lhs = if self.ctx.has_in() && self.at(Kind::PrivateIdentifier) {
             let left = self.parse_private_identifier();
-            self.expect(Kind::In)?;
-            let right = self.parse_binary_expression_or_higher(Precedence::Lowest)?;
+            self.expect(Kind::In);
+            let right = self.parse_binary_expression_or_higher(Precedence::Lowest);
             if let Expression::PrivateInExpression(private_in_expr) = right {
-                return Err(diagnostics::private_in_private(private_in_expr.span));
+                return self.fatal_error(diagnostics::private_in_private(private_in_expr.span));
             }
             self.ast.expression_private_in(self.end_span(lhs_span), left, right)
         } else {
             let has_pure_comment = self.lexer.trivia_builder.previous_token_has_pure_comment();
-            let mut expr = self.parse_unary_expression_or_higher(lhs_span)?;
+            let mut expr = self.parse_unary_expression_or_higher(lhs_span);
             if has_pure_comment {
                 Self::set_pure_on_call_or_new_expr(&mut expr);
             }
@@ -1069,7 +1075,7 @@ impl<'a> ParserImpl<'a> {
         lhs_span: Span,
         lhs: Expression<'a>,
         min_precedence: Precedence,
-    ) -> Result<Expression<'a>> {
+    ) -> Expression<'a> {
         // Pratt Parsing Algorithm
         // <https://matklad.github.io/2020/04/13/simple-but-powerful-pratt-parsing.html>
         let mut lhs = lhs;
@@ -1102,7 +1108,7 @@ impl<'a> ParserImpl<'a> {
                     break;
                 }
                 self.bump_any();
-                let type_annotation = self.parse_ts_type()?;
+                let type_annotation = self.parse_ts_type();
                 let span = self.end_span(lhs_span);
                 lhs = if kind == Kind::As {
                     self.ast.expression_ts_as(span, lhs, type_annotation)
@@ -1113,7 +1119,7 @@ impl<'a> ParserImpl<'a> {
             }
 
             self.bump_any(); // bump operator
-            let rhs = self.parse_binary_expression_or_higher(left_precedence)?;
+            let rhs = self.parse_binary_expression_or_higher(left_precedence);
 
             lhs = if kind.is_logical_operator() {
                 self.ast.expression_logical(
@@ -1134,7 +1140,7 @@ impl<'a> ParserImpl<'a> {
             };
         }
 
-        Ok(lhs)
+        lhs
     }
 
     /// Section 13.14 Conditional Expression
@@ -1146,23 +1152,23 @@ impl<'a> ParserImpl<'a> {
         lhs_span: Span,
         lhs: Expression<'a>,
         allow_return_type_in_arrow_function: bool,
-    ) -> Result<Expression<'a>> {
+    ) -> Expression<'a> {
         if !self.eat(Kind::Question) {
-            return Ok(lhs);
+            return lhs;
         }
         let consequent = self.context(Context::In, Context::empty(), |p| {
             p.parse_assignment_expression_or_higher_impl(
                 /* allow_return_type_in_arrow_function */ false,
             )
-        })?;
-        self.expect(Kind::Colon)?;
+        });
+        self.expect(Kind::Colon);
         let alternate =
-            self.parse_assignment_expression_or_higher_impl(allow_return_type_in_arrow_function)?;
-        Ok(self.ast.expression_conditional(self.end_span(lhs_span), lhs, consequent, alternate))
+            self.parse_assignment_expression_or_higher_impl(allow_return_type_in_arrow_function);
+        self.ast.expression_conditional(self.end_span(lhs_span), lhs, consequent, alternate)
     }
 
     /// `AssignmentExpression`[In, Yield, Await] :
-    pub(crate) fn parse_assignment_expression_or_higher(&mut self) -> Result<Expression<'a>> {
+    pub(crate) fn parse_assignment_expression_or_higher(&mut self) -> Expression<'a> {
         self.parse_assignment_expression_or_higher_impl(
             /* allow_return_type_in_arrow_function */ true,
         )
@@ -1171,7 +1177,7 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_assignment_expression_or_higher_impl(
         &mut self,
         allow_return_type_in_arrow_function: bool,
-    ) -> Result<Expression<'a>> {
+    ) -> Expression<'a> {
         let has_no_side_effects_comment =
             self.lexer.trivia_builder.previous_token_has_no_side_effects_comment();
         let has_pure_comment = self.lexer.trivia_builder.previous_token_has_pure_comment();
@@ -1180,30 +1186,30 @@ impl<'a> ParserImpl<'a> {
             return self.parse_yield_expression();
         }
         // `() => {}`, `(x) => {}`
-        if let Some(mut arrow_expr) = self.try_parse_parenthesized_arrow_function_expression(
-            allow_return_type_in_arrow_function,
-        )? {
-            if has_no_side_effects_comment {
-                if let Expression::ArrowFunctionExpression(func) = &mut arrow_expr {
-                    func.pure = true;
-                }
-            }
-            return Ok(arrow_expr);
-        }
-        // `async x => {}`
         if let Some(mut arrow_expr) = self
-            .try_parse_async_simple_arrow_function_expression(allow_return_type_in_arrow_function)?
+            .try_parse_parenthesized_arrow_function_expression(allow_return_type_in_arrow_function)
         {
             if has_no_side_effects_comment {
                 if let Expression::ArrowFunctionExpression(func) = &mut arrow_expr {
                     func.pure = true;
                 }
             }
-            return Ok(arrow_expr);
+            return arrow_expr;
+        }
+        // `async x => {}`
+        if let Some(mut arrow_expr) = self
+            .try_parse_async_simple_arrow_function_expression(allow_return_type_in_arrow_function)
+        {
+            if has_no_side_effects_comment {
+                if let Expression::ArrowFunctionExpression(func) = &mut arrow_expr {
+                    func.pure = true;
+                }
+            }
+            return arrow_expr;
         }
 
         let span = self.start_span();
-        let lhs = self.parse_binary_expression_or_higher(Precedence::Comma)?;
+        let lhs = self.parse_binary_expression_or_higher(Precedence::Comma);
         let kind = self.cur_kind();
 
         // `x => {}`
@@ -1213,13 +1219,13 @@ impl<'a> ParserImpl<'a> {
                 lhs,
                 /* async */ false,
                 allow_return_type_in_arrow_function,
-            )?;
+            );
             if has_no_side_effects_comment {
                 if let Expression::ArrowFunctionExpression(func) = &mut arrow_expr {
                     func.pure = true;
                 }
             }
-            return Ok(arrow_expr);
+            return arrow_expr;
         }
 
         if kind.is_assignment_operator() {
@@ -1231,7 +1237,7 @@ impl<'a> ParserImpl<'a> {
         }
 
         let mut expr =
-            self.parse_conditional_expression_rest(span, lhs, allow_return_type_in_arrow_function)?;
+            self.parse_conditional_expression_rest(span, lhs, allow_return_type_in_arrow_function);
 
         if has_pure_comment {
             Self::set_pure_on_call_or_new_expr(&mut expr);
@@ -1241,7 +1247,7 @@ impl<'a> ParserImpl<'a> {
             Self::set_pure_on_function_expr(&mut expr);
         }
 
-        Ok(expr)
+        expr
     }
 
     fn set_pure_on_call_or_new_expr(expr: &mut Expression<'a>) {
@@ -1287,7 +1293,7 @@ impl<'a> ParserImpl<'a> {
         span: Span,
         lhs: Expression<'a>,
         allow_return_type_in_arrow_function: bool,
-    ) -> Result<Expression<'a>> {
+    ) -> Expression<'a> {
         let operator = map_assignment_operator(self.cur_kind());
         // 13.15.5 Destructuring Assignment
         // LeftHandSideExpression = AssignmentExpression
@@ -1295,11 +1301,11 @@ impl<'a> ParserImpl<'a> {
         // AssignmentPattern[Yield, Await] :
         //    ObjectAssignmentPattern
         //    ArrayAssignmentPattern
-        let left = AssignmentTarget::cover(lhs, self)?;
+        let left = AssignmentTarget::cover(lhs, self);
         self.bump_any();
         let right =
-            self.parse_assignment_expression_or_higher_impl(allow_return_type_in_arrow_function)?;
-        Ok(self.ast.expression_assignment(self.end_span(span), operator, left, right))
+            self.parse_assignment_expression_or_higher_impl(allow_return_type_in_arrow_function);
+        self.ast.expression_assignment(self.end_span(span), operator, left, right)
     }
 
     /// Section 13.16 Sequence Expression
@@ -1307,18 +1313,18 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         span: Span,
         first_expression: Expression<'a>,
-    ) -> Result<Expression<'a>> {
+    ) -> Expression<'a> {
         let mut expressions = self.ast.vec1(first_expression);
         while self.eat(Kind::Comma) {
-            let expression = self.parse_assignment_expression_or_higher()?;
+            let expression = self.parse_assignment_expression_or_higher();
             expressions.push(expression);
         }
-        Ok(self.ast.expression_sequence(self.end_span(span), expressions))
+        self.ast.expression_sequence(self.end_span(span), expressions)
     }
 
     /// ``AwaitExpression`[Yield]` :
     ///     await `UnaryExpression`[?Yield, +Await]
-    fn parse_await_expression(&mut self, lhs_span: Span) -> Result<Expression<'a>> {
+    fn parse_await_expression(&mut self, lhs_span: Span) -> Expression<'a> {
         let span = self.start_span();
         if !self.ctx.has_await() {
             self.error(diagnostics::await_expression(self.cur_token().span()));
@@ -1326,23 +1332,23 @@ impl<'a> ParserImpl<'a> {
         self.bump_any();
         let argument = self.context(Context::Await, Context::empty(), |p| {
             p.parse_simple_unary_expression(lhs_span)
-        })?;
-        Ok(self.ast.expression_await(self.end_span(span), argument))
+        });
+        self.ast.expression_await(self.end_span(span), argument)
     }
 
     /// `Decorator`[Yield, Await]:
     ///   `DecoratorMemberExpression`[?Yield, ?Await]
     ///   ( `Expression`[+In, ?Yield, ?Await] )
     ///   `DecoratorCallExpression`
-    pub(crate) fn parse_decorator(&mut self) -> Result<Decorator<'a>> {
+    pub(crate) fn parse_decorator(&mut self) -> Decorator<'a> {
         let span = self.start_span();
         self.bump_any(); // bump @
         let expr = self.context(
             Context::Decorator,
             Context::empty(),
             Self::parse_lhs_expression_or_higher,
-        )?;
-        Ok(self.ast.decorator(self.end_span(span), expr))
+        );
+        self.ast.decorator(self.end_span(span), expr)
     }
 
     fn is_update_expression(&self) -> bool {

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -1,6 +1,5 @@
 use oxc_allocator::Box;
 use oxc_ast::ast::*;
-use oxc_diagnostics::Result;
 use oxc_span::Span;
 
 use super::FunctionKind;
@@ -28,28 +27,28 @@ impl<'a> ParserImpl<'a> {
                 && !self.peek_token().is_on_new_line
     }
 
-    pub(crate) fn parse_function_body(&mut self) -> Result<Box<'a, FunctionBody<'a>>> {
+    pub(crate) fn parse_function_body(&mut self) -> Box<'a, FunctionBody<'a>> {
         let span = self.start_span();
-        self.expect(Kind::LCurly)?;
+        self.expect(Kind::LCurly);
 
         let (directives, statements) = self.context(Context::Return, Context::empty(), |p| {
             p.parse_directives_and_statements(/* is_top_level */ false)
-        })?;
+        });
 
-        self.expect(Kind::RCurly)?;
-        Ok(self.ast.alloc_function_body(self.end_span(span), directives, statements))
+        self.expect(Kind::RCurly);
+        self.ast.alloc_function_body(self.end_span(span), directives, statements)
     }
 
     pub(crate) fn parse_formal_parameters(
         &mut self,
         params_kind: FormalParameterKind,
-    ) -> Result<(Option<TSThisParameter<'a>>, Box<'a, FormalParameters<'a>>)> {
+    ) -> (Option<TSThisParameter<'a>>, Box<'a, FormalParameters<'a>>) {
         let span = self.start_span();
-        self.expect(Kind::LParen)?;
+        self.expect(Kind::LParen);
         let this_param = if self.is_ts && self.at(Kind::This) {
-            let param = self.parse_ts_this_parameter()?;
+            let param = self.parse_ts_this_parameter();
             if !self.at(Kind::RParen) {
-                self.expect(Kind::Comma)?;
+                self.expect(Kind::Comma);
             }
             Some(param)
         } else {
@@ -59,11 +58,11 @@ impl<'a> ParserImpl<'a> {
             Kind::RParen,
             Self::parse_formal_parameter,
             Self::parse_rest_parameter,
-        )?;
-        self.expect(Kind::RParen)?;
+        );
+        self.expect(Kind::RParen);
         let formal_parameters =
             self.ast.alloc_formal_parameters(self.end_span(span), params_kind, list, rest);
-        Ok((this_param, formal_parameters))
+        (this_param, formal_parameters)
     }
 
     fn parse_parameter_modifiers(&mut self) -> Modifiers<'a> {
@@ -78,24 +77,24 @@ impl<'a> ParserImpl<'a> {
         modifiers
     }
 
-    fn parse_formal_parameter(&mut self) -> Result<FormalParameter<'a>> {
+    fn parse_formal_parameter(&mut self) -> FormalParameter<'a> {
         let span = self.start_span();
-        self.eat_decorators()?;
+        self.eat_decorators();
         let modifiers = self.parse_parameter_modifiers();
-        let pattern = self.parse_binding_pattern_with_initializer()?;
+        let pattern = self.parse_binding_pattern_with_initializer();
         let decorators = self.consume_decorators();
-        Ok(self.ast.formal_parameter(
+        self.ast.formal_parameter(
             self.end_span(span),
             decorators,
             pattern,
             modifiers.accessibility(),
             modifiers.contains_readonly(),
             modifiers.contains_override(),
-        ))
+        )
     }
 
-    fn parse_rest_parameter(&mut self) -> Result<BindingRestElement<'a>> {
-        let element = self.parse_rest_element()?;
+    fn parse_rest_parameter(&mut self) -> BindingRestElement<'a> {
+        let element = self.parse_rest_element();
         if self.at(Kind::Comma) {
             if matches!(self.peek_kind(), Kind::RCurly | Kind::RBrack) {
                 let span = self.cur_token().span();
@@ -106,7 +105,7 @@ impl<'a> ParserImpl<'a> {
                 self.error(diagnostics::rest_parameter_last(element.span));
             }
         }
-        Ok(element)
+        element
     }
 
     pub(crate) fn parse_function(
@@ -117,25 +116,25 @@ impl<'a> ParserImpl<'a> {
         generator: bool,
         func_kind: FunctionKind,
         modifiers: &Modifiers<'a>,
-    ) -> Result<Box<'a, Function<'a>>> {
+    ) -> Box<'a, Function<'a>> {
         let ctx = self.ctx;
         self.ctx = self.ctx.and_in(true).and_await(r#async).and_yield(generator);
 
-        let type_parameters = self.parse_ts_type_parameters()?;
+        let type_parameters = self.parse_ts_type_parameters();
 
         let (this_param, params) =
-            self.parse_formal_parameters(FormalParameterKind::FormalParameter)?;
+            self.parse_formal_parameters(FormalParameterKind::FormalParameter);
 
         let return_type =
-            self.parse_ts_return_type_annotation(Kind::Colon, /* is_type */ true)?;
+            self.parse_ts_return_type_annotation(Kind::Colon, /* is_type */ true);
 
-        let body = if self.at(Kind::LCurly) { Some(self.parse_function_body()?) } else { None };
+        let body = if self.at(Kind::LCurly) { Some(self.parse_function_body()) } else { None };
 
         self.ctx =
             self.ctx.and_in(ctx.has_in()).and_await(ctx.has_await()).and_yield(ctx.has_yield());
 
         if !self.is_ts && body.is_none() {
-            return Err(self.unexpected());
+            return self.unexpected();
         }
 
         let function_type = match func_kind {
@@ -159,7 +158,7 @@ impl<'a> ParserImpl<'a> {
         if FunctionType::TSDeclareFunction == function_type
             || FunctionType::TSEmptyBodyFunctionExpression == function_type
         {
-            self.asi()?;
+            self.asi();
         }
 
         self.verify_modifiers(
@@ -168,7 +167,7 @@ impl<'a> ParserImpl<'a> {
             diagnostics::modifier_cannot_be_used_here,
         );
 
-        Ok(self.ast.alloc_function(
+        self.ast.alloc_function(
             self.end_span(span),
             function_type,
             id,
@@ -180,16 +179,16 @@ impl<'a> ParserImpl<'a> {
             params,
             return_type,
             body,
-        ))
+        )
     }
 
     /// [Function Declaration](https://tc39.es/ecma262/#prod-FunctionDeclaration)
     pub(crate) fn parse_function_declaration(
         &mut self,
         stmt_ctx: StatementContext,
-    ) -> Result<Statement<'a>> {
+    ) -> Statement<'a> {
         let func_kind = FunctionKind::Declaration;
-        let decl = self.parse_function_impl(func_kind)?;
+        let decl = self.parse_function_impl(func_kind);
         if stmt_ctx.is_single_statement() {
             if decl.r#async {
                 self.error(diagnostics::async_function_declaration(Span::new(
@@ -203,20 +202,17 @@ impl<'a> ParserImpl<'a> {
                 )));
             }
         }
-        Ok(Statement::FunctionDeclaration(decl))
+        Statement::FunctionDeclaration(decl)
     }
 
     /// Parse function implementation in Javascript, cursor
     /// at `function` or `async function`
-    pub(crate) fn parse_function_impl(
-        &mut self,
-        func_kind: FunctionKind,
-    ) -> Result<Box<'a, Function<'a>>> {
+    pub(crate) fn parse_function_impl(&mut self, func_kind: FunctionKind) -> Box<'a, Function<'a>> {
         let span = self.start_span();
         let r#async = self.eat(Kind::Async);
-        self.expect(Kind::Function)?;
+        self.expect(Kind::Function);
         let generator = self.eat(Kind::Star);
-        let id = self.parse_function_id(func_kind, r#async, generator)?;
+        let id = self.parse_function_id(func_kind, r#async, generator);
         self.parse_function(span, id, r#async, generator, func_kind, &Modifiers::empty())
     }
 
@@ -227,11 +223,11 @@ impl<'a> ParserImpl<'a> {
         start_span: Span,
         func_kind: FunctionKind,
         modifiers: &Modifiers<'a>,
-    ) -> Result<Box<'a, Function<'a>>> {
+    ) -> Box<'a, Function<'a>> {
         let r#async = modifiers.contains(ModifierKind::Async);
-        self.expect(Kind::Function)?;
+        self.expect(Kind::Function);
         let generator = self.eat(Kind::Star);
-        let id = self.parse_function_id(func_kind, r#async, generator)?;
+        let id = self.parse_function_id(func_kind, r#async, generator);
         self.parse_function(start_span, id, r#async, generator, func_kind, modifiers)
     }
 
@@ -240,15 +236,15 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         span: Span,
         r#async: bool,
-    ) -> Result<Expression<'a>> {
+    ) -> Expression<'a> {
         let func_kind = FunctionKind::Expression;
-        self.expect(Kind::Function)?;
+        self.expect(Kind::Function);
 
         let generator = self.eat(Kind::Star);
-        let id = self.parse_function_id(func_kind, r#async, generator)?;
+        let id = self.parse_function_id(func_kind, r#async, generator);
         let function =
-            self.parse_function(span, id, r#async, generator, func_kind, &Modifiers::empty())?;
-        Ok(Expression::FunctionExpression(function))
+            self.parse_function(span, id, r#async, generator, func_kind, &Modifiers::empty());
+        Expression::FunctionExpression(function)
     }
 
     /// Section 15.4 Method Definitions
@@ -259,11 +255,7 @@ impl<'a> ParserImpl<'a> {
     ///   async `ClassElementName`
     /// `AsyncGeneratorMethod`
     ///   async * `ClassElementName`
-    pub(crate) fn parse_method(
-        &mut self,
-        r#async: bool,
-        generator: bool,
-    ) -> Result<Box<'a, Function<'a>>> {
+    pub(crate) fn parse_method(&mut self, r#async: bool, generator: bool) -> Box<'a, Function<'a>> {
         let span = self.start_span();
         self.parse_function(
             span,
@@ -279,7 +271,7 @@ impl<'a> ParserImpl<'a> {
     /// yield
     /// yield [no `LineTerminator` here] `AssignmentExpression`
     /// yield [no `LineTerminator` here] * `AssignmentExpression`
-    pub(crate) fn parse_yield_expression(&mut self) -> Result<Expression<'a>> {
+    pub(crate) fn parse_yield_expression(&mut self) -> Expression<'a> {
         let span = self.start_span();
         self.bump_any(); // advance `yield`
 
@@ -305,12 +297,12 @@ impl<'a> ParserImpl<'a> {
             );
             if !not_assignment_expr || delegate {
                 self.ctx = self.ctx.union_yield_if(true);
-                argument = Some(self.parse_assignment_expression_or_higher()?);
+                argument = Some(self.parse_assignment_expression_or_higher());
                 self.ctx = self.ctx.and_yield(has_yield);
             }
         }
 
-        Ok(self.ast.expression_yield(self.end_span(span), delegate, argument))
+        self.ast.expression_yield(self.end_span(span), delegate, argument)
     }
 
     // id: None - for AnonymousDefaultExportedFunctionDeclaration
@@ -319,7 +311,7 @@ impl<'a> ParserImpl<'a> {
         kind: FunctionKind,
         r#async: bool,
         generator: bool,
-    ) -> Result<Option<BindingIdentifier<'a>>> {
+    ) -> Option<BindingIdentifier<'a>> {
         let ctx = self.ctx;
         if kind.is_expression() {
             self.ctx = self.ctx.and_await(r#async).and_yield(generator);
@@ -336,11 +328,11 @@ impl<'a> ParserImpl<'a> {
                 Kind::LParen => {
                     self.error(diagnostics::expect_function_name(self.cur_token().span()));
                 }
-                kind if kind.is_reserved_keyword() => self.expect_without_advance(Kind::Ident)?,
+                kind if kind.is_reserved_keyword() => self.expect_without_advance(Kind::Ident),
                 _ => {}
             }
         }
 
-        Ok(id)
+        id
     }
 }

--- a/crates/oxc_parser/src/js/grammar.rs
+++ b/crates/oxc_parser/src/js/grammar.rs
@@ -1,69 +1,67 @@
 //! Cover Grammar for Destructuring Assignment
 
 use oxc_ast::ast::*;
-use oxc_diagnostics::Result;
 use oxc_span::GetSpan;
 
 use crate::{ParserImpl, diagnostics};
 
 pub trait CoverGrammar<'a, T>: Sized {
-    fn cover(value: T, p: &mut ParserImpl<'a>) -> Result<Self>;
+    fn cover(value: T, p: &mut ParserImpl<'a>) -> Self;
 }
 
 impl<'a> CoverGrammar<'a, Expression<'a>> for AssignmentTarget<'a> {
-    fn cover(expr: Expression<'a>, p: &mut ParserImpl<'a>) -> Result<Self> {
+    fn cover(expr: Expression<'a>, p: &mut ParserImpl<'a>) -> Self {
         match expr {
             Expression::ArrayExpression(array_expr) => {
-                ArrayAssignmentTarget::cover(array_expr.unbox(), p)
-                    .map(|pat| AssignmentTarget::ArrayAssignmentTarget(p.alloc(pat)))
+                let pat = ArrayAssignmentTarget::cover(array_expr.unbox(), p);
+                AssignmentTarget::ArrayAssignmentTarget(p.alloc(pat))
             }
             Expression::ObjectExpression(object_expr) => {
-                ObjectAssignmentTarget::cover(object_expr.unbox(), p)
-                    .map(|pat| AssignmentTarget::ObjectAssignmentTarget(p.alloc(pat)))
+                let pat = ObjectAssignmentTarget::cover(object_expr.unbox(), p);
+                AssignmentTarget::ObjectAssignmentTarget(p.alloc(pat))
             }
-            _ => SimpleAssignmentTarget::cover(expr, p).map(AssignmentTarget::from),
+            _ => AssignmentTarget::from(SimpleAssignmentTarget::cover(expr, p)),
         }
     }
 }
 
 impl<'a> CoverGrammar<'a, Expression<'a>> for SimpleAssignmentTarget<'a> {
-    #[expect(clippy::only_used_in_recursion)]
-    fn cover(expr: Expression<'a>, p: &mut ParserImpl<'a>) -> Result<Self> {
+    fn cover(expr: Expression<'a>, p: &mut ParserImpl<'a>) -> Self {
         match expr {
             Expression::Identifier(ident) => {
-                Ok(SimpleAssignmentTarget::AssignmentTargetIdentifier(ident))
+                SimpleAssignmentTarget::AssignmentTargetIdentifier(ident)
             }
             match_member_expression!(Expression) => {
                 let member_expr = MemberExpression::try_from(expr).unwrap();
-                Ok(SimpleAssignmentTarget::from(member_expr))
+                SimpleAssignmentTarget::from(member_expr)
             }
             Expression::ParenthesizedExpression(expr) => {
                 let span = expr.span;
                 match expr.unbox().expression {
                     Expression::ObjectExpression(_) | Expression::ArrayExpression(_) => {
-                        Err(diagnostics::invalid_assignment(span))
+                        p.fatal_error(diagnostics::invalid_assignment(span))
                     }
                     expr => SimpleAssignmentTarget::cover(expr, p),
                 }
             }
-            Expression::TSAsExpression(expr) => Ok(SimpleAssignmentTarget::TSAsExpression(expr)),
+            Expression::TSAsExpression(expr) => SimpleAssignmentTarget::TSAsExpression(expr),
             Expression::TSSatisfiesExpression(expr) => {
-                Ok(SimpleAssignmentTarget::TSSatisfiesExpression(expr))
+                SimpleAssignmentTarget::TSSatisfiesExpression(expr)
             }
             Expression::TSNonNullExpression(expr) => {
-                Ok(SimpleAssignmentTarget::TSNonNullExpression(expr))
+                SimpleAssignmentTarget::TSNonNullExpression(expr)
             }
-            Expression::TSTypeAssertion(expr) => Ok(SimpleAssignmentTarget::TSTypeAssertion(expr)),
+            Expression::TSTypeAssertion(expr) => SimpleAssignmentTarget::TSTypeAssertion(expr),
             Expression::TSInstantiationExpression(expr) => {
-                Err(diagnostics::invalid_lhs_assignment(expr.span()))
+                p.fatal_error(diagnostics::invalid_lhs_assignment(expr.span()))
             }
-            expr => Err(diagnostics::invalid_assignment(expr.span())),
+            expr => p.fatal_error(diagnostics::invalid_assignment(expr.span())),
         }
     }
 }
 
 impl<'a> CoverGrammar<'a, ArrayExpression<'a>> for ArrayAssignmentTarget<'a> {
-    fn cover(expr: ArrayExpression<'a>, p: &mut ParserImpl<'a>) -> Result<Self> {
+    fn cover(expr: ArrayExpression<'a>, p: &mut ParserImpl<'a>) -> Self {
         let mut elements = p.ast.vec();
         let mut rest = None;
 
@@ -72,53 +70,53 @@ impl<'a> CoverGrammar<'a, ArrayExpression<'a>> for ArrayAssignmentTarget<'a> {
             match elem {
                 match_expression!(ArrayExpressionElement) => {
                     let expr = Expression::try_from(elem).unwrap();
-                    let target = AssignmentTargetMaybeDefault::cover(expr, p)?;
+                    let target = AssignmentTargetMaybeDefault::cover(expr, p);
                     elements.push(Some(target));
                 }
                 ArrayExpressionElement::SpreadElement(elem) => {
                     if i == len - 1 {
                         rest = Some(p.ast.assignment_target_rest(
                             elem.span,
-                            AssignmentTarget::cover(elem.unbox().argument, p)?,
+                            AssignmentTarget::cover(elem.unbox().argument, p),
                         ));
                         if let Some(span) = expr.trailing_comma {
                             p.error(diagnostics::binding_rest_element_trailing_comma(span));
                         }
                     } else {
-                        return Err(diagnostics::spread_last_element(elem.span));
+                        return p.fatal_error(diagnostics::spread_last_element(elem.span));
                     }
                 }
                 ArrayExpressionElement::Elision(_) => elements.push(None),
             }
         }
 
-        Ok(p.ast.array_assignment_target(expr.span, elements, rest, expr.trailing_comma))
+        p.ast.array_assignment_target(expr.span, elements, rest, expr.trailing_comma)
     }
 }
 
 impl<'a> CoverGrammar<'a, Expression<'a>> for AssignmentTargetMaybeDefault<'a> {
-    fn cover(expr: Expression<'a>, p: &mut ParserImpl<'a>) -> Result<Self> {
+    fn cover(expr: Expression<'a>, p: &mut ParserImpl<'a>) -> Self {
         match expr {
             Expression::AssignmentExpression(assignment_expr) => {
-                let target = AssignmentTargetWithDefault::cover(assignment_expr.unbox(), p)?;
-                Ok(AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(p.alloc(target)))
+                let target = AssignmentTargetWithDefault::cover(assignment_expr.unbox(), p);
+                AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(p.alloc(target))
             }
             expr => {
-                let target = AssignmentTarget::cover(expr, p)?;
-                Ok(AssignmentTargetMaybeDefault::from(target))
+                let target = AssignmentTarget::cover(expr, p);
+                AssignmentTargetMaybeDefault::from(target)
             }
         }
     }
 }
 
 impl<'a> CoverGrammar<'a, AssignmentExpression<'a>> for AssignmentTargetWithDefault<'a> {
-    fn cover(expr: AssignmentExpression<'a>, p: &mut ParserImpl<'a>) -> Result<Self> {
-        Ok(p.ast.assignment_target_with_default(expr.span, expr.left, expr.right))
+    fn cover(expr: AssignmentExpression<'a>, p: &mut ParserImpl<'a>) -> Self {
+        p.ast.assignment_target_with_default(expr.span, expr.left, expr.right)
     }
 }
 
 impl<'a> CoverGrammar<'a, ObjectExpression<'a>> for ObjectAssignmentTarget<'a> {
-    fn cover(expr: ObjectExpression<'a>, p: &mut ParserImpl<'a>) -> Result<Self> {
+    fn cover(expr: ObjectExpression<'a>, p: &mut ParserImpl<'a>) -> Self {
         let mut properties = p.ast.vec();
         let mut rest = None;
 
@@ -126,51 +124,51 @@ impl<'a> CoverGrammar<'a, ObjectExpression<'a>> for ObjectAssignmentTarget<'a> {
         for (i, elem) in expr.properties.into_iter().enumerate() {
             match elem {
                 ObjectPropertyKind::ObjectProperty(property) => {
-                    let target = AssignmentTargetProperty::cover(property.unbox(), p)?;
+                    let target = AssignmentTargetProperty::cover(property.unbox(), p);
                     properties.push(target);
                 }
                 ObjectPropertyKind::SpreadProperty(spread) => {
                     if i == len - 1 {
                         rest = Some(p.ast.assignment_target_rest(
                             spread.span,
-                            AssignmentTarget::cover(spread.unbox().argument, p)?,
+                            AssignmentTarget::cover(spread.unbox().argument, p),
                         ));
                     } else {
-                        return Err(diagnostics::spread_last_element(spread.span));
+                        return p.fatal_error(diagnostics::spread_last_element(spread.span));
                     }
                 }
             }
         }
 
-        Ok(p.ast.object_assignment_target(expr.span, properties, rest))
+        p.ast.object_assignment_target(expr.span, properties, rest)
     }
 }
 
 impl<'a> CoverGrammar<'a, ObjectProperty<'a>> for AssignmentTargetProperty<'a> {
-    fn cover(property: ObjectProperty<'a>, p: &mut ParserImpl<'a>) -> Result<Self> {
+    fn cover(property: ObjectProperty<'a>, p: &mut ParserImpl<'a>) -> Self {
         if property.shorthand {
             let binding = match property.key {
                 PropertyKey::StaticIdentifier(ident) => {
                     let ident = ident.unbox();
                     p.ast.identifier_reference(ident.span, ident.name)
                 }
-                _ => return Err(p.unexpected()),
+                _ => return p.unexpected(),
             };
             // convert `CoverInitializedName`
             let init = p.state.cover_initialized_name.remove(&property.span.start).map(|e| e.right);
-            Ok(p.ast.assignment_target_property_assignment_target_property_identifier(
+            p.ast.assignment_target_property_assignment_target_property_identifier(
                 property.span,
                 binding,
                 init,
-            ))
+            )
         } else {
-            let binding = AssignmentTargetMaybeDefault::cover(property.value, p)?;
-            Ok(p.ast.assignment_target_property_assignment_target_property_property(
+            let binding = AssignmentTargetMaybeDefault::cover(property.value, p);
+            p.ast.assignment_target_property_assignment_target_property_property(
                 property.span,
                 property.key,
                 binding,
                 property.computed,
-            ))
+            )
         }
     }
 }

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -1,6 +1,5 @@
 use oxc_allocator::{Box, Vec};
 use oxc_ast::{NONE, ast::*};
-use oxc_diagnostics::Result;
 use oxc_span::{GetSpan, Span};
 use rustc_hash::FxHashMap;
 
@@ -14,34 +13,36 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         span: Span,
         phase: Option<ImportPhase>,
-    ) -> Result<Expression<'a>> {
-        self.expect(Kind::LParen)?;
+    ) -> Expression<'a> {
+        self.expect(Kind::LParen);
 
         if self.eat(Kind::RParen) {
-            return Err(oxc_diagnostics::OxcDiagnostic::error("import() requires a specifier.")
-                .with_label(self.end_span(span)));
+            return self.fatal_error(
+                oxc_diagnostics::OxcDiagnostic::error("import() requires a specifier.")
+                    .with_label(self.end_span(span)),
+            );
         }
 
         let has_in = self.ctx.has_in();
         self.ctx = self.ctx.and_in(true);
 
-        let expression = self.parse_assignment_expression_or_higher()?;
+        let expression = self.parse_assignment_expression_or_higher();
         let mut arguments = self.ast.vec();
         if self.eat(Kind::Comma) && !self.at(Kind::RParen) {
-            arguments.push(self.parse_assignment_expression_or_higher()?);
+            arguments.push(self.parse_assignment_expression_or_higher());
         }
 
         self.ctx = self.ctx.and_in(has_in);
         self.bump(Kind::Comma);
-        self.expect(Kind::RParen)?;
+        self.expect(Kind::RParen);
         let expr =
             self.ast.alloc_import_expression(self.end_span(span), expression, arguments, phase);
         self.module_record_builder.visit_import_expression(&expr);
-        Ok(Expression::ImportExpression(expr))
+        Expression::ImportExpression(expr)
     }
 
     /// Section 16.2.2 Import Declaration
-    pub(crate) fn parse_import_declaration(&mut self) -> Result<Statement<'a>> {
+    pub(crate) fn parse_import_declaration(&mut self) -> Statement<'a> {
         let span = self.start_span();
 
         self.bump_any(); // advance `import`
@@ -52,8 +53,8 @@ impl<'a> ParserImpl<'a> {
                     && self.peek_kind().is_binding_identifier()
                     && self.nth_at(2, Kind::Eq)))
         {
-            let decl = self.parse_ts_import_equals_declaration(span)?;
-            return Ok(Statement::from(decl));
+            let decl = self.parse_ts_import_equals_declaration(span);
+            return Statement::from(decl);
         }
 
         // `import type ...`
@@ -80,80 +81,75 @@ impl<'a> ParserImpl<'a> {
             // import "source"
             None
         } else {
-            Some(self.parse_import_declaration_specifiers()?)
+            Some(self.parse_import_declaration_specifiers())
         };
 
-        let source = self.parse_literal_string()?;
-        let with_clause = self.parse_import_attributes()?;
-        self.asi()?;
+        let source = self.parse_literal_string();
+        let with_clause = self.parse_import_attributes();
+        self.asi();
         let span = self.end_span(span);
-        Ok(self
-            .ast
-            .module_declaration_import_declaration(
-                span,
-                specifiers,
-                source,
-                phase,
-                with_clause,
-                import_kind,
-            )
-            .into())
+        Statement::from(self.ast.module_declaration_import_declaration(
+            span,
+            specifiers,
+            source,
+            phase,
+            with_clause,
+            import_kind,
+        ))
     }
 
     // Full Syntax: <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#syntax>
-    fn parse_import_declaration_specifiers(
-        &mut self,
-    ) -> Result<Vec<'a, ImportDeclarationSpecifier<'a>>> {
+    fn parse_import_declaration_specifiers(&mut self) -> Vec<'a, ImportDeclarationSpecifier<'a>> {
         let mut specifiers = self.ast.vec();
         // import defaultExport from "module-name";
         if self.cur_kind().is_binding_identifier() {
-            specifiers.push(self.parse_import_default_specifier()?);
+            specifiers.push(self.parse_import_default_specifier());
             if self.eat(Kind::Comma) {
                 match self.cur_kind() {
                     // import defaultExport, * as name from "module-name";
-                    Kind::Star => specifiers.push(self.parse_import_namespace_specifier()?),
+                    Kind::Star => specifiers.push(self.parse_import_namespace_specifier()),
                     // import defaultExport, { export1 [ , [...] ] } from "module-name";
                     Kind::LCurly => {
-                        let mut import_specifiers = self.parse_import_specifiers()?;
+                        let mut import_specifiers = self.parse_import_specifiers();
                         specifiers.append(&mut import_specifiers);
                     }
-                    _ => return Err(self.unexpected()),
+                    _ => return self.unexpected(),
                 }
             }
         // import * as name from "module-name";
         } else if self.at(Kind::Star) {
-            specifiers.push(self.parse_import_namespace_specifier()?);
+            specifiers.push(self.parse_import_namespace_specifier());
         // import { export1 , export2 as alias2 , [...] } from "module-name";
         } else if self.at(Kind::LCurly) {
-            let mut import_specifiers = self.parse_import_specifiers()?;
+            let mut import_specifiers = self.parse_import_specifiers();
             specifiers.append(&mut import_specifiers);
         };
 
-        self.expect(Kind::From)?;
-        Ok(specifiers)
+        self.expect(Kind::From);
+        specifiers
     }
 
     // import default from "module-name"
-    fn parse_import_default_specifier(&mut self) -> Result<ImportDeclarationSpecifier<'a>> {
+    fn parse_import_default_specifier(&mut self) -> ImportDeclarationSpecifier<'a> {
         let span = self.start_span();
-        let local = self.parse_binding_identifier()?;
+        let local = self.parse_binding_identifier();
         let span = self.end_span(span);
-        Ok(self.ast.import_declaration_specifier_import_default_specifier(span, local))
+        self.ast.import_declaration_specifier_import_default_specifier(span, local)
     }
 
     // import * as name from "module-name"
-    fn parse_import_namespace_specifier(&mut self) -> Result<ImportDeclarationSpecifier<'a>> {
+    fn parse_import_namespace_specifier(&mut self) -> ImportDeclarationSpecifier<'a> {
         let span = self.start_span();
         self.bump_any(); // advance `*`
-        self.expect(Kind::As)?;
-        let local = self.parse_binding_identifier()?;
+        self.expect(Kind::As);
+        let local = self.parse_binding_identifier();
         let span = self.end_span(span);
-        Ok(self.ast.import_declaration_specifier_import_namespace_specifier(span, local))
+        self.ast.import_declaration_specifier_import_namespace_specifier(span, local)
     }
 
     // import { export1 , export2 as alias2 , [...] } from "module-name";
-    fn parse_import_specifiers(&mut self) -> Result<Vec<'a, ImportDeclarationSpecifier<'a>>> {
-        self.expect(Kind::LCurly)?;
+    fn parse_import_specifiers(&mut self) -> Vec<'a, ImportDeclarationSpecifier<'a>> {
+        self.expect(Kind::LCurly);
         let list = self.context(Context::empty(), self.ctx, |p| {
             p.parse_delimited_list(
                 Kind::RCurly,
@@ -161,22 +157,20 @@ impl<'a> ParserImpl<'a> {
                 /* trailing_separator */ true,
                 Self::parse_import_specifier,
             )
-        })?;
-        self.expect(Kind::RCurly)?;
-        Ok(list)
+        });
+        self.expect(Kind::RCurly);
+        list
     }
 
     /// [Import Attributes](https://tc39.es/proposal-import-attributes)
-    fn parse_import_attributes(&mut self) -> Result<Option<WithClause<'a>>> {
+    fn parse_import_attributes(&mut self) -> Option<WithClause<'a>> {
         let attributes_keyword = match self.cur_kind() {
-            Kind::Assert if !self.cur_token().is_on_new_line => self.parse_identifier_name()?,
-            Kind::With => self.parse_identifier_name()?,
-            _ => {
-                return Ok(None);
-            }
+            Kind::Assert if !self.cur_token().is_on_new_line => self.parse_identifier_name(),
+            Kind::With => self.parse_identifier_name(),
+            _ => return None,
         };
         let span = self.start_span();
-        self.expect(Kind::LCurly)?;
+        self.expect(Kind::LCurly);
         let with_entries = self.context(Context::empty(), self.ctx, |p| {
             p.parse_delimited_list(
                 Kind::RCurly,
@@ -184,8 +178,8 @@ impl<'a> ParserImpl<'a> {
                 /*trailing_separator*/ true,
                 Self::parse_import_attribute,
             )
-        })?;
-        self.expect(Kind::RCurly)?;
+        });
+        self.expect(Kind::RCurly);
 
         let mut keys = FxHashMap::default();
         for e in &with_entries {
@@ -196,73 +190,75 @@ impl<'a> ParserImpl<'a> {
             }
         }
 
-        Ok(Some(self.ast.with_clause(self.end_span(span), attributes_keyword, with_entries)))
+        Some(self.ast.with_clause(self.end_span(span), attributes_keyword, with_entries))
     }
 
-    fn parse_import_attribute(&mut self) -> Result<ImportAttribute<'a>> {
+    fn parse_import_attribute(&mut self) -> ImportAttribute<'a> {
         let span = self.start_span();
         let key = match self.cur_kind() {
-            Kind::Str => ImportAttributeKey::StringLiteral(self.parse_literal_string()?),
-            _ => ImportAttributeKey::Identifier(self.parse_identifier_name()?),
+            Kind::Str => ImportAttributeKey::StringLiteral(self.parse_literal_string()),
+            _ => ImportAttributeKey::Identifier(self.parse_identifier_name()),
         };
-        self.expect(Kind::Colon)?;
-        let value = self.parse_literal_string()?;
-        Ok(self.ast.import_attribute(self.end_span(span), key, value))
+        self.expect(Kind::Colon);
+        let value = self.parse_literal_string();
+        self.ast.import_attribute(self.end_span(span), key, value)
     }
 
     pub(crate) fn parse_ts_export_assignment_declaration(
         &mut self,
         start_span: Span,
-    ) -> Result<Box<'a, TSExportAssignment<'a>>> {
-        self.expect(Kind::Eq)?;
-        let expression = self.parse_assignment_expression_or_higher()?;
-        self.asi()?;
-        Ok(self.ast.alloc_ts_export_assignment(self.end_span(start_span), expression))
+    ) -> Box<'a, TSExportAssignment<'a>> {
+        self.expect(Kind::Eq);
+        let expression = self.parse_assignment_expression_or_higher();
+        self.asi();
+        self.ast.alloc_ts_export_assignment(self.end_span(start_span), expression)
     }
 
     pub(crate) fn parse_ts_export_namespace(
         &mut self,
         start_span: Span,
-    ) -> Result<Box<'a, TSNamespaceExportDeclaration<'a>>> {
-        self.expect(Kind::As)?;
-        self.expect(Kind::Namespace)?;
-        let id = self.parse_identifier_name()?;
-        self.asi()?;
-        Ok(self.ast.alloc_ts_namespace_export_declaration(self.end_span(start_span), id))
+    ) -> Box<'a, TSNamespaceExportDeclaration<'a>> {
+        self.expect(Kind::As);
+        self.expect(Kind::Namespace);
+        let id = self.parse_identifier_name();
+        self.asi();
+        self.ast.alloc_ts_namespace_export_declaration(self.end_span(start_span), id)
     }
 
     /// [Exports](https://tc39.es/ecma262/#sec-exports)
-    pub(crate) fn parse_export_declaration(&mut self) -> Result<Statement<'a>> {
+    pub(crate) fn parse_export_declaration(&mut self) -> Statement<'a> {
         let span = self.start_span();
         self.bump_any(); // advance `export`
 
         let decl = match self.cur_kind() {
-            Kind::Eq if self.is_ts => self
-                .parse_ts_export_assignment_declaration(span)
-                .map(ModuleDeclaration::TSExportAssignment),
-            Kind::As if self.peek_at(Kind::Namespace) && self.is_ts => self
-                .parse_ts_export_namespace(span)
-                .map(ModuleDeclaration::TSNamespaceExportDeclaration),
-            Kind::Default => self
-                .parse_export_default_declaration(span)
-                .map(ModuleDeclaration::ExportDefaultDeclaration),
+            Kind::Eq if self.is_ts => ModuleDeclaration::TSExportAssignment(
+                self.parse_ts_export_assignment_declaration(span),
+            ),
+            Kind::As if self.peek_at(Kind::Namespace) && self.is_ts => {
+                ModuleDeclaration::TSNamespaceExportDeclaration(
+                    self.parse_ts_export_namespace(span),
+                )
+            }
+            Kind::Default => ModuleDeclaration::ExportDefaultDeclaration(
+                self.parse_export_default_declaration(span),
+            ),
             Kind::Star => {
-                self.parse_export_all_declaration(span).map(ModuleDeclaration::ExportAllDeclaration)
+                ModuleDeclaration::ExportAllDeclaration(self.parse_export_all_declaration(span))
             }
-            Kind::LCurly => self
-                .parse_export_named_specifiers(span)
-                .map(ModuleDeclaration::ExportNamedDeclaration),
-            Kind::Type if self.peek_at(Kind::LCurly) && self.is_ts => self
-                .parse_export_named_specifiers(span)
-                .map(ModuleDeclaration::ExportNamedDeclaration),
+            Kind::LCurly => {
+                ModuleDeclaration::ExportNamedDeclaration(self.parse_export_named_specifiers(span))
+            }
+            Kind::Type if self.peek_at(Kind::LCurly) && self.is_ts => {
+                ModuleDeclaration::ExportNamedDeclaration(self.parse_export_named_specifiers(span))
+            }
             Kind::Type if self.peek_at(Kind::Star) => {
-                self.parse_export_all_declaration(span).map(ModuleDeclaration::ExportAllDeclaration)
+                ModuleDeclaration::ExportAllDeclaration(self.parse_export_all_declaration(span))
             }
-            _ => self
-                .parse_export_named_declaration(span)
-                .map(ModuleDeclaration::ExportNamedDeclaration),
-        }?;
-        Ok(Statement::from(decl))
+            _ => {
+                ModuleDeclaration::ExportNamedDeclaration(self.parse_export_named_declaration(span))
+            }
+        };
+        Statement::from(decl)
     }
 
     // export NamedExports ;
@@ -276,12 +272,9 @@ impl<'a> ParserImpl<'a> {
     // ExportSpecifier :
     //   ModuleExportName
     //   ModuleExportName as ModuleExportName
-    fn parse_export_named_specifiers(
-        &mut self,
-        span: Span,
-    ) -> Result<Box<'a, ExportNamedDeclaration<'a>>> {
+    fn parse_export_named_specifiers(&mut self, span: Span) -> Box<'a, ExportNamedDeclaration<'a>> {
         let export_kind = self.parse_import_or_export_kind();
-        self.expect(Kind::LCurly)?;
+        self.expect(Kind::LCurly);
         let mut specifiers = self.context(Context::empty(), self.ctx, |p| {
             p.parse_delimited_list(
                 Kind::RCurly,
@@ -289,11 +282,11 @@ impl<'a> ParserImpl<'a> {
                 /* trailing_separator */ true,
                 Self::parse_export_named_specifier,
             )
-        })?;
-        self.expect(Kind::RCurly)?;
+        });
+        self.expect(Kind::RCurly);
         let (source, with_clause) = if self.eat(Kind::From) && self.cur_kind().is_literal() {
-            let source = self.parse_literal_string()?;
-            (Some(source), self.parse_import_attributes()?)
+            let source = self.parse_literal_string();
+            (Some(source), self.parse_import_attributes())
         } else {
             (None, None)
         };
@@ -336,47 +329,47 @@ impl<'a> ParserImpl<'a> {
             }
         }
 
-        self.asi()?;
+        self.asi();
         let span = self.end_span(span);
-        Ok(self.ast.alloc_export_named_declaration(
+        self.ast.alloc_export_named_declaration(
             span,
             None,
             specifiers,
             source,
             export_kind,
             with_clause,
-        ))
+        )
     }
 
     // export Declaration
     fn parse_export_named_declaration(
         &mut self,
         span: Span,
-    ) -> Result<Box<'a, ExportNamedDeclaration<'a>>> {
+    ) -> Box<'a, ExportNamedDeclaration<'a>> {
         let decl_span = self.start_span();
         // For tc39/proposal-decorators
         // For more information, please refer to <https://babeljs.io/docs/babel-plugin-proposal-decorators#decoratorsbeforeexport>
-        self.eat_decorators()?;
+        self.eat_decorators();
         let reserved_ctx = self.ctx;
         let modifiers =
-            if self.is_ts { self.eat_modifiers_before_declaration()? } else { Modifiers::empty() };
+            if self.is_ts { self.eat_modifiers_before_declaration() } else { Modifiers::empty() };
         self.ctx = self.ctx.union_ambient_if(modifiers.contains_declare());
 
-        let declaration = self.parse_declaration(decl_span, &modifiers)?;
+        let declaration = self.parse_declaration(decl_span, &modifiers);
         let export_kind = if declaration.is_type() {
             ImportOrExportKind::Type
         } else {
             ImportOrExportKind::Value
         };
         self.ctx = reserved_ctx;
-        Ok(self.ast.alloc_export_named_declaration(
+        self.ast.alloc_export_named_declaration(
             self.end_span(span),
             Some(declaration),
             self.ast.vec(),
             None,
             export_kind,
             NONE,
-        ))
+        )
     }
 
     // export default HoistableDeclaration[~Yield, +Await, +Default]
@@ -385,52 +378,52 @@ impl<'a> ParserImpl<'a> {
     fn parse_export_default_declaration(
         &mut self,
         span: Span,
-    ) -> Result<Box<'a, ExportDefaultDeclaration<'a>>> {
+    ) -> Box<'a, ExportDefaultDeclaration<'a>> {
         let exported = self.parse_keyword_identifier(Kind::Default);
         let decl_span = self.start_span();
         let has_no_side_effects_comment =
             self.lexer.trivia_builder.previous_token_has_no_side_effects_comment();
         // For tc39/proposal-decorators
         // For more information, please refer to <https://babeljs.io/docs/babel-plugin-proposal-decorators#decoratorsbeforeexport>
-        self.eat_decorators()?;
+        self.eat_decorators();
         let declaration = match self.cur_kind() {
-            Kind::Class => self
-                .parse_class_declaration(decl_span, /* modifiers */ &Modifiers::empty())
-                .map(ExportDefaultDeclarationKind::ClassDeclaration)?,
+            Kind::Class => ExportDefaultDeclarationKind::ClassDeclaration(
+                self.parse_class_declaration(decl_span, /* modifiers */ &Modifiers::empty()),
+            ),
             _ if self.at(Kind::Abstract) && self.peek_at(Kind::Class) && self.is_ts => {
                 // eat the abstract modifier
-                let modifiers = self.eat_modifiers_before_declaration()?;
-                self.parse_class_declaration(decl_span, &modifiers)
-                    .map(ExportDefaultDeclarationKind::ClassDeclaration)?
+                let modifiers = self.eat_modifiers_before_declaration();
+                ExportDefaultDeclarationKind::ClassDeclaration(
+                    self.parse_class_declaration(decl_span, &modifiers),
+                )
             }
             _ if self.at(Kind::Interface) && !self.peek_token().is_on_new_line && self.is_ts => {
-                self.parse_ts_interface_declaration(decl_span, &Modifiers::empty()).map(|decl| {
-                    match decl {
-                        Declaration::TSInterfaceDeclaration(decl) => {
-                            ExportDefaultDeclarationKind::TSInterfaceDeclaration(decl)
-                        }
-                        _ => unreachable!(),
+                let decl = self.parse_ts_interface_declaration(decl_span, &Modifiers::empty());
+                match decl {
+                    Declaration::TSInterfaceDeclaration(decl) => {
+                        ExportDefaultDeclarationKind::TSInterfaceDeclaration(decl)
                     }
-                })?
+                    _ => unreachable!(),
+                }
             }
             _ if self.at_function_with_async() => {
-                let mut func = self.parse_function_impl(FunctionKind::DefaultExport)?;
+                let mut func = self.parse_function_impl(FunctionKind::DefaultExport);
                 if has_no_side_effects_comment {
                     func.pure = true;
                 }
                 ExportDefaultDeclarationKind::FunctionDeclaration(func)
             }
             _ => {
-                let decl = self
-                    .parse_assignment_expression_or_higher()
-                    .map(ExportDefaultDeclarationKind::from)?;
-                self.asi()?;
+                let decl = ExportDefaultDeclarationKind::from(
+                    self.parse_assignment_expression_or_higher(),
+                );
+                self.asi();
                 decl
             }
         };
         let exported = ModuleExportName::IdentifierName(exported);
         let span = self.end_span(span);
-        Ok(self.ast.alloc_export_default_declaration(span, exported, declaration))
+        self.ast.alloc_export_default_declaration(span, exported, declaration)
     }
 
     // export ExportFromClause FromClause ;
@@ -438,25 +431,22 @@ impl<'a> ParserImpl<'a> {
     //   *
     //   * as ModuleExportName
     //   NamedExports
-    fn parse_export_all_declaration(
-        &mut self,
-        span: Span,
-    ) -> Result<Box<'a, ExportAllDeclaration<'a>>> {
+    fn parse_export_all_declaration(&mut self, span: Span) -> Box<'a, ExportAllDeclaration<'a>> {
         let export_kind = self.parse_import_or_export_kind();
         self.bump_any(); // bump `star`
-        let exported = self.eat(Kind::As).then(|| self.parse_module_export_name()).transpose()?;
-        self.expect(Kind::From)?;
-        let source = self.parse_literal_string()?;
-        let with_clause = self.parse_import_attributes()?;
-        self.asi()?;
+        let exported = self.eat(Kind::As).then(|| self.parse_module_export_name());
+        self.expect(Kind::From);
+        let source = self.parse_literal_string();
+        let with_clause = self.parse_import_attributes();
+        self.asi();
         let span = self.end_span(span);
-        Ok(self.ast.alloc_export_all_declaration(span, exported, source, with_clause, export_kind))
+        self.ast.alloc_export_all_declaration(span, exported, source, with_clause, export_kind)
     }
 
     // ImportSpecifier :
     //   ImportedBinding
     //   ModuleExportName as ImportedBinding
-    pub(crate) fn parse_import_specifier(&mut self) -> Result<ImportDeclarationSpecifier<'a>> {
+    pub(crate) fn parse_import_specifier(&mut self) -> ImportDeclarationSpecifier<'a> {
         let specifier_span = self.start_span();
         let peek_kind = self.peek_kind();
         let mut import_kind = ImportOrExportKind::Value;
@@ -478,37 +468,37 @@ impl<'a> ParserImpl<'a> {
             self.bump_any();
         }
         let (imported, local) = if self.peek_at(Kind::As) {
-            let imported = self.parse_module_export_name()?;
+            let imported = self.parse_module_export_name();
             self.bump(Kind::As);
-            let local = self.parse_binding_identifier()?;
+            let local = self.parse_binding_identifier();
             (imported, local)
         } else {
-            let local = self.parse_binding_identifier()?;
+            let local = self.parse_binding_identifier();
             (self.ast.module_export_name_identifier_name(local.span, local.name), local)
         };
-        Ok(self.ast.import_declaration_specifier_import_specifier(
+        self.ast.import_declaration_specifier_import_specifier(
             self.end_span(specifier_span),
             imported,
             local,
             import_kind,
-        ))
+        )
     }
 
     // ModuleExportName :
     //   IdentifierName
     //   StringLiteral
-    pub(crate) fn parse_module_export_name(&mut self) -> Result<ModuleExportName<'a>> {
+    pub(crate) fn parse_module_export_name(&mut self) -> ModuleExportName<'a> {
         match self.cur_kind() {
             Kind::Str => {
-                let literal = self.parse_literal_string()?;
+                let literal = self.parse_literal_string();
                 // ModuleExportName : StringLiteral
                 // It is a Syntax Error if IsStringWellFormedUnicode(the SV of StringLiteral) is false.
                 if literal.lossy || !literal.is_string_well_formed_unicode() {
                     self.error(diagnostics::export_lone_surrogate(literal.span));
                 };
-                Ok(ModuleExportName::StringLiteral(literal))
+                ModuleExportName::StringLiteral(literal)
             }
-            _ => Ok(ModuleExportName::IdentifierName(self.parse_identifier_name()?)),
+            _ => ModuleExportName::IdentifierName(self.parse_identifier_name()),
         }
     }
 
@@ -548,7 +538,7 @@ impl<'a> ParserImpl<'a> {
         ImportOrExportKind::Value
     }
 
-    fn parse_export_named_specifier(&mut self) -> Result<ExportSpecifier<'a>> {
+    fn parse_export_named_specifier(&mut self) -> ExportSpecifier<'a> {
         let specifier_span = self.start_span();
         let peek_kind = self.peek_kind();
         // export { type}              // name: `type`
@@ -575,9 +565,9 @@ impl<'a> ParserImpl<'a> {
             self.bump_any();
         }
 
-        let local = self.parse_module_export_name()?;
+        let local = self.parse_module_export_name();
         let exported =
-            if self.eat(Kind::As) { self.parse_module_export_name()? } else { local.clone() };
-        Ok(self.ast.export_specifier(self.end_span(specifier_span), local, exported, export_kind))
+            if self.eat(Kind::As) { self.parse_module_export_name() } else { local.clone() };
+        self.ast.export_specifier(self.end_span(specifier_span), local, exported, export_kind)
     }
 }

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -1,6 +1,5 @@
 use oxc_allocator::{Box, Vec};
 use oxc_ast::ast::*;
-use oxc_diagnostics::Result;
 use oxc_span::{Atom, GetSpan, Span};
 
 use super::{VariableDeclarationParent, grammar::CoverGrammar};
@@ -31,7 +30,7 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_directives_and_statements(
         &mut self,
         is_top_level: bool,
-    ) -> Result<(Vec<'a, Directive<'a>>, Vec<'a, Statement<'a>>)> {
+    ) -> (Vec<'a, Directive<'a>>, Vec<'a, Statement<'a>>) {
         let mut directives = self.ast.vec();
         let mut statements = self.ast.vec();
 
@@ -40,7 +39,7 @@ impl<'a> ParserImpl<'a> {
             if !is_top_level && self.at(Kind::RCurly) {
                 break;
             }
-            let stmt = self.parse_statement_list_item(StatementContext::StatementList)?;
+            let stmt = self.parse_statement_list_item(StatementContext::StatementList);
 
             if is_top_level {
                 if let Some(module_decl) = stmt.as_module_declaration() {
@@ -70,7 +69,7 @@ impl<'a> ParserImpl<'a> {
             statements.push(stmt);
         }
 
-        Ok((directives, statements))
+        (directives, statements)
     }
 
     /// `StatementListItem`[Yield, Await, Return] :
@@ -79,14 +78,14 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_statement_list_item(
         &mut self,
         stmt_ctx: StatementContext,
-    ) -> Result<Statement<'a>> {
+    ) -> Statement<'a> {
         let start_span = self.start_span();
 
         let has_no_side_effects_comment =
             self.lexer.trivia_builder.previous_token_has_no_side_effects_comment();
 
         if self.at(Kind::At) {
-            self.eat_decorators()?;
+            self.eat_decorators();
         }
 
         // For performance reasons, match orders are:
@@ -95,7 +94,7 @@ impl<'a> ParserImpl<'a> {
         // 3. peek token
         let mut stmt = match self.cur_kind() {
             Kind::LCurly => self.parse_block_statement(),
-            Kind::Semicolon => Ok(self.parse_empty_statement()),
+            Kind::Semicolon => self.parse_empty_statement(),
             Kind::If => self.parse_if_statement(),
             Kind::Do => self.parse_do_while_statement(),
             Kind::While => self.parse_while_statement(),
@@ -133,13 +132,13 @@ impl<'a> ParserImpl<'a> {
                 self.parse_ts_declaration_statement(start_span)
             }
             _ => self.parse_expression_or_labeled_statement(),
-        }?;
+        };
 
         if has_no_side_effects_comment {
             Self::set_pure_on_function_stmt(&mut stmt);
         }
 
-        Ok(stmt)
+        stmt
     }
 
     fn set_pure_on_function_stmt(stmt: &mut Statement<'a>) {
@@ -178,56 +177,52 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
-    fn parse_expression_or_labeled_statement(&mut self) -> Result<Statement<'a>> {
+    fn parse_expression_or_labeled_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
-        let expr = self.parse_expr()?;
+        let expr = self.parse_expr();
         if let Expression::Identifier(ident) = &expr {
             // Section 14.13 Labelled Statement
             // Avoids lookahead for a labeled statement, which is on a hot path
             if self.eat(Kind::Colon) {
                 let label = self.ast.label_identifier(ident.span, ident.name);
-                let body = self.parse_statement_list_item(StatementContext::Label)?;
-                return Ok(self.ast.statement_labeled(self.end_span(span), label, body));
+                let body = self.parse_statement_list_item(StatementContext::Label);
+                return self.ast.statement_labeled(self.end_span(span), label, body);
             }
         }
         self.parse_expression_statement(span, expr)
     }
 
     /// Section 14.2 Block Statement
-    pub(crate) fn parse_block(&mut self) -> Result<Box<'a, BlockStatement<'a>>> {
+    pub(crate) fn parse_block(&mut self) -> Box<'a, BlockStatement<'a>> {
         let span = self.start_span();
-        self.expect(Kind::LCurly)?;
+        self.expect(Kind::LCurly);
         let mut body = self.ast.vec();
         while !self.at(Kind::RCurly) && !self.at(Kind::Eof) {
-            let stmt = self.parse_statement_list_item(StatementContext::StatementList)?;
+            let stmt = self.parse_statement_list_item(StatementContext::StatementList);
             body.push(stmt);
         }
-        self.expect(Kind::RCurly)?;
-        Ok(self.ast.alloc_block_statement(self.end_span(span), body))
+        self.expect(Kind::RCurly);
+        self.ast.alloc_block_statement(self.end_span(span), body)
     }
 
-    pub(crate) fn parse_block_statement(&mut self) -> Result<Statement<'a>> {
-        let block = self.parse_block()?;
-        Ok(Statement::BlockStatement(block))
+    pub(crate) fn parse_block_statement(&mut self) -> Statement<'a> {
+        Statement::BlockStatement(self.parse_block())
     }
 
     /// Section 14.3.2 Variable Statement
-    pub(crate) fn parse_variable_statement(
-        &mut self,
-        stmt_ctx: StatementContext,
-    ) -> Result<Statement<'a>> {
+    pub(crate) fn parse_variable_statement(&mut self, stmt_ctx: StatementContext) -> Statement<'a> {
         let start_span = self.start_span();
         let decl = self.parse_variable_declaration(
             start_span,
             VariableDeclarationParent::Statement,
             &Modifiers::empty(),
-        )?;
+        );
 
         if stmt_ctx.is_single_statement() && decl.kind.is_lexical() {
             self.error(diagnostics::lexical_declaration_single_statement(decl.span));
         }
 
-        Ok(Statement::VariableDeclaration(decl))
+        Statement::VariableDeclaration(decl)
     }
 
     /// Section 14.4 Empty Statement
@@ -242,46 +237,44 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         span: Span,
         expression: Expression<'a>,
-    ) -> Result<Statement<'a>> {
-        self.asi()?;
-        Ok(self.ast.statement_expression(self.end_span(span), expression))
+    ) -> Statement<'a> {
+        self.asi();
+        self.ast.statement_expression(self.end_span(span), expression)
     }
 
     /// Section 14.6 If Statement
-    fn parse_if_statement(&mut self) -> Result<Statement<'a>> {
+    fn parse_if_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
         self.bump_any(); // bump `if`
-        let test = self.parse_paren_expression()?;
-        let consequent = self.parse_statement_list_item(StatementContext::If)?;
-        let alternate = self
-            .eat(Kind::Else)
-            .then(|| self.parse_statement_list_item(StatementContext::If))
-            .transpose()?;
-        Ok(self.ast.statement_if(self.end_span(span), test, consequent, alternate))
+        let test = self.parse_paren_expression();
+        let consequent = self.parse_statement_list_item(StatementContext::If);
+        let alternate =
+            self.eat(Kind::Else).then(|| self.parse_statement_list_item(StatementContext::If));
+        self.ast.statement_if(self.end_span(span), test, consequent, alternate)
     }
 
     /// Section 14.7.2 Do-While Statement
-    fn parse_do_while_statement(&mut self) -> Result<Statement<'a>> {
+    fn parse_do_while_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
         self.bump_any(); // advance `do`
-        let body = self.parse_statement_list_item(StatementContext::Do)?;
-        self.expect(Kind::While)?;
-        let test = self.parse_paren_expression()?;
+        let body = self.parse_statement_list_item(StatementContext::Do);
+        self.expect(Kind::While);
+        let test = self.parse_paren_expression();
         self.bump(Kind::Semicolon);
-        Ok(self.ast.statement_do_while(self.end_span(span), body, test))
+        self.ast.statement_do_while(self.end_span(span), body, test)
     }
 
     /// Section 14.7.3 While Statement
-    fn parse_while_statement(&mut self) -> Result<Statement<'a>> {
+    fn parse_while_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
         self.bump_any(); // bump `while`
-        let test = self.parse_paren_expression()?;
-        let body = self.parse_statement_list_item(StatementContext::While)?;
-        Ok(self.ast.statement_while(self.end_span(span), test, body))
+        let test = self.parse_paren_expression();
+        let body = self.parse_statement_list_item(StatementContext::While);
+        self.ast.statement_while(self.end_span(span), test, body)
     }
 
     /// Section 14.7.4 For Statement
-    fn parse_for_statement(&mut self) -> Result<Statement<'a>> {
+    fn parse_for_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
         self.bump_any(); // bump `for`
 
@@ -296,7 +289,7 @@ impl<'a> ParserImpl<'a> {
             false
         };
 
-        self.expect(Kind::LParen)?;
+        self.expect(Kind::LParen);
 
         // for (;..
         if self.at(Kind::Semicolon) {
@@ -327,13 +320,16 @@ impl<'a> ParserImpl<'a> {
             return self.parse_for_loop(span, None, r#await);
         }
 
-        let init_expression =
-            self.context(Context::empty(), Context::In, ParserImpl::parse_expr)?;
+        let init_expression = self.context(Context::empty(), Context::In, ParserImpl::parse_expr);
 
         // for (a.b in ...), for ([a] in ..), for ({a} in ..)
         if self.at(Kind::In) || self.at(Kind::Of) {
-            let target = AssignmentTarget::cover(init_expression, self)
-                .map_err(|_| diagnostics::unexpected_token(self.end_span(expr_span)))?;
+            let target = AssignmentTarget::cover(init_expression, self);
+            // Alter the error if failed to parse
+            if self.fatal_error.is_some() {
+                let span = self.end_span(expr_span);
+                self.fatal_error.as_mut().unwrap().error = diagnostics::unexpected_token(span);
+            }
             let for_stmt_left = ForStatementLeft::from(target);
             if !r#await && is_async_of {
                 self.error(diagnostics::for_loop_async_of(self.end_span(expr_span)));
@@ -351,12 +347,12 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         span: Span,
         r#await: bool,
-    ) -> Result<Statement<'a>> {
+    ) -> Statement<'a> {
         let start_span = self.start_span();
         let init_declaration = self.context(Context::empty(), Context::In, |p| {
             let decl_ctx = VariableDeclarationParent::For;
             p.parse_variable_declaration(start_span, decl_ctx, &Modifiers::empty())
-        })?;
+        });
 
         // for (.. a in) for (.. a of)
         if matches!(self.cur_kind(), Kind::In | Kind::Of) {
@@ -372,8 +368,8 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         span: Span,
         r#await: bool,
-    ) -> Result<Statement<'a>> {
-        let using_decl = self.parse_using_declaration(StatementContext::For)?;
+    ) -> Statement<'a> {
+        let using_decl = self.parse_using_declaration(StatementContext::For);
 
         if matches!(self.cur_kind(), Kind::In) {
             if using_decl.kind.is_await() {
@@ -401,30 +397,30 @@ impl<'a> ParserImpl<'a> {
         span: Span,
         init: Option<ForStatementInit<'a>>,
         r#await: bool,
-    ) -> Result<Statement<'a>> {
-        self.expect(Kind::Semicolon)?;
+    ) -> Statement<'a> {
+        self.expect(Kind::Semicolon);
         if let Some(ForStatementInit::VariableDeclaration(decl)) = &init {
             for d in &decl.declarations {
                 self.check_missing_initializer(d);
             }
         }
         let test = if !self.at(Kind::Semicolon) && !self.at(Kind::RParen) {
-            Some(self.context(Context::In, Context::empty(), ParserImpl::parse_expr)?)
+            Some(self.context(Context::In, Context::empty(), ParserImpl::parse_expr))
         } else {
             None
         };
-        self.expect(Kind::Semicolon)?;
+        self.expect(Kind::Semicolon);
         let update = if self.at(Kind::RParen) {
             None
         } else {
-            Some(self.context(Context::In, Context::empty(), ParserImpl::parse_expr)?)
+            Some(self.context(Context::In, Context::empty(), ParserImpl::parse_expr))
         };
-        self.expect(Kind::RParen)?;
+        self.expect(Kind::RParen);
         if r#await {
             self.error(diagnostics::for_await(self.end_span(span)));
         }
-        let body = self.parse_statement_list_item(StatementContext::For)?;
-        Ok(self.ast.statement_for(self.end_span(span), init, test, update, body))
+        let body = self.parse_statement_list_item(StatementContext::For);
+        self.ast.statement_for(self.end_span(span), init, test, update, body)
     }
 
     fn parse_for_in_or_of_loop(
@@ -432,43 +428,43 @@ impl<'a> ParserImpl<'a> {
         span: Span,
         r#await: bool,
         left: ForStatementLeft<'a>,
-    ) -> Result<Statement<'a>> {
+    ) -> Statement<'a> {
         let is_for_in = self.at(Kind::In);
         self.bump_any(); // bump `in` or `of`
         let right = if is_for_in {
             self.parse_expr()
         } else {
             self.parse_assignment_expression_or_higher()
-        }?;
-        self.expect(Kind::RParen)?;
+        };
+        self.expect(Kind::RParen);
 
         if r#await && is_for_in {
             self.error(diagnostics::for_await(self.end_span(span)));
         }
 
-        let body = self.parse_statement_list_item(StatementContext::For)?;
+        let body = self.parse_statement_list_item(StatementContext::For);
         let span = self.end_span(span);
 
         if is_for_in {
-            Ok(self.ast.statement_for_in(span, left, right, body))
+            self.ast.statement_for_in(span, left, right, body)
         } else {
-            Ok(self.ast.statement_for_of(span, r#await, left, right, body))
+            self.ast.statement_for_of(span, r#await, left, right, body)
         }
     }
 
     /// Section 14.8 Continue Statement
     /// Section 14.9 Break Statement
-    fn parse_break_or_continue_statement(&mut self) -> Result<Statement<'a>> {
+    fn parse_break_or_continue_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
         let kind = self.cur_kind();
         self.bump_any(); // bump `break` or `continue`
         let label =
-            if self.can_insert_semicolon() { None } else { Some(self.parse_label_identifier()?) };
-        self.asi()?;
+            if self.can_insert_semicolon() { None } else { Some(self.parse_label_identifier()) };
+        self.asi();
         let end_span = self.end_span(span);
         match kind {
-            Kind::Break => Ok(self.ast.statement_break(end_span, label)),
-            Kind::Continue => Ok(self.ast.statement_continue(end_span, label)),
+            Kind::Break => self.ast.statement_break(end_span, label),
+            Kind::Continue => self.ast.statement_continue(end_span, label),
             _ => unreachable!(),
         }
     }
@@ -477,14 +473,14 @@ impl<'a> ParserImpl<'a> {
     /// `ReturnStatement`[Yield, Await] :
     ///   return ;
     ///   return [no `LineTerminator` here] Expression[+In, ?Yield, ?Await] ;
-    fn parse_return_statement(&mut self) -> Result<Statement<'a>> {
+    fn parse_return_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
         self.bump_any(); // advance `return`
         let argument = if self.eat(Kind::Semicolon) || self.can_insert_semicolon() {
             None
         } else {
-            let expr = self.context(Context::In, Context::empty(), ParserImpl::parse_expr)?;
-            self.asi()?;
+            let expr = self.context(Context::In, Context::empty(), ParserImpl::parse_expr);
+            self.asi();
             Some(expr)
         };
         if !self.ctx.has_return() {
@@ -493,29 +489,29 @@ impl<'a> ParserImpl<'a> {
                 span.start + 6,
             )));
         }
-        Ok(self.ast.statement_return(self.end_span(span), argument))
+        self.ast.statement_return(self.end_span(span), argument)
     }
 
     /// Section 14.11 With Statement
-    fn parse_with_statement(&mut self) -> Result<Statement<'a>> {
+    fn parse_with_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
         self.bump_any(); // bump `with`
-        let object = self.parse_paren_expression()?;
-        let body = self.parse_statement_list_item(StatementContext::With)?;
+        let object = self.parse_paren_expression();
+        let body = self.parse_statement_list_item(StatementContext::With);
         let span = self.end_span(span);
-        Ok(self.ast.statement_with(span, object, body))
+        self.ast.statement_with(span, object, body)
     }
 
     /// Section 14.12 Switch Statement
-    fn parse_switch_statement(&mut self) -> Result<Statement<'a>> {
+    fn parse_switch_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
         self.bump_any(); // advance `switch`
-        let discriminant = self.parse_paren_expression()?;
-        let cases = self.parse_normal_list(Kind::LCurly, Kind::RCurly, Self::parse_switch_case)?;
-        Ok(self.ast.statement_switch(self.end_span(span), discriminant, cases))
+        let discriminant = self.parse_paren_expression();
+        let cases = self.parse_normal_list(Kind::LCurly, Kind::RCurly, Self::parse_switch_case);
+        self.ast.statement_switch(self.end_span(span), discriminant, cases)
     }
 
-    pub(crate) fn parse_switch_case(&mut self) -> Result<Option<SwitchCase<'a>>> {
+    pub(crate) fn parse_switch_case(&mut self) -> Option<SwitchCase<'a>> {
         let span = self.start_span();
         let test = match self.cur_kind() {
             Kind::Default => {
@@ -524,22 +520,22 @@ impl<'a> ParserImpl<'a> {
             }
             Kind::Case => {
                 self.bump_any();
-                let expression = self.parse_expr()?;
+                let expression = self.parse_expr();
                 Some(expression)
             }
-            _ => return Err(self.unexpected()),
+            _ => return self.unexpected(),
         };
-        self.expect(Kind::Colon)?;
+        self.expect(Kind::Colon);
         let mut consequent = self.ast.vec();
         while !matches!(self.cur_kind(), Kind::Case | Kind::Default | Kind::RCurly | Kind::Eof) {
-            let stmt = self.parse_statement_list_item(StatementContext::StatementList)?;
+            let stmt = self.parse_statement_list_item(StatementContext::StatementList);
             consequent.push(stmt);
         }
-        Ok(Some(self.ast.switch_case(self.end_span(span), test, consequent)))
+        Some(self.ast.switch_case(self.end_span(span), test, consequent))
     }
 
     /// Section 14.14 Throw Statement
-    fn parse_throw_statement(&mut self) -> Result<Statement<'a>> {
+    fn parse_throw_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
         self.bump_any(); // advance `throw`
         if self.cur_token().is_on_new_line {
@@ -549,50 +545,50 @@ impl<'a> ParserImpl<'a> {
                 self.cur_token().span(),
             ));
         }
-        let argument = self.parse_expr()?;
-        self.asi()?;
-        Ok(self.ast.statement_throw(self.end_span(span), argument))
+        let argument = self.parse_expr();
+        self.asi();
+        self.ast.statement_throw(self.end_span(span), argument)
     }
 
     /// Section 14.15 Try Statement
-    fn parse_try_statement(&mut self) -> Result<Statement<'a>> {
+    fn parse_try_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
         self.bump_any(); // bump `try`
 
-        let block = self.parse_block()?;
+        let block = self.parse_block();
 
-        let handler = self.at(Kind::Catch).then(|| self.parse_catch_clause()).transpose()?;
+        let handler = self.at(Kind::Catch).then(|| self.parse_catch_clause());
 
-        let finalizer = self.eat(Kind::Finally).then(|| self.parse_block()).transpose()?;
+        let finalizer = self.eat(Kind::Finally).then(|| self.parse_block());
 
         if handler.is_none() && finalizer.is_none() {
             let range = Span::new(block.span.end, block.span.end);
             self.error(diagnostics::expect_catch_finally(range));
         }
 
-        Ok(self.ast.statement_try(self.end_span(span), block, handler, finalizer))
+        self.ast.statement_try(self.end_span(span), block, handler, finalizer)
     }
 
-    fn parse_catch_clause(&mut self) -> Result<Box<'a, CatchClause<'a>>> {
+    fn parse_catch_clause(&mut self) -> Box<'a, CatchClause<'a>> {
         let span = self.start_span();
         self.bump_any(); // advance `catch`
         let pattern = if self.eat(Kind::LParen) {
-            let pattern = self.parse_binding_pattern(false)?;
-            self.expect(Kind::RParen)?;
+            let pattern = self.parse_binding_pattern(false);
+            self.expect(Kind::RParen);
             Some(pattern)
         } else {
             None
         };
-        let body = self.parse_block()?;
+        let body = self.parse_block();
         let param = pattern.map(|pattern| self.ast.catch_parameter(pattern.kind.span(), pattern));
-        Ok(self.ast.alloc_catch_clause(self.end_span(span), param, body))
+        self.ast.alloc_catch_clause(self.end_span(span), param, body)
     }
 
     /// Section 14.16 Debugger Statement
-    fn parse_debugger_statement(&mut self) -> Result<Statement<'a>> {
+    fn parse_debugger_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
         self.bump_any();
-        self.asi()?;
-        Ok(self.ast.statement_debugger(self.end_span(span)))
+        self.asi();
+        self.ast.statement_debugger(self.end_span(span))
     }
 }

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -2,53 +2,52 @@
 
 use oxc_allocator::{Box, Vec};
 use oxc_ast::ast::*;
-use oxc_diagnostics::Result;
 use oxc_span::{Atom, GetSpan, Span};
 
 use crate::{Context, ParserImpl, diagnostics, lexer::Kind};
 
 impl<'a> ParserImpl<'a> {
-    pub(crate) fn parse_jsx_expression(&mut self) -> Result<Expression<'a>> {
+    pub(crate) fn parse_jsx_expression(&mut self) -> Expression<'a> {
         if self.peek_at(Kind::RAngle) {
-            self.parse_jsx_fragment(false).map(Expression::JSXFragment)
+            Expression::JSXFragment(self.parse_jsx_fragment(false))
         } else {
-            self.parse_jsx_element(false).map(Expression::JSXElement)
+            Expression::JSXElement(self.parse_jsx_element(false))
         }
     }
 
     /// `JSXFragment` :
     ///   < > `JSXChildren_opt` < / >
-    fn parse_jsx_fragment(&mut self, in_jsx_child: bool) -> Result<Box<'a, JSXFragment<'a>>> {
+    fn parse_jsx_fragment(&mut self, in_jsx_child: bool) -> Box<'a, JSXFragment<'a>> {
         let span = self.start_span();
-        let opening_fragment = self.parse_jsx_opening_fragment(span)?;
-        let children = self.parse_jsx_children()?;
-        let closing_fragment = self.parse_jsx_closing_fragment(in_jsx_child)?;
-        Ok(self.ast.alloc_jsx_fragment(
+        let opening_fragment = self.parse_jsx_opening_fragment(span);
+        let children = self.parse_jsx_children();
+        let closing_fragment = self.parse_jsx_closing_fragment(in_jsx_child);
+        self.ast.alloc_jsx_fragment(
             self.end_span(span),
             opening_fragment,
             closing_fragment,
             children,
-        ))
+        )
     }
 
     /// <>
-    fn parse_jsx_opening_fragment(&mut self, span: Span) -> Result<JSXOpeningFragment> {
-        self.expect(Kind::LAngle)?;
-        self.expect_jsx_child(Kind::RAngle)?;
-        Ok(self.ast.jsx_opening_fragment(self.end_span(span)))
+    fn parse_jsx_opening_fragment(&mut self, span: Span) -> JSXOpeningFragment {
+        self.expect(Kind::LAngle);
+        self.expect_jsx_child(Kind::RAngle);
+        self.ast.jsx_opening_fragment(self.end_span(span))
     }
 
     /// </>
-    fn parse_jsx_closing_fragment(&mut self, in_jsx_child: bool) -> Result<JSXClosingFragment> {
+    fn parse_jsx_closing_fragment(&mut self, in_jsx_child: bool) -> JSXClosingFragment {
         let span = self.start_span();
-        self.expect(Kind::LAngle)?;
-        self.expect(Kind::Slash)?;
+        self.expect(Kind::LAngle);
+        self.expect(Kind::Slash);
         if in_jsx_child {
-            self.expect_jsx_child(Kind::RAngle)?;
+            self.expect_jsx_child(Kind::RAngle);
         } else {
-            self.expect(Kind::RAngle)?;
+            self.expect(Kind::RAngle);
         }
-        Ok(self.ast.jsx_closing_fragment(self.end_span(span)))
+        self.ast.jsx_closing_fragment(self.end_span(span))
     }
 
     /// `JSXElement` :
@@ -57,15 +56,15 @@ impl<'a> ParserImpl<'a> {
     /// `in_jsx_child`:
     ///     used for telling `JSXClosingElement` to parse the next jsx child or not
     ///     true when inside jsx element, false when at top level expression
-    fn parse_jsx_element(&mut self, in_jsx_child: bool) -> Result<Box<'a, JSXElement<'a>>> {
+    fn parse_jsx_element(&mut self, in_jsx_child: bool) -> Box<'a, JSXElement<'a>> {
         let span = self.start_span();
-        let opening_element = self.parse_jsx_opening_element(span, in_jsx_child)?;
+        let opening_element = self.parse_jsx_opening_element(span, in_jsx_child);
         let children =
-            if opening_element.self_closing { self.ast.vec() } else { self.parse_jsx_children()? };
+            if opening_element.self_closing { self.ast.vec() } else { self.parse_jsx_children() };
         let closing_element = if opening_element.self_closing {
             None
         } else {
-            let closing_element = self.parse_jsx_closing_element(in_jsx_child)?;
+            let closing_element = self.parse_jsx_closing_element(in_jsx_child);
             if !Self::jsx_element_name_eq(&opening_element.name, &closing_element.name) {
                 self.error(diagnostics::jsx_element_no_match(
                     opening_element.name.span(),
@@ -75,12 +74,7 @@ impl<'a> ParserImpl<'a> {
             }
             Some(closing_element)
         };
-        Ok(self.ast.alloc_jsx_element(
-            self.end_span(span),
-            opening_element,
-            closing_element,
-            children,
-        ))
+        self.ast.alloc_jsx_element(self.end_span(span), opening_element, closing_element, children)
     }
 
     /// `JSXOpeningElement` :
@@ -89,66 +83,63 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         span: Span,
         in_jsx_child: bool,
-    ) -> Result<Box<'a, JSXOpeningElement<'a>>> {
-        self.expect(Kind::LAngle)?;
-        let name = self.parse_jsx_element_name()?;
+    ) -> Box<'a, JSXOpeningElement<'a>> {
+        self.expect(Kind::LAngle);
+        let name = self.parse_jsx_element_name();
         // <Component<TsType> for tsx
-        let type_parameters = if self.is_ts { self.try_parse_type_arguments()? } else { None };
-        let attributes = self.parse_jsx_attributes()?;
+        let type_parameters = if self.is_ts { self.try_parse_type_arguments() } else { None };
+        let attributes = self.parse_jsx_attributes();
         let self_closing = self.eat(Kind::Slash);
         if !self_closing || in_jsx_child {
-            self.expect_jsx_child(Kind::RAngle)?;
+            self.expect_jsx_child(Kind::RAngle);
         } else {
-            self.expect(Kind::RAngle)?;
+            self.expect(Kind::RAngle);
         }
-        Ok(self.ast.alloc_jsx_opening_element(
+        self.ast.alloc_jsx_opening_element(
             self.end_span(span),
             self_closing,
             name,
             attributes,
             type_parameters,
-        ))
+        )
     }
 
-    fn parse_jsx_closing_element(
-        &mut self,
-        in_jsx_child: bool,
-    ) -> Result<Box<'a, JSXClosingElement<'a>>> {
+    fn parse_jsx_closing_element(&mut self, in_jsx_child: bool) -> Box<'a, JSXClosingElement<'a>> {
         let span = self.start_span();
-        self.expect(Kind::LAngle)?;
-        self.expect(Kind::Slash)?;
-        let name = self.parse_jsx_element_name()?;
+        self.expect(Kind::LAngle);
+        self.expect(Kind::Slash);
+        let name = self.parse_jsx_element_name();
         if in_jsx_child {
-            self.expect_jsx_child(Kind::RAngle)?;
+            self.expect_jsx_child(Kind::RAngle);
         } else {
-            self.expect(Kind::RAngle)?;
+            self.expect(Kind::RAngle);
         }
-        Ok(self.ast.alloc_jsx_closing_element(self.end_span(span), name))
+        self.ast.alloc_jsx_closing_element(self.end_span(span), name)
     }
 
     /// `JSXElementName` :
     ///   `JSXIdentifier`
     ///   `JSXNamespacedName`
     ///   `JSXMemberExpression`
-    fn parse_jsx_element_name(&mut self) -> Result<JSXElementName<'a>> {
+    fn parse_jsx_element_name(&mut self) -> JSXElementName<'a> {
         let span = self.start_span();
-        let identifier = self.parse_jsx_identifier()?;
+        let identifier = self.parse_jsx_identifier();
 
         // <namespace:property />
         if self.eat(Kind::Colon) {
-            let property = self.parse_jsx_identifier()?;
-            return Ok(self.ast.jsx_element_name_namespaced_name(
+            let property = self.parse_jsx_identifier();
+            return self.ast.jsx_element_name_namespaced_name(
                 self.end_span(span),
                 identifier,
                 property,
-            ));
+            );
         }
 
         // <member.foo.bar />
         if self.at(Kind::Dot) {
-            return self
-                .parse_jsx_member_expression(span, &identifier)
-                .map(JSXElementName::MemberExpression);
+            return JSXElementName::MemberExpression(
+                self.parse_jsx_member_expression(span, &identifier),
+            );
         }
 
         // References begin with a capital letter, `_` or `$` e.g. `<Foo>`, `<_foo>`, `<$foo>`.
@@ -173,7 +164,7 @@ impl<'a> ParserImpl<'a> {
         } else {
             JSXElementName::Identifier(self.alloc(identifier))
         };
-        Ok(element_name)
+        element_name
     }
 
     /// `JSXMemberExpression` :
@@ -183,7 +174,7 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         span: Span,
         object: &JSXIdentifier<'a>,
-    ) -> Result<Box<'a, JSXMemberExpression<'a>>> {
+    ) -> Box<'a, JSXMemberExpression<'a>> {
         let mut object = if object.name == "this" {
             self.ast.jsx_member_expression_object_this_expression(object.span)
         } else {
@@ -201,34 +192,34 @@ impl<'a> ParserImpl<'a> {
             }
 
             // <foo.bar>
-            let ident = self.parse_jsx_identifier()?;
+            let ident = self.parse_jsx_identifier();
             // `<foo.bar- />` is a syntax error.
             if ident.name.contains('-') {
-                return Err(diagnostics::unexpected_token(ident.span));
+                return self.fatal_error(diagnostics::unexpected_token(ident.span));
             }
             property = Some(ident);
             span = self.end_span(span);
         }
 
         if let Some(property) = property {
-            return Ok(self.ast.alloc_jsx_member_expression(self.end_span(span), object, property));
+            self.ast.alloc_jsx_member_expression(self.end_span(span), object, property)
+        } else {
+            self.unexpected()
         }
-
-        Err(self.unexpected())
     }
 
     /// `JSXChildren` :
     ///   `JSXChild` `JSXChildren_opt`
-    fn parse_jsx_children(&mut self) -> Result<Vec<'a, JSXChild<'a>>> {
+    fn parse_jsx_children(&mut self) -> Vec<'a, JSXChild<'a>> {
         let mut children = self.ast.vec();
         while !self.at(Kind::Eof) {
-            if let Some(child) = self.parse_jsx_child()? {
+            if let Some(child) = self.parse_jsx_child() {
                 children.push(child);
             } else {
                 break;
             }
         }
-        Ok(children)
+        children
     }
 
     /// `JSXChild` :
@@ -236,31 +227,31 @@ impl<'a> ParserImpl<'a> {
     ///   `JSXElement`
     ///   `JSXFragment`
     ///   { `JSXChildExpression_opt` }
-    fn parse_jsx_child(&mut self) -> Result<Option<JSXChild<'a>>> {
+    fn parse_jsx_child(&mut self) -> Option<JSXChild<'a>> {
         match self.cur_kind() {
             // </ close fragment
-            Kind::LAngle if self.peek_at(Kind::Slash) => Ok(None),
+            Kind::LAngle if self.peek_at(Kind::Slash) => None,
             // <> open fragment
             Kind::LAngle if self.peek_at(Kind::RAngle) => {
-                self.parse_jsx_fragment(true).map(JSXChild::Fragment).map(Some)
+                Some(JSXChild::Fragment(self.parse_jsx_fragment(true)))
             }
             // <ident open element
             Kind::LAngle if self.peek_at(Kind::Ident) || self.peek_kind().is_all_keyword() => {
-                self.parse_jsx_element(true).map(JSXChild::Element).map(Some)
+                Some(JSXChild::Element(self.parse_jsx_element(true)))
             }
             // {...expr}
             Kind::LCurly if self.peek_at(Kind::Dot3) => {
-                self.parse_jsx_spread_child().map(JSXChild::Spread).map(Some)
+                Some(JSXChild::Spread(self.parse_jsx_spread_child()))
             }
             // {expr}
             Kind::LCurly => {
-                self.parse_jsx_expression_container(/* is_jsx_child */ true)
-                    .map(JSXChild::ExpressionContainer)
-                    .map(Some)
+                Some(JSXChild::ExpressionContainer(
+                    self.parse_jsx_expression_container(/* is_jsx_child */ true),
+                ))
             }
             // text
-            Kind::JSXText => Ok(Some(JSXChild::Text(self.parse_jsx_text()))),
-            _ => Err(self.unexpected()),
+            Kind::JSXText => Some(JSXChild::Text(self.parse_jsx_text())),
+            _ => self.unexpected(),
         }
     }
 
@@ -268,133 +259,135 @@ impl<'a> ParserImpl<'a> {
     fn parse_jsx_expression_container(
         &mut self,
         in_jsx_child: bool,
-    ) -> Result<Box<'a, JSXExpressionContainer<'a>>> {
+    ) -> Box<'a, JSXExpressionContainer<'a>> {
         let span = self.start_span();
         self.bump_any(); // bump `{`
 
         let expr = if self.at(Kind::RCurly) {
             if in_jsx_child {
-                self.expect_jsx_child(Kind::RCurly)
+                self.expect_jsx_child(Kind::RCurly);
             } else {
-                self.expect(Kind::RCurly)
-            }?;
+                self.expect(Kind::RCurly);
+            }
             let span = self.end_span(span);
             // Handle comment between curly braces (ex. `{/* comment */}`)
             //                                            ^^^^^^^^^^^^^ span
             let expr = self.ast.jsx_empty_expression(Span::new(span.start + 1, span.end - 1));
             JSXExpression::EmptyExpression(expr)
         } else {
-            let expr = self.parse_jsx_assignment_expression().map(JSXExpression::from)?;
+            let expr = JSXExpression::from(self.parse_jsx_assignment_expression());
             if in_jsx_child {
-                self.expect_jsx_child(Kind::RCurly)
+                self.expect_jsx_child(Kind::RCurly);
             } else {
-                self.expect(Kind::RCurly)
-            }?;
+                self.expect(Kind::RCurly);
+            }
             expr
         };
 
-        Ok(self.ast.alloc_jsx_expression_container(self.end_span(span), expr))
+        self.ast.alloc_jsx_expression_container(self.end_span(span), expr)
     }
 
-    fn parse_jsx_assignment_expression(&mut self) -> Result<Expression<'a>> {
+    fn parse_jsx_assignment_expression(&mut self) -> Expression<'a> {
         self.context(Context::default().and_await(self.ctx.has_await()), self.ctx, |p| {
             let expr = p.parse_expr();
-            if let Ok(Expression::SequenceExpression(seq)) = &expr {
-                return Err(diagnostics::jsx_expressions_may_not_use_the_comma_operator(seq.span));
+            if let Expression::SequenceExpression(seq) = &expr {
+                p.fatal_error(diagnostics::jsx_expressions_may_not_use_the_comma_operator(seq.span))
+            } else {
+                expr
             }
-            expr
         })
     }
 
     /// `JSXChildExpression` :
     ///   { ... `AssignmentExpression` }
-    fn parse_jsx_spread_child(&mut self) -> Result<Box<'a, JSXSpreadChild<'a>>> {
+    fn parse_jsx_spread_child(&mut self) -> Box<'a, JSXSpreadChild<'a>> {
         let span = self.start_span();
         self.bump_any(); // bump `{`
-        self.expect(Kind::Dot3)?;
-        let expr = self.parse_jsx_assignment_expression()?;
-        self.expect_jsx_child(Kind::RCurly)?;
-        Ok(self.ast.alloc_jsx_spread_child(self.end_span(span), expr))
+        self.expect(Kind::Dot3);
+        let expr = self.parse_jsx_assignment_expression();
+        self.expect_jsx_child(Kind::RCurly);
+        self.ast.alloc_jsx_spread_child(self.end_span(span), expr)
     }
 
     /// `JSXAttributes` :
     ///   `JSXSpreadAttribute` `JSXAttributes_opt`
     ///   `JSXAttribute` `JSXAttributes_opt`
-    fn parse_jsx_attributes(&mut self) -> Result<Vec<'a, JSXAttributeItem<'a>>> {
+    fn parse_jsx_attributes(&mut self) -> Vec<'a, JSXAttributeItem<'a>> {
         let mut attributes = self.ast.vec();
         while !matches!(self.cur_kind(), Kind::Eof | Kind::LAngle | Kind::RAngle | Kind::Slash) {
             let attribute = match self.cur_kind() {
                 Kind::LCurly => {
-                    self.parse_jsx_spread_attribute().map(JSXAttributeItem::SpreadAttribute)
+                    JSXAttributeItem::SpreadAttribute(self.parse_jsx_spread_attribute())
                 }
-                _ => self.parse_jsx_attribute().map(JSXAttributeItem::Attribute),
-            }?;
+                _ => JSXAttributeItem::Attribute(self.parse_jsx_attribute()),
+            };
             attributes.push(attribute);
         }
-        Ok(attributes)
+        attributes
     }
 
     /// `JSXAttribute` :
     ///   `JSXAttributeName` `JSXAttributeInitializer_opt`
-    fn parse_jsx_attribute(&mut self) -> Result<Box<'a, JSXAttribute<'a>>> {
+    fn parse_jsx_attribute(&mut self) -> Box<'a, JSXAttribute<'a>> {
         let span = self.start_span();
-        let name = self.parse_jsx_attribute_name()?;
+        let name = self.parse_jsx_attribute_name();
         let value = if self.at(Kind::Eq) {
-            self.expect_jsx_attribute_value(Kind::Eq)?;
-            Some(self.parse_jsx_attribute_value()?)
+            self.expect_jsx_attribute_value(Kind::Eq);
+            Some(self.parse_jsx_attribute_value())
         } else {
             None
         };
-        Ok(self.ast.alloc_jsx_attribute(self.end_span(span), name, value))
+        self.ast.alloc_jsx_attribute(self.end_span(span), name, value)
     }
 
     /// `JSXSpreadAttribute` :
     ///   { ... `AssignmentExpression` }
-    fn parse_jsx_spread_attribute(&mut self) -> Result<Box<'a, JSXSpreadAttribute<'a>>> {
+    fn parse_jsx_spread_attribute(&mut self) -> Box<'a, JSXSpreadAttribute<'a>> {
         let span = self.start_span();
         self.bump_any(); // bump `{`
-        self.expect(Kind::Dot3)?;
-        let argument = self.parse_jsx_assignment_expression()?;
-        self.expect(Kind::RCurly)?;
-        Ok(self.ast.alloc_jsx_spread_attribute(self.end_span(span), argument))
+        self.expect(Kind::Dot3);
+        let argument = self.parse_jsx_assignment_expression();
+        self.expect(Kind::RCurly);
+        self.ast.alloc_jsx_spread_attribute(self.end_span(span), argument)
     }
 
     /// `JSXAttributeName` :
     ///   `JSXIdentifier`
     ///   `JSXNamespacedName`
-    fn parse_jsx_attribute_name(&mut self) -> Result<JSXAttributeName<'a>> {
+    fn parse_jsx_attribute_name(&mut self) -> JSXAttributeName<'a> {
         let span = self.start_span();
-        let identifier = self.parse_jsx_identifier()?;
+        let identifier = self.parse_jsx_identifier();
 
         if self.eat(Kind::Colon) {
-            let property = self.parse_jsx_identifier()?;
-            return Ok(self.ast.jsx_attribute_name_namespaced_name(
+            let property = self.parse_jsx_identifier();
+            return self.ast.jsx_attribute_name_namespaced_name(
                 self.end_span(span),
                 identifier,
                 property,
-            ));
+            );
         }
 
-        Ok(JSXAttributeName::Identifier(self.alloc(identifier)))
+        JSXAttributeName::Identifier(self.alloc(identifier))
     }
 
-    fn parse_jsx_attribute_value(&mut self) -> Result<JSXAttributeValue<'a>> {
+    fn parse_jsx_attribute_value(&mut self) -> JSXAttributeValue<'a> {
         match self.cur_kind() {
-            Kind::Str => self
-                .parse_literal_string()
-                .map(|str_lit| JSXAttributeValue::StringLiteral(self.alloc(str_lit))),
+            Kind::Str => {
+                let str_lit = self.parse_literal_string();
+                JSXAttributeValue::StringLiteral(self.alloc(str_lit))
+            }
             Kind::LCurly => {
-                let expr = self.parse_jsx_expression_container(/* is_jsx_child */ false)?;
-                Ok(JSXAttributeValue::ExpressionContainer(expr))
+                let expr = self.parse_jsx_expression_container(/* is_jsx_child */ false);
+                JSXAttributeValue::ExpressionContainer(expr)
             }
             Kind::LAngle => {
                 if self.peek_at(Kind::RAngle) {
-                    self.parse_jsx_fragment(false).map(JSXAttributeValue::Fragment)
+                    JSXAttributeValue::Fragment(self.parse_jsx_fragment(false))
                 } else {
-                    self.parse_jsx_element(false).map(JSXAttributeValue::Element)
+                    JSXAttributeValue::Element(self.parse_jsx_element(false))
                 }
             }
-            _ => Err(self.unexpected()),
+            _ => self.unexpected(),
         }
     }
 
@@ -402,17 +395,17 @@ impl<'a> ParserImpl<'a> {
     ///   `IdentifierStart`
     ///   `JSXIdentifier` `IdentifierPart`
     ///   `JSXIdentifier` [no `WhiteSpace` or Comment here] -
-    fn parse_jsx_identifier(&mut self) -> Result<JSXIdentifier<'a>> {
+    fn parse_jsx_identifier(&mut self) -> JSXIdentifier<'a> {
         let span = self.start_span();
         if !self.at(Kind::Ident) && !self.cur_kind().is_all_keyword() {
-            return Err(self.unexpected());
+            return self.unexpected();
         }
         // Currently at a valid normal Ident or Keyword, keep on lexing for `-` in `<component-name />`
         self.continue_lex_jsx_identifier();
         self.bump_any();
         let span = self.end_span(span);
         let name = span.source_text(self.source_text);
-        Ok(self.ast.jsx_identifier(span, name))
+        self.ast.jsx_identifier(span, name)
     }
 
     fn parse_jsx_text(&mut self) -> Box<'a, JSXText<'a>> {

--- a/crates/oxc_parser/src/lexer/mod.rs
+++ b/crates/oxc_parser/src/lexer/mod.rs
@@ -224,6 +224,11 @@ impl<'a> Lexer<'a> {
         token
     }
 
+    /// Advance source cursor to end of file.
+    pub fn advance_to_end(&mut self) {
+        self.source.advance_to_end();
+    }
+
     // ---------- Private Methods ---------- //
     fn error(&mut self, error: OxcDiagnostic) {
         self.errors.push(error);

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -1,6 +1,5 @@
 use oxc_allocator::Box;
 use oxc_ast::ast::*;
-use oxc_diagnostics::Result;
 use oxc_span::{GetSpan, Span};
 
 use crate::{
@@ -22,116 +21,115 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         span: Span,
         modifiers: &Modifiers<'a>,
-    ) -> Result<Declaration<'a>> {
+    ) -> Declaration<'a> {
         self.bump_any(); // bump `enum`
-        let id = self.parse_binding_identifier()?;
-        self.expect(Kind::LCurly)?;
+        let id = self.parse_binding_identifier();
+        self.expect(Kind::LCurly);
         let members = self.parse_delimited_list(
             Kind::RCurly,
             Kind::Comma,
             /* trailing_separator */ true,
             Self::parse_ts_enum_member,
-        )?;
-        self.expect(Kind::RCurly)?;
+        );
+        self.expect(Kind::RCurly);
         let span = self.end_span(span);
         self.verify_modifiers(
             modifiers,
             ModifierFlags::DECLARE | ModifierFlags::CONST,
             diagnostics::modifier_cannot_be_used_here,
         );
-        Ok(self.ast.declaration_ts_enum(
+        self.ast.declaration_ts_enum(
             span,
             id,
             members,
             modifiers.contains_const(),
             modifiers.contains_declare(),
-        ))
+        )
     }
 
-    pub(crate) fn parse_ts_enum_member(&mut self) -> Result<TSEnumMember<'a>> {
+    pub(crate) fn parse_ts_enum_member(&mut self) -> TSEnumMember<'a> {
         let span = self.start_span();
-        let id = self.parse_ts_enum_member_name()?;
+        let id = self.parse_ts_enum_member_name();
         let initializer = if self.eat(Kind::Eq) {
-            Some(self.parse_assignment_expression_or_higher()?)
+            Some(self.parse_assignment_expression_or_higher())
         } else {
             None
         };
-        Ok(self.ast.ts_enum_member(self.end_span(span), id, initializer))
+        self.ast.ts_enum_member(self.end_span(span), id, initializer)
     }
 
-    fn parse_ts_enum_member_name(&mut self) -> Result<TSEnumMemberName<'a>> {
+    fn parse_ts_enum_member_name(&mut self) -> TSEnumMemberName<'a> {
         match self.cur_kind() {
             Kind::Str => {
-                let literal = self.parse_literal_string()?;
-                Ok(TSEnumMemberName::String(self.alloc(literal)))
+                let literal = self.parse_literal_string();
+                TSEnumMemberName::String(self.alloc(literal))
             }
-            Kind::LBrack => match self.parse_computed_property_name()? {
-                Expression::StringLiteral(literal) => Ok(TSEnumMemberName::String(literal)),
+            Kind::LBrack => match self.parse_computed_property_name() {
+                Expression::StringLiteral(literal) => TSEnumMemberName::String(literal),
                 Expression::TemplateLiteral(template) if template.is_no_substitution_template() => {
-                    Ok(self.ast.ts_enum_member_name_string(
+                    self.ast.ts_enum_member_name_string(
                         template.span,
                         template.quasi().unwrap(),
                         Some(Atom::from(
                             Span::new(template.span.start + 1, template.span.end - 1)
                                 .source_text(self.source_text),
                         )),
-                    ))
+                    )
                 }
-                Expression::NumericLiteral(literal) => {
-                    Err(diagnostics::enum_member_cannot_have_numeric_name(literal.span()))
-                }
-                expr => Err(diagnostics::computed_property_names_not_allowed_in_enums(expr.span())),
+                Expression::NumericLiteral(literal) => self
+                    .fatal_error(diagnostics::enum_member_cannot_have_numeric_name(literal.span())),
+                expr => self.fatal_error(
+                    diagnostics::computed_property_names_not_allowed_in_enums(expr.span()),
+                ),
             },
-            Kind::NoSubstitutionTemplate | Kind::TemplateHead => Err(
+            Kind::NoSubstitutionTemplate | Kind::TemplateHead => self.fatal_error(
                 diagnostics::computed_property_names_not_allowed_in_enums(self.cur_token().span()),
             ),
-            kind if kind.is_number() => {
-                Err(diagnostics::enum_member_cannot_have_numeric_name(self.cur_token().span()))
-            }
+            kind if kind.is_number() => self.fatal_error(
+                diagnostics::enum_member_cannot_have_numeric_name(self.cur_token().span()),
+            ),
             _ => {
-                let ident_name = self.parse_identifier_name()?;
-                Ok(TSEnumMemberName::Identifier(self.alloc(ident_name)))
+                let ident_name = self.parse_identifier_name();
+                TSEnumMemberName::Identifier(self.alloc(ident_name))
             }
         }
     }
 
     /* ------------------- Annotation ----------------- */
 
-    pub(crate) fn parse_ts_type_annotation(
-        &mut self,
-    ) -> Result<Option<Box<'a, TSTypeAnnotation<'a>>>> {
+    pub(crate) fn parse_ts_type_annotation(&mut self) -> Option<Box<'a, TSTypeAnnotation<'a>>> {
         if !self.is_ts {
-            return Ok(None);
+            return None;
         }
         if !self.at(Kind::Colon) {
-            return Ok(None);
+            return None;
         }
         let span = self.start_span();
         self.bump_any(); // bump ':'
-        let type_annotation = self.parse_ts_type()?;
-        Ok(Some(self.ast.alloc_ts_type_annotation(self.end_span(span), type_annotation)))
+        let type_annotation = self.parse_ts_type();
+        Some(self.ast.alloc_ts_type_annotation(self.end_span(span), type_annotation))
     }
 
     pub(crate) fn parse_ts_type_alias_declaration(
         &mut self,
         span: Span,
         modifiers: &Modifiers<'a>,
-    ) -> Result<Declaration<'a>> {
-        self.expect(Kind::Type)?;
+    ) -> Declaration<'a> {
+        self.expect(Kind::Type);
 
-        let id = self.parse_binding_identifier()?;
-        let params = self.parse_ts_type_parameters()?;
-        self.expect(Kind::Eq)?;
+        let id = self.parse_binding_identifier();
+        let params = self.parse_ts_type_parameters();
+        self.expect(Kind::Eq);
 
         let annotation = if self.at(Kind::Intrinsic) && !self.peek_at(Kind::Dot) {
             let span = self.start_span();
             self.bump_any();
             self.ast.ts_type_intrinsic_keyword(self.end_span(span))
         } else {
-            self.parse_ts_type()?
+            self.parse_ts_type()
         };
 
-        self.asi()?;
+        self.asi();
         let span = self.end_span(span);
 
         self.verify_modifiers(
@@ -140,13 +138,13 @@ impl<'a> ParserImpl<'a> {
             diagnostics::modifier_cannot_be_used_here,
         );
 
-        Ok(self.ast.declaration_ts_type_alias(
+        self.ast.declaration_ts_type_alias(
             span,
             id,
             params,
             annotation,
             modifiers.contains_declare(),
-        ))
+        )
     }
 
     /* ---------------------  Interface  ------------------------ */
@@ -155,12 +153,12 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         span: Span,
         modifiers: &Modifiers<'a>,
-    ) -> Result<Declaration<'a>> {
-        self.expect(Kind::Interface)?; // bump interface
-        let id = self.parse_binding_identifier()?;
-        let type_parameters = self.parse_ts_type_parameters()?;
-        let (extends, _) = self.parse_heritage_clause()?;
-        let body = self.parse_ts_interface_body()?;
+    ) -> Declaration<'a> {
+        self.expect(Kind::Interface); // bump interface
+        let id = self.parse_binding_identifier();
+        let type_parameters = self.parse_ts_type_parameters();
+        let (extends, _) = self.parse_heritage_clause();
+        let body = self.parse_ts_interface_body();
         let extends = extends.map(|e| self.ast.ts_interface_heritages(e));
 
         self.verify_modifiers(
@@ -169,21 +167,21 @@ impl<'a> ParserImpl<'a> {
             diagnostics::modifier_cannot_be_used_here,
         );
 
-        Ok(self.ast.declaration_ts_interface(
+        self.ast.declaration_ts_interface(
             self.end_span(span),
             id,
             extends,
             type_parameters,
             body,
             modifiers.contains_declare(),
-        ))
+        )
     }
 
-    fn parse_ts_interface_body(&mut self) -> Result<Box<'a, TSInterfaceBody<'a>>> {
+    fn parse_ts_interface_body(&mut self) -> Box<'a, TSInterfaceBody<'a>> {
         let span = self.start_span();
-        let body_list =
-            self.parse_normal_list(Kind::LCurly, Kind::RCurly, Self::parse_ts_type_signature)?;
-        Ok(self.ast.alloc_ts_interface_body(self.end_span(span), body_list))
+        let body_list = self
+            .parse_normal_list(Kind::LCurly, Kind::RCurly, |p| Some(p.parse_ts_type_signature()));
+        self.ast.alloc_ts_interface_body(self.end_span(span), body_list)
     }
 
     pub(crate) fn is_at_interface_declaration(&mut self) -> bool {
@@ -194,16 +192,15 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
-    pub(crate) fn parse_ts_type_signature(&mut self) -> Result<Option<TSSignature<'a>>> {
+    pub(crate) fn parse_ts_type_signature(&mut self) -> TSSignature<'a> {
         if self.is_at_ts_index_signature_member() {
             let span = self.start_span();
             let modifiers = self.parse_modifiers(false, false, false);
-            return self
-                .parse_index_signature_declaration(span, &modifiers)
-                .map(|sig| Some(TSSignature::TSIndexSignature(self.alloc(sig))));
+            let sig = self.parse_index_signature_declaration(span, &modifiers);
+            return TSSignature::TSIndexSignature(self.alloc(sig));
         }
 
-        match self.cur_kind() {
+        let sig = match self.cur_kind() {
             Kind::LParen | Kind::LAngle => self.parse_ts_call_signature_member(),
             Kind::New if self.peek_at(Kind::LParen) || self.peek_at(Kind::LAngle) => {
                 self.parse_ts_constructor_signature_member()
@@ -215,8 +212,8 @@ impl<'a> ParserImpl<'a> {
                 self.parse_ts_setter_signature_member()
             }
             _ => self.parse_ts_property_or_method_signature_member(),
-        }
-        .map(Some)
+        };
+        sig
     }
 
     /// Must be at `[ident:` or `<modifiers> [ident:`
@@ -273,13 +270,13 @@ impl<'a> ParserImpl<'a> {
 
     /* ----------------------- Namespace & Module ----------------------- */
 
-    fn parse_ts_module_block(&mut self) -> Result<Box<'a, TSModuleBlock<'a>>> {
+    fn parse_ts_module_block(&mut self) -> Box<'a, TSModuleBlock<'a>> {
         let span = self.start_span();
-        self.expect(Kind::LCurly)?;
+        self.expect(Kind::LCurly);
         let (directives, statements) =
-            self.parse_directives_and_statements(/* is_top_level */ false)?;
-        self.expect(Kind::RCurly)?;
-        Ok(self.ast.alloc_ts_module_block(self.end_span(span), directives, statements))
+            self.parse_directives_and_statements(/* is_top_level */ false);
+        self.expect(Kind::RCurly);
+        self.ast.alloc_ts_module_block(self.end_span(span), directives, statements)
     }
 
     pub(crate) fn parse_ts_namespace_or_module_declaration_body(
@@ -287,27 +284,24 @@ impl<'a> ParserImpl<'a> {
         span: Span,
         kind: TSModuleDeclarationKind,
         modifiers: &Modifiers<'a>,
-    ) -> Result<Box<'a, TSModuleDeclaration<'a>>> {
+    ) -> Box<'a, TSModuleDeclaration<'a>> {
         self.verify_modifiers(
             modifiers,
             ModifierFlags::DECLARE | ModifierFlags::EXPORT,
             diagnostics::modifier_cannot_be_used_here,
         );
         let id = match self.cur_kind() {
-            Kind::Str => self.parse_literal_string().map(TSModuleDeclarationName::StringLiteral),
-            _ => self.parse_binding_identifier().map(TSModuleDeclarationName::Identifier),
-        }?;
+            Kind::Str => TSModuleDeclarationName::StringLiteral(self.parse_literal_string()),
+            _ => TSModuleDeclarationName::Identifier(self.parse_binding_identifier()),
+        };
 
         let body = if self.eat(Kind::Dot) {
             let span = self.start_span();
-            let decl = self.parse_ts_namespace_or_module_declaration_body(
-                span,
-                kind,
-                &Modifiers::empty(),
-            )?;
+            let decl =
+                self.parse_ts_namespace_or_module_declaration_body(span, kind, &Modifiers::empty());
             Some(TSModuleDeclarationBody::TSModuleDeclaration(decl))
         } else if self.at(Kind::LCurly) {
-            let block = self.parse_ts_module_block()?;
+            let block = self.parse_ts_module_block();
             Some(TSModuleDeclarationBody::TSModuleBlock(block))
         } else {
             None
@@ -319,89 +313,94 @@ impl<'a> ParserImpl<'a> {
             diagnostics::modifier_cannot_be_used_here,
         );
 
-        Ok(self.ast.alloc_ts_module_declaration(
+        self.ast.alloc_ts_module_declaration(
             self.end_span(span),
             id,
             body,
             kind,
             modifiers.contains_declare(),
-        ))
+        )
     }
 
     /* ----------------------- declare --------------------- */
 
-    pub(crate) fn parse_ts_declaration_statement(
-        &mut self,
-        start_span: Span,
-    ) -> Result<Statement<'a>> {
+    pub(crate) fn parse_ts_declaration_statement(&mut self, start_span: Span) -> Statement<'a> {
         let reserved_ctx = self.ctx;
-        let modifiers = self.eat_modifiers_before_declaration()?;
+        let modifiers = self.eat_modifiers_before_declaration();
         self.ctx = self
             .ctx
             .union_ambient_if(modifiers.contains_declare())
             .and_await(modifiers.contains_async());
-        let result = self.parse_declaration(start_span, &modifiers);
+        let decl = Statement::from(self.parse_declaration(start_span, &modifiers));
         self.ctx = reserved_ctx;
-        result.map(Statement::from)
+        decl
     }
 
     pub(crate) fn parse_declaration(
         &mut self,
         start_span: Span,
         modifiers: &Modifiers<'a>,
-    ) -> Result<Declaration<'a>> {
+    ) -> Declaration<'a> {
         match self.cur_kind() {
             Kind::Namespace => {
                 let kind = TSModuleDeclarationKind::Namespace;
                 self.bump_any();
-                self.parse_ts_namespace_or_module_declaration_body(start_span, kind, modifiers)
-                    .map(Declaration::TSModuleDeclaration)
+                Declaration::TSModuleDeclaration(
+                    self.parse_ts_namespace_or_module_declaration_body(start_span, kind, modifiers),
+                )
             }
             Kind::Module => {
                 let kind = TSModuleDeclarationKind::Module;
                 self.bump_any();
-                self.parse_ts_namespace_or_module_declaration_body(start_span, kind, modifiers)
-                    .map(Declaration::TSModuleDeclaration)
+                Declaration::TSModuleDeclaration(
+                    self.parse_ts_namespace_or_module_declaration_body(start_span, kind, modifiers),
+                )
             }
             Kind::Global => {
                 // declare global { }
                 let kind = TSModuleDeclarationKind::Global;
-                self.parse_ts_namespace_or_module_declaration_body(start_span, kind, modifiers)
-                    .map(Declaration::TSModuleDeclaration)
+                Declaration::TSModuleDeclaration(
+                    self.parse_ts_namespace_or_module_declaration_body(start_span, kind, modifiers),
+                )
             }
             Kind::Type => self.parse_ts_type_alias_declaration(start_span, modifiers),
             Kind::Enum => self.parse_ts_enum_declaration(start_span, modifiers),
             Kind::Interface if self.is_at_interface_declaration() => {
                 self.parse_ts_interface_declaration(start_span, modifiers)
             }
-            Kind::Class => self
-                .parse_class_declaration(start_span, modifiers)
-                .map(Declaration::ClassDeclaration),
+            Kind::Class => {
+                Declaration::ClassDeclaration(self.parse_class_declaration(start_span, modifiers))
+            }
             Kind::Import => {
                 self.bump_any();
                 self.parse_ts_import_equals_declaration(start_span)
             }
-            kind if kind.is_variable_declaration() => self
-                .parse_variable_declaration(
+            kind if kind.is_variable_declaration() => {
+                Declaration::VariableDeclaration(self.parse_variable_declaration(
                     start_span,
                     VariableDeclarationParent::Statement,
                     modifiers,
-                )
-                .map(Declaration::VariableDeclaration),
+                ))
+            }
             _ if self.at_function_with_async() => {
                 let declare = modifiers.contains(ModifierKind::Declare);
                 if declare {
-                    self.parse_ts_declare_function(start_span, modifiers)
-                        .map(Declaration::FunctionDeclaration)
+                    Declaration::FunctionDeclaration(
+                        self.parse_ts_declare_function(start_span, modifiers),
+                    )
                 } else if self.is_ts {
-                    self.parse_ts_function_impl(start_span, FunctionKind::Declaration, modifiers)
-                        .map(Declaration::FunctionDeclaration)
+                    Declaration::FunctionDeclaration(self.parse_ts_function_impl(
+                        start_span,
+                        FunctionKind::Declaration,
+                        modifiers,
+                    ))
                 } else {
-                    self.parse_function_impl(FunctionKind::Declaration)
-                        .map(Declaration::FunctionDeclaration)
+                    Declaration::FunctionDeclaration(
+                        self.parse_function_impl(FunctionKind::Declaration),
+                    )
                 }
             }
-            _ => Err(self.unexpected()),
+            _ => self.unexpected(),
         }
     }
 
@@ -409,88 +408,84 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         start_span: Span,
         modifiers: &Modifiers<'a>,
-    ) -> Result<Box<'a, Function<'a>>> {
+    ) -> Box<'a, Function<'a>> {
         let r#async = modifiers.contains(ModifierKind::Async);
-        self.expect(Kind::Function)?;
+        self.expect(Kind::Function);
         let func_kind = FunctionKind::TSDeclaration;
-        let id = self.parse_function_id(func_kind, r#async, false)?;
+        let id = self.parse_function_id(func_kind, r#async, false);
         self.parse_function(start_span, id, r#async, false, func_kind, modifiers)
     }
 
-    pub(crate) fn parse_ts_type_assertion(&mut self) -> Result<Expression<'a>> {
+    pub(crate) fn parse_ts_type_assertion(&mut self) -> Expression<'a> {
         let span = self.start_span();
-        self.expect(Kind::LAngle)?;
-        let type_annotation = self.parse_ts_type()?;
-        self.expect(Kind::RAngle)?;
+        self.expect(Kind::LAngle);
+        let type_annotation = self.parse_ts_type();
+        self.expect(Kind::RAngle);
         let lhs_span = self.start_span();
-        let expression = self.parse_simple_unary_expression(lhs_span)?;
-        Ok(self.ast.expression_ts_type_assertion(self.end_span(span), expression, type_annotation))
+        let expression = self.parse_simple_unary_expression(lhs_span);
+        self.ast.expression_ts_type_assertion(self.end_span(span), expression, type_annotation)
     }
 
-    pub(crate) fn parse_ts_import_equals_declaration(
-        &mut self,
-        span: Span,
-    ) -> Result<Declaration<'a>> {
+    pub(crate) fn parse_ts_import_equals_declaration(&mut self, span: Span) -> Declaration<'a> {
         let import_kind = if !self.peek_at(Kind::Eq) && self.eat(Kind::Type) {
             ImportOrExportKind::Type
         } else {
             ImportOrExportKind::Value
         };
 
-        let id = self.parse_binding_identifier()?;
+        let id = self.parse_binding_identifier();
 
-        self.expect(Kind::Eq)?;
+        self.expect(Kind::Eq);
 
         let reference_span = self.start_span();
         let module_reference = if self.eat(Kind::Require) {
-            self.expect(Kind::LParen)?;
-            let expression = self.parse_literal_string()?;
-            self.expect(Kind::RParen)?;
+            self.expect(Kind::LParen);
+            let expression = self.parse_literal_string();
+            self.expect(Kind::RParen);
             self.ast.ts_module_reference_external_module_reference(
                 self.end_span(reference_span),
                 expression,
             )
         } else {
-            let type_name = self.parse_ts_type_name()?;
+            let type_name = self.parse_ts_type_name();
             TSModuleReference::from(type_name)
         };
 
-        self.asi()?;
+        self.asi();
 
-        Ok(self.ast.declaration_ts_import_equals(
+        self.ast.declaration_ts_import_equals(
             self.end_span(span),
             id,
             module_reference,
             import_kind,
-        ))
+        )
     }
 
-    pub(crate) fn parse_ts_this_parameter(&mut self) -> Result<TSThisParameter<'a>> {
+    pub(crate) fn parse_ts_this_parameter(&mut self) -> TSThisParameter<'a> {
         let span = self.start_span();
         self.parse_class_element_modifiers(true);
-        self.eat_decorators()?;
+        self.eat_decorators();
 
         let this_span = self.start_span();
         self.bump_any();
         let this = self.end_span(this_span);
 
-        let type_annotation = self.parse_ts_type_annotation()?;
-        Ok(self.ast.ts_this_parameter(self.end_span(span), this, type_annotation))
+        let type_annotation = self.parse_ts_type_annotation();
+        self.ast.ts_this_parameter(self.end_span(span), this, type_annotation)
     }
 
-    pub(crate) fn eat_decorators(&mut self) -> Result<()> {
+    pub(crate) fn eat_decorators(&mut self) {
         if !self.at(Kind::At) {
-            return Ok(());
+            return;
         }
 
         let mut decorators = vec![];
         while self.at(Kind::At) {
-            let decorator = self.parse_decorator()?;
+            let decorator = self.parse_decorator();
             decorators.push(decorator);
         }
 
         self.state.decorators = decorators;
-        Ok(())
     }
 
     pub(crate) fn at_start_of_ts_declaration(&mut self) -> bool {

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1,6 +1,5 @@
 use oxc_allocator::{Box, Vec};
 use oxc_ast::{NONE, ast::*};
-use oxc_diagnostics::Result;
 use oxc_span::GetSpan;
 use oxc_syntax::operator::UnaryOperator;
 
@@ -11,12 +10,12 @@ use crate::{
 };
 
 impl<'a> ParserImpl<'a> {
-    pub(crate) fn parse_ts_type(&mut self) -> Result<TSType<'a>> {
+    pub(crate) fn parse_ts_type(&mut self) -> TSType<'a> {
         if self.is_start_of_function_type_or_constructor_type() {
             return self.parse_function_or_constructor_type();
         }
         let span = self.start_span();
-        let ty = self.parse_union_type_or_higher()?;
+        let ty = self.parse_union_type_or_higher();
         if !self.ctx.has_disallow_conditional_types()
             && !self.cur_token().is_on_new_line
             && self.eat(Kind::Extends)
@@ -25,48 +24,46 @@ impl<'a> ParserImpl<'a> {
                 Context::DisallowConditionalTypes,
                 Context::empty(),
                 Self::parse_ts_type,
-            )?;
-            self.expect(Kind::Question)?;
+            );
+            self.expect(Kind::Question);
             let true_type = self.context(
                 Context::empty(),
                 Context::DisallowConditionalTypes,
                 Self::parse_ts_type,
-            )?;
-            self.expect(Kind::Colon)?;
+            );
+            self.expect(Kind::Colon);
             let false_type = self.context(
                 Context::empty(),
                 Context::DisallowConditionalTypes,
                 Self::parse_ts_type,
-            )?;
-            return Ok(self.ast.ts_type_conditional_type(
+            );
+            return self.ast.ts_type_conditional_type(
                 self.end_span(span),
                 ty,
                 extends_type,
                 true_type,
                 false_type,
-            ));
+            );
         }
-        Ok(ty)
+        ty
     }
 
-    fn parse_function_or_constructor_type(&mut self) -> Result<TSType<'a>> {
+    fn parse_function_or_constructor_type(&mut self) -> TSType<'a> {
         let span = self.start_span();
         let r#abstract = self.eat(Kind::Abstract);
         let is_constructor_type = self.eat(Kind::New);
-        let type_parameters = self.parse_ts_type_parameters()?;
-        let (this_param, params) = self.parse_formal_parameters(FormalParameterKind::Signature)?;
+        let type_parameters = self.parse_ts_type_parameters();
+        let (this_param, params) = self.parse_formal_parameters(FormalParameterKind::Signature);
         let return_type = {
             let return_type_span = self.start_span();
-            let Some(return_type) =
-                self.parse_return_type(Kind::Arrow, /* is_type */ false)?
-            else {
-                return Err(self.unexpected());
+            let Some(return_type) = self.parse_return_type(Kind::Arrow, /* is_type */ false) else {
+                return self.unexpected();
             };
             self.ast.ts_type_annotation(self.end_span(return_type_span), return_type)
         };
 
         let span = self.end_span(span);
-        Ok(if is_constructor_type {
+        if is_constructor_type {
             if let Some(this_param) = &this_param {
                 // type Foo = new (this: number) => any;
                 self.error(diagnostics::ts_constructor_this_parameter(this_param.span));
@@ -80,7 +77,7 @@ impl<'a> ParserImpl<'a> {
             )
         } else {
             self.ast.ts_type_function_type(span, type_parameters, this_param, params, return_type)
-        })
+        }
     }
 
     fn is_start_of_function_type_or_constructor_type(&mut self) -> bool {
@@ -127,7 +124,8 @@ impl<'a> ParserImpl<'a> {
         }
         if matches!(self.cur_kind(), Kind::LBrack | Kind::LCurly) {
             let errors_count = self.errors_count();
-            if self.parse_binding_pattern_kind().is_ok() && errors_count == self.errors_count() {
+            self.parse_binding_pattern_kind();
+            if self.fatal_error.is_none() && errors_count == self.errors_count() {
                 return true;
             }
         }
@@ -136,39 +134,39 @@ impl<'a> ParserImpl<'a> {
 
     pub(crate) fn parse_ts_type_parameters(
         &mut self,
-    ) -> Result<Option<Box<'a, TSTypeParameterDeclaration<'a>>>> {
+    ) -> Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
         if !self.is_ts {
-            return Ok(None);
+            return None;
         }
         if !self.at(Kind::LAngle) {
-            return Ok(None);
+            return None;
         }
         let span = self.start_span();
-        self.expect(Kind::LAngle)?;
+        self.expect(Kind::LAngle);
         let params = self.parse_delimited_list(
             Kind::RAngle,
             Kind::Comma,
             /* trailing_separator */ true,
             Self::parse_ts_type_parameter,
-        )?;
-        self.expect(Kind::RAngle)?;
-        Ok(Some(self.ast.alloc_ts_type_parameter_declaration(self.end_span(span), params)))
+        );
+        self.expect(Kind::RAngle);
+        Some(self.ast.alloc_ts_type_parameter_declaration(self.end_span(span), params))
     }
 
-    pub(crate) fn parse_ts_implements_clause(&mut self) -> Result<Vec<'a, TSClassImplements<'a>>> {
-        self.expect(Kind::Implements)?;
-        let first = self.parse_ts_implement_name()?;
+    pub(crate) fn parse_ts_implements_clause(&mut self) -> Vec<'a, TSClassImplements<'a>> {
+        self.expect(Kind::Implements);
+        let first = self.parse_ts_implement_name();
         let mut implements = self.ast.vec();
         implements.push(first);
 
         while self.eat(Kind::Comma) {
-            implements.push(self.parse_ts_implement_name()?);
+            implements.push(self.parse_ts_implement_name());
         }
 
-        Ok(implements)
+        implements
     }
 
-    pub(crate) fn parse_ts_type_parameter(&mut self) -> Result<TSTypeParameter<'a>> {
+    pub(crate) fn parse_ts_type_parameter(&mut self) -> TSTypeParameter<'a> {
         let span = self.start_span();
 
         let modifiers = self.parse_modifiers(false, true, false);
@@ -178,11 +176,11 @@ impl<'a> ParserImpl<'a> {
             diagnostics::cannot_appear_on_a_type_parameter,
         );
 
-        let name = self.parse_binding_identifier()?;
-        let constraint = self.parse_ts_type_constraint()?;
-        let default = self.parse_ts_default_type()?;
+        let name = self.parse_binding_identifier();
+        let constraint = self.parse_ts_type_constraint();
+        let default = self.parse_ts_default_type();
 
-        Ok(self.ast.ts_type_parameter(
+        self.ast.ts_type_parameter(
             self.end_span(span),
             name,
             constraint,
@@ -190,14 +188,14 @@ impl<'a> ParserImpl<'a> {
             modifiers.contains(ModifierKind::In),
             modifiers.contains(ModifierKind::Out),
             modifiers.contains(ModifierKind::Const),
-        ))
+        )
     }
 
-    fn parse_intersection_type_or_higher(&mut self) -> Result<TSType<'a>> {
+    fn parse_intersection_type_or_higher(&mut self) -> TSType<'a> {
         self.parse_union_type_or_intersection_type(Kind::Amp, Self::parse_type_operator_or_higher)
     }
 
-    fn parse_union_type_or_higher(&mut self) -> Result<TSType<'a>> {
+    fn parse_union_type_or_higher(&mut self) -> TSType<'a> {
         self.parse_union_type_or_intersection_type(
             Kind::Pipe,
             Self::parse_intersection_type_or_higher,
@@ -208,20 +206,20 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         kind: Kind,
         parse_constituent_type: F,
-    ) -> Result<TSType<'a>>
+    ) -> TSType<'a>
     where
-        F: Fn(&mut Self) -> Result<TSType<'a>>,
+        F: Fn(&mut Self) -> TSType<'a>,
     {
         let span = self.start_span();
         let has_leading_operator = self.eat(kind);
         /* hasLeadingOperator && parseFunctionOrConstructorTypeToError(isUnionType) ||*/
-        let mut ty = parse_constituent_type(self)?;
+        let mut ty = parse_constituent_type(self);
         if self.at(kind) || has_leading_operator {
             let mut types = self.ast.vec1(ty);
             while self.eat(kind) {
                 types.push(
                     /*parseFunctionOrConstructorTypeToError(isUnionType) || */
-                    parse_constituent_type(self)?,
+                    parse_constituent_type(self),
                 );
             }
             let span = self.end_span(span);
@@ -231,10 +229,10 @@ impl<'a> ParserImpl<'a> {
                 _ => unreachable!(),
             };
         }
-        Ok(ty)
+        ty
     }
 
-    fn parse_type_operator_or_higher(&mut self) -> Result<TSType<'a>> {
+    fn parse_type_operator_or_higher(&mut self) -> TSType<'a> {
         match self.cur_kind() {
             Kind::KeyOf => self.parse_type_operator(TSTypeOperatorOperator::Keyof),
             Kind::Unique => self.parse_type_operator(TSTypeOperatorOperator::Unique),
@@ -248,40 +246,40 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
-    fn parse_type_operator(&mut self, operator: TSTypeOperatorOperator) -> Result<TSType<'a>> {
+    fn parse_type_operator(&mut self, operator: TSTypeOperatorOperator) -> TSType<'a> {
         let span = self.start_span();
         self.bump_any(); // bump operator
         let operator_span = self.end_span(span);
-        let ty = self.parse_type_operator_or_higher()?;
+        let ty = self.parse_type_operator_or_higher();
         if operator == TSTypeOperatorOperator::Readonly
             && !matches!(ty, TSType::TSArrayType(_))
             && !matches!(ty, TSType::TSTupleType(_))
         {
             self.error(diagnostics::readonly_in_array_or_tuple_type(operator_span));
         }
-        Ok(self.ast.ts_type_type_operator_type(self.end_span(span), operator, ty))
+        self.ast.ts_type_type_operator_type(self.end_span(span), operator, ty)
     }
 
-    fn parse_infer_type(&mut self) -> Result<TSType<'a>> {
+    fn parse_infer_type(&mut self) -> TSType<'a> {
         let span = self.start_span();
         self.bump_any(); // bump `infer`
-        let type_parameter = self.parse_type_parameter_of_infer_type()?;
-        Ok(self.ast.ts_type_infer_type(self.end_span(span), type_parameter))
+        let type_parameter = self.parse_type_parameter_of_infer_type();
+        self.ast.ts_type_infer_type(self.end_span(span), type_parameter)
     }
 
-    fn parse_type_parameter_of_infer_type(&mut self) -> Result<Box<'a, TSTypeParameter<'a>>> {
+    fn parse_type_parameter_of_infer_type(&mut self) -> Box<'a, TSTypeParameter<'a>> {
         let span = self.start_span();
-        let name = self.parse_binding_identifier()?;
-        let constraint = self.try_parse(Self::try_parse_constraint_of_infer_type).unwrap_or(None);
+        let name = self.parse_binding_identifier();
+        let constraint = self.try_parse(Self::parse_constraint_of_infer_type).unwrap_or(None);
         let span = self.end_span(span);
         let ts_type_parameter =
             self.ast.alloc_ts_type_parameter(span, name, constraint, None, false, false, false);
-        Ok(ts_type_parameter)
+        ts_type_parameter
     }
 
-    fn parse_postfix_type_or_higher(&mut self) -> Result<TSType<'a>> {
+    fn parse_postfix_type_or_higher(&mut self) -> TSType<'a> {
         let span = self.start_span();
-        let mut ty = self.parse_non_array_type()?;
+        let mut ty = self.parse_non_array_type();
 
         while !self.cur_token().is_on_new_line {
             match self.cur_kind() {
@@ -296,7 +294,7 @@ impl<'a> ParserImpl<'a> {
                 Kind::Question => {
                     // If next token is start of a type we have a conditional type
                     if self.lookahead(Self::next_token_is_start_of_type) {
-                        return Ok(ty);
+                        return ty;
                     }
                     self.bump_any();
                     ty = self.ast.ts_type_js_doc_nullable_type(
@@ -308,25 +306,25 @@ impl<'a> ParserImpl<'a> {
                 Kind::LBrack => {
                     self.bump_any();
                     if self.is_start_of_type(/* in_start_of_parameter */ false) {
-                        let index_type = self.parse_ts_type()?;
-                        self.expect(Kind::RBrack)?;
+                        let index_type = self.parse_ts_type();
+                        self.expect(Kind::RBrack);
                         ty = self.ast.ts_type_indexed_access_type(
                             self.end_span(span),
                             ty,
                             index_type,
                         );
                     } else {
-                        self.expect(Kind::RBrack)?;
+                        self.expect(Kind::RBrack);
                         ty = self.ast.ts_type_array_type(self.end_span(span), ty);
                     }
                 }
-                _ => return Ok(ty),
+                _ => return ty,
             }
         }
-        Ok(ty)
+        ty
     }
 
-    fn parse_non_array_type(&mut self) -> Result<TSType<'a>> {
+    fn parse_non_array_type(&mut self) -> TSType<'a> {
         match self.cur_kind() {
             Kind::Any
             | Kind::Unknown
@@ -341,7 +339,7 @@ impl<'a> ParserImpl<'a> {
             // Parse `null` as `TSNullKeyword` instead of null literal to align with typescript eslint.
             | Kind::Null => {
                 if let Some(ty) = self.try_parse(Self::parse_keyword_and_no_dot) {
-                    Ok(ty)
+                    ty
                 } else {
                     self.parse_type_reference()
                 }
@@ -378,7 +376,7 @@ impl<'a> ParserImpl<'a> {
             Kind::Void => {
                 let span = self.start_span();
                 self.bump_any();
-                Ok(self.ast.ts_type_void_keyword(self.end_span(span)))
+                self.ast.ts_type_void_keyword(self.end_span(span))
             }
             Kind::This => {
                 let span = self.start_span();
@@ -387,7 +385,7 @@ impl<'a> ParserImpl<'a> {
                 if self.peek_at(Kind::Is) && !self.peek_token().is_on_new_line {
                     return self.parse_this_type_predicate(this_type);
                 }
-                Ok(TSType::TSThisType(self.alloc(this_type)))
+                TSType::TSThisType(self.alloc(this_type))
             }
             Kind::Typeof => {
                 if self.peek_at(Kind::Import) {
@@ -419,7 +417,7 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
-    fn parse_keyword_and_no_dot(&mut self) -> Result<TSType<'a>> {
+    fn parse_keyword_and_no_dot(&mut self) -> TSType<'a> {
         let span = self.start_span();
         let ty = match self.cur_kind() {
             Kind::Any => {
@@ -466,12 +464,12 @@ impl<'a> ParserImpl<'a> {
                 self.bump_any();
                 self.ast.ts_type_null_keyword(self.end_span(span))
             }
-            _ => return Err(self.unexpected()),
+            _ => return self.unexpected(),
         };
         if self.at(Kind::Dot) {
-            return Err(self.unexpected());
+            return self.unexpected();
         }
-        Ok(ty)
+        ty
     }
 
     fn is_start_of_type(&mut self, in_start_of_parameter: bool) -> bool {
@@ -562,9 +560,9 @@ impl<'a> ParserImpl<'a> {
             || self.is_start_of_type(!is_js_doc_parameter)
     }
 
-    fn parse_mapped_type(&mut self) -> Result<TSType<'a>> {
+    fn parse_mapped_type(&mut self) -> TSType<'a> {
         let span = self.start_span();
-        self.expect(Kind::LCurly)?;
+        self.expect(Kind::LCurly);
         let mut readonly = TSMappedTypeModifierOperator::None;
         if self.eat(Kind::Readonly) {
             readonly = TSMappedTypeModifierOperator::True;
@@ -574,14 +572,14 @@ impl<'a> ParserImpl<'a> {
             readonly = TSMappedTypeModifierOperator::Minus;
         }
 
-        self.expect(Kind::LBrack)?;
+        self.expect(Kind::LBrack);
         let type_parameter_span = self.start_span();
         if !self.cur_kind().is_identifier_name() {
-            return Err(self.unexpected());
+            return self.unexpected();
         }
-        let name = self.parse_binding_identifier()?;
-        self.expect(Kind::In)?;
-        let constraint = self.parse_ts_type()?;
+        let name = self.parse_binding_identifier();
+        self.expect(Kind::In);
+        let constraint = self.parse_ts_type();
         let type_parameter = self.alloc(self.ast.ts_type_parameter(
             self.end_span(type_parameter_span),
             name,
@@ -592,8 +590,8 @@ impl<'a> ParserImpl<'a> {
             false,
         ));
 
-        let name_type = if self.eat(Kind::As) { Some(self.parse_ts_type()?) } else { None };
-        self.expect(Kind::RBrack)?;
+        let name_type = if self.eat(Kind::As) { Some(self.parse_ts_type()) } else { None };
+        self.expect(Kind::RBrack);
 
         let optional = match self.cur_kind() {
             Kind::Question => {
@@ -602,62 +600,57 @@ impl<'a> ParserImpl<'a> {
             }
             Kind::Minus => {
                 self.bump_any();
-                self.expect(Kind::Question)?;
+                self.expect(Kind::Question);
                 TSMappedTypeModifierOperator::Minus
             }
             Kind::Plus => {
                 self.bump_any();
-                self.expect(Kind::Question)?;
+                self.expect(Kind::Question);
                 TSMappedTypeModifierOperator::Plus
             }
             _ => TSMappedTypeModifierOperator::None,
         };
 
-        let type_annotation = self.eat(Kind::Colon).then(|| self.parse_ts_type()).transpose()?;
+        let type_annotation = self.eat(Kind::Colon).then(|| self.parse_ts_type());
         self.bump(Kind::Semicolon);
-        self.expect(Kind::RCurly)?;
+        self.expect(Kind::RCurly);
 
-        Ok(self.ast.ts_type_mapped_type(
+        self.ast.ts_type_mapped_type(
             self.end_span(span),
             type_parameter,
             name_type,
             type_annotation,
             optional,
             readonly,
-        ))
+        )
     }
 
-    fn parse_type_literal(&mut self) -> Result<TSType<'a>> {
+    fn parse_type_literal(&mut self) -> TSType<'a> {
         let span = self.start_span();
-        let member_list =
-            self.parse_normal_list(Kind::LCurly, Kind::RCurly, Self::parse_ts_type_signature)?;
-        Ok(self.ast.ts_type_type_literal(self.end_span(span), member_list))
+        let member_list = self
+            .parse_normal_list(Kind::LCurly, Kind::RCurly, |p| Some(p.parse_ts_type_signature()));
+        self.ast.ts_type_type_literal(self.end_span(span), member_list)
     }
 
-    fn parse_type_query(&mut self) -> Result<TSType<'a>> {
+    fn parse_type_query(&mut self) -> TSType<'a> {
         let span = self.start_span();
         self.bump_any(); // `bump `typeof`
-        let entity_name = self.parse_ts_type_name()?; // TODO: parseEntityName
+        let entity_name = self.parse_ts_type_name(); // TODO: parseEntityName
         let entity_name = TSTypeQueryExprName::from(entity_name);
         let type_arguments =
-            if self.cur_token().is_on_new_line { None } else { self.try_parse_type_arguments()? };
-        Ok(self.ast.ts_type_type_query(self.end_span(span), entity_name, type_arguments))
+            if self.cur_token().is_on_new_line { None } else { self.try_parse_type_arguments() };
+        self.ast.ts_type_type_query(self.end_span(span), entity_name, type_arguments)
     }
 
-    fn parse_this_type_predicate(&mut self, this_ty: TSThisType) -> Result<TSType<'a>> {
+    fn parse_this_type_predicate(&mut self, this_ty: TSThisType) -> TSType<'a> {
         let span = this_ty.span;
         self.bump_any(); // bump `is`
         // TODO: this should go through the ast builder.
         let parameter_name = TSTypePredicateName::This(this_ty);
         let type_span = self.start_span();
-        let ty = self.parse_ts_type()?;
+        let ty = self.parse_ts_type();
         let type_annotation = Some(self.ast.ts_type_annotation(self.end_span(type_span), ty));
-        Ok(self.ast.ts_type_type_predicate(
-            self.end_span(span),
-            parameter_name,
-            false,
-            type_annotation,
-        ))
+        self.ast.ts_type_type_predicate(self.end_span(span), parameter_name, false, type_annotation)
     }
 
     fn parse_this_type_node(&mut self) -> TSThisType {
@@ -666,23 +659,23 @@ impl<'a> ParserImpl<'a> {
         self.ast.ts_this_type(self.end_span(span))
     }
 
-    fn parse_ts_type_constraint(&mut self) -> Result<Option<TSType<'a>>> {
+    fn parse_ts_type_constraint(&mut self) -> Option<TSType<'a>> {
         if !self.at(Kind::Extends) {
-            return Ok(None);
+            return None;
         }
         self.bump_any();
-        Ok(Some(self.parse_ts_type()?))
+        Some(self.parse_ts_type())
     }
 
-    fn parse_ts_default_type(&mut self) -> Result<Option<TSType<'a>>> {
+    fn parse_ts_default_type(&mut self) -> Option<TSType<'a>> {
         if !self.at(Kind::Eq) {
-            return Ok(None);
+            return None;
         }
         self.bump_any();
-        Ok(Some(self.parse_ts_type()?))
+        Some(self.parse_ts_type())
     }
 
-    fn parse_template_type(&mut self, tagged: bool) -> Result<TSType<'a>> {
+    fn parse_template_type(&mut self, tagged: bool) -> TSType<'a> {
         let span = self.start_span();
         let mut types = self.ast.vec();
         let mut quasis = self.ast.vec();
@@ -692,11 +685,11 @@ impl<'a> ParserImpl<'a> {
             }
             Kind::TemplateHead => {
                 quasis.push(self.parse_template_element(tagged));
-                types.push(self.parse_ts_type()?);
+                types.push(self.parse_ts_type());
                 self.re_lex_template_substitution_tail();
                 loop {
                     match self.cur_kind() {
-                        Kind::Eof => self.expect(Kind::TemplateTail)?,
+                        Kind::Eof => self.expect(Kind::TemplateTail),
                         Kind::TemplateTail => {
                             quasis.push(self.parse_template_element(tagged));
                             break;
@@ -705,7 +698,7 @@ impl<'a> ParserImpl<'a> {
                             quasis.push(self.parse_template_element(tagged));
                         }
                         _ => {
-                            types.push(self.parse_ts_type()?);
+                            types.push(self.parse_ts_type());
                             self.re_lex_template_substitution_tail();
                         }
                     }
@@ -714,128 +707,127 @@ impl<'a> ParserImpl<'a> {
             _ => unreachable!("parse_template_literal"),
         }
 
-        Ok(self.ast.ts_type_template_literal_type(self.end_span(span), quasis, types))
+        self.ast.ts_type_template_literal_type(self.end_span(span), quasis, types)
     }
 
-    fn parse_asserts_type_predicate(&mut self) -> Result<TSType<'a>> {
+    fn parse_asserts_type_predicate(&mut self) -> TSType<'a> {
         let span = self.start_span();
         self.bump_any(); // bump `asserts`
         let parameter_name = if self.at(Kind::This) {
             TSTypePredicateName::This(self.parse_this_type_node())
         } else {
-            let ident_name = self.parse_identifier_name()?;
+            let ident_name = self.parse_identifier_name();
             TSTypePredicateName::Identifier(self.alloc(ident_name))
         };
         let mut type_annotation = None;
         if self.eat(Kind::Is) {
             let type_span = self.start_span();
-            let ty = self.parse_ts_type()?;
+            let ty = self.parse_ts_type();
             type_annotation = Some(self.ast.ts_type_annotation(self.end_span(type_span), ty));
         }
-        Ok(self.ast.ts_type_type_predicate(
+        self.ast.ts_type_type_predicate(
             self.end_span(span),
             parameter_name,
             /* asserts */ true,
             type_annotation,
-        ))
+        )
     }
 
-    fn parse_type_reference(&mut self) -> Result<TSType<'a>> {
+    fn parse_type_reference(&mut self) -> TSType<'a> {
         let span = self.start_span();
-        let type_name = self.parse_ts_type_name()?;
-        let type_parameters = self.parse_type_arguments_of_type_reference()?;
-        Ok(self.ast.ts_type_type_reference(self.end_span(span), type_name, type_parameters))
+        let type_name = self.parse_ts_type_name();
+        let type_parameters = self.parse_type_arguments_of_type_reference();
+        self.ast.ts_type_type_reference(self.end_span(span), type_name, type_parameters)
     }
 
-    fn parse_ts_implement_name(&mut self) -> Result<TSClassImplements<'a>> {
+    fn parse_ts_implement_name(&mut self) -> TSClassImplements<'a> {
         let span = self.start_span();
-        let type_name = self.parse_ts_type_name()?;
-        let type_parameters = self.parse_type_arguments_of_type_reference()?;
-        Ok(self.ast.ts_class_implements(self.end_span(span), type_name, type_parameters))
+        let type_name = self.parse_ts_type_name();
+        let type_parameters = self.parse_type_arguments_of_type_reference();
+        self.ast.ts_class_implements(self.end_span(span), type_name, type_parameters)
     }
 
-    pub(crate) fn parse_ts_type_name(&mut self) -> Result<TSTypeName<'a>> {
+    pub(crate) fn parse_ts_type_name(&mut self) -> TSTypeName<'a> {
         let span = self.start_span();
-        let ident = self.parse_identifier_name()?;
+        let ident = self.parse_identifier_name();
         let ident = self.ast.alloc_identifier_reference(ident.span, ident.name);
         let mut left = TSTypeName::IdentifierReference(ident);
         while self.eat(Kind::Dot) {
-            let right = self.parse_identifier_name()?;
+            let right = self.parse_identifier_name();
             left = self.ast.ts_type_name_qualified_name(self.end_span(span), left, right);
         }
-        Ok(left)
+        left
     }
 
     pub(crate) fn try_parse_type_arguments(
         &mut self,
-    ) -> Result<Option<Box<'a, TSTypeParameterInstantiation<'a>>>> {
+    ) -> Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
         if self.at(Kind::LAngle) {
             let span = self.start_span();
-            self.expect(Kind::LAngle)?;
+            self.expect(Kind::LAngle);
             let params = self.parse_delimited_list(
                 Kind::RAngle,
                 Kind::Comma,
                 /* trailing_separator */ true,
                 Self::parse_ts_type,
-            )?;
-            self.expect(Kind::RAngle)?;
-            return Ok(Some(
+            );
+            self.expect(Kind::RAngle);
+            return Some(
                 self.ast.alloc_ts_type_parameter_instantiation(self.end_span(span), params),
-            ));
+            );
         }
-        Ok(None)
+        None
     }
 
     fn parse_type_arguments_of_type_reference(
         &mut self,
-    ) -> Result<Option<Box<'a, TSTypeParameterInstantiation<'a>>>> {
+    ) -> Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
         self.re_lex_l_angle();
         if !self.cur_token().is_on_new_line && self.re_lex_l_angle() == Kind::LAngle {
             let span = self.start_span();
-            self.expect(Kind::LAngle)?;
+            self.expect(Kind::LAngle);
             let params = self.parse_delimited_list(
                 Kind::RAngle,
                 Kind::Comma,
                 /* trailing_separator */ true,
                 Self::parse_ts_type,
-            )?;
-            self.expect(Kind::RAngle)?;
-            return Ok(Some(
+            );
+            self.expect(Kind::RAngle);
+            return Some(
                 self.ast.alloc_ts_type_parameter_instantiation(self.end_span(span), params),
-            ));
+            );
         }
-        Ok(None)
+        None
     }
 
     pub(crate) fn parse_type_arguments_in_expression(
         &mut self,
-    ) -> Result<Option<Box<'a, TSTypeParameterInstantiation<'a>>>> {
+    ) -> Option<Box<'a, TSTypeParameterInstantiation<'a>>> {
         if !self.is_ts {
-            return Ok(None);
+            return None;
         }
         let span = self.start_span();
         if self.re_lex_l_angle() != Kind::LAngle {
-            return Ok(None);
+            return None;
         }
-        self.expect(Kind::LAngle)?;
+        self.expect(Kind::LAngle);
         let params = self.parse_delimited_list(
             Kind::RAngle,
             Kind::Comma,
             /* trailing_separator */ true,
             Self::parse_ts_type,
-        )?;
+        );
         // `a < b> = c`` is valid but `a < b >= c` is BinaryExpression
         if matches!(self.re_lex_right_angle(), Kind::GtEq) {
-            return Err(self.unexpected());
+            return self.unexpected();
         }
         self.re_lex_ts_r_angle();
-        self.expect(Kind::RAngle)?;
+        self.expect(Kind::RAngle);
         if self.can_follow_type_arguments_in_expr() {
-            return Ok(Some(
-                self.ast.alloc_ts_type_parameter_instantiation(self.end_span(span), params),
-            ));
+            Some(self.ast.alloc_ts_type_parameter_instantiation(self.end_span(span), params))
+        } else {
+            self.unexpected()
         }
-        Err(self.unexpected())
     }
 
     fn can_follow_type_arguments_in_expr(&mut self) -> bool {
@@ -850,32 +842,30 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
-    fn parse_tuple_type(&mut self) -> Result<TSType<'a>> {
+    fn parse_tuple_type(&mut self) -> TSType<'a> {
         let span = self.start_span();
-        self.expect(Kind::LBrack)?;
+        self.expect(Kind::LBrack);
         let elements = self.parse_delimited_list(
             Kind::RBrack,
             Kind::Comma,
             /* trailing_separator */ true,
             Self::parse_tuple_element_name_or_tuple_element_type,
-        )?;
-        self.expect(Kind::RBrack)?;
-        Ok(self.ast.ts_type_tuple_type(self.end_span(span), elements))
+        );
+        self.expect(Kind::RBrack);
+        self.ast.ts_type_tuple_type(self.end_span(span), elements)
     }
 
-    pub(super) fn parse_tuple_element_name_or_tuple_element_type(
-        &mut self,
-    ) -> Result<TSTupleElement<'a>> {
+    pub(super) fn parse_tuple_element_name_or_tuple_element_type(&mut self) -> TSTupleElement<'a> {
         if self.lookahead(Self::is_tuple_element_name) {
             let span = self.start_span();
             let dotdotdot = self.eat(Kind::Dot3);
             let member_span = self.start_span();
-            let label = self.parse_identifier_name()?;
+            let label = self.parse_identifier_name();
             let optional = self.eat(Kind::Question);
-            self.expect(Kind::Colon)?;
-            let element_type = self.parse_tuple_element_type()?;
+            self.expect(Kind::Colon);
+            let element_type = self.parse_tuple_element_type();
             let span = self.end_span(span);
-            return Ok(if dotdotdot {
+            return if dotdotdot {
                 let type_annotation = self.ast.ts_type_named_tuple_member(
                     self.end_span(member_span),
                     element_type,
@@ -892,7 +882,7 @@ impl<'a> ParserImpl<'a> {
                     label,
                     optional,
                 ))
-            });
+            };
         }
         self.parse_tuple_element_type()
     }
@@ -913,37 +903,37 @@ impl<'a> ParserImpl<'a> {
         self.at(Kind::Question) && self.peek_at(Kind::Colon)
     }
 
-    fn parse_tuple_element_type(&mut self) -> Result<TSTupleElement<'a>> {
+    fn parse_tuple_element_type(&mut self) -> TSTupleElement<'a> {
         let span = self.start_span();
         if self.eat(Kind::Dot3) {
-            let ty = self.parse_ts_type()?;
-            return Ok(self.ast.ts_tuple_element_rest_type(self.end_span(span), ty));
+            let ty = self.parse_ts_type();
+            return self.ast.ts_tuple_element_rest_type(self.end_span(span), ty);
         }
-        let ty = self.parse_ts_type()?;
+        let ty = self.parse_ts_type();
         if let TSType::JSDocNullableType(ty) = ty {
             if ty.span.start == ty.type_annotation.span().start {
-                Ok(self.ast.ts_tuple_element_optional_type(ty.span, ty.unbox().type_annotation))
+                self.ast.ts_tuple_element_optional_type(ty.span, ty.unbox().type_annotation)
             } else {
-                Ok(TSTupleElement::JSDocNullableType(ty))
+                TSTupleElement::JSDocNullableType(ty)
             }
         } else {
-            Ok(TSTupleElement::from(ty))
+            TSTupleElement::from(ty)
         }
     }
 
-    fn parse_parenthesized_type(&mut self) -> Result<TSType<'a>> {
+    fn parse_parenthesized_type(&mut self) -> TSType<'a> {
         let span = self.start_span();
         self.bump_any(); // bump `(`
-        let ty = self.parse_ts_type()?;
-        self.expect(Kind::RParen)?;
-        Ok(if self.options.preserve_parens {
+        let ty = self.parse_ts_type();
+        self.expect(Kind::RParen);
+        if self.options.preserve_parens {
             self.ast.ts_type_parenthesized_type(self.end_span(span), ty)
         } else {
             ty
-        })
+        }
     }
 
-    fn parse_literal_type_node(&mut self, negative: bool) -> Result<TSType<'a>> {
+    fn parse_literal_type_node(&mut self, negative: bool) -> TSType<'a> {
         let span = self.start_span();
         if negative {
             self.bump_any(); // bump `-`
@@ -953,7 +943,7 @@ impl<'a> ParserImpl<'a> {
             self.parse_template_literal_expression(false)
         } else {
             self.parse_literal_expression()
-        }?;
+        };
 
         let span = self.end_span(span);
         let literal = if negative {
@@ -968,80 +958,73 @@ impl<'a> ParserImpl<'a> {
                 Expression::BigIntLiteral(literal) => TSLiteral::BigIntLiteral(literal),
                 Expression::StringLiteral(literal) => TSLiteral::StringLiteral(literal),
                 Expression::TemplateLiteral(literal) => TSLiteral::TemplateLiteral(literal),
-                _ => return Err(self.unexpected()),
+                _ => return self.unexpected(),
             }
         };
 
-        Ok(self.ast.ts_type_literal_type(span, literal))
+        self.ast.ts_type_literal_type(span, literal)
     }
 
-    fn parse_ts_import_type(&mut self) -> Result<TSType<'a>> {
+    fn parse_ts_import_type(&mut self) -> TSType<'a> {
         let span = self.start_span();
         let is_type_of = self.eat(Kind::Typeof);
-        self.expect(Kind::Import)?;
-        self.expect(Kind::LParen)?;
-        let argument = self.parse_ts_type()?;
+        self.expect(Kind::Import);
+        self.expect(Kind::LParen);
+        let argument = self.parse_ts_type();
         let options =
-            if self.eat(Kind::Comma) { Some(self.parse_object_expression()?) } else { None };
-        self.expect(Kind::RParen)?;
-        let qualifier = if self.eat(Kind::Dot) { Some(self.parse_ts_type_name()?) } else { None };
-        let type_arguments = self.parse_type_arguments_of_type_reference()?;
-        Ok(self.ast.ts_type_import_type(
+            if self.eat(Kind::Comma) { Some(self.parse_object_expression()) } else { None };
+        self.expect(Kind::RParen);
+        let qualifier = if self.eat(Kind::Dot) { Some(self.parse_ts_type_name()) } else { None };
+        let type_arguments = self.parse_type_arguments_of_type_reference();
+        self.ast.ts_type_import_type(
             self.end_span(span),
             argument,
             options,
             qualifier,
             type_arguments,
             is_type_of,
-        ))
+        )
     }
 
-    fn try_parse_constraint_of_infer_type(&mut self) -> Result<Option<TSType<'a>>> {
+    fn parse_constraint_of_infer_type(&mut self) -> Option<TSType<'a>> {
         if self.eat(Kind::Extends) {
             let constraint = self.context(
                 Context::DisallowConditionalTypes,
                 Context::empty(),
                 Self::parse_ts_type,
-            )?;
+            );
             if self.ctx.has_disallow_conditional_types() || !self.at(Kind::Question) {
-                return Ok(Some(constraint));
+                return Some(constraint);
             }
         }
-        Err(self.unexpected())
+        self.unexpected()
     }
 
     pub(crate) fn parse_ts_return_type_annotation(
         &mut self,
         kind: Kind,
         is_type: bool,
-    ) -> Result<Option<Box<'a, TSTypeAnnotation<'a>>>> {
+    ) -> Option<Box<'a, TSTypeAnnotation<'a>>> {
         if !self.is_ts {
-            return Ok(None);
+            return None;
         }
         if !self.at(Kind::Colon) {
-            return Ok(None);
+            return None;
         }
         let span = self.start_span();
-        Ok(self
-            .parse_return_type(kind, is_type)?
-            .map(|return_type| self.ast.alloc_ts_type_annotation(self.end_span(span), return_type)))
+        self.parse_return_type(kind, is_type)
+            .map(|return_type| self.ast.alloc_ts_type_annotation(self.end_span(span), return_type))
     }
 
-    fn parse_return_type(
-        &mut self,
-        return_kind: Kind,
-        is_type: bool,
-    ) -> Result<Option<TSType<'a>>> {
+    fn parse_return_type(&mut self, return_kind: Kind, is_type: bool) -> Option<TSType<'a>> {
         if self.should_parse_return_type(return_kind, is_type) {
-            return self
-                .context(
-                    Context::empty(),
-                    Context::DisallowConditionalTypes,
-                    Self::parse_type_or_type_predicate,
-                )
-                .map(Some);
+            return Some(self.context(
+                Context::empty(),
+                Context::DisallowConditionalTypes,
+                Self::parse_type_or_type_predicate,
+            ));
         }
-        Ok(None)
+        None
     }
 
     fn should_parse_return_type(&mut self, return_kind: Kind, _is_type: bool) -> bool {
@@ -1062,7 +1045,7 @@ impl<'a> ParserImpl<'a> {
         false
     }
 
-    fn parse_type_or_type_predicate(&mut self) -> Result<TSType<'a>> {
+    fn parse_type_or_type_predicate(&mut self) -> TSType<'a> {
         let span = self.start_span();
         let type_predicate_variable = if self.cur_kind().is_identifier_name() {
             self.try_parse(Self::parse_type_predicate_prefix)
@@ -1070,57 +1053,57 @@ impl<'a> ParserImpl<'a> {
             None
         };
         let type_span = self.start_span();
-        let ty = self.parse_ts_type()?;
+        let ty = self.parse_ts_type();
         if let Some(id) = type_predicate_variable {
             let type_annotation = Some(self.ast.ts_type_annotation(self.end_span(type_span), ty));
             let parameter_name = TSTypePredicateName::Identifier(self.alloc(id));
-            return Ok(self.ast.ts_type_type_predicate(
+            return self.ast.ts_type_type_predicate(
                 self.end_span(span),
                 parameter_name,
                 false,
                 type_annotation,
-            ));
+            );
         }
-        Ok(ty)
+        ty
     }
 
-    fn parse_type_predicate_prefix(&mut self) -> Result<IdentifierName<'a>> {
-        let id = self.parse_identifier_name()?;
+    fn parse_type_predicate_prefix(&mut self) -> IdentifierName<'a> {
+        let id = self.parse_identifier_name();
         let token = self.cur_token();
         if token.kind == Kind::Is && !token.is_on_new_line {
             self.bump_any();
-            return Ok(id);
+            return id;
         }
-        Err(self.unexpected())
+        self.unexpected()
     }
 
     pub(crate) fn is_next_at_type_member_name(&mut self) -> bool {
         self.peek_kind().is_literal_property_name() || self.peek_at(Kind::LBrack)
     }
 
-    pub(crate) fn parse_ts_call_signature_member(&mut self) -> Result<TSSignature<'a>> {
+    pub(crate) fn parse_ts_call_signature_member(&mut self) -> TSSignature<'a> {
         let span = self.start_span();
-        let type_parameters = self.parse_ts_type_parameters()?;
-        let (this_param, params) = self.parse_formal_parameters(FormalParameterKind::Signature)?;
-        let return_type = self.parse_ts_return_type_annotation(Kind::Colon, false)?;
+        let type_parameters = self.parse_ts_type_parameters();
+        let (this_param, params) = self.parse_formal_parameters(FormalParameterKind::Signature);
+        let return_type = self.parse_ts_return_type_annotation(Kind::Colon, false);
         self.parse_type_member_semicolon();
-        Ok(self.ast.ts_signature_call_signature_declaration(
+        self.ast.ts_signature_call_signature_declaration(
             self.end_span(span),
             type_parameters,
             this_param,
             params,
             return_type,
-        ))
+        )
     }
 
-    pub(crate) fn parse_ts_getter_signature_member(&mut self) -> Result<TSSignature<'a>> {
+    pub(crate) fn parse_ts_getter_signature_member(&mut self) -> TSSignature<'a> {
         let span = self.start_span();
-        self.expect(Kind::Get)?;
-        let (key, computed) = self.parse_property_name()?;
-        let (this_param, params) = self.parse_formal_parameters(FormalParameterKind::Signature)?;
-        let return_type = self.parse_ts_return_type_annotation(Kind::Colon, false)?;
+        self.expect(Kind::Get);
+        let (key, computed) = self.parse_property_name();
+        let (this_param, params) = self.parse_formal_parameters(FormalParameterKind::Signature);
+        let return_type = self.parse_ts_return_type_annotation(Kind::Colon, false);
         self.parse_type_member_semicolon();
-        Ok(self.ast.ts_signature_method_signature(
+        self.ast.ts_signature_method_signature(
             self.end_span(span),
             key,
             computed,
@@ -1130,22 +1113,22 @@ impl<'a> ParserImpl<'a> {
             this_param,
             params,
             return_type,
-        ))
+        )
     }
 
-    pub(crate) fn parse_ts_setter_signature_member(&mut self) -> Result<TSSignature<'a>> {
+    pub(crate) fn parse_ts_setter_signature_member(&mut self) -> TSSignature<'a> {
         let span = self.start_span();
-        self.expect(Kind::Set)?;
-        let (key, computed) = self.parse_property_name()?;
-        let (this_param, params) = self.parse_formal_parameters(FormalParameterKind::Signature)?;
-        let return_type = self.parse_ts_return_type_annotation(Kind::Colon, false)?;
+        self.expect(Kind::Set);
+        let (key, computed) = self.parse_property_name();
+        let (this_param, params) = self.parse_formal_parameters(FormalParameterKind::Signature);
+        let return_type = self.parse_ts_return_type_annotation(Kind::Colon, false);
         self.parse_type_member_semicolon();
         if let Some(return_type) = return_type.as_ref() {
             self.error(diagnostics::a_set_accessor_cannot_have_a_return_type_annotation(
                 return_type.span,
             ));
         }
-        Ok(self.ast.ts_signature_method_signature(
+        self.ast.ts_signature_method_signature(
             self.end_span(span),
             key,
             computed,
@@ -1155,12 +1138,10 @@ impl<'a> ParserImpl<'a> {
             this_param,
             params,
             return_type,
-        ))
+        )
     }
 
-    pub(crate) fn parse_ts_property_or_method_signature_member(
-        &mut self,
-    ) -> Result<TSSignature<'a>> {
+    pub(crate) fn parse_ts_property_or_method_signature_member(&mut self) -> TSSignature<'a> {
         let span = self.start_span();
         let readonly = self.at(Kind::Readonly) && self.is_next_at_type_member_name();
 
@@ -1168,18 +1149,18 @@ impl<'a> ParserImpl<'a> {
             self.bump_any();
         }
 
-        let (key, computed) = self.parse_property_name()?;
+        let (key, computed) = self.parse_property_name();
         let optional = self.eat(Kind::Question);
 
         if self.at(Kind::LParen) || self.at(Kind::LAngle) {
             let TSSignature::TSCallSignatureDeclaration(call_signature) =
-                self.parse_ts_call_signature_member()?
+                self.parse_ts_call_signature_member()
             else {
                 unreachable!()
             };
             self.parse_type_member_semicolon();
             let call_signature = call_signature.unbox();
-            Ok(self.ast.ts_signature_method_signature(
+            self.ast.ts_signature_method_signature(
                 self.end_span(span),
                 key,
                 computed,
@@ -1189,68 +1170,68 @@ impl<'a> ParserImpl<'a> {
                 call_signature.this_param,
                 call_signature.params,
                 call_signature.return_type,
-            ))
+            )
         } else {
-            let type_annotation = self.parse_ts_type_annotation()?;
+            let type_annotation = self.parse_ts_type_annotation();
             self.parse_type_member_semicolon();
-            Ok(self.ast.ts_signature_property_signature(
+            self.ast.ts_signature_property_signature(
                 self.end_span(span),
                 computed,
                 optional,
                 readonly,
                 key,
                 type_annotation,
-            ))
+            )
         }
     }
 
-    pub(crate) fn parse_ts_constructor_signature_member(&mut self) -> Result<TSSignature<'a>> {
+    pub(crate) fn parse_ts_constructor_signature_member(&mut self) -> TSSignature<'a> {
         let span = self.start_span();
-        self.expect(Kind::New)?;
+        self.expect(Kind::New);
 
-        let type_parameters = self.parse_ts_type_parameters()?;
-        let (this_param, params) = self.parse_formal_parameters(FormalParameterKind::Signature)?;
+        let type_parameters = self.parse_ts_type_parameters();
+        let (this_param, params) = self.parse_formal_parameters(FormalParameterKind::Signature);
 
         if let Some(this_param) = this_param {
             // interface Foo { new(this: number): Foo }
             self.error(diagnostics::ts_constructor_this_parameter(this_param.span));
         }
 
-        let return_type = self.parse_ts_return_type_annotation(Kind::Colon, false)?;
+        let return_type = self.parse_ts_return_type_annotation(Kind::Colon, false);
         self.parse_type_member_semicolon();
 
-        Ok(self.ast.ts_signature_construct_signature_declaration(
+        self.ast.ts_signature_construct_signature_declaration(
             self.end_span(span),
             type_parameters,
             params,
             return_type,
-        ))
+        )
     }
 
     pub(crate) fn parse_index_signature_declaration(
         &mut self,
         span: Span,
         modifiers: &Modifiers<'a>,
-    ) -> Result<TSIndexSignature<'a>> {
+    ) -> TSIndexSignature<'a> {
         self.verify_modifiers(
             modifiers,
             ModifierFlags::READONLY | ModifierFlags::STATIC,
             diagnostics::cannot_appear_on_an_index_signature,
         );
         self.bump(Kind::LBrack);
-        let parameters = self.ast.vec1(self.parse_ts_index_signature_name()?);
-        self.expect(Kind::RBrack)?;
-        let Some(type_annotation) = self.parse_ts_type_annotation()? else {
-            return Err(self.unexpected());
+        let parameters = self.ast.vec1(self.parse_ts_index_signature_name());
+        self.expect(Kind::RBrack);
+        let Some(type_annotation) = self.parse_ts_type_annotation() else {
+            return self.unexpected();
         };
         self.parse_type_member_semicolon();
-        Ok(self.ast.ts_index_signature(
+        self.ast.ts_index_signature(
             self.end_span(span),
             parameters,
             type_annotation,
             modifiers.contains(ModifierKind::Readonly),
             modifiers.contains(ModifierKind::Static),
-        ))
+        )
     }
 
     fn parse_type_member_semicolon(&mut self) {
@@ -1263,16 +1244,16 @@ impl<'a> ParserImpl<'a> {
         self.bump(Kind::Semicolon);
     }
 
-    fn parse_ts_index_signature_name(&mut self) -> Result<TSIndexSignatureName<'a>> {
+    fn parse_ts_index_signature_name(&mut self) -> TSIndexSignatureName<'a> {
         let span = self.start_span();
-        let name = self.parse_identifier_name()?.name;
-        let type_annotation = self.parse_ts_type_annotation()?;
+        let name = self.parse_identifier_name().name;
+        let type_annotation = self.parse_ts_type_annotation();
 
         if type_annotation.is_none() {
-            return Err(self.unexpected());
+            return self.unexpected();
         }
 
-        Ok(self.ast.ts_index_signature_name(self.end_span(span), name, type_annotation.unwrap()))
+        self.ast.ts_index_signature_name(self.end_span(span), name, type_annotation.unwrap())
     }
 
     pub(crate) fn parse_class_element_modifiers(
@@ -1310,34 +1291,26 @@ impl<'a> ParserImpl<'a> {
         Modifiers::new(modifiers, flags)
     }
 
-    fn parse_js_doc_unknown_or_nullable_type(&mut self) -> Result<TSType<'a>> {
+    fn parse_js_doc_unknown_or_nullable_type(&mut self) -> TSType<'a> {
         let span = self.start_span();
         self.bump_any(); // bump `?`
-        let type_annotation = self.parse_ts_type()?;
+        let type_annotation = self.parse_ts_type();
         let span = self.end_span(span);
         if matches!(
             self.cur_kind(),
             Kind::Comma | Kind::RCurly | Kind::RParen | Kind::RAngle | Kind::Eq | Kind::Pipe
         ) {
-            Ok(self.ast.ts_type_js_doc_unknown_type(span))
+            self.ast.ts_type_js_doc_unknown_type(span)
         } else {
-            Ok(self.ast.ts_type_js_doc_nullable_type(
-                span,
-                type_annotation,
-                /* postfix */ false,
-            ))
+            self.ast.ts_type_js_doc_nullable_type(span, type_annotation, /* postfix */ false)
         }
     }
 
-    fn parse_js_doc_non_nullable_type(&mut self) -> Result<TSType<'a>> {
+    fn parse_js_doc_non_nullable_type(&mut self) -> TSType<'a> {
         let span = self.start_span();
         self.bump_any(); // bump `!`
-        let ty = self.parse_non_array_type()?;
-        Ok(self.ast.ts_type_js_doc_non_nullable_type(
-            self.end_span(span),
-            ty,
-            /* postfix */ false,
-        ))
+        let ty = self.parse_non_array_type();
+        self.ast.ts_type_js_doc_non_nullable_type(self.end_span(span), ty, /* postfix */ false)
     }
 
     fn is_binary_operator(&self) -> bool {

--- a/tasks/benchmark/benches/parser.rs
+++ b/tasks/benchmark/benches/parser.rs
@@ -30,6 +30,7 @@ fn bench_parser(criterion: &mut Criterion) {
     group.finish();
 }
 
+#[expect(dead_code)]
 fn bench_estree(criterion: &mut Criterion) {
     let mut group = criterion.benchmark_group("estree");
     for file in TestFiles::complicated().files().iter().take(1) {
@@ -61,5 +62,5 @@ fn bench_estree(criterion: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(parser, bench_parser, bench_estree);
+criterion_group!(parser, bench_parser);
 criterion_main!(parser);

--- a/tasks/common/src/test_file.rs
+++ b/tasks/common/src/test_file.rs
@@ -61,12 +61,12 @@ impl TestFiles {
         Self { files: vec![file] }
     }
 
-    fn complicated_urls() -> [&'static str; 5] {
+    fn complicated_urls() -> [&'static str; 3] {
         [
             // TypeScript syntax (2.81MB)
-            "https://raw.githubusercontent.com/microsoft/TypeScript/v5.3.3/src/compiler/checker.ts",
+            // "https://raw.githubusercontent.com/microsoft/TypeScript/v5.3.3/src/compiler/checker.ts",
             // Real world app tsx (1.0M)
-            "https://raw.githubusercontent.com/oxc-project/benchmark-files/main/cal.com.tsx",
+            // "https://raw.githubusercontent.com/oxc-project/benchmark-files/main/cal.com.tsx",
             // Real world content-heavy app jsx (3K)
             "https://raw.githubusercontent.com/oxc-project/benchmark-files/main/RadixUIAdoptionSection.jsx",
             // Heavy with classes (554K)


### PR DESCRIPTION
In parser, optimize for common case that file parses successfully.

Instead of `parse_*` methods returning `Result<T>`s which are checked with `?` in the caller, always return a valid node `T`.

In case of a fatal parsing error:

* Record the error in `fatal_error` property of `ParserImpl`.
* Also record current length of `errors`.
* Fast forward the lexer to EOF, so parsing will come to an end swiftly.
* Create a dummy node of the required type and return it.

At end of parsing, if `fatal_error.is_some()`, then there was a fatal error. In that case:

* Truncate `errors` to the length it was at time of the fatal error (because more errors may occur as the parser finds it's unexpectedly at EOF).
* Add `fatal_error` to `errors`.

i.e. all parse methods never fail, they just return nonsense if there's a fatal error. This removes all the branches implicit in `?`.

Currently does not work correctly. `RadixUIAdoptionSection.jsx`, `pdf.mjs` and `antd.js` are parsed correctly, but `checker.ts` and `cal.com.tsx` both go into an infinite loop.

In this PR, I have disabled all benchmarks except the 3 working parser benchmarks.

Locally (MacBook Air M3), I'm seeing 6% - 8% speed-up on the 3 files which work.

@Boshen The substantive changes are in `oxc_parser/src/lib.rs` and `oxc_parser/src/cursor.rs`. All the rest of the diff is just making parse methods return `T` instead of `Result<T>` and adapting the calling code accordingly.
