### PR TITLE
refactor(transformer/legacy-decorator): split the transforming decorated class into two parts and run them in `exit_class` and `exit_statement` respectively

### DIFF
--- a/crates/oxc_transformer/src/decorator/mod.rs
+++ b/crates/oxc_transformer/src/decorator/mod.rs
@@ -40,6 +40,13 @@ impl<'a> Traverse<'a> for Decorator<'a, '_> {
     }
 
     #[inline]
+    fn exit_class(&mut self, node: &mut Class<'a>, ctx: &mut TraverseCtx<'a>) {
+        if self.options.legacy {
+            self.legacy_decorator.exit_class(node, ctx);
+        }
+    }
+
+    #[inline]
     fn enter_method_definition(
         &mut self,
         node: &mut MethodDefinition<'a>,

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -268,6 +268,7 @@ impl<'a> Traverse<'a> for TransformerImpl<'a, '_> {
     }
 
     fn exit_class(&mut self, class: &mut Class<'a>, ctx: &mut TraverseCtx<'a>) {
+        self.decorator.exit_class(class, ctx);
         self.x2_es2022.exit_class(class, ctx);
     }
 

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -374,20 +374,20 @@ Symbol span mismatch for "C":
 after transform: SymbolId(0): Span { start: 11, end: 12 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol span mismatch for "C":
-after transform: SymbolId(3): Span { start: 0, end: 0 }
+after transform: SymbolId(5): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(1): Span { start: 11, end: 12 }
 Symbol span mismatch for "D":
-after transform: SymbolId(1): Span { start: 87, end: 88 }
+after transform: SymbolId(1): Span { start: 85, end: 86 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol span mismatch for "D":
-after transform: SymbolId(4): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(3): Span { start: 87, end: 88 }
+after transform: SymbolId(6): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(3): Span { start: 85, end: 86 }
 Symbol span mismatch for "E":
-after transform: SymbolId(2): Span { start: 171, end: 172 }
+after transform: SymbolId(2): Span { start: 167, end: 168 }
 rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol span mismatch for "E":
-after transform: SymbolId(5): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(5): Span { start: 171, end: 172 }
+after transform: SymbolId(7): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(5): Span { start: 167, end: 168 }
 
 * oxc/with-class-private-properties-unnamed-default-export/input.ts
 Symbol flags mismatch for "_default":

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties/input.ts
@@ -21,3 +21,13 @@ export default class E {
     return this.prop;
   }
 }
+
+class F {
+  @dec
+  prop = 0;
+}
+
+export class G {
+  @dec
+  prop = 0;
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/with-class-private-properties/output.js
@@ -29,3 +29,17 @@ let E = class E {
 };
 E = babelHelpers.decorate([dec], E);
 export default E;
+
+class F {
+  constructor() {
+    babelHelpers.defineProperty(this, "prop", 0);
+  }
+}
+babelHelpers.decorate([dec], F.prototype, "prop", void 0);
+
+export class G {
+  constructor() {
+    babelHelpers.defineProperty(this, "prop", 0);
+  }
+}
+babelHelpers.decorate([dec], G.prototype, "prop", void 0);


### PR DESCRIPTION
close: #10147 

Since `class-properties` will transform the class first, which causes the property will transform into `defineProperty(xxx)` and insert in the constructor. This results in the decorators being lost. This PR splits the logic into two parts, one part used to transform decorators in `exit_class`, which runs before class-properties transformation. The other part is to transform `class A {}` into `let A = class A {}` in `exit_statement`.