### PR TITLE
fix(ast/estree): Fix `TSInstantiationExpression`

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1597,6 +1597,7 @@ pub struct TSNamespaceExportDeclaration<'a> {
 pub struct TSInstantiationExpression<'a> {
     pub span: Span,
     pub expression: Expression<'a>,
+    #[estree(rename = "typeArguments")]
     pub type_parameters: Box<'a, TSTypeParameterInstantiation<'a>>,
 }
 

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -3307,7 +3307,7 @@ impl ESTree for TSInstantiationExpression<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
-        state.serialize_field("typeParameters", &self.type_parameters);
+        state.serialize_field("typeArguments", &self.type_parameters);
         state.end();
     }
 }

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -1951,7 +1951,7 @@ function deserializeTSInstantiationExpression(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     expression: deserializeExpression(pos + 8),
-    typeParameters: deserializeBoxTSTypeParameterInstantiation(pos + 24),
+    typeArguments: deserializeBoxTSTypeParameterInstantiation(pos + 24),
   };
 }
 

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -2026,7 +2026,7 @@ function deserializeTSInstantiationExpression(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     expression: deserializeExpression(pos + 8),
-    typeParameters: deserializeBoxTSTypeParameterInstantiation(pos + 24),
+    typeArguments: deserializeBoxTSTypeParameterInstantiation(pos + 24),
   };
 }
 

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -1410,7 +1410,7 @@ export interface TSNamespaceExportDeclaration extends Span {
 export interface TSInstantiationExpression extends Span {
   type: 'TSInstantiationExpression';
   expression: Expression;
-  typeParameters: TSTypeParameterInstantiation;
+  typeArguments: TSTypeParameterInstantiation;
 }
 
 export type ImportOrExportKind = 'value' | 'type';

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -2,7 +2,7 @@ commit: 15392346
 
 estree_typescript Summary:
 AST Parsed     : 10618/10725 (99.00%)
-Positive Passed: 7087/10725 (66.08%)
+Positive Passed: 7089/10725 (66.10%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APISample_compile.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APISample_linter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/APISample_parseConfig.ts
@@ -1182,7 +1182,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/initializersInAmbientEn
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inlineMappedTypeModifierDeclarationEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/innerExtern.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceAndStaticDeclarations1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceofOnInstantiationExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceofTypeAliasToGenericClass.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiateContextualTypes.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiateContextuallyTypedGenericThis.ts
@@ -4400,7 +4399,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/ty
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/typeAliasesDoNotMerge.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/constraintSatisfactionWithAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/constraintSatisfactionWithEmptyObject.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/wrappedAndRecursiveConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiersReverseMappedTypes.ts


### PR DESCRIPTION
Renames field from `typeParameters` to `typeArguments` field for the Estree serialiser on  the `TSInstantiationExpression` node.

Part of our broader work to align our AST's ESTree output with that of TS-ESLint's. Relates to #9705 
