### PR TITLE
refactor(semantic): align handling of declaring symbol for function with TypeScript

### DIFF
--- a/crates/oxc_linter/src/snapshots/eslint_no_redeclare.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_redeclare.snap
@@ -35,12 +35,12 @@ source: crates/oxc_linter/src/tester.rs
    ·     ╰── `a` has already been declared here
    ╰────
 
-  × Identifier `a` has already been declared
+  ⚠ eslint(no-redeclare): 'a' is already defined.
    ╭─[no_redeclare.tsx:1:10]
  1 │ function a() {} function a() {}
    ·          ┬               ┬
-   ·          │               ╰── It can not be redeclared here
-   ·          ╰── `a` has already been declared here
+   ·          │               ╰── It can not be redeclare here.
+   ·          ╰── 'a' is already defined.
    ╰────
 
   ⚠ eslint(no-redeclare): 'a' is already defined.

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -4,7 +4,7 @@ use std::ptr;
 
 use oxc_ast::{AstKind, ast::*};
 use oxc_ecmascript::{BoundNames, IsSimpleParameterList};
-use oxc_span::{GetSpan, SourceType};
+use oxc_span::GetSpan;
 use oxc_syntax::{
     scope::{ScopeFlags, ScopeId},
     symbol::SymbolFlags,
@@ -133,24 +133,6 @@ impl<'a> Binder<'a> for Class<'a> {
     }
 }
 
-// It is a Syntax Error if the LexicallyDeclaredNames of StatementList contains any duplicate entries,
-// unless the source text matched by this production is not strict mode code
-// and the duplicate entries are only bound by FunctionDeclarations.
-// https://tc39.es/ecma262/#sec-block-level-function-declarations-web-legacy-compatibility-semantics
-fn function_as_var(flags: ScopeFlags, source_type: SourceType) -> bool {
-    flags.is_function() || (source_type.is_script() && flags.is_top())
-}
-
-/// Check if the function is not allowed to be redeclared.
-pub fn is_function_redeclared_not_allowed(
-    func: &Function<'_>,
-    builder: &SemanticBuilder<'_>,
-) -> bool {
-    let current_scope_flags = builder.current_scope_flags();
-    (current_scope_flags.is_strict_mode() || func.r#async || func.generator)
-        && !function_as_var(current_scope_flags, builder.source_type)
-}
-
 /// Check for Annex B `if (foo) function a() {} else function b() {}`
 fn is_function_part_of_if_statement(function: &Function, builder: &SemanticBuilder) -> bool {
     if builder.current_scope_flags().is_strict_mode() {
@@ -189,29 +171,18 @@ impl<'a> Binder<'a> for Function<'a> {
                 );
                 ident.symbol_id.set(Some(symbol_id));
             } else {
-                let excludes = if self.is_declaration() {
-                    // The visitor is already inside the function scope,
-                    // retrieve the parent scope for the function id to bind to.
-                    if is_function_redeclared_not_allowed(self, builder) {
-                        SymbolFlags::BlockScopedVariableExcludes
-                    } else {
-                        SymbolFlags::FunctionScopedVariableExcludes
-                    }
-                } else if self.is_expression() {
-                    // https://tc39.es/ecma262/#sec-runtime-semantics-instantiateordinaryfunctionexpression
-                    // 5. Perform ! funcEnv.CreateImmutableBinding(name, false).
-                    SymbolFlags::empty()
-                } else {
-                    unreachable!(
-                        "Currently we haven't create a symbol for typescript syntax function"
-                    );
-                };
-
                 let symbol_id = builder.declare_symbol(
                     ident.span,
                     &ident.name,
                     SymbolFlags::Function,
-                    excludes,
+                    if builder.source_type.is_typescript() {
+                        SymbolFlags::FunctionExcludes
+                    } else {
+                        // `var x; function x() {}` is valid in non-strict mode, but `TypeScript`
+                        // doesn't care about non-strict mode, so we need to exclude this,
+                        // and further check in checker.
+                        SymbolFlags::FunctionExcludes - SymbolFlags::FunctionScopedVariable
+                    },
                 );
                 ident.symbol_id.set(Some(symbol_id));
             }

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -143,7 +143,7 @@ bitflags! {
         /// Block-scoped declarations are not allowed to be re-declared
         /// they can not merge with anything in the value space
         const BlockScopedVariableExcludes = Self::Value.bits();
-
+        const FunctionExcludes = Self::Value.bits() & !(Self::Function.bits() | Self::ValueModule.bits() | Self::Class.bits());
         const ClassExcludes = (Self::Value.bits() | Self::TypeAlias.bits()) & !(Self::ValueModule.bits() | Self::Interface.bits());
         const ImportBindingExcludes = Self::Import.bits() | Self::TypeImport.bits();
         // Type specific excludes

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -281,18 +281,6 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022
    ·                ╰── It can not be redeclared here
  5 │     }
    ╰────
-
-  × Identifier `x` has already been declared
-   ╭─[babel/packages/babel-parser/test/fixtures/es2022/class-static-block/duplicate-function-var-name/input.js:3:11]
- 2 │     static {
- 3 │       var x;
-   ·           ┬
-   ·           ╰── `x` has already been declared here
- 4 │       function x() {}
-   ·                ┬
-   ·                ╰── It can not be redeclared here
- 5 │     }
-   ╰────
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/top-level-await-unambiguous/module/input.js
 
   × `await` is only allowed within async functions and at the top levels of modules
@@ -1346,16 +1334,6 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
 
   × Identifier `foo` has already been declared
-   ╭─[babel/packages/babel-parser/test/fixtures/core/scope/dupl-bind-class-func/input.js:1:7]
- 1 │ class foo {};
-   ·       ─┬─
-   ·        ╰── `foo` has already been declared here
- 2 │ function foo () {};
-   ·          ─┬─
-   ·           ╰── It can not be redeclared here
-   ╰────
-
-  × Identifier `foo` has already been declared
    ╭─[babel/packages/babel-parser/test/fixtures/core/scope/dupl-bind-class-let/input.js:1:7]
  1 │ class foo {};
    ·       ─┬─
@@ -1391,14 +1369,6 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·            ╰── `f` has already been declared here
    ╰────
 
-  × Identifier `f` has already been declared
-   ╭─[babel/packages/babel-parser/test/fixtures/core/scope/dupl-bind-func-gen/input.js:1:12]
- 1 │ { function f() {} function* f() {} }
-   ·            ┬                ┬
-   ·            │                ╰── It can not be redeclared here
-   ·            ╰── `f` has already been declared here
-   ╰────
-
   × Identifier `foo` has already been declared
    ╭─[babel/packages/babel-parser/test/fixtures/core/scope/dupl-bind-func-module/input.js:1:10]
  1 │ function foo() {}
@@ -1407,24 +1377,6 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  2 │ function foo() {}
    ·          ─┬─
    ·           ╰── It can not be redeclared here
-   ╰────
-
-  × Identifier `foo` has already been declared
-   ╭─[babel/packages/babel-parser/test/fixtures/core/scope/dupl-bind-func-module/input.js:1:10]
- 1 │ function foo() {}
-   ·          ─┬─
-   ·           ╰── `foo` has already been declared here
- 2 │ function foo() {}
-   ·          ─┬─
-   ·           ╰── It can not be redeclared here
-   ╰────
-
-  × Identifier `foo` has already been declared
-   ╭─[babel/packages/babel-parser/test/fixtures/core/scope/dupl-bind-func-module-sloppy/input.js:1:12]
- 1 │ { function foo() {} function foo() {} }
-   ·            ─┬─               ─┬─
-   ·             │                 ╰── It can not be redeclared here
-   ·             ╰── `foo` has already been declared here
    ╰────
 
   × Identifier `foo` has already been declared

--- a/tasks/coverage/snapshots/parser_test262.snap
+++ b/tasks/coverage/snapshots/parser_test262.snap
@@ -2680,24 +2680,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
     ╰────
 
   × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-function.js:24:18]
