### PR TITLE
fix(linter): fix `rule_id` for some diagnostics formats

### DIFF
--- a/apps/oxlint/src/output_formatter/checkstyle.rs
+++ b/apps/oxlint/src/output_formatter/checkstyle.rs
@@ -52,8 +52,8 @@ fn format_checkstyle(diagnostics: &[Error]) -> String {
                      Severity::Error => "error",
                      _ => "warning",
                  };
-                 let message = rule_id.as_ref().map_or_else(|| xml_escape(message), |rule_id| Cow::Owned(format!("{} ({rule_id})", xml_escape(message))));
-                 let source = rule_id.as_ref().map_or_else(|| Cow::Borrowed(""), |rule_id| Cow::Owned(format!("eslint.rules.{rule_id}")));
+                 let message =  xml_escape(message);
+                 let source = rule_id.as_ref().map_or(Cow::Borrowed(""), |v| xml_escape(v));
                  let line = format!(r#"<error line="{}" column="{}" severity="{severity}" message="{message}" source="{source}" />"#, start.line, start.column);
                  acc.push_str(&line);
                  acc

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=checkstyle test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=checkstyle test.js@oxlint.snap
@@ -5,7 +5,7 @@ source: apps/oxlint/src/tester.rs
 arguments: --format=checkstyle test.js
 working directory: fixtures/output_formatter_diagnostic
 ----------
-<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"><file name="test.js"><error line="5" column="1" severity="error" message="`debugger` statement is not allowed" source="" /><error line="1" column="10" severity="warning" message="Function &apos;foo&apos; is declared but never used." source="" /><error line="1" column="17" severity="warning" message="Parameter &apos;b&apos; is declared but never used. Unused parameters should start with a &apos;_&apos;." source="" /></file></checkstyle>
+<?xml version="1.0" encoding="utf-8"?><checkstyle version="4.3"><file name="test.js"><error line="5" column="1" severity="error" message="`debugger` statement is not allowed" source="eslint(no-debugger)" /><error line="1" column="10" severity="warning" message="Function &apos;foo&apos; is declared but never used." source="eslint(no-unused-vars)" /><error line="1" column="17" severity="warning" message="Parameter &apos;b&apos; is declared but never used. Unused parameters should start with a &apos;_&apos;." source="eslint(no-unused-vars)" /></file></checkstyle>
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=github test.js@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__output_formatter_diagnostic_--format=github test.js@oxlint.snap
@@ -5,9 +5,9 @@ source: apps/oxlint/src/tester.rs
 arguments: --format=github test.js
 working directory: fixtures/output_formatter_diagnostic
 ----------
-::error file=test.js,line=5,endLine=5,col=1,endColumn=10,title=oxlint::`debugger` statement is not allowed
-::warning file=test.js,line=1,endLine=1,col=10,endColumn=13,title=oxlint::Function 'foo' is declared but never used.
-::warning file=test.js,line=1,endLine=1,col=17,endColumn=18,title=oxlint::Parameter 'b' is declared but never used. Unused parameters should start with a '_'.
+::error file=test.js,line=5,endLine=5,col=1,endColumn=10,title=eslint(no-debugger)::`debugger` statement is not allowed
+::warning file=test.js,line=1,endLine=1,col=10,endColumn=13,title=eslint(no-unused-vars)::Function 'foo' is declared but never used.
+::warning file=test.js,line=1,endLine=1,col=17,endColumn=18,title=eslint(no-unused-vars)::Parameter 'b' is declared but never used. Unused parameters should start with a '_'.
 ----------
 CLI result: LintFoundErrors
 ----------

--- a/crates/oxc_diagnostics/src/reporter.rs
+++ b/crates/oxc_diagnostics/src/reporter.rs
@@ -91,6 +91,7 @@ impl DiagnosticResult {
     }
 }
 
+#[derive(Debug)]
 pub struct Info {
     pub start: InfoPosition,
     pub end: InfoPosition,
@@ -100,6 +101,7 @@ pub struct Info {
     pub rule_id: Option<String>,
 }
 
+#[derive(Debug)]
 pub struct InfoPosition {
     pub line: usize,
     pub column: usize,
@@ -112,7 +114,8 @@ impl Info {
         let mut filename = String::new();
         let mut message = String::new();
         let mut severity = Severity::Warning;
-        let mut rule_id = None;
+        let rule_id = diagnostic.code().map(|code| code.to_string());
+
         if let Some(mut labels) = diagnostic.labels() {
             if let Some(source) = diagnostic.source_code() {
                 if let Some(label) = labels.next() {
@@ -136,11 +139,11 @@ impl Info {
                             severity = Severity::Error;
                         }
                         let msg = diagnostic.to_string();
+
                         // Our messages usually comes with `eslint(rule): message`
-                        (rule_id, message) = msg.split_once(':').map_or_else(
-                            || (None, msg.to_string()),
-                            |(id, msg)| (Some(id.to_string()), msg.trim().to_string()),
-                        );
+                        message = msg
+                            .split_once(':')
+                            .map_or_else(|| msg.to_string(), |(_, msg)| msg.trim().to_string());
                     }
                 }
             }


### PR DESCRIPTION
closes #10204