### PR TITLE
perf(ast): remove `write!` macro where unnecessary

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -1,5 +1,8 @@
 #![warn(missing_docs)]
-use std::{borrow::Cow, fmt};
+use std::{
+    borrow::Cow,
+    fmt::{self, Display},
+};
 
 use oxc_allocator::{Box, Vec};
 use oxc_span::{Atom, Span};
@@ -370,20 +373,20 @@ impl<'a> Expression<'a> {
     }
 }
 
-impl fmt::Display for IdentifierName<'_> {
+impl Display for IdentifierName<'_> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         self.name.fmt(f)
     }
 }
 
-impl fmt::Display for IdentifierReference<'_> {
+impl Display for IdentifierReference<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.name.fmt(f)
     }
 }
 
-impl fmt::Display for BindingIdentifier<'_> {
+impl Display for BindingIdentifier<'_> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.name.fmt(f)
@@ -1099,10 +1102,9 @@ impl VariableDeclarationKind {
     }
 }
 
-impl fmt::Display for VariableDeclarationKind {
+impl Display for VariableDeclarationKind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let s = self.as_str();
-        write!(f, "{s}")
+        self.as_str().fmt(f)
     }
 }
 
@@ -1846,14 +1848,13 @@ impl ExportDefaultDeclarationKind<'_> {
     }
 }
 
-impl fmt::Display for ModuleExportName<'_> {
+impl Display for ModuleExportName<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let s = match self {
-            Self::IdentifierName(identifier) => identifier.name.to_string(),
-            Self::IdentifierReference(identifier) => identifier.name.to_string(),
-            Self::StringLiteral(literal) => format!(r#""{}""#, literal.value),
-        };
-        write!(f, "{s}")
+        match self {
+            Self::IdentifierName(identifier) => identifier.name.fmt(f),
+            Self::IdentifierReference(identifier) => identifier.name.fmt(f),
+            Self::StringLiteral(literal) => write!(f, r#""{}""#, literal.value),
+        }
     }
 }
 

--- a/crates/oxc_ast/src/ast_impl/literal.rs
+++ b/crates/oxc_ast/src/ast_impl/literal.rs
@@ -1,6 +1,9 @@
 //! Literals
 
-use std::{borrow::Cow, fmt};
+use std::{
+    borrow::Cow,
+    fmt::{self, Display},
+};
 
 use oxc_allocator::{Allocator, CloneIn, Dummy};
 use oxc_data_structures::inline_string::InlineString;
@@ -16,14 +19,14 @@ impl BooleanLiteral {
     }
 }
 
-impl fmt::Display for BooleanLiteral {
+impl Display for BooleanLiteral {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.as_str().fmt(f)
     }
 }
 
-impl fmt::Display for NullLiteral {
+impl Display for NullLiteral {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         "null".fmt(f)
@@ -64,7 +67,7 @@ impl NumericLiteral<'_> {
     }
 }
 
-impl fmt::Display for NumericLiteral<'_> {
+impl Display for NumericLiteral<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // We have 2 choices here:
         // 1. Only use the `value` field. or
@@ -103,7 +106,7 @@ impl AsRef<str> for StringLiteral<'_> {
     }
 }
 
-impl fmt::Display for StringLiteral<'_> {
+impl Display for StringLiteral<'_> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.value.fmt(f)
@@ -122,13 +125,13 @@ impl BigIntLiteral<'_> {
     }
 }
 
-impl fmt::Display for BigIntLiteral<'_> {
+impl Display for BigIntLiteral<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.raw.fmt(f)
     }
 }
 
-impl fmt::Display for RegExp<'_> {
+impl Display for RegExp<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "/{}/{}", self.pattern, self.flags)
     }
@@ -195,10 +198,10 @@ impl ContentEq for RegExpPattern<'_> {
     }
 }
 
-impl fmt::Display for RegExpPattern<'_> {
+impl Display for RegExpPattern<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Raw(it) | Self::Invalid(it) => write!(f, "{it}"),
+            Self::Raw(it) | Self::Invalid(it) => it.fmt(f),
             Self::Pattern(it) => it.fmt(f),
         }
     }
@@ -265,7 +268,7 @@ impl TryFrom<u8> for RegExpFlags {
     }
 }
 
-impl fmt::Display for RegExpFlags {
+impl Display for RegExpFlags {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.to_inline_string().as_str())
     }


### PR DESCRIPTION
Same as #10230, but for `oxc_ast` crate.

Replace usages of `write!` macro with either `fmt.write_str(...)` for static strings or `Display::fmt` / `Debug::fmt` for other values, where it's not being used to concatenate multiple values.

`Formatter::write_str` is more performant, as it avoids various checks. `Display::fmt` / `Debug::fmt` may also perform a little better in some cases, and will be equivalent in others. But in all cases it should be better for compile times, due to avoiding macro expansion and trait resolution.

Also, avoid allocating temporary `String`s in `Display` impl for `ModuleExportName`.