- 23 │ 
- 24 │ { async function f() {} async function f() {} }
-    ·                  ┬                     ┬
-    ·                  │                     ╰── It can not be redeclared here
-    ·                  ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-generator.js:24:18]
- 23 │ 
- 24 │ { async function f() {} async function* f() {} }
-    ·                  ┬                      ┬
-    ·                  │                      ╰── It can not be redeclared here
-    ·                  ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
     ╭─[test262/test/language/block-scope/syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-generator.js:24:18]
  23 │ 
  24 │ { async function f() {} async function* f() {} }
@@ -2730,24 +2712,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
  24 │ { async function f() {} function f() {} }
     ·                  ┬               ┬
     ·                  │               ╰── It can not be redeclared here
-    ·                  ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/async-function-name-redeclaration-attempt-with-function.js:24:18]
- 23 │ 
- 24 │ { async function f() {} function f() {} }
-    ·                  ┬               ┬
-    ·                  │               ╰── It can not be redeclared here
-    ·                  ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/async-function-name-redeclaration-attempt-with-generator.js:24:18]
- 23 │ 
- 24 │ { async function f() {} function* f() {} }
-    ·                  ┬                ┬
-    ·                  │                ╰── It can not be redeclared here
     ·                  ╰── `f` has already been declared here
     ╰────
 
@@ -2788,24 +2752,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
     ╰────
 
   × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-async-function.js:24:19]
- 23 │ 
- 24 │ { async function* f() {} async function f() {} }
-    ·                   ┬                     ┬
-    ·                   │                     ╰── It can not be redeclared here
-    ·                   ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-async-generator.js:24:19]
- 23 │ 
- 24 │ { async function* f() {} async function* f() {} }
-    ·                   ┬                      ┬
-    ·                   │                      ╰── It can not be redeclared here
-    ·                   ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
     ╭─[test262/test/language/block-scope/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-async-generator.js:24:19]
  23 │ 
  24 │ { async function* f() {} async function* f() {} }
@@ -2838,24 +2784,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
  24 │ { async function* f() {} function f() {} }
     ·                   ┬               ┬
     ·                   │               ╰── It can not be redeclared here
-    ·                   ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-function.js:24:19]
- 23 │ 
- 24 │ { async function* f() {} function f() {} }
-    ·                   ┬               ┬
-    ·                   │               ╰── It can not be redeclared here
-    ·                   ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-generator.js:24:19]
- 23 │ 
- 24 │ { async function* f() {} function* f() {} }
-    ·                   ┬                ┬
-    ·                   │                ╰── It can not be redeclared here
     ·                   ╰── `f` has already been declared here
     ╰────
 
@@ -2896,24 +2824,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
     ╰────
 
   × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/class-name-redeclaration-attempt-with-async-function.js:24:9]
- 23 │ 
- 24 │ { class f {} async function f() {} }
-    ·         ┬                   ┬
-    ·         │                   ╰── It can not be redeclared here
-    ·         ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/class-name-redeclaration-attempt-with-async-generator.js:24:9]
- 23 │ 
- 24 │ { class f {} async function* f() {} }
-    ·         ┬                    ┬
-    ·         │                    ╰── It can not be redeclared here
-    ·         ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
     ╭─[test262/test/language/block-scope/syntax/redeclaration/class-name-redeclaration-attempt-with-async-generator.js:24:9]
  23 │ 
  24 │ { class f {} async function* f() {} }
@@ -2946,24 +2856,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
  23 │ { class f {} function f() {} }
     ·         ┬             ┬
     ·         │             ╰── It can not be redeclared here
-    ·         ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/class-name-redeclaration-attempt-with-function.js:23:9]
- 22 │ 
- 23 │ { class f {} function f() {} }
-    ·         ┬             ┬
-    ·         │             ╰── It can not be redeclared here
-    ·         ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/class-name-redeclaration-attempt-with-generator.js:24:9]
- 23 │ 
- 24 │ { class f {} function* f() {} }
-    ·         ┬              ┬
-    ·         │              ╰── It can not be redeclared here
     ·         ╰── `f` has already been declared here
     ╰────
 
@@ -3161,24 +3053,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
     ╰────
 
   × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/function-name-redeclaration-attempt-with-async-function.js:24:12]
- 23 │ 
- 24 │ { function f() {} async function f() {} }
-    ·            ┬                     ┬
-    ·            │                     ╰── It can not be redeclared here
-    ·            ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/function-name-redeclaration-attempt-with-async-generator.js:24:12]
- 23 │ 
- 24 │ { function f() {} async function* f() {} }
-    ·            ┬                      ┬
-    ·            │                      ╰── It can not be redeclared here
-    ·            ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
     ╭─[test262/test/language/block-scope/syntax/redeclaration/function-name-redeclaration-attempt-with-async-generator.js:24:12]
  23 │ 
  24 │ { function f() {} async function* f() {} }
