### PR TITLE
perf(cfg, diagnostics, lexer, syntax, tasks): remove `write!` macro where unnecessary

### DIFF
--- a/crates/oxc_cfg/src/dot.rs
+++ b/crates/oxc_cfg/src/dot.rs
@@ -1,4 +1,7 @@
-use std::{borrow::Cow, fmt};
+use std::{
+    borrow::Cow,
+    fmt::{self, Debug, Display},
+};
 
 use itertools::Itertools as _;
 use petgraph::{
@@ -104,12 +107,12 @@ impl<'a> Attr<'a> {
     }
 }
 
-impl fmt::Debug for Attr<'_> {
+impl Debug for Attr<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Int(i) => write!(f, "{i}"),
-            Self::String(s) => write!(f, "{s:?}"),
-            Self::Identifier(ident) => write!(f, "{ident}"), // display instead of debug
+            Self::Int(i) => Display::fmt(i, f),
+            Self::String(s) => Debug::fmt(s, f),
+            Self::Identifier(ident) => Display::fmt(ident, f), // Display instead of Debug
         }
     }
 }
@@ -167,17 +170,17 @@ where
     }
 }
 
-impl fmt::Debug for Attrs<'_> {
+impl Debug for Attrs<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if self.0.is_empty() {
             return Ok(());
         }
 
-        let l = self.0.len();
         for (i, (k, v)) in self.0.iter().enumerate() {
-            write!(f, "{k}={v:?}")?;
-            if i < l - 1 {
-                write!(f, ", ")?;
+            if i == 0 {
+                write!(f, "{k}={v:?}")?;
+            } else {
+                write!(f, ", {k}={v:?}")?;
             }
         }
 

--- a/crates/oxc_diagnostics/src/lib.rs
+++ b/crates/oxc_diagnostics/src/lib.rs
@@ -105,7 +105,7 @@ impl OxcCode {
     }
 }
 
-impl fmt::Display for OxcCode {
+impl Display for OxcCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match (&self.scope, &self.number) {
             (Some(scope), Some(number)) => write!(f, "{scope}({number})"),
@@ -126,9 +126,9 @@ pub struct OxcDiagnosticInner {
     pub url: Option<Cow<'static, str>>,
 }
 
-impl fmt::Display for OxcDiagnostic {
+impl Display for OxcDiagnostic {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", &self.message)
+        self.message.fmt(f)
     }
 }
 

--- a/crates/oxc_parser/src/lexer/kind.rs
+++ b/crates/oxc_parser/src/lexer/kind.rs
@@ -1,6 +1,6 @@
 //! ECMAScript Token Kinds
 
-use std::fmt;
+use std::fmt::{self, Display};
 
 /// Lexer token kind
 ///
@@ -693,8 +693,8 @@ impl Kind {
     }
 }
 
-impl fmt::Display for Kind {
+impl Display for Kind {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.to_str())
+        self.to_str().fmt(f)
     }
 }

--- a/crates/oxc_syntax/src/es_target.rs
+++ b/crates/oxc_syntax/src/es_target.rs
@@ -63,6 +63,6 @@ impl fmt::Display for ESTarget {
             Self::ES2025 => "es2025",
             Self::ESNext => "esnext",
         };
-        write!(f, "{s}",)
+        f.write_str(s)
     }
 }

--- a/tasks/rulegen/src/main.rs
+++ b/tasks/rulegen/src/main.rs
@@ -621,22 +621,23 @@ impl RuleKind {
 
 impl Display for RuleKind {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::ESLint => write!(f, "eslint"),
-            Self::Typescript => write!(f, "typescript-eslint"),
-            Self::Jest => write!(f, "eslint-plugin-jest"),
-            Self::Unicorn => write!(f, "eslint-plugin-unicorn"),
-            Self::Import => write!(f, "eslint-plugin-import"),
-            Self::React => write!(f, "eslint-plugin-react"),
-            Self::ReactPerf => write!(f, "eslint-plugin-react-perf"),
-            Self::JSXA11y => write!(f, "eslint-plugin-jsx-a11y"),
-            Self::Oxc => write!(f, "oxc"),
-            Self::NextJS => write!(f, "eslint-plugin-next"),
-            Self::JSDoc => write!(f, "eslint-plugin-jsdoc"),
-            Self::Node => write!(f, "eslint-plugin-n"),
-            Self::Promise => write!(f, "eslint-plugin-promise"),
-            Self::Vitest => write!(f, "eslint-plugin-vitest"),
-        }
+        let kind_name = match self {
+            Self::ESLint => "eslint",
+            Self::Typescript => "typescript-eslint",
+            Self::Jest => "eslint-plugin-jest",
+            Self::Unicorn => "eslint-plugin-unicorn",
+            Self::Import => "eslint-plugin-import",
+            Self::React => "eslint-plugin-react",
+            Self::ReactPerf => "eslint-plugin-react-perf",
+            Self::JSXA11y => "eslint-plugin-jsx-a11y",
+            Self::Oxc => "oxc",
+            Self::NextJS => "eslint-plugin-next",
+            Self::JSDoc => "eslint-plugin-jsdoc",
+            Self::Node => "eslint-plugin-n",
+            Self::Promise => "eslint-plugin-promise",
+            Self::Vitest => "eslint-plugin-vitest",
+        };
+        f.write_str(kind_name)
     }
 }
 

--- a/tasks/website/src/linter/rules/html.rs
+++ b/tasks/website/src/linter/rules/html.rs
@@ -81,7 +81,7 @@ impl HtmlWriter {
         // Write the opening tag
         write!(s, "<{tag}")?;
         if attrs.is_empty() {
-            writeln!(s, ">")?;
+            s.write_str(">\n")?;
         } else {
             writeln!(s, " {attrs}>")?;
         }


### PR DESCRIPTION
Same as #10230, for small changes to various crates.

Replace usages of `write!` macro with either `fmt.write_str(...)` for static strings or `Display::fmt` / `Debug::fmt` for other values, where it's not being used to concatenate multiple values.

`Formatter::write_str` is more performant, as it avoids various checks. `Display::fmt` / `Debug::fmt` may also perform a little better in some cases, and will be equivalent in others. But in all cases it should be better for compile times, due to avoiding macro expansion and trait resolution.
