### PR TITLE
fix(parser): correct the method's `FormalParameterKind` to `UniqueFormalParameters`

### DIFF
--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -116,6 +116,7 @@ impl<'a> ParserImpl<'a> {
         r#async: bool,
         generator: bool,
         func_kind: FunctionKind,
+        param_kind: FormalParameterKind,
         modifiers: &Modifiers<'a>,
     ) -> Result<Box<'a, Function<'a>>> {
         let ctx = self.ctx;
@@ -123,8 +124,7 @@ impl<'a> ParserImpl<'a> {
 
         let type_parameters = self.parse_ts_type_parameters()?;
 
-        let (this_param, params) =
-            self.parse_formal_parameters(FormalParameterKind::FormalParameter)?;
+        let (this_param, params) = self.parse_formal_parameters(param_kind)?;
 
         let return_type =
             self.parse_ts_return_type_annotation(Kind::Colon, /* is_type */ true)?;
@@ -217,7 +217,15 @@ impl<'a> ParserImpl<'a> {
         self.expect(Kind::Function)?;
         let generator = self.eat(Kind::Star);
         let id = self.parse_function_id(func_kind, r#async, generator)?;
-        self.parse_function(span, id, r#async, generator, func_kind, &Modifiers::empty())
+        self.parse_function(
+            span,
+            id,
+            r#async,
+            generator,
+            func_kind,
+            FormalParameterKind::FormalParameter,
+            &Modifiers::empty(),
+        )
     }
 
     /// Parse function implementation in Typescript, cursor
@@ -232,7 +240,15 @@ impl<'a> ParserImpl<'a> {
         self.expect(Kind::Function)?;
         let generator = self.eat(Kind::Star);
         let id = self.parse_function_id(func_kind, r#async, generator)?;
-        self.parse_function(start_span, id, r#async, generator, func_kind, modifiers)
+        self.parse_function(
+            start_span,
+            id,
+            r#async,
+            generator,
+            func_kind,
+            FormalParameterKind::FormalParameter,
+            modifiers,
+        )
     }
 
     /// [Function Expression](https://tc39.es/ecma262/#prod-FunctionExpression)
@@ -246,8 +262,15 @@ impl<'a> ParserImpl<'a> {
 
         let generator = self.eat(Kind::Star);
         let id = self.parse_function_id(func_kind, r#async, generator)?;
-        let function =
-            self.parse_function(span, id, r#async, generator, func_kind, &Modifiers::empty())?;
+        let function = self.parse_function(
+            span,
+            id,
+            r#async,
+            generator,
+            func_kind,
+            FormalParameterKind::FormalParameter,
+            &Modifiers::empty(),
+        )?;
         Ok(Expression::FunctionExpression(function))
     }
 
@@ -271,6 +294,7 @@ impl<'a> ParserImpl<'a> {
             r#async,
             generator,
             FunctionKind::Expression,
+            FormalParameterKind::UniqueFormalParameters,
             &Modifiers::empty(),
         )
     }

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -415,7 +415,15 @@ impl<'a> ParserImpl<'a> {
         self.expect(Kind::Function)?;
         let func_kind = FunctionKind::TSDeclaration;
         let id = self.parse_function_id(func_kind, r#async, false)?;
-        self.parse_function(start_span, id, r#async, false, func_kind, modifiers)
+        self.parse_function(
+            start_span,
+            id,
+            r#async,
+            false,
+            func_kind,
+            FormalParameterKind::FormalParameter,
+            modifiers,
+        )
     }
 
     pub(crate) fn parse_ts_type_assertion(&mut self) -> Result<Expression<'a>> {

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -3,14 +3,13 @@ commit: 578ac4df
 parser_babel Summary:
 AST Parsed     : 2303/2322 (99.18%)
 Positive Passed: 2282/2322 (98.28%)
-Negative Passed: 1554/1673 (92.89%)
+Negative Passed: 1555/1673 (92.95%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/invalid-startindex-and-startline-specified-without-startcolumn/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/startline-and-startcolumn-specified/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/startline-specified/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/class-methods/direct-super-in-object-method/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/destructuring/error-operator-for-default/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/for-of/invalid-let-as-identifier/input.js
-Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/object/disallow-duplicate-method-params/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2015/uncategorised/335/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2017/async-functions/async-await-as-arrow-binding-identifier/input.js
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2017/async-functions/await-binding-inside-arrow-params-inside-async-arrow-params/input.js
@@ -3788,6 +3787,16 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·     ─┬─
    ·      ╰── `,` expected
  4 │ })
+   ╰────
+
+  × Identifier `a` has already been declared
+   ╭─[babel/packages/babel-parser/test/fixtures/es2015/object/disallow-duplicate-method-params/input.js:2:9]
+ 1 │ ({
+ 2 │     bar(a, a) {}
+   ·         ┬  ┬
+   ·         │  ╰── It can not be redeclared here
+   ·         ╰── `a` has already been declared here
+ 3 │ })
    ╰────
 
   × Expected `,` but found `*`

--- a/tasks/coverage/snapshots/parser_test262.snap
+++ b/tasks/coverage/snapshots/parser_test262.snap
@@ -3,9 +3,7 @@ commit: bc5c1417
 parser_test262 Summary:
 AST Parsed     : 44293/44293 (100.00%)
 Positive Passed: 44293/44293 (100.00%)
-Negative Passed: 4517/4519 (99.96%)
-Expect Syntax Error: tasks/coverage/test262/test/language/expressions/object/method-definition/early-errors-object-async-method-duplicate-parameters.js
-Expect Syntax Error: tasks/coverage/test262/test/language/expressions/object/method-definition/early-errors-object-method-duplicate-parameters.js
+Negative Passed: 4519/4519 (100.00%)
 
   × '0'-prefixed octal literals and octal escape sequences are deprecated
     ╭─[test262/test/annexB/language/expressions/template-literal/legacy-octal-escape-sequence-strict.js:19:4]
@@ -18685,6 +18683,16 @@ Expect Syntax Error: tasks/coverage/test262/test/language/expressions/object/met
  36 │     
     ╰────
 
+  × Identifier `a` has already been declared
+    ╭─[test262/test/language/expressions/object/method-definition/early-errors-object-async-method-duplicate-parameters.js:28:13]
+ 27 │ ({
+ 28 │   async foo(a, a) { }
+    ·             ┬  ┬
+    ·             │  ╰── It can not be redeclared here
+    ·             ╰── `a` has already been declared here
+ 29 │ })
+    ╰────
+
   × Illegal 'use strict' directive in function with non-simple parameter list
     ╭─[test262/test/language/expressions/object/method-definition/early-errors-object-method-NSPL-with-USD.js:17:15]
  16 │ ({
@@ -18732,6 +18740,16 @@ Expect Syntax Error: tasks/coverage/test262/test/language/expressions/object/met
  17 │   async foo () { super() }
     ·                  ───────
  18 │ })
+    ╰────
+
+  × Identifier `a` has already been declared
+    ╭─[test262/test/language/expressions/object/method-definition/early-errors-object-method-duplicate-parameters.js:27:7]
+ 26 │ ({
+ 27 │   foo(a, a) { }
+    ·       ┬  ┬
+    ·       │  ╰── It can not be redeclared here
+    ·       ╰── `a` has already been declared here
+ 28 │ })
     ╰────
 
   × Cannot assign to 'eval' in strict mode

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -25096,6 +25096,16 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
     ╰────
 
   × Identifier `x` has already been declared
+    ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithDuplicateParameters.ts:35:9]
+ 34 │ var b = {
+ 35 │     foo(x, x) { },
+    ·         ┬  ┬
+    ·         │  ╰── It can not be redeclared here
+    ·         ╰── `x` has already been declared here
+ 36 │     a: function foo(x: number, x: string) { },
+    ╰────
+
+  × Identifier `x` has already been declared
     ╭─[typescript/tests/cases/conformance/types/objectTypeLiteral/callSignatures/callSignaturesWithDuplicateParameters.ts:37:12]
  36 │     a: function foo(x: number, x: string) { },
  37 │     b: <T>(x: T, x: T) => { }


### PR DESCRIPTION
https://tc39.es/ecma262/#sec-method-definitions-static-semantics-early-errors

15.4.1 Static Semantics: Early Errors
[MethodDefinition](https://tc39.es/ecma262/#prod-MethodDefinition) : [ClassElementName](https://tc39.es/ecma262/#prod-ClassElementName) ( [UniqueFormalParameters](https://tc39.es/ecma262/#prod-UniqueFormalParameters) ) { [FunctionBody](https://tc39.es/ecma262/#prod-FunctionBody) }
It is a Syntax Error if [FunctionBodyContainsUseStrict](https://tc39.es/ecma262/#sec-static-semantics-functionbodycontainsusestrict) of [FunctionBody](https://tc39.es/ecma262/#prod-FunctionBody) is true and [IsSimpleParameterList](https://tc39.es/ecma262/#sec-static-semantics-issimpleparameterlist) of [UniqueFormalParameters](https://tc39.es/ecma262/#prod-UniqueFormalParameters) is false.
It is a Syntax Error if any element of the [BoundNames](https://tc39.es/ecma262/#sec-static-semantics-boundnames) of [UniqueFormalParameters](https://tc39.es/ecma262/#prod-UniqueFormalParameters) also occurs in the [LexicallyDeclaredNames](https://tc39.es/ecma262/#sec-static-semantics-lexicallydeclarednames) of [FunctionBody](https://tc39.es/ecma262/#prod-FunctionBody).

As you can see, the parameters of the method definition should be `UniqueFormalParameters`.
