### PR TITLE
fix(parser): fix parsing lone surrogates in `StringLiteral`s

### DIFF
--- a/crates/oxc_codegen/tests/integration/unit.rs
+++ b/crates/oxc_codegen/tests/integration/unit.rs
@@ -510,10 +510,16 @@ fn string() {
     test_minify("let x = '\\'\\'\\'\"\"\"${}';", "let x=`'''\"\"\"\\${}`;");
 
     // Lossy replacement character
-    test("let x = \"�\";", "let x = \"�\";\n");
-    test_minify("let x = \"�\";", "let x=`�`;");
-    test("let x = \"� ��� �\";", "let x = \"� ��� �\";\n");
-    test_minify("let x = \"� ��� �\";", "let x=`� ��� �`;");
+    test("let x = \"�\\u{FFFD}\";", "let x = \"��\";\n");
+    test_minify("let x = \"�\\u{FFFD}\";", "let x=`��`;");
+    test(
+        "let x = \"� ��� \\u{FFFD} \\u{FFFD}\\u{FFFD}\\u{FFFD} �\";",
+        "let x = \"� ��� � ��� �\";\n",
+    );
+    test_minify(
+        "let x = \"� ��� \\u{FFFD} \\u{FFFD}\\u{FFFD}\\u{FFFD} �\";",
+        "let x=`� ��� � ��� �`;",
+    );
     // Lone surrogates
     test(
         "let x = \"\\uD800 \\uDBFF \\uDC00 \\uDFFF\";",
@@ -523,6 +529,8 @@ fn string() {
         "let x = \"\\uD800 \\uDBFF \\uDC00 \\uDFFF\";",
         "let x=`\\ud800 \\udbff \\udc00 \\udfff`;",
     );
+    test("let x = \"\\uD800\u{41}\";", "let x = \"\\ud800A\";\n");
+    test_minify("let x = \"\\uD800\u{41}\";", "let x=`\\ud800A`;");
     // Invalid pairs
     test(
         "let x = \"\\uD800\\uDBFF \\uDC00\\uDFFF\";",
@@ -534,12 +542,12 @@ fn string() {
     );
     // Lone surrogates and lossy replacement characters
     test(
-        "let x = \"���\\uD800\\uDBFF���\\uDC00\\uDFFF���\";",
-        "let x = \"���\\ud800\\udbff���\\udc00\\udfff���\";\n",
+        "let x = \"��\\u{FFFD}\\u{FFFD}\\uD800\\uDBFF��\\u{FFFD}\\u{FFFD}\\uDC00\\uDFFF��\\u{FFFD}\\u{FFFD}\";",
+        "let x = \"����\\ud800\\udbff����\\udc00\\udfff����\";\n",
     );
     test_minify(
-        "let x = \"���\\uD800\\uDBFF���\\uDC00\\uDFFF���\";",
-        "let x=`���\\ud800\\udbff���\\udc00\\udfff���`;",
+        "let x = \"��\\u{FFFD}\\u{FFFD}\\uD800\\uDBFF��\\u{FFFD}\\u{FFFD}\\uDC00\\uDFFF��\\u{FFFD}\\u{FFFD}\";",
+        "let x=`����\\ud800\\udbff����\\udc00\\udfff����`;",
     );
 
     test_minify(


### PR DESCRIPTION
Fix 2 edge cases when parsing lone surrogates in `StringLiteral`s:

* Lone surrogate followed by `\u{...}` escape e.g. `"\uD800\u{41}"`.
* Escaped lossy replacement character after lone surrogate e.g. `"\uD800 \u{FFFD}"`.