@@ -3211,24 +3085,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
  23 │ { function f() {} function f() {} }
     ·            ┬               ┬
     ·            │               ╰── It can not be redeclared here
-    ·            ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/function-name-redeclaration-attempt-with-function.js:23:12]
- 22 │ 
- 23 │ { function f() {} function f() {} }
-    ·            ┬               ┬
-    ·            │               ╰── It can not be redeclared here
-    ·            ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/function-name-redeclaration-attempt-with-generator.js:24:12]
- 23 │ 
- 24 │ { function f() {} function* f() {} }
-    ·            ┬                ┬
-    ·            │                ╰── It can not be redeclared here
     ·            ╰── `f` has already been declared here
     ╰────
 
@@ -3269,24 +3125,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
     ╰────
 
   × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/generator-name-redeclaration-attempt-with-async-function.js:24:13]
- 23 │ 
- 24 │ { function* f() {} async function f() {} }
-    ·             ┬                     ┬
-    ·             │                     ╰── It can not be redeclared here
-    ·             ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/generator-name-redeclaration-attempt-with-async-generator.js:24:13]
- 23 │ 
- 24 │ { function* f() {} async function* f() {} }
-    ·             ┬                      ┬
-    ·             │                      ╰── It can not be redeclared here
-    ·             ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
     ╭─[test262/test/language/block-scope/syntax/redeclaration/generator-name-redeclaration-attempt-with-async-generator.js:24:13]
  23 │ 
  24 │ { function* f() {} async function* f() {} }
@@ -3319,24 +3157,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
  24 │ { function* f() {} function f() {} }
     ·             ┬               ┬
     ·             │               ╰── It can not be redeclared here
-    ·             ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/generator-name-redeclaration-attempt-with-function.js:24:13]
- 23 │ 
- 24 │ { function* f() {} function f() {} }
-    ·             ┬               ┬
-    ·             │               ╰── It can not be redeclared here
-    ·             ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/generator-name-redeclaration-attempt-with-generator.js:24:13]
- 23 │ 
- 24 │ { function* f() {} function* f() {} }
-    ·             ┬                ┬
-    ·             │                ╰── It can not be redeclared here
     ·             ╰── `f` has already been declared here
     ╰────
 
@@ -3377,24 +3197,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
     ╰────
 
   × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-async-function.js:40:9]
- 39 │ 
- 40 │ { { var f; } async function f() {}; }
-    ·         ┬                   ┬
-    ·         │                   ╰── It can not be redeclared here
-    ·         ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-async-generator.js:40:9]
- 39 │ 
- 40 │ { { var f; } async function* f() {}; }
-    ·         ┬                    ┬
-    ·         │                    ╰── It can not be redeclared here
-    ·         ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
     ╭─[test262/test/language/block-scope/syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-async-generator.js:40:9]
  39 │ 
  40 │ { { var f; } async function* f() {}; }
@@ -3427,24 +3229,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
  39 │ { { var f; } function f() {} }
     ·         ┬             ┬
     ·         │             ╰── It can not be redeclared here
-    ·         ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-function.js:39:9]
- 38 │ 
- 39 │ { { var f; } function f() {} }
-    ·         ┬             ┬
-    ·         │             ╰── It can not be redeclared here
-    ·         ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/inner-block-var-name-redeclaration-attempt-with-generator.js:40:9]
- 39 │ 
- 40 │ { { var f; } function* f() {}; }
-    ·         ┬              ┬
-    ·         │              ╰── It can not be redeclared here
     ·         ╰── `f` has already been declared here
     ╰────
 
@@ -3611,24 +3395,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
     ╰────
 
   × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/var-name-redeclaration-attempt-with-async-function.js:24:7]
- 23 │ 
- 24 │ { var f; async function f() {} }
-    ·       ┬                 ┬
-    ·       │                 ╰── It can not be redeclared here
-    ·       ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/var-name-redeclaration-attempt-with-async-generator.js:24:7]
- 23 │ 
- 24 │ { var f; async function* f() {} }
-    ·       ┬                  ┬
-    ·       │                  ╰── It can not be redeclared here
-    ·       ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
     ╭─[test262/test/language/block-scope/syntax/redeclaration/var-name-redeclaration-attempt-with-async-generator.js:24:7]
  23 │ 
  24 │ { var f; async function* f() {} }
@@ -3661,24 +3427,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
  23 │ { var f; function f() {} }
     ·       ┬           ┬
     ·       │           ╰── It can not be redeclared here
-    ·       ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/var-name-redeclaration-attempt-with-function.js:23:7]
- 22 │ 
- 23 │ { var f; function f() {} }
-    ·       ┬           ┬
-    ·       │           ╰── It can not be redeclared here
-    ·       ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/var-name-redeclaration-attempt-with-generator.js:24:7]
- 23 │ 
- 24 │ { var f; function* f() {} }
-    ·       ┬            ┬
-    ·       │            ╰── It can not be redeclared here
     ·       ╰── `f` has already been declared here
     ╰────
 
@@ -24881,17 +24629,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
     ·                  ╰── It can not be redeclared here
     ╰────
 
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/module-code/early-dup-export-decl.js:17:17]
- 16 │ 
- 17 │ export function f() {}
-    ·                 ┬
-    ·                 ╰── `f` has already been declared here
- 18 │ export function *f() {}
-    ·                  ┬
-    ·                  ╰── It can not be redeclared here
-    ╰────
-
   × Duplicated default export
     ╭─[test262/test/language/module-code/early-dup-export-dflt-id.js:18:8]
  17 │ var x, y;
@@ -24975,28 +24712,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
     ╰────
 
   × Identifier `x` has already been declared
-    ╭─[test262/test/language/module-code/early-dup-top-function-async-generator.js:19:10]
- 18 │ 
- 19 │ function x() {}
-    ·          ┬
-    ·          ╰── `x` has already been declared here
- 20 │ async function* x() {}
-    ·                 ┬
-    ·                 ╰── It can not be redeclared here
-    ╰────
-
-  × Identifier `x` has already been declared
-    ╭─[test262/test/language/module-code/early-dup-top-function-async.js:19:10]
- 18 │ 
- 19 │ function x() {}
-    ·          ┬
-    ·          ╰── `x` has already been declared here
- 20 │ async function x() {}
-    ·                ┬
-    ·                ╰── It can not be redeclared here
-    ╰────
-
-  × Identifier `x` has already been declared
     ╭─[test262/test/language/module-code/early-dup-top-function-async.js:19:10]
  18 │ 
  19 │ function x() {}
