### PR TITLE
feat(ast_tools): record `TypeId` of containers on types

### DIFF
--- a/tasks/ast_tools/src/schema/defs/box.rs
+++ b/tasks/ast_tools/src/schema/defs/box.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use super::{Def, Derives, Schema, TypeDef, TypeId, extensions::layout::Layout};
+use super::{Containers, Def, Derives, Schema, TypeDef, TypeId, extensions::layout::Layout};
 
 /// Type definition for a `Box`.
 #[derive(Debug)]
@@ -9,13 +9,20 @@ pub struct BoxDef {
     pub id: TypeId,
     pub name: String,
     pub inner_type_id: TypeId,
+    pub containers: Containers,
     pub layout: Layout,
 }
 
 impl BoxDef {
     /// Create new [`BoxDef`].
     pub fn new(name: String, inner_type_id: TypeId) -> Self {
-        Self { id: TypeId::DUMMY, name, inner_type_id, layout: Layout::default() }
+        Self {
+            id: TypeId::DUMMY,
+            name,
+            inner_type_id,
+            containers: Containers::default(),
+            layout: Layout::default(),
+        }
     }
 
     /// Get inner type.

--- a/tasks/ast_tools/src/schema/defs/cell.rs
+++ b/tasks/ast_tools/src/schema/defs/cell.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use super::{Def, Derives, Schema, TypeDef, TypeId, extensions::layout::Layout};
+use super::{Containers, Def, Derives, Schema, TypeDef, TypeId, extensions::layout::Layout};
 
 /// Type definition for a `Cell`.
 #[derive(Debug)]
@@ -9,13 +9,20 @@ pub struct CellDef {
     pub id: TypeId,
     pub name: String,
     pub inner_type_id: TypeId,
+    pub containers: Containers,
     pub layout: Layout,
 }
 
 impl CellDef {
     /// Create new [`CellDef`].
     pub fn new(name: String, inner_type_id: TypeId) -> Self {
-        Self { id: TypeId::DUMMY, name, inner_type_id, layout: Layout::default() }
+        Self {
+            id: TypeId::DUMMY,
+            name,
+            inner_type_id,
+            containers: Containers::default(),
+            layout: Layout::default(),
+        }
     }
 
     /// Get inner type.

--- a/tasks/ast_tools/src/schema/defs/enum.rs
+++ b/tasks/ast_tools/src/schema/defs/enum.rs
@@ -8,7 +8,7 @@ use syn::Ident;
 use crate::utils::{create_ident, pluralize};
 
 use super::{
-    Def, Derives, File, FileId, Schema, TypeDef, TypeId, Visibility,
+    Containers, Def, Derives, File, FileId, Schema, TypeDef, TypeId, Visibility,
     extensions::{
         ast_builder::AstBuilderType,
         clone_in::CloneInType,
@@ -33,6 +33,7 @@ pub struct EnumDef {
     #[expect(unused)]
     pub is_foreign: bool,
     pub file_id: FileId,
+    pub containers: Containers,
     #[expect(unused)]
     pub visibility: Visibility,
     pub generated_derives: Derives,
@@ -70,6 +71,7 @@ impl EnumDef {
             has_lifetime,
             is_foreign,
             file_id,
+            containers: Containers::default(),
             visibility,
             generated_derives,
             variants,

--- a/tasks/ast_tools/src/schema/defs/mod.rs
+++ b/tasks/ast_tools/src/schema/defs/mod.rs
@@ -115,6 +115,23 @@ pub trait Def {
     }
 }
 
+/// IDs of container types containing a type.
+///
+/// e.g. If `Option<Expression>` exists in AST, `Containers::option_id` for `Expression` type def
+/// will contain the [`TypeId`] of `Option<Expression>`.
+#[derive(Clone, Default, Debug)]
+#[expect(clippy::struct_field_names)]
+pub struct Containers {
+    /// [`TypeId`] of `Option` containing this type, if it exists in AST
+    pub option_id: Option<TypeId>,
+    /// [`TypeId`] of `Box` containing this type, if it exists in AST
+    pub box_id: Option<TypeId>,
+    /// [`TypeId`] of `Vec` containing this type, if it exists in AST
+    pub vec_id: Option<TypeId>,
+    /// [`TypeId`] of `Cell` containing this type, if it exists in AST
+    pub cell_id: Option<TypeId>,
+}
+
 /// Visibility of a struct / enum / struct field.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Visibility {

--- a/tasks/ast_tools/src/schema/defs/option.rs
+++ b/tasks/ast_tools/src/schema/defs/option.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use super::{Def, Derives, Schema, TypeDef, TypeId, extensions::layout::Layout};
+use super::{Containers, Def, Derives, Schema, TypeDef, TypeId, extensions::layout::Layout};
 
 /// Type definition for an `Option`.
 #[derive(Debug)]
@@ -9,13 +9,20 @@ pub struct OptionDef {
     pub id: TypeId,
     pub name: String,
     pub inner_type_id: TypeId,
+    pub containers: Containers,
     pub layout: Layout,
 }
 
 impl OptionDef {
     /// Create new [`OptionDef`].
     pub fn new(name: String, inner_type_id: TypeId) -> Self {
-        Self { id: TypeId::DUMMY, name, inner_type_id, layout: Layout::default() }
+        Self {
+            id: TypeId::DUMMY,
+            name,
+            inner_type_id,
+            containers: Containers::default(),
+            layout: Layout::default(),
+        }
     }
 
     /// Get inner type.

--- a/tasks/ast_tools/src/schema/defs/primitive.rs
+++ b/tasks/ast_tools/src/schema/defs/primitive.rs
@@ -1,7 +1,7 @@
 use proc_macro2::TokenStream;
 use quote::quote;
 
-use super::{Def, Derives, Schema, TypeDef, TypeId, extensions::layout::Layout};
+use super::{Containers, Def, Derives, Schema, TypeDef, TypeId, extensions::layout::Layout};
 
 /// Type definition for a primitive type.
 ///
@@ -12,13 +12,19 @@ use super::{Def, Derives, Schema, TypeDef, TypeId, extensions::layout::Layout};
 pub struct PrimitiveDef {
     pub id: TypeId,
     pub name: &'static str,
+    pub containers: Containers,
     pub layout: Layout,
 }
 
 impl PrimitiveDef {
     /// Create new [`PrimitiveDef`].
     pub fn new(name: &'static str) -> Self {
-        Self { id: TypeId::DUMMY, name, layout: Layout::default() }
+        Self {
+            id: TypeId::DUMMY,
+            name,
+            containers: Containers::default(),
+            layout: Layout::default(),
+        }
     }
 }
 

--- a/tasks/ast_tools/src/schema/defs/struct.rs
+++ b/tasks/ast_tools/src/schema/defs/struct.rs
@@ -7,7 +7,7 @@ use quote::quote;
 use crate::utils::{create_ident_tokens, pluralize};
 
 use super::{
-    Def, Derives, File, FileId, Schema, TypeDef, TypeId, Visibility,
+    Containers, Def, Derives, File, FileId, Schema, TypeDef, TypeId, Visibility,
     extensions::{
         ast_builder::{AstBuilderStructField, AstBuilderType},
         clone_in::{CloneInStructField, CloneInType},
@@ -30,6 +30,7 @@ pub struct StructDef {
     pub has_lifetime: bool,
     pub is_foreign: bool,
     pub file_id: FileId,
+    pub containers: Containers,
     #[expect(unused)]
     pub visibility: Visibility,
     pub generated_derives: Derives,
@@ -65,6 +66,7 @@ impl StructDef {
             has_lifetime,
             is_foreign,
             file_id,
+            containers: Containers::default(),
             visibility,
             generated_derives,
             fields,

--- a/tasks/ast_tools/src/schema/defs/vec.rs
+++ b/tasks/ast_tools/src/schema/defs/vec.rs
@@ -2,7 +2,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 
 use super::{
-    Def, Derives, Schema, TypeDef, TypeId,
+    Containers, Def, Derives, Schema, TypeDef, TypeId,
     extensions::{layout::Layout, visit::VisitVec},
 };
 
@@ -12,6 +12,7 @@ pub struct VecDef {
     pub id: TypeId,
     pub name: String,
     pub inner_type_id: TypeId,
+    pub containers: Containers,
     pub visit: VisitVec,
     pub layout: Layout,
 }
@@ -23,6 +24,7 @@ impl VecDef {
             id: TypeId::DUMMY,
             name,
             inner_type_id,
+            containers: Containers::default(),
             visit: VisitVec::default(),
             layout: Layout::default(),
         }


### PR DESCRIPTION
In the `Schema` built by `oxc_ast_tools`, container types e.g. `Box<T>` record the `TypeId` of their inner type `T`. Also record the reverse mapping in the schema - store the `TypeId` of `Box<T>` in the type def for `T`.
