### PR TITLE
perf(linter): remove `write!` macro where unnecessary

### DIFF
--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -1,6 +1,6 @@
 use std::{
     cell::{Ref, RefCell},
-    fmt,
+    fmt::{self, Debug, Display},
 };
 
 use itertools::Itertools;
@@ -371,7 +371,7 @@ impl TryFrom<Oxlintrc> for ConfigStoreBuilder {
     }
 }
 
-impl fmt::Debug for ConfigStoreBuilder {
+impl Debug for ConfigStoreBuilder {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ConfigStoreBuilder")
             .field("rules", &self.rules)
@@ -389,13 +389,13 @@ pub enum ConfigBuilderError {
     InvalidConfigFile { file: String, reason: String },
 }
 
-impl std::fmt::Display for ConfigBuilderError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Display for ConfigBuilderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ConfigBuilderError::UnknownRules { rules } => {
-                write!(f, "unknown rules: ")?;
+                f.write_str("unknown rules: ")?;
                 for rule in rules {
-                    write!(f, "{}", rule.full_name())?;
+                    Display::fmt(&rule.full_name(), f)?;
                 }
                 Ok(())
             }

--- a/crates/oxc_linter/src/config/globals.rs
+++ b/crates/oxc_linter/src/config/globals.rs
@@ -115,7 +115,7 @@ impl Visitor<'_> for GlobalValueVisitor {
     type Value = GlobalValue;
 
     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(formatter, "'readonly', 'writable', 'off', or a boolean")
+        formatter.write_str("'readonly', 'writable', 'off', or a boolean")
     }
 
     fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>

--- a/crates/oxc_linter/src/config/plugins.rs
+++ b/crates/oxc_linter/src/config/plugins.rs
@@ -156,7 +156,7 @@ impl<'de> Deserialize<'de> for LintPlugins {
             type Value = LintPlugins;
 
             fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
-                write!(formatter, "a list of plugin names")
+                formatter.write_str("a list of plugin names")
             }
 
             fn visit_str<E: de::Error>(self, value: &str) -> Result<Self::Value, E> {

--- a/crates/oxc_linter/src/loader/mod.rs
+++ b/crates/oxc_linter/src/loader/mod.rs
@@ -66,8 +66,8 @@ impl LoadError {
 impl fmt::Display for LoadError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::TooLarge => write!(f, "file is too large. Only files up to 4GB are supported."),
-            Self::NoExtension => write!(f, "no extension"),
+            Self::TooLarge => f.write_str("file is too large. Only files up to 4GB are supported."),
+            Self::NoExtension => f.write_str("no extension"),
             Self::UnsupportedFileType(ext) => write!(f, "unsupported file type: {ext}"),
         }
     }

--- a/crates/oxc_linter/src/rule.rs
+++ b/crates/oxc_linter/src/rule.rs
@@ -148,15 +148,16 @@ impl TryFrom<&str> for RuleCategory {
 
 impl fmt::Display for RuleCategory {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Correctness => write!(f, "Correctness"),
-            Self::Suspicious => write!(f, "Suspicious"),
-            Self::Pedantic => write!(f, "Pedantic"),
-            Self::Perf => write!(f, "Perf"),
-            Self::Style => write!(f, "Style"),
-            Self::Restriction => write!(f, "Restriction"),
-            Self::Nursery => write!(f, "Nursery"),
-        }
+        let category_name = match self {
+            Self::Correctness => "Correctness",
+            Self::Suspicious => "Suspicious",
+            Self::Pedantic => "Pedantic",
+            Self::Perf => "Perf",
+            Self::Style => "Style",
+            Self::Restriction => "Restriction",
+            Self::Nursery => "Nursery",
+        };
+        f.write_str(category_name)
     }
 }
 

--- a/crates/oxc_linter/src/rules/eslint/sort_imports.rs
+++ b/crates/oxc_linter/src/rules/eslint/sort_imports.rs
@@ -437,12 +437,13 @@ impl FromStr for ImportKind {
 
 impl Display for ImportKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ImportKind::None => write!(f, "None"),
-            ImportKind::All => write!(f, "All"),
-            ImportKind::Multiple => write!(f, "Multiple"),
-            ImportKind::Single => write!(f, "Single"),
-        }
+        let kind_name = match self {
+            ImportKind::None => "None",
+            ImportKind::All => "All",
+            ImportKind::Multiple => "Multiple",
+            ImportKind::Single => "Single",
+        };
+        f.write_str(kind_name)
     }
 }
 

--- a/crates/oxc_linter/src/rules/oxc/const_comparisons.rs
+++ b/crates/oxc_linter/src/rules/oxc/const_comparisons.rs
@@ -386,12 +386,13 @@ enum CmpOp {
 
 impl std::fmt::Display for CmpOp {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Lt => write!(f, "<"),
-            Self::Le => write!(f, "<="),
-            Self::Ge => write!(f, ">="),
-            Self::Gt => write!(f, ">"),
-        }
+        let op = match self {
+            Self::Lt => "<",
+            Self::Le => "<=",
+            Self::Ge => ">=",
+            Self::Gt => ">",
+        };
+        f.write_str(op)
     }
 }
 


### PR DESCRIPTION
Same as #10230, but for linter.

Replace usages of `write!` macro with either `fmt.write_str(...)` for static strings or `Display::fmt` / `Debug::fmt` for other values, where it's not being used to concatenate multiple values.

`Formatter::write_str` is more performant, as it avoids various checks. `Display::fmt` / `Debug::fmt` may also perform a little better in some cases, and will be equivalent in others. But in all cases it should be better for compile times, due to avoiding macro expansion and trait resolution.
