### PR TITLE
feat(minifier): compress assignment to prefix increment

### DIFF
--- a/crates/oxc_minifier/src/peephole/minimize_conditions.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditions.rs
@@ -1,9 +1,6 @@
 use oxc_allocator::TakeIn;
 use oxc_ast::ast::*;
-use oxc_ecmascript::{
-    ToInt32,
-    constant_evaluation::{ConstantEvaluation, ConstantValue, DetermineValueType},
-};
+use oxc_ecmascript::constant_evaluation::{ConstantEvaluation, ConstantValue, DetermineValueType};
 use oxc_span::GetSpan;
 use oxc_syntax::es_target::ESTarget;
 
@@ -287,25 +284,16 @@ impl<'a> PeepholeOptimizations {
         let Expression::NumericLiteral(num) = &expr.right else {
             return None;
         };
-
         let target = expr.left.as_simple_assignment_target_mut()?;
-
-        let operator = match num.value.to_int_32() {
-            1 => Some(UpdateOperator::Decrement),
-            -1 => Some(UpdateOperator::Increment),
-            _ => None,
+        let operator = if num.value == 1.0 {
+            UpdateOperator::Decrement
+        } else if num.value == -1.0 {
+            UpdateOperator::Increment
+        } else {
+            return None;
         };
-
-        operator.map(|operator| {
-            let target = std::mem::replace(
-                target,
-                ctx.ast.simple_assignment_target_assignment_target_identifier(
-                    target.span(),
-                    "_", // Won't be placed into the target code
-                ),
-            );
-            ctx.ast.expression_update(expr.span, operator, true, target)
-        })
+        let target = target.take_in(&ctx.ast.allocator);
+        Some(ctx.ast.expression_update(expr.span, operator, true, target))
     }
 }
 

--- a/crates/oxc_minifier/src/peephole/minimize_conditions.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditions.rs
@@ -274,6 +274,7 @@ impl<'a> PeepholeOptimizations {
     }
 
     /// Compress `a -= 1` to `--a` and `a -= -1` to `++a`
+    #[expect(clippy::float_cmp)]
     fn try_compress_assignment_to_update_expression(
         expr: &mut AssignmentExpression<'a>,
         ctx: Ctx<'a, '_>,
@@ -292,7 +293,7 @@ impl<'a> PeepholeOptimizations {
         } else {
             return None;
         };
-        let target = target.take_in(&ctx.ast.allocator);
+        let target = target.take_in(ctx.ast.allocator);
         Some(ctx.ast.expression_update(expr.span, operator, true, target))
     }
 }

--- a/crates/oxc_minifier/src/peephole/minimize_conditions.rs
+++ b/crates/oxc_minifier/src/peephole/minimize_conditions.rs
@@ -276,43 +276,36 @@ impl<'a> PeepholeOptimizations {
         true
     }
 
-    /// Compress `a = a + b` to `a += b`
+    /// Compress `a -= 1` to `--a` and `a -= -1` to `++a`
     fn try_compress_assignment_to_update_expression(
         expr: &mut AssignmentExpression<'a>,
         ctx: Ctx<'a, '_>,
     ) -> Option<Expression<'a>> {
-        let target = expr.left.as_simple_assignment_target_mut()?;
         if !matches!(expr.operator, AssignmentOperator::Subtraction) {
             return None;
         }
-        match &expr.right {
-            Expression::NumericLiteral(num) if num.value.to_int_32() == 1 => {
-                // The `_` will not be placed to the target code.
-                let target = std::mem::replace(
-                    target,
-                    ctx.ast
-                        .simple_assignment_target_assignment_target_identifier(target.span(), "_"),
-                );
-                Some(ctx.ast.expression_update(expr.span, UpdateOperator::Decrement, true, target))
-            }
-            Expression::UnaryExpression(un)
-                if matches!(un.operator, UnaryOperator::UnaryNegation) =>
-            {
-                let Expression::NumericLiteral(num) = &un.argument else { return None };
-                (num.value.to_int_32() == 1).then(|| {
-                    // The `_` will not be placed to the target code.
-                    let target = std::mem::replace(
-                        target,
-                        ctx.ast.simple_assignment_target_assignment_target_identifier(
-                            target.span(),
-                            "_",
-                        ),
-                    );
-                    ctx.ast.expression_update(expr.span, UpdateOperator::Increment, true, target)
-                })
-            }
+        let Expression::NumericLiteral(num) = &expr.right else {
+            return None;
+        };
+
+        let target = expr.left.as_simple_assignment_target_mut()?;
+
+        let operator = match num.value.to_int_32() {
+            1 => Some(UpdateOperator::Decrement),
+            -1 => Some(UpdateOperator::Increment),
             _ => None,
-        }
+        };
+
+        operator.map(|operator| {
+            let target = std::mem::replace(
+                target,
+                ctx.ast.simple_assignment_target_assignment_target_identifier(
+                    target.span(),
+                    "_", // Won't be placed into the target code
+                ),
+            );
+            ctx.ast.expression_update(expr.span, operator, true, target)
+        })
     }
 }
 

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -1405,8 +1405,7 @@ mod test {
     #[test]
     fn test_fold_subtraction_assignment() {
         test("x -= 1", "--x");
-        // FIXME
-        // test("x -= -1", "++x");
+        test("x -= -1", "++x");
         test_same("x -= 2");
         test_same("x += 1"); // The string concatenation may be triggered, so we don't fold this.
         test_same("x += -1");


### PR DESCRIPTION
Fixes one test previously commented out in #8604.

The removed match arm for `UnaryNegation` was probably unnecessary because `UnaryExpression(UnaryNegation, NumericLiteral(1))` seems to be evaluated to `NumericLiteral(-1)` in a preceding minifier step and all tests are still green. But I might be wrong as this is my first contribution to the minifier.