### PR TITLE
feat(ecmascript): add `is_pure_call` to `MayHaveSideEffectsContext`

### DIFF
--- a/crates/oxc_ecmascript/src/side_effects/context.rs
+++ b/crates/oxc_ecmascript/src/side_effects/context.rs
@@ -1,3 +1,5 @@
+use oxc_ast::ast::Expression;
+
 use crate::is_global_reference::IsGlobalReference;
 
 pub trait MayHaveSideEffectsContext: IsGlobalReference {
@@ -6,4 +8,10 @@ pub trait MayHaveSideEffectsContext: IsGlobalReference {
     /// Pure annotations are the comments that marks that a expression is pure.
     /// For example, `/* @__PURE__ */`, `/* #__NO_SIDE_EFFECTS__ */`.
     fn respect_annotations(&self) -> bool;
+
+    /// Whether to treat this function call as pure.
+    ///
+    /// This function is called for normal function calls, new calls, and
+    /// tagged template calls (`foo()`, `new Foo()`, ``foo`b` ``).
+    fn is_pure_call(&self, callee: &Expression) -> bool;
 }

--- a/crates/oxc_minifier/src/ctx.rs
+++ b/crates/oxc_minifier/src/ctx.rs
@@ -29,6 +29,10 @@ impl oxc_ecmascript::side_effects::MayHaveSideEffectsContext for Ctx<'_, '_> {
     fn respect_annotations(&self) -> bool {
         true
     }
+
+    fn is_pure_call(&self, _callee: &Expression) -> bool {
+        false
+    }
 }
 
 impl<'a> ConstantEvaluationCtx<'a> for Ctx<'a, '_> {


### PR DESCRIPTION
Expected to be used for [`treeshake.manualPureFunctions`](https://rollupjs.org/configuration-options/#treeshake-manualpurefunctions) support.