### PR TITLE
style(ast): reformat `AstBuilder` doc comments

### DIFF
--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -22,7 +22,8 @@ pub struct AstBuilder<'a> {
 impl<'a> AstBuilder<'a> {
     /// Build a [`Program`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_program`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_program`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -60,7 +61,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`Program`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::program`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::program`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -92,7 +94,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`Program`] with `scope_id`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_program_with_scope_id`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_program_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -132,7 +135,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`Program`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::program_with_scope_id`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::program_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1300,7 +1304,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`IdentifierName`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_identifier_name`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_identifier_name`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1315,7 +1320,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`IdentifierName`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::identifier_name`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::identifier_name`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1330,7 +1336,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`IdentifierReference`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_identifier_reference`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_identifier_reference`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1349,7 +1356,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`IdentifierReference`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::identifier_reference`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::identifier_reference`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1368,7 +1376,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`IdentifierReference`] with `reference_id`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_identifier_reference_with_reference_id`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_identifier_reference_with_reference_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1393,7 +1402,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`IdentifierReference`] with `reference_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::identifier_reference_with_reference_id`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::identifier_reference_with_reference_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1417,7 +1427,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BindingIdentifier`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_binding_identifier`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_binding_identifier`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1436,7 +1447,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BindingIdentifier`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::binding_identifier`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::binding_identifier`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1451,7 +1463,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BindingIdentifier`] with `symbol_id`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_binding_identifier_with_symbol_id`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_binding_identifier_with_symbol_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1476,7 +1489,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BindingIdentifier`] with `symbol_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::binding_identifier_with_symbol_id`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::binding_identifier_with_symbol_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1497,7 +1511,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`LabelIdentifier`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_label_identifier`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_label_identifier`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1512,7 +1527,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`LabelIdentifier`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::label_identifier`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::label_identifier`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1527,7 +1543,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ThisExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_this_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_this_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1538,7 +1555,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ThisExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::this_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::this_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1549,7 +1567,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ArrayExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_array_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_array_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1567,7 +1586,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ArrayExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::array_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::array_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1610,7 +1630,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`Elision`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_elision`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_elision`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1621,7 +1642,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`Elision`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::elision`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::elision`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1632,7 +1654,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ObjectExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_object_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_object_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1650,7 +1673,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ObjectExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::object_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::object_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1712,7 +1736,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ObjectProperty`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_object_property`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_object_property`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1738,7 +1763,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ObjectProperty`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::object_property`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::object_property`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1797,7 +1823,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TemplateLiteral`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_template_literal`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_template_literal`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1815,7 +1842,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TemplateLiteral`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::template_literal`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::template_literal`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1833,7 +1861,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TaggedTemplateExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_tagged_template_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_tagged_template_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1861,7 +1890,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TaggedTemplateExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::tagged_template_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::tagged_template_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1887,7 +1917,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TemplateElement`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_template_element`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_template_element`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1905,7 +1936,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TemplateElement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::template_element`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::template_element`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1923,7 +1955,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TemplateElement`] with `lone_surrogates`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_template_element_with_lone_surrogates`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_template_element_with_lone_surrogates`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -1943,7 +1976,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TemplateElement`] with `lone_surrogates`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::template_element_with_lone_surrogates`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::template_element_with_lone_surrogates`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2032,7 +2066,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ComputedMemberExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_computed_member_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_computed_member_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2052,7 +2087,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ComputedMemberExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::computed_member_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::computed_member_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2075,7 +2111,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`StaticMemberExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_static_member_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_static_member_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2095,7 +2132,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`StaticMemberExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::static_member_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::static_member_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2115,7 +2153,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`PrivateFieldExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_private_field_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_private_field_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2135,7 +2174,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`PrivateFieldExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::private_field_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::private_field_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2155,7 +2195,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`CallExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_call_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_call_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2187,7 +2228,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`CallExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::call_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::call_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2215,7 +2257,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`CallExpression`] with `pure`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_call_expression_with_pure`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_call_expression_with_pure`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2249,7 +2292,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`CallExpression`] with `pure`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::call_expression_with_pure`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::call_expression_with_pure`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2279,7 +2323,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`NewExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_new_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_new_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2308,7 +2353,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`NewExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::new_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::new_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2331,7 +2377,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`NewExpression`] with `pure`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_new_expression_with_pure`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_new_expression_with_pure`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2362,7 +2409,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`NewExpression`] with `pure`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::new_expression_with_pure`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::new_expression_with_pure`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2390,7 +2438,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`MetaProperty`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_meta_property`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_meta_property`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2408,7 +2457,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`MetaProperty`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::meta_property`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::meta_property`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2426,7 +2476,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`SpreadElement`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_spread_element`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_spread_element`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2438,7 +2489,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`SpreadElement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::spread_element`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::spread_element`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2466,7 +2518,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`UpdateExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_update_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_update_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2486,7 +2539,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`UpdateExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::update_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::update_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2506,7 +2560,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`UnaryExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_unary_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_unary_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2524,7 +2579,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`UnaryExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::unary_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::unary_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2542,7 +2598,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BinaryExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_binary_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_binary_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2562,7 +2619,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BinaryExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::binary_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::binary_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2582,7 +2640,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`PrivateInExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_private_in_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_private_in_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2600,7 +2659,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`PrivateInExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::private_in_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::private_in_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2618,7 +2678,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`LogicalExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_logical_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_logical_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2638,7 +2699,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`LogicalExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::logical_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::logical_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2658,7 +2720,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ConditionalExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_conditional_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_conditional_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2678,7 +2741,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ConditionalExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::conditional_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::conditional_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2698,7 +2762,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`AssignmentExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_assignment_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_assignment_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2718,7 +2783,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`AssignmentExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::assignment_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::assignment_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2911,7 +2977,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ArrayAssignmentTarget`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_array_assignment_target`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_array_assignment_target`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2931,7 +2998,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ArrayAssignmentTarget`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::array_assignment_target`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::array_assignment_target`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2954,7 +3022,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ObjectAssignmentTarget`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_object_assignment_target`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_object_assignment_target`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2972,7 +3041,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ObjectAssignmentTarget`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::object_assignment_target`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::object_assignment_target`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -2990,7 +3060,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`AssignmentTargetRest`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_assignment_target_rest`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_assignment_target_rest`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -3006,7 +3077,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`AssignmentTargetRest`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::assignment_target_rest`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::assignment_target_rest`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -3042,7 +3114,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`AssignmentTargetWithDefault`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_assignment_target_with_default`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_assignment_target_with_default`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -3060,7 +3133,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`AssignmentTargetWithDefault`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::assignment_target_with_default`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::assignment_target_with_default`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -3120,7 +3194,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`AssignmentTargetPropertyIdentifier`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_assignment_target_property_identifier`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_assignment_target_property_identifier`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -3138,7 +3213,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`AssignmentTargetPropertyIdentifier`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::assignment_target_property_identifier`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::assignment_target_property_identifier`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -3156,7 +3232,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`AssignmentTargetPropertyProperty`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_assignment_target_property_property`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_assignment_target_property_property`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -3176,7 +3253,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`AssignmentTargetPropertyProperty`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::assignment_target_property_property`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::assignment_target_property_property`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -3199,7 +3277,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`SequenceExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_sequence_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_sequence_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -3215,7 +3294,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`SequenceExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::sequence_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::sequence_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -3231,7 +3311,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`Super`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_super`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_super`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -3242,7 +3323,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`Super`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::super_`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::super_`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -3253,7 +3335,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`AwaitExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_await_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_await_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -3265,7 +3348,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`AwaitExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::await_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::await_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -3281,7 +3365,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ChainExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_chain_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_chain_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -3293,7 +3378,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ChainExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::chain_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::chain_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -3390,7 +3476,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ParenthesizedExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_parenthesized_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_parenthesized_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -3406,7 +3493,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ParenthesizedExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::parenthesized_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::parenthesized_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -3838,7 +3926,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`Directive`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_directive`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_directive`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -3859,7 +3948,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`Directive`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::directive`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::directive`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -3880,7 +3970,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`Hashbang`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_hashbang`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_hashbang`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -3895,7 +3986,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`Hashbang`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::hashbang`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::hashbang`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -3910,7 +4002,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BlockStatement`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_block_statement`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_block_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -3922,7 +4015,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BlockStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::block_statement`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::block_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -3938,7 +4032,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BlockStatement`] with `scope_id`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_block_statement_with_scope_id`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_block_statement_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -3956,7 +4051,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BlockStatement`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::block_statement_with_scope_id`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::block_statement_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -4481,7 +4577,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`VariableDeclaration`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_variable_declaration`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_variable_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -4501,7 +4598,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`VariableDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::variable_declaration`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::variable_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -4521,7 +4619,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`VariableDeclarator`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_variable_declarator`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_variable_declarator`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -4543,7 +4642,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`VariableDeclarator`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::variable_declarator`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::variable_declarator`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -4565,7 +4665,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`EmptyStatement`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_empty_statement`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_empty_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -4576,7 +4677,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`EmptyStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::empty_statement`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::empty_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -4587,7 +4689,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ExpressionStatement`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_expression_statement`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_expression_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -4603,7 +4706,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ExpressionStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::expression_statement`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::expression_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -4619,7 +4723,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`IfStatement`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_if_statement`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_if_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -4639,7 +4744,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`IfStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::if_statement`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::if_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -4659,7 +4765,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`DoWhileStatement`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_do_while_statement`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_do_while_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -4677,7 +4784,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`DoWhileStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::do_while_statement`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::do_while_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -4695,7 +4803,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`WhileStatement`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_while_statement`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_while_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -4713,7 +4822,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`WhileStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::while_statement`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::while_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -4731,7 +4841,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ForStatement`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_for_statement`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_for_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -4753,7 +4864,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ForStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::for_statement`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::for_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -4775,7 +4887,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ForStatement`] with `scope_id`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_for_statement_with_scope_id`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_for_statement_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -4799,7 +4912,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ForStatement`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::for_statement_with_scope_id`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::for_statement_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -4851,7 +4965,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ForInStatement`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_for_in_statement`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_for_in_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -4871,7 +4986,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ForInStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::for_in_statement`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::for_in_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -4891,7 +5007,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ForInStatement`] with `scope_id`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_for_in_statement_with_scope_id`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_for_in_statement_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -4913,7 +5030,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ForInStatement`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::for_in_statement_with_scope_id`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::for_in_statement_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -4963,7 +5081,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ForOfStatement`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_for_of_statement`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_for_of_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -4985,7 +5104,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ForOfStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::for_of_statement`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::for_of_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5007,7 +5127,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ForOfStatement`] with `scope_id`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_for_of_statement_with_scope_id`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_for_of_statement_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5031,7 +5152,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ForOfStatement`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::for_of_statement_with_scope_id`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::for_of_statement_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5058,7 +5180,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ContinueStatement`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_continue_statement`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_continue_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5074,7 +5197,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ContinueStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::continue_statement`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::continue_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5090,7 +5214,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BreakStatement`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_break_statement`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_break_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5106,7 +5231,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BreakStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::break_statement`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::break_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5122,7 +5248,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ReturnStatement`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_return_statement`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_return_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5138,7 +5265,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ReturnStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::return_statement`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::return_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5154,7 +5282,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`WithStatement`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_with_statement`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_with_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5172,7 +5301,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`WithStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::with_statement`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::with_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5190,7 +5320,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`SwitchStatement`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_switch_statement`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_switch_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5208,7 +5339,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`SwitchStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::switch_statement`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::switch_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5226,7 +5358,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`SwitchStatement`] with `scope_id`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_switch_statement_with_scope_id`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_switch_statement_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5246,7 +5379,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`SwitchStatement`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::switch_statement_with_scope_id`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::switch_statement_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5269,7 +5403,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`SwitchCase`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_switch_case`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_switch_case`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5287,7 +5422,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`SwitchCase`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::switch_case`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::switch_case`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5305,7 +5441,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`LabeledStatement`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_labeled_statement`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_labeled_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5323,7 +5460,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`LabeledStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::labeled_statement`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::labeled_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5341,7 +5479,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ThrowStatement`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_throw_statement`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_throw_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5353,7 +5492,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ThrowStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::throw_statement`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::throw_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5369,7 +5509,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TryStatement`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_try_statement`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_try_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5399,7 +5540,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TryStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::try_statement`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::try_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5424,7 +5566,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`CatchClause`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_catch_clause`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_catch_clause`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5450,7 +5593,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`CatchClause`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::catch_clause`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::catch_clause`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5471,7 +5615,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`CatchClause`] with `scope_id`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_catch_clause_with_scope_id`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_catch_clause_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5499,7 +5644,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`CatchClause`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::catch_clause_with_scope_id`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::catch_clause_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5522,7 +5668,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`CatchParameter`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_catch_parameter`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_catch_parameter`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5534,7 +5681,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`CatchParameter`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::catch_parameter`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::catch_parameter`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5550,7 +5698,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`DebuggerStatement`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_debugger_statement`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_debugger_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5561,7 +5710,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`DebuggerStatement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::debugger_statement`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::debugger_statement`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5572,7 +5722,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BindingPattern`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_binding_pattern`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_binding_pattern`] instead.
     ///
     /// ## Parameters
     /// * `kind`
@@ -5593,7 +5744,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BindingPattern`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::binding_pattern`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::binding_pattern`] instead.
     ///
     /// ## Parameters
     /// * `kind`
@@ -5716,7 +5868,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`AssignmentPattern`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_assignment_pattern`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_assignment_pattern`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5734,7 +5887,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`AssignmentPattern`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::assignment_pattern`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::assignment_pattern`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5752,7 +5906,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ObjectPattern`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_object_pattern`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_object_pattern`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5773,7 +5928,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ObjectPattern`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::object_pattern`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::object_pattern`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5794,7 +5950,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BindingProperty`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_binding_property`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_binding_property`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5816,7 +5973,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BindingProperty`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::binding_property`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::binding_property`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5838,7 +5996,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ArrayPattern`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_array_pattern`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_array_pattern`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5859,7 +6018,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ArrayPattern`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::array_pattern`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::array_pattern`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5880,7 +6040,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BindingRestElement`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_binding_rest_element`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_binding_rest_element`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5896,7 +6057,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BindingRestElement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::binding_rest_element`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::binding_rest_element`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5912,7 +6074,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`Function`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_function`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_function`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -5967,7 +6130,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`Function`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::function`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::function`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -6023,7 +6187,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`Function`] with `scope_id` and `pure`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_function_with_scope_id_and_pure`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_function_with_scope_id_and_pure`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -6082,7 +6247,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`Function`] with `scope_id` and `pure`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::function_with_scope_id_and_pure`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::function_with_scope_id_and_pure`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -6144,7 +6310,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`FormalParameters`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_formal_parameters`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_formal_parameters`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -6167,7 +6334,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`FormalParameters`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::formal_parameters`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::formal_parameters`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -6190,7 +6358,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`FormalParameter`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_formal_parameter`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_formal_parameter`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -6214,7 +6383,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`FormalParameter`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::formal_parameter`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::formal_parameter`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -6241,7 +6411,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`FunctionBody`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_function_body`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_function_body`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -6259,7 +6430,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`FunctionBody`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::function_body`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::function_body`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -6277,7 +6449,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ArrowFunctionExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_arrow_function_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_arrow_function_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -6319,7 +6492,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ArrowFunctionExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::arrow_function_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::arrow_function_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -6362,7 +6536,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ArrowFunctionExpression`] with `scope_id` and `pure`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_arrow_function_expression_with_scope_id_and_pure`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_arrow_function_expression_with_scope_id_and_pure`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -6408,7 +6583,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ArrowFunctionExpression`] with `scope_id` and `pure`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::arrow_function_expression_with_scope_id_and_pure`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::arrow_function_expression_with_scope_id_and_pure`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -6457,7 +6633,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`YieldExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_yield_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_yield_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -6475,7 +6652,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`YieldExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::yield_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::yield_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -6493,7 +6671,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`Class`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_class`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_class`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -6545,7 +6724,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`Class`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::class`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::class`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -6599,7 +6779,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`Class`] with `scope_id`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_class_with_scope_id`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_class_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -6653,7 +6834,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`Class`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::class_with_scope_id`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::class_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -6710,7 +6892,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ClassBody`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_class_body`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_class_body`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -6722,7 +6905,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`ClassBody`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::class_body`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::class_body`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -6956,7 +7140,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`MethodDefinition`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_method_definition`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_method_definition`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7005,7 +7190,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`MethodDefinition`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::method_definition`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::method_definition`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7057,7 +7243,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`PropertyDefinition`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_property_definition`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_property_definition`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7115,7 +7302,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`PropertyDefinition`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::property_definition`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::property_definition`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7176,7 +7364,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`PrivateIdentifier`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_private_identifier`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_private_identifier`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7191,7 +7380,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`PrivateIdentifier`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::private_identifier`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::private_identifier`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7206,7 +7396,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`StaticBlock`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_static_block`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_static_block`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7218,7 +7409,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`StaticBlock`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::static_block`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::static_block`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7234,7 +7426,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`StaticBlock`] with `scope_id`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_static_block_with_scope_id`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_static_block_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7252,7 +7445,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`StaticBlock`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::static_block_with_scope_id`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::static_block_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7425,7 +7619,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`AccessorProperty`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_accessor_property`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_accessor_property`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7471,7 +7666,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`AccessorProperty`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::accessor_property`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::accessor_property`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7520,7 +7716,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ImportExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_import_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_import_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7540,7 +7737,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ImportExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::import_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::import_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7560,7 +7758,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ImportDeclaration`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_import_declaration`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_import_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7594,7 +7793,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ImportDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::import_declaration`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::import_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7685,7 +7885,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ImportSpecifier`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_import_specifier`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_import_specifier`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7705,7 +7906,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ImportSpecifier`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::import_specifier`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::import_specifier`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7725,7 +7927,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ImportDefaultSpecifier`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_import_default_specifier`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_import_default_specifier`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7741,7 +7944,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ImportDefaultSpecifier`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::import_default_specifier`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::import_default_specifier`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7757,7 +7961,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ImportNamespaceSpecifier`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_import_namespace_specifier`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_import_namespace_specifier`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7773,7 +7978,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ImportNamespaceSpecifier`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::import_namespace_specifier`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::import_namespace_specifier`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7789,7 +7995,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`WithClause`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_with_clause`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_with_clause`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7807,7 +8014,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`WithClause`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::with_clause`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::with_clause`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7825,7 +8033,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ImportAttribute`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_import_attribute`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_import_attribute`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7843,7 +8052,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ImportAttribute`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::import_attribute`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::import_attribute`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7919,7 +8129,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ExportNamedDeclaration`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_export_named_declaration`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_export_named_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7953,7 +8164,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ExportNamedDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::export_named_declaration`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::export_named_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -7990,7 +8202,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ExportDefaultDeclaration`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_export_default_declaration`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_export_default_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -8008,7 +8221,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ExportDefaultDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::export_default_declaration`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::export_default_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -8026,7 +8240,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ExportAllDeclaration`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_export_all_declaration`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_export_all_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -8057,7 +8272,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ExportAllDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::export_all_declaration`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::export_all_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -8085,7 +8301,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ExportSpecifier`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_export_specifier`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_export_specifier`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -8105,7 +8322,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build an [`ExportSpecifier`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::export_specifier`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::export_specifier`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -8523,7 +8741,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`V8IntrinsicExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_v_8_intrinsic_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_v_8_intrinsic_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -8541,7 +8760,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`V8IntrinsicExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::v_8_intrinsic_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::v_8_intrinsic_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -8559,7 +8779,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BooleanLiteral`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_boolean_literal`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_boolean_literal`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -8571,7 +8792,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BooleanLiteral`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::boolean_literal`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::boolean_literal`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -8583,7 +8805,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`NullLiteral`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_null_literal`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_null_literal`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -8594,7 +8817,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`NullLiteral`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::null_literal`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::null_literal`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -8605,7 +8829,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`NumericLiteral`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_numeric_literal`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_numeric_literal`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -8625,7 +8850,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`NumericLiteral`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::numeric_literal`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::numeric_literal`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -8645,7 +8871,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`StringLiteral`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_string_literal`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_string_literal`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -8666,7 +8893,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`StringLiteral`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::string_literal`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::string_literal`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -8687,7 +8915,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`StringLiteral`] with `lone_surrogates`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_string_literal_with_lone_surrogates`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_string_literal_with_lone_surrogates`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -8710,7 +8939,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`StringLiteral`] with `lone_surrogates`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::string_literal_with_lone_surrogates`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::string_literal_with_lone_surrogates`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -8736,7 +8966,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BigIntLiteral`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_big_int_literal`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_big_int_literal`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -8752,7 +8983,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`BigIntLiteral`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::big_int_literal`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::big_int_literal`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -8773,7 +9005,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`RegExpLiteral`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_reg_exp_literal`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_reg_exp_literal`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -8791,7 +9024,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`RegExpLiteral`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::reg_exp_literal`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::reg_exp_literal`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -8809,7 +9043,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXElement`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_element`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_jsx_element`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -8838,7 +9073,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXElement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_element`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::jsx_element`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -8865,7 +9101,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXOpeningElement`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_opening_element`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_jsx_opening_element`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -8896,7 +9133,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXOpeningElement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_opening_element`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::jsx_opening_element`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -8924,7 +9162,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXClosingElement`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_closing_element`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_jsx_closing_element`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -8940,7 +9179,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXClosingElement`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_closing_element`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::jsx_closing_element`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -8956,7 +9196,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXFragment`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_fragment`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_jsx_fragment`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -8976,7 +9217,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXFragment`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_fragment`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::jsx_fragment`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -8999,7 +9241,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXOpeningFragment`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_opening_fragment`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_jsx_opening_fragment`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -9010,7 +9253,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXOpeningFragment`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_opening_fragment`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::jsx_opening_fragment`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -9021,7 +9265,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXClosingFragment`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_closing_fragment`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_jsx_closing_fragment`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -9032,7 +9277,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXClosingFragment`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_closing_fragment`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::jsx_closing_fragment`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -9145,7 +9391,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXNamespacedName`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_namespaced_name`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_jsx_namespaced_name`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -9163,7 +9410,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXNamespacedName`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_namespaced_name`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::jsx_namespaced_name`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -9181,7 +9429,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXMemberExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_member_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_jsx_member_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -9199,7 +9448,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXMemberExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_member_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::jsx_member_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -9293,7 +9543,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXExpressionContainer`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_expression_container`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_jsx_expression_container`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -9309,7 +9560,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXExpressionContainer`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_expression_container`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::jsx_expression_container`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -9334,7 +9586,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXEmptyExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_empty_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_jsx_empty_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -9345,7 +9598,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXEmptyExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_empty_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::jsx_empty_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -9390,7 +9644,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXAttribute`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_attribute`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_jsx_attribute`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -9408,7 +9663,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXAttribute`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_attribute`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::jsx_attribute`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -9426,7 +9682,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXSpreadAttribute`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_spread_attribute`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_jsx_spread_attribute`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -9442,7 +9699,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXSpreadAttribute`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_spread_attribute`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::jsx_spread_attribute`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -9612,7 +9870,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXIdentifier`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_identifier`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_jsx_identifier`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -9627,7 +9886,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXIdentifier`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_identifier`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::jsx_identifier`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -9735,7 +9995,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXSpreadChild`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_spread_child`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_jsx_spread_child`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -9747,7 +10008,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXSpreadChild`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_spread_child`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::jsx_spread_child`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -9763,7 +10025,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXText`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_jsx_text`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_jsx_text`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -9779,7 +10042,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSXText`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::jsx_text`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::jsx_text`] instead.
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
@@ -9800,7 +10064,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSThisParameter`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_this_parameter`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_this_parameter`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -9825,7 +10090,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSThisParameter`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_this_parameter`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_this_parameter`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -9846,7 +10112,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSEnumDeclaration`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_enum_declaration`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_enum_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -9868,7 +10135,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSEnumDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_enum_declaration`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_enum_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -9890,7 +10158,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSEnumDeclaration`] with `scope_id`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_enum_declaration_with_scope_id`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_enum_declaration_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -9921,7 +10190,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSEnumDeclaration`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_enum_declaration_with_scope_id`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_enum_declaration_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -9948,7 +10218,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSEnumMember`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_enum_member`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_enum_member`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -9966,7 +10237,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSEnumMember`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_enum_member`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_enum_member`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -10048,7 +10320,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeAnnotation`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_type_annotation`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_type_annotation`] instead.
     ///
     /// ## Parameters
     /// * `span`: starts at the `:` token and ends at the end of the type annotation
@@ -10064,7 +10337,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeAnnotation`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_type_annotation`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_type_annotation`] instead.
     ///
     /// ## Parameters
     /// * `span`: starts at the `:` token and ends at the end of the type annotation
