### PR TITLE
refactor(codegen): print string literals containing lone surrogates without reference to `raw`

### DIFF
--- a/crates/oxc_codegen/tests/integration/esbuild.rs
+++ b/crates/oxc_codegen/tests/integration/esbuild.rs
@@ -363,15 +363,15 @@ fn test_string() {
     test("let x = '\\U000123AB'", "let x = \"U000123AB\";\n");
     test("let x = '\\u{123AB}'", "let x = \"\u{123ab}\";\n");
     test("let x = '\\uD808\\uDFAB'", "let x = \"\u{123ab}\";\n");
-    test("let x = '\\uD808'", "let x = '\\uD808';\n"); // lone surrogate
-    test("let x = '\\uD808X'", "let x = '\\uD808X';\n");
-    test("let x = '\\uDFAB'", "let x = '\\uDFAB';\n");
-    test("let x = '\\uDFABX'", "let x = '\\uDFABX';\n");
+    test("let x = '\\uD808'", "let x = \"\\ud808\";\n"); // lone surrogate
+    test("let x = '\\uD808X'", "let x = \"\\ud808X\";\n");
+    test("let x = '\\uDFAB'", "let x = \"\\udfab\";\n");
+    test("let x = '\\uDFABX'", "let x = \"\\udfabX\";\n");
 
     test("let x = '\\x80'", "let x = \"\u{80}\";\n");
     test("let x = '\\xFF'", "let x = \"ÿ\";\n");
     test("let x = '\\xF0\\x9F\\x8D\\x95'", "let x = \"ð\u{9f}\u{8d}\u{95}\";\n");
-    test("let x = '\\uD801\\uDC02\\uDC03\\uD804'", "let x = '\\uD801\\uDC02\\uDC03\\uD804';\n"); // lossy
+    test("let x = '\\uD801\\uDC02\\uDC03\\uD804'", "let x = \"𐐂\\udc03\\ud804\";\n"); // surrogates
 }
 
 #[test]

--- a/crates/oxc_codegen/tests/integration/unit.rs
+++ b/crates/oxc_codegen/tests/integration/unit.rs
@@ -143,7 +143,7 @@ fn unicode_escape() {
     test("console.log('こんにちは');", "console.log(\"こんにちは\");\n");
     test("console.log('안녕하세요');", "console.log(\"안녕하세요\");\n");
     test("console.log('🧑‍🤝‍🧑');", "console.log(\"🧑‍🤝‍🧑\");\n");
-    test("console.log(\"\\uD800\\uD801\")", "console.log(\"\\uD800\\uD801\");\n");
+    test("console.log(\"\\uD800\\uD801\")", "console.log(\"\\ud800\\ud801\");\n");
 }
 
 #[test]


### PR DESCRIPTION
#10041 changed how lone surrogates are handled in `StringLiteral`s.

`StringLiteral`s which include lone surrogates now have the `lone_surrogates` flag set, and `value` encodes lone surrogates as `\u{FFFD}XXXX`, where `XXXX` is the code unit encoded as hex.

Codegen check the `lone_surrogates` flag and decode the lone surrogates if they're present. This means that:

1. A `StringLiteral` no longer needs to have `raw` field populated, so you can (if you choose to for some reason) create a new `StringLiteral` containing lone surrogates.

2. `StringLiteral`s containing lone surrogates now have any other characters escaped same as how `StringLiteral`s without lone surrogates are printed.
