### PR TITLE
perf(transformer): do not update options from comments when `only_remove_type_imports` is enabled

### DIFF
--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -121,12 +121,20 @@ impl<'a> Transformer<'a> {
 
         self.ctx.source_type = program.source_type;
         self.ctx.source_text = program.source_text;
-        jsx::update_options_with_comments(
-            &program.comments,
-            &mut self.typescript,
-            &mut self.jsx,
-            &self.ctx,
-        );
+
+        // Update options from comments when source type is JSX or TypeScript which has enabled `only_remove_type_imports`.
+        // Because if `only_remove_type_imports` is enabled, no imports will be removed, so that we don't care about
+        // TypeScript's `jsx_pragma` and `jsx_pragma_frag` options.
+        if program.source_type.is_jsx()
+            && (!program.source_type.is_typescript() || !self.typescript.only_remove_type_imports)
+        {
+            jsx::update_options_with_comments(
+                &program.comments,
+                &mut self.typescript,
+                &mut self.jsx,
+                &self.ctx,
+            );
+        }
 
         let mut transformer = TransformerImpl {
             common: Common::new(&self.env, &self.ctx),

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 578ac4df
 
-Passed: 141/233
+Passed: 143/235
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -43,7 +43,7 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), R
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(10)]
 
 
-# babel-plugin-transform-typescript (2/15)
+# babel-plugin-transform-typescript (4/17)
 * class-property-definition/input.ts
 Unresolved references mismatch:
 after transform: ["const"]

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/jsx/retain-jsx-pragm/input.tsx
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/jsx/retain-jsx-pragm/input.tsx
@@ -1,0 +1,4 @@
+// @jsx JSX
+import JSX from "module"
+
+() => <div></div>

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/jsx/retain-jsx-pragm/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/jsx/retain-jsx-pragm/output.js
@@ -1,0 +1,2 @@
+import JSX from "module";
+() => <div></div>;

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/jsx/with-only-remove-import-types/input.tsx
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/jsx/with-only-remove-import-types/input.tsx
@@ -1,0 +1,4 @@
+// @jsx JSX
+import JSX from "module"
+
+() => <div></div>

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/jsx/with-only-remove-import-types/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/jsx/with-only-remove-import-types/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["transform-typescript", { "onlyRemoveTypeImports": true }]]
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/jsx/with-only-remove-import-types/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/jsx/with-only-remove-import-types/output.js
@@ -1,0 +1,2 @@
+import JSX from "module";
+() => <div></div>;


### PR DESCRIPTION
Because if `only_remove_type_imports` is enabled, no imports will be removed, so we don't care about TypeScript's `jsx_pragma` and `jsx_pragma_frag` options.

<img width="869" alt="image" src="https://github.com/user-attachments/assets/1a3787f6-3af4-44b4-bf5e-e3db27b07659" />