@@ -10080,7 +10354,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSLiteralType`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_literal_type`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_literal_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -10092,7 +10367,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSLiteralType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_literal_type`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_literal_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -10976,7 +11252,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSConditionalType`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_conditional_type`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_conditional_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11005,7 +11282,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSConditionalType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_conditional_type`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_conditional_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11030,7 +11308,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSConditionalType`] with `scope_id`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_conditional_type_with_scope_id`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_conditional_type_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11061,7 +11340,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSConditionalType`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_conditional_type_with_scope_id`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_conditional_type_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11095,7 +11375,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSUnionType`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_union_type`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_union_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11107,7 +11388,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSUnionType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_union_type`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_union_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11123,7 +11405,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSIntersectionType`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_intersection_type`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_intersection_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11139,7 +11422,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSIntersectionType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_intersection_type`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_intersection_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11155,7 +11439,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSParenthesizedType`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_parenthesized_type`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_parenthesized_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11171,7 +11456,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSParenthesizedType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_parenthesized_type`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_parenthesized_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11187,7 +11473,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeOperator`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_type_operator`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_type_operator`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11205,7 +11492,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeOperator`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_type_operator`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_type_operator`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11223,7 +11511,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSArrayType`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_array_type`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_array_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11235,7 +11524,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSArrayType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_array_type`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_array_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11251,7 +11541,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSIndexedAccessType`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_indexed_access_type`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_indexed_access_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11269,7 +11560,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSIndexedAccessType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_indexed_access_type`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_indexed_access_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11287,7 +11579,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTupleType`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_tuple_type`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_tuple_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11303,7 +11596,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTupleType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_tuple_type`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_tuple_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11319,7 +11613,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSNamedTupleMember`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_named_tuple_member`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_named_tuple_member`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11339,7 +11634,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSNamedTupleMember`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_named_tuple_member`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_named_tuple_member`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11359,7 +11655,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSOptionalType`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_optional_type`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_optional_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11371,7 +11668,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSOptionalType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_optional_type`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_optional_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11387,7 +11685,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSRestType`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_rest_type`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_rest_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11399,7 +11698,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSRestType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_rest_type`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_rest_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11447,7 +11747,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSAnyKeyword`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_any_keyword`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_any_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11458,7 +11759,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSAnyKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_any_keyword`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_any_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11469,7 +11771,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSStringKeyword`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_string_keyword`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_string_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11480,7 +11783,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSStringKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_string_keyword`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_string_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11491,7 +11795,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSBooleanKeyword`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_boolean_keyword`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_boolean_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11502,7 +11807,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSBooleanKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_boolean_keyword`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_boolean_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11513,7 +11819,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSNumberKeyword`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_number_keyword`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_number_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11524,7 +11831,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSNumberKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_number_keyword`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_number_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11535,7 +11843,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSNeverKeyword`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_never_keyword`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_never_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11546,7 +11855,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSNeverKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_never_keyword`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_never_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11557,7 +11867,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSIntrinsicKeyword`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_intrinsic_keyword`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_intrinsic_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11568,7 +11879,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSIntrinsicKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_intrinsic_keyword`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_intrinsic_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11579,7 +11891,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSUnknownKeyword`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_unknown_keyword`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_unknown_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11590,7 +11903,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSUnknownKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_unknown_keyword`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_unknown_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11601,7 +11915,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSNullKeyword`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_null_keyword`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_null_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11612,7 +11927,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSNullKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_null_keyword`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_null_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11623,7 +11939,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSUndefinedKeyword`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_undefined_keyword`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_undefined_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11634,7 +11951,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSUndefinedKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_undefined_keyword`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_undefined_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11645,7 +11963,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSVoidKeyword`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_void_keyword`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_void_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11656,7 +11975,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSVoidKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_void_keyword`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_void_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11667,7 +11987,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSSymbolKeyword`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_symbol_keyword`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_symbol_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11678,7 +11999,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSSymbolKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_symbol_keyword`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_symbol_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11689,7 +12011,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSThisType`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_this_type`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_this_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11700,7 +12023,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSThisType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_this_type`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_this_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11711,7 +12035,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSObjectKeyword`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_object_keyword`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_object_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11722,7 +12047,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSObjectKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_object_keyword`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_object_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11733,7 +12059,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSBigIntKeyword`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_big_int_keyword`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_big_int_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11744,7 +12071,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSBigIntKeyword`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_big_int_keyword`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_big_int_keyword`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11755,7 +12083,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeReference`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_type_reference`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_type_reference`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11776,7 +12105,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeReference`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_type_reference`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_type_reference`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11855,7 +12185,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSQualifiedName`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_qualified_name`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_qualified_name`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11873,7 +12204,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSQualifiedName`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_qualified_name`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_qualified_name`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11891,7 +12223,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeParameterInstantiation`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_type_parameter_instantiation`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_type_parameter_instantiation`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11907,7 +12240,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeParameterInstantiation`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_type_parameter_instantiation`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_type_parameter_instantiation`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11923,7 +12257,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeParameter`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_type_parameter`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_type_parameter`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11949,7 +12284,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeParameter`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_type_parameter`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_type_parameter`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11978,7 +12314,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeParameterDeclaration`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_type_parameter_declaration`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_type_parameter_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -11994,7 +12331,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeParameterDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_type_parameter_declaration`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_type_parameter_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -12010,7 +12348,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeAliasDeclaration`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_type_alias_declaration`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_type_alias_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -12042,7 +12381,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeAliasDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_type_alias_declaration`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_type_alias_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -12070,7 +12410,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeAliasDeclaration`] with `scope_id`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_type_alias_declaration_with_scope_id`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_type_alias_declaration_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -12104,7 +12445,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeAliasDeclaration`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_type_alias_declaration_with_scope_id`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_type_alias_declaration_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -12141,7 +12483,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSClassImplements`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_class_implements`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_class_implements`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -12166,7 +12509,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSClassImplements`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_class_implements`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_class_implements`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -12187,7 +12531,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSInterfaceDeclaration`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_interface_declaration`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_interface_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -12223,7 +12568,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSInterfaceDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_interface_declaration`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_interface_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -12254,7 +12600,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSInterfaceDeclaration`] with `scope_id`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_interface_declaration_with_scope_id`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_interface_declaration_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -12292,7 +12639,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSInterfaceDeclaration`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_interface_declaration_with_scope_id`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_interface_declaration_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -12333,7 +12681,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSInterfaceBody`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_interface_body`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_interface_body`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -12349,7 +12698,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSInterfaceBody`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_interface_body`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_interface_body`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -12365,7 +12715,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSPropertySignature`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_property_signature`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_property_signature`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -12399,7 +12750,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSPropertySignature`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_property_signature`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_property_signature`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -12687,7 +13039,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSIndexSignature`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_index_signature`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_index_signature`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -12718,7 +13071,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSIndexSignature`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_index_signature`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_index_signature`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -12746,7 +13100,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSCallSignatureDeclaration`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_call_signature_declaration`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_call_signature_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -12779,7 +13134,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSCallSignatureDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_call_signature_declaration`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_call_signature_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -12815,7 +13171,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSMethodSignature`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_method_signature`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_method_signature`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -12862,7 +13219,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSMethodSignature`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_method_signature`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_method_signature`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -12911,7 +13269,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSMethodSignature`] with `scope_id`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_method_signature_with_scope_id`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_method_signature_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -12960,7 +13319,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSMethodSignature`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_method_signature_with_scope_id`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_method_signature_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13012,7 +13372,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSConstructSignatureDeclaration`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_construct_signature_declaration`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_construct_signature_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13043,7 +13404,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSConstructSignatureDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_construct_signature_declaration`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_construct_signature_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13071,7 +13433,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSConstructSignatureDeclaration`] with `scope_id`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_construct_signature_declaration_with_scope_id`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_construct_signature_declaration_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13104,7 +13467,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSConstructSignatureDeclaration`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_construct_signature_declaration_with_scope_id`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_construct_signature_declaration_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13140,7 +13504,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSIndexSignatureName`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_index_signature_name`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_index_signature_name`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13166,7 +13531,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSIndexSignatureName`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_index_signature_name`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_index_signature_name`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13188,7 +13554,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSInterfaceHeritage`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_interface_heritage`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_interface_heritage`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13213,7 +13580,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSInterfaceHeritage`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_interface_heritage`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_interface_heritage`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13234,7 +13602,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypePredicate`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_type_predicate`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_type_predicate`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13262,7 +13631,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypePredicate`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_type_predicate`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_type_predicate`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13316,7 +13686,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSModuleDeclaration`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_module_declaration`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_module_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13338,7 +13709,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSModuleDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_module_declaration`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_module_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13360,7 +13732,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSModuleDeclaration`] with `scope_id`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_module_declaration_with_scope_id`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_module_declaration_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13384,7 +13757,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSModuleDeclaration`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_module_declaration_with_scope_id`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_module_declaration_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13562,7 +13936,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSModuleBlock`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_module_block`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_module_block`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13580,7 +13955,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSModuleBlock`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_module_block`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_module_block`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13598,7 +13974,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeLiteral`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_type_literal`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_type_literal`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13614,7 +13991,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeLiteral`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_type_literal`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_type_literal`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13630,7 +14008,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSInferType`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_infer_type`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_infer_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13645,7 +14024,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSInferType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_infer_type`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_infer_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13660,7 +14040,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeQuery`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_type_query`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_type_query`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13681,7 +14062,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeQuery`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_type_query`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_type_query`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13737,7 +14119,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSImportType`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_import_type`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_import_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13772,7 +14155,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSImportType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_import_type`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_import_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13803,7 +14187,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSFunctionType`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_function_type`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_function_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13838,7 +14223,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSFunctionType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_function_type`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_function_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13869,7 +14255,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSFunctionType`] with `scope_id`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_function_type_with_scope_id`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_function_type_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13906,7 +14293,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSFunctionType`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_function_type_with_scope_id`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_function_type_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13946,7 +14334,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSConstructorType`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_constructor_type`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_constructor_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -13979,7 +14368,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSConstructorType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_constructor_type`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_constructor_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14009,7 +14399,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSMappedType`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_mapped_type`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_mapped_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14044,7 +14435,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSMappedType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_mapped_type`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_mapped_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14081,7 +14473,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSMappedType`] with `scope_id`.
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_mapped_type_with_scope_id`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_mapped_type_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14118,7 +14511,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSMappedType`] with `scope_id`, and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_mapped_type_with_scope_id`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_mapped_type_with_scope_id`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14158,7 +14552,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTemplateLiteralType`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_template_literal_type`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_template_literal_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14176,7 +14571,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTemplateLiteralType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_template_literal_type`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_template_literal_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14194,7 +14590,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSAsExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_as_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_as_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14212,7 +14609,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSAsExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_as_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_as_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14230,7 +14628,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSSatisfiesExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_satisfies_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_satisfies_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14248,7 +14647,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSSatisfiesExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_satisfies_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_satisfies_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14266,7 +14666,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeAssertion`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_type_assertion`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_type_assertion`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14284,7 +14685,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSTypeAssertion`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_type_assertion`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_type_assertion`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14302,7 +14704,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSImportEqualsDeclaration`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_import_equals_declaration`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_import_equals_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14322,7 +14725,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSImportEqualsDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_import_equals_declaration`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_import_equals_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14363,7 +14767,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSExternalModuleReference`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_external_module_reference`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_external_module_reference`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14379,7 +14784,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSExternalModuleReference`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_external_module_reference`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_external_module_reference`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14395,7 +14801,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSNonNullExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_non_null_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_non_null_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14411,7 +14818,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSNonNullExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_non_null_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_non_null_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14427,7 +14835,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`Decorator`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_decorator`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_decorator`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14439,7 +14848,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`Decorator`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::decorator`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::decorator`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14451,7 +14861,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSExportAssignment`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_export_assignment`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_export_assignment`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14467,7 +14878,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSExportAssignment`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_export_assignment`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_export_assignment`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14483,7 +14895,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSNamespaceExportDeclaration`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_namespace_export_declaration`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_namespace_export_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14499,7 +14912,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSNamespaceExportDeclaration`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_namespace_export_declaration`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_namespace_export_declaration`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14515,7 +14929,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSInstantiationExpression`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_ts_instantiation_expression`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_ts_instantiation_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14540,7 +14955,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`TSInstantiationExpression`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::ts_instantiation_expression`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::ts_instantiation_expression`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14564,7 +14980,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSDocNullableType`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_js_doc_nullable_type`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_js_doc_nullable_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14582,7 +14999,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSDocNullableType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::js_doc_nullable_type`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::js_doc_nullable_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14600,7 +15018,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSDocNonNullableType`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_js_doc_non_nullable_type`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_js_doc_non_nullable_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14618,7 +15037,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSDocNonNullableType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::js_doc_non_nullable_type`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::js_doc_non_nullable_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14636,7 +15056,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSDocUnknownType`].
     ///
