### PR TITLE
feat(semantic/scoping): add `declaration` and `flags` fields for Redeclaraion

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -63,7 +63,7 @@ impl<'a> Binder<'a> for VariableDeclarator<'a> {
                     if let Some(symbol_id) =
                         builder.check_redeclaration(scope_id, span, &name, excludes, true)
                     {
-                        builder.add_redeclare_variable(symbol_id, span);
+                        builder.add_redeclare_variable(symbol_id, includes, span);
                         declared_symbol_id = Some(symbol_id);
 
                         // remove current scope binding and add to target scope

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -388,7 +388,7 @@ impl<'a> SemanticBuilder<'a> {
     ) -> SymbolId {
         if let Some(symbol_id) = self.check_redeclaration(scope_id, span, name, excludes, true) {
             self.scoping.union_symbol_flag(symbol_id, includes);
-            self.add_redeclare_variable(symbol_id, span);
+            self.add_redeclare_variable(symbol_id, includes, span);
             return symbol_id;
         }
 
@@ -561,8 +561,13 @@ impl<'a> SemanticBuilder<'a> {
         }
     }
 
-    pub(crate) fn add_redeclare_variable(&mut self, symbol_id: SymbolId, span: Span) {
-        self.scoping.add_symbol_redeclaration(symbol_id, span);
+    pub(crate) fn add_redeclare_variable(
+        &mut self,
+        symbol_id: SymbolId,
+        flags: SymbolFlags,
+        span: Span,
+    ) {
+        self.scoping.add_symbol_redeclaration(symbol_id, flags, self.current_node_id, span);
     }
 }
 


### PR DESCRIPTION
`declaration` and `flags` are also fields of the symbol. Before, we only had a span info in `symbol_redeclarations`, which means we have no way to know what the redeclaration AST node is and what the symbol flags is 