### PR TITLE
fix(ast): fix `Display` impl for `RegExpFlags`

### DIFF
--- a/crates/oxc_ast/src/ast_impl/literal.rs
+++ b/crates/oxc_ast/src/ast_impl/literal.rs
@@ -270,7 +270,7 @@ impl TryFrom<u8> for RegExpFlags {
 
 impl Display for RegExpFlags {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.to_inline_string().as_str())
+        self.to_inline_string().as_str().fmt(f)
     }
 }
 


### PR DESCRIPTION
I *think* this was incorrect before, because `Formatter::write_str` bypasses formatting options. `str::fmt` should be used instead.
