### PR TITLE
refactor(linter): use `FormalParameter::has_modifier` to detect parameter properties

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_useless_constructor.rs
@@ -2,7 +2,8 @@ use oxc_ast::{
     AstKind,
     ast::{
         Argument, BindingPattern, BindingPatternKind, BindingRestElement, CallExpression,
-        Expression, FormalParameters, FunctionBody, MethodDefinition, Statement, TSAccessibility,
+        Expression, FormalParameter, FormalParameters, FunctionBody, MethodDefinition, Statement,
+        TSAccessibility,
     },
 };
 use oxc_diagnostics::OxcDiagnostic;
@@ -151,13 +152,7 @@ fn lint_empty_constructor<'a>(
 
     // allow constructors with access modifiers since they actually declare
     // class members
-    if constructor
-        .value
-        .params
-        .items
-        .iter()
-        .any(|param| param.accessibility.is_some() || param.readonly)
-    {
+    if constructor.value.params.items.iter().any(FormalParameter::has_modifier) {
         return;
     }
 

--- a/crates/oxc_linter/src/rules/typescript/no_unnecessary_parameter_property_assignment.rs
+++ b/crates/oxc_linter/src/rules/typescript/no_unnecessary_parameter_property_assignment.rs
@@ -66,18 +66,8 @@ impl Rule for NoUnnecessaryParameterPropertyAssignment {
             return;
         }
 
-        let parameter_properties: Vec<_> = method
-            .value
-            .params
-            .items
-            .iter()
-            .filter(|param| {
-                // TypeScript offers special syntax for turning a constructor parameter into a class property with the same name and value.
-                // These are called parameter properties and are created by prefixing a constructor argument with one of the visibility modifiers public, private, protected, or readonly
-                // https://www.typescriptlang.org/docs/handbook/2/classes.html#parameter-properties
-                param.accessibility.is_some() || param.readonly
-            })
-            .collect();
+        let parameter_properties: Vec<_> =
+            method.value.params.items.iter().filter(|param| param.has_modifier()).collect();
 
         if parameter_properties.is_empty() {
             return;


### PR DESCRIPTION
By using this function, the code is shorter and the missing check for the `override` modifier is added.

This PR is the result of splitting #10081 into smaller PRs.