@@ -25016,28 +24731,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
  20 │ function* x() {}
     ·           ┬
     ·           ╰── It can not be redeclared here
-    ╰────
-
-  × Identifier `x` has already been declared
-    ╭─[test262/test/language/module-code/early-dup-top-function-generator.js:19:10]
- 18 │ 
- 19 │ function x() {}
-    ·          ┬
-    ·          ╰── `x` has already been declared here
- 20 │ function* x() {}
-    ·           ┬
-    ·           ╰── It can not be redeclared here
-    ╰────
-
-  × Identifier `x` has already been declared
-    ╭─[test262/test/language/module-code/early-dup-top-function.js:19:10]
- 18 │ 
- 19 │ function x() {}
-    ·          ┬
-    ·          ╰── `x` has already been declared here
- 20 │ function x() {}
-    ·          ┬
-    ·          ╰── It can not be redeclared here
     ╰────
 
   × Identifier `x` has already been declared
@@ -25197,28 +24890,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
     ·                               ╰── It can not be redeclared here
     ╰────
 
-  × Identifier `A` has already been declared
-    ╭─[test262/test/language/module-code/export-default-asyncfunction-declaration-binding-exists.js:22:7]
- 21 │ 
- 22 │ class A {};
-    ·       ┬
-    ·       ╰── `A` has already been declared here
- 23 │ export default async function A() {}
-    ·                               ┬
-    ·                               ╰── It can not be redeclared here
-    ╰────
-
-  × Identifier `AG` has already been declared
-    ╭─[test262/test/language/module-code/export-default-asyncgenerator-declaration-binding-exists.js:22:7]
- 21 │ 
- 22 │ class AG {}
-    ·       ─┬
-    ·        ╰── `AG` has already been declared here
- 23 │ export default async function * AG() {}
-    ·                                 ─┬
-    ·                                  ╰── It can not be redeclared here
-    ╰────
-
   × Identifier `AG` has already been declared
     ╭─[test262/test/language/module-code/export-default-asyncgenerator-declaration-binding-exists.js:22:7]
  21 │ 
@@ -25240,29 +24911,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
     ·                         ┬
     ·                         ╰── It can not be redeclared here
  24 │ 
-    ╰────
-
-  × Identifier `F` has already been declared
-    ╭─[test262/test/language/module-code/export-default-function-declaration-binding-exists.js:22:7]
- 21 │ 
- 22 │ class F {}
-    ·       ┬
-    ·       ╰── `F` has already been declared here
- 23 │ export default function F() {}
-    ·                         ┬
-    ·                         ╰── It can not be redeclared here
- 24 │ 
-    ╰────
-
-  × Identifier `G` has already been declared
-    ╭─[test262/test/language/module-code/export-default-generator-declaration-binding-exists.js:22:7]
- 21 │ 
- 22 │ class G {}
-    ·       ┬
-    ·       ╰── `G` has already been declared here
- 23 │ export default function * G() {}
-    ·                           ┬
-    ·                           ╰── It can not be redeclared here
     ╰────
 
   × Identifier `G` has already been declared
@@ -26034,28 +25682,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
  25 │ function f() {}
     ·          ┬
     ·          ╰── It can not be redeclared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/module-code/parse-err-hoist-lex-fun.js:24:5]
- 23 │ 
- 24 │ var f;
-    ·     ┬
-    ·     ╰── `f` has already been declared here
- 25 │ function f() {}
-    ·          ┬
-    ·          ╰── It can not be redeclared here
-    ╰────
-
-  × Identifier `g` has already been declared
-    ╭─[test262/test/language/module-code/parse-err-hoist-lex-gen.js:26:5]
- 25 │ 
- 26 │ var g;
-    ·     ┬
-    ·     ╰── `g` has already been declared here
- 27 │ function* g() {}
-    ·           ┬
-    ·           ╰── It can not be redeclared here
     ╰────
 
   × Identifier `g` has already been declared
@@ -38615,24 +38241,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
     ╰────
 
   × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-function.js:24:37]
- 23 │ 
- 24 │ switch (0) { case 1: async function f() {} default: async function f() {} }
-    ·                                     ┬                              ┬
-    ·                                     │                              ╰── It can not be redeclared here
-    ·                                     ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-generator.js:24:37]
- 23 │ 
- 24 │ switch (0) { case 1: async function f() {} default: async function* f() {} }
-    ·                                     ┬                               ┬
-    ·                                     │                               ╰── It can not be redeclared here
-    ·                                     ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
     ╭─[test262/test/language/statements/switch/syntax/redeclaration/async-function-name-redeclaration-attempt-with-async-generator.js:24:37]
  23 │ 
  24 │ switch (0) { case 1: async function f() {} default: async function* f() {} }
@@ -38665,24 +38273,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
  24 │ switch (0) { case 1: async function f() {} default: function f() {} }
     ·                                     ┬                        ┬
     ·                                     │                        ╰── It can not be redeclared here
-    ·                                     ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/async-function-name-redeclaration-attempt-with-function.js:24:37]
- 23 │ 
- 24 │ switch (0) { case 1: async function f() {} default: function f() {} }
-    ·                                     ┬                        ┬
-    ·                                     │                        ╰── It can not be redeclared here
-    ·                                     ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/async-function-name-redeclaration-attempt-with-generator.js:24:37]
- 23 │ 
- 24 │ switch (0) { case 1: async function f() {} default: function* f() {} }
-    ·                                     ┬                         ┬
-    ·                                     │                         ╰── It can not be redeclared here
     ·                                     ╰── `f` has already been declared here
     ╰────
 
@@ -38723,24 +38313,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
     ╰────
 
   × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-async-function.js:24:38]
- 23 │ 
- 24 │ switch (0) { case 1: async function* f() {} default: async function f() {} }
-    ·                                      ┬                              ┬
-    ·                                      │                              ╰── It can not be redeclared here
-    ·                                      ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-async-generator.js:24:38]
- 23 │ 
- 24 │ switch (0) { case 1: async function* f() {} default: async function* f() {} }
-    ·                                      ┬                               ┬
-    ·                                      │                               ╰── It can not be redeclared here
-    ·                                      ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
     ╭─[test262/test/language/statements/switch/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-async-generator.js:24:38]
  23 │ 
  24 │ switch (0) { case 1: async function* f() {} default: async function* f() {} }
