### PR TITLE
fix(span/estree): skip `ModuleKind::Unambiguous` varient for `estree`

### DIFF
--- a/crates/oxc_span/src/generated/derive_estree.rs
+++ b/crates/oxc_span/src/generated/derive_estree.rs
@@ -33,7 +33,7 @@ impl ESTree for ModuleKind {
         match self {
             Self::Script => JsonSafeString("script").serialize(serializer),
             Self::Module => JsonSafeString("module").serialize(serializer),
-            Self::Unambiguous => JsonSafeString("unambiguous").serialize(serializer),
+            Self::Unambiguous => unreachable!("This enum variant is skipped."),
         }
     }
 }

--- a/crates/oxc_span/src/source_type/mod.rs
+++ b/crates/oxc_span/src/source_type/mod.rs
@@ -58,6 +58,7 @@ pub enum ModuleKind {
     /// Note2: Dynamic import expression is not ESM syntax.
     ///
     /// See <https://babel.dev/docs/options#misc-options>
+    #[estree(skip)]
     Unambiguous = 2,
 }
 

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -4122,8 +4122,6 @@ function deserializeModuleKind(pos) {
       return 'script';
     case 1:
       return 'module';
-    case 2:
-      return 'unambiguous';
     default:
       throw new Error(`Unexpected discriminant ${uint8[pos]} for ModuleKind`);
   }

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -4197,8 +4197,6 @@ function deserializeModuleKind(pos) {
       return 'script';
     case 1:
       return 'module';
-    case 2:
-      return 'unambiguous';
     default:
       throw new Error(`Unexpected discriminant ${uint8[pos]} for ModuleKind`);
   }

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -1484,7 +1484,7 @@ export interface Span {
   end: number;
 }
 
-export type ModuleKind = 'script' | 'module' | 'unambiguous';
+export type ModuleKind = 'script' | 'module';
 
 export interface Pattern extends Span {
   type: 'Pattern';


### PR DESCRIPTION
close: #10139

The `ModuleKind::Unambiguous` can only occur in the parser stage, after being parsed, the `ModuleKind` certainly changes to `ModuleKind::Script` or `ModuleKind::Module`; otherwise is a bug in the parser. 