### PR TITLE
refactor(semantic): align handling of declaring symbol for `class` with TypeScript

### DIFF
--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -122,11 +122,7 @@ impl<'a> Binder<'a> for Class<'a> {
                 ident.span,
                 &ident.name,
                 SymbolFlags::Class,
-                if self.is_declaration() {
-                    SymbolFlags::ClassExcludes
-                } else {
-                    SymbolFlags::empty()
-                },
+                SymbolFlags::ClassExcludes,
             );
             ident.symbol_id.set(Some(symbol_id));
         }

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -144,7 +144,8 @@ bitflags! {
         /// they can not merge with anything in the value space
         const BlockScopedVariableExcludes = Self::Value.bits();
         const FunctionExcludes = Self::Value.bits() & !(Self::Function.bits() | Self::ValueModule.bits() | Self::Class.bits());
-        const ClassExcludes = (Self::Value.bits() | Self::TypeAlias.bits()) & !(Self::ValueModule.bits() | Self::Interface.bits());
+        const ClassExcludes = (Self::Value.bits() | Self::Type.bits()) & !(Self::ValueModule.bits() | Self::Function.bits() | Self::Interface.bits());
+
         const ImportBindingExcludes = Self::Import.bits() | Self::TypeImport.bits();
         // Type specific excludes
         const TypeAliasExcludes = Self::Type.bits();

--- a/tasks/coverage/snapshots/parser_test262.snap
+++ b/tasks/coverage/snapshots/parser_test262.snap
@@ -2698,15 +2698,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
     ╰────
 
   × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/async-function-name-redeclaration-attempt-with-class.js:24:18]
- 23 │ 
- 24 │ { async function f() {} class f {} }
-    ·                  ┬            ┬
-    ·                  │            ╰── It can not be redeclared here
-    ·                  ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
     ╭─[test262/test/language/block-scope/syntax/redeclaration/async-function-name-redeclaration-attempt-with-const.js:24:18]
  23 │ 
  24 │ { async function f() {} const f = 0 }
@@ -2766,15 +2757,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
  24 │ { async function* f() {} async function* f() {} }
     ·                   ┬                      ┬
     ·                   │                      ╰── It can not be redeclared here
-    ·                   ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-class.js:24:19]
- 23 │ 
- 24 │ { async function* f() {} class f {} }
-    ·                   ┬            ┬
-    ·                   │            ╰── It can not be redeclared here
     ·                   ╰── `f` has already been declared here
     ╰────
 
@@ -3089,15 +3071,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
     ╰────
 
   × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/function-name-redeclaration-attempt-with-class.js:23:12]
- 22 │ 
- 23 │ { function f() {} class f {} }
-    ·            ┬            ┬
-    ·            │            ╰── It can not be redeclared here
-    ·            ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
     ╭─[test262/test/language/block-scope/syntax/redeclaration/function-name-redeclaration-attempt-with-const.js:23:12]
  22 │ 
  23 │ { function f() {} const f = 0 }
@@ -3157,15 +3130,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
  24 │ { function* f() {} async function* f() {} }
     ·             ┬                      ┬
     ·             │                      ╰── It can not be redeclared here
-    ·             ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/block-scope/syntax/redeclaration/generator-name-redeclaration-attempt-with-class.js:24:13]
- 23 │ 
- 24 │ { function* f() {} class f {} }
-    ·             ┬            ┬
-    ·             │            ╰── It can not be redeclared here
     ·             ╰── `f` has already been declared here
     ╰────
 
@@ -38295,15 +38259,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
     ╰────
 
   × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/async-function-name-redeclaration-attempt-with-class.js:24:37]
- 23 │ 
- 24 │ switch (0) { case 1: async function f() {} default: class f {} }
-    ·                                     ┬                     ┬
-    ·                                     │                     ╰── It can not be redeclared here
-    ·                                     ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
     ╭─[test262/test/language/statements/switch/syntax/redeclaration/async-function-name-redeclaration-attempt-with-const.js:24:37]
  23 │ 
  24 │ switch (0) { case 1: async function f() {} default: const f = 0 }
@@ -38363,15 +38318,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
  24 │ switch (0) { case 1: async function* f() {} default: async function* f() {} }
     ·                                      ┬                               ┬
     ·                                      │                               ╰── It can not be redeclared here
-    ·                                      ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/async-generator-name-redeclaration-attempt-with-class.js:24:38]
- 23 │ 
- 24 │ switch (0) { case 1: async function* f() {} default: class f {} }
-    ·                                      ┬                     ┬
-    ·                                      │                     ╰── It can not be redeclared here
     ·                                      ╰── `f` has already been declared here
     ╰────
 
@@ -38601,15 +38547,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
     ╰────
 
   × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/function-name-redeclaration-attempt-with-class.js:23:31]
