### PR TITLE
fix(codegen): do not escape `$` in strings unless using backtick as quote

### DIFF
--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -675,7 +675,7 @@ impl<'a> Codegen<'a> {
                     self.print_ascii_byte(b'`');
                 }
                 '$' => {
-                    if chars.peek() == Some(&'{') {
+                    if quote == Quote::Backtick && chars.peek() == Some(&'{') {
                         self.print_ascii_byte(b'\\');
                     }
                     self.print_ascii_byte(b'$');

--- a/crates/oxc_codegen/tests/integration/unit.rs
+++ b/crates/oxc_codegen/tests/integration/unit.rs
@@ -500,6 +500,13 @@ fn getter_setter() {
 
 #[test]
 fn string() {
+    test("let x = \"${}\";", "let x = \"${}\";\n");
+    test_minify("let x = \"${}\";", "let x=\"${}\";");
+    test("let x = '\"\"${}';", "let x = \"\\\"\\\"${}\";\n");
+    test_minify("let x = '\"\"${}';", "let x='\"\"${}';");
+    test("let x = '\"\"\\'\\'${}';", "let x = \"\\\"\\\"''${}\";\n");
+    test_minify("let x = '\"\"\\'\\'${}';", "let x=`\"\"''\\${}`;");
+
     test_minify(
         r#";'eval("\'\\vstr\\ving\\v\'") === "\\vstr\\ving\\v"'"#,
         r#";`eval("'\\vstr\\ving\\v'") === "\\vstr\\ving\\v"`;"#,

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -21,7 +21,7 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 
 3.20 MB    | 1.01 MB    | 1.01 MB    | 324.14 kB  | 331.56 kB  | echarts.js
 
-6.69 MB    | 2.28 MB    | 2.31 MB    | 466.10 kB  | 488.28 kB  | antd.js   
+6.69 MB    | 2.28 MB    | 2.31 MB    | 466.11 kB  | 488.28 kB  | antd.js   
 
-10.95 MB   | 3.35 MB    | 3.49 MB    | 860.95 kB  | 915.50 kB  | typescript.js
+10.95 MB   | 3.35 MB    | 3.49 MB    | 860.94 kB  | 915.50 kB  | typescript.js
 


### PR DESCRIPTION
When printing `"${"`, it's unnecessary to escape the `$` unless the quote character is a backtick.
