### PR TITLE
fix(ast/estree): Fix `AccessorProperty` node

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1561,6 +1561,7 @@ pub struct AssignmentPattern<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[estree(add_fields(decorators = TsEmptyArray))]
 pub struct ObjectPattern<'a> {
     pub span: Span,
     pub properties: Vec<'a, BindingProperty<'a>>,
@@ -2282,10 +2283,12 @@ pub enum AccessorPropertyType {
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[rustfmt::skip]
-#[estree(field_order(
-    r#type, span, key, value, computed, r#static,
-    decorators, definite, type_annotation, accessibility,
-))]
+#[estree(
+    add_fields(declare = TsFalse, optional = TsFalse, r#override = TsFalse, readonly = TsFalse),
+    field_order(
+      r#type, span, key, value, computed, r#static, decorators, definite, type_annotation,
+      accessibility, optional, r#override, readonly, declare)
+)]
 pub struct AccessorProperty<'a> {
     pub span: Span,
     pub r#type: AccessorPropertyType,

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1295,6 +1295,7 @@ impl ESTree for ObjectPattern<'_> {
             "properties",
             &AppendTo { array: &self.properties, after: &self.rest },
         );
+        state.serialize_ts_field("decorators", &crate::serialize::TsEmptyArray(self));
         state.end();
     }
 }
@@ -1635,6 +1636,10 @@ impl ESTree for AccessorProperty<'_> {
         state.serialize_ts_field("definite", &self.definite);
         state.serialize_ts_field("typeAnnotation", &self.type_annotation);
         state.serialize_ts_field("accessibility", &self.accessibility);
+        state.serialize_ts_field("optional", &crate::serialize::TsFalse(self));
+        state.serialize_ts_field("override", &crate::serialize::TsFalse(self));
+        state.serialize_ts_field("readonly", &crate::serialize::TsFalse(self));
+        state.serialize_ts_field("declare", &crate::serialize::TsFalse(self));
         state.end();
     }
 }

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -734,6 +734,7 @@ function deserializeObjectPattern(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     properties,
+    decorators: [],
   };
 }
 
