### PR TITLE
refactor(isolated_declarations): use `FormalParameter::has_modifier` to detect parameter properties

### DIFF
--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -264,7 +264,7 @@ impl<'a> IsolatedDeclarations<'a> {
     ) -> ArenaVec<'a, ClassElement<'a>> {
         let mut elements = self.ast.vec();
         for (index, param) in function.params.items.iter().enumerate() {
-            if param.accessibility.is_some() || param.readonly {
+            if param.has_modifier() {
                 let type_annotation =
                     if param.accessibility.is_some_and(TSAccessibility::is_private) {
                         None


### PR DESCRIPTION
By using this function, the code is shorter and the missing check for the `override` modifier is added.

This PR is the result of splitting https://github.com/oxc-project/oxc/pull/10081 into smaller PRs.