### PR TITLE
feat(napi/parser): auto download wasm binding on webcontainer

### DIFF
--- a/napi/parser/bindings.js
+++ b/napi/parser/bindings.js
@@ -359,6 +359,14 @@ if (!nativeBinding || process.env.NAPI_RS_FORCE_WASI) {
   }
 }
 
+if (!nativeBinding && globalThis.process?.versions?.["webcontainer"]) {
+  try {
+    nativeBinding = require('./webcontainer-fallback.js');
+  } catch (err) {
+    loadErrors.push(err)
+  }
+}
+
 if (!nativeBinding) {
   if (loadErrors.length > 0) {
     // TODO Link to documentation with potential fixes

--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -42,6 +42,7 @@
     "wrap.mjs",
     "wasm.mjs",
     "bindings.js",
+    "webcontainer-fallback.js",
     "deserialize-js.js",
     "deserialize-ts.js"
   ],

--- a/napi/parser/package.json
+++ b/napi/parser/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "build-dev": "napi build --no-dts-cache --platform --js bindings.js",
     "build": "pnpm run build-dev --features allocator --release",
+    "postbuild-dev": "node patch.mjs",
     "build-wasi": "pnpm run build-dev --release --target wasm32-wasip1-threads",
     "build-npm-dir": "rm -rf npm-dir && napi create-npm-dirs --npm-dir npm-dir && pnpm napi artifacts --npm-dir npm-dir --output-dir .",
     "build-browser-bundle": "node build-browser-bundle.mjs",

--- a/napi/parser/patch.mjs
+++ b/napi/parser/patch.mjs
@@ -1,0 +1,18 @@
+import fs from 'node:fs';
+
+const filename = './bindings.js';
+let data = fs.readFileSync(filename, 'utf-8');
+data = data.replace(
+  '\nif (!nativeBinding) {',
+  (s) =>
+    `
+if (!nativeBinding && globalThis.process?.versions?.["webcontainer"]) {
+  try {
+    nativeBinding = require('./webcontainer-fallback.js');
+  } catch (err) {
+    loadErrors.push(err)
+  }
+}
+` + s,
+);
+fs.writeFileSync(filename, data);

--- a/napi/parser/webcontainer-fallback.js
+++ b/napi/parser/webcontainer-fallback.js
@@ -1,10 +1,10 @@
 const fs = require('node:fs');
 const childProcess = require('node:child_process');
 
-const rolldownPkg = JSON.parse(
+const pkg = JSON.parse(
   fs.readFileSync(require.resolve('oxc-parser/package.json'), 'utf-8'),
 );
-const version = rolldownPkg.version;
+const version = pkg.version;
 const baseDir = `/tmp/oxc-parser-${version}`;
 const bindingEntry = `${baseDir}/node_modules/@oxc-parser/binding-wasm32-wasi/parser.wasi.cjs`;
 

--- a/napi/parser/webcontainer-fallback.js
+++ b/napi/parser/webcontainer-fallback.js
@@ -1,0 +1,23 @@
+const fs = require('node:fs');
+const childProcess = require('node:child_process');
+
+const rolldownPkg = JSON.parse(
+  fs.readFileSync(require.resolve('oxc-parser/package.json'), 'utf-8'),
+);
+const version = rolldownPkg.version;
+const baseDir = `/tmp/oxc-parser-${version}`;
+const bindingEntry = `${baseDir}/node_modules/@oxc-parser/binding-wasm32-wasi/parser.wasi.cjs`;
+
+if (!fs.existsSync(bindingEntry)) {
+  fs.rmSync(baseDir, { recursive: true, force: true });
+  fs.mkdirSync(baseDir, { recursive: true });
+  const bindingPkg = `@oxc-parser/binding-wasm32-wasi@${version}`;
+  // eslint-disable-next-line: no-console
+  console.log(`[oxc-parser] Downloading ${bindingPkg} on WebContainer...`);
+  childProcess.execFileSync('pnpm', ['i', bindingPkg], {
+    cwd: baseDir,
+    stdio: 'inherit',
+  });
+}
+
+module.exports = require(bindingEntry);


### PR DESCRIPTION
Oxc-parser equivalent of https://github.com/rolldown/rolldown/pull/3922

As discussed within Stackblitz and Rolldown team, stackblitz's package swap isn't as simple nor as perfect as I thought, so Rolldown went with auto downloading wasm binding during runtime. I suggest doing the same for `oxc-parser`.

~TODO: I need to figure out how to patch `binding.js` during build pipeline.~
TODO: Let nuxt folks know if this is released.

This is yet again only testable with the actual release, so trial-and-error expected :smile: 
(At least, I tested running webcontainer-fallback.js directly on stackblitz https://stackblitz.com/edit/stackblitz-starters-yvuqgxo6?file=webcontainer-fallback.js)