### PR TITLE
fix(ci): paths-filter ignore list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,9 +134,12 @@ jobs:
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
+          predicate-quantifier: "every"
           filters: |
             src:
               - '!crates/oxc_linter/**'
+              - '!crates/oxc_language_server/**'
+              - '!editors/**'
       - uses: ./.github/actions/clone-submodules
         if: steps.filter.outputs.src == 'true'
       - uses: oxc-project/setup-rust@cd82e1efec7fef815e2c23d296756f31c7cdc03d # v1.0.0
@@ -206,6 +209,7 @@ jobs:
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
+          predicate-quantifier: "every"
           filters: |
             src:
               - '!.github/**'


### PR DESCRIPTION
closes #10140

it works: https://github.com/oxc-project/oxc/pull/10143/checks

docs:
>  Optional parameter to override the default behavior of file matching algorithm. 
   By default files that match at least one pattern defined by the filters will be included.
   This parameter allows to override the "at least one pattern" behavior to make it so that
   all of the patterns have to match or otherwise the file is excluded. 
   An example scenario where this is useful if you would like to match all 
   .ts files in a sub-directory but not .md files. 
   The filters below will match markdown files despite the exclusion syntax UNLESS 
   you specify 'every' as the predicate-quantifier parameter. When you do that, 
   it will only match the .ts files in the subdirectory as expected.
   backend:
    - 'pkg/a/b/c/**'
    - '!**/*.jpeg'
    - '!**/*.md'
   predicate-quantifier: 'some'

_https://github.com/dorny/paths-filter?tab=readme-ov-file#usage_