### PR TITLE
refactor(editor): use warning background when the plugin is deactived

### DIFF
--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -282,9 +282,9 @@ export async function activate(context: ExtensionContext) {
     let bgColor = new ThemeColor(
       enable
         ? 'statusBarItem.activeBackground'
-        : 'statusBarItem.errorBackground',
+        : 'statusBarItem.warningBackground',
     );
-    myStatusBarItem.text = `oxc: ${enable ? '$(check-all)' : '$(circle-slash)'}`;
+    myStatusBarItem.text = `oxc: ${enable ? '$(check-all)' : '$(check)'}`;
 
     myStatusBarItem.backgroundColor = bgColor;
   }


### PR DESCRIPTION
On: 
![grafik](https://github.com/user-attachments/assets/057eaa57-dcdc-414f-98d5-1ff5e593009e)

Off:
![grafik](https://github.com/user-attachments/assets/bcab0fab-93ff-4984-8f74-3ba2ca8724ba)