@@ -38773,24 +38345,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
  24 │ switch (0) { case 1: async function* f() {} default: function f() {} }
     ·                                      ┬                        ┬
     ·                                      │                        ╰── It can not be redeclared here
-    ·                                      ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-function.js:24:38]
- 23 │ 
- 24 │ switch (0) { case 1: async function* f() {} default: function f() {} }
-    ·                                      ┬                        ┬
-    ·                                      │                        ╰── It can not be redeclared here
-    ·                                      ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-generator.js:24:38]
- 23 │ 
- 24 │ switch (0) { case 1: async function* f() {} default: function* f() {} }
-    ·                                      ┬                         ┬
-    ·                                      │                         ╰── It can not be redeclared here
     ·                                      ╰── `f` has already been declared here
     ╰────
 
@@ -38831,24 +38385,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
     ╰────
 
   × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/class-name-redeclaration-attempt-with-async-function.js:24:28]
- 23 │ 
- 24 │ switch (0) { case 1: class f {} default: async function f() {} }
-    ·                            ┬                            ┬
-    ·                            │                            ╰── It can not be redeclared here
-    ·                            ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/class-name-redeclaration-attempt-with-async-generator.js:24:28]
- 23 │ 
- 24 │ switch (0) { case 1: class f {} default: async function* f() {} }
-    ·                            ┬                             ┬
-    ·                            │                             ╰── It can not be redeclared here
-    ·                            ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
     ╭─[test262/test/language/statements/switch/syntax/redeclaration/class-name-redeclaration-attempt-with-async-generator.js:24:28]
  23 │ 
  24 │ switch (0) { case 1: class f {} default: async function* f() {} }
@@ -38881,24 +38417,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
  23 │ switch (0) { case 1: class f {} default: function f() {} }
     ·                            ┬                      ┬
     ·                            │                      ╰── It can not be redeclared here
-    ·                            ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/class-name-redeclaration-attempt-with-function.js:23:28]
- 22 │ 
- 23 │ switch (0) { case 1: class f {} default: function f() {} }
-    ·                            ┬                      ┬
-    ·                            │                      ╰── It can not be redeclared here
-    ·                            ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/class-name-redeclaration-attempt-with-generator.js:24:28]
- 23 │ 
- 24 │ switch (0) { case 1: class f {} default: function* f() {} }
-    ·                            ┬                       ┬
-    ·                            │                       ╰── It can not be redeclared here
     ·                            ╰── `f` has already been declared here
     ╰────
 
@@ -39011,24 +38529,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
     ╰────
 
   × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/function-name-redeclaration-attempt-with-async-function.js:24:31]
- 23 │ 
- 24 │ switch (0) { case 1: function f() {} default: async function f() {} }
-    ·                               ┬                              ┬
-    ·                               │                              ╰── It can not be redeclared here
-    ·                               ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/function-name-redeclaration-attempt-with-async-generator.js:24:31]
- 23 │ 
- 24 │ switch (0) { case 1: function f() {} default: async function* f() {} }
-    ·                               ┬                               ┬
-    ·                               │                               ╰── It can not be redeclared here
-    ·                               ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
     ╭─[test262/test/language/statements/switch/syntax/redeclaration/function-name-redeclaration-attempt-with-async-generator.js:24:31]
  23 │ 
  24 │ switch (0) { case 1: function f() {} default: async function* f() {} }
@@ -39061,24 +38561,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
  23 │ switch (0) { case 1: function f() {} default: function f() {} }
     ·                               ┬                        ┬
     ·                               │                        ╰── It can not be redeclared here
-    ·                               ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/function-name-redeclaration-attempt-with-function.js:23:31]
- 22 │ 
- 23 │ switch (0) { case 1: function f() {} default: function f() {} }
-    ·                               ┬                        ┬
-    ·                               │                        ╰── It can not be redeclared here
-    ·                               ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/function-name-redeclaration-attempt-with-generator.js:24:31]
- 23 │ 
- 24 │ switch (0) { case 1: function f() {} default: function* f() {} }
-    ·                               ┬                         ┬
-    ·                               │                         ╰── It can not be redeclared here
     ·                               ╰── `f` has already been declared here
     ╰────
 
@@ -39119,24 +38601,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
     ╰────
 
   × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/generator-name-redeclaration-attempt-with-async-function.js:24:32]
- 23 │ 
- 24 │ switch (0) { case 1: function* f() {} default: async function f() {} }
-    ·                                ┬                              ┬
-    ·                                │                              ╰── It can not be redeclared here
-    ·                                ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/generator-name-redeclaration-attempt-with-async-generator.js:24:32]
- 23 │ 
- 24 │ switch (0) { case 1: function* f() {} default: async function* f() {} }
-    ·                                ┬                               ┬
-    ·                                │                               ╰── It can not be redeclared here
-    ·                                ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
     ╭─[test262/test/language/statements/switch/syntax/redeclaration/generator-name-redeclaration-attempt-with-async-generator.js:24:32]
  23 │ 
  24 │ switch (0) { case 1: function* f() {} default: async function* f() {} }
@@ -39169,24 +38633,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
  24 │ switch (0) { case 1: function* f() {} default: function f() {} }
     ·                                ┬                        ┬
     ·                                │                        ╰── It can not be redeclared here
-    ·                                ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/generator-name-redeclaration-attempt-with-function.js:24:32]
- 23 │ 
- 24 │ switch (0) { case 1: function* f() {} default: function f() {} }
-    ·                                ┬                        ┬
-    ·                                │                        ╰── It can not be redeclared here
-    ·                                ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/generator-name-redeclaration-attempt-with-generator.js:24:32]
- 23 │ 
- 24 │ switch (0) { case 1: function* f() {} default: function* f() {} }
-    ·                                ┬                         ┬
-    ·                                │                         ╰── It can not be redeclared here
     ·                                ╰── `f` has already been declared here
     ╰────
 
@@ -39299,24 +38745,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
     ╰────
 
   × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/var-name-redeclaration-attempt-with-async-function.js:24:26]
- 23 │ 
- 24 │ switch (0) { case 1: var f; default: async function f() {} }
-    ·                          ┬                          ┬
-    ·                          │                          ╰── It can not be redeclared here
-    ·                          ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/var-name-redeclaration-attempt-with-async-generator.js:24:26]
- 23 │ 
- 24 │ switch (0) { case 1: var f; default: async function* f() {} }
-    ·                          ┬                           ┬
-    ·                          │                           ╰── It can not be redeclared here
-    ·                          ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
     ╭─[test262/test/language/statements/switch/syntax/redeclaration/var-name-redeclaration-attempt-with-async-generator.js:24:26]
  23 │ 
  24 │ switch (0) { case 1: var f; default: async function* f() {} }
