### PR TITLE
TEST: do not pre-allocate capacity for semantic data

### DIFF
--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -241,11 +241,13 @@ impl<'a> SemanticBuilder<'a> {
                 (stats_with_excess, Some(stats))
             };
             self.nodes.reserve(stats.nodes as usize);
+            /*
             self.scoping.reserve(
                 stats.symbols as usize,
                 stats.references as usize,
                 stats.scopes as usize,
             );
+            */
 
             // Visit AST to generate scopes tree etc
             self.visit_program(program);


### PR DESCRIPTION
Just a test to see how much it costs not allocating enough capacity for scopes, symbols, references (as opposed to nodes). The answer is quite a lot.