### PR TITLE
style(all): remove unnecessary semi-colons

### DIFF
--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -156,7 +156,7 @@ impl Runner for LintRunner {
                 }) {
                     stdout.write_all(end.as_bytes()).or_else(Self::check_for_writer_error).unwrap();
                     stdout.flush().unwrap();
-                };
+                }
 
                 return CliRunResult::LintNoFilesFound;
             }
@@ -391,7 +391,7 @@ impl Runner for LintRunner {
         }) {
             stdout.write_all(end.as_bytes()).or_else(Self::check_for_writer_error).unwrap();
             stdout.flush().unwrap();
-        };
+        }
 
         if diagnostic_result.errors_count() > 0 {
             CliRunResult::LintFoundErrors

--- a/crates/oxc_ast/src/ast_impl/literal.rs
+++ b/crates/oxc_ast/src/ast_impl/literal.rs
@@ -89,7 +89,7 @@ impl StringLiteral<'_> {
                     if (0xd800..=0xdfff).contains(&hex) {
                         return false;
                     }
-                };
+                }
             }
         }
         true

--- a/crates/oxc_cfg/src/dot.rs
+++ b/crates/oxc_cfg/src/dot.rs
@@ -34,7 +34,7 @@ impl DisplayDot for ControlFlowGraph {
                         attrs += ("style", "dotted");
                     } else if matches!(weight, EdgeType::Error(_)) {
                         attrs += ("color", "red");
-                    };
+                    }
 
                     format!("{attrs:?}")
                 },

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -995,7 +995,7 @@ impl Gen for ImportAttribute<'_> {
             ImportAttributeKey::StringLiteral(literal) => {
                 p.print_string_literal(literal, false);
             }
-        };
+        }
         p.print_colon();
         p.print_soft_space();
         p.print_string_literal(&self.value, false);
@@ -1105,7 +1105,7 @@ impl Gen for ModuleExportName<'_> {
             Self::IdentifierName(ident) => ident.print(p, ctx),
             Self::IdentifierReference(ident) => ident.print(p, ctx),
             Self::StringLiteral(literal) => p.print_string_literal(literal, false),
-        };
+        }
     }
 }
 

--- a/crates/oxc_codegen/src/sourcemap_builder.rs
+++ b/crates/oxc_codegen/src/sourcemap_builder.rs
@@ -416,7 +416,7 @@ impl SourcemapBuilder {
 
                         break 'lines;
                     }
-                };
+                }
 
                 // Line break found.
                 // `byte_offset_from_line_start` is now the length of line *including* line break.

--- a/crates/oxc_diagnostics/src/reporter.rs
+++ b/crates/oxc_diagnostics/src/reporter.rs
@@ -131,7 +131,7 @@ impl Info {
 
                         if let Some(name) = span_content.name() {
                             filename = name.to_string();
-                        };
+                        }
                         if matches!(diagnostic.severity(), Some(Severity::Error)) {
                             severity = Severity::Error;
                         }

--- a/crates/oxc_formatter/src/formatter/buffer.rs
+++ b/crates/oxc_formatter/src/formatter/buffer.rs
@@ -581,7 +581,7 @@ fn clean_interned(
                             most_flat.iter().rev().for_each(|element| element_stack.push(element));
                         }
                         element => cleaned.push(element.clone()),
-                    };
+                    }
                 }
 
                 Interned::new(cleaned)

--- a/crates/oxc_formatter/src/formatter/printer/mod.rs
+++ b/crates/oxc_formatter/src/formatter/printer/mod.rs
@@ -203,7 +203,7 @@ impl<'a> Printer<'a> {
                 match mode {
                     DedentMode::Level => indent_stack.start_dedent(),
                     DedentMode::Root => indent_stack.reset_indent(),
-                };
+                }
                 stack.push(TagKind::Dedent, args);
             }
 
@@ -281,10 +281,10 @@ impl<'a> Printer<'a> {
                 match mode {
                     DedentMode::Level => indent_stack.end_dedent(),
                     DedentMode::Root => indent_stack.pop(),
-                };
+                }
                 stack.pop(tag.kind())?;
             }