@@ -39349,24 +38777,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
  23 │ switch (0) { case 1: var f; default: function f() {} }
     ·                          ┬                    ┬
     ·                          │                    ╰── It can not be redeclared here
-    ·                          ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/var-name-redeclaration-attempt-with-function.js:23:26]
- 22 │ 
- 23 │ switch (0) { case 1: var f; default: function f() {} }
-    ·                          ┬                    ┬
-    ·                          │                    ╰── It can not be redeclared here
-    ·                          ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/var-name-redeclaration-attempt-with-generator.js:24:26]
- 23 │ 
- 24 │ switch (0) { case 1: var f; default: function* f() {} }
-    ·                          ┬                     ┬
-    ·                          │                     ╰── It can not be redeclared here
     ·                          ╰── `f` has already been declared here
     ╰────
 
@@ -39569,18 +38979,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
     ·                 ┬  ┬
     ·                 │  ╰── It can not be redeclared here
     ·                 ╰── `x` has already been declared here
-    ╰────
-
-  × Identifier `e` has already been declared
-    ╭─[test262/test/language/statements/try/early-catch-function.js:23:14]
- 22 │     try {
- 23 │     } catch (e) {
-    ·              ┬
-    ·              ╰── `e` has already been declared here
- 24 │         function e(){}
-    ·                  ┬
-    ·                  ╰── It can not be redeclared here
- 25 │     }
     ╰────
 
   × Identifier `e` has already been declared

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: 15392346
 parser_typescript Summary:
 AST Parsed     : 6522/6531 (99.86%)
 Positive Passed: 6511/6531 (99.69%)
-Negative Passed: 1288/5754 (22.38%)
+Negative Passed: 1290/5754 (22.42%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration24.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment7.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment8.ts
@@ -56,7 +56,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/amdDependenc
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/amdDependencyCommentName4.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/amdModuleName2.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/anonymousClassExpression2.ts
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/anyDeclare.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/anyIdenticalToItself.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/anyIndexedAccessArrayNoException.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/anyMappedTypesError.ts
@@ -159,6 +158,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/augmentExpor
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/augmentExportEquals7.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/augmentedClassWithPrototypePropertyOnModule.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/augmentedTypesEnum3.ts
+Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/augmentedTypesModules2.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/augmentedTypesModules3.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/autoTypeAssignedUsingDestructuringFromNeverNoCrash.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/autolift3.ts
@@ -320,6 +320,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classMemberI
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classMemberInitializerWithLamdaScoping4.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classMergedWithInterfaceMultipleBasesNoError.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classOrder2.ts
+Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classOverloadForFunction.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classOverloadForFunction2.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classPropertyErrorOnNameOnly.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classSideInheritance1.ts
@@ -392,7 +393,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/configFileEx
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conflictingDeclarationsImportFromNamespace1.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conflictingDeclarationsImportFromNamespace2.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conflictingMemberTypesInBases.ts
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conflictingTypeAnnotatedVar.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/conflictingTypeParameterSymbolTransfer.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/consistentAliasVsNonAliasRecordBehavior.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-access.ts
@@ -612,7 +612,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/duplicateErr
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/duplicateErrorClassExpression.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/duplicateErrorNameNotFound.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierDifferentModifiers.ts
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierInCatchBlock.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierRelatedSpans1.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierRelatedSpans2.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/duplicateIdentifierRelatedSpans3.ts
@@ -637,6 +636,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/duplicatePac
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/duplicatePackage_withErrors.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/duplicatePropertiesInStrictMode.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/duplicateStringNamedProperty1.ts
+Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/duplicateSymbolsExportMatching.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/duplicateTypeParameters1.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/duplicateTypeParameters2.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/duplicateTypeParameters3.ts
@@ -1947,7 +1947,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/systemModule
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/systemModule9.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/taggedTemplateWithoutDeclaredHelper.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/targetTypeBaseCalls.ts
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/targetTypeCastTest.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/targetTypeTest1.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/targetTypeTest3.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/targetTypeVoidFunc.ts
@@ -2257,7 +2256,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/useBeforeDec
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_propertyAssignment.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration_superClass.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/useUnknownInCatchVariables01.ts
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/varAndFunctionShareName.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/varNameConflictsWithImportInDifferentPartOfModule.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/vararg.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/variableDeclaratorResolvedDuringContextualTyping.ts
@@ -2855,6 +2853,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/modul
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/importEmptyFromModuleNotExisted.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/multipleDefaultExports01.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/multipleDefaultExports02.ts
+Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/multipleDefaultExports04.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/modules/multipleDefaultExports05.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/restParameters/readonlyRestParameters.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts
@@ -3273,7 +3272,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/externalM
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/fixSignatureCaching.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/functions/functionImplementationErrors.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/functions/functionImplementations.ts
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/functions/functionNameConflicts.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/functions/functionOverloadCompatibilityWithVoid01.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/functions/functionOverloadErrors.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/conformance/functions/parameterInitializersForwardReferencing.2.ts
@@ -5196,6 +5194,18 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╰────
   help: Try insert a semicolon here
 
+  × Identifier `myFn` has already been declared
+   ╭─[typescript/tests/cases/compiler/anyDeclare.ts:3:9]
+ 2 │ module myMod {
+ 3 │     var myFn;
+   ·         ──┬─
+   ·           ╰── `myFn` has already been declared here
+ 4 │     function myFn() {  }
+   ·              ──┬─
+   ·                ╰── It can not be redeclared here
+ 5 │ }
+   ╰────
+
   × Cannot assign to 'arguments' in strict mode
     ╭─[typescript/tests/cases/compiler/argumentsReferenceInConstructor4_Js.ts:18:9]
  17 │          */
@@ -5361,18 +5371,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
     ·       ╰── It can not be redeclared here
  22 │ 
     ╰────
-
-  × Identifier `c2` has already been declared
-   ╭─[typescript/tests/cases/compiler/augmentedTypesClass2a.ts:2:7]
- 1 │ //// class then function
- 2 │ class c2 { public foo() { } } // error
-   ·       ─┬
-   ·        ╰── `c2` has already been declared here
- 3 │ function c2() { } // error
-   ·          ─┬
-   ·           ╰── It can not be redeclared here
- 4 │ var c2 = () => { }
-   ╰────
 
   × Identifier `c2` has already been declared
    ╭─[typescript/tests/cases/compiler/augmentedTypesClass2a.ts:2:7]
@@ -5558,65 +5556,17 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  20 │ 
     ╰────
 
-  × Identifier `m2a` has already been declared
-    ╭─[typescript/tests/cases/compiler/augmentedTypesModules.ts:25:8]
- 24 │ 
- 25 │ module m2a { var y = 2; }
-    ·        ─┬─
-    ·         ╰── `m2a` has already been declared here
- 26 │ function m2a() { }; // error since the module is instantiated
-    ·          ─┬─
-    ·           ╰── It can not be redeclared here
- 27 │ 
-    ╰────
-
-  × Identifier `m2b` has already been declared
-    ╭─[typescript/tests/cases/compiler/augmentedTypesModules.ts:28:8]
- 27 │ 
- 28 │ module m2b { export var y = 2; }
-    ·        ─┬─
-    ·         ╰── `m2b` has already been declared here
- 29 │ function m2b() { };  // error since the module is instantiated
-    ·          ─┬─
-    ·           ╰── It can not be redeclared here
- 30 │ 
-    ╰────
-
-  × Identifier `m2a` has already been declared
-   ╭─[typescript/tests/cases/compiler/augmentedTypesModules2.ts:5:8]
- 4 │ 
- 5 │ module m2a { var y = 2; }
-   ·        ─┬─
-   ·         ╰── `m2a` has already been declared here
- 6 │ function m2a() { }; // error since the module is instantiated
-   ·          ─┬─
+  × Identifier `x2` has already been declared
+   ╭─[typescript/tests/cases/compiler/augmentedTypesVar.ts:6:5]
+ 5 │ // var then function
+ 6 │ var x2 = 1; // error
+   ·     ─┬
+   ·      ╰── `x2` has already been declared here
+ 7 │ function x2() { } // error
+   ·          ─┬
    ·           ╰── It can not be redeclared here
- 7 │ 
+ 8 │ 
    ╰────
-
-  × Identifier `m2b` has already been declared
-    ╭─[typescript/tests/cases/compiler/augmentedTypesModules2.ts:8:8]
-  7 │ 
-  8 │ module m2b { export var y = 2; }
-    ·        ─┬─
-    ·         ╰── `m2b` has already been declared here
-  9 │ function m2b() { };  // error since the module is instantiated
-    ·          ─┬─
-    ·           ╰── It can not be redeclared here
- 10 │ 
-    ╰────
-
-  × Identifier `m2cc` has already been declared
-    ╭─[typescript/tests/cases/compiler/augmentedTypesModules2.ts:14:8]
- 13 │ 
- 14 │ module m2cc { export var y = 2; }
-    ·        ──┬─
-    ·          ╰── `m2cc` has already been declared here
- 15 │ function m2cc() { }; // error to have module first
-    ·          ──┬─
-    ·            ╰── It can not be redeclared here
- 16 │ 
-    ╰────
 
   × Identifier `x4` has already been declared
     ╭─[typescript/tests/cases/compiler/augmentedTypesVar.ts:13:5]
@@ -6001,16 +5951,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  2 │     public {[name:string]:VariableDeclaration};
    ·            ─
  3 │ }
