### PR TITLE
feat(ast)!: remove unused `Function::symbol_id` method

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, fmt};
 
 use oxc_allocator::{Box, Vec};
 use oxc_span::{Atom, Span};
-use oxc_syntax::{operator::UnaryOperator, scope::ScopeFlags, symbol::SymbolId};
+use oxc_syntax::{operator::UnaryOperator, scope::ScopeFlags};
 
 use crate::ast::*;
 
@@ -1305,14 +1305,6 @@ impl<'a> Function<'a> {
     #[inline]
     pub fn name(&self) -> Option<Atom<'a>> {
         self.id.as_ref().map(|id| id.name)
-    }
-
-    /// Get the [`SymbolId`] this [`Function`] is bound to.
-    ///
-    /// Returns [`None`] for anonymous functions.
-    #[inline]
-    pub fn symbol_id(&self) -> Option<SymbolId> {
-        self.id.as_ref().map(BindingIdentifier::symbol_id)
     }
 
     /// Returns `true` if this function uses overload signatures or `declare function` statements.


### PR DESCRIPTION
A few reasons I wanted to remove this method:

1. This method is unused.
2. All symbol ID methods are defined in https://github.com/oxc-project/oxc/blob/48a0394618cc16f707ef036eb5f375be9aef7809/crates/oxc_ast/src/generated/get_id.rs
3. Getting the symbol ID from the function directly is rare; ￼A common scenario is to check if a binding exists and then use that binding to retrieve a symbol ID.
4. This is not a convention for `OXC` usages