### PR TITLE
feat(ast_tools): support `#[estree(skip)]` for enum varient

### DIFF
--- a/tasks/ast_tools/src/generators/raw_transfer.rs
+++ b/tasks/ast_tools/src/generators/raw_transfer.rs
@@ -10,7 +10,8 @@ use crate::{
     Generator, RAW_TRANSFER_JS_DESERIALIZER_PATH, RAW_TRANSFER_TS_DESERIALIZER_PATH,
     codegen::{Codegen, DeriveId},
     derives::estree::{
-        get_fieldless_variant_value, get_struct_field_name, should_flatten_field, should_skip_field,
+        get_fieldless_variant_value, get_struct_field_name, should_flatten_field,
+        should_skip_enum_variant, should_skip_field,
     },
     output::Output,
     schema::{
@@ -400,7 +401,10 @@ fn generate_enum(
     };
 
     let body = body.unwrap_or_else(|| {
-        let mut variants = enum_def.all_variants(schema).collect::<Vec<_>>();
+        let mut variants = enum_def
+            .all_variants(schema)
+            .filter(|variant| !should_skip_enum_variant(variant))
+            .collect::<Vec<_>>();
         variants.sort_by_key(|variant| variant.discriminant);
 
         let switch_cases = variants.into_iter().fold(String::new(), |mut s, variant| {

--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -7,7 +7,8 @@ use itertools::Itertools;
 use crate::{
     Codegen, Generator, TYPESCRIPT_DEFINITIONS_PATH,
     derives::estree::{
-        get_fieldless_variant_value, get_struct_field_name, should_flatten_field, should_skip_field,
+        get_fieldless_variant_value, get_struct_field_name, should_flatten_field,
+        should_skip_enum_variant, should_skip_field,
     },
     output::Output,
     schema::{Def, EnumDef, FieldDef, Schema, StructDef, TypeDef},
@@ -319,6 +320,7 @@ fn generate_ts_type_def_for_enum(enum_def: &EnumDef, schema: &Schema) -> Option<
     let mut variant_type_names = enum_def
         .variants
         .iter()
+        .filter(|variant| !should_skip_enum_variant(variant))
         .map(|variant| {
             if let Some(variant_type) = variant.field_type(schema) {
                 if let Some(converter_name) = &variant.estree.via {

--- a/tasks/ast_tools/src/schema/extensions/estree.rs
+++ b/tasks/ast_tools/src/schema/extensions/estree.rs
@@ -63,6 +63,7 @@ pub struct ESTreeStructField {
 /// Configuration for ESTree generator on an enum variant.
 #[derive(Default, Debug)]
 pub struct ESTreeEnumVariant {
+    pub skip: bool,
     pub rename: Option<String>,
     pub via: Option<String>,
     pub is_ts: bool,


### PR DESCRIPTION
Part of #10139

`#[estree(skip)]` has been supported for struct field. This PR supports the enum variant.