### PR TITLE
fix(linter): fix `Display` impl for `ConfigBuilderError`

### DIFF
--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -394,8 +394,12 @@ impl Display for ConfigBuilderError {
         match self {
             ConfigBuilderError::UnknownRules { rules } => {
                 f.write_str("unknown rules: ")?;
-                for rule in rules {
-                    Display::fmt(&rule.full_name(), f)?;
+                for (i, rule) in rules.iter().enumerate() {
+                    if i == 0 {
+                        Display::fmt(&rule.full_name(), f)?;
+                    } else {
+                        write!(f, ", {}", rule.full_name())?;
+                    }
                 }
                 Ok(())
             }


### PR DESCRIPTION
If multiple rules, previously their names would be concatenated without any delimiters in between. Add `, ` between the rule names.
