### PR TITLE
fix(semantic): define a variable in a function expression whose name is the same as the function name which is considered a redeclaration

### DIFF
--- a/crates/oxc_semantic/tests/integration/symbols.rs
+++ b/crates/oxc_semantic/tests/integration/symbols.rs
@@ -451,3 +451,12 @@ fn test_class_merging() {
     .contains_flags(SymbolFlags::Interface)
     .test();
 }
+
+#[test]
+fn test_redeclaration() {
+    SemanticTester::js("(function n(n) { console.log (n) }) ()")
+        .has_symbol("n") // the first `n` is the function expression
+        .equal_flags(SymbolFlags::Function) // param `n` is a SymbolFlags::FunctionScopedVariable
+        .has_number_of_references(0) // no references to the function
+        .test();
+}


### PR DESCRIPTION
```js
(function n(n) {})()
```

The function `n` symbol will insert into the function itself scope, which causes param `n` to be considered a redeclaration, but it is not. 