### PR TITLE
ci(codegen): add benchmark for minified printing

### DIFF
--- a/tasks/benchmark/benches/codegen.rs
+++ b/tasks/benchmark/benches/codegen.rs
@@ -27,6 +27,18 @@ fn bench_codegen(criterion: &mut Criterion) {
         });
         group.finish();
 
+        // Codegen minified
+        let mut group = criterion.benchmark_group("codegen_minify");
+        group.bench_function(id.clone(), |b| {
+            b.iter_with_large_drop(|| {
+                CodeGenerator::new()
+                    .with_options(CodegenOptions { minify: true, ..CodegenOptions::default() })
+                    .build(&program)
+                    .map
+            });
+        });
+        group.finish();
+
         // Codegen sourcemap
         let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
 


### PR DESCRIPTION
Add a benchmark for codegen with `minify: true` option.

Primarily this is to see what (if any) effect #10046 has on performance. We may want to remove it again later.