### PR TITLE
perf(codegen): optimize `Codegen::print_list` method

### DIFF
--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -455,25 +455,15 @@ impl<'a> Codegen<'a> {
         self.needs_semicolon = false;
     }
 
-    // We tried optimizing this to move the `index != 0` check out of the loop:
-    // ```
-    // let mut iter = items.iter();
-    // let Some(item) = iter.next() else { return };
-    // item.print(self, ctx);
-    // for item in iter {
-    //     self.print_comma();
-    //     self.print_soft_space();
-    //     item.print(self, ctx);
-    // }
-    // ```
-    // But it turned out this was actually a bit slower.
-    // <https://github.com/oxc-project/oxc/pull/5221>
+    #[inline]
     fn print_list<T: Gen>(&mut self, items: &[T], ctx: Context) {
-        for (index, item) in items.iter().enumerate() {
-            if index != 0 {
-                self.print_comma();
-                self.print_soft_space();
-            }
+        let Some((first, rest)) = items.split_first() else {
+            return;
+        };
+        first.print(self, ctx);
+        for item in rest {
+            self.print_comma();
+            self.print_soft_space();
             item.print(self, ctx);
         }
     }


### PR DESCRIPTION
It looks like has fewer instructions than before. See https://godbolt.org/z/jE1o5rvGq

NOTE: This approach didn't bring notable performance improvement, so I don't have a strong opinion on which way.