### PR TITLE
feat(editor): add named fixes for code actions

### DIFF
--- a/apps/oxlint/src/snapshots/_-D correctness fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-D correctness fixtures__linter__debugger.js@oxlint.snap
@@ -11,7 +11,7 @@ working directory:
  1 | debugger;
    : ^^^^^^^^^
    `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
 Finished in <variable>ms on 1 file with 99 rules using 1 threads.

--- a/apps/oxlint/src/snapshots/_-c fixtures__linter__eslintrc.json fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__linter__eslintrc.json fixtures__linter__debugger.js@oxlint.snap
@@ -11,7 +11,7 @@ working directory:
  1 | debugger;
    : ^^^^^^^^^
    `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
 Finished in <variable>ms on 1 file with 99 rules using 1 threads.

--- a/apps/oxlint/src/snapshots/_-c fixtures__overrides__directories-config.json fixtures__overrides@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_-c fixtures__overrides__directories-config.json fixtures__overrides@oxlint.snap
@@ -11,28 +11,28 @@ working directory:
  1 | debugger;
    : ^^^^^^^^^
    `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
    ,-[fixtures/overrides/lib/tests/index.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
   x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
    ,-[fixtures/overrides/src/oxlint.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
    ,-[fixtures/overrides/src/tests/index.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
 Found 2 warnings and 2 errors.
 Finished in <variable>ms on 7 files with 98 rules using 1 threads.

--- a/apps/oxlint/src/snapshots/_fixtures__astro__debugger.astro@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__astro__debugger.astro@oxlint.snap
@@ -13,7 +13,7 @@ working directory:
    : ^^^^^^^^
  3 | ---
    `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
     ,-[fixtures/astro/debugger.astro:11:3]
@@ -22,7 +22,7 @@ working directory:
     :   ^^^^^^^^
  12 | </script>
     `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
     ,-[fixtures/astro/debugger.astro:15:3]
@@ -31,7 +31,7 @@ working directory:
     :   ^^^^^^^^
  16 | </script>
     `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
     ,-[fixtures/astro/debugger.astro:19:3]
@@ -40,7 +40,7 @@ working directory:
     :   ^^^^^^^^
  20 | </script>
     `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
 Found 4 warnings and 0 errors.
 Finished in <variable>ms on 1 file with 99 rules using 1 threads.

--- a/apps/oxlint/src/snapshots/_fixtures__linter@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter@oxlint.snap
@@ -11,14 +11,14 @@ working directory:
  1 | debugger;
    : ^^^^^^^^^
    `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
    ,-[fixtures/linter/fix.js:1:1]
  1 | debugger
    : ^^^^^^^^
    `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/use-isnan.html\eslint(use-isnan)]8;;\: Requires calls to isNaN() when checking for NaN
    ,-[fixtures/linter/nan.js:1:8]

--- a/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js fixtures__linter__nan.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js fixtures__linter__nan.js@oxlint.snap
@@ -11,7 +11,7 @@ working directory:
  1 | debugger;
    : ^^^^^^^^^
    `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/use-isnan.html\eslint(use-isnan)]8;;\: Requires calls to isNaN() when checking for NaN
    ,-[fixtures/linter/nan.js:1:8]

--- a/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__linter__debugger.js@oxlint.snap
@@ -11,7 +11,7 @@ working directory:
  1 | debugger;
    : ^^^^^^^^^
    `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
 Finished in <variable>ms on 1 file with 99 rules using 1 threads.

--- a/apps/oxlint/src/snapshots/_fixtures__svelte__debugger.svelte@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__svelte__debugger.svelte@oxlint.snap
@@ -13,7 +13,7 @@ working directory:
    :     ^^^^^^^^^
  3 | 
    `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
 Finished in <variable>ms on 1 file with 99 rules using 1 threads.

--- a/apps/oxlint/src/snapshots/_fixtures__vue__debugger.vue@oxlint.snap
+++ b/apps/oxlint/src/snapshots/_fixtures__vue__debugger.vue@oxlint.snap
@@ -13,7 +13,7 @@ working directory:
    :     ^^^^^^^^
  7 | </script>
    `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
     ,-[fixtures/vue/debugger.vue:11:5]
@@ -22,7 +22,7 @@ working directory:
     :     ^^^^^^^^^
  12 | </script>
     `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
 Found 2 warnings and 0 errors.
 Finished in <variable>ms on 1 file with 99 rules using 1 threads.