@@ -956,6 +957,10 @@ function deserializeAccessorProperty(pos) {
     definite: deserializeBool(pos + 82),
     typeAnnotation: deserializeOptionBoxTSTypeAnnotation(pos + 88),
     accessibility: deserializeOptionTSAccessibility(pos + 96),
+    optional: false,
+    override: false,
+    readonly: false,
+    declare: false,
   };
 }
 

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -523,6 +523,7 @@ export interface AssignmentPattern extends Span {
 export interface ObjectPattern extends Span {
   type: 'ObjectPattern';
   properties: Array<BindingProperty | BindingRestElement>;
+  decorators?: [];
 }
 
 export interface BindingProperty extends Span {
@@ -692,6 +693,10 @@ export interface AccessorProperty extends Span {
   definite?: boolean;
   typeAnnotation?: TSTypeAnnotation | null;
   accessibility?: TSAccessibility | null;
+  optional?: false;
+  override?: false;
+  readonly?: false;
+  declare?: false;
 }
 
 export interface ImportExpression extends Span {

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -2,7 +2,7 @@ commit: 15392346
 
 estree_typescript Summary:
 AST Parsed     : 10623/10725 (99.05%)
-Positive Passed: 5318/10725 (49.59%)
+Positive Passed: 5354/10725 (49.92%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APISample_Watch.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APISample_WatchWithDefaults.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APISample_WatchWithOwnWatchHost.ts
@@ -190,7 +190,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigintWithoutLib.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/binaryArithmeticControlFlowGraphNotTooLarge.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bind2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bindingPatternCannotBeOnlyInferenceSource.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/bindingPatternContextualTypeDoesNotCauseWidening.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bindingPatternOmittedExpressionNesting.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingCaptureThisInFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/blockScopedBindingUsedBeforeDef.ts
@@ -298,7 +297,6 @@ Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsNull.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classExtendsNull2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFieldSuperAccessible.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/classFunctionMerging.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/classHeritageWithTrailingSeparator.ts
 Expected `{` but found `EOF`
@@ -595,7 +593,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/contravariantInferenceA
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contravariantOnlyInferenceFromAnnotatedFunction.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/contravariantOnlyInferenceWithAnnotatedOptionalParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowAliasedDiscriminants.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowAutoAccessor1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowBreakContinueWithLabel.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowCaching.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowDestructuringLoop.ts
@@ -3145,8 +3142,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedTypeParameters9.t
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesWithUnderscoreInBindingElement.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unusedVariablesinModules1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/unwitnessedTypeParameterVariance.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_classDecorators.1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_classDecorators.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_destructuring.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_propertyAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/useBeforeDefinitionInDeclarationFiles.ts
@@ -3268,8 +3263,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticB
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock7.ts
 A 'yield' expression is only allowed in a generator body.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlock8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlockUseBeforeDef4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/classStaticBlock/classStaticBlockUseBeforeDef5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/automaticConstructors/derivedClassWithoutExplicitConstructor3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/classConstructorAccessibility2.ts
@@ -3367,19 +3360,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemb
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/accessorsOverrideProperty9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationES2022.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/assignParameterPropertyToPropertyDeclarationESNext.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor10.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor11.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor7.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessor9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorAllowedModifiers.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorExperimentalDecorators.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/autoAccessorNoUseDefineForClassFields.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/constructorParameterShadowsOuterScopes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/constructorParameterShadowsOuterScopes2.ts
@@ -3478,12 +3460,10 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/dec
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/decoratorOnClassMethod19.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/method/parameter/decoratorOnClassMethodParameter3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty12.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/class/property/decoratorOnClassProperty13.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorMetadata-jsdoc.ts
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorMetadata.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorMetadataWithTypeOnlyImport.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/decorators/legacyDecorators-contextualTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/directives/ts-expect-error-nocheck.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/directives/ts-expect-error.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/directives/ts-ignore.ts
@@ -3716,7 +3696,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/de
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment5SiblingInitializer.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringAssignabilityCheck.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringCatch.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringControlFlow.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringEvaluationOrder.ts
@@ -3762,8 +3741,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/de
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration1ES5iterable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration1ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringVoid.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringVoidStrictNullChecks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringWithLiteralInitializers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns01_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns01_ES5iterable.ts
@@ -3777,7 +3754,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/em
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns04_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns04_ES5iterable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns04_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyObjectBindingPatternParameter04.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyVariableDeclarationBindingPatterns01_ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyVariableDeclarationBindingPatterns01_ES5iterable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyVariableDeclarationBindingPatterns01_ES6.ts
@@ -4234,28 +4210,17 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDe
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classSuper/esDecorators-classDeclaration-classSuper.4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classSuper/esDecorators-classDeclaration-classSuper.5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classSuper/esDecorators-classDeclaration-classSuper.6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classThisReference/esDecorators-classDeclaration-classThisReference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-commentPreservation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-commonjs-classNamespaceMerge.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-commonjs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-classDecorator.2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-nonStaticPrivateAutoAccessor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-staticComputedAutoAccessor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-missingEmitHelpers-staticPrivateAutoAccessor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-parameterProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-setFunctionName.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-sourceMap.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-nonStaticAbstractAccessor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-nonStaticAccessor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-nonStaticPrivateAccessor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-staticAccessor.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/fields/esDecorators-classDeclaration-fields-staticPrivateAccessor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/classSuper/esDecorators-classExpression-classSuper.1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/classSuper/esDecorators-classExpression-classSuper.3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/classSuper/esDecorators-classExpression-classSuper.4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/classSuper/esDecorators-classExpression-classSuper.5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/classSuper/esDecorators-classExpression-classSuper.6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-commentPreservation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.17.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.5.ts
@@ -4268,7 +4233,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classEx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/namedEvaluation/esDecorators-classExpression-namedEvaluation.8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-arguments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-contextualTypes.2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-contextualTypes.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-decoratorExpression.1.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-decoratorExpression.2.ts


### PR DESCRIPTION
Align our AST's ESTree output with that of TS-ESLint's for the`AccessorProperty` node. Relates to #9705 

Add `optional`, `override`, `readonly`, and  `declare` fields to `AccessorProperty` when serializing to TS estree.