### PR TITLE
perf(ast_tools): reduce `String` allocations

### DIFF
--- a/tasks/ast_tools/src/parse/mod.rs
+++ b/tasks/ast_tools/src/parse/mod.rs
@@ -109,5 +109,6 @@ fn analyse_file(
 ///
 /// [`Ident`]: struct@Ident
 fn ident_name(ident: &Ident) -> String {
-    ident.to_string().trim_start_matches("r#").to_string()
+    let name = ident.to_string();
+    if let Some(unprefixed) = name.strip_prefix("r#") { unprefixed.to_string() } else { name }
 }


### PR DESCRIPTION
`ident_name` generate only 1 `String` in common case, instead of 2.