-        };
+        }
 
         Ok(())
     }
@@ -1102,7 +1102,7 @@ impl<'a, 'print> FitsMeasurer<'a, 'print> {
                 match mode {
                     DedentMode::Level => self.indent_stack.start_dedent(),
                     DedentMode::Root => self.indent_stack.reset_indent(),
-                };
+                }
                 self.stack.push(TagKind::Dedent, args);
             }
 

--- a/crates/oxc_formatter/src/formatter/trivia.rs
+++ b/crates/oxc_formatter/src/formatter/trivia.rs
@@ -65,26 +65,24 @@ impl Format<'_> for FormatLeadingComments<'_> {
             write!(f, [comment])?;
 
             match comment.kind() {
-                CommentKind::Block | CommentKind::InlineBlock => {
-                    match comment.lines_after() {
-                        0 => {
-                            let should_nestle =
-                                leading_comments_iter.peek().is_some_and(|next_comment| {
-                                    should_nestle_adjacent_doc_comments(comment, next_comment)
-                                });
+                CommentKind::Block | CommentKind::InlineBlock => match comment.lines_after() {
+                    0 => {
+                        let should_nestle =
+                            leading_comments_iter.peek().is_some_and(|next_comment| {
+                                should_nestle_adjacent_doc_comments(comment, next_comment)
+                            });
 
-                            write!(f, [maybe_space(!should_nestle)])?;
+                        write!(f, [maybe_space(!should_nestle)])?;
+                    }
+                    1 => {
+                        if comment.lines_before() == 0 {
+                            write!(f, [soft_line_break_or_space()])?;
+                        } else {
+                            write!(f, [hard_line_break()])?;
                         }
-                        1 => {
-                            if comment.lines_before() == 0 {
-                                write!(f, [soft_line_break_or_space()])?;
-                            } else {
-                                write!(f, [hard_line_break()])?;
-                            }
-                        }
-                        _ => write!(f, [empty_line()])?,
-                    };
-                }
+                    }
+                    _ => write!(f, [empty_line()])?,
+                },
                 CommentKind::Line => match comment.lines_after() {
                     0 | 1 => write!(f, [hard_line_break()])?,
                     _ => write!(f, [empty_line()])?,
@@ -165,7 +163,7 @@ impl Format<'_> for FormatTrailingComments<'_> {
                                 }
                                 1 => write!(f, [hard_line_break()])?,
                                 _ => write!(f, [empty_line()])?,
-                            };
+                            }
 
                             write!(f, [comment])
                         })),

--- a/crates/oxc_isolated_declarations/src/class.rs
+++ b/crates/oxc_isolated_declarations/src/class.rs
@@ -333,7 +333,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         }
                     }
                     _ => continue,
-                };
+                }
             }
         }
 

--- a/crates/oxc_isolated_declarations/src/signatures.rs
+++ b/crates/oxc_isolated_declarations/src/signatures.rs
@@ -39,7 +39,7 @@ impl<'a> IsolatedDeclarations<'a> {
                         entry.0 |= method.return_type.is_none();
                         entry.2 = Some(&mut method.return_type);
                     }
-                };
+                }
             }
         });
 

--- a/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
+++ b/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
@@ -133,7 +133,7 @@ impl IsolatedLintHandler {
                     })
                     .collect();
                 return Some(Self::wrap_diagnostics(path, &source_text, reports, start));
-            };
+            }
 
             let semantic_ret = SemanticBuilder::new()
                 .with_cfg(true)
@@ -151,7 +151,7 @@ impl IsolatedLintHandler {
                     })
                     .collect();
                 return Some(Self::wrap_diagnostics(path, &source_text, reports, start));
-            };
+            }
 
             let mut semantic = semantic_ret.semantic;
             semantic.set_irregular_whitespaces(ret.irregular_whitespaces);

--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -42,7 +42,7 @@ impl<'a> PeepholeOptimizations {
         } {
             *expr = folded_expr;
             state.changed = true;
-        };
+        }
     }
 
     #[expect(clippy::float_cmp)]

