### PR TITLE
refactor(minifier): prefer `is_empty()` over `len() == 0`

### DIFF
--- a/crates/oxc_minifier/src/peephole/fold_constants.rs
+++ b/crates/oxc_minifier/src/peephole/fold_constants.rs
@@ -431,7 +431,7 @@ impl<'a> PeepholeOptimizations {
                     None
                 };
                 left_last_quasi.value.cooked = new_cooked;
-                if right.quasis.len() > 0 {
+                if !right.quasis.is_empty() {
                     left_last_quasi.tail = false;
                 }
                 left.quasis.extend(right.quasis.drain(1..)); // first quasi is already handled

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -194,7 +194,7 @@ impl<'a> PeepholeOptimizations {
         let Expression::ArrayExpression(array_expr) = e else {
             return false;
         };
-        if array_expr.elements.len() == 0 {
+        if array_expr.elements.is_empty() {
             return true;
         }
 
@@ -211,7 +211,7 @@ impl<'a> PeepholeOptimizations {
             state.changed = true;
         }
 
-        if array_expr.elements.len() == 0 {
+        if array_expr.elements.is_empty() {
             return true;
         }
 
@@ -332,7 +332,7 @@ impl<'a> PeepholeOptimizations {
             if e.to_primitive(&ctx).is_symbol() != Some(false) {
                 pending_to_string_required_exprs.push(e);
             } else if !self.remove_unused_expression(&mut e, state, ctx) {
-                if pending_to_string_required_exprs.len() > 0 {
+                if !pending_to_string_required_exprs.is_empty() {
                     // flush pending to string required expressions
                     let expressions =
                         ctx.ast.vec_from_iter(pending_to_string_required_exprs.drain(..));
@@ -360,7 +360,7 @@ impl<'a> PeepholeOptimizations {
             }
         }
 
-        if pending_to_string_required_exprs.len() > 0 {
+        if !pending_to_string_required_exprs.is_empty() {
             let expressions = ctx.ast.vec_from_iter(pending_to_string_required_exprs.drain(..));
             let mut quasis = ctx.ast.vec_from_iter(
                 iter::repeat_with(|| {
@@ -419,7 +419,7 @@ impl<'a> PeepholeOptimizations {
                     pending_spread_elements.push(prop);
                 }
                 ObjectPropertyKind::ObjectProperty(prop) => {
-                    if pending_spread_elements.len() > 0 {
+                    if !pending_spread_elements.is_empty() {
                         // flush pending spread elements
                         transformed_elements.push(ctx.ast.expression_object(
                             prop.span(),
@@ -449,7 +449,7 @@ impl<'a> PeepholeOptimizations {
             }
         }
 
-        if pending_spread_elements.len() > 0 {
+        if !pending_spread_elements.is_empty() {
             transformed_elements.push(ctx.ast.expression_object(
                 object_expr.span,
                 pending_spread_elements,

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -93,7 +93,7 @@ impl<'a> PeepholeOptimizations {
         object: &Expression<'a>,
         ctx: Ctx<'a, '_>,
     ) -> Option<Expression<'a>> {
-        if args.len() >= 1 {
+        if !args.is_empty() {
             return None;
         }
         let Expression::StringLiteral(s) = object else { return None };


### PR DESCRIPTION
Prefer `!collection.is_empty()` over `collection.len() > 0`. With some collections, `is_empty` is more optimized.

Flagged by clippy in Rust 1.86.0.
