### PR TITLE
fix(transformer/legacy-decorator): do not emit decorator metadata if the class is not decorated or it is typescript syntax

### DIFF
--- a/crates/oxc_transformer/src/decorator/legacy/metadata.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/metadata.rs
@@ -107,12 +107,22 @@ impl<'a, 'ctx> LegacyDecoratorMetadata<'a, 'ctx> {
 
 impl<'a> Traverse<'a> for LegacyDecoratorMetadata<'a, '_> {
     fn enter_class(&mut self, class: &mut Class<'a>, ctx: &mut TraverseCtx<'a>) {
+        if class.is_expression() || class.is_typescript_syntax() {
+            return;
+        }
+
         let constructor = class.body.body.iter_mut().find_map(|item| match item {
             ClassElement::MethodDefinition(method) if method.kind.is_constructor() => Some(method),
             _ => None,
         });
 
         if let Some(constructor) = constructor {
+            if class.decorators.is_empty()
+                && constructor.value.params.items.iter().all(|param| param.decorators.is_empty())
+            {
+                return;
+            }
+
             let serialized_type =
                 self.serialize_parameter_types_of_node(&constructor.value.params, ctx);
             let metadata_decorator =
@@ -127,7 +137,7 @@ impl<'a> Traverse<'a> for LegacyDecoratorMetadata<'a, '_> {
         method: &mut MethodDefinition<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        if method.kind.is_constructor() {
+        if method.kind.is_constructor() || method.value.is_typescript_syntax() {
             return;
         }
 
@@ -159,10 +169,10 @@ impl<'a> Traverse<'a> for LegacyDecoratorMetadata<'a, '_> {
         prop: &mut PropertyDefinition<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        if !prop.decorators.is_empty() {
-            prop.decorators
-                .push(self.create_design_type_metadata(prop.type_annotation.as_ref(), ctx));
+        if prop.declare || prop.decorators.is_empty() {
+            return;
         }
+        prop.decorators.push(self.create_design_type_metadata(prop.type_annotation.as_ref(), ctx));
     }
 
     #[inline]

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 578ac4df
 
-Passed: 140/229
+Passed: 140/231
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -346,7 +346,7 @@ after transform: SymbolId(4): ScopeId(1)
 rebuilt        : SymbolId(5): ScopeId(4)
 
 
-# legacy-decorators (2/68)
+# legacy-decorators (2/70)
 * oxc/metadata/bound-type-reference/input.ts
 Symbol reference IDs mismatch for "BoundTypeReference":
 after transform: SymbolId(0): [ReferenceId(1), ReferenceId(3), ReferenceId(4), ReferenceId(5), ReferenceId(6)]
@@ -358,6 +358,20 @@ Symbol span mismatch for "Example":
 after transform: SymbolId(4): Span { start: 0, end: 0 }
 rebuilt        : SymbolId(3): Span { start: 87, end: 94 }
 
+* oxc/metadata/typescript-syntax/input.ts
+Bindings mismatch:
+after transform: ScopeId(0): ["A", "B"]
+rebuilt        : ScopeId(0): ["B"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Scope children mismatch:
+after transform: ScopeId(2): [ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(1): [ScopeId(2)]
+Unresolved references mismatch:
+after transform: ["dec", "m"]
+rebuilt        : []
+
 * oxc/metadata/unbound-type-reference/input.ts
 Symbol span mismatch for "Example":
 after transform: SymbolId(0): Span { start: 6, end: 13 }
@@ -368,6 +382,14 @@ rebuilt        : SymbolId(2): Span { start: 6, end: 13 }
 Unresolved reference IDs mismatch for "UnboundTypeReference":
 after transform: [ReferenceId(1), ReferenceId(2), ReferenceId(3)]
 rebuilt        : [ReferenceId(4), ReferenceId(5)]
+
+* oxc/metadata/without-decorator/input.ts
+Symbol span mismatch for "C":
+after transform: SymbolId(2): Span { start: 106, end: 107 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol span mismatch for "C":
+after transform: SymbolId(3): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(3): Span { start: 106, end: 107 }
 
 * oxc/with-class-private-properties/input.ts
 Symbol span mismatch for "C":

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/typescript-syntax/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/typescript-syntax/input.ts
@@ -1,0 +1,9 @@
+@dec
+declare class A {}
+
+
+class B {
+  @m
+  method();
+  method() {}
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/typescript-syntax/output.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/typescript-syntax/output.ts
@@ -1,0 +1,3 @@
+class B {
+  method() {}
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/without-decorator/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/without-decorator/input.ts
@@ -1,0 +1,16 @@
+class A {
+  prop = 0;
+  constructor() {}
+}
+
+class B {
+  @dec
+  prop = 0;
+  constructor() {}
+}
+
+@dec
+class C {
+  prop = 0;
+  constructor() {}
+}

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/without-decorator/output.js
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/without-decorator/output.js
@@ -1,0 +1,17 @@
+
+class A {
+  prop = 0;
+  constructor() {}
+}
+
+class B {
+  prop = 0;
+  constructor() {}
+}
+babelHelpers.decorate([dec, babelHelpers.decorateMetadata("design:type", Object)], B.prototype, "prop", void 0);
+
+let C = class C {
+  prop = 0;
+  constructor() {}
+};
+C = babelHelpers.decorate([dec, babelHelpers.decorateMetadata("design:paramtypes", [])], C);


### PR DESCRIPTION
Align with `typescript`