--- a/crates/oxc_minifier/src/peephole/minimize_conditions.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditions.rs
@@ -51,7 +51,7 @@ impl<'a> PeepholeOptimizations {
             } {
                 *expr = folded_expr;
                 local_change = true;
-            };
+            }
             if local_change {
                 changed = true;
             } else {

--- a/crates/oxc_minifier/src/peephole/minimize_for_statement.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_for_statement.rs
@@ -21,7 +21,7 @@ impl<'a> PeepholeOptimizations {
             } else {
                 return;
             }
-        };
+        }
 
         let Statement::IfStatement(if_stmt) = first else {
             return;

--- a/crates/oxc_minifier/src/peephole/minimize_statements.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_statements.rs
@@ -62,7 +62,7 @@ impl<'a> PeepholeOptimizations {
                 .is_break()
             {
                 break;
-            };
+            }
         }
         if let Some(stmt) = keep_var.get_variable_declaration_statement() {
             result.push(stmt);

--- a/crates/oxc_minifier/src/peephole/remove_dead_code.rs
+++ b/crates/oxc_minifier/src/peephole/remove_dead_code.rs
@@ -205,7 +205,7 @@ impl<'a, 'b> PeepholeOptimizations {
                 }
             } else {
                 keep_var.visit_statement(&if_stmt.consequent);
-            };
+            }
             let var_stmt = keep_var.get_variable_declaration_statement();
             let has_var_stmt = var_stmt.is_some();
             if let Some(var_stmt) = var_stmt {

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -176,7 +176,7 @@ impl<'a> PeepholeOptimizations {
             if start > end {
                 return None;
             }
-        };
+        }
         Some(ctx.ast.expression_string_literal(
             span,
             s.value.as_str().substring(start_idx, end_idx),

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -923,7 +923,7 @@ impl<'a> PeepholeOptimizations {
                 *computed = false;
             }
             return;
-        };
+        }
         let PropertyKey::StringLiteral(s) = key else { return };
         let value = s.value.as_str();
         if is_identifier_name(value) {
@@ -1177,7 +1177,7 @@ impl<'a> LatePeepholeOptimizations {
                     {
                         catch.param = None;
                     }
-                };
+                }
             }
         }
     }

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -127,7 +127,7 @@ impl<'a> ParserImpl<'a> {
         } else if self.at(Kind::LCurly) {
             let mut import_specifiers = self.parse_import_specifiers()?;
             specifiers.append(&mut import_specifiers);
-        };
+        }
 
         self.expect(Kind::From)?;
         Ok(specifiers)
@@ -505,7 +505,7 @@ impl<'a> ParserImpl<'a> {
                 // It is a Syntax Error if IsStringWellFormedUnicode(the SV of StringLiteral) is false.
                 if literal.lone_surrogates || !literal.is_string_well_formed_unicode() {
                     self.error(diagnostics::export_lone_surrogate(literal.span));
-                };
+                }
                 Ok(ModuleExportName::StringLiteral(literal))
             }
             _ => Ok(ModuleExportName::IdentifierName(self.parse_identifier_name()?)),

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -534,7 +534,7 @@ impl<'a> ParserImpl<'a> {
     fn flow_error(&mut self) -> Option<OxcDiagnostic> {
         if !self.source_type.is_javascript() {
             return None;
-        };
+        }
         let span = self.lexer.trivia_builder.comments.first()?.span;
         if span.source_text(self.source_text).contains("@flow") {
             self.errors.clear();

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -188,7 +188,7 @@ impl<'a> Binder<'a> for Function<'a> {
                 PropertyKind::Get => *flags |= ScopeFlags::GetAccessor,
                 PropertyKind::Set => *flags |= ScopeFlags::SetAccessor,
                 PropertyKind::Init => {}
-            };
+            }
         }
 
         // Save `@__NO_SIDE_EFFECTS__`

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -429,7 +429,7 @@ pub fn check_function_declaration<'a>(
         } else if !is_if_stmt_or_labeled_stmt {
             ctx.error(function_declaration_non_strict(decl.span));
         }
-    };
+    }
 }
 
 // It is a Syntax Error if IsLabelledFunction(Statement) is true.
