### PR TITLE
feat(minifier): compress `foo == true` into `foo == 1`

### DIFF
--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1324,9 +1324,9 @@ mod test {
 
     #[test]
     fn test_fold_true_false_comparison() {
-        test("v = x == true", "v = x == !0");
-        test("v = x == false", "v = x == !1");
-        test("v = x != true", "v = x != !0");
+        test("v = x == true", "v = x == 1");
+        test("v = x == false", "v = x == 0");
+        test("v = x != true", "v = x != 1");
         test("v = x < true", "v = x < !0");
         test("v = x <= true", "v = x <= !0");
         test("v = x > true", "v = x > !0");

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -13,7 +13,7 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 
 555.77 kB  | 270.84 kB  | 270.13 kB  | 88.26 kB   | 90.80 kB   | d3.js     
 
-1.01 MB    | 440.17 kB  | 458.89 kB  | 122.38 kB  | 126.71 kB  | bundle.min.js
+1.01 MB    | 440.17 kB  | 458.89 kB  | 122.37 kB  | 126.71 kB  | bundle.min.js
 
 1.25 MB    | 647.00 kB  | 646.76 kB  | 160.28 kB  | 163.73 kB  | three.js  
 


### PR DESCRIPTION
Compress `foo == true` into `foo == 1`.

This is safe because `true` and `false` are replaced with `1` and `0` first in `IsLooselyEqual`.
https://tc39.es/ecma262/multipage/abstract-operations.html#sec-islooselyequal:~:text=9.%20If,(y)).

