### PR TITLE
fix(ast/estree): Fix `TSPropertySignature` by adding custom serializer

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -928,6 +928,7 @@ pub struct TSInterfaceBody<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[estree(via = TSPropertySignatureValue)]
 pub struct TSPropertySignature<'a> {
     pub span: Span,
     pub computed: bool,

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -2862,16 +2862,7 @@ impl ESTree for TSInterfaceBody<'_> {
 
 impl ESTree for TSPropertySignature<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let mut state = serializer.serialize_struct();
-        state.serialize_field("type", &JsonSafeString("TSPropertySignature"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
-        state.serialize_field("computed", &self.computed);
-        state.serialize_field("optional", &self.optional);
-        state.serialize_field("readonly", &self.readonly);
-        state.serialize_field("key", &self.key);
-        state.serialize_field("typeAnnotation", &self.type_annotation);
-        state.end();
+        crate::serialize::TSPropertySignatureValue(self).serialize(serializer)
     }
 }
 

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -718,6 +718,7 @@ impl ESTree for ClassImplements<'_, '_> {
 }
 
 /// Serializer for `TSPropertySignature`.
+#[ast_meta]
 pub struct TSPropertySignatureValue<'b>(pub &'b TSPropertySignature<'b>);
 
 impl ESTree for TSPropertySignatureValue<'_> {

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -717,6 +717,27 @@ impl ESTree for ClassImplements<'_, '_> {
     }
 }
 
+/// Serializer for `TSPropertySignature`.
+pub struct TSPropertySignatureValue<'b>(pub &'b TSPropertySignature<'b>);
+
+impl ESTree for TSPropertySignatureValue<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let ts_param = self.0;
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", &JsonSafeString("TSPropertySignature"));
+        state.serialize_field("start", &ts_param.span.start);
+        state.serialize_field("end", &ts_param.span.end);
+        state.serialize_field("accessibility", &Null(self));
+        state.serialize_field("computed", &ts_param.computed);
+        state.serialize_field("key", &ts_param.key);
+        state.serialize_field("typeAnnotation", &ts_param.type_annotation);
+        state.serialize_field("optional", &False(self));
+        state.serialize_field("readonly", &False(self));
+        state.serialize_field("static", &False(self));
+        state.end();
+    }
+}
+
 /// Serializer for `global` field of `TSModuleDeclaration`.
 #[ast_meta]
 #[estree(ts_type = "boolean", raw_deser = "THIS.kind === 'global'")]

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -2,7 +2,7 @@ commit: 15392346
 
 estree_typescript Summary:
 AST Parsed     : 10623/10725 (99.05%)
