### PR TITLE
refactor(parser): use `AstBuilder::string_literal_with_lone_surrogates`

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -414,9 +414,7 @@ impl<'a> ParserImpl<'a> {
         let raw = Atom::from(unsafe {
             self.source_text.get_unchecked(span.start as usize..span.end as usize)
         });
-        let mut string_literal = self.ast.string_literal(span, value, Some(raw));
-        string_literal.lone_surrogates = lone_surrogates;
-        Ok(string_literal)
+        Ok(self.ast.string_literal_with_lone_surrogates(span, value, Some(raw), lone_surrogates))
     }
 
     /// Section [Array Expression](https://tc39.es/ecma262/#prod-ArrayLiteral)


### PR DESCRIPTION
Small refactor to parser. Use `AstBuilder::string_literal_with_lone_surrogates` method, rather than calling `AstBuilder::string_literal` and then setting `lone_surrogates` field afterwards.