-   ╰────
-
-  × Identifier `foo` has already been declared
-   ╭─[typescript/tests/cases/compiler/classOverloadForFunction.ts:1:7]
- 1 │ class foo { };
-   ·       ─┬─
-   ·        ╰── `foo` has already been declared here
- 2 │ function foo() {}
-   ·          ─┬─
-   ·           ╰── It can not be redeclared here
    ╰────
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
@@ -6646,6 +6586,28 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  1 │ const x = <div>
  2 │ <<<<<<< HEAD
    · ──
+   ╰────
+
+  × Identifier `foo` has already been declared
+   ╭─[typescript/tests/cases/compiler/conflictingTypeAnnotatedVar.ts:1:5]
+ 1 │ var foo: string;
+   ·     ─────┬─────
+   ·          ╰── `foo` has already been declared here
+ 2 │ function foo(): number { }
+   ·          ─┬─
+   ·           ╰── It can not be redeclared here
+ 3 │ function foo(): number { }
+   ╰────
+
+  × Identifier `foo` has already been declared
+   ╭─[typescript/tests/cases/compiler/conflictingTypeAnnotatedVar.ts:1:5]
+ 1 │ var foo: string;
+   ·     ─────┬─────
+   ·          ╰── `foo` has already been declared here
+ 2 │ function foo(): number { }
+ 3 │ function foo(): number { }
+   ·          ─┬─
+   ·           ╰── It can not be redeclared here
    ╰────
 
   × Identifier `x` has already been declared
@@ -7711,6 +7673,32 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  20 │     return 0;
     ╰────
 
