### PR TITLE
fix(ast/estree): Fix `ObjectProperty` node

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -379,7 +379,7 @@ pub enum ObjectPropertyKind<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "Property", field_order(span, method, shorthand, computed, key, value, kind))]
+#[estree(rename = "Property", add_fields(optional = TsFalse), field_order(span, optional, method, shorthand, computed, key, value, kind))]
 pub struct ObjectProperty<'a> {
     pub span: Span,
     pub kind: PropertyKind,

--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -379,7 +379,11 @@ pub enum ObjectPropertyKind<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "Property", add_fields(optional = TsFalse), field_order(span, optional, method, shorthand, computed, key, value, kind))]
+#[estree(
+    rename = "Property",
+    add_fields(optional = TsFalse),
+    field_order(span, method, shorthand, computed, key, value, kind, optional),
+)]
 pub struct ObjectProperty<'a> {
     pub span: Span,
     pub kind: PropertyKind,

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -238,13 +238,13 @@ impl ESTree for ObjectProperty<'_> {
         state.serialize_field("type", &JsonSafeString("Property"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_ts_field("optional", &crate::serialize::TsFalse(self));
         state.serialize_field("method", &self.method);
         state.serialize_field("shorthand", &self.shorthand);
         state.serialize_field("computed", &self.computed);
         state.serialize_field("key", &self.key);
         state.serialize_field("value", &self.value);
         state.serialize_field("kind", &self.kind);
+        state.serialize_ts_field("optional", &crate::serialize::TsFalse(self));
         state.end();
     }
 }

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -238,6 +238,7 @@ impl ESTree for ObjectProperty<'_> {
         state.serialize_field("type", &JsonSafeString("Property"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
+        state.serialize_ts_field("optional", &crate::serialize::TsFalse(self));
         state.serialize_field("method", &self.method);
         state.serialize_field("shorthand", &self.shorthand);
         state.serialize_field("computed", &self.computed);

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -127,13 +127,13 @@ function deserializeObjectProperty(pos) {
     type: 'Property',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    optional: false,
     method: deserializeBool(pos + 48),
     shorthand: deserializeBool(pos + 49),
     computed: deserializeBool(pos + 50),
     key: deserializePropertyKey(pos + 16),
     value: deserializeExpression(pos + 32),
     kind: deserializePropertyKind(pos + 8),
+    optional: false,
   };
 }
 

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -127,6 +127,7 @@ function deserializeObjectProperty(pos) {
     type: 'Property',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
+    optional: false,
     method: deserializeBool(pos + 48),
     shorthand: deserializeBool(pos + 49),
     computed: deserializeBool(pos + 50),

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -100,13 +100,13 @@ export type ObjectPropertyKind = ObjectProperty | SpreadElement;
 
 export interface ObjectProperty extends Span {
   type: 'Property';
-  optional?: false;
   method: boolean;
   shorthand: boolean;
   computed: boolean;
   key: PropertyKey;
   value: Expression;
   kind: PropertyKind;
+  optional?: false;
 }
 
 export type PropertyKey = IdentifierName | PrivateIdentifier | Expression;

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -100,6 +100,7 @@ export type ObjectPropertyKind = ObjectProperty | SpreadElement;
 
 export interface ObjectProperty extends Span {
   type: 'Property';
+  optional?: false;
   method: boolean;
   shorthand: boolean;
   computed: boolean;

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -2,7 +2,7 @@ commit: 15392346
 
 estree_typescript Summary:
 AST Parsed     : 10623/10725 (99.05%)
-Positive Passed: 4547/10725 (42.40%)
+Positive Passed: 5318/10725 (49.59%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APISample_Watch.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APISample_WatchWithDefaults.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APISample_WatchWithOwnWatchHost.ts
@@ -28,9 +28,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorInferredReturnT
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorWithRestParam.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasOfGenericFunctionWithRestBehavedSameAsUnaliased.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasOnMergedModuleInterface.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInGenericFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInObjectLiteral.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInOrExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsedAsNameValue.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasesInSystemModule1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasesInSystemModule2.ts
@@ -84,129 +81,60 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/amdModuleName1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonClassDeclarationEmitIsAnon.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonymousClassDeclarationDoesntPrintWithReadonly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonymousClassExpression2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyAndUnknownHaveFalsyComponents.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyMappedTypesError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsAsPropertyName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsAsPropertyName2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsSpreadRestIterables.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsUsedInClassFieldInitializerOrStaticInitializationBlock.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsUsedInObjectLiteralProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arityErrorRelatedSpanBindingPattern.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayBestCommonTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayBindingPatternOmittedExpressions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayCast.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayConcat3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayConcatMap.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayDestructuringInSwitch1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayDestructuringInSwitch2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFilter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFind.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFrom.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/arrayFromAsync.ts
 `await` is only allowed within async functions and at the top levels of modules
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralInNonVarArgParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralTypeInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayOfExportedClass.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/arraySigChecking.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayToLocaleStringES2015.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayToLocaleStringES2020.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayToLocaleStringES5.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionErrorSpan.ts
 Line terminator not permitted before arrow
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionParsingDoesNotConfuseParenthesizedObjectForArrowHead.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionParsingGenericInObject.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionWithObjectLiteralBody5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrowFunctionWithObjectLiteralBody6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asiAmbientFunctionDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asiBreak.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asiContinue.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/asiInES6Classes.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/asiReturn.ts
 A 'return' statement can only be used within a function body.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assertionFunctionWildcardImport1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assertionFunctionsCanNarrowByDiscriminant.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assign1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignToEnum.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignToExistingClass.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignToFn.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/assignToInvalidLHS.ts
 Cannot assign to this expression
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompat1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatBug2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatBug3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatBug5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatForEnums.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatFunctionsWithOptionalArgs.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability11.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability13.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability14.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability15.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability16.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability17.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability18.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability19.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability20.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability21.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability22.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability23.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability24.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability25.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability26.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability27.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability28.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability29.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability30.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability31.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability32.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability33.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability34.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability35.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability36.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability37.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability38.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability39.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability40.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability41.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability42.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability43.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability46.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability_checking-apply-member-off-of-function-interface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability_checking-call-member-off-of-function-interface.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentIndexedToPrimitives.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentNestedInLiterals.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentNonObjectTypeConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentRestElementWithErrorSourceType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentToAnyArrayRestParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentToExpandingArrayType.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/assignmentToInstantiationExpression.ts
 The left-hand side of an assignment expression must be a variable or a property access.
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentToObject.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentToObjectAndFunction.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/assignmentToParenthesizedExpression1.ts
 Cannot assign to this expression
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentToReferenceTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncArrowInClassES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionReturnExpressionErrorSpans.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionReturnType.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionTempVariableScoping.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionsAcrossFiles.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionsAndStrictNullChecks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncIteratorExtraParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncYieldStarContextualType.ts
@@ -234,7 +162,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentedTypesModules4.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentedTypesVar.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/autoAsiForStaticsInClassDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/autoTypeAssignedUsingDestructuringFromNeverNoCrash.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/autolift3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/autolift4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/autonumberingInEnums.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/avoidCycleWithVoidExpressionReturnedFromArrow.ts
@@ -258,7 +185,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseConstraintOfDecorat
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseExpressionTypeParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseTypeAfterDerivedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bestChoiceType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/bestCommonTypeWithContextualTyping.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigintWithLib.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigintWithoutLib.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/binaryArithmeticControlFlowGraphNotTooLarge.ts
@@ -277,18 +203,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedEnumVariable
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedEnumVariablesUseBeforeDef_verbatimModuleSyntax.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedFunctionDeclarationInStrictModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedNamespaceDifferentFile.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedVariablesUseBeforeDef.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bluebirdStaticThis.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bom-utf8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/booleanFilterAnyArray.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/booleanLiteralsContextuallyTypedFromUnion.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakTarget1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakTarget2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakTarget3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakTarget4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakTarget5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/breakTarget6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/builtinIterator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedContextualTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution2.ts
@@ -298,7 +220,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution5
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callOfConditionalTypeWithConcreteBranches.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callsOnComplexSignatures.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cannotIndexGenericWritingError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/captureThisInSuperCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop1_ES6.ts
@@ -317,10 +238,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop8
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop9_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedParametersInInitializers1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedShorthandPropertyAssignmentNoCheck.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/castExpressionParentheses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/castParentheses.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/castTest.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cf.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedAssignment1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/chainedAssignmentChecking.ts
@@ -373,16 +291,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclaredBeforeClas
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionNames.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/classExpressionPropertyModifiers.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionTest1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionTest2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionWithResolutionOfNamespaceOfSameName01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionWithStaticProperties2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionWithStaticPropertiesES62.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendingAbstractClassWithMemberCalledTheSameAsItsOwnTypeParam.ts
 tasks/coverage/typescript/tests/cases/compiler/classExtendingAny.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsAcrossFiles.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsNull.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsNull2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFieldSuperAccessible.ts
@@ -405,22 +318,18 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/classSideInheritance3.t
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classStaticInitializersUsePropertiesBeforeDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classStaticPropertyTypeGuard.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classTypeParametersInStatics.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classUsedBeforeInitializedVariables.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classVarianceCircularity.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classVarianceResolveCircularity1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classVarianceResolveCircularity2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classdecl.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/clinterfaces.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleGenericOnSelfMember.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleTest1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleWithPriorInstantiatedModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cloduleWithPriorUninstantiatedModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/clodulesDerivedClasses.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/coAndContraVariantInferences8.ts
@@ -453,19 +362,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterF
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterInType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterInterfaceMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterUnderscoreIUsage.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalFunctionInProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndLocalVarInProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionSuperAndPropertyNameAsConstuctorParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndEnumInGlobal.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInAccessors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInConstructor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInLambda.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInMethod.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndLocalVarInProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/collisionThisExpressionAndPropertyNameAsConstuctorParameter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commaOperatorInConditionalExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commaOperatorLeftSideUnused.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentEmitAtEndOfFile1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentEmitOnParenthesizedAssertionInReturnStatement.ts
@@ -511,12 +410,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentWithUnreasonable
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsAfterCaseClauses1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsAfterCaseClauses2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsAfterCaseClauses3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsAfterFunctionExpression1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsAfterSpread.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsArgumentsOfCallExpression1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsArgumentsOfCallExpression2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsAtEndOfFile1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsBeforeFunctionExpression1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsBeforeVariableStatement1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsClassMembers.ts
@@ -533,14 +430,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsMultiModuleMultiFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsMultiModuleSingleFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnJSXExpressionsArePreserved.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnObjectLiteral2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnObjectLiteral3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnObjectLiteral4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnObjectLiteral5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnPropertyOfObjectLiteral1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOnRequireStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsOverloads.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsPropertySignature1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsVarDecl.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsVariableStatement1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsdoNotEmitComments.ts
@@ -555,7 +447,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/complexClassRelationshi
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/complexNarrowingWithAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/complexRecursiveCollections.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/complicatedIndexedAccessKeyofReliesOnKeyofNeverUpperBound.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/complicatedIndexesOfIntersectionsAreInferencable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/complicatedPrivacy.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/compositeContextualSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/compositeGenericFunction.ts
@@ -572,9 +463,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertyNameWit
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedTypesKeyofNoIndexSignatureType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/computerPropertiesInES5ShouldBeTransformed.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/concatClassAndString.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalEqualityOnLiteralObjects.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalEqualityTestingNullability.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalExpressions2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeAnyUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeAssignabilityWhenDeferred.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeBasedContextualTypeReturnTypeWidening.ts
@@ -637,11 +526,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintOfRecursively
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintReferencingTypeParameterFromSameTypeParameterList.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintWithIndexedAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorArgs.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorAsType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorParametersInVariableDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorReturningAPrimitive.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorStaticParamName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorWithParameterPropertiesAndPrivateFields.es2015.ts
@@ -655,9 +542,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualOverloadListF
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualOverloadListFromUnionWithPrimitiveNoImplicitAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualPropertyOfGenericFilteringMappedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualPropertyOfGenericMappedType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualReturnTypeOfIIFE.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualReturnTypeOfIIFE2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualReturnTypeOfIIFE3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSigInstantiationRestParams.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureConditionalTypeInstantiationUsingDefault.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInArrayElementLibEs2015.ts
@@ -665,60 +549,28 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInAr
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInObjectFreeze.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstantiation2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstantiation4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignature_objectLiteralMethodMayReturnNever.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTupleTypeParameterReadonly.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeAppliedToVarArgs.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeArrayReturnType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeBasedOnIntersectionWithAnyInTheMix1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeBasedOnIntersectionWithAnyInTheMix2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeBasedOnIntersectionWithAnyInTheMix3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeBasedOnIntersectionWithAnyInTheMix4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeBasedOnIntersectionWithAnyInTheMix5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeCaching.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeForInitalizedVariablesFiltersUndefined.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeFunctionObjectPropertyIntersection.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeIterableUnions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeLogicalOr.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeObjectSpreadExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeOfIndexedAccessParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeSelfReferencing.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeShouldBeLiteral.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypesNegatedTypeLikeConstraintInGenericMappedType1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypesNegatedTypeLikeConstraintInGenericMappedType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypesNegatedTypeLikeConstraintInGenericMappedType3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping16.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping17.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping18.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping19.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping20.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping21.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping34.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping35.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping36.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping37.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingArrayDestructuringWithDefaults.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingFunctionReturningFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfAccessors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfObjectLiterals.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfObjectLiterals2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfOptionalMembers.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfTooShortOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingWithGenericAndNonGenericSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingWithGenericSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypeAsyncFunctionReturnTypeFromUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypeGeneratorReturnTypeFromUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedBooleanLiterals.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedByDiscriminableUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedGenericAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedJsxAttribute2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedJsxChildren.tsx
@@ -729,8 +581,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParame
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParametersWithInitializers4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedParametersWithQuestionToken.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedSymbolNamedProperties.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingOrOperator.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingOrOperator2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextuallyTypingRestParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/continueLabel.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/continueNotInIterationStatement4.ts
@@ -745,7 +595,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/contravariantInferenceA
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contravariantOnlyInferenceFromAnnotatedFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contravariantOnlyInferenceWithAnnotatedOptionalParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowAliasedDiscriminants.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowArrays.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowAutoAccessor1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowBreakContinueWithLabel.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowCaching.ts
@@ -753,7 +602,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowDestructurin
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowDestructuringParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowDestructuringVariablesInTryCatch.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowFavorAssertedTypeThroughTypePredicate.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowForIndexSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowForStatementContinueIntoIncrementor1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowInitializedDestructuringVariables.ts
 tasks/coverage/typescript/tests/cases/compiler/controlFlowInstanceof.ts
@@ -769,7 +617,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowPropertyInit
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowSelfReferentialLoop.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowUnionContainingTypeParameter1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowWithIncompleteTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/convertClassExpressionToFunctionFromObjectProperty2.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/convertKeywordsYes.ts
 Classes can't have a field named 'constructor'
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/copyrightWithNewLine1.ts
@@ -804,16 +651,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileGenericType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileImportChainInExportAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileImportModuleWithExportAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileMethods.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileModuleAssignmentInObjectLiteralProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileModuleContinuation.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileObjectLiteralWithAccessors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileObjectLiteralWithOnlyGetter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileObjectLiteralWithOnlySetter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileRegressionTests.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileRestParametersOfFunctionAndFunctionType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationBuiltInType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationTypeLiteral.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeAnnotationVisibilityErrorTypeLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileTypeofInAnonymousType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileWithClassNameConflictingWithClassReferredByExtendsClause.ts
@@ -823,8 +665,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileWithExtendsClau
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declInput.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declInput3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationAssertionNodeNotReusedWhenTypeNotEquivalent1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAliasFromIndirectFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAmdModuleDefault.ts
@@ -890,11 +730,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDetached
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDistributiveConditionalWithInfer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitDuplicateParameterDestructuring.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitEnumReadonlyProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitEnumReferenceViaImportEquals.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExactOptionalPropertyTypesNodeNotReused.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpandoWithGenericConstraint.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExportAliasVisibiilityMarking.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExportAssignedNamespaceNoTripleSlashTypesReference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitExpressionInExtends7.ts
@@ -967,7 +805,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitParamete
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPathMappingMonorepo2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrefersPathKindBasedOnBundling.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrefersPathKindBasedOnBundling2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPreserveReferencedImports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPreservesHasNoDefaultLibDirective.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrivateAsync.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrivateNameCausesError.ts
@@ -977,12 +814,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPromise.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPropertyNumericStringKey.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitProtectedMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitQualifiedAliasTypeArgument.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitReadonlyComputedProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitRecursiveConditionalAliasPreserved.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitReexportedSymlinkReference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitReexportedSymlinkReference2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitReexportedSymlinkReference3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitResolveTypesIfNotReusable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitRetainedAnnotationRetainsImportInOutput.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitRetainsJsdocyComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitScopeConsistency3.ts
@@ -994,7 +829,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitSymlinkP
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitToDeclarationDirWithCompositeOption.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitToDeclarationDirWithDeclarationOption.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitToDeclarationDirWithoutCompositeAndDeclarationOptions.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTopLevelNodeFromCrossFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTopLevelNodeFromCrossFile2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTransitiveImportOfHtmlDeclarationItem.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTripleSlashReferenceAmbientModule.ts
@@ -1031,19 +865,13 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFileNoCrashO
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFilesGeneratingTypeReferences.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFilesWithTypeReferences3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFilesWithTypeReferences4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFunctionTypeNonlocalShouldNotBeAnError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationImportTypeAliasInferredAndEmittable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationMaps.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationMapsMultifile.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationMapsOutFile.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationMapsOutFile2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationMapsWithSourceMap.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationMapsWithoutDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationNoDanglingGenerics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationQuotedMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationTypecheckNoUseBeforeReferenceCheck.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationsForFileShadowingGlobalNoError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationsForIndirectTypeAliasReference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationsForInferredTypeFromOtherFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationsIndirectGeneratedAliasReference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationsWithRecursiveInternalTypesProduceUniqueTypeParams.ts
@@ -1070,11 +898,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorReferenceOnOth
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorReferences.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deduplicateImportsInSystem.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deepComparisons.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/deepElaborationsIntoArrowExpressions.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/deepExcessPropertyCheckingWhenTargetIsIntersection.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deepKeysIndexing.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedAssignabilityErrorsCombined.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedAssignabilityIssue.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedCheck.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedMappedTypes.ts
@@ -1082,8 +906,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/deeplyNestedTemplateLit
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultDeclarationEmitDefaultImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultDeclarationEmitNamedCorrectly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultDeclarationEmitShadowedNamedCorrectly.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultIndexProps1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultIndexProps2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultIsNotVisibleInLocalScope.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultNamedExportWithType1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/defaultNamedExportWithType2.ts
@@ -1103,8 +925,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/deferredLookupTypeResol
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/definiteAssignmentOfDestructuredVariable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deleteExpressionMustBeOptional.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/deleteExpressionMustBeOptional_exactOptionalPropertyTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/deleteReadonly.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/derivedClassConstructorWithExplicitReturns01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/derivedTypeCallingBaseImplWithOptionalParams.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructureCatchClause.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructureComputedProperty.ts
@@ -1140,7 +960,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringWithNewExp
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringWithNumberLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/detachedCommentAtStartOfLambdaFunction1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/detachedCommentAtStartOfLambdaFunction2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/didYouMeanElaborationsForExpressionsWhichCouldBeCalled.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminableUnionWithIntersectedMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantElementAccessCheck.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantNarrowingCouldBeCircular.ts
@@ -1150,12 +969,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantUsingEvalua
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantsAndNullOrUndefined.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantsAndPrimitives.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminantsAndTypePredicates.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminateObjectTypesOnly.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminateWithMissingProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminateWithOptionalProperty2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminateWithOptionalProperty3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminateWithOptionalProperty4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminatedUnionErrorMessage.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminatedUnionJsxElement.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminatedUnionWithIndexSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/discriminatingUnionWithUnionPropertyAgainstUndefinedWithoutStrictNullChecks.ts
@@ -1176,7 +992,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotEmitPinnedDetached
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotEmitTripleSlashCommentsInEmptyFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotEmitTripleSlashCommentsOnNotEmittedNode.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotInferUnrelatedTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotWidenAtObjectLiteralPropertyAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotemitTripleSlashComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doWhileUnreachableCode.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doYouNeedToChangeYourTargetLibraryES2015.ts
@@ -1187,7 +1002,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/dottedNamesInSystem.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doubleMixinConditionalTypeBaseClassWorks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreEnumEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreLabels.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/doubleUnderscoreMappedTypes.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst11.ts
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst12.ts
@@ -1195,7 +1009,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst14.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst15.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst16.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst18.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst2.ts
 Missing initializer in const declaration
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/downlevelLetConst4.ts
@@ -1206,13 +1019,10 @@ tasks/coverage/typescript/tests/cases/compiler/dtsEmitTripleSlashAvoidUnnecessar
 Unexpected estree file content error: 2 != 3
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateDefaultExport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateErrorAssignability.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateErrorClassExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateErrorNameNotFound.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierBindingElementInParameterDeclaration1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierBindingElementInParameterDeclaration2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierDifferentModifiers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierDifferentSpelling.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierRelatedSpans6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierRelatedSpans7.ts
@@ -1224,15 +1034,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateLabel4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateLocalVariable1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateLocalVariable2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateLocalVariable4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateObjectLiteralProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateObjectLiteralProperty_computedName1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateObjectLiteralProperty_computedName2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateObjectLiteralProperty_computedName3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateObjectLiteralProperty_computedNameNegative1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_packageIdIncludesSubModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_referenceTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_subModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicatePropertiesInStrictMode.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateStringNamedProperty1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateSymbolsExportMatching.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateVarAndImport.ts
@@ -1270,7 +1077,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitDecoratorMetadata_r
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitHelpersWithLocalCollisions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitMemberAccessExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitMethodCalledNew.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitOneLineVariableDeclarationRemoveCommentsFalse.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitPinnedCommentsOnTopOfFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitPreComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSkipsThisWithRestParameter.ts
@@ -1280,7 +1086,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSuperCallBeforeEmit
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSuperCallBeforeEmitPropertyDeclaration1ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSuperCallBeforeEmitPropertyDeclarationAndParameterPropertyDeclaration1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSuperCallBeforeEmitPropertyDeclarationAndParameterPropertyDeclaration1ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitThisInObjectLiteralGetter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitTopOfFileTripleSlashCommentOnNotEmittedNodeIfRemoveCommentsIsFalse.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyArrayDestructuringExpressionVisitedByTransformer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyEnum.ts
@@ -1340,32 +1145,23 @@ Unexpected estree file content error: 1 != 4
 tasks/coverage/typescript/tests/cases/compiler/erasableSyntaxOnlyDeclaration.ts
 Unexpected estree file content error: 1 != 5
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorCause.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorConstructorSubtypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorElaboration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorElaborationDivesIntoApparentlyPresentPropsOnly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorForBareSpecifierWithImplicitModuleResolutionNone.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorForConflictingExportEqualsValue.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorForUsingPropertyOfTypeAsType03.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorForwardReferenceForwadingConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessageOnIntersectionsWithDiscriminants01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessagesIntersectionTypes01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessagesIntersectionTypes02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorOnEnumReferenceInCondition.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorOnUnionVsObjectShouldDeeplyDisambiguate.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorOnUnionVsObjectShouldDeeplyDisambiguate2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorsOnUnionsOfOverlappingObjects01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorsWithInvokablesInUnions01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es2015modulekind.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es2015modulekindWithES6Target.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es2018ObjectAssign.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionDoStatements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionForOfStatements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionLongObjectLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionNestedLoops.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionObjectLiterals.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-asyncFunctionWhileStatements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-commonjs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5-commonjs2.ts
@@ -1398,7 +1194,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5ModuleInternalNamedI
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5ModuleWithModuleGenAmd.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5ModuleWithModuleGenCommonjs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5ModuleWithoutModuleGenTarget.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5SetterparameterDestructuringNotElided.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es5andes6module.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6-umd2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ClassTest.ts
@@ -1469,34 +1264,25 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/evalOrArgumentsInDeclar
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/eventEmitterPatternWithRecordOfFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/evolvingArrayTypeInAssert.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exactSpellingSuggestion.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertiesInOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckIntersectionWithIndexSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckIntersectionWithRecursiveType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckWithEmptyObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckWithMultipleDiscriminants.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckWithNestedArrayIntersection.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckWithSpread.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckWithUnions.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyCheckingIntersectionWithConditional.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyChecksWithNestedIntersections.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyErrorForFunctionTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessPropertyErrorsSuppressed.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/excessivelyLargeTupleSpread.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exhaustiveSwitchCheckCircularity.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exhaustiveSwitchWithWideningLiteralTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionBlockShadowing.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionContextualTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionContextualTypesJSDocInTs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionContextualTypesNoValue.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionExpressionsWithDynamicNames.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionNestedAssigments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionNestedAssigmentsDeclared.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionNullishProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionSymbolProperty.ts
 tasks/coverage/typescript/tests/cases/compiler/expandoFunctionSymbolPropertyJs.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/explicitAnyAfterSpreadNoImplicitAnyError.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/exportAlreadySeen.ts
 'export' modifier cannot be used here.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportArrayBindingPattern.ts
@@ -1568,14 +1354,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsAmd.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsClassNoRedeclarationError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsClassRedeclarationError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsCommonJs.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsDefaultProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsProperty2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportEqualsUmd.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportImportAndClodule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportImportCanSubstituteConstEnumForValue.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportImportNonInstantiatedModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportImportNonInstantiatedModule2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportInterfaceClassAndValue.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportInterfaceClassAndValueWithDuplicatesInImportList.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportNamespaceDeclarationRetainsVisibility.ts
@@ -1598,7 +1381,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/expressionWithJS
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/expressionsForbiddenInParameterInitializers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendBaseClassBeforeItsDeclared.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendingClassFromAliasAndUsageInIndexer.ts
 tasks/coverage/typescript/tests/cases/compiler/extendsUntypedModule.ts
 Unexpected estree file content error: 1 != 3
 
@@ -1620,8 +1402,6 @@ serde_json::from_str(oxc_json) error: number out of range at line 41 column 29
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fallbackToBindingPatternForTypeInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fatArrowSelf.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/fatarrowfunctions.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/fatarrowfunctionsInFunctions.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors1.ts
 A rest parameter cannot be optional
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors4.ts
@@ -1638,12 +1418,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/forLoopWithDestructurin
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forOfTransformsExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forwardRefInEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forwardRefInTypeDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/freshLiteralInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/freshLiteralTypesInIntersections.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/funcdecl.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionAndInterfaceWithSeparateErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionArgShadowing.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall14.ts
@@ -1654,27 +1432,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCall18.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionCallOnConstrainedTypeVariable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionDeclarationWithResolutionOfTypeNamedArguments01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionDeclarationWithResolutionOfTypeOfSameName01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionExpressionShadowedByParams.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionExpressionWithResolutionOfTypeNamedArguments01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionExpressionWithResolutionOfTypeOfSameName01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionExpressionWithResolutionOfTypeOfSameName02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionInIfStatementInModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionLikeInParameterInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionMergedWithModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads14.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads17.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads18.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads19.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads22.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads35.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads36.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads38.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads39.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads40.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads42.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads43.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads44.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads45.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloadsOnGenericArity1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloadsRecursiveGenericReturnType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionReturnTypeQuery.ts
@@ -1683,20 +1446,15 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionSubtypingOfVarA
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionTypeArgumentArityErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithAnyReturnTypeAndNoReturnExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionsWithImplicitReturnTypeAssignableToUndefined.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fuzzy.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorES6InAMDModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorES6_4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArray1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArrayExtenstions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArrayMethods1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericAssignmentCompatWithInterfaces1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallInferenceConditionalType1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallInferenceConditionalType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallInferenceWithGenericLocalFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallOnMemberReturningClosedOverObject.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallWithObjectLiteralArguments1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallWithinOwnBodyCastTypeParameterIdentity.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassImplementingGenericInterfaceFromAnotherModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassPropertyInheritanceSpecialization.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassWithStaticFactory.ts
@@ -1708,7 +1466,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraint2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraintDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraintSatisfaction1.ts
 tasks/coverage/typescript/tests/cases/compiler/genericDefaultsJs.ts
 Unexpected estree file content error: 1 != 2
 
@@ -1726,7 +1483,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInterfaceFunctio
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericIsNeverEmptyObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericMappedTypeAsClause.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericMemberFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericObjectLitReturnType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericObjectSpreadResultInSwitch.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericRecursiveImplicitConstructorErrors1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericRecursiveImplicitConstructorErrors2.ts
@@ -1744,15 +1500,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeWithMultiple
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithCallSignatures1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithIndexerOfTypeParameterType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericsAndHigherOrderFunctions.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericsWithDuplicateTypeParameters1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericsWithoutTypeParameters1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/getParameterNameAtPosition.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/getSetEnumerable.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/getsetReturnTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/getterSetterNonAccessor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/gettersAndSetters.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/gettersAndSettersTypesAgree.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalIsContextualKeyword.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalThisCapture.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/higherOrderMappedIndexLookupInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/homomorphicMappedTypeNesting.ts
@@ -1767,7 +1516,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/ifStatementInternalComm
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ignoredJsxAttributes.tsx
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/illegalModifiersOnClassElements.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/illegalSuperCallsInConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementArrayInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementGenericWithMismatchedTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareFunctionExprWithoutFormalType.ts
@@ -1780,7 +1528,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyFromCircular
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyFunctionInvocationWithAnyArguements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyFunctionOverloadWithImplicitAnyReturnType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyFunctionReturnNullOrUndefined.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyGenericTypeInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyGetAndSetAccessorWithAnyReturnType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyInCatch.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyWidenToAny.ts
@@ -1871,16 +1618,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/importedModuleClassName
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importsInAmbientModules2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importsInAmbientModules3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inKeywordAndUnknown.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inOperatorWithFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/incompatibleTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/incorrectNumberOfTypeArgumentsDuringErrorReporting.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/incorrectRecursiveMappedTypeConstraint.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexClassByNumber.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexIntoEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexSignatureAndMappedType.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/indexSignatureMustHaveTypeAnnotation.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexSignatureOfTypeUnknownStillRequiresIndexSignature.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/indexSignatureTypeCheck.ts
 Unexpected token
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/indexSignatureTypeCheck2.ts
@@ -1892,24 +1635,19 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/indexSignatureWi
 Expected `]` but found `,`
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/indexSignatureWithoutTypeAnnotation1.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexSignaturesInferentialTyping.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/indexTypeCheck.ts
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexTypeNoSubstitutionTemplateLiteral.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/indexWithoutParamType.ts
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessAndNullableNarrowing.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessCanBeHighOrder.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessKeyofNestedSimplifiedSubstituteUnwrapped.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessNormalization.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessRelation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessRetainsIndexSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessTypeConstraints.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessWithFreshObjectLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessWithVariableElement.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexerA.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/indexerAsOptional.ts
 Unexpected token
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/indexerConstraints2.ts
@@ -1927,7 +1665,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferFromGenericFunctio
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferFromGenericFunctionReturnTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferFromGenericFunctionReturnTypes3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferFromNestedSameShapeTuple.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferObjectTypeFromStringLiteralToKeyof.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferPropertyWithContextSensitiveReturnStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferRestArgumentsMappedTuple.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferSecondaryParameter.ts
@@ -1948,21 +1685,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceOptionalProper
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceShouldFailOnEvolvingArrays.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceUnionOfObjectsMappedContextualType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingObjectLiteralMethod1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingObjectLiteralMethod2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingUsingApparentType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingUsingApparentType3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionTypeNested.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionTypeSyntacticScenarios.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithObjectLiteralProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentiallyTypingAnEmptyArray.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferredNonidentifierTypesGetQuotes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferredRestTypeFixedOnce.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferredReturnTypeIncorrectReuse1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferrenceInfiniteLoopWithSubtyping.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferringAnyFunctionType5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/infiniteConstraints.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedConstructorPropertyContextualType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedConstructorWithRestParams.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedConstructorWithRestParams2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedMembersAndIndexSignaturesFromDifferentBases.ts
@@ -1984,7 +1711,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiateContextualTy
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiateContextuallyTypedGenericThis.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiatedTypeAliasDisplay.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiationExpressionErrorNoCrash.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/interface0.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceAssignmentCompat.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceContextualType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceDeclaration3.ts
@@ -2036,9 +1762,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionApparentTyp
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionConstraintReduction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionOfMixinConstructorTypeAndNonConstructorType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionOfTypeVariableHasApparentSignatures.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionPropertyCheck.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionReductionGenericStringLikeType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionSatisfiesConstraint.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionTypeInference1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionTypeNormalization.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionType_useDefineForClassFields.ts
@@ -2048,7 +1772,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionsAndReadonl
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intraBindingPatternReferences.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidThisEmitInContextualObjectLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidTripleSlashReference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidTypeNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/invariantGenericErrorElaboration.ts
@@ -2221,7 +1944,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxCallElaborationCheck
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxCallbackWithDestructuring.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxChildWrongType.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenArrayWrongType.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenGenericContextualTypes.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenIndividualErrorElaborations.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenSingleChildConfusableWithMultipleChildrenNoError.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenWrongType.tsx
@@ -2267,19 +1989,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxSpreadFirstUnionNoEr
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxViaImport.2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxViaImport.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/keyRemappingKeyofResult.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/keyofDoesntContainSymbols.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/keyofIsLiteralContexualType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/keyofModuleObjectHasCorrectKeys.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/keyofObjectWithGlobalSymbolIncluded.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/keywordExpressionInternalComments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/keywordField.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/knockout.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/lambdaParamTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/lambdaParameterWithTupleArgsHasCorrectAssignability.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/lambdaPropSelf.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/largeControlFlowGraph.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/largeTupleTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/lastPropertyInLiteralWins.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundConstraintTypeChecksCorrectly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundDestructuringImplicitAnyError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/lateBoundFunctionMemberAssignmentDeclarations.ts
@@ -2314,8 +2031,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/library_RegExpExecArray
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/library_StringSlice.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/lift.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/limitDeepInstantiations.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/literalFreshnessPropagationOnNarrowing.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/literalIntersectionYieldsLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/literalWideningWithCompoundLikeAssignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/literals-negative.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/literalsInComputedProperties1.ts
@@ -2361,7 +2076,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeWithAsClauseA
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeWithCombinedTypeMappers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedTypeWithNameClauseAppliedToArrayType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/matchReturnTypeInAllBranches.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/matchingOfObjectLiteralConstraints.ts
 tasks/coverage/typescript/tests/cases/compiler/maxNodeModuleJsDepthDefaultsToZero.ts
 Unexpected estree file content error: 2 != 4
 
@@ -2369,12 +2083,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/maximum10SpellingSugges
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/memberAccessMustUseModuleInstances.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/memberOverride.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/memberVariableDeclarations1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergeSymbolReexportInterface.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergeSymbolReexportedTypeAliasInstantiation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergeSymbolRexportFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergeWithImportedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarationExports.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedEnumDeclarationCodeGen.ts
@@ -2470,7 +2181,6 @@ Unexpected estree file content error: 2 != 4
 tasks/coverage/typescript/tests/cases/compiler/modulePreserve4.ts
 Unexpected estree file content error: 5 != 12
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePreserve5.ts
 tasks/coverage/typescript/tests/cases/compiler/modulePreserveImportHelpers.ts
 Unexpected estree file content error: 2 != 4
 
@@ -2554,19 +2264,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleVisibilityTest1.t
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleVisibilityTest2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/module_augmentUninstantiatedModule2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduledecl.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiImportExport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiLineContextDiagnosticWithPretty.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/multiLinePropertyAccessAndArrowFunctionIndent1.ts
 A 'return' statement can only be used within a function body.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiSignatureTypeInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multipleExportAssignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multipleExports.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/multipleInferenceContexts.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multivar.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mutuallyRecursiveCallbacks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mutuallyRecursiveInterfaceDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nameCollisionsInPropertyAssignments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespaceDisambiguationInUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespaceNotMergedWithFunctionDefaultExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue2.ts
@@ -2588,22 +2293,18 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingNoInfer1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingOfDottedNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingOfQualifiedNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingOrderIndependent.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingPastLastAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingPastLastAssignmentInModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingRestGenericCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofParenthesized1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingUnionToUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingUnionWithBang.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nearbyIdenticalGenericLambdasAssignable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedExcessPropertyChecking.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedFreshLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedGenericConditionalTypeWithGenericImportType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedGenericSpreadInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedHomomorphicMappedTypesWithArrayConstraint1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedLoopTypeGuards.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedLoops.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedObjectRest.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedRecursiveArraysOrObjectsError01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedSuperCallEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedTypeVariableInfersLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/neverAsDiscriminantType.ts
@@ -2615,12 +2316,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCheckDoesNotReportErr
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCheckNoEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCheckRequiresEmitDeclarationOnly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCircularDefinitionOnExportOfPrivateInMergedNamespace.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInAccessors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInConstructor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInLambda.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInMethod.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCollisionThisExpressionAndLocalVarInProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashOnImportShadowing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashOnMixin.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashOnNoLib.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noCrashOnThisTypeUsage.ts
@@ -2666,7 +2361,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitUseStrict_com
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitUseStrict_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitUseStrict_system.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitUseStrict_umd.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noInferUnionExcessPropertyCheck1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noIterationTypeErrorsInCFA.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noObjectKeysToKeyofT.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noRepeatedPropertyNames.ts
@@ -2703,44 +2397,24 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullableAndObjectInt
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullableReduction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullableReductionNonStrict.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullableWithNullableGenericIndexedAccessArg.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonObjectUnionNestedExcessPropertyCheck.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nongenericConditionalNotPartiallyComputed.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonstrictTemplateWithNotOctalPrintsAsIs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/normalizedIntersectionTooComplex.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/null.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/numberAssignableToEnumInsideUnion.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/numberVsBigIntOperations.ts
 Missing initializer in const declaration
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericEnumMappedType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectAssignLikeNonUnionResult.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectBindingPatternContextuallyTypesArgument.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectBindingPattern_restElementWithPropertyName.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectCreate.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectCreate2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectCreationOfElementAccessExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectFreeze.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectFreezeLiteralsDontWiden.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectIndexer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectInstantiationFromUnionSpread.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLitGetterSetter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLitIndexerContextualType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLitPropertyScoping.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLitStructuralTypeMismatch.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLitTargetTypeCallSite.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteral1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteral2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralArraySpecialization.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralComputedNameNoDeclarationError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralEnumPropertyNames.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralExcessProperties.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralFreshnessWithSpread.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralFunctionArgContextualTyping.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralIndexerErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralIndexerNoImplicitAny.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralIndexers.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/objectLiteralMemberWithModifiers1.ts
 'public' modifier cannot be used here.
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/objectLiteralMemberWithModifiers2.ts
@@ -2748,29 +2422,18 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/objectLiteralMem
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/objectLiteralMemberWithQuestionMark1.ts
 Expected `,` but found `?`
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralParameterResolution.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralPropertyImplicitlyAny.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralReferencingInternalProperties.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralThisWidenedOnUse.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralWithGetAccessorInsideFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralWithNumericPropertyName.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralsAgainstUnionsOfArrays01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectRestBindingContextualInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectRestSpread.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectSpreadWithinMethodWithinObjectWithSpread.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/observableInferenceCanBeMade.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/omitTypeTestErrors01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/omitTypeTests01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/operatorAddNullUndefined.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalAccessorsInInterface1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalChainWithInstantiationExpression2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParamArgsTest.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParameterInDestructuringWithInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParameterProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParameterRetainsNull.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalPropertiesTest.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalTupleElementsAndUndefined.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionsOutAndNoModuleGen.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/out-flag.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/out-flag3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/outModuleConcatCommonjs.ts
@@ -2783,14 +2446,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadAssignmentCompa
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadGenericFunctionWithRestArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadModifiersMustAgree.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadOnConstInObjectLiteralImplementingAnInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOverNonCTLambdas.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionOverNonCTObjectLit.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadResolutionTest1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadedConstructorFixesInferencesAppropriately.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsWithComputedNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsWithConstraints.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsWithProvisionalErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overrideBaseIntersectionMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overshifts.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterDecoratorsEmitCrash.ts
@@ -2814,7 +2473,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseInvalidNullableTyp
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseReplacementCharacter.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/parserConstructorDeclaration12.ts
 Type parameters cannot appear on a constructor declaration
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/partialDiscriminatedUnionMemberHasGoodError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/partialOfLargeAPIIsAbleToBeWorkedWith.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/partiallyDiscriminantedUnions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution3_classic.ts
@@ -2904,7 +2562,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseIdentityWithAny2
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseIdentityWithConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promisePermutations2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promisePermutations3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseVoidErrorCallback.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseWithResolvers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propTypeValidatorInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccessExpressionInnerComments.ts
@@ -2940,9 +2597,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactSFCAndFunctionReso
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactTagNameComponentWithPropsNoOOM.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactTagNameComponentWithPropsNoOOM2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactTransitiveImportHasValidDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyInDeclarationFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyMembers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyPropertySubtypeRelationDirected.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyTupleAndArrayElaboration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveArrayNotCircular.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseCheck2.ts
@@ -2959,10 +2614,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignme
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveFieldSetting.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveGenericTypeHierarchy.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveInferenceBug.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveLetConst.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveMods.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveObjectLiteral.ts
 tasks/coverage/typescript/tests/cases/compiler/recursiveResolveDeclaredMembers.ts
 Unexpected estree file content error: 1 != 2
 
@@ -3001,10 +2653,8 @@ Unexpected estree file content error: 1 != 3
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireEmitSemicolon.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfAnEmptyFile1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/requireOfJsonFileWithoutExtensionResolvesToTs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requiredInitializedParameter1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/requiredMappedTypeModifierTrumpsVariance.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reservedWords.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/resolveInterfaceNameWithSameLetDeclarationName1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/resolveInterfaceNameWithSameLetDeclarationName2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/resolveModuleNameWithSameLetDeclarationName1.ts
@@ -3037,7 +2687,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/restTypeRetainsMappynes
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/restUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/restUnion2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/restUnion3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnInConstructor1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypeInferenceNotTooBroad.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypePredicateIsInstantiateInContextOfTarget.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reuseInnerModuleMember.ts
@@ -3060,11 +2709,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypePrimit
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeRecursiveInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedUnionInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/satisfiesEmit.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfInLambdas.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencingFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencingFile2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencingFile3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/setMethods.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/shadowedFunctionScopedVariablesByBlockScopedOnes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/shadowedReservedCompilerDeclarationsWithNoEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/shadowingViaLocalValueOrBindingElement.ts
@@ -3075,12 +2722,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/shorthand-property-es6-
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/shorthand-property-es6-es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/shorthandOfExportedEntity01_targetES2015_CommonJS.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/shorthandOfExportedEntity02_targetES5_CommonJS.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/shorthandPropertyAssignmentInES6Module.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/shorthandPropertyAssignmentsInDestructuring.ts
 Invalid assignment in object literal
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/shorthandPropertyAssignmentsInDestructuring_ES6.ts
 Invalid assignment in object literal
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/shorthandPropertyUndefined.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/shouldNotPrintNullEscapesIntoOctalLiterals.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sideEffectImports1.ts
 tasks/coverage/typescript/tests/cases/compiler/sideEffectImports2.ts
@@ -3097,9 +2742,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureCombiningRestP
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureInstantiationWithRecursiveConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/signatureOverloadsWithComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/silentNeverPropagation.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/simpleArrowFunctionParameterReferencedInObjectLiteral1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/simplifyingConditionalWithInteriorConditionalIsRelated.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/slightlyIndirectedDeepObjectLiteralElaborations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-Comment1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-Comments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-FileWithComments.ts
@@ -3155,11 +2798,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDest
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationEnums.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationExportAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationExportAssignmentCommonjs.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationFunctionPropertyAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationFunctions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationLabeled.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationStatements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapWithCaseSensitiveFileNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapWithCaseSensitiveFileNamesAndOutDir.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapWithMultipleFilesWithCopyright.ts
@@ -3168,27 +2809,19 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapWithNonCaseSen
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/specedNoStackBlown.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/specialIntersectionsInMappedTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializeVarArgs1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializedInheritedConstructors1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializedOverloadWithRestParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionGlobal1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionGlobal2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionGlobal3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionGlobal4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionJSXAttribute.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spellingSuggestionLeadingUnderscores01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadExpressionContainingObjectExpressionContextualType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadExpressionContextualType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadExpressionContextualTypeWithNamespace.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadIdenticalTypesRemoved.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadIntersection.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadInvalidArgumentType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadObjectNoCircular1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadObjectWithIndexDoesNotAddUndefinedToLocalIndex.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadOfObjectLiteralAssignableToIndexSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadOfParamsFromGeneratorMakesRequiredParams.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadParameterTupleType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadTupleAccessedByTypeParameter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/spreadTypeRemovesReadonly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spuriousCircularityOnTypeImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/spyComparisonChecking.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stackDepthLimitCastingType.ts
@@ -3222,14 +2855,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictNullNotNullIndexT
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictOptionalProperties1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictOptionalProperties2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictSubtypeAndNarrowing.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringLiteralObjectLiteralDeclaration1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringLiteralPropertyNameWithLineContinuation1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringMappingAssignability.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringMatchAll.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringPropCodeGen.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringRawType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stripMembersOptionality.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/structural1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/styleOptions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/styledComponentsInstantiaionLimitNotReached.ts
 tasks/coverage/typescript/tests/cases/compiler/subclassThisTypeAssignable01.ts
@@ -3249,21 +2877,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatD
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesFromGenericTypeButWithNoTypeArguments1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatDerivesNonGenericTypeButWithTypeArguments1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatHasNoBaseType1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallInNonStaticMethod.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallInStaticMethod.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallInsideObjectLiteralExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallWithCommentEmit01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superInObjectLiterals_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/superInObjectLiterals_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superNewCall1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/super_inside-object-literal-getters-and-setters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchCaseCircularRefeference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchCaseInternalComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/switchCaseNarrowsMatchingClausesEvenWhenNonMatchingClausesExist.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/symbolLinkDeclarationEmitModuleNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/symbolLinkDeclarationEmitModuleNamesImportRef.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/symbolLinkDeclarationEmitModuleNamesRootDir.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/symbolObserverMismatchingPolyfillsWorkTogether.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/symlinkedWorkspaceDependenciesNoDirectLinkGeneratesDeepNonrelativeName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/symlinkedWorkspaceDependenciesNoDirectLinkGeneratesNonrelativeName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/symlinkedWorkspaceDependenciesNoDirectLinkOptionalGeneratesNonrelativeName.ts
@@ -3298,7 +2919,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModuleNonTopLevel
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModuleTargetES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModuleTrailingComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemNamespaceAliasEmit.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemObjectShorthandRename.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplateStringWithSymbolExpression01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplateStringsHexadecimalEscapes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplateStringsHexadecimalEscapesES6.ts
@@ -3313,9 +2933,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplateWithoutDe
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplatesInDifferentScopes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplatesInModuleAndGlobal.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tailRecursiveConditionalTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypeObjectLiteral.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypeObjectLiteralToAny.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypeTest1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypeTest2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypeTest3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateExpressionAsPossiblyDiscriminantValue.ts
@@ -3332,21 +2949,17 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateStringsArrayTyp
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateStringsArrayTypeNotDefinedES5Mode.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateStringsArrayTypeRedefinedInES6Mode.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/testContainerList.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisBinding.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisBinding2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisConditionalOnMethodReturnOfGenericInstance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInAccessors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInClassBodyStaticESNext.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInConstructorParameter2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInGenericStaticMembers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInPropertyBoundDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInSuperCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInSuperCall1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInTupleTypeParameterConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInTypeQuery.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisPredicateInObjectLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/this_inside-enum-should-not-be-allowed.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/this_inside-object-literal-getters-and-setters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/topFunctionTypeNotCallable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevel.ts
 tasks/coverage/typescript/tests/cases/compiler/topLevelBlockExpando.ts
@@ -3355,18 +2968,14 @@ Unexpected estree file content error: 1 != 2
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevelExports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/topLevelLambda4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/trackedSymbolsNoCrash.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/trailingCommasES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/transformArrowInBlockScopedLoopVarInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/transformNestedGeneratorsWithTry.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/transformParenthesizesConditionalSubexpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tripleSlashInCommentNotParsed.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tripleSlashReferenceAbsoluteWindowsPath.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tripleSlashTypesReferenceWithMissingExports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/trivialSubtypeReductionNoStructuralCheck.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/trivialSubtypeReductionNoStructuralCheck2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tryCatchFinallyControlFlow.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tryStatementInternalComments.ts
@@ -3386,12 +2995,9 @@ Unexpected estree file content error: 1 != 3
 tasks/coverage/typescript/tests/cases/compiler/tslibReExportHelpers2.ts
 Unexpected estree file content error: 1 != 3
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxAttributeQuickinfoTypesSameAsObjectLiteral.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxAttributesHasInferrableIndex.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxDeepAttributeAssignabilityError.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxDefaultImports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxDiscriminantPropertyInference.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxInferenceShouldNotYieldAnyOnUnions.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxInvokeComponentType.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxNoTypeAnnotatedSFC.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxNotUsingApparentTypeOfSFC.tsx
@@ -3407,14 +3013,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasDeclarationEmi
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasDeclarationEmit2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasFunctionTypeSharedSymbol.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAnnotationBestCommonTypeInArrayLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgInference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgInference2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgInferenceWithNull.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentDefaultUsesConstraintOnCircularDefault.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAssertionToGenericFunctionType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAssignabilityErrorMessage.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeCheckObjectLiteralMethodBody.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeComparisonCaching.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeConstraintsWithConstructSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardConstructorClassAndNumber.ts
@@ -3427,27 +3028,21 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowByUntype
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardOnContainerTypeNoHang.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInfer1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceCacheInvalidation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceFBoundedTypeParams.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceLiteralUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceWithExcessProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInferenceWithExcessPropertiesJsx.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeInterfaceDeclarationsInBlockStatements1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeMatch2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeNamedUndefined1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeNamedUndefined2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfEnumAndVarRedeclarations.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfOnTypeArg.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfYieldWithUnionInContextualReturnType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterCompatibilityAccrossDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterConstraintInstantiation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterExtendsPrimitive.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterLeak.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePartameterConstraintInstantiatedWithDefaultWhenCheckingDefault.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicateAcceptingPartialOfRefinedType.ts
@@ -3459,10 +3054,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicateTopLevelTy
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicateWithThisParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesCanNarrowByDiscriminant.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesOptionalChaining1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives3.ts
@@ -3470,10 +3063,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeResolution.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeVal.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeVariableConstraintIntersections.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeVariableConstraintedToAliasNotAssignableToUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeVariableTypeGuards.ts
@@ -3484,11 +3075,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typedArraysCrossAssigna
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofAmbientExternalModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofImportInstantiationExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofObjectInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofThisInMethodSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofUnknownSymbol.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofUsedBeforeBlockScoped.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/umdDependencyComment2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/umdDependencyCommentName1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/umdDependencyCommentName2.ts
@@ -3497,38 +3086,28 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/umdGlobalConflict.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/umdNamedAmdMode.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/umdNamespaceMergedWithGlobalAugmentationIsNotCircular.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unaryPlus.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/uncaughtCompilerError1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undeclaredModuleError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undeclaredVarEmit.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedArgumentInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedAssignableToGenericMappedIntersection.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedSymbolReferencedInArrayLiteral1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedTypeArgument2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreEscapedNameInEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreTest1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreThisInDerivedClass01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreThisInDerivedClass02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionCallMixedTypeParameterPresence.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionErrorMessageOnMatchingDiscriminant.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionExcessPropertyCheckNoApparentPropTypeMismatchErrors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionExcessPropsWithPartialMember.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionOfClassCalls.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionOfEnumInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionPropertyOfProtectedAndIntersectionProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionReductionMutualSubtypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionReductionWithStringMappingAndIdenticalBaseTypeExistsNoCrash.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionSignaturesWithThisParameter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionSubtypeReductionErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeParameterInference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeWithIndexAndMethodSignature.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeWithIndexedLiteralType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeWithLeadingOperator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionWithIndexSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/uniqueSymbolAllowsIndexInObjectWithIndexSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/uniqueSymbolPropertyDeclarationEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownLikeUnionObjectFlagsNotPropagated.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unknownPropertiesAreAssignableToObjectUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unmatchedParameterPositions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unmetTypeConstraintInImportCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unreachableDeclarations.ts
@@ -3540,7 +3119,6 @@ Unexpected estree file content error: 2 != 3
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedDestructuring.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedDestructuringParameters.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImportDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImportWithSpread.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedImports12.ts
@@ -3567,7 +3145,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters9.t
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesWithUnderscoreInBindingElement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinModules1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unwitnessedTypeParameterVariance.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_classDecorators.1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_classDecorators.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_destructuring.ts
@@ -3601,19 +3178,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidReturnIndexUnionInf
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/voidUndefinedReduction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/vueLikeDataAndPropsInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/vueLikeDataAndPropsInference2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/weakType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/webworkerIterable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/whileStatementInnerComments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/widenToAny1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/widenedTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/widenedTypes1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/withExportDecl.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/withImportDecl.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/withStatementInternalComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/yieldInForInInDownlevelGenerator.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/yieldStringLiteral.ts
 A 'yield' expression is only allowed in a generator body.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/Symbols/ES5SymbolProperty1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsExternal.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsPatterns.ts
@@ -3643,7 +3215,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es2017/
 Cannot use `await` as an identifier in an async context
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts
 Cannot use `await` as an identifier in an async context
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration8_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction11_es5.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction5_es5.ts
 Cannot use `await` as an identifier in an async context
@@ -3658,7 +3229,6 @@ Unexpected estree file content error: 1 != 2
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts
 Cannot use `await` as an identifier in an async context
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration8_es5.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction5_es6.ts
 Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncAwaitIsolatedModules_es6.ts
@@ -3672,20 +3242,17 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es6/fun
 Cannot use `await` as an identifier in an async context
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts
 Cannot use `await` as an identifier in an async context
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration8_es6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncOrYieldAsBindingIdentifier1.ts
 Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/asyncGenerators/asyncGeneratorGenericNonWrappedReturn.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/asyncGenerators/asyncGeneratorParameterEvaluation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/asyncGenerators/asyncGeneratorPromiseNextType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInstantiations1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classBody/classWithEmptyBody.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendingOptionalChain.ts
 Expected `{` but found `?.`
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/constructorFunctionTypeIsAssignableToBaseType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classWithPredefinedTypesAsNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/modifierOnClassDeclarationMemberInFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classWithStaticFieldInParameterBindingPattern.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classWithStaticFieldInParameterBindingPattern.3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classWithStaticFieldInParameterBindingPattern.ts
@@ -3694,7 +3261,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpress
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/classWithStaticFieldInParameterInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/genericClassExpressionInFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpressions/modifierOnClassExpressionMemberInFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock17.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock22.ts
 Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock24.ts
@@ -3726,7 +3292,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorD
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/superCalls/derivedClassConstructorWithoutSuperCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/superCalls/derivedClassParameterProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/superCalls/derivedClassSuperCallsWithThisArg.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/superCalls/derivedClassSuperProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/superCalls/derivedClassSuperStatementPosition.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/superCalls/emitStatementsBeforeSuperCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/superCalls/emitStatementsBeforeSuperCallWithDefineFields.ts
@@ -3825,11 +3390,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemb
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/instanceMemberInitialization.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/instanceMemberWithComputedPropertyName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/instanceMemberWithComputedPropertyName2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/accessorWithES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/accessorsAreNotContextuallyTyped.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/ambientAccessors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberAccessorDeclarations/typeOfThisInAccessor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/derivedTypeAccessesHiddenBaseCallViaSuperPropertyAccess.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyNamedConstructor.ts
 Classes can't have a field named 'constructor'
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyNamedPrototype.ts
@@ -3846,7 +3408,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemb
 tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/thisPropertyOverridesAccessors.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/twoAccessorsWithSameName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/constEnums/constEnum3.ts
@@ -3863,9 +3424,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlF
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowBinaryOrExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowBindingElement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowBindingPatternOrder.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowDeleteOperator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowDestructuringDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowElementAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowElementAccessNoCrash1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowGenericTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowInOperator.ts
@@ -3899,7 +3458,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/type
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicatesWithPrivateName01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicatesWithPrivateName02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typeReferenceRelatedFiles.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/declarationEmit/typeofImportTypeOnlyExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/1.0lib-noErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor3.ts
@@ -3988,9 +3546,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/import
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionShouldNotGetParen.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/dynamicImport/importCallExpressionWithTypeArgument.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es2015/asyncGenerators/emitter.asyncGenerators.objectLiteralMethods.es2015.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es2018/asyncGenerators/emitter.asyncGenerators.objectLiteralMethods.es2018.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/emitter/es5/asyncGenerators/emitter.asyncGenerators.objectLiteralMethods.es5.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/enums/awaitAndYield.ts
 `await` is only allowed within async functions and at the top levels of modules
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumBasics.ts
@@ -4007,9 +3562,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumMergingErr
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/enums/enumShadowedInfinityNaN.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2016/es2016IntlAPIs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useObjectValuesAndEntries1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useObjectValuesAndEntries2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useObjectValuesAndEntries3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2017/useObjectValuesAndEntries4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2018/es2018IntlAPIs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2019/allowUnescapedParagraphAndLineSeparatorsInStringLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2019/globalThisGlobalExportAsGlobal.ts
@@ -4018,13 +3570,10 @@ Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2019/importMeta/importMeta.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2019/importMeta/importMetaNarrowing.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/constructBigint.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/es2020IntlAPIs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/intlNumberFormatES2020.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/modules/exportAsNamespace3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/modules/exportAsNamespace4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/modules/exportAsNamespace_nonExistent.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2021/logicalAssignment/logicalAssignment10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2022/arbitraryModuleNamespaceIdentifiers/arbitraryModuleNamespaceIdentifiers_exportEmpty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2022/arbitraryModuleNamespaceIdentifiers/arbitraryModuleNamespaceIdentifiers_importEmpty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2022/arbitraryModuleNamespaceIdentifiers/arbitraryModuleNamespaceIdentifiers_module.ts
@@ -4032,36 +3581,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2022/es2022IntlAPI
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2022/es2024SharedMemory.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2023/intlNumberFormatES2023.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2023/intlNumberFormatES5UseGrouping.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2024/resizableArrayBuffer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2024/sharedMemory.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty18.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty19.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty20.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty21.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty22.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty28.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty29.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty30.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty31.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty32.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty33.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty34.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty36.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty52.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty53.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty54.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty55.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty56.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty57.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty58.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty60.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty61.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType19.ts
@@ -4133,7 +3653,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithGetterSetterInES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithLiteralPropertyNameInES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithMethodInES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithPropertyAccessInHeritageClause1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithPropertyAssignmentInES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithStaticPropertyAssignmentInES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/classDeclaration/emitClassDeclarationWithSuperMethodCall01.ts
@@ -4160,84 +3679,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperti
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames13_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames16_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames16_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames18_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames18_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames19_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames19_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames1_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames1_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames20_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames20_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames22_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames22_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames23_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames23_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames25_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames25_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames26_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames26_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames28_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames28_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames29_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames29_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames30_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames30_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames31_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames31_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames33_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames33_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames34_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames34_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames46_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames46_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames47_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames47_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames48_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames48_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames49_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames49_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames4_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames4_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames50_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames50_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames51_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames51_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames5_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames5_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames6_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames6_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames7_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames7_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames8_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames8_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames9_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNames9_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType10_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType10_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType1_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType1_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType2_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType2_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType3_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType3_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType4_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType4_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType5_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType5_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType6_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType6_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType7_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType7_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType8_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType8_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType9_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType9_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit5_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit5_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit6_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesDeclarationEmit6_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesSourceMap2_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/computedProperties/computedPropertyNamesSourceMap2_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/accessor/decoratorOnClassAccessor1.es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass2.es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/decorators/class/decoratorOnClass3.es6.ts
@@ -4338,20 +3787,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/destructu
 Missing initializer in destructuring declaration
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyVariableDeclarationBindingPatterns02_ES6.ts
 Missing initializer in destructuring declaration
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern14.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern15.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern16.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern17.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern18.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern19.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern20.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern21.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern22.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern23.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern24.ts
@@ -4366,7 +3809,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/it
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/nonIterableRestElement1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/nonIterableRestElement2.ts
@@ -4449,10 +3891,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/functionD
 Cannot use `yield` as an identifier in a generator context
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration5_es6.ts
 Cannot use `yield` as an identifier in a generator context
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration8_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionDeclarations/FunctionDeclaration9_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionPropertyAssignments/FunctionPropertyAssignments1_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/functionPropertyAssignments/FunctionPropertyAssignments5_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsAmd/anonymousDefaultExportsAmd.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsAmd/decoratedDefaultExportsGetExportedAmd.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/moduleExportsAmd/defaultExportsGetExportedAmd.ts
@@ -4501,10 +3939,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/multiple
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/multipleDefaultExports04.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/multipleDefaultExports05.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/modules/reExportDefaultExport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/newTarget/invalidNewTarget.es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/newTarget/invalidNewTarget.es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/newTarget/newTarget.es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/newTarget/newTarget.es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/restParameters/emitRestParametersFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/restParameters/emitRestParametersFunctionES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/restParameters/emitRestParametersFunctionExpression.ts
@@ -4514,33 +3948,17 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/restParameters/e
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/restParameters/emitRestParametersMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/restParameters/emitRestParametersMethodES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/restParameters/readonlyRestParameters.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesErrorFromNoneExistingIdentifier.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesFunctionArgument.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesFunctionArgument2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesWithModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesWithModuleES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/arraySpreadImportHelpers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/arraySpreadInCall.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInArray9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/spread/iteratorSpreadInCall5.ts
@@ -4754,7 +4172,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/variableD
 Missing initializer in const declaration
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/variableDeclarations/VariableDeclaration6_es6.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression10_es6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression12_es6.ts
 A 'yield' expression is only allowed in a generator body.
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression14_es6.ts
@@ -4768,14 +4185,8 @@ A 'yield' expression is only allowed in a generator body.
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/YieldExpression2_es6.ts
 A 'yield' expression is only allowed in a generator body.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorNoImplicitReturns.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck28.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck32.ts
 A 'yield' expression is only allowed in a generator body.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck41.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck42.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck43.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck44.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck46.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck62.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck63.ts
 tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/yieldExpressionInControlFlow.ts
@@ -4845,14 +4256,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classEx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/classSuper/esDecorators-classExpression-classSuper.5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/classSuper/esDecorators-classExpression-classSuper.6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-commentPreservation.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.14.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.17.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.6.ts
@@ -4923,10 +4331,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOp
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrExpressionIsContextuallyTyped.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrExpressionIsNotContextuallyTyped.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrOperatorWithEveryType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrOperatorWithTypeParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorOtherInvalidOperation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorOtherValidOperation.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/commaOperator/commaOperatorWithSecondOperandObjectType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorConditionIsBooleanType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorConditionIsNumberType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/conditonalOperator/conditionalOperatorConditionIsObjectType.ts
@@ -4943,7 +4349,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextu
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/getSetAccessorContextualTyping.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/iterableContextualTyping1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/objectLiteralContextualTyping.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/parenthesizedContexualTyping1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/parenthesizedContexualTyping2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/parenthesizedContexualTyping3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/contextualTyping/superCallParameterContextualTyping1.ts
@@ -4979,8 +4384,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/function
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functions/contextuallyTypedIifeStrict.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/functions/typeOfThisInFunctionExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/identifiers/scopeResolutionIdentifiers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperator12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperatorInAsyncGenerator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperatorInParameterBindingPattern.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/nullishCoalescingOperator/nullishCoalescingOperatorInParameterBindingPattern.ts
@@ -4990,7 +4393,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/o
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/objectLiterals/objectLiteralGettersAndSetters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/callChain.3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/callChain.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/callChainInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/callChainWithSuper.ts
@@ -5011,7 +4413,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/superPro
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/superPropertyAccess/superPropertyAccessNoError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/thisKeyword/thisInInvalidContexts.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/thisKeyword/thisInInvalidContextsExternalModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/thisKeyword/thisInObjectLiterals.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/thisKeyword/typeOfThisInConstructorParamList.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeAssertions/constAssertionOnEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeAssertions/constAssertions.ts
@@ -5044,25 +4445,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuar
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInRightOperandOfOrOrOperator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsObjectMethods.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsOnClassProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsWithAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOf.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typePredicateOnVariableDeclaration01.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfactionWithDefaultExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_asConstArrays.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_contextualTyping1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_contextualTyping2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_contextualTyping3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_ensureInterfaceImpl.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_errorLocations1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_optionalMemberConformance.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_propNameConstraining.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_propertyNameFulfillment.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_propertyValueConformance1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_propertyValueConformance2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_propertyValueConformance3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeSatisfaction/typeSatisfaction_vacuousIntersectionOfContextualTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithAnyOtherType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithBooleanType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithEnumType.ts
@@ -5143,10 +4533,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/esne
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/esnext/esnextmodulekindWithES5Target9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/esnext/exnextmodulekindExportClassNameWithObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAmbientClassNameWithObject.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentAndDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentConstrainedGenericType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentMergedInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentOfExportNamespaceWithDefault.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportAssignmentTopLevelEnumdule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportClassNameWithObjectAMD.ts
@@ -5157,7 +4544,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/expo
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportNonInitializedVariablesInIfThenStatementNoCrash1.ts
 Missing initializer in const declaration
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportNonLocalDeclarations.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportNonVisibleType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/exportTypeMergedWithExportStarAsNamespace.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/globalAugmentationModuleResolution.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithExtensions.ts
@@ -5167,14 +4553,12 @@ Unexpected estree file content error: 1 != 2
 tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleResolutionWithoutExtension4.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/moduleScoping.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/multipleExportDefault1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/multipleExportDefault2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/multipleExportDefault3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/multipleExportDefault4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/multipleExportDefault5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/multipleExportDefault6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/reexportClassDefinition.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/relativePathToDeclarationFile.ts
 tasks/coverage/typescript/tests/cases/conformance/externalModules/rewriteRelativeImportExtensions/emit.ts
 Unexpected estree file content error: 4 != 5
@@ -5208,18 +4592,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/topL
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/topLevelModuleDeclarationAndFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeAndNamespaceExportMerge.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/allowsImportingTsExtension.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/computedPropertyName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/enums.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/exportDefault.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/filterNamespace_import.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/generic.ts
 tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/grammarErrors.ts
 Unexpected estree file content error: 3 != 4
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/implementsClause.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importClause_default.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importClause_namedImports.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importClause_namespaceImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importDefaultNamedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importDefaultNamedType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importEqualsDeclaration.ts
@@ -5227,10 +4607,6 @@ tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/impor
 Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/importsNotUsedAsValues_error.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceImportTypeQuery.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceImportTypeQuery2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceImportTypeQuery3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceImportTypeQuery4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceMemberAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/preserveValueImports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/preserveValueImports_module.ts
@@ -5303,7 +4679,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interface
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithMultipleBaseTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithPropertyOfEveryType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/AmbientModuleAndNonAmbientClassWithSameNameAndCommonRoot.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/AmbientModuleAndNonAmbientFunctionWithTheSameNameAndCommonRoot.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithModuleMemberThatUsesClassTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithStaticFunctionAndExportedFunctionThatShareAName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithStaticFunctionAndNonExportedFunctionThatShareAName.ts
@@ -5313,11 +4688,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/Decl
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleWithSameNameAndCommonRoot.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleWithSameNameAndCommonRootES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/EnumAndModuleWithSameNameAndCommonRoot.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/FunctionAndModuleWithSameNameAndCommonRoot.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/FunctionAndModuleWithSameNameAndDifferentCommonRoot.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ModuleAndClassWithSameNameAndCommonRoot.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ModuleAndEnumWithSameNameAndCommonRoot.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ModuleAndFunctionWithSameNameAndCommonRoot.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedAndNonExportedClassesOfTheSameName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedAndNonExportedInterfacesOfTheSameName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedAndNonExportedLocalVarsOfTheSameName.ts
@@ -5329,7 +4701,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/Decl
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesWithTheSameNameAndSameCommonRoot.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/codeGeneration/exportCodeGen.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/codeGeneration/importStatements.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/codeGeneration/importStatementsInterfaces.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/codeGeneration/nameCollision.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportClassWhichExtendsInterfaceWithInaccessibleType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportClassWithAccessibleTypesInTypeParameterConstraintsClassHeritageListMemberTypeAnnotations.ts
@@ -5337,13 +4708,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/expo
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportFunctionWithAccessibleTypesInParameterAndReturnTypeAnnotation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportFunctionWithInaccessibleTypesInParameterTypeAnnotation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportFunctionWithInaccessibleTypesInReturnTypeAnnotation.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportInterfaceWithAccessibleTypesInTypeParameterConstraintsClassHeritageListMemberTypeAnnotations.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportInterfaceWithInaccessibleTypeInTypeParameterConstraint.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportModuleWithAccessibleTypesOnItsExportedMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportObjectLiteralAndObjectTypeLiteralWithAccessibleTypesInMemberTypeAnnotations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportObjectLiteralAndObjectTypeLiteralWithAccessibleTypesInNestedMemberTypeAnnotations.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportVariableWithAccessibleTypeInTypeAnnotation.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportVariableWithInaccessibleTypeInTypeAnnotation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ModuleWithExportedAndNonExportedEnums.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ModuleWithExportedAndNonExportedImportAlias.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/importDeclarations/circularImportAlias.ts
@@ -5356,7 +4723,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/modu
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/instantiatedModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/invalidNestedModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/nestedModules.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/nonInstantiatedModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/reExportAliasMakesInstantiated.ts
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/checkExportsObjectAssignProperty.ts
 Unexpected estree file content error: 1 != 4
@@ -5524,9 +4890,7 @@ Unexpected estree file content error: 1 != 2
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenCanBeTupleType.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty14.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty16.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxGenericTagHasCorrectInferences.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxIntersectionElementPropsType.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxSubtleSkipContextSensitiveBug.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxUnionSFXContextualTypeInferredCorrectly.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/commentEmittingInPreserveJsx1.tsx
@@ -5548,7 +4912,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxParsin
 JSX expressions may not use the comma operator
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuite.tsx
 JSX expressions may not use the comma operator
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxSpreadOverwritesAttributeStrict.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformChildren.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformCustomImport.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformCustomImportPragma.tsx
@@ -5558,17 +4921,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxs/jsxJsxsCjsT
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformNestedSelfClosingChild.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformSubstitutesNames.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformSubstitutesNamesFragment.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeErrors.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution14.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution15.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution16.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution3.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution4.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxCorrectlyParseLessThanComparison1.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName6.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution17.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution19.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEmit1.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxExternalModuleEmit2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentPreserveEmit.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentReactEmit.tsx
@@ -5577,35 +4935,20 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxLibraryManage
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxOpeningClosingNames.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxPreserveEmit1.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxPreserveEmit3.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit1.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit8.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitEntities.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitNesting.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution10.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution11.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution12.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution13.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution14.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution15.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution16.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution17.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution2.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution3.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution4.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution5.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution6.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution7.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution8.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadAttributesResolution9.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadChildren.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadChildrenInvalidType.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload1.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload2.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload4.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload5.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload6.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponents3.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments1.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments5.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxTypeArgumentsJsxPreserveOutput.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxTypeErrors.tsx
@@ -5873,15 +5216,8 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/override/over
 override' modifier already seen.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/override8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/override/overrideWithoutNoImplicitOverride1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript3/Accessors/parserES3Accessors3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript3/Accessors/parserES3Accessors4.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors10.ts
 'public' modifier cannot be used here.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Accessors/parserAccessors9.ts
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression10.ts
 Unexpected estree file content error: 1 != 2
 
@@ -5906,7 +5242,6 @@ Unexpected estree file content error: 1 != 2
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression17.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression7.ts
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ArrowFunctionExpressions/parserArrowFunctionExpression8.ts
 Unexpected estree file content error: 1 != 2
 
@@ -5915,9 +5250,6 @@ Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClass1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClass2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName4.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName6.ts
 Computed property names are not allowed in enums.
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration11.ts
@@ -5950,8 +5282,6 @@ Expected `{` but found `EOF`
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/IncompleteMemberVariables/parserErrorRecovery_IncompleteMemberVariable1.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/VariableLists/parserErrorRecovery_VariableList1.ts
 Identifier expected. 'return' is a reserved word that cannot be used here.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserCommaInTypeMemberList2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserErrantSemicolonInClass1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnStatementInBlock1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnStatementInBlock3.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserStatementIsNotAMemberVariableDeclaration1.ts
@@ -6008,7 +5338,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/M
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ObjectLiterals/parserObjectLiterals1.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ObjectTypes/parserObjectType6.ts
 Unexpected token
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList1.ts
@@ -6018,10 +5347,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
 A rest parameter cannot be optional
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList9.ts
 A rest parameter cannot be optional
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertyAssignments/parserFunctionPropertyAssignment1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertyAssignments/parserFunctionPropertyAssignment2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertyAssignments/parserFunctionPropertyAssignment3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertyAssignments/parserFunctionPropertyAssignment4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RealWorld/parserindenter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509546.ts
@@ -6032,7 +5357,6 @@ Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509698.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser618973.ts
 'export' modifier cannot be used here.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parserNotHexLiteral1.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity3.ts
 Unexpected flag a in regular expression literal
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/BreakStatements/parser_breakTarget1.ts
@@ -6057,7 +5381,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
 A 'return' statement can only be used within a function body.
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ReturnStatements/parserReturnStatement2.ts
 A 'return' statement can only be used within a function body.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ReturnStatements/parserReturnStatement4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement16.ts
@@ -6069,7 +5392,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
 A 'return' statement can only be used within a function body.
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserWithStatement2.ts
 A 'return' statement can only be used within a function body.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration1.ts
@@ -6081,8 +5403,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/p
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parser15.4.4.14-9-2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserArgumentList1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserAstSpans1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserInExpression1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserKeywordsAsIdentifierName1.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserNotRegex1.ts
 A 'return' statement can only be used within a function body.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserRealSource1.ts
@@ -6105,21 +5425,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/p
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserUsingConstructorAsIdentifier.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName16.ts
 Computed property names are not allowed in enums.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName17.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName2.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName26.ts
 Computed property names are not allowed in enums.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName3.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName34.ts
 Computed property names are not allowed in enums.
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName35.ts
 Expected `]` but found `,`
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName37.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName41.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName5.ts
 'public' modifier cannot be used here.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement16.ts
@@ -6153,7 +5466,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/constru
 Constructor can't have get/set modifier
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/constructorNameInGenerator.ts
 Constructor can't be a generator
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/constructorNameInObjectLiteralAccessor.ts
 tasks/coverage/typescript/tests/cases/conformance/salsa/enumMergeWithExpando.ts
 Unexpected estree file content error: 1 != 2
 
@@ -6225,7 +5537,6 @@ Unexpected estree file content error: 1 != 3
 tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment19.ts
 Unexpected estree file content error: 1 != 3
 
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/salsa/typeFromPropertyAssignment29.ts
 tasks/coverage/typescript/tests/cases/conformance/salsa/varRequireFromTypescript.ts
 Unexpected estree file content error: 1 != 2
 
@@ -6237,33 +5548,21 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerS7.3_A1.1_T2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannerS7.6_A4.2_T1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/scannertest1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInitializer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInvalidInitializer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/everyTypeWithInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/recursiveInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.15.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsInForAwaitOf.2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsInForAwaitOf.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsInForOf.1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsInForOf.4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsTopLevelOfModule.1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsWithImportHelpers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarationsWithIteratorObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.11.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.15.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarations.3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsDeclarationEmit.1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsDeclarationEmit.2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsInForAwaitOf.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsInForOf.1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsNamedEvaluationDecoratorsAndClassFields.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsTopLevelOfModule.1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsTopLevelOfModule.2.ts
@@ -6281,7 +5580,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableS
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithESClassDecorators.8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithESClassDecorators.9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithImportHelpers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithIteratorObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithLegacyClassDecorators.1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithLegacyClassDecorators.10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithLegacyClassDecorators.11.ts
@@ -6319,11 +5617,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/continueS
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-await-ofStatements/emitter.forAwait.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-await-ofStatements/forAwaitPerIterationBindingDownlevel.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatements.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatementsAsyncIdentifier.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of10.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of12.ts
 Unexpected token
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of20.ts
@@ -6332,15 +5628,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofSta
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of29.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of30.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of31.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of34.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of35.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of37.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/forStatements/forStatements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/forStatements/forStatementsMultipleValidDecl.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/ifDoWhileStatements/ifDoWhileStatements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/labeledStatements/labeledStatementDeclarationListInLoopNoCrash2.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/labeledStatements/labeledStatementExportDeclarationNoCrash1.ts
 Missing initializer in const declaration
@@ -6353,8 +5644,6 @@ Generators can only be declared at the top level or inside a block
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/returnStatements/invalidReturnStatements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/returnStatements/returnStatementNoAsiAfterTransform.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/returnStatements/returnStatements.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/switchStatements/switchStatements.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/throwStatements/throwInEnclosingStatements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/throwStatements/throwStatements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/tryStatements/catchClauseWithTypeAnnotation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/anyAsConstructor.ts
@@ -6365,20 +5654,17 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/any/assignEver
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.es2018.1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/conditionalTypes1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/conditionalTypes2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/conditionalTypesExcessProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypes1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypesWithExtends1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypesWithExtends2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/inferTypesWithExtendsDependingOnTypeVariables.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/conditional/variance.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/asyncFunctions/contextuallyTypeAsyncFunctionAwaitOperand.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/asyncFunctions/contextuallyTypeAsyncFunctionReturnType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes01.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes02.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedBindingInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedBindingInitializerNegative.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedObjectLiteralMethodDeclaration01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceWithTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionWitoutTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeAmbient.ts
@@ -6396,7 +5682,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importT
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeNonString.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/import/importWithTypeArguments.ts
 Expected `from` but found `<`
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/contextualIntersectionType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionAndUnionTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionAsWeakTypeSource.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionMemberOfUnionNarrowsCorrectly.ts
@@ -6404,9 +5689,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/i
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionOfUnionOfUnitTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionReduction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionReductionStrict.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionThisTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeEquivalence.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeInference2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeInference3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeMembers.ts
@@ -6476,7 +5759,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedT
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypes6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypesAndObjects.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypesArraysTuples.ts
@@ -6489,10 +5771,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/duplic
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/duplicatePropertyNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/duplicateStringIndexers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/indexSignatures1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeHidingMembersOfExtendedObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeHidingMembersOfObject.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeHidingMembersOfObjectAssignmentCompat.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeHidingMembersOfObjectAssignmentCompat2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypePropertyAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithCallSignatureAppearsToBeFunctionType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithCallSignatureHidingMembersOfExtendedFunction.ts
@@ -6504,7 +5783,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/object
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithNumericProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithStringAndNumberIndexSignatureToAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithStringIndexerHidingObjectIndexer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/objectTypeWithStringNamedPropertyOfIllegalCharacters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/typesWithOptionalProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/typesWithPublicConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/typesWithSpecializedCallSignatures.ts
@@ -6513,16 +5791,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/cla
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/classWithOnlyPublicMembersEquivalentToInterface2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/classWithOptionalParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/optionalMethods.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/never/neverTypeErrors1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/never/neverTypeErrors2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/assignObjectToNonPrimitive.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAccessProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAndEmptyObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAndTypeVariables.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAsProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAssignError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveConstraintOfIndexAccessType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignatureWithOptionalParameterAndInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignatureWithoutAnnotationsOrBody.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignatureWithoutReturnTypeAnnotationInference.ts
@@ -6536,7 +5808,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLite
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/identicalCallSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/identicalCallSignatures2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/identicalCallSignatures3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/parametersWithNoAnnotationAreAny.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParameterWithoutAnnotationIsAnyArray.ts
 A rest parameter must be last in a parameter list
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/restParametersOfNonArrayTypes.ts
@@ -6561,17 +5832,13 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLite
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/indexSignatures/multipleStringIndexers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexerConstrainsPropertyDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexerConstrainsPropertyDeclarations2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexingResults.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerConstrainsPropertyDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexerConstrainsPropertyDeclarations2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/indexSignatures/stringIndexingResults.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/methodSignatures/functionLiterals.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/methodSignatures/methodSignaturesWithOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/methodSignatures/methodSignaturesWithOverloads2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/propertySignatures/numericStringNamedPropertyEquivalence.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/propertySignatures/propertyNameWithoutTypeAnnotation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/propertySignatures/propertyNamesOfReservedWords.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/propertySignatures/stringNamedPropertyAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/boolean/invalidBooleanAssignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/enum/invalidEnumAssignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/enum/validEnumAssignments.ts
@@ -6625,27 +5892,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingType
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeReferences/genericTypeReferenceWithoutTypeArgument2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeReferences/genericTypeReferenceWithoutTypeArgument3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeReferences/nonGenericTypeReferenceWithTypeArguments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpread.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadComputedProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadIndexSignature.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadNegative.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadNoTransform.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadRepeatedComplexity.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadRepeatedNullCheckPerf.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadSetonlyAccessor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/objectSpreadStrictNull.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadContextualTypedBindingPattern.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadDuplicate.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadDuplicateExact.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadExcessProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadMethods.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadNonObject1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadNonPrimitive.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadObjectOrFalsy.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadOverwritesProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadOverwritesPropertyStrict.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadUnion.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadUnion3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralCheckedInIf01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralCheckedInIf02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralMatchedInSwitch01.ts
@@ -6653,9 +5907,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAndLogicalOrExpressions01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAndParenthesizedExpressions01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAndTuples01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTags01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTags02.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTags03.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTypeParameterConstraint01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTypeParameterConstraint02.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInVariableDeclarations01.ts
@@ -6673,18 +5925,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesWithVariousOperators01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesWithVariousOperators02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/contextualThisType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/declarationFiles.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/inferThisType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/looseThisTypeInFunctions.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeErrors2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInAccessors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInAccessorsNegative.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInObjectLiterals.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInObjectLiterals2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInTaggedTemplateCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInTypePredicate.ts
@@ -6708,7 +5954,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/variadic
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/variadicTuples2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/variadicTuples3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/directDependenceBetweenTypeAliases.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/genericTypeAliases.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/intrinsicTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/typeAliases.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/typeAliasesDoNotMerge.ts
@@ -6731,22 +5976,17 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/typeParameterAsTypeParameterConstraintTransitively2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/wrappedAndRecursiveConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/wrappedAndRecursiveConstraints3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/wrappedAndRecursiveConstraints4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterAsBaseType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/innerTypeParameterShadowingOuterOne.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/innerTypeParameterShadowingOuterOne2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithConstraints5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/propertyAccessOnTypeParameterWithoutConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/staticMembersUsingClassTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiersReverseMappedTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiersWithIntersection.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterDirectlyConstrainedToItself.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParametersAvailableInNestedScope3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSubtyping.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSupertype.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/anyAssignabilityInInheritance.ts
@@ -6823,13 +6063,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationsh
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/heterogeneousArrayLiterals.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/equalityWithEnumTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/equalityWithIntersectionTypes01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/equalityWithUnionTypes01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/independentPropertyVariance.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/optionalProperties01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/optionalProperties02.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/typeAssertionsWithIntersectionTypes01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/typeAssertionsWithUnionTypes01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/instanceOf/narrowingConstrainedTypeVariable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/instanceOf/narrowingGenericTypeFromInstanceof01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/infiniteExpansionThroughInstantiation.ts
@@ -6946,8 +6180,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationsh
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithNonSymmetricSubtypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectLiteralArgs.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgs2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndConstraints2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndConstraints3.ts
@@ -6964,7 +6196,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationsh
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithTupleType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericClassWithFunctionTypedMemberArguments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericClassWithObjectTypeArgsAndConstraints.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferences.ts
@@ -6981,7 +6212,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/contextu
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/contextualTypeWithUnionTypeIndexSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/contextualTypeWithUnionTypeMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/contextualTypeWithUnionTypeObjectLiteral.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/discriminatedUnionTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/discriminatedUnionTypes3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeCallSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeCallSignatures2.ts
@@ -6995,7 +6225,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTyp
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeFromArrayLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeIndexSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeMembers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeReduction2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbols.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsErrors.ts


### PR DESCRIPTION
Align our AST's ESTree output with that of TS-ESLint's for the`ObjectProperty` node. Relates to #9705 

Add `optional` field and set to `false` fo the `ObjectProperty` when serializing to TS estree.