### PR TITLE
fix(ast/estree): Fix `JSXOpeningFragment`

### DIFF
--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -128,7 +128,7 @@ pub struct JSXFragment<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(via = JSXOpeningFragmentConverter)]
+#[estree(via = JSXOpeningFragmentConverter, add_fields(attributes = JSXOpeningFragmentAttributes, selfClosing = TsFalse))]
 pub struct JSXOpeningFragment {
     /// Node location in source code
     pub span: Span,

--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -128,7 +128,7 @@ pub struct JSXFragment<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(add_fields(attributes = JSXOpeningFragmentAttributes, selfClosing = False))]
+#[estree(via = JSXOpeningFragmentConverter)]
 pub struct JSXOpeningFragment {
     /// Node location in source code
     pub span: Span,

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -2026,13 +2026,7 @@ impl ESTree for JSXFragment<'_> {
 
 impl ESTree for JSXOpeningFragment {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let mut state = serializer.serialize_struct();
-        state.serialize_field("type", &JsonSafeString("JSXOpeningFragment"));
-        state.serialize_field("start", &self.span.start);
-        state.serialize_field("end", &self.span.end);
-        state.serialize_field("attributes", &crate::serialize::JSXOpeningFragmentAttributes(self));
-        state.serialize_field("selfClosing", &crate::serialize::False(self));
-        state.end();
+        crate::serialize::JSXOpeningFragmentConverter(self).serialize(serializer)
     }
 }
 

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -918,7 +918,6 @@ impl ESTree for JSXOpeningFragmentConverter<'_> {
         state.serialize_field("type", &JsonSafeString("JSXOpeningFragment"));
         state.serialize_field("start", &self.0.span.start);
         state.serialize_field("end", &self.0.span.end);
-
         if !S::INCLUDE_TS_FIELDS {
             state.serialize_field("attributes", &EmptyArray(()));
             state.serialize_field("selfClosing", &False(()));

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -909,7 +909,7 @@ impl ESTree for JSXElementThisExpression<'_> {
 }
 
 #[ast_meta]
-#[estree(ts_type = "JSXOpeningFragment", raw_deser = "todo")]
+#[estree(raw_deser = "'TODO'")]
 pub struct JSXOpeningFragmentConverter<'b>(pub &'b JSXOpeningFragment);
 
 impl ESTree for JSXOpeningFragmentConverter<'_> {

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -908,6 +908,12 @@ impl ESTree for JSXElementThisExpression<'_> {
     }
 }
 
+/// Serializer for `JSXOpeningFragment`.
+///
+/// Add `attributes` and `selfClosing` fields in JS AST, but not in TS AST.
+/// Acorn-JSX has these fields, but TS-ESLint parser does not.
+//
+// TODO: Find a better way to do this.
 #[ast_meta]
 #[estree(raw_deser = "
     const node = {

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -909,12 +909,21 @@ impl ESTree for JSXElementThisExpression<'_> {
 }
 
 #[ast_meta]
-#[estree(ts_type = "Array<JSXAttributeItem>", raw_deser = "[]")]
-pub struct JSXOpeningFragmentAttributes<'b>(#[expect(dead_code)] pub &'b JSXOpeningFragment);
+#[estree(ts_type = "JSXOpeningFragment", raw_deser = "todo")]
+pub struct JSXOpeningFragmentConverter<'b>(pub &'b JSXOpeningFragment);
 
-impl ESTree for JSXOpeningFragmentAttributes<'_> {
+impl ESTree for JSXOpeningFragmentConverter<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        [(); 0].serialize(serializer);
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", &JsonSafeString("JSXOpeningFragment"));
+        state.serialize_field("start", &self.0.span.start);
+        state.serialize_field("end", &self.0.span.end);
+
+        if !S::INCLUDE_TS_FIELDS {
+            state.serialize_field("attributes", &EmptyArray(()));
+            state.serialize_field("selfClosing", &False(()));
+        }
+        state.end();
     }
 }
 

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -870,6 +870,17 @@ impl ESTree for JSXOpeningElementSelfClosing<'_, '_> {
     }
 }
 
+#[ast_meta]
+#[estree(ts_type = "Array<JSXAttributeItem>", raw_deser = "[]")]
+#[ts]
+pub struct JSXOpeningFragmentAttributes<'b>(#[expect(dead_code)] pub &'b JSXOpeningFragment);
+
+impl ESTree for JSXOpeningFragmentAttributes<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        [(); 0].serialize(serializer);
+    }
+}
+
 /// Serializer for `IdentifierReference` variant of `JSXElementName` and `JSXMemberExpressionObject`.
 ///
 /// Convert to `JSXIdentifier`.

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -909,7 +909,18 @@ impl ESTree for JSXElementThisExpression<'_> {
 }
 
 #[ast_meta]