+  × Identifier `x` has already been declared
+    ╭─[typescript/tests/cases/compiler/duplicateIdentifierInCatchBlock.ts:12:9]
+ 11 │ try { } catch (e) {
+ 12 │     var x;
+    ·         ┬
+    ·         ╰── `x` has already been declared here
+ 13 │     function x() { } // error
+    ·              ┬
+    ·              ╰── It can not be redeclared here
+ 14 │     function e() { } // error
+    ╰────
+
+  × Identifier `e` has already been declared
+    ╭─[typescript/tests/cases/compiler/duplicateIdentifierInCatchBlock.ts:11:16]
+ 10 │ 
+ 11 │ try { } catch (e) {
+    ·                ┬
+    ·                ╰── `e` has already been declared here
+ 12 │     var x;
+ 13 │     function x() { } // error
+ 14 │     function e() { } // error
+    ·              ┬
+    ·              ╰── It can not be redeclared here
+ 15 │     var p: string;
+    ╰────
+
   × Label `target` has already been declared
    ╭─[typescript/tests/cases/compiler/duplicateLabel1.ts:1:1]
  1 │ target:
@@ -7733,20 +7721,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·      ╰── It can not be redeclared here
  4 │   while (true) {
    ╰────
-
-  × Identifier `F` has already been declared
-    ╭─[typescript/tests/cases/compiler/duplicateSymbolsExportMatching.ts:49:12]
- 48 │ module M {
- 49 │     module F {
-    ·            ┬
-    ·            ╰── `F` has already been declared here
- 50 │         var t;
- 51 │     }
- 52 │     export function F() { } // Only one error for duplicate identifier (don't consider visibility)
-    ·                     ┬
-    ·                     ╰── It can not be redeclared here
- 53 │ }
-    ╰────
 
   × 'super' can only be referenced in members of derived classes or object literal expressions.
     ╭─[typescript/tests/cases/compiler/emitThisInSuperMethodCall.ts:10:17]
@@ -9950,16 +9924,16 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  14 │ 
     ╰────
 
-  × Identifier `C` has already been declared
-    ╭─[typescript/tests/cases/compiler/nameCollisions.ts:33:11]
- 32 │ 
- 33 │     class C { }
-    ·           ┬
-    ·           ╰── `C` has already been declared here
- 34 │     function C() { } // error
+  × Identifier `f` has already been declared
+    ╭─[typescript/tests/cases/compiler/nameCollisions.ts:24:9]
+ 23 │ 
+ 24 │     var f;
+    ·         ┬
+    ·         ╰── `f` has already been declared here
+ 25 │     function f() { } //error
     ·              ┬
     ·              ╰── It can not be redeclared here
- 35 │ 
+ 26 │ 
     ╰────
 
   × Identifier `C2` has already been declared
@@ -12145,6 +12119,18 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  9 │     function package() { }
    ╰────
 
+  × Identifier `package` has already been declared
+    ╭─[typescript/tests/cases/compiler/strictModeReservedWord.ts:8:9]
+  7 │     let let = "blah";
+  8 │     var package = "hello"
+    ·         ───┬───
+    ·            ╰── `package` has already been declared here
+  9 │     function package() { }
+    ·              ───┬───
+    ·                 ╰── It can not be redeclared here
+ 10 │     function bar(private, implements, let) { }
+    ╰────
+
   × The keyword 'package' is reserved
     ╭─[typescript/tests/cases/compiler/strictModeReservedWord.ts:9:14]
   8 │     var package = "hello"
@@ -13184,6 +13170,18 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  5 │ f `123qdawdrqw${ 1 }${
    ╰────
 
+  × Identifier `Point` has already been declared
+   ╭─[typescript/tests/cases/compiler/targetTypeCastTest.ts:1:13]
+ 1 │ declare var Point: { new(x:number, y:number): {x: number; y: number; }; }
+   ·             ──────────────────────────────┬──────────────────────────────
+   ·                                           ╰── `Point` has already been declared here
+ 2 │ 
+ 3 │ function Point(x, y) {
+   ·          ──┬──
+   ·            ╰── It can not be redeclared here
+ 4 │     this.x = x;
+   ╰────
+
   × Bad escape sequence in untagged template literal
    ╭─[typescript/tests/cases/compiler/templateLiteralEscapeSequence.ts:3:2]
  2 │ 
@@ -13621,6 +13619,16 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  2 │ var x1 = /[a-z/]$/i;
    ╰────
   help: Try insert a semicolon here
+
+  × Identifier `myFn` has already been declared
+   ╭─[typescript/tests/cases/compiler/varAndFunctionShareName.ts:1:5]
+ 1 │ var myFn;
+   ·     ──┬─
+   ·       ╰── `myFn` has already been declared here
+ 2 │ function myFn(): any { }
+   ·          ──┬─
+   ·            ╰── It can not be redeclared here
+   ╰────
 
   × Unexpected token
     ╭─[typescript/tests/cases/compiler/varArgConstructorMemberParameter.ts:10:25]
@@ -16959,19 +16967,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  5 │ }
    ╰────
 
-  × Identifier `f` has already been declared
-   ╭─[typescript/tests/cases/conformance/es6/modules/multipleDefaultExports04.ts:1:25]
- 1 │ export default function f() {
-   ·                         ┬
-   ·                         ╰── `f` has already been declared here
- 2 │ }
- 3 │ 
- 4 │ export default function f() {
-   ·                         ┬
-   ·                         ╰── It can not be redeclared here
- 5 │ }
-   ╰────
-
   × Unexpected new.target expression
    ╭─[typescript/tests/cases/conformance/es6/newTarget/invalidNewTarget.es5.ts:1:11]
  1 │ const a = new.target;
@@ -19989,6 +19984,30 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·               ─┬─
    ·                ╰── `,` expected
    ╰────
+
+  × Identifier `fn2` has already been declared
+    ╭─[typescript/tests/cases/conformance/functions/functionNameConflicts.ts:8:9]
+  7 │ 
+  8 │     var fn2;
+    ·         ─┬─
+    ·          ╰── `fn2` has already been declared here
+  9 │     function fn2() { }
+    ·              ─┬─
+    ·               ╰── It can not be redeclared here
+ 10 │ }
+    ╰────
+
+  × Identifier `fn4` has already been declared
+    ╭─[typescript/tests/cases/conformance/functions/functionNameConflicts.ts:16:9]
+ 15 │ function func() {
+ 16 │     var fn4;
+    ·         ─┬─
+    ·          ╰── `fn4` has already been declared here
+ 17 │     function fn4() { }
+    ·              ─┬─
+    ·               ╰── It can not be redeclared here
+ 18 │ 
+    ╰────
 
   × A rest parameter must be last in a parameter list
     ╭─[typescript/tests/cases/conformance/functions/functionOverloadErrorsSyntax.ts:9:25]

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -99,7 +99,6 @@ semantic error: Unexpected token
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-static-block/duplicate-function-var-name/input.js
 semantic error: Identifier `x` has already been declared
-Identifier `x` has already been declared
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/top-level-await-unambiguous/module/input.js
 semantic error: `await` is only allowed within async functions and at the top levels of modules


### PR DESCRIPTION
The `Symbol` is based on the `TypeScript` implementation, but `TypeScript` doesn't support non-strict mode. So we tweaked the implementation to support non-strict mode before, but that held us back from adding symbol id for `declare function`, because `declare function oxc(): number; declare function oxc(): void` is valid, but we have no idea except introducing more symbol flags by to check whether it is a declare function. But introducing more symbol flags will lead to greater discrepancies between our implementation and `TypeScript`. https://github.com/oxc-project/oxc/pull/10074 has re-implemented the function redeclaration check in `checker` so that this PR can make a change to align with `TypeScript` implementation without leading to unexpected errors.

A lot of error messages are removed in snapshots, because they are all duplicated, which was introduced by https://github.com/oxc-project/oxc/pull/10074