@@ -460,7 +460,7 @@ pub fn check_function_declaration_in_labeled_statement<'a>(
             }
             ctx.error(function_declaration_non_strict(decl.span));
         }
-    };
+    }
 }
 
 // It is a Syntax Error if any element of the LexicallyDeclaredNames of
@@ -890,7 +890,7 @@ pub fn check_super<'a>(sup: &Super, node: &AstNode<'a>, ctx: &SemanticBuilder<'a
                     ctx.error(unexpected_super_call(super_call_span));
                 }
                 return;
-            };
+            }
         }
 
         // ModuleBody : ModuleItemList

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -372,7 +372,7 @@ pub fn check_class<'a>(class: &Class<'a>, ctx: &SemanticBuilder<'a>) {
                         ctx.error(constructor_implementation_missing(a.key.span()));
                     } else {
                         ctx.error(function_implementation_missing(a.key.span()));
-                    };
+                    }
                 }
             }
         }

--- a/crates/oxc_semantic/src/class/table.rs
+++ b/crates/oxc_semantic/src/class/table.rs
@@ -107,7 +107,7 @@ impl<'a> ClassTable<'a> {
         let class_id = self.declarations.push(node_id);
         if let Some(parent_id) = parent_id {
             self.parent_ids.insert(class_id, parent_id);
-        };
+        }
         self.elements.push(IndexVec::default());
         self.private_identifier_references.push(Vec::new());
         class_id

--- a/crates/oxc_semantic/tests/integration/util/class_tester.rs
+++ b/crates/oxc_semantic/tests/integration/util/class_tester.rs
@@ -17,7 +17,7 @@ impl<'a> ClassTester<'a> {
 
             if class.id.clone().is_some_and(|id| id.name == name) {
                 return Some(class_id);
-            };
+            }
 
             None
         });

--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -361,7 +361,7 @@ impl<'a> Traverse<'a> for ArrowFunctionConverter<'a> {
             if let Some(ident) = self.get_this_identifier(this.span, ctx) {
                 *element_name = JSXElementName::IdentifierReference(ident);
             }
-        };
+        }
     }
 
     fn enter_jsx_member_expression_object(
@@ -921,7 +921,7 @@ impl<'a> ArrowFunctionConverter<'a> {
                 param_binding.create_read_expression(ctx),
                 false,
             ));
-        };
+        }
 
         // Create a parameter for the value if it's an assignment.
         if is_assignment {

--- a/crates/oxc_transformer/src/decorator/legacy/metadata.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/metadata.rs
@@ -457,7 +457,7 @@ impl<'a> LegacyDecoratorMetadata<'a, '_> {
                     return Self::global_object(ctx);
                 }
                 _ => {}
-            };
+            }
 
             let serialized_constituent = self.serialize_type_node(t, ctx);
             if matches!(&serialized_constituent, Expression::Identifier(ident) if ident.name == "Object")

--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -116,7 +116,7 @@ impl<'a> Traverse<'a> for LegacyDecorator<'a, '_> {
                 self.transform_export_default_class(stmt, ctx);
             }
             _ => {}
-        };
+        }
     }
 
     #[inline]
@@ -340,7 +340,7 @@ impl<'a> LegacyDecorator<'a, '_> {
                 has_private_in_expression_in_decorator,
                 ctx,
             );
-        };
+        }
     }
 
     /// Transforms a decorated class declaration and appends the resulting statements. If

--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -195,7 +195,7 @@ impl<'a> ObjectRestSpread<'a, '_> {
         // Allow `{...x} = {}` and `[{...x}] = []`.
         if !Self::has_nested_target_rest(&assign_expr.left) {
             return;
-        };
+        }
 
         // If not an top `({ ...y })`, walk the pattern and create references for all the objects with a rest.
         if !matches!(&assign_expr.left, AssignmentTarget::ObjectAssignmentTarget(t) if t.rest.is_some())

--- a/crates/oxc_transformer/src/es2020/optional_chaining.rs
+++ b/crates/oxc_transformer/src/es2020/optional_chaining.rs
@@ -101,7 +101,7 @@ impl<'a> Traverse<'a> for OptionalChaining<'a, '_> {
                 self.transform_update_expression(expr, ctx);
             }
             _ => {}
