### PR TITLE
fix(isolated_declarations,linter,semantic,transformer): use `FormalParameter::has_modifier` to detect parameter property

### DIFF
--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -264,7 +264,7 @@ impl<'a> IsolatedDeclarations<'a> {
     ) -> ArenaVec<'a, ClassElement<'a>> {
         let mut elements = self.ast.vec();
         for (index, param) in function.params.items.iter().enumerate() {
-            if param.accessibility.is_some() || param.readonly {
+            if param.has_modifier() {
                 let type_annotation =
                     if param.accessibility.is_some_and(TSAccessibility::is_private) {
                         None

--- a/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
@@ -2,7 +2,8 @@ use oxc_ast::{
     AstKind,
     ast::{
         Argument, BindingPattern, BindingPatternKind, BindingRestElement, CallExpression,
-        Expression, FormalParameters, FunctionBody, MethodDefinition, Statement, TSAccessibility,
+        Expression, FormalParameter, FormalParameters, FunctionBody, MethodDefinition, Statement,
+        TSAccessibility,
     },
 };
 use oxc_diagnostics::OxcDiagnostic;
@@ -151,13 +152,7 @@ fn lint_empty_constructor<'a>(
 
     // allow constructors with access modifiers since they actually declare
     // class members
-    if constructor
-        .value
-        .params
-        .items
-        .iter()
-        .any(|param| param.accessibility.is_some() || param.readonly)
-    {
+    if constructor.value.params.items.iter().any(FormalParameter::has_modifier) {
         return;
     }
 

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_parameter_property_assignment.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_parameter_property_assignment.rs
@@ -66,18 +66,8 @@ impl Rule for NoUnnecessaryParameterPropertyAssignment {
             return;
         }
 
-        let parameter_properties: Vec<_> = method
-            .value
-            .params
-            .items
-            .iter()
-            .filter(|param| {
-                // TypeScript offers special syntax for turning a constructor parameter into a class property with the same name and value.
-                // These are called parameter properties and are created by prefixing a constructor argument with one of the visibility modifiers public, private, protected, or readonly
-                // https://www.typescriptlang.org/docs/handbook/2/classes.html#parameter-properties
-                param.accessibility.is_some() || param.readonly
-            })
-            .collect();
+        let parameter_properties: Vec<_> =
+            method.value.params.items.iter().filter(|param| param.has_modifier()).collect();
 
         if parameter_properties.is_empty() {
             return;

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -165,18 +165,18 @@ pub fn check_formal_parameters(params: &FormalParameters, ctx: &SemanticBuilder<
         !params.kind.is_signature() && ctx.current_scope_flags().is_constructor();
     let mut has_optional = false;
 
-    for item in &params.items {
+    for param in &params.items {
         // function a(optional?: number, required: number) { }
-        if has_optional && !item.pattern.optional && !item.pattern.kind.is_assignment_pattern() {
-            ctx.error(required_parameter_after_optional_parameter(item.span));
+        if has_optional && !param.pattern.optional && !param.pattern.kind.is_assignment_pattern() {
+            ctx.error(required_parameter_after_optional_parameter(param.span));
         }
-        if item.pattern.optional {
+        if param.pattern.optional {
             has_optional = true;
         }
 
         // function a(public x: number) { }
-        if !is_inside_constructor && item.accessibility.is_some() {
-            ctx.error(parameter_property_outside_constructor(item.span));
+        if !is_inside_constructor && param.has_modifier() {
+            ctx.error(parameter_property_outside_constructor(param.span));
         }
     }
 }
@@ -487,7 +487,7 @@ pub fn check_method_definition<'a>(method: &MethodDefinition<'a>, ctx: &Semantic
     // Illegal to have `constructor(public foo);`
     if method.kind.is_constructor() && is_empty_body {
         for param in &method.value.params.items {
-            if param.accessibility.is_some() {
+            if param.has_modifier() {
                 ctx.error(parameter_property_only_in_constructor_impl(param.span));
             }
         }

--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -327,7 +327,7 @@ impl<'a> Traverse<'a> for TypeScriptAnnotations<'a, '_> {
         // for each of them in the constructor body.
         if def.kind == MethodDefinitionKind::Constructor {
             for param in def.value.params.items.as_mut_slice() {
-                if param.accessibility.is_some() || param.readonly || param.r#override {
+                if param.has_modifier() {
                     if let Some(id) = param.pattern.get_binding_identifier() {
                         self.assignments.push(Assignment {
                             span: id.span,

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -11991,6 +11991,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
   help: Try insert a semicolon here
 
   × A parameter property is only allowed in a constructor implementation.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:3:9]
+ 2 │     not_constructor(
+ 3 │         readonly r,
+   ·         ──────────
+ 4 │         public pu: number,
+   ╰────
+
+  × A parameter property is only allowed in a constructor implementation.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:4:9]
  3 │         readonly r,
  4 │         public pu: number,
@@ -12029,6 +12037,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·         ───────────────────
  8 │         // Also works on AssignmentPattern
    ╰────
+
+  × A parameter property is only allowed in a constructor implementation.
+    ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:9:9]
+  8 │         // Also works on AssignmentPattern
+  9 │         readonly x = 0,
+    ·         ──────────────
+ 10 │         public y?: number = 0) {}
+    ╰────
 
   × A parameter property is only allowed in a constructor implementation.
     ╭─[babel/packages/babel-parser/test/fixtures/typescript/class/parameter-properties-not-constructor/input.ts:10:9]
@@ -12132,6 +12148,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
 
   × A parameter property is only allowed in a constructor implementation.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/parameter-properties/input.ts:2:3]
+ 1 │ function foo(
+ 2 │   readonly r,
+   ·   ──────────
+ 3 │   public pu: number,
+   ╰────
+
+  × A parameter property is only allowed in a constructor implementation.
    ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/parameter-properties/input.ts:3:3]
  2 │   readonly r,
  3 │   public pu: number,
@@ -12169,6 +12193,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  6 │   public readonly pur,
    ·   ───────────────────
  7 │   readonly x = 0,
+   ╰────
+
+  × A parameter property is only allowed in a constructor implementation.
+   ╭─[babel/packages/babel-parser/test/fixtures/typescript/function/parameter-properties/input.ts:7:3]
+ 6 │   public readonly pur,
+ 7 │   readonly x = 0,
+   ·   ──────────────
+ 8 │   public y?: number = 0
    ╰────
 
   × A parameter property is only allowed in a constructor implementation.

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: 15392346
 parser_typescript Summary:
 AST Parsed     : 6522/6531 (99.86%)
 Positive Passed: 6511/6531 (99.69%)
-Negative Passed: 1288/5754 (22.38%)
+Negative Passed: 1291/5754 (22.44%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration24.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment7.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment8.ts
@@ -1754,7 +1754,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reactNamespa
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reactNamespaceMissingDeclaration.tsx
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/reactReduxLikeDeferredInferenceAllowsAssignment.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/readonlyAssignmentInSubclassOfClassExpression.ts
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/readonlyInNonPropertyParameters.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/readonlyMembers.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/readonlyPropertySubtypeRelationDirected.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/readonlyTupleAndArrayElaboration.ts
@@ -2381,7 +2380,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/c
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorParameterProperties.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorParameterProperties2.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/readonlyConstructorAssignment.ts
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/readonlyInAmbientClass.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/readonlyInConstructorParameters.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorWithAssignableReturnExpression.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/superCalls/derivedClassParameterProperties.ts
@@ -3665,7 +3663,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/override/
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/override/override8.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/override/override9.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/override/overrideKeywordOrder.ts
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/override/overrideParameterProperty.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/override/overrideWithoutNoImplicitOverride1.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/override/override_js2.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/override/override_js3.ts
@@ -11114,6 +11111,30 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╰────
   help: Try insert a semicolon here
 
+  × A parameter property is only allowed in a constructor implementation.
+   ╭─[typescript/tests/cases/compiler/readonlyInNonPropertyParameters.ts:3:9]
+ 2 │ class X {
+ 3 │     method(readonly x: number) {}
+   ·            ──────────────────
+ 4 │     set x(readonly value: number) {}
+   ╰────
+
+  × A parameter property is only allowed in a constructor implementation.
+   ╭─[typescript/tests/cases/compiler/readonlyInNonPropertyParameters.ts:4:8]
+ 3 │     method(readonly x: number) {}
+ 4 │     set x(readonly value: number) {}
+   ·           ──────────────────────
+ 5 │ }
+   ╰────
+
+  × A parameter property is only allowed in a constructor implementation.
+   ╭─[typescript/tests/cases/compiler/readonlyInNonPropertyParameters.ts:6:2]
+ 5 │ }
+ 6 │ (readonly x) => 0;
+   ·  ──────────
+ 7 │ // OK to use `readonly` as a name
+   ╰────
+
   × Identifier `bar` has already been declared
    ╭─[typescript/tests/cases/compiler/reassignStaticProp.ts:3:12]
  2 │  
@@ -14661,6 +14682,22 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·     ─────┬─────
    ·          ╰── it cannot be redeclared here
  9 │ }
+   ╰────
+
+  × TS(2369): A parameter property is only allowed in a constructor implementation.
+   ╭─[typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/readonlyInAmbientClass.ts:2:14]
+ 1 │ declare class C{
+ 2 │     constructor(readonly x: number);
+   ·                 ──────────────────
+ 3 │     method(readonly x: number);
+   ╰────
+
+  × A parameter property is only allowed in a constructor implementation.
+   ╭─[typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/readonlyInAmbientClass.ts:3:9]
+ 2 │     constructor(readonly x: number);
+ 3 │     method(readonly x: number);
+   ·            ──────────────────
+ 4 │ }
    ╰────
 
   × TS(1030): readonly' modifier already seen.
@@ -20728,6 +20765,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  20 │ 
     ╰────
   help: Remove the duplicate modifier.
+
+  × A parameter property is only allowed in a constructor implementation.
+    ╭─[typescript/tests/cases/conformance/override/overrideParameterProperty.ts:25:5]
+ 24 │ 
+ 25 │   m(override p1: "hello") {}
+    ·     ────────────────────
+ 26 │ }
+    ╰────
 
   × Invalid Character `
   │ `


### PR DESCRIPTION
Using `FormalParameter::has_modifier` makes code shorter, more explicit and also fixes code which hasn't checked for the `override` and `readonly` modifier before.