### PR TITLE
test(editor): add test for `oxc.fixAll` command

### DIFF
--- a/editors/vscode/.vscode-test.mjs
+++ b/editors/vscode/.vscode-test.mjs
@@ -1,4 +1,9 @@
 import { defineConfig } from '@vscode/test-cli';
+import { existsSync, mkdirSync } from 'node:fs';
+
+if (!existsSync('./test_workspace')) {
+  mkdirSync('./test_workspace');
+}
 
 export default defineConfig({
   files: 'out/**/*.spec.js',

--- a/editors/vscode/client/extension.spec.ts
+++ b/editors/vscode/client/extension.spec.ts
@@ -1,9 +1,10 @@
 import { deepStrictEqual, notEqual, strictEqual } from 'assert';
-import { commands, extensions, window, workspace } from 'vscode';
+import { readFile } from 'fs/promises';
+import { commands, extensions, Uri, window, workspace, WorkspaceEdit } from 'vscode';
 
-// const WORKSPACE_DIR = workspace.workspaceFolders![0].uri.toString();
-// const filePath = WORKSPACE_DIR + '/debugger.js';
-// const fileUri = Uri.parse(filePath);
+const WORKSPACE_DIR = workspace.workspaceFolders![0].uri.toString();
+const filePath = WORKSPACE_DIR + '/debugger.js';
+const fileUri = Uri.parse(filePath);
 
 const sleep = (time: number) => new Promise((r) => setTimeout(r, time));
 
@@ -13,11 +14,11 @@ suite('commands', () => {
     await ext.activate();
   });
 
-  // suiteTeardown(async () => {
-  //   const edit = new WorkspaceEdit();
-  //   edit.deleteFile(fileUri);
-  //   await workspace.applyEdit(edit);
-  // });
+  suiteTeardown(async () => {
+    const edit = new WorkspaceEdit();
+    edit.deleteFile(fileUri);
+    await workspace.applyEdit(edit);
+  });
 
   test('listed commands', async () => {
     const oxcCommands = (await commands.getCommands(true)).filter(x => x.startsWith('oxc.'));
@@ -49,30 +50,29 @@ suite('commands', () => {
 
     const isEnabledAfter = workspace.getConfiguration('oxc').get<boolean>('enable');
     strictEqual(isEnabledAfter, false);
+
+    // enable it for other tests
+    await commands.executeCommand('oxc.toggleEnable');
+    await sleep(500);
   });
 
-  // ToDo: check why this is not working,
-  // even with .gitignore deleted in th test_workspace
-  //
-  // test('oxc.fixAll', async () => {
-  //   const edit = new WorkspaceEdit();
-  //   edit.createFile(fileUri, {
-  //     contents: Buffer.from('/* 😊 */debugger;'),
-  //   });
-  //
-  //   await workspace.applyEdit(edit);
-  //   await window.showTextDocument(fileUri);
-  //   await sleep(500);
-  //   await commands.executeCommand('oxc.fixAll', {
-  //     uri: fileUri.toString(),
-  //   });
-  //   await workspace.saveAll();
-  //   await sleep(1000);
-  //
-  //   const content = await readFile(fileUri.fsPath, {
-  //     encoding: 'utf8',
-  //   });
-  //
-  //  strictEqual(content, '/* 😊 */');
-  // });
+  test('oxc.fixAll', async () => {
+    const edit = new WorkspaceEdit();
+    edit.createFile(fileUri, {
+      contents: Buffer.from('/* 😊 */debugger;'),
+    });
+
+    await workspace.applyEdit(edit);
+    await window.showTextDocument(fileUri);
+    await commands.executeCommand('oxc.fixAll', {
+      uri: fileUri.toString(),
+    });
+    await workspace.saveAll();
+
+    const content = await readFile(fileUri.fsPath, {
+      encoding: 'utf8',
+    });
+
+    strictEqual(content, '/* 😊 */');
+  });
 });

--- a/editors/vscode/test_workspace/.gitignore
+++ b/editors/vscode/test_workspace/.gitignore
@@ -1,2 +1,0 @@
-**
-!.gitignore


### PR DESCRIPTION
our first intergration test between vscode and the language server 🥳 