### PR TITLE
refactor(ast/estree): alter `Program` start span with converter

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -30,7 +30,7 @@ use super::{macros::inherit_variants, *};
 )]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(field_order(span, directives, source_type, hashbang))]
+#[estree(field_order(span, directives, source_type, hashbang), via = ProgramConverter)]
 pub struct Program<'a> {
     pub span: Span,
     pub source_type: SourceType,

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -16,17 +16,7 @@ use crate::ast::ts::*;
 
 impl ESTree for Program<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let mut state = serializer.serialize_struct();
-        state.serialize_field("type", &JsonSafeString("Program"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
-        state.serialize_field(
-            "body",
-            &AppendToConcat { array: &self.directives, after: &self.body },
-        );
-        self.source_type.serialize(FlatStructSerializer(&mut state));
-        state.serialize_field("hashbang", &self.hashbang);
-        state.end();
+        crate::serialize::ProgramConverter(self).serialize(serializer)
     }
 }
 

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -37,14 +37,16 @@ function deserialize(buffer, sourceTextInput, sourceLenInput) {
 function deserializeProgram(pos) {
   const body = deserializeVecDirective(pos + 88);
   body.push(...deserializeVecStatement(pos + 120));
-  return {
+  let start = deserializeU32(pos);
+  const program = {
     type: 'Program',
-    start: deserializeU32(pos),
+    start,
     end: deserializeU32(pos + 4),
     body,
     sourceType: deserializeModuleKind(pos + 9),
     hashbang: deserializeOptionHashbang(pos + 64),
   };
+  return program;
 }
 
 function deserializeIdentifierName(pos) {

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -37,14 +37,17 @@ function deserialize(buffer, sourceTextInput, sourceLenInput) {
 function deserializeProgram(pos) {
   const body = deserializeVecDirective(pos + 88);
   body.push(...deserializeVecStatement(pos + 120));
-  return {
+  let start = deserializeU32(pos);
+  if (body.length > 0) start = body[0].start;
+  const program = {
     type: 'Program',
-    start: deserializeU32(pos),
+    start,
     end: deserializeU32(pos + 4),
     body,
     sourceType: deserializeModuleKind(pos + 9),
     hashbang: deserializeOptionHashbang(pos + 64),
   };
+  return program;
 }
 
 function deserializeIdentifierName(pos) {


### PR DESCRIPTION
#10134 fixed the start span of `Program` in TS AST to align with TS-ESLint.

Change the method this is achieved by - use a custom converter instead of mutating the AST in `to_estree_ts_json` and `to_pretty_estree_ts_json`. This method is more convoluted, but I think it's preferable if serialization does not have side effect of mutating the AST.
