### PR TITLE
refactor(lexer): remove unnecessary line

### DIFF
--- a/crates/oxc_parser/src/lexer/string.rs
+++ b/crates/oxc_parser/src/lexer/string.rs
@@ -109,7 +109,6 @@ macro_rules! handle_string_literal_escape {
                         // mean `!table.matches(b)` on this branch prevents exiting this loop until
                         // `source` is positioned on a UTF-8 character boundary again.
                         $lexer.source.next_byte_unchecked();
-                        continue;
                     }
                     b if b == $delimiter => {
                         // End of string found. Push last chunk to `str`.


### PR DESCRIPTION
Tiny refactor to lexer. Remove a pointless line from string parsing code.