### PR TITLE
test(minifier): update `cargo minsize` snapshot

### DIFF
--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -7,7 +7,7 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 
 287.63 kB  | 89.33 kB   | 90.07 kB   | 30.95 kB   | 31.95 kB   | jquery.js 
 
-342.15 kB  | 117.25 kB  | 118.14 kB  | 43.31 kB   | 44.37 kB   | vue.js    
+342.15 kB  | 117.25 kB  | 118.14 kB  | 43.29 kB   | 44.37 kB   | vue.js    
 
 544.10 kB  | 71.38 kB   | 72.48 kB   | 25.85 kB   | 26.20 kB   | lodash.js 
 
@@ -21,7 +21,7 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 
 3.20 MB    | 1.01 MB    | 1.01 MB    | 324.14 kB  | 331.56 kB  | echarts.js
 
-6.69 MB    | 2.28 MB    | 2.31 MB    | 466.12 kB  | 488.28 kB  | antd.js   
+6.69 MB    | 2.28 MB    | 2.31 MB    | 466.10 kB  | 488.28 kB  | antd.js   
 
 10.95 MB   | 3.35 MB    | 3.49 MB    | 860.95 kB  | 915.50 kB  | typescript.js
 


### PR DESCRIPTION
Update `minsize` snapshot. It had got out of date.