### PR TITLE
perf(linter): inline `PRE_DEFINE_VAR` and use `array` format

### DIFF
--- a/crates/oxc_linter/src/globals.rs
+++ b/crates/oxc_linter/src/globals.rs
@@ -1,12 +1,4 @@
-use phf::{Map, phf_map, phf_set};
-
-pub const PRE_DEFINE_VAR: Map<&'static str, bool> = phf_map! {
-    "undefined" => false,
-    "Infinity" => false,
-    "NaN" => false,
-    "eval" => false,
-    "arguments" => false,
-};
+use phf::phf_set;
 
 pub const GLOBAL_OBJECT_NAMES: phf::Set<&'static str> = phf_set! {
     "global",

--- a/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
@@ -4,7 +4,9 @@ use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
 use oxc_syntax::symbol::SymbolId;
 
-use crate::{context::LintContext, globals::PRE_DEFINE_VAR, rule::Rule};
+use crate::{context::LintContext, rule::Rule};
+
+const PRE_DEFINE_VAR: [&str; 5] = ["undefined", "Infinity", "NaN", "eval", "arguments"];
 
 fn no_shadow_restricted_names_diagnostic(shadowed_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Shadowing of global properties such as 'undefined' is not allowed.")
@@ -79,7 +81,7 @@ impl Rule for NoShadowRestrictedNames {
     fn run_on_symbol(&self, symbol_id: SymbolId, ctx: &LintContext<'_>) {
         let name = ctx.scoping().symbol_name(symbol_id);
 
-        if !PRE_DEFINE_VAR.contains_key(name) {
+        if !PRE_DEFINE_VAR.contains(&name) {
             return;
         }
 


### PR DESCRIPTION
Related to #10076 