-Positive Passed: 3622/10725 (33.77%)
+Positive Passed: 4156/10725 (38.75%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APISample_Watch.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APISample_WatchWithDefaults.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APISample_WatchWithOwnWatchHost.ts
@@ -33,17 +33,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessorWithRestParam.t
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/addMoreOverloadsToBaseSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasOfGenericFunctionWithRestBehavedSameAsUnaliased.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasOnMergedModuleInterface.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInAccessorsOfClass.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInArray.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInFunctionExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInGenericFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInIndexerOfClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInObjectLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInOrExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInTypeArgumentOfExtendsClause.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsageInVarAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasUsedAsNameValue.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasWithInterfaceExportAssignmentUsedInVarInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasesInSystemModule1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/aliasesInSystemModule2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/allowImportClausesToMergeWithTypes.ts
@@ -97,8 +90,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonClassDeclarationEmi
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonymousClassDeclarationDoesntPrintWithReadonly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anonymousClassExpression2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyAndUnknownHaveFalsyComponents.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyIsAssignableToObject.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyIsAssignableToVoid.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/anyMappedTypesError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arguments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/argumentsAsPropertyName.ts
@@ -113,7 +104,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAssignmentTest6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayAugment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayBestCommonTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayBindingPatternOmittedExpressions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayCast.ts
@@ -121,14 +111,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayConcat3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayConcatMap.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayDestructuringInSwitch1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayDestructuringInSwitch2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFakeFlatNoCrashInferenceDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFilter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFind.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayFrom.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/arrayFromAsync.ts
 `await` is only allowed within async functions and at the top levels of modules
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralComments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralContextualType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralInNonVarArgParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayLiteralTypeInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/arrayOfExportedClass.ts
@@ -154,13 +142,11 @@ A 'return' statement can only be used within a function body.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assertionFunctionWildcardImport1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assertionFunctionsCanNarrowByDiscriminant.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assign1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignLambdaToNominalSubtypeOfFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignToEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignToExistingClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignToFn.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/assignToInvalidLHS.ts
 Cannot assign to this expression
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignToObjectTypeWithPrototypeProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompat1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatBug2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatBug3.ts
@@ -213,7 +199,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability_checking-apply-member-off-of-function-interface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatability_checking-call-member-off-of-function-interface.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentCompatibilityForConstrainedTypeParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentIndexedToPrimitives.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentNestedInLiterals.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentNonObjectTypeConstraints.ts
@@ -230,24 +215,17 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/assignmentToReferenceTy
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncArrowInClassES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionReturnExpressionErrorSpans.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionReturnType.2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionReturnType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionTempVariableScoping.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionsAcrossFiles.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionsAndStrictNullChecks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncIteratorExtraParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncYieldStarContextualType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals1_1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals2_1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals3_1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals4_1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals6_1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentedTypeBracketNamedPropertyAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentedTypesClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentedTypesClass2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/augmentedTypesClass2a.ts
@@ -294,7 +272,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/bestChoiceType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bestCommonTypeReturnStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bestCommonTypeWithContextualTyping.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bestCommonTypeWithOptionalProperties.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/betterErrorForUnionCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigintWithLib.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigintWithoutLib.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/binaryArithmeticControlFlowGraphNotTooLarge.ts
@@ -332,7 +309,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution3
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cachedModuleResolution5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callOfConditionalTypeWithConcreteBranches.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/callSignaturesShouldBeResolvedBeforeSpecialization.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callbacksDontShareTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/callsOnComplexSignatures.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/cannotIndexGenericWritingError.ts
@@ -356,7 +332,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop9
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop9_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedParametersInInitializers1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedShorthandPropertyAssignmentNoCheck.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/caseInsensitiveFileSystemWithCapsImportTypeDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/castExpressionParentheses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/castParentheses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/castTest.ts
@@ -385,7 +360,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkSuperCallBeforeThi
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkSuperCallBeforeThisAccessing6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkSuperCallBeforeThisAccessing7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkSuperCallBeforeThisAccessing8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkTypePredicateForRedundantProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkerInitializationCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/checkingObjectWithThisInNamePositionNoCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularAccessorAnnotations.ts
@@ -408,12 +382,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularResolvedSignatu
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularTypeArgumentsLocalAndOuterNoCrash1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularTypeofWithFunctionModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularlyConstrainedMappedTypeContainingConditionalNoInfiniteInstantiationDepth.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularlyReferentialInterfaceAccessNoCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularlySimplifyingConditionalTypesNoCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classAccessorInitializationInferenceWithElementAccess1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classAttributeInferenceTemplate.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classDeclaredBeforeClassFactory.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExpressionNames.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/classExpressionPropertyModifiers.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
@@ -436,11 +408,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFieldSuperAccessib
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFunctionMerging.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/classHeritageWithTrailingSeparator.ts
 Expected `{` but found `EOF`
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementingInterfaceIndexer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsImportedInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsMethodWIthTupleArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classImplementsPrimitive.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classIndexer4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping3.ts
@@ -451,7 +421,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/classNameReferencesInSt
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classNonUniqueSymbolMethodHasSymbolIndexer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classPropInitializationInferenceWithElementAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classReferencedInContextualParameterWithinItsOwnBaseExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classSideInheritance2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classSideInheritance3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classStaticInitializersUsePropertiesBeforeDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classStaticPropertyTypeGuard.ts
@@ -610,7 +579,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/comparisonOfPartialDeep
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/complexClassRelationships.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/complexNarrowingWithAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/complexRecursiveCollections.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/complicatedGenericRecursiveBaseClassReference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/complicatedIndexedAccessKeyofReliesOnKeyofNeverUpperBound.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/complicatedIndexesOfIntersectionsAreInferencable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/complicatedPrivacy.ts
@@ -645,7 +613,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeVariance
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypesASI.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conflictingDeclarationsImportFromNamespace1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conflictingDeclarationsImportFromNamespace2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/conflictingMemberTypesInBases.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conflictingTypeParameterSymbolTransfer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/consistentAliasVsNonAliasRecordBehavior.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarationShadowedByVarDeclaration.ts
@@ -692,11 +659,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/constWithNonNull.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constantEnumAssert.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintCheckInGenericBaseTypeReference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintOfRecursivelyMappedTypeWithConditionalIsResolvable.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintPropagationThroughReturnTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintReferencingTypeParameterFromSameTypeParameterList.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintWithIndexedAccess.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraints0.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/constraintsThatReferenceOtherContstraints1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorAsType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads4.ts
@@ -724,11 +688,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureCond
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInArrayElementLibEs2015.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInArrayElementLibEs5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInObjectFreeze.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstantiation1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstantiation2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstantiation4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstatiationContravariance.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignatureInstatiationCovariance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualSignature_objectLiteralMethodMayReturnNever.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTupleTypeParameterReadonly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypeAny.ts
@@ -754,7 +715,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypesNegatedT
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping16.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping17.ts
@@ -763,19 +723,13 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping19.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping20.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping21.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping25.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping26.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping27.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping34.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping35.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping36.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping37.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTyping9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingArrayDestructuringWithDefaults.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contextualTypingFunctionReturningFunction.ts
@@ -818,7 +772,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/contravariantInferenceA
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contravariantOnlyInferenceFromAnnotatedFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contravariantOnlyInferenceWithAnnotatedOptionalParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowAliasedDiscriminants.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowAnalysisOnBareThisKeyword.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowArrays.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowAutoAccessor1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowBreakContinueWithLabel.ts
@@ -849,10 +802,8 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/convertKeywordsY
 Classes can't have a field named 'constructor'
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/copyrightWithNewLine1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/copyrightWithoutNewLine1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/correctOrderOfPromiseMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/correlatedUnions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/covariance1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashDeclareGlobalTypeofExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashInEmitTokenWithComment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashInGetTextOfComputedPropertyName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashInResolveInterface.ts
@@ -863,9 +814,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/crashRegressionTest.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/curiousNestedConditionalEvaluationResult.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/customAsyncIterator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/customEventDetail.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicGenericTypeInstantiation.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicGenericTypeInstantiationInference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/cyclicTypeInstantiation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileAccessors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileAmbientExternalModuleWithSingleExportedModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileCallSignatures.ts
@@ -876,13 +824,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileEmitDeclaration
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileEnumUsedAsValue.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileEnums.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileExportAssignmentImportInternalModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileExportAssignmentOfGenericInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForClassWithMultipleBaseClasses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForExportedImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForInterfaceWithOptionalFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileForInterfaceWithRestParams.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileFunctions.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileGenericClassWithGenericExtendedClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileGenericType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileGenericType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileImportChainInExportAssignment.ts
@@ -915,7 +861,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declInput.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declInput3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationAssertionNodeNotReusedWhenTypeNotEquivalent1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAliasFromIndirectFile.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAliasInlineing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAmdModuleDefault.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAmdModuleNameDirective.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitAnyComputedPropertyInClass.ts
@@ -995,7 +940,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitFBounded
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForDefaultExportClassExtendingExpression01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForGlobalishSpecifierSymlink.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForGlobalishSpecifierSymlink2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitForModuleImportingModuleAugmentationRetainsImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitGlobalThisPreserved.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitHasTypesRefOnNamespaceUse.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitHigherOrderRetainedGenerics.ts
@@ -1011,7 +955,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferred
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredTypeAlias9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInferredUndefinedPropFromFunctionInArray.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitInlinedDistributiveConditional.ts
@@ -1059,10 +1002,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOptional
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOptionalMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitOverloadedPrivateInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitParameterProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPartialNodeReuseTypeOf.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPartialNodeReuseTypeReferences.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPartialReuseComputedProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPathMappingMonorepo.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPathMappingMonorepo2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrefersPathKindBasedOnBundling.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitPrefersPathKindBasedOnBundling2.ts
@@ -1078,15 +1017,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitProtecte
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitQualifiedAliasTypeArgument.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitReadonlyComputedProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitRecursiveConditionalAliasPreserved.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitRedundantTripleSlashModuleAugmentation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitReexportedSymlinkReference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitReexportedSymlinkReference2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitReexportedSymlinkReference3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitResolveTypesIfNotReusable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitRetainedAnnotationRetainsImportInOutput.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitRetainsJsdocyComments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitReusesLambdaParameterNodes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitScopeConsistency.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitScopeConsistency3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitShadowingInferNotRenamed.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitSimpleComputedNames1.ts
@@ -1131,8 +1067,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitWithDefa
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitWithInvalidPackageJsonTypings.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFileNoCrashOnExtraExportModifier.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFilesGeneratingTypeReferences.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFilesWithTypeReferences1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFilesWithTypeReferences2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFilesWithTypeReferences3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFilesWithTypeReferences4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationFunctionTypeNonlocalShouldNotBeAnError.ts
@@ -1163,7 +1097,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declareFileExportAssign
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declareModifierOnTypeAlias.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declaredExternalModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declaredExternalModuleWithExportAssignment.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataConditionalType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataElidedImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataElidedImportOnDeclare.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/decoratorMetadataGenericTypeVariable.ts
@@ -1281,10 +1214,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessors1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/divergentAccessorsTypes8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/divideAndConquerIntersections.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotElaborateAssignabilityToTypeParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotEmitDetachedComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotEmitDetachedCommentsAtStartOfConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotEmitDetachedCommentsAtStartOfFunctionBody.ts
@@ -1341,7 +1272,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierRela
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierRelatedSpans6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierRelatedSpans7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierShouldNotShortCircuitBaseTypeBinding.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateInterfaceMembers1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateLabel1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateLabel2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateLabel3.ts
@@ -1361,7 +1291,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_subMod
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicatePropertiesInStrictMode.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateStringNamedProperty1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateSymbolsExportMatching.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateTypeParameters3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateVarAndImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateVarAndImport2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/duplicateVariablesByScope.ts
@@ -1374,7 +1303,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicImportsDeclarati
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicModuleTypecheckError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/dynamicNamesErrors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/elaboratedErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/elaboratedErrorsOnNullableTargets01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/elementAccessExpressionInternalComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/elidedEmbeddedStatementsReplacedWithSemicolon.ts
@@ -1410,9 +1338,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSuperCallBeforeEmit
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSuperCallBeforeEmitPropertyDeclarationAndParameterPropertyDeclaration1ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitThisInObjectLiteralGetter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitTopOfFileTripleSlashCommentOnNotEmittedNodeIfRemoveCommentsIsFalse.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyAnonymousObjectNarrowing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyArrayDestructuringExpressionVisitedByTransformer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyDeclarationEmitIsModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyIndexer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyModuleName.ts
@@ -1477,22 +1403,16 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorElaboration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorElaborationDivesIntoApparentlyPresentPropsOnly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorForBareSpecifierWithImplicitModuleResolutionNone.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorForConflictingExportEqualsValue.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorForUsingPropertyOfTypeAsType02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorForUsingPropertyOfTypeAsType03.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorForwardReferenceForwadingConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorInfoForRelatedIndexTypesNoConstraintElaboration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessageOnIntersectionsWithDiscriminants01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessageOnObjectLiteralType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessagesIntersectionTypes01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessagesIntersectionTypes02.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessagesIntersectionTypes03.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorMessagesIntersectionTypes04.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorOnEnumReferenceInCondition.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorOnUnionVsObjectShouldDeeplyDisambiguate.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorOnUnionVsObjectShouldDeeplyDisambiguate2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorTypesAsTypeArguments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorWithSameNameType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorWithTruncatedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorsForCallAndAssignmentAreSimilar.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorsInGenericTypeReference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/errorsOnUnionsOfOverlappingObjects01.ts
@@ -1576,7 +1496,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/es6ImportNameSpa
 Unexpected token
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportWithExport.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportWithTypesAndValues.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/es6ImportWithoutFromClauseWithExport.ts
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/es6Module.ts
@@ -1602,7 +1521,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropImportTS
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropNamedDefaultImports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropTslibHelpers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleInteropUsesExportStarWhenDefaultPlusNames.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/esModuleIntersectionCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/esNextWeakRefs_IterableWeakMap.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/escapedIdentifiers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/escapedReservedCompilerNamedIdentifier.ts
@@ -1630,7 +1548,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionContextu
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionContextualTypesJSDocInTs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionContextualTypesNoValue.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionExpressionsWithDynamicNames.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionExpressionsWithDynamicNames2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionNestedAssigments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionNestedAssigmentsDeclared.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/expandoFunctionNullishProperty.ts
@@ -1650,7 +1567,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignedTypeAsTyp
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentImportMergeNoCrash.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentOfDeclaredExternalModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentOfGenericType1.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/exportAssignmentWithDeclareAndExportModifiers.ts
@@ -1723,22 +1639,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportInterfaceClassAnd
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportInterfaceClassAndValueWithDuplicatesInImportList.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportNamespaceDeclarationRetainsVisibility.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportObjectRest.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportPrivateType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportRedeclarationTypeAliases.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSameNameFuncVar.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierReferencingOuterDeclaration2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportSpecifierReferencingOuterDeclaration4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValues9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarForValuesInSystem.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportStarFromEmptyModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportToString.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/exportTwoInterfacesWithSameName.ts
@@ -1755,7 +1659,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/expressionsForbiddenInP
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendArray.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendBaseClassBeforeItsDeclared.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendGenericArray.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendGenericArray2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendedInterfaceGenericType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendedInterfacesWithDuplicateTypeParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/extendingClassFromAliasAndUsageInIndexer.ts
@@ -1797,7 +1700,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/flatArrayNoExcessiveSta
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/flowControlTypeGuardThenSwitch.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forLoopEndingMultilineComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forLoopWithDestructuringDoesNotElideFollowingStatement.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/forOfStringConstituents.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forOfTransformsExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forwardRefInEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/forwardRefInTypeDeclaration.ts
@@ -1830,17 +1732,13 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads16.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads17.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads18.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads19.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads20.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads21.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads22.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads34.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads35.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads36.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads37.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads38.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads39.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads40.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads41.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads42.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads43.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionOverloads44.ts
@@ -1852,13 +1750,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionReturnTypeQuery
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionSignatureAssignmentCompat1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionSubtypingOfVarArgs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionSubtypingOfVarArgs2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionToFunctionWithPropError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionTypeArgumentArityErrors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionTypeArgumentArrayAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithAnyReturnTypeAndNoReturnExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionWithDefaultParameterWithNoStatements4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/functionsWithImplicitReturnTypeAssignableToUndefined.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/funduleUsedAcrossFileBoundary.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/fuzzy.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorES6InAMDModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/generatorES6_4.ts
@@ -1868,8 +1763,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArgumentCallSigA
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArray1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArrayExtenstions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArrayMethods1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericArrayPropertyAssignment.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericAssignmentCompatOfFunctionSignatures1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericAssignmentCompatWithInterfaces1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallInferenceConditionalType1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallInferenceConditionalType2.ts
@@ -1878,30 +1771,24 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallOnMemberRetu
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallWithObjectLiteralArguments1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallWithinOwnBodyCastTypeParameterIdentity.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCallbacksAndClassHierarchy.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCapturingFunctionNarrowing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericChainedCalls.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassImplementingGenericInterfaceFromAnotherModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassPropertyInheritanceSpecialization.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassWithStaticFactory.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassWithStaticsUsingTypeArguments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClasses2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClasses4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassesInModule2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericClassesRedeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericCombinators2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConditionalConstrainedToUnknownNotAssignableToConcreteObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraint2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraint3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraintDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericConstraintSatisfaction1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericDefaults.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericDefaultsErrors.ts
 tasks/coverage/typescript/tests/cases/compiler/genericDefaultsJs.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericDerivedTypeWithSpecializedBase2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionInference1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionInference2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctions3.ts
@@ -1912,7 +1799,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionsWithOpt
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionsWithOptionalParameters3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericImplements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericIndexedAccessMethodIntersectionCanBeAccessed.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericIndexedAccessVarianceComparisonResultCorrect.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInference2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInferenceDefaultTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInferenceDefaultTypeParameterJsxReact.tsx
@@ -1922,14 +1808,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInterfaceFunctio
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInterfaceImplementation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInterfaceTypeCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericIsNeverEmptyObject.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericLambaArgWithoutTypeArguments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericMappedTypeAsClause.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericMemberFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericMethodOverspecialization.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericObjectLitReturnType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericObjectSpreadResultInSwitch.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericOverloadSignatures.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericPrototypeProperty2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericRecursiveImplicitConstructorErrors1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericRecursiveImplicitConstructorErrors2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericRestArgs.ts
@@ -1949,19 +1833,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeWithCallable
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeWithMultipleBases1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeWithMultipleBases2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeWithMultipleBases3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericTypeWithNonGenericBaseMisMatch.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithCallSignatureReturningSpecialization.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithCallSignatures1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericWithIndexerOfTypeParameterType2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics0.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics1NoError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics2NoError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics4NoError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/generics5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericsAndHigherOrderFunctions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericsWithDuplicateTypeParameters1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericsWithoutTypeParameters1.ts
@@ -1970,7 +1847,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/getSetEnumerable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/getsetReturnTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/getterErrorMessageNotDuplicated.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/getterSetterNonAccessor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/getterSetterSubtypeAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/gettersAndSetters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/gettersAndSettersTypesAgree.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/globalIsContextualKeyword.ts
@@ -1995,7 +1871,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/illegalSuperCallsInCons
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementArrayInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementGenericWithMismatchedTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementInterfaceAnyMemberWithVoid.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementPublicPropertyAsPrivate.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implementsInClassExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyAmbients.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareFunctionExprWithoutFormalType.ts
@@ -2003,7 +1878,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareFunct
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareFunctionWithoutFormalType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareMemberWithoutType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareMemberWithoutType2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareTypePropertyWithoutType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyDeclareVariablesWithoutTypeAndInit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyFromCircularInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/implicitAnyFunctionInvocationWithAnyArguements.ts
@@ -2034,7 +1908,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDecl.ts
 tasks/coverage/typescript/tests/cases/compiler/importDeclFromTypeNodeInJsSource.ts
 Unexpected estree file content error: 2 != 3
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclWithExportModifier.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclWithExportModifierAndExportAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importDeclarationNotCheckedAsValueWhenTargetNonValue.ts
@@ -2082,7 +1955,6 @@ tasks/coverage/typescript/tests/cases/compiler/importNonExportedMember9.ts
 Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importNotElidedWhenNotFound.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/importOnAliasedIdentifiers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importPropertyFromMappedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/importShouldNotBeElidedInDeclarationEmit.ts
 tasks/coverage/typescript/tests/cases/compiler/importTypeResolutionJSDocEOF.ts
@@ -2106,8 +1978,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/inKeywordAndIntersectio
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inKeywordAndUnknown.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inKeywordTypeguard.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inOperatorWithFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/incompatibleExports1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/incompatibleExports2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/incompatibleGenericTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/incompatibleTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/incorrectNumberOfTypeArgumentsDuringErrorReporting.ts
@@ -2140,12 +2010,10 @@ Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessAndNullableNarrowing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessCanBeHighOrder.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessConstraints.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessImplicitlyAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessKeyofNestedSimplifiedSubstituteUnwrapped.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessNormalization.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessRelation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessRetainsIndexSignature.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessToThisTypeOnIntersection01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessTypeConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessWithFreshObjectLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexedAccessWithVariableElement.ts
@@ -2154,7 +2022,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexer2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexerA.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/indexerAsOptional.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexerConstraints.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/indexerConstraints2.ts
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/indexerReturningTypeParameter1.ts
@@ -2190,8 +2057,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceErasedSignatur
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceExactOptionalProperties1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceExactOptionalProperties2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceFromIncompleteSource.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceLimit.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceOfNullableObjectTypesWithCommonBase.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceOptionalProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceOptionalPropertiesStrict.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceOptionalPropertiesToIndexSignatures.ts
@@ -2204,39 +2069,24 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingUsingA
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingUsingApparentType3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionTypeNested.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionTypeSyntacticScenarios.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithFunctionTypeZip.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingWithObjectLiteralProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentiallyTypingAnEmptyArray.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferredNonidentifierTypesGetQuotes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferredRestTypeFixedOnce.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferredReturnTypeIncorrectReuse1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferrenceInfiniteLoopWithSubtyping.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferringAnyFunctionType1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferringAnyFunctionType5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/infiniteConstraints.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/infiniteExpandingTypeThroughInheritanceInstantiation.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingBaseTypes1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingBaseTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingOverloads.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypeAssignability.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypes5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyExpandingTypesNonGenericBase.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/infinitelyGenerativeInheritance1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritSameNamePrivatePropertiesFromDifferentOrigins.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritSameNamePrivatePropertiesFromSameOrigin.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritSameNamePropertiesWithDifferentOptionality.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritSameNamePropertiesWithDifferentVisibility.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritance1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedConstructorPropertyContextualType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedConstructorWithRestParams.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedConstructorWithRestParams2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedGenericCallSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedMembersAndIndexSignaturesFromDifferentBases.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedMembersAndIndexSignaturesFromDifferentBases2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedStringIndexersFromDifferentBaseTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inheritedStringIndexersFromDifferentBaseTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/initializePropertiesWithRenamedLet.ts
@@ -2244,13 +2094,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/initializedParameterBef
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/initializersInAmbientEnums.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inlineMappedTypeModifierDeclarationEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inlineSourceMap2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inlinedAliasAssignableToConstraintSameAsAlias.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/innerBoundLambdaEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/innerExtern.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceAndStaticDeclarations1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceOfAssignability.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceOfInExternalModules.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceSubtypeCheck1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceofNarrowReadonlyArray.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceofOnInstantiationExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceofTypeAliasToGenericClass.ts
@@ -2261,12 +2109,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiatedBaseTypeCon
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiatedReturnTypeContravariance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiatedTypeAliasDisplay.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiationExpressionErrorNoCrash.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces0.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interface0.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceAssignmentCompat.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceClassMerging.ts
@@ -2283,7 +2125,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceImplementation8.ts
@@ -2293,7 +2134,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceMergedUnconstr
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceOnly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfacePropertiesWithSameName1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfacePropertiesWithSameName2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfacePropertiesWithSameName3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceSubtyping.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceWithCommaSeparators.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceWithOptionalProperty.ts
@@ -2337,12 +2177,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideL
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideTopLevelModuleWithExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideTopLevelModuleWithoutExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalAliasWithDottedNameEmit.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalImportInstantiatedModuleMergedWithClassNotReferencingInstance.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalImportInstantiatedModuleMergedWithClassNotReferencingInstanceNoConflict.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalImportInstantiatedModuleNotReferencingInstance.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalImportUnInstantiatedModuleMergedWithClassNotReferencingInstance.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalImportUnInstantiatedModuleMergedWithClassNotReferencingInstanceNoConflict.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/internalImportUnInstantiatedModuleNotReferencingInstanceNoConflict.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionApparentTypeCaching.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionConstraintReduction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionOfMixinConstructorTypeAndNonConstructorType.ts
@@ -2352,7 +2186,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionReductionGe
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionSatisfiesConstraint.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionTypeInference1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionTypeNormalization.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionTypeWithLeadingOperator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionType_useDefineForClassFields.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionWithConstructSignaturePrototypeResult.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionsAndOptionalProperties.ts
@@ -2362,8 +2195,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionsAndReadonl
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionsOfLargeUnions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intersectionsOfLargeUnions2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/intraBindingPatternReferences.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/intrinsics.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidConstraint1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidThisEmitInContextualObjectLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidTripleSlashReference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/invalidTypeNames.ts
@@ -2373,7 +2204,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/ipromise3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ipromise4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isDeclarationVisibleNodeKinds.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorTypes1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsAugmentation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsClasses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsClassesExpressions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedDeclarationErrorsDefault.ts
@@ -2404,7 +2234,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesNonAmbie
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesReExportAlias.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesReExportType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesRequiresPreserveConstEnum.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesShadowGlobalTypeNotValue.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesSourceMap.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesSpecifiedModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/isolatedModulesUnspecifiedModule.ts
@@ -2537,7 +2366,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsdocInTypeScript.ts
 tasks/coverage/typescript/tests/cases/compiler/jsdocReferenceGlobalTypeInCommonJs.ts
 Unexpected estree file content error: 2 != 3
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsonFileImportChecksCallCorrectlyTwice.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxCallElaborationCheckNoCrash1.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxCallbackWithDestructuring.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxChildWrongType.tsx
@@ -2546,7 +2374,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenGenericConte
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenIndividualErrorElaborations.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenSingleChildConfusableWithMultipleChildrenNoError.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenWrongType.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxClassAttributeResolution.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxComplexSignatureHasApplicabilityError.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxComponentTypeErrors.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxContainsOnlyTriviaWhiteSpacesNotCountedAsChild.tsx
@@ -2554,7 +2381,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxElementClassTooManyP
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxElementType.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxElementTypeLiteral.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxElementTypeLiteralWithGeneric.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxElementsAsIdentifierNames.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxEmptyExpressionNotCountedAsChild.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxEmptyExpressionNotCountedAsChild2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxExcessPropsAndAssignability.tsx
@@ -2581,14 +2407,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxIntrinsicUnions.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxIssuesErrorWhenTagExpectsTooManyArguments.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxLibraryManagedAttributesUnusedGeneric.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxLocalNamespaceIndexSignatureNoCrash.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceElementChildrenAttributeIgnoredWhenReactJsx.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceGlobalReexport.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceGlobalReexportMissingAliasTarget.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceImplicitImportJSXNamespace.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceImplicitImportJSXNamespaceFromConfigPickedOverGlobalOne.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceImplicitImportJSXNamespaceFromPragmaPickedOverGlobalOne.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceNoElementChildrenAttributeReactJsx.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespacePrefixIntrinsics.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceReexports.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespacedNameNotComparedToNonMatchingIndexSignature.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxPartialSpread.tsx
@@ -2637,7 +2460,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/libTypeScriptOverrideSi
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/libTypeScriptOverrideSimpleConfig.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/libTypeScriptSubfileResolving.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/libTypeScriptSubfileResolvingConfig.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/libdtsFix.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/library_ArraySlice.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/library_DatePrototypeProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/library_ObjectPrototypeProperties.ts
@@ -2656,7 +2478,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/localImportNameVsGlobal
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/localTypeParameterInferencePriority.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/m7Bugs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/manyConstExports.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/mapGroupBy.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mapOnTupleTypes01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mapOnTupleTypes02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mappedArrayTupleIntersections.ts
@@ -2702,11 +2523,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/maximum10SpellingSugges
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/memberAccessMustUseModuleInstances.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/memberOverride.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/memberVariableDeclarations1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergeMultipleInterfacesReexported.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergeSymbolReexportInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergeSymbolReexportedTypeAliasInstantiation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergeSymbolRexportFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergeWithImportedNamespace.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergeWithImportedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarationExports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedDeclarations1.ts
@@ -2722,20 +2541,17 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclaration
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/metadataImportType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/metadataOfEventAlias.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/metadataOfUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/methodContainingLocalFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/methodInAmbientClass1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/methodSignatureHandledDeclarationKindForSymbol.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mismatchedGenericArguments1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingCommaInTemplateStringsArray.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingDomElements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingFunctionImplementation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingImportAfterModuleImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/missingTypeArguments3.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/misspelledNewMetaProperty.ts
 The only valid meta property for new is new.target
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixedExports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixedTypeEnumComparison.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixinIntersectionIsValidbaseType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mixinOverMappedTypeNoCrash.ts
@@ -2758,15 +2574,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_Using
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_Worker.asynciterable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_Worker.iterable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAliasAsFunctionArgument.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceSharingName4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceWithSameName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationCollidingNamesInAugmentation1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDeclarationEmit1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDeclarationEmit2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDisallowedExtensions.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDoesInterfaceMergeOfReexport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDoesNamespaceEnumMergeOfReexport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDoesNamespaceMergeOfReexport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationDuringSyntheticDefaultCheck.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationEnumClassMergeOfReexportIsError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationExtendAmbientModule1.ts
@@ -2776,12 +2588,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationExten
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal6_1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal7_1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationGlobal8_1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationImportsAndExports1.ts
@@ -2805,7 +2612,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleAugmentationsImpo
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleClassArrayCodeGenTest.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleCodeGenTest5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleCodegenTest4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleDeclarationExportStarShadowingGlobalIsNameable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleDuplicateIdentifiers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleElementsInWrongContext.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleElementsInWrongContext2.ts
@@ -2844,8 +2650,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePrologueCommonjs.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePrologueES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePrologueSystem.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/modulePrologueUmd.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleReopenedTypeOtherBlock.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleReopenedTypeSameBlock.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionNoTsCJS.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleResolutionNoTsESM.ts
 tasks/coverage/typescript/tests/cases/compiler/moduleResolutionWithExtensions_notSupported.ts
@@ -2919,40 +2723,25 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleVisibilityTest1.t
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduleVisibilityTest2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/module_augmentUninstantiatedModule2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/moduledecl.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiExtendsSplitInterfaces2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiImportExport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiLineContextDiagnosticWithPretty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiLineErrors.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/multiLinePropertyAccessAndArrowFunctionIndent1.ts
 A 'return' statement can only be used within a function body.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multiSignatureTypeInference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/multipleBaseInterfaesWithIncompatibleProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multipleExportAssignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multipleExports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multipleInferenceContexts.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/multivar.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/mutrec.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mutuallyRecursiveCallbacks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mutuallyRecursiveGenericBaseTypes1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/mutuallyRecursiveInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/mutuallyRecursiveInterfaceDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nameCollisionsInPropertyAssignments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/namedImportNonExistentName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespaceDisambiguationInUnion.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespaceMergedWithFunctionWithOverloadsUsage.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespaceMergedWithImportAliasNoCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/namespaceNotMergedWithFunctionDefaultExport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByBooleanComparison.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByClauseExpressionInSwitchTrue9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByInstanceof.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowByParenthesizedSwitchExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowBySwitchDiscriminantUndefinedCase1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowCommaOperatorNestedWithinLHS.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowRefinedConstLikeParameterBIndingElementNameInInnerScope.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowTypeByInstanceof.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowedConstInMethod.ts
@@ -2973,21 +2762,15 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingPastLastAssign
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingPastLastAssignmentInModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingRestGenericCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofDiscriminant.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofParenthesized1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingTypeofUndefined1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingUnionToUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingUnionWithBang.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nearbyIdenticalGenericLambdasAssignable.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedCallbackErrorNotFlattened.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedExcessPropertyChecking.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedFreshLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedGenericConditionalTypeWithGenericImportType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedGenericSpreadInference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedGenerics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedHomomorphicMappedTypesWithArrayConstraint1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedInfinitelyExpandedRecursiveTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedLoopTypeGuards.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedLoops.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nestedObjectRest.ts
@@ -3048,7 +2831,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyParameters
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyReferencingDeclaredInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyStringIndexerOnObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyUnionNormalizedObjectLiteral1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyWithOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsExclusions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitReturnsInAsync2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitSymbolToString.ts
@@ -3087,10 +2869,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nodeResolution8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonArrayRestArgs.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonConflictingRecursiveBaseTypeMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonContextuallyTypedLogicalOr.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonExportedElementsOfMergedModules.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonIdenticalTypeConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonInferrableTypePropagation1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonInferrableTypePropagation2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonInferrableTypePropagation3.ts
@@ -3101,12 +2881,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullReferenceMatchin
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullableAndObjectIntersections.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullableReduction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullableReductionNonStrict.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullableTypes1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonNullableWithNullableGenericIndexedAccessArg.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonObjectUnionNestedExcessPropertyCheck.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nondistributiveConditionalTypeInfer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nongenericConditionalNotPartiallyComputed.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/nongenericPartialInstantiationsRelatedInBothDirections.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/nonstrictTemplateWithNotOctalPrintsAsIs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/normalizedIntersectionTooComplex.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/null.ts
@@ -3114,8 +2891,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/numberAssignableToEnumI
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/numberVsBigIntOperations.ts
 Missing initializer in const declaration
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericEnumMappedType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexExpressions.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectAssignLikeNonUnionResult.ts
@@ -3126,7 +2901,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectCreate2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectCreationOfElementAccessExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectFreeze.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectFreezeLiteralsDontWiden.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectGroupBy.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectIndexer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectInstantiationFromUnionSpread.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLitGetterSetter.ts
@@ -3166,7 +2940,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/observableInferenceCanB
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/omitTypeHelperModifiers01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/omitTypeTestErrors01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/omitTypeTests01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/operationsAvailableOnPromisedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/operatorAddNullUndefined.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalAccessorsInInterface1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalChainWithInstantiationExpression2.ts
@@ -3213,12 +2986,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadRet.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadReturnTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadedConstructorFixesInferencesAppropriately.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadingOnConstants1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadresolutionWithConstraintCheckingDeferred.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsWithComputedNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsWithConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsWithProvisionalErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overrideBaseIntersectionMethod.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/overridingPrivateStaticMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overshifts.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterDecoratorsEmitCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/parameterDestructuringObjectLiteral.ts
@@ -3238,14 +3009,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/parenthesizedExpression
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseEntityNameWithReservedWord.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseInvalidNonNullableTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseInvalidNullableTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseObjectLiteralsWithoutTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseReplacementCharacter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/parseShortform.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/parserConstructorDeclaration12.ts
 Type parameters cannot appear on a constructor declaration
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/partialDiscriminatedUnionMemberHasGoodError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/partialOfLargeAPIIsAbleToBeWorkedWith.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/partialTypeNarrowedToByTypeGuard.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/partiallyDiscriminantedUnions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution3_classic.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/pathMappingBasedModuleResolution3_node.ts
@@ -3282,7 +3050,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/prefixIncrementAsOperan
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/prefixUnaryOperatorsOnExportedVariables.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/preserveConstEnums.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/prespecializedGenericMembers1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/primaryExpressionMods.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/primitiveUnionDetection.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCannotNameAccessorDeclFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyCannotNameVarTypeDeclFile.ts
@@ -3323,7 +3090,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyTypeParametersOf
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyVar.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privacyVarDeclFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateFieldAssignabilityFromUnknown.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/privateInterfaceProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privatePropertyInUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/privatePropertyUsingObjectType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/promiseChaining.ts
@@ -3347,11 +3113,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/propTypeValidatorInfere
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propagationOfPromiseInitialization.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertiesAndIndexers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertiesAndIndexers2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccess1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAccessExpressionInnerComments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyIdentityWithPrivacyMismatch.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyNamesWithStringLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyOrdering2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertyParameterWithQuestionMark.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/propertySignatures.ts
@@ -3359,20 +3122,15 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/protectedAccessThroughC
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/protectedMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/protoAsIndexInIndexExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/protoAssignment.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/prototypeOnConstructorFunctions.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/publicMemberImplementedAsPrivateInDerivedClass.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/qualify.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/quickinfoTypeAtReturnPositionsInaccurate.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/raiseErrorOnParameterProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ramdaToolsNoInfinite.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/ramdaToolsNoInfinite2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportGlobalDeclaration1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportGlobalDeclaration2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reExportUndefined1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reachabilityChecks7.ts
@@ -3389,21 +3147,17 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactSFCAndFunctionReso
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactTagNameComponentWithPropsNoOOM.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactTagNameComponentWithPropsNoOOM2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reactTransitiveImportHasValidDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyAssignmentInSubclassOfClassExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyInDeclarationFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyPropertySubtypeRelationDirected.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/readonlyTupleAndArrayElaboration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reboundBaseClassSymbol.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveArrayNotCircular.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseCheck2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveBaseCheck6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveClassBaseType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveClassReferenceTest.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalCrash2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalCrash3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalCrash4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalEvaluationNonInfinite.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveConditionalTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExcessPropertyChecks.ts
@@ -3412,7 +3166,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignme
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveExportAssignmentAndFindAliasedType3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveFieldSetting.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveGenericTypeHierarchy.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveIdenticalAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveInferenceBug.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveInheritance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveInheritance3.ts
@@ -3425,19 +3178,12 @@ Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveResolveTypeMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveReverseMappedType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveSpecializationOfExtendedTypeWithError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveSpecializationOfSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTupleTypeInference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTupleTypes1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTupleTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeAliasWithSpreadConditionalReturnNotCircular.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeComparison.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeComparison2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeParameterReferenceError1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeParameterReferenceError2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypeRelations.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveTypes1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveUnionTypeInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursivelyExpandingUnionNoStackoverflow.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursivelySpecializedConstructorDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/redeclarationOfVarWithGenericType.ts
@@ -3457,12 +3203,10 @@ Unexpected flag a in regular expression literal
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/regularExpressionWithNonBMPFlags.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/relatedViaDiscriminatedTypeNoError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/relatedViaDiscriminatedTypeNoError2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/relationComplexityError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/renamingDestructuredPropertyInFunctionType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/renamingDestructuredPropertyInFunctionType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/renamingDestructuredPropertyInFunctionType3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reorderProperties.ts
 tasks/coverage/typescript/tests/cases/compiler/requireAsFunctionInExternalModule.ts
 Unexpected estree file content error: 1 != 3
 
@@ -3507,10 +3251,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/restUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/restUnion2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/restUnion3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnInConstructor1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnInfiniteIntersection.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypeInferenceNotTooBroad.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypePredicateIsInstantiateInContextOfTarget.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/returnTypeTypeArguments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reuseInnerModuleMember.ts
 tasks/coverage/typescript/tests/cases/compiler/reuseTypeAnnotationImportTypeInGlobalThisTypeArgument.ts
 Unexpected estree file content error: 2 != 4
@@ -3530,15 +3272,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeLimite
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypePrimitiveConstraintProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedTypeRecursiveInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/reverseMappedUnionInference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/reversedRecusiveTypeInstantiation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/satisfiesEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfInLambdas.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencingFile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencingFile2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencingFile3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/selfReferencingTypeReferenceInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/setMethods.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/setterBeforeGetter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/shadowedFunctionScopedVariablesByBlockScopedOnes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/shadowedReservedCompilerDeclarationsWithNoEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/shadowingViaLocalValueOrBindingElement.ts
@@ -3579,7 +3318,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-Comment1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-Comments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-FileWithComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-SingleSpace1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMap-StringLiteralWithNewLine.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapForFunctionInInternalModuleWithCommentPrecedingStatement01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapForFunctionWithCommentPrecedingStatement01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapSample.ts
@@ -3647,7 +3385,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapWithNonCaseSen
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/specedNoStackBlown.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/specialIntersectionsInMappedTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializationError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializationsShouldNotAffectEachOther.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializeVarArgs1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializedInheritedConstructors1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/specializedOverloadWithRestParameters.ts
@@ -3679,20 +3416,16 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticAnonymousTypeNotR
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticFieldWithInterfaceContext.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticGetter1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticGetter2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInheritance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInitializersAndLegacyClassDecorators.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticInterfaceAssignmentCompat.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMemberExportAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMethodReferencingTypeArgument1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMethodWithTypeParameterExtendsClauseDeclFile.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/staticMismatchBecauseOfPrototype.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/staticPrototypeProperty.ts
 Classes may not have a static property named prototype
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/statics.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stradac.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictFunctionTypes1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictFunctionTypesErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictModeEnumMemberNameReserved.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictModeReservedWord.ts
@@ -3712,9 +3445,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictOptionalPropertie
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictOptionalProperties2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictSubtypeAndNarrowing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictTypeofUnionNarrowing.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringIndexerAndConstructor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringIndexerAndConstructor1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringIndexerAssignments1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringLiteralObjectLiteralDeclaration1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringLiteralPropertyNameWithLineContinuation1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringMappingAssignability.ts
@@ -3732,10 +3462,7 @@ tasks/coverage/typescript/tests/cases/compiler/subclassThisTypeAssignable02.ts
 Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/subclassWithPolymorphicThisIsAssignable.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/substituteReturnTypeSatisfiesConstraint.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypeForIndexedAccessType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypeNoMergeOfAssignableType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypesCompareCorrectlyInRestrictiveInstances.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/substitutionTypesInIndexedAccessTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/subtypeReductionUnionConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/super1.ts
@@ -3796,7 +3523,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModuleTargetES6.t
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModuleTrailingComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemNamespaceAliasEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemObjectShorthandRename.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedPrimitiveNarrowing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplateStringWithSymbolExpression01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplateStringsHexadecimalEscapes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplateStringsHexadecimalEscapesES6.ts
@@ -3811,7 +3537,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplateWithoutDe
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplatesInDifferentScopes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/taggedTemplatesInModuleAndGlobal.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tailRecursiveConditionalTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypeCastTest.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypeObjectLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypeObjectLiteralToAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/targetTypeTest1.ts
@@ -3871,7 +3596,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressio
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessCallExpressionCoercion3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/truthinessPromiseCoercion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tryCatchFinallyControlFlow.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tryStatementInternalComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsconfigMapOptionsAreCaseInsensitive.ts
@@ -3914,13 +3638,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAliasFunctionTypeSh
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAnnotationBestCommonTypeInArrayLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgInference2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgInference2WithError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgInferenceWithNull.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentDefaultUsesConstraintOnCircularDefault.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceOrdering.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceWithConstraintAsCommonRoot.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceWithRecursivelyReferencedTypeAliasToTypeLiteral01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeArgumentInferenceWithRecursivelyReferencedTypeAliasToTypeLiteral02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAssertionToGenericFunctionType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeAssignabilityErrorMessage.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeCheckObjectLiteralMethodBody.ts
@@ -3934,7 +3654,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardConstructorPri
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowByMutableUntypedField.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowByUntypedField.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty2.ts
@@ -3959,7 +3678,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeNamedUndefined2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfEnumAndVarRedeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfOnTypeArg.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeOfYieldWithUnionInContextualReturnType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParamExtendsOtherTypeParam.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterAssignmentCompat1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterCompatibilityAccrossDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterConstrainedToOuterTypeParameter2.ts
@@ -3967,15 +3685,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterConstraint
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterExplicitlyExtendsAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterExtendsPrimitive.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithConstraints.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterLeak.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParameterOrderReversal.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersInStaticAccessors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeParametersInStaticMethods.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePartameterConstraintInstantiatedWithDefaultWhenCheckingDefault.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicateAcceptingPartialOfRefinedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicateFreshLiteralWidening.ts
@@ -3989,14 +3699,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion.t
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesInUnion_noMatch.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesOptionalChaining1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesOptionalChaining2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typePredicatesOptionalChaining3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives13.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives5.ts
@@ -4005,9 +3713,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeReferenceDirectives9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeResolution.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeUsedAsTypeLiteralIndex.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeUsedAsValueError.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeUsedAsValueError2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeVal.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeVariableConstraintIntersections.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeVariableConstraintedToAliasNotAssignableToUnion.ts
@@ -4019,12 +3724,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/typedArraysCrossAssigna
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofAmbientExternalModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofImportInstantiationExpression.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofInObjectLiteralType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofObjectInference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofSimple.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofStripsFreshness.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofThisInMethodSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofUnknownSymbol.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofUsedBeforeBlockScoped.ts
@@ -4040,13 +3741,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/uncaughtCompilerError1.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undeclaredModuleError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undeclaredVarEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedArgumentInference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedAsDiscriminantWithUnknown.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedAssignableToGenericMappedIntersection.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedSymbolReferencedInArrayLiteral1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedTypeArgument2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/undefinedTypeAssignment4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreEscapedNameInEnum.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreMapFirst.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreTest1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreThisInDerivedClass01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/underscoreThisInDerivedClass02.ts
@@ -4054,23 +3752,18 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionCallMixedTypeParam
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionErrorMessageOnMatchingDiscriminant.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionExcessPropertyCheckNoApparentPropTypeMismatchErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionExcessPropsWithPartialMember.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionOfArraysFilterCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionOfClassCalls.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionOfEnumInference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionPropertyExistence.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionPropertyOfProtectedAndIntersectionProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionReductionMutualSubtypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionReductionWithStringMappingAndIdenticalBaseTypeExistsNoCrash.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionRelationshipCheckPasses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionSignaturesWithThisParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionSubtypeReductionErrors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeErrorMessageTypeRefs01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeParameterInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeWithIndexAndMethodSignature.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeWithIndexAndTuple.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeWithIndexedLiteralType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeWithLeadingOperator.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionTypeWithRecursiveSubtypeReduction3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unionWithIndexSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/uniqueSymbolAllowsIndexInObjectWithIndexSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/uniqueSymbolAssignmentOnGlobalAugmentationSuceeds.ts
@@ -4115,8 +3808,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParameterProperty
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedParametersWithUnderscore.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedSetterInClass2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameterInInterface2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesWithUnderscoreInBindingElement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinModules1.ts
@@ -4126,7 +3817,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_cl
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_classDecorators.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_destructuring.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_propertyAssignment.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_superClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDefinitionInDeclarationFiles.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/useStrictLikePrologueString01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/usingModuleWithExportImportInValuePosition.ts
@@ -4146,7 +3836,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceCantBeStrictWhi
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceMeasurement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceProblingAndZeroOrderIndexSignatureRelationsAlign.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceProblingAndZeroOrderIndexSignatureRelationsAlign2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceReferences.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/varianceRepeatedlyPropegatesWithUnreliableFlag.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/verbatim-declarations-parameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/verbatimModuleSyntaxDefaultValue.ts
@@ -4167,19 +3856,13 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/widenedTypes1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/withExportDecl.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/withImportDecl.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/withStatementInternalComments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/wrappedRecursiveGenericType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/yieldInForInInDownlevelGenerator.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/yieldStringLiteral.ts
 A 'yield' expression is only allowed in a generator body.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/Symbols/ES5SymbolProperty1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/Symbols/ES5SymbolProperty4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/Symbols/ES5SymbolProperty5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/Symbols/ES5SymbolProperty7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/additionalChecks/noPropertyAccessFromIndexSignature1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsExternal.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsPatterns.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsPatterns_merging3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientEnumDeclaration1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientEnumDeclaration2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientExternalModuleInsideNonAmbient.ts
@@ -4198,7 +3881,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncAw
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncAwait_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncMethodWithSuperConflict_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncMethodWithSuper_es2017.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitBinaryExpression/awaitBinaryExpression5_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression1_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression2_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/awaitCallExpression/awaitCallExpression3_es2017.ts
@@ -4223,7 +3905,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncAwait
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncAwaitNestedClasses_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncAwait_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncMethodWithSuper_es5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitBinaryExpression/awaitBinaryExpression5_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallExpression/awaitCallExpression1_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallExpression/awaitCallExpression2_es5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallExpression/awaitCallExpression3_es5.ts
@@ -4234,7 +3915,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallE
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/awaitCallExpression/awaitCallExpression8_es5.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration12_es5.ts
 Cannot use `await` as an identifier in an async context
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration15_es5.ts
 tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration16_es5.ts
 Unexpected estree file content error: 1 != 2
 
@@ -4247,7 +3927,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncAwait
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncAwait_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncMethodWithSuper_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncWithVarShadowing_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression5_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression1_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression2_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression3_es6.ts
@@ -4261,7 +3940,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/await_unar
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/await_unaryExpression_es6_2.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration12_es6.ts
 Cannot use `await` as an identifier in an async context
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration15_es6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts
 Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration8_es6.ts
@@ -4270,20 +3948,13 @@ Cannot use `await` as an identifier in an async context
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/asyncGenerators/asyncGeneratorGenericNonWrappedReturn.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/asyncGenerators/asyncGeneratorParameterEvaluation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/asyncGenerators/asyncGeneratorPromiseNextType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractClinterfaceAssignability.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInstantiations1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAndInterfaceMergeConflictingMembers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classAndInterfaceWithSameName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classBody/classWithEmptyBody.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classExtendingClassLikeType.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendingOptionalChain.ts
 Expected `{` but found `?.`
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classIsSubtypeOfBaseType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/constructorFunctionTypeIsAssignableToBaseType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/constructorFunctionTypeIsAssignableToBaseType2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classImplementsMergedClassInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/classWithPredefinedTypesAsNames.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/mergedClassInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/mergedInheritedClassInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classDeclarations/modifierOnClassDeclarationMemberInFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classExpression.ts
@@ -4346,13 +4017,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/clas
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/instancePropertyInClassType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/classTypes/staticPropertyNotInClassType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/constructorFunctionTypes/classWithStaticMembers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesPrivates.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesProtectedMembers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesProtectedMembers2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesProtectedMembers3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesProtectedMembers4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesPublicMembers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassOverridesWithoutSubtype.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity3.ts
@@ -4372,7 +4036,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/priv
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameComputedPropertyName4.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameConstructorReserved.ts
 Classes can't have an element named '#constructor'
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameConstructorSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameEmitHelpers.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameEnum.ts
 Unexpected token
@@ -4408,7 +4071,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinClasses
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinWithBaseDependingOnSelfNoCrash1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationES2022.ts
@@ -4471,7 +4133,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/constEnums/importEli
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/controlFlow/assertionTypePredicates1.ts
 Expected `,` but found `is`
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowAliasing.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowAssignmentExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowAssignmentPatternOrder.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowBinaryOrExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowBindingElement.ts
@@ -4480,21 +4141,16 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlF
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowDeleteOperator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowDestructuringDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowElementAccess.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowElementAccess2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowElementAccessNoCrash1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowForInStatement2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowGenericTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIfStatement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowInOperator.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowInstanceofExtendsFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowIterationErrorsAsync.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowNoIntermediateErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowNullishCoalesce.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowOptionalChain.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowOptionalChain2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowOptionalChain3.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowParameter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowStringIndex.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/controlFlowWithTemplateLiterals.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/dependentDestructuredVariables.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/controlFlow/dependentDestructuredVariablesFromNestedPatterns.ts
@@ -4540,13 +4196,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/met
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodParameter3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty13.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorCallGeneric.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorMetadata-jsdoc.ts
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorMetadata.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorMetadataWithTypeOnlyImport.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/legacyDecorators-contextualTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/directives/multiline.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/directives/ts-expect-error-nocheck.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/directives/ts-expect-error.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/directives/ts-ignore.ts
@@ -4650,7 +4304,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/modules/expor
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2020/modules/exportAsNamespace_nonExistent.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2021/logicalAssignment/logicalAssignment10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2021/logicalAssignment/logicalAssignment2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2021/logicalAssignment/logicalAssignment3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2021/logicalAssignment/logicalAssignment4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2021/logicalAssignment/logicalAssignment8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2021/logicalAssignment/logicalAssignment9.ts
@@ -4665,28 +4318,19 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2024/resizableArra
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es2024/sharedMemory.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolDeclarationEmit9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty11.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty14.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty15.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty16.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty17.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty18.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty19.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty20.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty21.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty22.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty23.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty24.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty25.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty28.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty29.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty3.ts
@@ -4697,10 +4341,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolPr
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty34.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty35.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty36.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty37.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty38.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty41.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty52.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty53.ts
@@ -4709,14 +4350,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolPr
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty56.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty57.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty58.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty59.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty60.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty61.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolProperty9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType16.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType17.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType18.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType19.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/Symbols/symbolType20.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/arrowFunction/disallowLineTerminatorBeforeArrow.ts
@@ -5100,7 +4736,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of54.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of55.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of56.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of58.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/for-ofStatements/for-of8.ts
@@ -5438,13 +5073,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck46.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck62.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck63.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/generatorTypeCheck7.ts
 tasks/coverage/typescript/tests/cases/conformance/es6/yieldExpressions/yieldExpressionInControlFlow.ts
 Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCanBeAssigned1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsReference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/emitCompoundExponentiationAssignmentWithIndexingOnLHS2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/emitCompoundExponentiationAssignmentWithIndexingOnLHS3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es7/exponentiationOperator/emitCompoundExponentiationAssignmentWithIndexingOnLHS4.ts
@@ -5534,17 +5167,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLit
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiterals3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOperator3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOperatorASI.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOperatorAmbiguity.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/asOperator/asOperatorContextualType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/assignmentGenericLookupTypeNarrowing.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/assignmentLHSIsReference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/assignmentTypeNarrowing.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentLHSCanBeAssigned.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentLHSCannotBeAssigned.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentLHSCanBeAssigned.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsReference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithAnyAndEveryType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithConstrainedTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithInvalidOperands.ts
@@ -5567,7 +5197,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOp
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalObjects.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIntersectionType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnCallSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnConstructorSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipObjectsOnInstantiatedCallSignature.ts
@@ -5576,7 +5205,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOp
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipPrimitiveType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNoRelationshipTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNumberOperand.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithNumericLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsUndefined.ts
@@ -5587,7 +5215,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOp
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnInstantiatedConstructorSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithSubtypeObjectOnOptionalProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithValidOperands.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithInvalidOperands.es2015.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithRHSHasSymbolHasInstance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/logicalAndOperator/logicalAndOperatorWithEveryType.ts
@@ -5664,14 +5291,12 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/o
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/objectLiterals/objectLiteralGettersAndSetters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/objectLiterals/objectLiteralNormalization.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/callChain.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/callChain.3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/callChain.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/callChainInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/callChainWithSuper.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/callChain/parentheses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/delete/deleteChain.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/elementAccessChain/elementAccessChain.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/elementAccessChain/elementAccessChain.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/optionalChainingInArrow.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/optionalChainingInLoop.ts
@@ -5680,7 +5305,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optional
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/optionalChainingInParameterInitializer.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/optionalChainingInParameterInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/optionalChainingInference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/propertyAccessChain/propertyAccessChain.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/propertyAccessChain/propertyAccessChain.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/optionalChaining/taggedTemplateChain/taggedTemplateChain.ts
 Tagged template expressions are not permitted in an optional chain
@@ -5695,8 +5319,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/thisKeyw
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/thisKeyword/typeOfThisInConstructorParamList.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeAssertions/constAssertionOnEnum.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeAssertions/constAssertions.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeAssertions/duplicatePropertiesInTypeAssertions01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeAssertions/duplicatePropertiesInTypeAssertions02.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/TypeGuardWithEnumUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardEnums.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardFunction.ts
@@ -5707,14 +5329,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuar
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardNarrowsToLiteralTypeUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormInstanceOf.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormInstanceOfOnInterface.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormIsTypeOnInterfaces.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormThisMember.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormThisMemberErrors.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormTypeOfPrimitiveSubtype.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardOfFromPropNameInUnionType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardTypeOfUndefined.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsDefeat.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsInClassAccessors.ts
@@ -5733,7 +5352,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuar
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsOnClassProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsWithAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOf.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfBySymbolHasInstance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typePredicateASI.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typePredicateOnVariableDeclaration01.ts
@@ -5924,15 +5542,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/type
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/namespaceMemberAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/preserveValueImports.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/preserveValueImports_module.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/typesOnlyExternalModuleStillHasInstance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd-augmentation-1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd-augmentation-2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd-augmentation-3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd-augmentation-4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/externalModules/umd8.ts
@@ -5980,22 +5594,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarati
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergeThreeInterfaces2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergeTwoInterfaces.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergeTwoInterfaces2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInheritedMembersSatisfyAbstractBase.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithConflictingPropertyNames.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithConflictingPropertyNames2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithIndexers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithIndexers2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheritedPrivates.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheritedPrivates2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheritedPrivates3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithMultipleBases.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithMultipleBases2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithMultipleBases3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithMultipleBases4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithTheSameNameButDifferentArity.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/twoInterfacesDifferentRootModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/twoInterfacesDifferentRootModule2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/declarationMerging/twoMergedInterfacesWithDifferingOverloads.ts
@@ -6003,30 +5609,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interface
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/derivedInterfaceIncompatibleWithBaseIndexer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersection.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceExtendsObjectIntersectionErrors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceThatHidesBaseProperty.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceThatHidesBaseProperty2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceThatIndirectlyInheritsFromItself.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithCallSignaturesThatHidesBaseSignature.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithCallSignaturesThatHidesBaseSignature2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithConstructSignaturesThatHidesBaseSignature.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithConstructSignaturesThatHidesBaseSignature2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithMultipleBaseTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithMultipleBaseTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithPropertyOfEveryType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithPropertyThatIsPrivateInBaseType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithPropertyThatIsPrivateInBaseType2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithStringIndexerHidingBaseTypeIndexer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithStringIndexerHidingBaseTypeIndexer2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithStringIndexerHidingBaseTypeIndexer3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtendingClasses/implementingAnInterfaceExtendingClassWithPrivates.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtendingClasses/implementingAnInterfaceExtendingClassWithPrivates2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtendingClasses/implementingAnInterfaceExtendingClassWithProtecteds.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithPrivates.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithPrivates2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithProtecteds.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithProtecteds2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/AmbientModuleAndAmbientFunctionWithTheSameNameAndCommonRoot.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/AmbientModuleAndAmbientWithSameNameAndCommonRoot.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/AmbientModuleAndNonAmbientClassWithSameNameAndCommonRoot.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/AmbientModuleAndNonAmbientFunctionWithTheSameNameAndCommonRoot.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithModuleMemberThatUsesClassTypeParameter.ts
@@ -6063,14 +5649,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/expo
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportFunctionWithInaccessibleTypesInParameterTypeAnnotation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportFunctionWithInaccessibleTypesInReturnTypeAnnotation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportInterfaceWithAccessibleTypesInTypeParameterConstraintsClassHeritageListMemberTypeAnnotations.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportInterfaceWithInaccessibleTypeInIndexerTypeAnnotations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportInterfaceWithInaccessibleTypeInTypeParameterConstraint.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportModuleWithAccessibleTypesOnItsExportedMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportObjectLiteralAndObjectTypeLiteralWithAccessibleTypesInMemberTypeAnnotations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportObjectLiteralAndObjectTypeLiteralWithAccessibleTypesInNestedMemberTypeAnnotations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportVariableWithAccessibleTypeInTypeAnnotation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ExportVariableWithInaccessibleTypeInTypeAnnotation.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ModuleWithExportedAndNonExportedClasses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ModuleWithExportedAndNonExportedEnums.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/exportDeclarations/ModuleWithExportedAndNonExportedImportAlias.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/importDeclarations/circularImportAlias.ts
@@ -6079,10 +5663,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/impo
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/importDeclarations/invalidImportAliasIdentifiers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/importDeclarations/shadowedInternalModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleBody/moduleWithStatementsOfEveryKind.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/InvalidNonInstantiatedModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/asiPreventsParsingAsNamespace05.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/instantiatedModule.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/invalidInstantiatedModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/invalidNestedModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/nestedModules.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/nonInstantiatedModule.ts
@@ -6237,7 +5819,6 @@ Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/parseLinkTag.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/parseThrowsTag.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/seeTag1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsdoc/seeTag2.ts
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/syntaxErrors.ts
 Unexpected estree file content error: 1 != 2
@@ -6252,20 +5833,9 @@ tasks/coverage/typescript/tests/cases/conformance/jsdoc/typedefMultipleTypeParam
 Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenCanBeTupleType.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty1.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty10.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty11.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty12.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty13.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty14.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty16.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty2.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty3.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty4.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty5.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty6.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty7.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty8.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxGenericTagHasCorrectInferences.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxIntersectionElementPropsType.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxSubtleSkipContextSensitiveBug.tsx
@@ -6300,9 +5870,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxs/jsxJsxsCjsT
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformSubstitutesNames.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformSubstitutesNamesFragment.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeErrors.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution1.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution10.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution11.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution12.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution14.tsx
@@ -6314,52 +5882,23 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeReso
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution5.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution6.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution7.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution8.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution9.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxCorrectlyParseLessThanComparison1.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDefaultAttributesResolution1.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDefaultAttributesResolution2.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDefaultAttributesResolution3.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName2.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName3.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName4.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDynamicTagName6.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution1.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution10.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution11.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution12.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution13.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution15.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution17.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution19.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution3.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution4.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxElementResolution9.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxEmit1.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxExternalModuleEmit2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentPreserveEmit.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentReactEmit.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType1.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType2.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType3.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType4.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType5.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType6.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType7.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType8.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxGenericAttributesType9.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxInArrowFunction.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxIntrinsicAttributeErrors.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxOpeningClosingNames.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxParseTests1.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxParseTests2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxPreserveEmit1.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxPreserveEmit3.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefaultTypeParameter1.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefaultTypeParameter2.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactComponentWithDefaultTypeParameter3.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit1.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmit8.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitEntities.tsx
@@ -6387,20 +5926,14 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadChildre
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxSpreadChildrenInvalidType.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload1.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload2.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload3.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload4.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload5.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload6.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentWithDefaultTypeParameter1.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentWithDefaultTypeParameter2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponents2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponents3.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments1.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments3.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments4.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments5.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxTypeArgumentResolution.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxTypeArgumentsJsxPreserveOutput.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxTypeErrors.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType1.tsx
@@ -6713,10 +6246,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/C
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName5.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName6.ts
 Computed property names are not allowed in enums.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ComputedPropertyNames/parserES5ComputedPropertyName8.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration11.ts
 Type parameters cannot appear on a constructor declaration
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ConstructorDeclarations/parserConstructorDeclaration3.ts
@@ -6747,10 +6278,8 @@ Expected `{` but found `EOF`
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/IncompleteMemberVariables/parserErrorRecovery_IncompleteMemberVariable1.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/VariableLists/parserErrorRecovery_VariableList1.ts
 Identifier expected. 'return' is a reserved word that cannot be used here.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserCommaInTypeMemberList1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserCommaInTypeMemberList2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserErrantSemicolonInClass1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnPropertySignature2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnStatementInBlock1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnStatementInBlock3.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserStatementIsNotAMemberVariableDeclaration1.ts
@@ -6784,8 +6313,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
 Unexpected token
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexSignatures/parserIndexSignature3.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexSignatures/parserIndexSignature4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexSignatures/parserIndexSignature5.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexSignatures/parserIndexSignature6.ts
 Unexpected token
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/IndexSignatures/parserIndexSignature7.ts
@@ -6824,9 +6351,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/M
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ObjectLiterals/parserObjectLiterals1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ObjectTypes/parserObjectType2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ObjectTypes/parserObjectType3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ObjectTypes/parserObjectType4.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ObjectTypes/parserObjectType6.ts
 Unexpected token
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList1.ts
@@ -6840,19 +6364,12 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/P
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertyAssignments/parserFunctionPropertyAssignment2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertyAssignments/parserFunctionPropertyAssignment3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertyAssignments/parserFunctionPropertyAssignment4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature11.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/PropertySignatures/parserPropertySignature9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Protected/Protected9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RealWorld/parserindenter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509546.ts
@@ -6860,11 +6377,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/R
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509546_2.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509668.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509677.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509698.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser618973.ts
 'export' modifier cannot be used here.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser643728.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parser645484.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegressionTests/parserNotHexLiteral1.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity3.ts
@@ -6906,10 +6421,8 @@ A 'return' statement can only be used within a function body.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Symbols/parserES5SymbolProperty9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration1.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/VariableDeclarations/parserVariableDeclaration10.ts
 Unexpected token
@@ -6944,9 +6457,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/p
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserUnicode2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserUnicode3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/parserUsingConstructorAsIdentifier.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName13.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName14.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName15.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName16.ts
 Computed property names are not allowed in enums.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName17.ts
@@ -6954,7 +6465,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/C
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName19.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName20.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName21.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName26.ts
 Computed property names are not allowed in enums.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/ComputedPropertyNames/parserComputedPropertyName3.ts
@@ -6974,10 +6484,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/I
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement22.ts
 The left-hand side of a `for...of` statement may not be `async`
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement25.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript6/Symbols/parserSymbolProperty9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/pedantic/noUncheckedIndexedAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/pedantic/noUncheckedIndexedAccessDestructuring.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/references/library-reference-1.ts
@@ -7096,7 +6604,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/scanner/ecmascript5/
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInvalidInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/everyTypeWithInitializer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/invalidMultipleVariableDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/recursiveInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/awaitUsingDeclarations.10.ts
@@ -7196,7 +6703,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofSta
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-ofTypeCheck10.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/forStatements/forStatements.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/forStatements/forStatementsMultipleInvalidDecl.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/forStatements/forStatementsMultipleValidDecl.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/ifDoWhileStatements/ifDoWhileStatements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/labeledStatements/labeledStatementDeclarationListInLoopNoCrash2.ts
@@ -7268,7 +6774,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/i
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionReduction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionReductionStrict.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionThisTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeEquivalence.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionTypeInference2.ts
@@ -7279,16 +6784,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/i
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionWithIndexSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionWithUnionConstraint.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/intersectionsAndEmptyObjects.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/operatorsAndIntersectionTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/intersection/recursiveIntersectionTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/keyof/circularIndexedAccessErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/keyof/keyofAndForIn.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/keyof/keyofAndIndexedAccess2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/keyof/keyofAndIndexedAccessErrors.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/keyof/keyofIntersection.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/booleanLiteralTypes1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/booleanLiteralTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/enumLiteralTypes1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/enumLiteralTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/enumLiteralTypes3.ts
@@ -7297,8 +6797,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/litera
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypesAndDestructuring.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypesAndTypeAssertions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/literalTypesWidenInParameterPosition.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/numericLiteralTypes1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/numericLiteralTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/numericStringLiteralTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringEnumLiteralTypes1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/stringEnumLiteralTypes2.ts
@@ -7331,7 +6829,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/literal/templa
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/localTypes/localTypes1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/localTypes/localTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/localTypes/localTypes3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/localTypes/localTypes4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/isomorphicMappedTypeInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeAsClauseRelationships.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypeAsClauses.ts
@@ -7356,8 +6853,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedT
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypesGenericTuples.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/mappedTypesGenericTuples2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/mapped/recursiveMappedTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/augmentedTypeAssignmentCompatIndexSignature.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/augmentedTypeBracketAccessIndexSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/classWithPrivateProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/classWithProtectedProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/duplicateNumericIndexers.ts
@@ -7387,13 +6882,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/members/typesW
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/classWithOnlyPublicMembersEquivalentToInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/classWithOnlyPublicMembersEquivalentToInterface2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/classWithOptionalParameter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/genericInstantiationEquivalentToObjectLiteral.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/namedTypes/optionalMethods.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/never/neverInference.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/never/neverIntersectionNotCallable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/never/neverTypeErrors1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/never/neverTypeErrors2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/never/neverUnionIntersection.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/assignObjectToNonPrimitive.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAccessProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAndEmptyObject.ts
@@ -7401,8 +6892,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/n
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAsProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveAssignError.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveConstraintOfIndexAccessType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/nonPrimitive/nonPrimitiveUnionIntersection.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignatureWithOptionalParameterAndInitializer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignatureWithoutAnnotationsOrBody.ts
@@ -7450,7 +6939,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLite
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/methodSignatures/functionLiterals.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/methodSignatures/methodSignaturesWithOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/methodSignatures/methodSignaturesWithOverloads2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/objectTypeLiteralSyntax.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/propertySignatures/numericStringNamedPropertyEquivalence.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/propertySignatures/propertyNameWithoutTypeAnnotation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/objectTypeLiteral/propertySignatures/propertyNamesOfReservedWords.ts
@@ -7463,7 +6951,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/enu
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/null/validNullAssignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/assignFromNumberInterface2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/extendNumberInterface.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/invalidNumberAssignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/number/validNumberAssignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/assignFromStringInterface2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/string/extendStringInterface.ts
@@ -7471,7 +6958,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/str
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/invalidUndefinedAssignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/invalidUndefinedValues.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/undefined/validUndefinedAssignments.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/void/invalidAssignmentsToVoid.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/void/invalidVoidAssignments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/primitives/void/invalidVoidValues.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/rest/genericObjectRest.ts
@@ -7505,10 +6991,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingType
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/functionLiteralForOverloads.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/functionLiteralForOverloads2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeLiterals/unionTypeLiterals.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/circularTypeofWithVarOrFunc.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/recursiveTypesWithTypeof.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeQueryOnClass.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeQueryWithReservedWords.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofANonExportedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofAnExportedType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofThis.ts
@@ -7538,7 +7022,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadO
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadOverwritesProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadOverwritesPropertyStrict.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadUnion.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadUnion2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadUnion3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/spread/spreadUnion4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralCheckedInIf01.ts
@@ -7578,8 +7061,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisT
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeErrors2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInAccessors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInAccessorsNegative.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInBasePropertyAndDerivedContainerOfBase01.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInClasses.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions4.ts
@@ -7592,7 +7073,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisT
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeOptionalCall.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeSyntacticContext.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/unionThisTypeInFunctions.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/castingTuple.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/contextualTypeTupleEnd.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts
@@ -7609,15 +7089,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/unionsOf
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/variadicTuples1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/variadicTuples2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/variadicTuples3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/circularTypeAliasForUnionWithInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/directDependenceBetweenTypeAliases.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/genericTypeAliases.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/intrinsicKeyword.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/intrinsicTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/typeAliases.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/typeAliasesDoNotMerge.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/typeAliasesForObjectTypes.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/recurringTypeParamForContainerOfBase01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithIncorrectNumberOfTypeArguments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/callGenericFunctionWithZeroTypeArguments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts
@@ -7688,7 +7164,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationsh
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembers2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembers3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembers4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembers5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersAccessibility.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersNumericNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithObjectMembersOptionality.ts
@@ -7697,7 +7172,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationsh
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithStringIndexer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithStringIndexer2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithStringIndexer3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance4.ts
@@ -7731,7 +7205,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationsh
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/bestCommonType/heterogeneousArrayLiterals.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/equalityStrictNulls.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/equalityWithEnumTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/equalityWithIntersectionTypes01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/comparable/equalityWithUnionTypes01.ts
@@ -7745,9 +7218,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationsh
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/instanceOf/narrowingGenericTypeFromInstanceof01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/infiniteExpansionThroughInstantiation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/infiniteExpansionThroughInstantiation2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/infiniteExpansionThroughTypeInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/nominalSubtypeCheckOfTypeParameter.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/nominalSubtypeCheckOfTypeParameter2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedProperty2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedPropertyCheckedNominally.ts
@@ -7888,11 +7359,9 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationsh
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericFunctionParameters.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferences.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferencesJsx.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/keyofInferenceIntersectsResults.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/keyofInferenceLowerPriorityThanReturn.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/noInfer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionAndIntersectionInference3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionTypeInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/widenedTypes/arrayLiteralWidened.ts
@@ -7902,7 +7371,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/contextu
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/contextualTypeWithUnionTypeIndexSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/contextualTypeWithUnionTypeMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/contextualTypeWithUnionTypeObjectLiteral.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/discriminatedUnionTypes1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/discriminatedUnionTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/discriminatedUnionTypes3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeCallSignatures.ts
@@ -7919,13 +7387,11 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTyp
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeMembers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeReadonly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeReduction2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/union/unionTypeWithIndexSignature.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbols.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarations.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsDeclarationsErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsErrors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/uniqueSymbol/uniqueSymbolsPropertyNames.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/unknown/unknownControlFlow.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/unknown/unknownType1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/unknown/unknownType2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/witness/witness.ts


### PR DESCRIPTION
Align our AST's ESTree output with that of TS-ESLint's for`TSPropertySignature` node. Relates to #9705 

Adds a custom estree serializer for this node. 

The reason I went for the custom serializer is because I didn't find a good way of using the existing estree macro to add a estree field named `static` which is of course a reserved keyword.

Initially I tried to just add this macro to the node:`#[estree(add_fields(static = False)]`

However on running `just ast` this resulted in 
```thread 'main' panicked at tasks/ast_tools/src/parse/parse.rs:590:17:
Invalid use of `#[estree]` on `TSPropertySignature` type
stack backtrace:
   0: _rust_begin_unwind
   1: core::panicking::panic_fmt
   2: oxc_ast_tools::parse::parse::Parser::parse_type_attrs
   3: oxc_ast_tools::parse::parse::Parser::parse_struct
....
```

Next I tried:  `#[estree(add_fields(r#static = False)]` which just resulted in the field key being serialized as `r#static` instead of the expected `static`.