### PR TITLE
refactor(ast_tools): shorten code

### DIFF
--- a/tasks/ast_tools/src/output/yaml.rs
+++ b/tasks/ast_tools/src/output/yaml.rs
@@ -23,7 +23,7 @@ impl Output {
 
         let mut code = "src:\n".to_string();
         for path in paths {
-            writeln!(&mut code, "  - '{path}'").unwrap();
+            writeln!(code, "  - '{path}'").unwrap();
         }
 
         Self::Yaml { path: watch_list_path.to_string(), code }


### PR DESCRIPTION
Tiny refactor. `writeln!` does not require an explicit `&mut` reference. Shorten this code.