### PR TITLE
fix(linter): enable multi-file analysis for nested configs

### DIFF
--- a/apps/oxlint/fixtures/issue_10054/.oxlintrc.json
+++ b/apps/oxlint/fixtures/issue_10054/.oxlintrc.json
@@ -1,0 +1,6 @@
+{
+  "plugins": ["import"],
+  "rules": {
+    "import/no-cycle": "error"
+  }
+}

--- a/apps/oxlint/fixtures/issue_10054/a.ts
+++ b/apps/oxlint/fixtures/issue_10054/a.ts
@@ -1,0 +1,3 @@
+import { b } from "./b";
+
+console.log(b);

--- a/apps/oxlint/fixtures/issue_10054/b.ts
+++ b/apps/oxlint/fixtures/issue_10054/b.ts
@@ -1,0 +1,3 @@
+import "./a";
+
+export const b = "b";

--- a/apps/oxlint/src/snapshots/fixtures_issue_10054@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures_issue_10054@oxlint.snap
@@ -1,0 +1,33 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: issue_10054
+working directory: fixtures
+----------
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html\eslint-plugin-import(no-cycle)]8;;\: Dependency cycle detected
+   ,-[issue_10054/a.ts:1:19]
+ 1 | import { b } from "./b";
+   :                   ^^^^^
+ 2 | 
+   `----
+  help: These paths form a cycle:
+        -> ./b - fixtures/issue_10054/b.ts
+        -> ./a - fixtures/issue_10054/a.ts
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html\eslint-plugin-import(no-cycle)]8;;\: Dependency cycle detected
+   ,-[issue_10054/b.ts:1:8]
+ 1 | import "./a";
+   :        ^^^^^
+ 2 | 
+   `----
+  help: These paths form a cycle:
+        -> ./a - fixtures/issue_10054/a.ts
+        -> ./b - fixtures/issue_10054/b.ts
+
+Found 0 warnings and 2 errors.
+Finished in <variable>ms on 2 files using 1 threads.
+----------
+CLI result: LintFoundErrors
+----------


### PR DESCRIPTION
- fixes #10054 

previously, multi-file analysis was only enabled when the root `.oxlintrc.json` contained the import plugin. now, we enable if any `.oxlintrc.json` has the import plugin.