-#[estree(raw_deser = "'TODO'")]
+#[estree(raw_deser = "
+    const node = {
+        type: 'JSXOpeningFragment',
+        start: DESER[u32](POS_OFFSET.span.start),
+        end: DESER[u32](POS_OFFSET.span.end),
+        /* IF_JS */
+        attributes: [],
+        selfClosing: false,
+        /* END_IF_JS */
+    };
+    node
+")]
 pub struct JSXOpeningFragmentConverter<'b>(pub &'b JSXOpeningFragment);
 
 impl ESTree for JSXOpeningFragmentConverter<'_> {

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -1175,13 +1175,7 @@ function deserializeJSXFragment(pos) {
 }
 
 function deserializeJSXOpeningFragment(pos) {
-  return {
-    type: 'JSXOpeningFragment',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
-    attributes: [],
-    selfClosing: false,
-  };
+  return todo;
 }
 
 function deserializeJSXClosingFragment(pos) {

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -1175,7 +1175,14 @@ function deserializeJSXFragment(pos) {
 }
 
 function deserializeJSXOpeningFragment(pos) {
-  return 'TODO';
+  const node = {
+    type: 'JSXOpeningFragment',
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+    attributes: [],
+    selfClosing: false,
+  };
+  return node;
 }
 
 function deserializeJSXClosingFragment(pos) {

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -1175,7 +1175,7 @@ function deserializeJSXFragment(pos) {
 }
 
 function deserializeJSXOpeningFragment(pos) {
-  return todo;
+  return 'TODO';
 }
 
 function deserializeJSXClosingFragment(pos) {

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -1253,7 +1253,12 @@ function deserializeJSXFragment(pos) {
 }
 
 function deserializeJSXOpeningFragment(pos) {
-  return 'TODO';
+  const node = {
+    type: 'JSXOpeningFragment',
+    start: deserializeU32(pos),
+    end: deserializeU32(pos + 4),
+  };
+  return node;
 }
 
 function deserializeJSXClosingFragment(pos) {

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -1253,7 +1253,7 @@ function deserializeJSXFragment(pos) {
 }
 
 function deserializeJSXOpeningFragment(pos) {
-  return todo;
+  return 'TODO';
 }
 
 function deserializeJSXClosingFragment(pos) {

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -1253,13 +1253,7 @@ function deserializeJSXFragment(pos) {
 }
 
 function deserializeJSXOpeningFragment(pos) {
-  return {
-    type: 'JSXOpeningFragment',
-    start: deserializeU32(pos),
-    end: deserializeU32(pos + 4),
-    attributes: [],
-    selfClosing: false,
-  };
+  return todo;
 }
 
 function deserializeJSXClosingFragment(pos) {

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -858,6 +858,8 @@ export interface JSXFragment extends Span {
 
 export interface JSXOpeningFragment extends Span {
   type: 'JSXOpeningFragment';
+  attributes?: Array<JSXAttributeItem>;
+  selfClosing?: false;
 }
 
 export interface JSXClosingFragment extends Span {

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -856,12 +856,6 @@ export interface JSXFragment extends Span {
   children: Array<JSXChild>;
 }
 
-export interface JSXOpeningFragment extends Span {
-  type: 'JSXOpeningFragment';
-  attributes: Array<JSXAttributeItem>;
-  selfClosing: false;
-}
-
 export interface JSXClosingFragment extends Span {
   type: 'JSXClosingFragment';
 }
@@ -1748,7 +1742,6 @@ export type Node =
   | JSXOpeningElement
   | JSXClosingElement
   | JSXFragment
-  | JSXOpeningFragment
   | JSXClosingFragment
   | JSXNamespacedName
   | JSXMemberExpression

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -856,6 +856,10 @@ export interface JSXFragment extends Span {
   children: Array<JSXChild>;
 }
 
+export interface JSXOpeningFragment extends Span {
+  type: 'JSXOpeningFragment';
+}
+
 export interface JSXClosingFragment extends Span {
   type: 'JSXClosingFragment';
 }
@@ -1742,6 +1746,7 @@ export type Node =
   | JSXOpeningElement
   | JSXClosingElement
   | JSXFragment
+  | JSXOpeningFragment
   | JSXClosingFragment
   | JSXNamespacedName
   | JSXMemberExpression

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -2,7 +2,7 @@ commit: 15392346
 
 estree_typescript Summary:
 AST Parsed     : 10618/10725 (99.00%)
-Positive Passed: 8024/10725 (74.82%)
+Positive Passed: 8047/10725 (75.03%)
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/ClassDeclarationWithInvalidConstOnPropertyDeclaration.ts
 A class member cannot have the 'const' keyword.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractPropertyInConstructor.ts
@@ -689,7 +689,6 @@ Unexpected estree file content error: 1 != 2
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionInference2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericFunctionsAndConditionalInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericIndexedAccessMethodIntersectionCanBeAccessed.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInferenceDefaultTypeParameterJsxReact.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericInstanceOf.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericIsNeverEmptyObject.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/genericMappedTypeAsClause.ts
@@ -978,18 +977,8 @@ Unexpected estree file content error: 1 != 2
 tasks/coverage/typescript/tests/cases/compiler/jsdocReferenceGlobalTypeInCommonJs.ts
 Unexpected estree file content error: 2 != 3
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxChildrenIndividualErrorElaborations.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxElementClassTooManyParams.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxElementTypeLiteralWithGeneric.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryAndJsxFragmentFactory.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryAndJsxFragmentFactoryErrorNotIdentifier.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryAndJsxFragmentFactoryNull.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFactoryButNoJsxFragmentFactory.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFragReactReferenceErrors.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFragmentAndFactoryUsedOnFragmentUse.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFragmentFactoryNoUnusedLocals.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFragmentFactoryReference.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxFragmentWrongType.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxInferenceProducesLiteralAsExpected.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceImplicitImportJSXNamespaceFromConfigPickedOverGlobalOne.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/jsxNamespaceImplicitImportJSXNamespaceFromPragmaPickedOverGlobalOne.tsx
@@ -1542,7 +1531,6 @@ Unexpected estree file content error: 1 != 3
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxAttributesHasInferrableIndex.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxDefaultImports.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/tsxNotUsingApparentTypeOfSFC.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/tupleTypeInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/twiceNestedKeyofIndexInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeConstraintsWithConstructSignatures.ts
@@ -2743,17 +2731,13 @@ Unexpected estree file content error: 1 != 5
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/typedefMultipleTypeParameters.ts
 Unexpected estree file content error: 1 != 2
 
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty14.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/checkJsxChildrenProperty16.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/commentEmittingInPreserveJsx1.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/correctlyMarkAliasAsReferences1.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/correctlyMarkAliasAsReferences2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/correctlyMarkAliasAsReferences3.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/correctlyMarkAliasAsReferences4.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxAndJsxFragPragma.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxAndJsxFragPragmaOverridesCompilerOptions.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxFactoryDeclarationsLocalTypes.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/inline/inlineJsxFactoryWithFragmentIsError.tsx
 tasks/coverage/typescript/tests/cases/conformance/jsx/jsxCheckJsxNoTypeArgumentsAllowed.tsx
 Unexpected estree file content error: 1 != 2
 
@@ -2761,21 +2745,15 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxParsin
 JSX expressions may not use the comma operator
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuite.tsx
 JSX expressions may not use the comma operator
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformCustomImport.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformCustomImportPragma.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxs/jsxJsxsCjsTransformSubstitutesNamesFragment.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution14.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution15.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxAttributeResolution16.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxCorrectlyParseLessThanComparison1.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentPreserveEmit.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxFragmentReactEmit.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxLibraryManagedAttributes.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxOpeningClosingNames.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitEntities.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitNesting.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxStatelessFunctionComponentsWithTypeArguments5.tsx
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxTypeArgumentsJsxPreserveOutput.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType1.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType2.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxUnionElementType3.tsx
@@ -3511,7 +3489,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationsh
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/genericContextualTypes3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferences.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/intraExpressionInferencesJsx.tsx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/keyofInferenceLowerPriorityThanReturn.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/noInfer.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeRelationships/typeInference/unionTypeInference.ts


### PR DESCRIPTION
Fix `JSXOpeningFragment` node estree TS serialization by skipping `selfClosing` and `attributes` fields when AST is TS.

Part of our broader work to align our AST's ESTree output with that of TS-ESLint's. Relates to #9705 
