### PR TITLE
feat(language_server): search for nested configurations by initialization

### DIFF
--- a/crates/oxc_language_server/src/linter/config_walker.rs
+++ b/crates/oxc_language_server/src/linter/config_walker.rs
@@ -1,0 +1,90 @@
+use std::{
+    ffi::OsStr,
+    path::PathBuf,
+    sync::{Arc, mpsc},
+};
+
+use ignore::DirEntry;
+
+use crate::OXC_CONFIG_FILE;
+
+pub struct ConfigWalker {
+    inner: ignore::WalkParallel,
+}
+
+struct WalkBuilder {
+    sender: mpsc::Sender<Vec<Arc<OsStr>>>,
+}
+
+impl<'s> ignore::ParallelVisitorBuilder<'s> for WalkBuilder {
+    fn build(&mut self) -> Box<dyn ignore::ParallelVisitor + 's> {
+        Box::new(WalkCollector { paths: vec![], sender: self.sender.clone() })
+    }
+}
+
+struct WalkCollector {
+    paths: Vec<Arc<OsStr>>,
+    sender: mpsc::Sender<Vec<Arc<OsStr>>>,
+}
+
+impl Drop for WalkCollector {
+    fn drop(&mut self) {
+        let paths = std::mem::take(&mut self.paths);
+        self.sender.send(paths).unwrap();
+    }
+}
+
+impl ignore::ParallelVisitor for WalkCollector {
+    fn visit(&mut self, entry: Result<ignore::DirEntry, ignore::Error>) -> ignore::WalkState {
+        match entry {
+            Ok(entry) => {
+                if Self::is_wanted_entry(&entry) {
+                    self.paths.push(entry.path().as_os_str().into());
+                }
+                ignore::WalkState::Continue
+            }
+            Err(_err) => ignore::WalkState::Skip,
+        }
+    }
+}
+
+impl WalkCollector {
+    fn is_wanted_entry(entry: &DirEntry) -> bool {
+        let Some(file_type) = entry.file_type() else { return false };
+        if file_type.is_dir() {
+            return false;
+        }
+        let Some(file_name) = entry.path().file_name() else { return false };
+
+        file_name == OXC_CONFIG_FILE
+    }
+}
+
+impl ConfigWalker {
+    /// Will not canonicalize paths.
+    /// # Panics
+    pub fn new(path: &PathBuf) -> Self {
+        // Turning off `follow_links` because:
+        // * following symlinks is a really slow syscall
+        // * it is super rare to have symlinked source code
+        let inner: ignore::WalkParallel = ignore::WalkBuilder::new(path)
+            // disable skip hidden, which will not not search for files starting with a dot
+            .hidden(false)
+            // disable all gitignore features
+            .parents(false)
+            .ignore(false)
+            .git_global(false)
+            .follow_links(false)
+            .build_parallel();
+
+        Self { inner }
+    }
+
+    pub fn paths(self) -> Vec<Arc<OsStr>> {
+        let (sender, receiver) = mpsc::channel::<Vec<Arc<OsStr>>>();
+        let mut builder = WalkBuilder { sender };
+        self.inner.visit(&mut builder);
+        drop(builder);
+        receiver.into_iter().flatten().collect()
+    }
+}

--- a/crates/oxc_language_server/src/linter/mod.rs
+++ b/crates/oxc_language_server/src/linter/mod.rs
@@ -1,6 +1,7 @@
 use oxc_data_structures::rope::{Rope, get_line_column};
 use tower_lsp::lsp_types::Position;
 
+pub mod config_walker;
 pub mod error_with_position;
 mod isolated_lint_handler;
 pub mod server_linter;


### PR DESCRIPTION
Now the client does not need to send a second request after initialization.
The initialization part is done on the server side. The client only needs to send future changes because file-watchers on servers are not recommended: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeWatchedFiles