### PR TITLE
test(transformer/legacy-decorator): enable `class-properties` plugin for class-related tests

### DIFF
--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties-unnamed-default-export/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties-unnamed-default-export/input.ts
@@ -1,7 +1,7 @@
 @dec
 export default class {
-  #prop = 0;
+  prop = 0;
   meth() {
-    return this.#prop;
+    return this.prop;
   }
 }

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties-unnamed-default-export/options.json
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties-unnamed-default-export/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "transform-legacy-decorator",
+    "transform-class-properties"
+  ]
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties-unnamed-default-export/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties-unnamed-default-export/output.js
@@ -1,7 +1,9 @@
 let _default = class {
-  #prop = 0;
+  constructor() {
+    babelHelpers.defineProperty(this, "prop", 0);
+  }
   meth() {
-    return this.#prop;
+    return this.prop;
   }
 };
 _default = babelHelpers.decorate([dec], _default);

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties/input.ts
@@ -1,23 +1,23 @@
 @dec
 class C {
-  #prop = 0;
+  prop = 0;
   meth() {
-    return this.#prop;
+    return this.prop;
   }
 }
 
 @dec
 export class D {
-  #prop = 0;
+  prop = 0;
   meth() {
-    return this.#prop;
+    return this.prop;
   }
 }
 
 @dec
 export default class E {
-  #prop = 0;
+  prop = 0;
   meth() {
-    return this.#prop;
+    return this.prop;
   }
 }

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties/options.json
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "transform-legacy-decorator",
+    "transform-class-properties"
+  ]
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties/output.js
@@ -1,24 +1,30 @@
 let C = class C {
-  #prop = 0;
+  constructor() {
+    babelHelpers.defineProperty(this, "prop", 0);
+  }
   meth() {
-    return this.#prop;
+    return this.prop;
   }
 };
 C = babelHelpers.decorate([dec], C);
 
 let D = class D {
-  #prop = 0;
+  constructor() {
+    babelHelpers.defineProperty(this, "prop", 0);
+  }
   meth() {
-    return this.#prop;
+    return this.prop;
   }
 };
 D = babelHelpers.decorate([dec], D);
-
 export { D };
+
 let E = class E {
-  #prop = 0;
+  constructor() {
+    babelHelpers.defineProperty(this, "prop", 0);
+  }
   meth() {
-    return this.#prop;
+    return this.prop;
   }
 };
 E = babelHelpers.decorate([dec], E);


### PR DESCRIPTION
These tests were added in https://github.com/oxc-project/oxc/pull/9952 for testing `legacy-decorator` plugin interacting with `class-properties`, but these tests didn't enable `class-properties` plugin.