-    /// If you want the built node to be allocated in the memory arena, use [`AstBuilder::alloc_js_doc_unknown_type`] instead.
+    /// If you want the built node to be allocated in the memory arena,
+    /// use [`AstBuilder::alloc_js_doc_unknown_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
@@ -14647,7 +15068,8 @@ impl<'a> AstBuilder<'a> {
 
     /// Build a [`JSDocUnknownType`], and store it in the memory arena.
     ///
-    /// Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::js_doc_unknown_type`] instead.
+    /// Returns a [`Box`] containing the newly-allocated node.
+    /// If you want a stack-allocated node, use [`AstBuilder::js_doc_unknown_type`] instead.
     ///
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node

--- a/tasks/ast_tools/src/generators/ast_builder.rs
+++ b/tasks/ast_tools/src/generators/ast_builder.rs
@@ -215,15 +215,14 @@ fn generate_builder_methods_for_struct_impl(
     let struct_name = struct_def.name();
     let article = article_for(struct_name);
     let fn_doc1 = format!(" Build {article} [`{struct_name}`]{doc_postfix}.");
-    let fn_doc2 = format!(
-        " If you want the built node to be allocated in the memory arena, use [`AstBuilder::{alloc_fn_name}`] instead."
-    );
+    let fn_doc2 = " If you want the built node to be allocated in the memory arena,";
+    let fn_doc3 = format!(" use [`AstBuilder::{alloc_fn_name}`] instead.");
     let alloc_doc1 = format!(
         " Build {article} [`{struct_name}`]{doc_postfix}, and store it in the memory arena."
     );
-    let alloc_doc2 = format!(
-        " Returns a [`Box`] containing the newly-allocated node. If you want a stack-allocated node, use [`AstBuilder::{fn_name}`] instead."
-    );
+    let alloc_doc2 = " Returns a [`Box`] containing the newly-allocated node.";
+    let alloc_doc3 =
+        format!(" If you want a stack-allocated node, use [`AstBuilder::{fn_name}`] instead.");
     let params_docs = generate_doc_comment_for_params(params);
 
     quote! {
@@ -231,6 +230,7 @@ fn generate_builder_methods_for_struct_impl(
         #[doc = #fn_doc1]
         #[doc = ""]
         #[doc = #fn_doc2]
+        #[doc = #fn_doc3]
         #params_docs
         #[inline]
         pub fn #fn_name #generic_params (self, #fn_params) -> #struct_ty #where_clause {
@@ -241,6 +241,7 @@ fn generate_builder_methods_for_struct_impl(
         #[doc = #alloc_doc1]
         #[doc = ""]
         #[doc = #alloc_doc2]
+        #[doc = #alloc_doc3]
         #params_docs
         #[inline]
         pub fn #alloc_fn_name #generic_params (self, #fn_params) -> Box<'a, #struct_ty> #where_clause {


### PR DESCRIPTION
Style change only. Format doc comments on `AstBuilder` methods to make them more readable.
