### PR TITLE
feat(ecmascript): add `property_read_side_effects` to `MayHaveSideEffectsContext`

### DIFF
--- a/crates/oxc_ecmascript/src/side_effects/context.rs
+++ b/crates/oxc_ecmascript/src/side_effects/context.rs
@@ -2,6 +2,18 @@ use oxc_ast::ast::Expression;
 
 use crate::is_global_reference::IsGlobalReference;
 
+#[derive(Default, Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PropertyReadSideEffects {
+    /// Treat all property read accesses as side effect free.
+    None,
+    /// Treat non-member property accesses as side effect free.
+    /// Member property accesses are still considered to have side effects.
+    OnlyMemberPropertyAccess,
+    /// Treat all property read accesses as possible side effects.
+    #[default]
+    All,
+}
+
 pub trait MayHaveSideEffectsContext: IsGlobalReference {
     /// Whether to respect the pure annotations.
     ///
@@ -14,4 +26,7 @@ pub trait MayHaveSideEffectsContext: IsGlobalReference {
     /// This function is called for normal function calls, new calls, and
     /// tagged template calls (`foo()`, `new Foo()`, ``foo`b` ``).
     fn is_pure_call(&self, callee: &Expression) -> bool;
+
+    /// Whether property read accesses have side effects.
+    fn property_read_side_effects(&self) -> PropertyReadSideEffects;
 }

--- a/crates/oxc_ecmascript/src/side_effects/may_have_side_effects.rs
+++ b/crates/oxc_ecmascript/src/side_effects/may_have_side_effects.rs
@@ -5,7 +5,7 @@ use crate::{
     to_primitive::ToPrimitive,
 };
 
-use super::context::MayHaveSideEffectsContext;
+use super::{PropertyReadSideEffects, context::MayHaveSideEffectsContext};
 
 /// Returns true if subtree changes application state.
 ///
@@ -398,7 +398,9 @@ impl MayHaveSideEffects for MemberExpression<'_> {
         match self {
             MemberExpression::ComputedMemberExpression(e) => e.may_have_side_effects(ctx),
             MemberExpression::StaticMemberExpression(e) => e.may_have_side_effects(ctx),
-            MemberExpression::PrivateFieldExpression(_) => true,
+            MemberExpression::PrivateFieldExpression(_) => {
+                ctx.property_read_side_effects() != PropertyReadSideEffects::None
+            }
         }
     }
 }
@@ -446,6 +448,9 @@ fn property_access_may_have_side_effects(
     if object.may_have_side_effects(ctx) {
         return true;
     }
+    if ctx.property_read_side_effects() == PropertyReadSideEffects::None {
+        return false;
+    }
 
     match property {
         "length" => {
@@ -463,6 +468,9 @@ fn integer_index_property_access_may_have_side_effects(
 ) -> bool {
     if object.may_have_side_effects(ctx) {
         return true;
+    }
+    if ctx.property_read_side_effects() == PropertyReadSideEffects::None {
+        return false;
     }
     match object {
         Expression::StringLiteral(s) => property as usize >= s.value.encode_utf16().count(),

--- a/crates/oxc_ecmascript/src/side_effects/mod.rs
+++ b/crates/oxc_ecmascript/src/side_effects/mod.rs
@@ -1,5 +1,5 @@
 mod context;
 mod may_have_side_effects;
 
-pub use context::MayHaveSideEffectsContext;
+pub use context::{MayHaveSideEffectsContext, PropertyReadSideEffects};
 pub use may_have_side_effects::MayHaveSideEffects;

--- a/crates/oxc_minifier/src/ctx.rs
+++ b/crates/oxc_minifier/src/ctx.rs
@@ -4,7 +4,7 @@ use oxc_ast::{AstBuilder, ast::*};
 use oxc_ecmascript::constant_evaluation::{
     ConstantEvaluation, ConstantEvaluationCtx, ConstantValue, binary_operation_evaluate_value,
 };
-use oxc_ecmascript::side_effects::MayHaveSideEffects;
+use oxc_ecmascript::side_effects::{MayHaveSideEffects, PropertyReadSideEffects};
 use oxc_semantic::{IsGlobalReference, Scoping};
 use oxc_traverse::TraverseCtx;
 
@@ -32,6 +32,10 @@ impl oxc_ecmascript::side_effects::MayHaveSideEffectsContext for Ctx<'_, '_> {
 
     fn is_pure_call(&self, _callee: &Expression) -> bool {
         false
+    }
+
+    fn property_read_side_effects(&self) -> PropertyReadSideEffects {
+        PropertyReadSideEffects::All
     }
 }
 


### PR DESCRIPTION
For [`treeshake.propertyReadSideEffects`](https://rollupjs.org/configuration-options/#treeshake-propertyreadsideeffects) support.
Currently, `PropertyReadSideEffects::OnlyMemberPropertyAccess` and `PropertyReadSideEffects::All` works the same.