-        };
+        }
     }
 
     // `#[inline]` because this is a hot path
@@ -335,14 +335,14 @@ impl<'a> OptionalChaining<'a, '_> {
         //                              ^^^^^^ ^^^^^^^^ Here we will wrap the right part with a `delete` unary expression
         if is_delete {
             chain_expr = ctx.ast.expression_unary(SPAN, UnaryOperator::Delete, chain_expr);
-        };
+        }
 
         // If this chain expression is a callee of a CallExpression, we need to transform it to accept a proper context
         // `(Foo?.["m"])();` -> `(...  _Foo["m"].bind(_Foo))();`
         //                                       ^^^^^^^^^^^ Here we will handle the `right` part to bind a proper context
         if matches!(ctx.ancestor(1), Ancestor::CallExpressionCallee(_)) {
             chain_expr = self.transform_expression_to_bind_context(chain_expr, ctx);
-        };
+        }
         // Clear states
         self.temp_binding = None;
         self.call_context = CallContext::None;

--- a/crates/oxc_transformer/src/es2022/class_properties/instance_prop_init.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/instance_prop_init.rs
@@ -35,7 +35,7 @@ impl<'a> ClassProperties<'a, '_> {
             // No symbol clashes possible. Just re-parent first-level scopes (faster).
             let mut updater = FastInstanceInitializerVisitor::new(self, ctx);
             updater.visit_expression(value);
-        };
+        }
     }
 }
 

--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -247,7 +247,7 @@ impl<'a> ClassProperties<'a, '_> {
         let Expression::CallExpression(call_expr) = expr else { unreachable!() };
         if matches!(&call_expr.callee, Expression::PrivateFieldExpression(_)) {
             self.transform_call_expression_impl(call_expr, ctx);
-        };
+        }
     }
 
     fn transform_call_expression_impl(
@@ -466,7 +466,7 @@ impl<'a> ClassProperties<'a, '_> {
         let Expression::AssignmentExpression(assign_expr) = expr else { unreachable!() };
         if matches!(&assign_expr.left, AssignmentTarget::PrivateFieldExpression(_)) {
             self.transform_assignment_expression_impl(expr, ctx);
-        };
+        }
     }
 
     fn transform_assignment_expression_impl(
@@ -906,7 +906,7 @@ impl<'a> ClassProperties<'a, '_> {
         let Expression::UpdateExpression(update_expr) = expr else { unreachable!() };
         if matches!(&update_expr.argument, SimpleAssignmentTarget::PrivateFieldExpression(_)) {
             self.transform_update_expression_impl(expr, ctx);
-        };
+        }
     }
 
     // TODO: Split up this function into 2 halves for static and instance props

--- a/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
@@ -113,7 +113,7 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_, '_> {
                 self.transform_call_expression_for_super_computed_member_expr(call_expr, ctx);
             }
             _ => {}
-        };
+        }
     }
 
     fn transform_call_expression_for_super_static_member_expr(
@@ -182,7 +182,7 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_, '_> {
                 self.transform_assignment_expression_for_super_computed_member_expr(expr, ctx);
             }
             _ => {}
-        };
+        }
     }
 
     /// Transform assignment expression where the left-hand side is a static member expression
@@ -320,7 +320,7 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_, '_> {
                 self.transform_update_expression_for_super_computed_member_expr(expr, ctx);
             }
             _ => {}
-        };
+        }
     }
 
     /// Transform update expression (`++` or `--`) where argument is a static member expression

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -190,7 +190,7 @@ impl<'a, 'ctx> AutomaticScriptBindings<'a, 'ctx> {
                 if self.is_development { "reactJsxDevRuntime" } else { "reactJsxRuntime" };
             let id = self.add_require_statement(var_name, self.jsx_runtime_importer, false, ctx);
             self.require_jsx = Some(id);
-        };
+        }
         self.require_jsx.as_ref().unwrap().create_read_reference(ctx)
     }
 
