### PR TITLE
fix(editor): enable regex parsing in language server

### DIFF
--- a/crates/oxc_language_server/fixtures/linter/regexp_feature/.oxlintrc.json
+++ b/crates/oxc_language_server/fixtures/linter/regexp_feature/.oxlintrc.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "no-useless-escape": "error",
+    "no-control-regex": "error"
+  }
+}

--- a/crates/oxc_language_server/fixtures/linter/regexp_feature/index.ts
+++ b/crates/oxc_language_server/fixtures/linter/regexp_feature/index.ts
@@ -1,0 +1,2 @@
+let regex = /([^\/]+)/g;
+let regex2 = /[^\u0000-\u00FF]/g;

--- a/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
+++ b/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
@@ -119,6 +119,7 @@ impl IsolatedLintHandler {
             let ret = Parser::new(&allocator, javascript_source_text, source_type)
                 .with_options(ParseOptions {
                     allow_return_outside_function: true,
+                    parse_regular_expression: true,
                     ..ParseOptions::default()
                 })
                 .parse();

--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -73,4 +73,21 @@ mod test {
         Tester::new_with_linter(linter)
             .test_and_snapshot_single_file("fixtures/linter/issue_9958/issue.ts");
     }
+
+    // Test case for https://github.com/oxc-project/oxc/issues/9957
+    #[test]
+    fn test_regexp() {
+        let config_store = ConfigStoreBuilder::from_oxlintrc(
+            true,
+            Oxlintrc::from_file(&PathBuf::from("fixtures/linter/regexp_feature/.oxlintrc.json"))
+                .unwrap(),
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+        let linter = Linter::new(LintOptions::default(), config_store).with_fix(FixKind::SafeFix);
+
+        Tester::new_with_linter(linter)
+            .test_and_snapshot_single_file("fixtures/linter/regexp_feature/index.ts");
+    }
 }

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_regexp_feature_index.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_regexp_feature_index.ts.snap
@@ -1,0 +1,25 @@
+---
+source: crates/oxc_language_server/src/linter/tester.rs
+---
+code: "eslint(no-control-regex)"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-control-regex"
+message: "Unexpected control character\nhelp: '\\u0000' is not a valid control character."
+range: Range { start: Position { line: 1, character: 13 }, end: Position { line: 1, character: 32 } }
+related_information[0].message: ""
+related_information[0].location.uri: "file://<variable>/fixtures/linter/regexp_feature/index.ts"
+related_information[0].location.range: Range { start: Position { line: 1, character: 13 }, end: Position { line: 1, character: 32 } }
+severity: Some(Error)
+source: Some("oxc")
+tags: None
+            
+
+code: "eslint(no-useless-escape)"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-useless-escape"
+message: "Unnecessary escape character '/'\nhelp: Replace `\\/` with `/`."
+range: Range { start: Position { line: 0, character: 16 }, end: Position { line: 0, character: 18 } }
+related_information[0].message: ""
+related_information[0].location.uri: "file://<variable>/fixtures/linter/regexp_feature/index.ts"
+related_information[0].location.range: Range { start: Position { line: 0, character: 16 }, end: Position { line: 0, character: 18 } }
+severity: Some(Error)
+source: Some("oxc")
+tags: None


### PR DESCRIPTION
- fixes https://github.com/oxc-project/oxc/issues/10029
- fixes https://github.com/oxc-project/oxc/issues/9957