### PR TITLE
perf(codegen): faster printing quotes

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -9,7 +9,7 @@ use oxc_syntax::{
 };
 
 use crate::{
-    Codegen, Context, Operator,
+    Codegen, Context, Operator, Quote,
     binary_expr_visitor::{BinaryExpressionVisitor, Binaryish, BinaryishOperator},
 };
 
@@ -82,11 +82,11 @@ impl Gen for Directive<'_> {
         while let Some(c) = chars.next() {
             match c {
                 '"' => {
-                    quote = b'\'';
+                    quote = Quote::Single;
                     break;
                 }
                 '\'' => {
-                    quote = b'"';
+                    quote = Quote::Double;
                     break;
                 }
                 '\\' => {
@@ -95,9 +95,9 @@ impl Gen for Directive<'_> {
                 _ => {}
             }
         }
-        p.print_ascii_byte(quote);
+        quote.print(p);
         p.print_str(directive);
-        p.print_ascii_byte(quote);
+        quote.print(p);
         p.print_ascii_byte(b';');
         p.print_soft_newline();
     }

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -107,7 +107,7 @@ pub struct Codegen<'a> {
     indent: u32,
 
     /// Fast path for [CodegenOptions::single_quote]
-    quote: u8,
+    quote: Quote,
     /// Fast path for if print comments
     print_comments: bool,
 
@@ -163,7 +163,7 @@ impl<'a> Codegen<'a> {
             start_of_default_export: 0,
             is_jsx: false,
             indent: 0,
-            quote: b'"',
+            quote: Quote::Double,
             print_comments,
             comments: CommentsMap::default(),
             legal_comments: vec![],
@@ -174,7 +174,7 @@ impl<'a> Codegen<'a> {
     /// Pass options to the code generator.
     #[must_use]
     pub fn with_options(mut self, options: CodegenOptions) -> Self {
-        self.quote = if options.single_quote { b'\'' } else { b'"' };
+        self.quote = if options.single_quote { Quote::Single } else { Quote::Double };
         self.print_comments = options.print_comments();
         self.options = options;
         self
@@ -194,7 +194,7 @@ impl<'a> Codegen<'a> {
     /// A source map will be generated if [`CodegenOptions::source_map_path`] is set.
     #[must_use]
     pub fn build(mut self, program: &Program<'a>) -> CodegenReturn {
-        self.quote = if self.options.single_quote { b'\'' } else { b'"' };
+        self.quote = if self.options.single_quote { Quote::Single } else { Quote::Double };
         self.source_text = program.source_text;
         self.code.reserve(program.source_text.len());
         if self.print_comments {
@@ -604,26 +604,26 @@ impl<'a> Codegen<'a> {
                     _ => {}
                 }
             }
-            let mut quote = b'"';
+            let mut quote = Quote::Double;
             if allow_backtick && double_cost >= backtick_cost {
-                quote = b'`';
+                quote = Quote::Backtick;
                 if backtick_cost > single_cost {
-                    quote = b'\'';
+                    quote = Quote::Single;
                 }
             } else if double_cost > single_cost {
-                quote = b'\'';
+                quote = Quote::Single;
             }
             quote
         } else {
             self.quote
         };
 
-        self.print_ascii_byte(quote);
+        quote.print(self);
         self.print_unquoted_utf16(s, quote);
-        self.print_ascii_byte(quote);
+        quote.print(self);
     }
 
-    fn print_unquoted_utf16(&mut self, s: &StringLiteral<'_>, quote: u8) {
+    fn print_unquoted_utf16(&mut self, s: &StringLiteral<'_>, quote: Quote) {
         let mut chars = s.value.chars().peekable();
 
         while let Some(c) = chars.next() {
@@ -640,7 +640,7 @@ impl<'a> Codegen<'a> {
                 '\u{b}' => self.print_str("\\v"), // \v
                 '\u{c}' => self.print_str("\\f"), // \f
                 '\n' => {
-                    if quote == b'`' {
+                    if quote == Quote::Backtick {
                         self.print_ascii_byte(b'\n');
                     } else {
                         self.print_str("\\n");
@@ -656,19 +656,19 @@ impl<'a> Codegen<'a> {
                 PS => self.print_str("\\u2029"),
                 '\u{a0}' => self.print_str("\\xA0"),
                 '\'' => {
-                    if quote == b'\'' {
+                    if quote == Quote::Single {
                         self.print_ascii_byte(b'\\');
                     }
                     self.print_ascii_byte(b'\'');
                 }
                 '\"' => {
-                    if quote == b'"' {
+                    if quote == Quote::Double {
                         self.print_ascii_byte(b'\\');
                     }
                     self.print_ascii_byte(b'"');
                 }
                 '`' => {
-                    if quote == b'`' {
+                    if quote == Quote::Backtick {
                         self.print_ascii_byte(b'\\');
                     }
                     self.print_ascii_byte(b'`');
@@ -783,5 +783,22 @@ impl<'a> Codegen<'a> {
         if let Some(sourcemap_builder) = self.sourcemap_builder.as_mut() {
             sourcemap_builder.add_source_mapping_for_name(self.code.as_bytes(), span, name);
         }
+    }
+}
+
+/// Quote character.
+#[derive(Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+enum Quote {
+    Single = b'\'',
+    Double = b'"',
+    Backtick = b'`',
+}
+
+impl Quote {
+    #[inline]
+    fn print(self, codegen: &mut Codegen<'_>) {
+        // SAFETY: All variants of `Quote` are ASCII bytes
+        unsafe { codegen.code.print_byte_unchecked(self as u8) };
     }
 }


### PR DESCRIPTION
Avoid checks when printing quotes, by introducing a `Quote` enum which is statically known to be an ASCII character.
