### PR TITLE
feat(minifier): compress `if (foo, !!bar)` to `if (foo, bar)`

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_expression_in_boolean_context.rs
@@ -112,6 +112,11 @@ impl<'a> PeepholeOptimizations {
                     return true;
                 }
             }
+            Expression::SequenceExpression(seq_expr) => {
+                if let Some(last) = seq_expr.expressions.last_mut() {
+                    return self.try_fold_expr_in_boolean_context(last, ctx);
+                }
+            }
             _ => {}
         }
         false
@@ -143,5 +148,6 @@ mod test {
         test("if (anything1 ? anything2 : (0, false));", "anything1 && anything2");
         test("if(!![]);", "");
         test("if (+a === 0) { b } else { c }", "+a == 0 ? b : c"); // should not be folded to `a ? b : c` (`+a` might be NaN)
+        test("if (foo, !!bar) { let baz }", "if (foo, bar) { let baz }");
     }
 }

--- a/tasks/minsize/minsize.snap
+++ b/tasks/minsize/minsize.snap
@@ -11,17 +11,17 @@ Original   | minified   | minified   | gzip       | gzip       | Fixture
 
 544.10 kB  | 71.38 kB   | 72.48 kB   | 25.85 kB   | 26.20 kB   | lodash.js 
 
-555.77 kB  | 270.84 kB  | 270.13 kB  | 88.26 kB   | 90.80 kB   | d3.js     
+555.77 kB  | 270.83 kB  | 270.13 kB  | 88.25 kB   | 90.80 kB   | d3.js     
 
 1.01 MB    | 440.17 kB  | 458.89 kB  | 122.37 kB  | 126.71 kB  | bundle.min.js
 
 1.25 MB    | 647.00 kB  | 646.76 kB  | 160.28 kB  | 163.73 kB  | three.js  
 
-2.14 MB    | 716.14 kB  | 724.14 kB  | 161.79 kB  | 181.07 kB  | victory.js
+2.14 MB    | 716.13 kB  | 724.14 kB  | 161.80 kB  | 181.07 kB  | victory.js
 
-3.20 MB    | 1.01 MB    | 1.01 MB    | 324.14 kB  | 331.56 kB  | echarts.js
+3.20 MB    | 1.01 MB    | 1.01 MB    | 324.12 kB  | 331.56 kB  | echarts.js
 
 6.69 MB    | 2.28 MB    | 2.31 MB    | 466.11 kB  | 488.28 kB  | antd.js   
 
-10.95 MB   | 3.35 MB    | 3.49 MB    | 860.94 kB  | 915.50 kB  | typescript.js
+10.95 MB   | 3.35 MB    | 3.49 MB    | 860.93 kB  | 915.50 kB  | typescript.js
 


### PR DESCRIPTION
 `if (foo, !!bar)` can be compressed to `if (foo, bar)` because the last value is used as a boolean.