### PR TITLE
refactor(ast_tools): move `ident_name` function to `utils` module

### DIFF
--- a/tasks/ast_tools/src/parse/load.rs
+++ b/tasks/ast_tools/src/parse/load.rs
@@ -9,10 +9,10 @@ use syn::{
     punctuated::Punctuated,
 };
 
-use crate::schema::FileId;
+use crate::{schema::FileId, utils::ident_name};
 
 use super::{
-    FxIndexMap, ident_name,
+    FxIndexMap,
     parse::convert_expr_to_string,
     skeleton::{EnumSkeleton, Skeleton, StructSkeleton},
 };

--- a/tasks/ast_tools/src/parse/mod.rs
+++ b/tasks/ast_tools/src/parse/mod.rs
@@ -48,7 +48,6 @@
 //! [`Generator`]: crate::Generator
 
 use oxc_index::IndexVec;
-use syn::Ident;
 
 use crate::{
     Codegen, log, log_success,
@@ -103,12 +102,4 @@ fn analyse_file(
     log_success!();
 
     File::new(file_path)
-}
-
-/// Convert [`Ident`] to `String`, removing `r#` from start.
-///
-/// [`Ident`]: struct@Ident
-fn ident_name(ident: &Ident) -> String {
-    let name = ident.to_string();
-    if let Some(unprefixed) = name.strip_prefix("r#") { unprefixed.to_string() } else { name }
 }

--- a/tasks/ast_tools/src/parse/parse.rs
+++ b/tasks/ast_tools/src/parse/parse.rs
@@ -14,13 +14,12 @@ use crate::{
         BoxDef, CellDef, Def, EnumDef, FieldDef, File, FileId, MetaId, MetaType, OptionDef,
         PrimitiveDef, Schema, StructDef, TypeDef, TypeId, VariantDef, VecDef, Visibility,
     },
-    utils::{FxIndexMap, FxIndexSet},
+    utils::{FxIndexMap, FxIndexSet, ident_name},
 };
 
 use super::{
     Derives,
     attr::{AttrLocation, AttrPart, AttrPartListElement, AttrPositions, AttrProcessor},
-    ident_name,
     skeleton::{EnumSkeleton, Skeleton, StructSkeleton},
 };
 

--- a/tasks/ast_tools/src/utils.rs
+++ b/tasks/ast_tools/src/utils.rs
@@ -63,6 +63,14 @@ pub fn create_ident_tokens(name: &str) -> TokenStream {
     }
 }
 
+/// Convert [`Ident`] to `String`, removing `r#` from start.
+///
+/// [`Ident`]: struct@Ident
+pub fn ident_name(ident: &Ident) -> String {
+    let name = ident.to_string();
+    if let Some(unprefixed) = name.strip_prefix("r#") { unprefixed.to_string() } else { name }
+}
+
 /// Convert integer to [`LitInt`].
 ///
 /// This prints without a `usize` postfix. i.e. `123` not `123usize`.


### PR DESCRIPTION
Pure refactor. Move this utility function to `utils` module.