--- a/apps/oxlint/src/snapshots/fixtures__auto_config_detection_debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__auto_config_detection_debugger.js@oxlint.snap
@@ -11,7 +11,7 @@ working directory: fixtures/auto_config_detection
  1 | debugger;
    : ^^^^^^^^^
    `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
 Found 0 warnings and 1 error.
 Finished in <variable>ms on 1 file using 1 threads.

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_--disable-nested-config@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_--disable-nested-config@oxlint.snap
@@ -28,7 +28,7 @@ working directory: fixtures/extends_config
  1 | debugger;
    : ^^^^^^^^^
    `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
 Found 3 warnings and 0 errors.
 Finished in <variable>ms on 4 files with 99 rules using 1 threads.

--- a/apps/oxlint/src/snapshots/fixtures__extends_config_overrides_same_directory@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__extends_config_overrides_same_directory@oxlint.snap
@@ -11,7 +11,7 @@ working directory: fixtures/extends_config
  1 | debugger;
    : ^^^^^^^^^
    `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
 Finished in <variable>ms on 1 file using 1 threads.

--- a/apps/oxlint/src/snapshots/fixtures__linter_debugger.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__linter_debugger.js@oxlint.snap
@@ -11,7 +11,7 @@ working directory: fixtures/linter
  1 | debugger;
    : ^^^^^^^^^
    `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
 Found 1 warning and 0 errors.
 Finished in <variable>ms on 1 file with 99 rules using 1 threads.

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_-A no-console@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_-A no-console@oxlint.snap
@@ -11,21 +11,21 @@ working directory: fixtures/nested_config
  1 | debugger;
    : ^^^^^^^^^
    `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
    ,-[package1-empty-config/debugger.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
   x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
    ,-[package2-no-config/debugger.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
 Found 1 warning and 2 errors.
 Finished in <variable>ms on 7 files using 1 threads.

--- a/apps/oxlint/src/snapshots/fixtures__nested_config_@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__nested_config_@oxlint.snap
@@ -18,14 +18,14 @@ working directory: fixtures/nested_config
  1 | debugger;
    : ^^^^^^^^^
    `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
   ! ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html\eslint(no-debugger)]8;;\: `debugger` statement is not allowed
    ,-[package1-empty-config/debugger.js:1:1]
  1 | debugger;
    : ^^^^^^^^^
    `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
   x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: eslint(no-console): Unexpected console statement.
    ,-[package2-no-config/console.ts:1:1]
@@ -39,7 +39,7 @@ working directory: fixtures/nested_config
  1 | debugger;
    : ^^^^^^^^^
    `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
   x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html\eslint(no-console)]8;;\: eslint(no-console): Unexpected console statement.
    ,-[package3-deep-config/src/components/component.js:2:3]

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=default test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=default test.js@oxlint.snap
@@ -30,7 +30,7 @@ working directory: fixtures/output_formatter_diagnostic
  5 | debugger;
    : ^^^^^^^^^
    `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
 Found 2 warnings and 1 error.
 Finished in <variable>ms on 1 file using 1 threads.

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=json test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=json test.js@oxlint.snap
@@ -6,7 +6,7 @@ arguments: --format=json test.js
 working directory: fixtures/output_formatter_diagnostic
 ----------
 [
-	{"message": "`debugger` statement is not allowed","code": "eslint(no-debugger)","severity": "error","causes": [],"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html","help": "Delete this code.","filename": "test.js","labels": [{"span": {"offset": 38,"length": 9}}],"related": []},
+	{"message": "`debugger` statement is not allowed","code": "eslint(no-debugger)","severity": "error","causes": [],"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html","help": "Remove the debugger statement","filename": "test.js","labels": [{"span": {"offset": 38,"length": 9}}],"related": []},
 	{"message": "Function 'foo' is declared but never used.","code": "eslint(no-unused-vars)","severity": "warning","causes": [],"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html","help": "Consider removing this declaration.","filename": "test.js","labels": [{"label": "'foo' is declared here","span": {"offset": 9,"length": 3}}],"related": []},
 	{"message": "Parameter 'b' is declared but never used. Unused parameters should start with a '_'.","code": "eslint(no-unused-vars)","severity": "warning","causes": [],"url": "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-unused-vars.html","help": "Consider removing this parameter.","filename": "test.js","labels": [{"label": "'b' is declared here","span": {"offset": 16,"length": 1}}],"related": []}
 ]

--- a/apps/oxlint/src/snapshots/fixtures__report_unused_directives_-c .oxlintrc.json --report-unused-disable-directives test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__report_unused_directives_-c .oxlintrc.json --report-unused-disable-directives test.js@oxlint.snap
@@ -29,7 +29,7 @@ working directory: fixtures/report_unused_directives
     : ^^^^^^^^^
  11 | 
     `----
