### PR TITLE
fix(various): unwrap `Result` of `write!` macro

### DIFF
--- a/apps/oxlint/src/output_formatter/stylish.rs
+++ b/apps/oxlint/src/output_formatter/stylish.rs
@@ -72,7 +72,7 @@ fn format_stylish(diagnostics: &[Error]) -> String {
             .max()
             .unwrap_or(0);
 
-        let _ = write!(output, "\n\u{1b}[4m{filename}\u{1b}[0m\n");
+        writeln!(output, "\n\u{1b}[4m{filename}\u{1b}[0m").unwrap();
 
         for diagnostic in diagnostics {
             match diagnostic.severity() {
@@ -89,23 +89,23 @@ fn format_stylish(diagnostics: &[Error]) -> String {
             let info = Info::new(diagnostic);
             let rule = diagnostic.code().map_or_else(String::new, |code| code.to_string());
             let position = format!("{}:{}", info.start.line, info.start.column);
-            let _ = writeln!(
+            writeln!(
                 output,
                 "  \u{1b}[2m{position:max_len_width$}\u{1b}[0m  {severity_str}  {diagnostic}  \u{1b}[2m{rule}\u{1b}[0m"
-            );
+            ).unwrap();
         }
     }
 
     let total = total_errors + total_warnings;
     if total > 0 {
         let summary_color = if total_errors > 0 { "\u{1b}[31m" } else { "\u{1b}[33m" };
-        let _ = writeln!(
+        writeln!(
             output,
             "\n{summary_color}✖ {total} problem{} ({total_errors} error{}, {total_warnings} warning{})\u{1b}[0m",
             if total == 1 { "" } else { "s" },
             if total_errors == 1 { "" } else { "s" },
             if total_warnings == 1 { "" } else { "s" }
-        );
+        ).unwrap();
     }
 
     output

--- a/crates/oxc_isolated_declarations/tests/mod.rs
+++ b/crates/oxc_isolated_declarations/tests/mod.rs
@@ -28,10 +28,11 @@ fn transform(path: &Path, source_text: &str) -> String {
             .map(|d| d.clone().with_source_code(Arc::clone(&source)))
             .fold(String::new(), |s, error| s + &format!("{error:?}"));
 
-        let _ = write!(
+        write!(
             snapshot,
             "==================== Errors ====================\n{error_messages}\n\n```"
-        );
+        )
+        .unwrap();
     }
 
     snapshot

--- a/crates/oxc_language_server/src/linter/tester.rs
+++ b/crates/oxc_language_server/src/linter/tester.rs
@@ -31,8 +31,8 @@ fn get_snapshot_from_report(report: &DiagnosticReport) -> String {
                 .enumerate()
                 .map(|(i, info)| {
                     let mut result = String::new();
-                    let _ =
-                        write!(result, "related_information[{}].message: {:?}", i, info.message);
+                    write!(result, "related_information[{}].message: {:?}", i, info.message)
+                        .unwrap();
                     // replace everything between `file://` and `oxc_language_server` with `<variable>`, to avoid
                     // the absolute path causing snapshot test failures in different environments
                     let mut location = info.location.uri.to_string();
@@ -46,13 +46,14 @@ fn get_snapshot_from_report(report: &DiagnosticReport) -> String {
                         "<variable>",
                     );
 
-                    let _ =
-                        write!(result, "\nrelated_information[{i}].location.uri: {location:?}",);
-                    let _ = write!(
+                    write!(result, "\nrelated_information[{i}].location.uri: {location:?}",)
+                        .unwrap();
+                    write!(
                         result,
                         "\nrelated_information[{}].location.range: {:?}",
                         i, info.location.range
-                    );
+                    )
+                    .unwrap();
                     result
                 })
                 .collect::<Vec<_>>()

--- a/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
+++ b/crates/oxc_linter/src/rules/typescript/consistent_type_imports.rs
@@ -285,9 +285,9 @@ fn format_word_list<'a>(words: &[Cow<'a, str>]) -> Cow<'a, str> {
             let mut result = String::with_capacity(words.len() * 2);
             for (i, word) in words.iter().enumerate() {
                 if i == words.len() - 1 {
-                    let _ = write!(result, "and {word}");
+                    write!(result, "and {word}").unwrap();
                 } else {
-                    let _ = write!(result, "{word}, ");
+                    write!(result, "{word}, ").unwrap();
                 }
             }
             Cow::Owned(result)

--- a/tasks/minsize/src/lib.rs
+++ b/tasks/minsize/src/lib.rs
@@ -68,7 +68,7 @@ pub fn run() -> Result<(), io::Error> {
     let mut out = String::new();
 
     let width = 10;
-    let _ = writeln!(
+    writeln!(
         out,
         "{:width$} | {:width$} | {:width$} | {:width$} | {:width$} |",
         "",
@@ -77,8 +77,9 @@ pub fn run() -> Result<(), io::Error> {
         "Oxc",
         "ESBuild",
         width = width,
-    );
-    let _ = writeln!(
+    )
+    .unwrap();
+    writeln!(
         out,
         "{:width$} | {:width$} | {:width$} | {:width$} | {:width$} | Fixture",
         "Original",
@@ -87,7 +88,8 @@ pub fn run() -> Result<(), io::Error> {
         "gzip",
         "gzip",
         width = width,
-    );
+    )
+    .unwrap();
 
     let fixture_width = files
         .files()

--- a/tasks/prettier_conformance/src/lib.rs
+++ b/tasks/prettier_conformance/src/lib.rs
@@ -89,14 +89,15 @@ impl TestRunner {
             total_failed_file_count += failed_test_files.len();
 
             for (path, (failed, passed, ratio)) in failed_test_files {
-                let _ = writeln!(
+                writeln!(
                     failed_reports,
                     "| {} | {}{} | {:.2}% |",
                     path.strip_prefix(fixtures_root()).unwrap().to_string_lossy(),
                     "💥".repeat(failed),
                     "✨".repeat(passed),
                     ratio * 100.0
-                );
+                )
+                .unwrap();
             }
         }
 

--- a/tasks/transform_conformance/src/lib.rs
+++ b/tasks/transform_conformance/src/lib.rs
@@ -155,9 +155,7 @@ impl TestRunner {
             if failed.is_empty() {
                 all_passed.push(case);
             } else {
-                snapshot.push_str("# ");
-                snapshot.push_str(&case);
-                let _ = writeln!(snapshot, " ({}/{})", passed.len(), num_of_tests);
+                writeln!(snapshot, "# {case} ({}/{})", passed.len(), num_of_tests).unwrap();
                 for test_case in failed {
                     if self.options.r#override {
                         test_case.write_override_output();


### PR DESCRIPTION
#10196 replaced the anti-pattern of `str.push_str(&format!("..."));` with `let _ = write!(str, "...");`.

However, this ignores the `Result` returned by `write!` macro. It's unspecified what happens when the `String` reaches capacity - it may return `Result::Err`, or may panic. Ensure we get a panic, rather than silently generating incorrect output by calling `unwrap()` on the `Result`.

This problem could never arise in practice on 64-bit systems because max capacity of `String` is enormous, but it's not impossible on 32-bit systems (e.g. WASM).