- 22 │ 
- 23 │ switch (0) { case 1: function f() {} default: class f {} }
-    ·                               ┬                     ┬
-    ·                               │                     ╰── It can not be redeclared here
-    ·                               ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
     ╭─[test262/test/language/statements/switch/syntax/redeclaration/function-name-redeclaration-attempt-with-const.js:23:31]
  22 │ 
  23 │ switch (0) { case 1: function f() {} default: const f = 0 }
@@ -38669,15 +38606,6 @@ Expect to Parse: tasks/coverage/test262/test/language/statements/function/S14_A5
  24 │ switch (0) { case 1: function* f() {} default: async function* f() {} }
     ·                                ┬                               ┬
     ·                                │                               ╰── It can not be redeclared here
-    ·                                ╰── `f` has already been declared here
-    ╰────
-
-  × Identifier `f` has already been declared
-    ╭─[test262/test/language/statements/switch/syntax/redeclaration/generator-name-redeclaration-attempt-with-class.js:24:32]
- 23 │ 
- 24 │ switch (0) { case 1: function* f() {} default: class f {} }
-    ·                                ┬                     ┬
-    ·                                │                     ╰── It can not be redeclared here
     ·                                ╰── `f` has already been declared here
     ╰────
 

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -2,8 +2,8 @@ commit: 15392346
 
 parser_typescript Summary:
 AST Parsed     : 6522/6531 (99.86%)