-  help: Delete this code.
+  help: Remove the debugger statement
 
   ! Unused eslint-enable directive (no matching eslint-disable directives were found).
     ,-[test.js:22:3]

--- a/crates/oxc_language_server/src/linter/error_with_position.rs
+++ b/crates/oxc_language_server/src/linter/error_with_position.rs
@@ -40,6 +40,7 @@ pub struct ErrorReport {
 
 #[derive(Debug, Clone)]
 pub struct FixedContent {
+    pub message: Option<String>,
     pub code: String,
     pub range: Range,
 }

--- a/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
+++ b/crates/oxc_language_server/src/linter/isolated_lint_handler.rs
@@ -162,6 +162,7 @@ impl IsolatedLintHandler {
                 .into_iter()
                 .map(|msg| {
                     let fixed_content = msg.fix.map(|f| FixedContent {
+                        message: f.message.map(|m| m.to_string()),
                         code: f.content.to_string(),
                         range: Range {
                             start: offset_to_position(

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_astro_debugger.astro.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_astro_debugger.astro.snap
@@ -3,7 +3,7 @@ source: crates/oxc_language_server/src/linter/tester.rs
 ---
 code: "eslint(no-debugger)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger"
-message: "`debugger` statement is not allowed\nhelp: Delete this code."
+message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"
 range: Range { start: Position { line: 1, character: 0 }, end: Position { line: 1, character: 8 } }
 related_information[0].message: ""
 related_information[0].location.uri: "file://<variable>/fixtures/linter/astro/debugger.astro"
@@ -15,7 +15,7 @@ tags: None
 
 code: "eslint(no-debugger)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger"
-message: "`debugger` statement is not allowed\nhelp: Delete this code."
+message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"
 range: Range { start: Position { line: 10, character: 2 }, end: Position { line: 10, character: 10 } }
 related_information[0].message: ""
 related_information[0].location.uri: "file://<variable>/fixtures/linter/astro/debugger.astro"
@@ -27,7 +27,7 @@ tags: None
 
 code: "eslint(no-debugger)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger"
-message: "`debugger` statement is not allowed\nhelp: Delete this code."
+message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"
 range: Range { start: Position { line: 14, character: 2 }, end: Position { line: 14, character: 10 } }
 related_information[0].message: ""
 related_information[0].location.uri: "file://<variable>/fixtures/linter/astro/debugger.astro"
@@ -39,7 +39,7 @@ tags: None
 
 code: "eslint(no-debugger)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger"
-message: "`debugger` statement is not allowed\nhelp: Delete this code."
+message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"
 range: Range { start: Position { line: 18, character: 2 }, end: Position { line: 18, character: 10 } }
 related_information[0].message: ""
 related_information[0].location.uri: "file://<variable>/fixtures/linter/astro/debugger.astro"

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_svelte_debugger.svelte.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_svelte_debugger.svelte.snap
@@ -3,7 +3,7 @@ source: crates/oxc_language_server/src/linter/tester.rs
 ---
 code: "eslint(no-debugger)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger"
-message: "`debugger` statement is not allowed\nhelp: Delete this code."
+message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"
 range: Range { start: Position { line: 1, character: 1 }, end: Position { line: 1, character: 10 } }
 related_information[0].message: ""
 related_information[0].location.uri: "file://<variable>/fixtures/linter/svelte/debugger.svelte"

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_vue_debugger.vue.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_vue_debugger.vue.snap
@@ -3,7 +3,7 @@ source: crates/oxc_language_server/src/linter/tester.rs
 ---
 code: "eslint(no-debugger)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger"
-message: "`debugger` statement is not allowed\nhelp: Delete this code."
+message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"
 range: Range { start: Position { line: 5, character: 4 }, end: Position { line: 5, character: 12 } }
 related_information[0].message: ""
 related_information[0].location.uri: "file://<variable>/fixtures/linter/vue/debugger.vue"
@@ -15,7 +15,7 @@ tags: None
 
 code: "eslint(no-debugger)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger"
-message: "`debugger` statement is not allowed\nhelp: Delete this code."
+message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"
 range: Range { start: Position { line: 10, character: 4 }, end: Position { line: 10, character: 13 } }
 related_information[0].message: ""
 related_information[0].location.uri: "file://<variable>/fixtures/linter/vue/debugger.vue"

--- a/crates/oxc_linter/src/fixer/fix.rs
+++ b/crates/oxc_linter/src/fixer/fix.rs
@@ -121,8 +121,6 @@ impl FixKind {
 pub struct RuleFix<'a> {
     kind: FixKind,
     /// A suggestion message. Will be shown in editors via code actions.
-    ///
-    /// NOTE: code actions aren't implemented yet.
     message: Option<Cow<'a, str>>,
     /// The actual that will be applied to the source code.
     ///
@@ -239,7 +237,9 @@ impl<'a> RuleFix<'a> {
 
     #[inline]
     pub fn into_fix(self, source_text: &str) -> Fix<'a> {
-        self.fix.normalize_fixes(source_text)
+        let mut fix = self.fix.normalize_fixes(source_text);
+        fix.message = self.message;
+        fix
     }
 
     #[inline]
@@ -275,6 +275,9 @@ impl<'a> Deref for RuleFix<'a> {
 #[non_exhaustive]
 pub struct Fix<'a> {
     pub content: Cow<'a, str>,
+    /// A brief suggestion message describing the fix. Will be shown in
+    /// editors via code actions.
+    pub message: Option<Cow<'a, str>>,
     pub span: Span,
 }
 
@@ -288,6 +291,10 @@ impl<'new> CloneIn<'new> for Fix<'_> {
                 Cow::Owned(s) => Cow::Owned(s.clone()),
             },
             span: self.span,
+            message: self.message.as_ref().map(|s| match s {
+                Cow::Borrowed(s) => Cow::Borrowed(allocator.alloc_str(s)),
+                Cow::Owned(s) => Cow::Owned(s.clone()),
+            }),
         }
     }
 }
@@ -300,17 +307,17 @@ impl Default for Fix<'_> {
 
 impl<'a> Fix<'a> {
     pub const fn delete(span: Span) -> Self {
-        Self { content: Cow::Borrowed(""), span }
+        Self { content: Cow::Borrowed(""), message: None, span }
     }
 
     pub fn new<T: Into<Cow<'a, str>>>(content: T, span: Span) -> Self {
-        Self { content: content.into(), span }
+        Self { content: content.into(), message: None, span }
     }
 
     /// Creates a [`Fix`] that doesn't change the source code.
     #[inline]
     pub const fn empty() -> Self {
-        Self { content: Cow::Borrowed(""), span: SPAN }
+        Self { content: Cow::Borrowed(""), message: None, span: SPAN }
     }
 }
 
@@ -506,7 +513,7 @@ impl<'a> CompositeFix<'a> {
         let mut output = String::new();
 
         for fix in fixes {
-            let Fix { content, span } = fix;
+            let Fix { content, span, .. } = fix;
             // negative range or overlapping ranges is invalid
             if span.start > span.end {
                 debug_assert!(false, "Negative range is invalid: {span:?}");

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -304,7 +304,7 @@ impl<'a> Fixer<'a> {
         let mut filtered_messages = Vec::with_capacity(self.messages.len());
 
         for mut m in self.messages {
-            let Some(Fix { content, span }) = m.fix.as_ref() else {
+            let Some(Fix { content, span, .. }) = m.fix.as_ref() else {
                 filtered_messages.push(m);
                 continue;
             };
@@ -399,16 +399,23 @@ mod test {
     }
 
     const TEST_CODE: &str = "var answer = 6 * 7;";
-    const INSERT_AT_END: Fix = Fix { span: Span::new(19, 19), content: Cow::Borrowed("// end") };
-    const INSERT_AT_START: Fix = Fix { span: Span::new(0, 0), content: Cow::Borrowed("// start") };
-    const INSERT_AT_MIDDLE: Fix = Fix { span: Span::new(13, 13), content: Cow::Borrowed("5 *") };
-    const REPLACE_ID: Fix = Fix { span: Span::new(4, 10), content: Cow::Borrowed("foo") };
-    const REPLACE_VAR: Fix = Fix { span: Span::new(0, 3), content: Cow::Borrowed("let") };
-    const REPLACE_NUM: Fix = Fix { span: Span::new(13, 14), content: Cow::Borrowed("5") };
+    const INSERT_AT_END: Fix =
+        Fix { span: Span::new(19, 19), content: Cow::Borrowed("// end"), message: None };
+    const INSERT_AT_START: Fix =
+        Fix { span: Span::new(0, 0), content: Cow::Borrowed("// start"), message: None };
+    const INSERT_AT_MIDDLE: Fix =
+        Fix { span: Span::new(13, 13), content: Cow::Borrowed("5 *"), message: None };
+    const REPLACE_ID: Fix =
+        Fix { span: Span::new(4, 10), content: Cow::Borrowed("foo"), message: None };
+    const REPLACE_VAR: Fix =
+        Fix { span: Span::new(0, 3), content: Cow::Borrowed("let"), message: None };
+    const REPLACE_NUM: Fix =
+        Fix { span: Span::new(13, 14), content: Cow::Borrowed("5"), message: None };
     const REMOVE_START: Fix = Fix::delete(Span::new(0, 4));
     const REMOVE_MIDDLE: Fix = Fix::delete(Span::new(5, 10));
     const REMOVE_END: Fix = Fix::delete(Span::new(14, 18));
-    const REVERSE_RANGE: Fix = Fix { span: Span::new(3, 0), content: Cow::Borrowed(" ") };
+    const REVERSE_RANGE: Fix =
+        Fix { span: Span::new(3, 0), content: Cow::Borrowed(" "), message: None };
 
     fn get_fix_result(messages: Vec<Message>) -> FixResult {
         Fixer::new(TEST_CODE, messages).fix()

--- a/crates/oxc_linter/src/snapshots/eslint_no_debugger.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_debugger.snap
@@ -6,4 +6,4 @@ source: crates/oxc_linter/src/tester.rs
  1 │ if (foo) debugger
    ·          ────────
    ╰────
-  help: Replace `debugger` with `{}`.
+  help: Remove the debugger statement

--- a/editors/vscode/client/extension.spec.ts
+++ b/editors/vscode/client/extension.spec.ts
@@ -121,7 +121,7 @@ suite('E2E Diagnostics', () => {
     strictEqual(diagnostics.length, 1);
     assert(typeof diagnostics[0].code == 'object');
     strictEqual(diagnostics[0].code.target.authority, 'oxc.rs');
-    strictEqual(diagnostics[0].message, '`debugger` statement is not allowed\nhelp: Delete this code.');
+    strictEqual(diagnostics[0].message, '`debugger` statement is not allowed\nhelp: Remove the debugger statement');
     strictEqual(diagnostics[0].severity, DiagnosticSeverity.Warning);
     strictEqual(diagnostics[0].range.start.line, 0);
     strictEqual(diagnostics[0].range.start.character, 8);
@@ -159,7 +159,7 @@ suite('E2E Diagnostics', () => {
       [
         {
           isPreferred: true,
-          title: 'Fix this `debugger` statement is not allowed\nhelp problem',
+          title: 'Remove the debugger statement',
         },
         {
           isPreferred: false,
@@ -189,7 +189,7 @@ suite('E2E Diagnostics', () => {
     strictEqual(diagnostics.length, 1);
     assert(typeof diagnostics[0].code == 'object');
     strictEqual(diagnostics[0].code.target.authority, 'oxc.rs');
-    strictEqual(diagnostics[0].message, '`debugger` statement is not allowed\nhelp: Delete this code.');
+    strictEqual(diagnostics[0].message, '`debugger` statement is not allowed\nhelp: Remove the debugger statement');
     strictEqual(diagnostics[0].severity, DiagnosticSeverity.Warning);
     strictEqual(diagnostics[0].range.start.line, 0);
     strictEqual(diagnostics[0].range.start.character, 8);


### PR DESCRIPTION
- related to https://github.com/oxc-project/oxc/issues/10038

This allows a `Fix` to have a message associated with it as well, similar to `RuleFix`. This is used by the editor to show code actions for a given lint error. For a start, I've added a message to the `no-debugger` rule and modified a test that shows this gets an improved code action message in VS Code.