### PR TITLE
refactor(linter): use items of `oxc_ast::ast` module directly

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/prefer_object_spread.rs
+++ b/crates/oxc_linter/src/rules/eslint/prefer_object_spread.rs
@@ -2,14 +2,10 @@ use std::cmp::max;
 
 use oxc_allocator::Box;
 use oxc_ast::AstKind;
-use oxc_ast::ast::Expression;
-use oxc_ast::ast::ObjectExpression;
-use oxc_ast::ast::ObjectPropertyKind;
-use oxc_ast::ast::PropertyKind;
+use oxc_ast::ast::{Expression, ObjectExpression, ObjectPropertyKind, PropertyKind};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_span::GetSpan;
-use oxc_span::Span;
+use oxc_span::{GetSpan, Span};
 
 use crate::{AstNode, ast_util::is_method_call, context::LintContext, rule::Rule};
 
@@ -121,7 +117,7 @@ impl Rule for PreferObjectSpread {
 
         for (idx, arg) in call_expr.arguments.iter().enumerate() {
             let Some(Expression::ObjectExpression(obj_expr)) =
-                arg.as_expression().map(oxc_ast::ast::Expression::get_inner_expression)
+                arg.as_expression().map(Expression::get_inner_expression)
             else {
                 if idx == 0 {
                     return;

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_role.rs
@@ -1,6 +1,6 @@
 use oxc_ast::{
     AstKind,
-    ast::{JSXAttributeValue, JSXExpression},
+    ast::{JSXAttributeItem, JSXAttributeValue, JSXExpression},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -150,7 +150,7 @@ impl Rule for AriaRole {
                     return;
                 }
 
-                let oxc_ast::ast::JSXAttributeItem::Attribute(attr) = aria_role else {
+                let JSXAttributeItem::Attribute(attr) = aria_role else {
                     return;
                 };
 

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_autofocus.rs
@@ -1,4 +1,4 @@
-use oxc_ast::AstKind;
+use oxc_ast::{AstKind, ast::JSXAttributeItem};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -106,7 +106,7 @@ impl Rule for NoAutofocus {
 
         if self.ignore_non_dom {
             if HTML_TAG.contains(&element_type) {
-                if let oxc_ast::ast::JSXAttributeItem::Attribute(attr) = autofocus {
+                if let JSXAttributeItem::Attribute(attr) = autofocus {
                     ctx.diagnostic_with_fix(no_autofocus_diagnostic(attr.span), |fixer| {
                         fixer.delete(&attr.span)
                     });
@@ -115,7 +115,7 @@ impl Rule for NoAutofocus {
             return;
         }
 
-        if let oxc_ast::ast::JSXAttributeItem::Attribute(attr) = autofocus {
+        if let JSXAttributeItem::Attribute(attr) = autofocus {
             ctx.diagnostic_with_fix(no_autofocus_diagnostic(attr.span), |fixer| {
                 fixer.delete(&attr.span)
             });

--- a/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
+++ b/crates/oxc_linter/src/rules/react/exhaustive_deps.rs
@@ -9,7 +9,8 @@ use oxc_ast::{
     ast::{
         Argument, ArrayExpressionElement, ArrowFunctionExpression, BindingPatternKind,
         CallExpression, ChainElement, Expression, Function, FunctionBody, IdentifierReference,
-        MemberExpression, StaticMemberExpression, VariableDeclarationKind,
+        MemberExpression, StaticMemberExpression, TSTypeAnnotation, TSTypeParameter,
+        TSTypeReference, VariableDeclarationKind,
     },
     match_expression,
 };
@@ -1012,18 +1013,15 @@ impl<'a> Visit<'a> for ExhaustiveDepsVisitor<'a, '_> {
         self.stack.pop();
     }
 
-    fn visit_ts_type_annotation(&mut self, _it: &oxc_ast::ast::TSTypeAnnotation<'a>) {
+    fn visit_ts_type_annotation(&mut self, _it: &TSTypeAnnotation<'a>) {
         // noop
     }
 
-    fn visit_ts_type_reference(&mut self, _it: &oxc_ast::ast::TSTypeReference<'a>) {
+    fn visit_ts_type_reference(&mut self, _it: &TSTypeReference<'a>) {
         // noop
     }
 
-    fn visit_ts_type_parameters(
-        &mut self,
-        _it: &oxc_allocator::Vec<'a, oxc_ast::ast::TSTypeParameter<'a>>,
-    ) {
+    fn visit_ts_type_parameters(&mut self, _it: &oxc_allocator::Vec<'a, TSTypeParameter<'a>>) {
         // noop
     }
 

--- a/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
+++ b/crates/oxc_linter/src/rules/react/jsx_curly_brace_presence.rs
@@ -565,7 +565,7 @@ fn has_adjacent_jsx_expression_containers<'a>(
         .into_iter()
         // [prev id, next id] -> [prev node, next node], removing out-of-bounds indices
         .filter_map(|idx| idx.and_then(|idx| children.get(idx)))
-        .any(oxc_ast::ast::JSXChild::is_expression_container)
+        .any(JSXChild::is_expression_container)
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/typescript/ban_types.rs
+++ b/crates/oxc_linter/src/rules/typescript/ban_types.rs
@@ -1,5 +1,5 @@
 use cow_utils::CowUtils;
-use oxc_ast::AstKind;
+use oxc_ast::{AstKind, ast::TSTypeName};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -63,8 +63,8 @@ impl Rule for BanTypes {
         match node.kind() {
             AstKind::TSTypeReference(ty) => {
                 let name = match &ty.type_name {
-                    oxc_ast::ast::TSTypeName::IdentifierReference(v) => &v.name,
-                    oxc_ast::ast::TSTypeName::QualifiedName(_) => return,
+                    TSTypeName::IdentifierReference(v) => &v.name,
+                    TSTypeName::QualifiedName(_) => return,
                 };
 
                 match name.as_str() {

--- a/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
+++ b/crates/oxc_linter/src/rules/unicorn/consistent_function_scoping.rs
@@ -1,6 +1,9 @@
 use rustc_hash::FxHashSet;
 
-use oxc_ast::AstKind;
+use oxc_ast::{
+    AstKind,
+    ast::{Function, IdentifierReference, JSXElementName, ThisExpression},
+};
 use oxc_ast_visit::{Visit, walk};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
@@ -254,22 +257,22 @@ struct ReferencesFinder {
 }
 
 impl<'a> Visit<'a> for ReferencesFinder {
-    fn visit_identifier_reference(&mut self, it: &oxc_ast::ast::IdentifierReference<'a>) {
+    fn visit_identifier_reference(&mut self, it: &IdentifierReference<'a>) {
         self.references.push(it.reference_id());
     }
 
-    fn visit_jsx_element_name(&mut self, _it: &oxc_ast::ast::JSXElementName<'a>) {
+    fn visit_jsx_element_name(&mut self, _it: &JSXElementName<'a>) {
         // Ignore references in JSX elements e.g. `Foo` in `<Foo>`.
         // No need to walk children as only references they may contain are also JSX identifiers.
     }
 
-    fn visit_this_expression(&mut self, _: &oxc_ast::ast::ThisExpression) {
+    fn visit_this_expression(&mut self, _: &ThisExpression) {
         if self.in_function == 0 {
             self.is_parent_this_referenced = true;
         }
     }
 
-    fn visit_function(&mut self, func: &oxc_ast::ast::Function<'a>, flags: ScopeFlags) {
+    fn visit_function(&mut self, func: &Function<'a>, flags: ScopeFlags) {
         self.in_function += 1;
         walk::walk_function(self, func, flags);
         self.in_function -= 1;

--- a/crates/oxc_linter/src/rules/unicorn/no_length_as_slice_end.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_length_as_slice_end.rs
@@ -1,5 +1,6 @@
 use oxc_ast::{
-    ast::{Argument, Expression, MemberExpression}, AstKind
+    AstKind,
+    ast::{Argument, Expression, MemberExpression},
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;

--- a/crates/oxc_linter/src/rules/unicorn/no_length_as_slice_end.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_length_as_slice_end.rs
@@ -1,4 +1,6 @@
-use oxc_ast::{AstKind, ast::MemberExpression};
+use oxc_ast::{
+    ast::{Argument, Expression, MemberExpression}, AstKind
+};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
@@ -57,14 +59,14 @@ impl Rule for NoLengthAsSliceEnd {
             return;
         }
 
-        if call_expr.arguments.iter().any(oxc_ast::ast::Argument::is_spread) {
+        if call_expr.arguments.iter().any(Argument::is_spread) {
             return;
         }
 
         let Some(MemberExpression::StaticMemberExpression(second_argument)) = call_expr.arguments
             [1]
         .as_expression()
-        .map(oxc_ast::ast::Expression::without_parentheses)
+        .map(Expression::without_parentheses)
         .and_then(|e| e.get_member_expr()) else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_magic_array_flat_depth.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_magic_array_flat_depth.rs
@@ -60,7 +60,7 @@ impl Rule for NoMagicArrayFlatDepth {
 
         let first_arg = call_expression.arguments.first().expect("missing argument");
         let Some(Expression::NumericLiteral(arg)) =
-            first_arg.as_expression().map(oxc_ast::ast::Expression::without_parentheses)
+            first_arg.as_expression().map(Expression::without_parentheses)
         else {
             return;
         };

--- a/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
+++ b/crates/oxc_linter/src/rules/unicorn/no_static_only_class.rs
@@ -1,4 +1,4 @@
-use oxc_ast::AstKind;
+use oxc_ast::{AstKind, ast::ClassElement};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
@@ -74,19 +74,19 @@ impl Rule for NoStaticOnlyClass {
         }
         if class.body.body.iter().any(|node| {
             match node {
-                oxc_ast::ast::ClassElement::MethodDefinition(v) => {
+                ClassElement::MethodDefinition(v) => {
                     if v.accessibility.is_some() {
                         return true;
                     }
                 }
-                oxc_ast::ast::ClassElement::PropertyDefinition(v) => {
+                ClassElement::PropertyDefinition(v) => {
                     if v.accessibility.is_some() || v.readonly || v.declare {
                         return true;
                     }
                 }
-                oxc_ast::ast::ClassElement::AccessorProperty(_)
-                | oxc_ast::ast::ClassElement::StaticBlock(_)
-                | oxc_ast::ast::ClassElement::TSIndexSignature(_) => {}
+                ClassElement::AccessorProperty(_)
+                | ClassElement::StaticBlock(_)
+                | ClassElement::TSIndexSignature(_) => {}
             }
 
             if node.r#static() {

--- a/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
+++ b/crates/oxc_linter/src/rules/unicorn/prefer_array_flat.rs
@@ -1,7 +1,8 @@
 use oxc_ast::{
     AstKind,
     ast::{
-        Argument, ArrayExpressionElement, BindingPatternKind, CallExpression, Expression, Statement,
+        Argument, ArrayExpressionElement, BindingPatternKind, CallExpression, Expression,
+        MemberExpression, Statement,
     },
 };
 use oxc_diagnostics::OxcDiagnostic;
@@ -107,7 +108,7 @@ fn check_array_flat_map_case<'a>(call_expr: &CallExpression<'a>, ctx: &LintConte
     let target_fix_span = call_expr
         .callee
         .as_member_expression()
-        .and_then(oxc_ast::ast::MemberExpression::static_property_info)
+        .and_then(MemberExpression::static_property_info)
         .map(|v| Span::new(v.0.start, call_expr.span.end));
 
     if let Some(span) = target_fix_span {
@@ -182,7 +183,7 @@ fn check_array_reduce_case<'a>(call_expr: &CallExpression<'a>, ctx: &LintContext
                     let target_fix_span = call_expr
                         .callee
                         .as_member_expression()
-                        .and_then(oxc_ast::ast::MemberExpression::static_property_info)
+                        .and_then(MemberExpression::static_property_info)
                         .map(|v| Span::new(v.0.start, call_expr.span.end));
 
                     debug_assert!(target_fix_span.is_some());
@@ -229,7 +230,7 @@ fn check_array_reduce_case<'a>(call_expr: &CallExpression<'a>, ctx: &LintContext
             let target_fix_span = call_expr
                 .callee
                 .as_member_expression()
-                .and_then(oxc_ast::ast::MemberExpression::static_property_info)
+                .and_then(MemberExpression::static_property_info)
                 .map(|v| Span::new(v.0.start, call_expr.span.end));
 
             debug_assert!(target_fix_span.is_some());

--- a/crates/oxc_linter/src/rules/unicorn/require_array_join_separator.rs
+++ b/crates/oxc_linter/src/rules/unicorn/require_array_join_separator.rs
@@ -1,4 +1,7 @@
-use oxc_ast::{AstKind, ast::MemberExpression};
+use oxc_ast::{
+    AstKind,
+    ast::{Argument, MemberExpression},
+};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::{GetSpan, Span};
@@ -100,7 +103,7 @@ impl Rule for RequireArrayJoinSeparator {
             if is_method_call(call_expr, None, Some(&["call"]), Some(1), Some(1))
                 && !member_expr.optional()
                 && !call_expr.optional
-                && !call_expr.arguments.iter().any(oxc_ast::ast::Argument::is_spread)
+                && !call_expr.arguments.iter().any(Argument::is_spread)
                 && is_array_prototype_property(member_expr_obj, "join")
             {
                 ctx.diagnostic_with_fix(


### PR DESCRIPTION
All other lint rules do it this way and it leads to less noisy code.