-Positive Passed: 6510/6531 (99.68%)
-Negative Passed: 1296/5754 (22.52%)
+Positive Passed: 6511/6531 (99.69%)
+Negative Passed: 1290/5754 (22.42%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration24.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment7.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment8.ts
@@ -220,6 +220,9 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/callOnInstan
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/callOverloadViaElementAccessExpression.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/callOverloads1.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/callOverloads2.ts
+Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/callOverloads3.ts
+Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/callOverloads4.ts
+Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/callOverloads5.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/callSignaturesShouldBeResolvedBeforeSpecialization.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/callWithWrongNumberOfTypeArguments.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/callbackArgsDifferByOptionality.ts
@@ -318,6 +321,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classMemberI
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classMergedWithInterfaceMultipleBasesNoError.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classOrder2.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classOverloadForFunction.ts
+Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classOverloadForFunction2.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classPropertyErrorOnNameOnly.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classSideInheritance1.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/classSideInheritance2.ts
@@ -848,6 +852,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/forInStrictN
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/forwardDeclaredCommonTypes01.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/forwardRefInClassProperties.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/forwardRefInEnum.ts
+Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/funClodule.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionAndImportNameConflict.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionAndInterfaceWithSeparateErrors.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/functionArgShadowing.ts
@@ -1880,6 +1885,7 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/spreadInvali
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/spreadOfParamsFromGeneratorMakesRequiredParams.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/spyComparisonChecking.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticAsIdentifier.ts
+Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticClassMemberError.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution4.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticInstanceResolution5.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/staticMemberExportAccess.ts
@@ -4557,20 +4563,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/bom-utf16be.ts
  1 │ ￾瘀愀爀 砀㴀㄀　㬀ഀ਀
    · ─
    ╰────
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/constructorOverloads5.ts
-
-  × Identifier `RegExp` has already been declared
-   ╭─[typescript/tests/cases/compiler/constructorOverloads5.ts:4:21]
- 3 │  declare module M {
- 4 │     export function RegExp(pattern: string): RegExp;
-   ·                     ───┬──
-   ·                        ╰── `RegExp` has already been declared here
- 5 │     export function RegExp(pattern: string, flags: string): RegExp;
- 6 │     export class RegExp {
-   ·                  ───┬──
-   ·                     ╰── It can not be redeclared here
- 7 │         constructor(pattern: string);
-   ╰────
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/elidedEmbeddedStatementsReplacedWithSemicolon.ts
 
   × 'with' statements are not allowed
@@ -5476,30 +5468,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  13 │     foo() {
     ╰────
 
-  × Identifier `y3` has already been declared
-    ╭─[typescript/tests/cases/compiler/augmentedTypesFunction.ts:13:10]
- 12 │ // function then class
- 13 │ function y3() { } // error
-    ·          ─┬
-    ·           ╰── `y3` has already been declared here
- 14 │ class y3 { } // error
-    ·       ─┬
-    ·        ╰── It can not be redeclared here
- 15 │ 
-    ╰────
-
-  × Identifier `y3a` has already been declared
-    ╭─[typescript/tests/cases/compiler/augmentedTypesFunction.ts:16:10]
- 15 │ 
- 16 │ function y3a() { } // error
-    ·          ─┬─
-    ·           ╰── `y3a` has already been declared here
- 17 │ class y3a { public foo() { } } // error
-    ·       ─┬─
-    ·        ╰── It can not be redeclared here
- 18 │ 
-    ╰────
-
   × Identifier `y4` has already been declared
     ╭─[typescript/tests/cases/compiler/augmentedTypesFunction.ts:20:10]
  19 │ // function then enum
@@ -5857,42 +5825,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·       ─
    ╰────
 
-  × Identifier `Foo` has already been declared
-   ╭─[typescript/tests/cases/compiler/callOverloads3.ts:1:10]
- 1 │ function Foo():Foo; // error
-   ·          ─┬─
-   ·           ╰── `Foo` has already been declared here
- 2 │ function Foo(s:string):Foo; // error
- 3 │ class Foo { // error
-   ·       ─┬─
-   ·        ╰── It can not be redeclared here
- 4 │     bar1() { /*WScript.Echo("bar1");*/ }
-   ╰────
-
-  × Identifier `Foo` has already been declared
-   ╭─[typescript/tests/cases/compiler/callOverloads4.ts:1:10]
- 1 │ function Foo():Foo; // error
-   ·          ─┬─
-   ·           ╰── `Foo` has already been declared here
- 2 │ function Foo(s:string):Foo; // error
- 3 │ class Foo { // error
-   ·       ─┬─
-   ·        ╰── It can not be redeclared here
- 4 │     bar1() { /*WScript.Echo("bar1");*/ }
-   ╰────
-
-  × Identifier `Foo` has already been declared
-   ╭─[typescript/tests/cases/compiler/callOverloads5.ts:1:10]
- 1 │ function Foo():Foo; // error
-   ·          ─┬─
-   ·           ╰── `Foo` has already been declared here
- 2 │ function Foo(s:string):Foo; // error
- 3 │ class Foo { // error
-   ·       ─┬─
-   ·        ╰── It can not be redeclared here
- 4 │     bar1(s:string);
-   ╰────
-
   × Unexpected token
    ╭─[typescript/tests/cases/compiler/cannotInvokeNewOnErrorExpression.ts:5:22]
  4 │ }
@@ -5995,16 +5927,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  2 │     public {[name:string]:VariableDeclaration};
    ·            ─
  3 │ }
-   ╰────
-
-  × Identifier `bar` has already been declared
-   ╭─[typescript/tests/cases/compiler/classOverloadForFunction2.ts:1:10]
- 1 │ function bar(): string;
-   ·          ─┬─
-   ·           ╰── `bar` has already been declared here
- 2 │ class bar {}
-   ·       ─┬─
-   ·        ╰── It can not be redeclared here
    ╰────
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
@@ -8307,20 +8229,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╰────
   help: This iterator's type will be inferred from the iterable. You can safely remove the type annotation.
 
-  × Identifier `foo3` has already been declared
-    ╭─[typescript/tests/cases/compiler/funClodule.ts:15:10]
- 14 │ 
- 15 │ function foo3() { }
-    ·          ──┬─
-    ·            ╰── `foo3` has already been declared here
- 16 │ module foo3 {
- 17 │      export function x(): any { }
- 18 │ }
- 19 │ class foo3 { } // Should error
-    ·       ──┬─
-    ·         ╰── It can not be redeclared here
-    ╰────
-
   × Identifier `aaaaa` has already been declared
    ╭─[typescript/tests/cases/compiler/functionAndPropertyNameConflict.ts:2:12]
  1 │ class C65 {
@@ -10004,18 +9912,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
     ·              ┬
     ·              ╰── It can not be redeclared here
  26 │ 
-    ╰────
-
-  × Identifier `C2` has already been declared
-    ╭─[typescript/tests/cases/compiler/nameCollisions.ts:36:14]
- 35 │ 
- 36 │     function C2() { }
-    ·              ─┬
-    ·               ╰── `C2` has already been declared here
- 37 │     class C2 { } // error
-    ·           ─┬
-    ·            ╰── It can not be redeclared here
- 38 │ 
     ╰────
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
@@ -12119,18 +12015,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    · ──────
    ╰────
   help: A `break` statement can only be used within an enclosing iteration or switch statement.
-
-  × Identifier `Foo` has already been declared
-    ╭─[typescript/tests/cases/compiler/staticClassMemberError.ts:9:10]
-  8 │ // just want to make sure this one doesn't crash the compiler
-  9 │ function Foo();
-    ·          ─┬─
-    ·           ╰── `Foo` has already been declared here
- 10 │ class Foo {
-    ·       ─┬─
-    ·        ╰── It can not be redeclared here
- 11 │  static bar;
-    ╰────
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[typescript/tests/cases/compiler/staticClassProps.ts:4:15]

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -4612,7 +4612,12 @@ after transform: ScopeId(6): [ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), S
 rebuilt        : ScopeId(4): [ScopeId(5), ScopeId(6)]
 
 tasks/coverage/typescript/tests/cases/compiler/constructorOverloads5.ts
-semantic error: Identifier `RegExp` has already been declared
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): ["M"]
+rebuilt        : ScopeId(0): []
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/constructorOverloads9.ts
 semantic error: Scope children mismatch:


### PR DESCRIPTION
Same as #10086 but for `class`