### PR TITLE
fix(ast_tools): fix calculation of number of bytes required for `Derives` bitmap

### DIFF
--- a/tasks/ast_tools/src/schema/derives.rs
+++ b/tasks/ast_tools/src/schema/derives.rs
@@ -6,7 +6,7 @@ use std::{
 use crate::{DERIVES, codegen::DeriveId};
 
 /// Number of bytes required for bit set which can represent all [`DeriveId`]s.
-const NUM_BYTES: usize = (DERIVES.len() + 7).div_ceil(8);
+const NUM_BYTES: usize = DERIVES.len().div_ceil(8);
 
 /// Bit set with a bit for each [`DeriveId`].
 #[derive(Clone, Copy)]


### PR DESCRIPTION
#10196 changed this line:

```diff
- const NUM_BYTES: usize = (DERIVES.len() + 7) / 8;
+ const NUM_BYTES: usize = (DERIVES.len() + 7).div_ceil(8);
```

But that's not equivalent. The correct version with `div_ceil` is:

```rs
const NUM_BYTES: usize = DERIVES.len().div_ceil(8);
```
