### PR TITLE
fix(ast_tools): remove `r#` prefix from attr parts during parsing

### DIFF
--- a/tasks/ast_tools/src/derives/estree.rs
+++ b/tasks/ast_tools/src/derives/estree.rs
@@ -111,7 +111,6 @@ fn parse_estree_attr(location: AttrLocation, part: AttrPart) -> Result<()> {
                 let mut field_indices = vec![];
                 for list_element in list {
                     let field_name = list_element.try_into_tag()?;
-                    let field_name = field_name.trim_start_matches("r#");
                     let field_index = all_field_names
                         .clone()
                         .position(|this_field_name| this_field_name == field_name)

--- a/tasks/ast_tools/src/parse/parse.rs
+++ b/tasks/ast_tools/src/parse/parse.rs
@@ -784,7 +784,7 @@ fn process_attr(
             for meta in parts {
                 match &meta {
                     Meta::Path(path) => {
-                        let part_name = path.get_ident().ok_or(())?.to_string();
+                        let part_name = ident_name(path.get_ident().ok_or(())?);
                         process_attr_part(
                             processor,
                             attr_name,
@@ -793,7 +793,7 @@ fn process_attr(
                         )?;
                     }
                     Meta::NameValue(name_value) => {
-                        let part_name = name_value.path.get_ident().ok_or(())?.to_string();
+                        let part_name = ident_name(name_value.path.get_ident().ok_or(())?);
                         let str = convert_expr_to_string(&name_value.value);
                         process_attr_part(
                             processor,
@@ -803,7 +803,7 @@ fn process_attr(
                         )?;
                     }
                     Meta::List(meta_list) => {
-                        let part_name = meta_list.path.get_ident().ok_or(())?.to_string();
+                        let part_name = ident_name(meta_list.path.get_ident().ok_or(())?);
                         let list = parse_attr_part_list(meta_list)?;
                         process_attr_part(
                             processor,
@@ -827,16 +827,16 @@ fn parse_attr_part_list(meta_list: &MetaList) -> Result<Vec<AttrPartListElement>
         .into_iter()
         .map(|meta| match meta {
             Meta::Path(path) => {
-                let part_name = path.get_ident().ok_or(())?.to_string();
+                let part_name = ident_name(path.get_ident().ok_or(())?);
                 Ok(AttrPartListElement::Tag(part_name))
             }
             Meta::NameValue(name_value) => {
-                let part_name = name_value.path.get_ident().ok_or(())?.to_string();
+                let part_name = ident_name(name_value.path.get_ident().ok_or(())?);
                 let str = convert_expr_to_string(&name_value.value);
                 Ok(AttrPartListElement::String(part_name, str))
             }
             Meta::List(meta_list) => {
-                let part_name = meta_list.path.get_ident().ok_or(())?.to_string();
+                let part_name = ident_name(meta_list.path.get_ident().ok_or(())?);
                 let list = parse_attr_part_list(&meta_list)?;
                 Ok(AttrPartListElement::List(part_name, list))
             }


### PR DESCRIPTION
Remove `r#` prefix from attribute keys when parsing attributes.

This fixes parsing e.g. `#[estree(add_fields(r#static = False))]`.