@@ -261,7 +261,7 @@ impl<'a, 'ctx> AutomaticModuleBindings<'a, 'ctx> {
                 self.add_import_jsx_dev(ctx);
             } else {
                 self.import_jsx = Some(self.add_jsx_import_statement("jsx", ctx));
-            };
+            }
         }
         self.import_jsx.as_ref().unwrap().create_read_reference(ctx)
     }
@@ -272,7 +272,7 @@ impl<'a, 'ctx> AutomaticModuleBindings<'a, 'ctx> {
                 self.add_import_jsx_dev(ctx);
             } else {
                 self.import_jsxs = Some(self.add_jsx_import_statement("jsxs", ctx));
-            };
+            }
         }
         self.import_jsxs.as_ref().unwrap().create_read_reference(ctx)
     }

--- a/crates/oxc_transformer/src/options/babel/env/targets.rs
+++ b/crates/oxc_transformer/src/options/babel/env/targets.rs
@@ -48,7 +48,7 @@ impl TryFrom<BabelTargets> for EngineTargets {
                     // TODO: Implement `Version::from_number`
                     if matches!(value, BabelTargetsValue::Int(_) | BabelTargetsValue::Float(_)) {
                         continue;
-                    };
+                    }
                     let BabelTargetsValue::String(v) = value else {
                         return Err(format!("{value:?} is not a string for {key}."));
                     };

--- a/crates/oxc_transformer/src/proposals/explicit_resource_management.rs
+++ b/crates/oxc_transformer/src/proposals/explicit_resource_management.rs
@@ -133,7 +133,7 @@ impl<'a> Traverse<'a> for ExplicitResourceManagement<'a, '_> {
 
             let new_body = ctx.ast.vec_from_array([using_stmt, old_body]);
             for_of_stmt.body = ctx.ast.statement_block_with_scope_id(SPAN, new_body, scope_id);
-        };
+        }
     }
 
     /// Transform class static block.
@@ -519,7 +519,7 @@ impl<'a> ExplicitResourceManagement<'a, '_> {
                     VariableDeclarationKind::Using | VariableDeclarationKind::AwaitUsing
                 ) {
                     continue;
-                };
+                }
                 needs_await = needs_await || var_decl.kind == VariableDeclarationKind::AwaitUsing;
 
                 var_decl.kind = VariableDeclarationKind::Const;
@@ -642,7 +642,7 @@ impl<'a> ExplicitResourceManagement<'a, '_> {
             ) && !self.top_level_using.contains_key(&address)
             {
                 continue;
-            };
+            }
             let is_await_using = variable_declaration.kind == VariableDeclarationKind::AwaitUsing
                 || self.top_level_using.get(&address).copied().unwrap_or(false);
             needs_await = needs_await || is_await_using;

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -567,7 +567,7 @@ impl IdentifierReferenceRename<'_, '_> {
         // Don't need to rename the identifier if it's not a member of the enum,
         if !self.previous_enum_members.contains_key(&ident.name) {
             return false;
-        };
+        }
 
         let scoping = self.ctx.scoping.scoping();
         let Some(symbol_id) = scoping.get_reference(ident.reference_id()).symbol_id() else {
@@ -625,6 +625,6 @@ impl<'a> VisitMut<'a> for IdentifierReferenceRename<'a, '_> {
             _ => {
                 walk_mut::walk_expression(self, expr);
             }
-        };
+        }
     }
 }

--- a/tasks/coverage/src/main.rs
+++ b/tasks/coverage/src/main.rs
@@ -33,5 +33,5 @@ fn main() {
             args.run_runtime();
         }
         _ => args.run_default(),
-    };
+    }
 }

--- a/tasks/prettier_conformance/src/spec.rs
+++ b/tasks/prettier_conformance/src/spec.rs
@@ -172,14 +172,14 @@ impl VisitMut<'_> for SpecParser {
                                 }
                             }
                             _ => {}
-                        };
+                        }
                         if name != "errors" {
                             snapshot_options.push((
                                 name.to_string(),
                                 obj_prop.value.span().source_text(&self.source_text).to_string(),
                             ));
                         }
-                    };
+                    }
                 }
             });
         }


### PR DESCRIPTION
Remove unnecessary semi-colons. Flagged by clippy in Rust 1.86.0.