### PR TITLE
feat(language_server): use linter runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,7 +1806,6 @@ dependencies = [
 name = "oxc_language_server"
 version = "0.16.6"
 dependencies = [
- "cow-utils",
  "env_logger",
  "futures",
  "globset",
@@ -1814,11 +1813,8 @@ dependencies = [
  "insta",
  "log",
  "oxc_allocator",
- "oxc_data_structures",
  "oxc_diagnostics",
  "oxc_linter",
- "oxc_parser",
- "oxc_semantic",
  "papaya",
  "rustc-hash",
  "serde",
@@ -1854,6 +1850,7 @@ dependencies = [
  "oxc_ast_visit",
  "oxc_cfg",
  "oxc_codegen",
+ "oxc_data_structures",
  "oxc_diagnostics",
  "oxc_ecmascript",
  "oxc_index",

--- a/crates/oxc_language_server/Cargo.toml
+++ b/crates/oxc_language_server/Cargo.toml
@@ -23,13 +23,10 @@ doctest = false
 
 [dependencies]
 oxc_allocator = { workspace = true }
-oxc_data_structures = { workspace = true, features = ["rope"] }
 oxc_diagnostics = { workspace = true }
-oxc_linter = { workspace = true }
-oxc_parser = { workspace = true }
-oxc_semantic = { workspace = true }
+oxc_linter = { workspace = true, features = ["language_server"] }
 
-cow-utils = { workspace = true }
+#
 env_logger = { workspace = true, features = ["humantime"] }
 futures = { workspace = true }
 globset = { workspace = true }

--- a/crates/oxc_language_server/fixtures/linter/cross_module_extended_config/.oxlintrc.json
+++ b/crates/oxc_language_server/fixtures/linter/cross_module_extended_config/.oxlintrc.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "./config/.oxlintrc.json"
+  ]
+}

--- a/crates/oxc_language_server/fixtures/linter/cross_module_extended_config/config/.oxlintrc.json
+++ b/crates/oxc_language_server/fixtures/linter/cross_module_extended_config/config/.oxlintrc.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "import"
+  ],
+  "rules": {
+    "import/no-cycle": "error"
+  }
+}

--- a/crates/oxc_language_server/fixtures/linter/cross_module_extended_config/dep-a.ts
+++ b/crates/oxc_language_server/fixtures/linter/cross_module_extended_config/dep-a.ts
@@ -1,0 +1,4 @@
+// should report cycle detected
+import { b } from './dep-b.ts';
+
+b();

--- a/crates/oxc_language_server/fixtures/linter/cross_module_extended_config/dep-b.ts
+++ b/crates/oxc_language_server/fixtures/linter/cross_module_extended_config/dep-b.ts
@@ -1,0 +1,4 @@
+// this file is also included in dep-a.ts and dep-a.ts should report a no-cycle diagnostic
+import './dep-a.ts';
+
+export function b() { /* ... */ }

--- a/crates/oxc_language_server/fixtures/linter/cross_module_nested_config/dep-a.ts
+++ b/crates/oxc_language_server/fixtures/linter/cross_module_nested_config/dep-a.ts
@@ -1,0 +1,4 @@
+// should report cycle detected
+import { b } from './dep-b.ts';
+
+b();

--- a/crates/oxc_language_server/fixtures/linter/cross_module_nested_config/dep-b.ts
+++ b/crates/oxc_language_server/fixtures/linter/cross_module_nested_config/dep-b.ts
@@ -1,0 +1,4 @@
+// this file is also included in dep-a.ts and dep-a.ts should report a no-cycle diagnostic
+import './dep-a.ts';
+
+export function b() { /* ... */ }

--- a/crates/oxc_language_server/fixtures/linter/cross_module_nested_config/folder/.oxlintrc.json
+++ b/crates/oxc_language_server/fixtures/linter/cross_module_nested_config/folder/.oxlintrc.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "import"
+  ],
+  "rules": {
+    "import/no-cycle": "error"
+  }
+}

--- a/crates/oxc_language_server/fixtures/linter/cross_module_nested_config/folder/folder-dep-a.ts
+++ b/crates/oxc_language_server/fixtures/linter/cross_module_nested_config/folder/folder-dep-a.ts
@@ -1,0 +1,4 @@
+// should report cycle detected
+import { b } from './folder-dep-b.ts';
+
+b();

--- a/crates/oxc_language_server/fixtures/linter/cross_module_nested_config/folder/folder-dep-b.ts
+++ b/crates/oxc_language_server/fixtures/linter/cross_module_nested_config/folder/folder-dep-b.ts
@@ -1,0 +1,4 @@
+// this file is also included in folder-dep-a.ts and folder-dep-a.ts should report a no-cycle diagnostic
+import './folder-dep-a.ts';
+
+export function b() { /* ... */ }

--- a/crates/oxc_language_server/src/linter/error_with_position.rs
+++ b/crates/oxc_language_server/src/linter/error_with_position.rs
@@ -1,5 +1,6 @@
-use std::{path::PathBuf, str::FromStr};
+use std::{borrow::Cow, path::PathBuf, str::FromStr};
 
+use oxc_linter::MessageWithPosition;
 use tower_lsp_server::{
     UriExt,
     lsp_types::{
@@ -7,37 +8,11 @@ use tower_lsp_server::{
     },
 };
 
-use cow_utils::CowUtils;
-use oxc_diagnostics::{Error, Severity};
-
-use crate::linter::offset_to_position;
-
-const LINT_DOC_LINK_PREFIX: &str = "https://oxc.rs/docs/guide/usage/linter/rules";
-
-#[derive(Debug)]
-pub struct ErrorWithPosition {
-    pub start_pos: Position,
-    pub end_pos: Position,
-    pub miette_err: Error,
-    pub fixed_content: Option<FixedContent>,
-    pub labels_with_pos: Vec<LabeledSpanWithPosition>,
-}
-
-#[derive(Debug)]
-pub struct LabeledSpanWithPosition {
-    pub start_pos: Position,
-    pub end_pos: Position,
-    pub message: Option<String>,
-}
+use oxc_diagnostics::Severity;
 
 #[derive(Debug, Clone)]
 pub struct DiagnosticReport {
     pub diagnostic: lsp_types::Diagnostic,
-    pub fixed_content: Option<FixedContent>,
-}
-#[derive(Debug)]
-pub struct ErrorReport {
-    pub error: Error,
     pub fixed_content: Option<FixedContent>,
 }
 
@@ -55,115 +30,96 @@ fn cmp_range(first: &Range, other: &Range) -> std::cmp::Ordering {
     }
 }
 
-/// parse `OxcCode` to `Option<(scope, number)>`
-fn parse_diagnostic_code(code: &str) -> Option<(&str, &str)> {
-    if !code.ends_with(')') {
-        return None;
-    }
-    let right_parenthesis_pos = code.rfind('(')?;
-    Some((&code[0..right_parenthesis_pos], &code[right_parenthesis_pos + 1..code.len() - 1]))
-}
+fn message_with_position_to_lsp_diagnostic(
+    message: &MessageWithPosition<'_>,
+    path: &PathBuf,
+) -> lsp_types::Diagnostic {
+    let severity = match message.severity {
+        Severity::Error => Some(lsp_types::DiagnosticSeverity::ERROR),
+        _ => Some(lsp_types::DiagnosticSeverity::WARNING),
+    };
+    let uri = lsp_types::Uri::from_file_path(path).unwrap();
 
-impl ErrorWithPosition {
-    pub fn new(
-        error: Error,
-        text: &str,
-        fixed_content: Option<FixedContent>,
-        start: usize,
-    ) -> Self {
-        let labels = error.labels().map_or(vec![], Iterator::collect);
-        let labels_with_pos: Vec<LabeledSpanWithPosition> = labels
+    let related_information = message.labels.as_ref().map(|spans| {
+        spans
             .iter()
-            .map(|labeled_span| LabeledSpanWithPosition {
-                start_pos: offset_to_position(labeled_span.offset() + start, text),
-                end_pos: offset_to_position(
-                    labeled_span.offset() + start + labeled_span.len(),
-                    text,
-                ),
-                message: labeled_span.label().map(ToString::to_string),
-            })
-            .collect();
-
-        let start_pos = labels_with_pos[0].start_pos;
-        let end_pos = labels_with_pos[labels_with_pos.len() - 1].end_pos;
-
-        Self { miette_err: error, start_pos, end_pos, labels_with_pos, fixed_content }
-    }
-
-    fn to_lsp_diagnostic(&self, path: &PathBuf) -> lsp_types::Diagnostic {
-        let severity = match self.miette_err.severity() {
-            Some(Severity::Error) => Some(lsp_types::DiagnosticSeverity::ERROR),
-            _ => Some(lsp_types::DiagnosticSeverity::WARNING),
-        };
-        let related_information = Some(
-            self.labels_with_pos
-                .iter()
-                .map(|labeled_span| lsp_types::DiagnosticRelatedInformation {
-                    location: lsp_types::Location {
-                        uri: lsp_types::Uri::from_file_path(path).unwrap(),
-                        range: lsp_types::Range {
-                            start: lsp_types::Position {
-                                line: labeled_span.start_pos.line,
-                                character: labeled_span.start_pos.character,
-                            },
-                            end: lsp_types::Position {
-                                line: labeled_span.end_pos.line,
-                                character: labeled_span.end_pos.character,
-                            },
+            .map(|span| lsp_types::DiagnosticRelatedInformation {
+                location: lsp_types::Location {
+                    uri: uri.clone(),
+                    range: lsp_types::Range {
+                        start: lsp_types::Position {
+                            line: span.start().line,
+                            character: span.start().character,
+                        },
+                        end: lsp_types::Position {
+                            line: span.end().line,
+                            character: span.end().character,
                         },
                     },
-                    message: labeled_span.message.clone().unwrap_or_default(),
-                })
-                .collect(),
-        );
-        let range = related_information.as_ref().map_or(
-            Range { start: self.start_pos, end: self.end_pos },
-            |infos: &Vec<DiagnosticRelatedInformation>| {
-                let mut ret_range = Range {
-                    start: Position { line: u32::MAX, character: u32::MAX },
-                    end: Position { line: u32::MAX, character: u32::MAX },
-                };
-                for info in infos {
-                    if cmp_range(&ret_range, &info.location.range) == std::cmp::Ordering::Greater {
-                        ret_range = info.location.range;
-                    }
-                }
-                ret_range
-            },
-        );
-        let code = self.miette_err.code().map(|item| item.to_string());
-        let code_description = code.as_ref().and_then(|code| {
-            let (scope, number) = parse_diagnostic_code(code)?;
-            Some(CodeDescription {
-                href: Uri::from_str(&format!(
-                    "{LINT_DOC_LINK_PREFIX}/{}/{number}",
-                    scope.strip_prefix("eslint-plugin-").unwrap_or(scope).cow_replace("-", "_")
-                ))
-                .ok()?,
+                },
+                message: span.message().unwrap_or(&Cow::Borrowed("")).to_string(),
             })
-        });
-        let message = self.miette_err.help().map_or_else(
-            || self.miette_err.to_string(),
-            |help| format!("{}\nhelp: {}", self.miette_err, help),
-        );
+            .collect()
+    });
 
-        lsp_types::Diagnostic {
-            range,
-            severity,
-            code: code.map(NumberOrString::String),
-            message,
-            source: Some("oxc".into()),
-            code_description,
-            related_information,
-            tags: None,
-            data: None,
-        }
+    let range = related_information.as_ref().map_or(
+        Range {
+            start: Position { line: u32::MAX, character: u32::MAX },
+            end: Position { line: u32::MAX, character: u32::MAX },
+        },
+        |infos: &Vec<DiagnosticRelatedInformation>| {
+            let mut ret_range = Range {
+                start: Position { line: u32::MAX, character: u32::MAX },
+                end: Position { line: u32::MAX, character: u32::MAX },
+            };
+            for info in infos {
+                if cmp_range(&ret_range, &info.location.range) == std::cmp::Ordering::Greater {
+                    ret_range = info.location.range;
+                }
+            }
+            ret_range
+        },
+    );
+    let code = message.code.to_string();
+    let code_description =
+        message.url.as_ref().map(|url| CodeDescription { href: Uri::from_str(url).ok().unwrap() });
+    let message = message.help.as_ref().map_or_else(
+        || message.message.to_string(),
+        |help| format!("{}\nhelp: {}", message.message, help),
+    );
+
+    lsp_types::Diagnostic {
+        range,
+        severity,
+        code: Some(NumberOrString::String(code)),
+        message,
+        source: Some("oxc".into()),
+        code_description,
+        related_information,
+        tags: None,
+        data: None,
     }
+}
 
-    pub fn into_diagnostic_report(self, path: &PathBuf) -> DiagnosticReport {
-        DiagnosticReport {
-            diagnostic: self.to_lsp_diagnostic(path),
-            fixed_content: self.fixed_content,
-        }
+pub fn message_with_position_to_lsp_diagnostic_report(
+    message: &MessageWithPosition<'_>,
+    path: &PathBuf,
+) -> DiagnosticReport {
+    DiagnosticReport {
+        diagnostic: message_with_position_to_lsp_diagnostic(message, path),
+        fixed_content: message.fix.as_ref().map(|infos| FixedContent {
+            message: infos.span.message().map(std::string::ToString::to_string),
+            code: infos.content.to_string(),
+            range: Range {
+                start: Position {
+                    line: infos.span.start().line,
+                    character: infos.span.start().character,
+                },
+                end: Position {
+                    line: infos.span.end().line,
+                    character: infos.span.end().character,
+                },
+            },
+        }),
     }
 }

--- a/crates/oxc_language_server/src/linter/mod.rs
+++ b/crates/oxc_language_server/src/linter/mod.rs
@@ -1,64 +1,7 @@
-use oxc_data_structures::rope::{Rope, get_line_column};
-use tower_lsp_server::lsp_types::Position;
-
 pub mod config_walker;
 pub mod error_with_position;
-mod isolated_lint_handler;
+pub mod isolated_lint_handler;
 pub mod server_linter;
 
 #[cfg(test)]
 mod tester;
-
-#[expect(clippy::cast_possible_truncation)]
-pub fn offset_to_position(offset: usize, source_text: &str) -> Position {
-    // TODO(perf): share a single instance of `Rope`
-    let rope = Rope::from_str(source_text);
-    let (line, column) = get_line_column(&rope, offset as u32, source_text);
-    Position::new(line, column)
-}
-
-#[cfg(test)]
-mod test {
-    use crate::linter::offset_to_position;
-
-    #[test]
-    fn single_line() {
-        let source = "foo.bar!;";
-        assert_position(source, 0, (0, 0));
-        assert_position(source, 4, (0, 4));
-        assert_position(source, 9, (0, 9));
-    }
-
-    #[test]
-    fn multi_line() {
-        let source = "console.log(\n  foo.bar!\n);";
-        assert_position(source, 0, (0, 0));
-        assert_position(source, 12, (0, 12));
-        assert_position(source, 13, (1, 0));
-        assert_position(source, 23, (1, 10));
-        assert_position(source, 24, (2, 0));
-        assert_position(source, 26, (2, 2));
-    }
-
-    #[test]
-    fn multi_byte() {
-        let source = "let foo = \n  '👍';";
-        assert_position(source, 10, (0, 10));
-        assert_position(source, 11, (1, 0));
-        assert_position(source, 14, (1, 3));
-        assert_position(source, 18, (1, 5));
-        assert_position(source, 19, (1, 6));
-    }
-
-    #[test]
-    #[should_panic(expected = "out of bounds")]
-    fn out_of_bounds() {
-        offset_to_position(100, "foo");
-    }
-
-    fn assert_position(source: &str, offset: usize, expected: (u32, u32)) {
-        let position = offset_to_position(offset, source);
-        assert_eq!(position.line, expected.0);
-        assert_eq!(position.character, expected.1);
-    }
-}

--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -7,24 +7,28 @@ use oxc_linter::{ConfigStoreBuilder, FixKind, LintOptions, Linter};
 use crate::linter::error_with_position::DiagnosticReport;
 use crate::linter::isolated_lint_handler::IsolatedLintHandler;
 
+use super::isolated_lint_handler::IsolatedLintHandlerOptions;
+
+#[derive(Clone)]
 pub struct ServerLinter {
     linter: Arc<Linter>,
+    options: Arc<IsolatedLintHandlerOptions>,
 }
 
 impl ServerLinter {
-    pub fn new() -> Self {
+    pub fn new(options: IsolatedLintHandlerOptions) -> Self {
         let config_store =
             ConfigStoreBuilder::default().build().expect("Failed to build config store");
         let linter = Linter::new(LintOptions::default(), config_store).with_fix(FixKind::SafeFix);
-        Self { linter: Arc::new(linter) }
+        Self { linter: Arc::new(linter), options: Arc::new(options) }
     }
 
-    pub fn new_with_linter(linter: Linter) -> Self {
-        Self { linter: Arc::new(linter) }
+    pub fn new_with_linter(linter: Linter, options: IsolatedLintHandlerOptions) -> Self {
+        Self { linter: Arc::new(linter), options: Arc::new(options) }
     }
 
     pub fn run_single(&self, uri: &Uri, content: Option<String>) -> Option<Vec<DiagnosticReport>> {
-        IsolatedLintHandler::new(Arc::clone(&self.linter))
+        IsolatedLintHandler::new(Arc::clone(&self.linter), Arc::clone(&self.options))
             .run_single(&uri.to_file_path().unwrap(), content)
     }
 }
@@ -36,6 +40,7 @@ mod test {
     use super::*;
     use crate::linter::tester::Tester;
     use oxc_linter::{LintFilter, LintFilterKind, Oxlintrc};
+    use rustc_hash::FxHashMap;
 
     #[test]
     fn test_no_errors() {
@@ -50,7 +55,7 @@ mod test {
             .with_filter(&LintFilter::deny(LintFilterKind::parse("no-console".into()).unwrap()))
             .build()
             .unwrap();
-        let linter = Linter::new(LintOptions::default(), config_store).with_fix(FixKind::SafeFix);
+        let linter = Linter::new(LintOptions::default(), config_store);
 
         Tester::new_with_linter(linter)
             .with_snapshot_suffix("deny_no_console")
@@ -68,7 +73,7 @@ mod test {
         .unwrap()
         .build()
         .unwrap();
-        let linter = Linter::new(LintOptions::default(), config_store).with_fix(FixKind::SafeFix);
+        let linter = Linter::new(LintOptions::default(), config_store);
 
         Tester::new_with_linter(linter)
             .test_and_snapshot_single_file("fixtures/linter/issue_9958/issue.ts");
@@ -85,7 +90,7 @@ mod test {
         .unwrap()
         .build()
         .unwrap();
-        let linter = Linter::new(LintOptions::default(), config_store).with_fix(FixKind::SafeFix);
+        let linter = Linter::new(LintOptions::default(), config_store);
 
         Tester::new_with_linter(linter)
             .test_and_snapshot_single_file("fixtures/linter/regexp_feature/index.ts");
@@ -109,16 +114,21 @@ mod test {
         .build()
         .unwrap();
         let linter = Linter::new(LintOptions::default(), config_store);
-
-        Tester::new_with_linter(linter)
+        let server_linter = ServerLinter::new_with_linter(
+            linter,
+            IsolatedLintHandlerOptions {
+                use_cross_module: true,
+                root_path: std::env::current_dir().expect("could not get current dir"),
+            },
+        );
+        Tester::new_with_server_linter(server_linter)
             .test_and_snapshot_single_file("fixtures/linter/cross_module/debugger.ts");
     }
 
     #[test]
-    // ToDo: only available with runtime oxc-project/oxc#10268
     fn test_cross_module_no_cycle() {
         let config_store = ConfigStoreBuilder::from_oxlintrc(
-            false,
+            true,
             Oxlintrc::from_file(&PathBuf::from("fixtures/linter/cross_module/.oxlintrc.json"))
                 .unwrap(),
         )
@@ -126,8 +136,106 @@ mod test {
         .build()
         .unwrap();
         let linter = Linter::new(LintOptions::default(), config_store);
+        let server_linter = ServerLinter::new_with_linter(
+            linter,
+            IsolatedLintHandlerOptions {
+                use_cross_module: true,
+                root_path: std::env::current_dir().expect("could not get current dir"),
+            },
+        );
 
-        Tester::new_with_linter(linter)
+        Tester::new_with_server_linter(server_linter)
             .test_and_snapshot_single_file("fixtures/linter/cross_module/dep-a.ts");
+    }
+
+    #[test]
+    fn test_cross_module_no_cycle_nested_config() {
+        let folder_config_path =
+            &PathBuf::from("fixtures/linter/cross_module_nested_config/folder/.oxlintrc.json");
+        let default_store =
+            ConfigStoreBuilder::from_oxlintrc(false, Oxlintrc::default()).unwrap().build().unwrap();
+        let folder_store = ConfigStoreBuilder::from_oxlintrc(
+            false,
+            Oxlintrc::from_file(folder_config_path).unwrap(),
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+        let folder_folder_absolute_path =
+            std::env::current_dir().unwrap().join(folder_config_path.parent().unwrap());
+
+        // do not insert the default store
+        let mut nested_configs = FxHashMap::default();
+        nested_configs.insert(folder_folder_absolute_path, folder_store);
+
+        let linter =
+            Linter::new_with_nested_configs(LintOptions::default(), default_store, nested_configs);
+        let server_linter = ServerLinter::new_with_linter(
+            linter,
+            IsolatedLintHandlerOptions {
+                use_cross_module: true,
+                root_path: std::env::current_dir().expect("could not get current dir"),
+            },
+        );
+
+        Tester::new_with_server_linter(server_linter.clone())
+            .test_and_snapshot_single_file("fixtures/linter/cross_module_nested_config/dep-a.ts");
+
+        Tester::new_with_server_linter(server_linter).test_and_snapshot_single_file(
+            "fixtures/linter/cross_module_nested_config/folder/folder-dep-a.ts",
+        );
+    }
+
+    #[test]
+    fn test_cross_module_no_cycle_extended_config() {
+        // ConfigStore searches for the extended config by itself
+        // but the LSP still finds the second config with the file walker
+        // to simulate the behavior, we build it like the server
+        let extended_config_path =
+            &PathBuf::from("fixtures/linter/cross_module_extended_config/.oxlintrc.json");
+        let folder_config_path =
+            &PathBuf::from("fixtures/linter/cross_module_extended_config/config/.oxlintrc.json");
+
+        let default_store =
+            ConfigStoreBuilder::from_oxlintrc(false, Oxlintrc::default()).unwrap().build().unwrap();
+        let extended_store = ConfigStoreBuilder::from_oxlintrc(
+            false,
+            Oxlintrc::from_file(extended_config_path).unwrap(),
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+        let folder_store = ConfigStoreBuilder::from_oxlintrc(
+            false,
+            Oxlintrc::from_file(folder_config_path).unwrap(),
+        )
+        .unwrap()
+        .build()
+        .unwrap();
+
+        let folder_folder_absolute_path =
+            std::env::current_dir().unwrap().join(folder_config_path.parent().unwrap());
+        let extended_folder_absolute_path =
+            std::env::current_dir().unwrap().join(extended_config_path.parent().unwrap());
+
+        // do not insert the default store
+        let mut nested_configs = FxHashMap::default();
+        nested_configs.insert(folder_folder_absolute_path, folder_store);
+        nested_configs.insert(extended_folder_absolute_path, extended_store);
+
+        let linter =
+            Linter::new_with_nested_configs(LintOptions::default(), default_store, nested_configs);
+
+        let server_linter = ServerLinter::new_with_linter(
+            linter,
+            IsolatedLintHandlerOptions {
+                use_cross_module: true,
+                root_path: std::env::current_dir().expect("could not get current dir"),
+            },
+        );
+
+        Tester::new_with_server_linter(server_linter)
+            .test_and_snapshot_single_file("fixtures/linter/cross_module_extended_config/dep-a.ts");
     }
 }

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_astro_debugger.astro.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_astro_debugger.astro.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_language_server/src/linter/tester.rs
 ---
 code: "eslint(no-debugger)"
-code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
 message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"
 range: Range { start: Position { line: 1, character: 0 }, end: Position { line: 1, character: 8 } }
 related_information[0].message: ""
@@ -14,7 +14,7 @@ tags: None
             
 
 code: "eslint(no-debugger)"
-code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
 message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"
 range: Range { start: Position { line: 10, character: 2 }, end: Position { line: 10, character: 10 } }
 related_information[0].message: ""
@@ -26,7 +26,7 @@ tags: None
             
 
 code: "eslint(no-debugger)"
-code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
 message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"
 range: Range { start: Position { line: 14, character: 2 }, end: Position { line: 14, character: 10 } }
 related_information[0].message: ""
@@ -38,7 +38,7 @@ tags: None
             
 
 code: "eslint(no-debugger)"
-code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
 message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"
 range: Range { start: Position { line: 18, character: 2 }, end: Position { line: 18, character: 10 } }
 related_information[0].message: ""

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_cross_module_debugger.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_cross_module_debugger.ts.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_language_server/src/linter/tester.rs
 ---
 code: "eslint(no-debugger)"
-code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
 message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"
 range: Range { start: Position { line: 1, character: 0 }, end: Position { line: 1, character: 9 } }
 related_information[0].message: ""

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_cross_module_extended_config_dep-a.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_cross_module_extended_config_dep-a.ts.snap
@@ -3,10 +3,10 @@ source: crates/oxc_language_server/src/linter/tester.rs
 ---
 code: "eslint-plugin-import(no-cycle)"
 code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html"
-message: "Dependency cycle detected\nhelp: These paths form a cycle: \n-> ./dep-b.ts - fixtures/linter/cross_module/dep-b.ts\n-> ./dep-a.ts - fixtures/linter/cross_module/dep-a.ts"
+message: "Dependency cycle detected\nhelp: These paths form a cycle: \n-> ./dep-b.ts - fixtures/linter/cross_module_extended_config/dep-b.ts\n-> ./dep-a.ts - fixtures/linter/cross_module_extended_config/dep-a.ts"
 range: Range { start: Position { line: 1, character: 18 }, end: Position { line: 1, character: 30 } }
 related_information[0].message: ""
-related_information[0].location.uri: "file://<variable>/fixtures/linter/cross_module/dep-a.ts"
+related_information[0].location.uri: "file://<variable>/fixtures/linter/cross_module_extended_config/dep-a.ts"
 related_information[0].location.range: Range { start: Position { line: 1, character: 18 }, end: Position { line: 1, character: 30 } }
 severity: Some(Error)
 source: Some("oxc")

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_cross_module_nested_config_dep-a.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_cross_module_nested_config_dep-a.ts.snap
@@ -1,0 +1,4 @@
+---
+source: crates/oxc_language_server/src/linter/tester.rs
+---
+No diagnostic reports

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_cross_module_nested_config_folder_folder-dep-a.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_cross_module_nested_config_folder_folder-dep-a.ts.snap
@@ -1,0 +1,13 @@
+---
+source: crates/oxc_language_server/src/linter/tester.rs
+---
+code: "eslint-plugin-import(no-cycle)"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html"
+message: "Dependency cycle detected\nhelp: These paths form a cycle: \n-> ./folder-dep-b.ts - fixtures/linter/cross_module_nested_config/folder/folder-dep-b.ts\n-> ./folder-dep-a.ts - fixtures/linter/cross_module_nested_config/folder/folder-dep-a.ts"
+range: Range { start: Position { line: 1, character: 18 }, end: Position { line: 1, character: 37 } }
+related_information[0].message: ""
+related_information[0].location.uri: "file://<variable>/fixtures/linter/cross_module_nested_config/folder/folder-dep-a.ts"
+related_information[0].location.range: Range { start: Position { line: 1, character: 18 }, end: Position { line: 1, character: 37 } }
+severity: Some(Error)
+source: Some("oxc")
+tags: None

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_hello_world.js@deny_no_console.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_hello_world.js@deny_no_console.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_language_server/src/linter/tester.rs
 ---
 code: "eslint(no-console)"
-code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html"
 message: "eslint(no-console): Unexpected console statement.\nhelp: Delete this console statement."
 range: Range { start: Position { line: 0, character: 0 }, end: Position { line: 0, character: 11 } }
 related_information[0].message: ""

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_issue_9958_issue.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_issue_9958_issue.ts.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_language_server/src/linter/tester.rs
 ---
 code: "eslint(no-extra-boolean-cast)"
-code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-extra-boolean-cast"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-extra-boolean-cast.html"
 message: "Redundant double negation\nhelp: Remove the double negation as it will already be coerced to a boolean"
 range: Range { start: Position { line: 3, character: 14 }, end: Position { line: 3, character: 17 } }
 related_information[0].message: ""
@@ -14,7 +14,7 @@ tags: None
             
 
 code: "typescript-eslint(no-non-null-asserted-optional-chain)"
-code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/typescript_eslint/no-non-null-asserted-optional-chain"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/typescript/no-non-null-asserted-optional-chain.html"
 message: "Optional chain expressions can return undefined by design: using a non-null assertion is unsafe and wrong.\nhelp: Remove the non-null assertion."
 range: Range { start: Position { line: 11, character: 18 }, end: Position { line: 11, character: 19 } }
 related_information[0].message: "non-null assertion made after optional chain"

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_regexp_feature_index.ts.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_regexp_feature_index.ts.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_language_server/src/linter/tester.rs
 ---
 code: "eslint(no-control-regex)"
-code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-control-regex"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-control-regex.html"
 message: "Unexpected control character\nhelp: '\\u0000' is not a valid control character."
 range: Range { start: Position { line: 1, character: 13 }, end: Position { line: 1, character: 32 } }
 related_information[0].message: ""
@@ -14,7 +14,7 @@ tags: None
             
 
 code: "eslint(no-useless-escape)"
-code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-useless-escape"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-useless-escape.html"
 message: "Unnecessary escape character '/'\nhelp: Replace `\\/` with `/`."
 range: Range { start: Position { line: 0, character: 16 }, end: Position { line: 0, character: 18 } }
 related_information[0].message: ""

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_svelte_debugger.svelte.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_svelte_debugger.svelte.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_language_server/src/linter/tester.rs
 ---
 code: "eslint(no-debugger)"
-code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
 message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"
 range: Range { start: Position { line: 1, character: 1 }, end: Position { line: 1, character: 10 } }
 related_information[0].message: ""

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_vue_debugger.vue.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_vue_debugger.vue.snap
@@ -2,7 +2,7 @@
 source: crates/oxc_language_server/src/linter/tester.rs
 ---
 code: "eslint(no-debugger)"
-code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
 message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"
 range: Range { start: Position { line: 5, character: 4 }, end: Position { line: 5, character: 12 } }
 related_information[0].message: ""
@@ -14,7 +14,7 @@ tags: None
             
 
 code: "eslint(no-debugger)"
-code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger"
+code_description.href: "https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-debugger.html"
 message: "`debugger` statement is not allowed\nhelp: Remove the debugger statement"
 range: Range { start: Position { line: 10, character: 4 }, end: Position { line: 10, character: 13 } }
 related_information[0].message: ""

--- a/crates/oxc_language_server/src/linter/tester.rs
+++ b/crates/oxc_language_server/src/linter/tester.rs
@@ -6,7 +6,10 @@ use tower_lsp_server::{
     lsp_types::{CodeDescription, NumberOrString, Uri},
 };
 
-use super::{error_with_position::DiagnosticReport, server_linter::ServerLinter};
+use super::{
+    error_with_position::DiagnosticReport, isolated_lint_handler::IsolatedLintHandlerOptions,
+    server_linter::ServerLinter,
+};
 
 /// Given a file path relative to the crate root directory, return the URI of the file.
 pub fn get_file_uri(relative_file_path: &str) -> Uri {
@@ -89,11 +92,27 @@ pub struct Tester<'t> {
 
 impl Tester<'_> {
     pub fn new() -> Self {
-        Self { snapshot_suffix: None, server_linter: ServerLinter::new() }
+        Self {
+            snapshot_suffix: None,
+            server_linter: ServerLinter::new(IsolatedLintHandlerOptions {
+                use_cross_module: false,
+                root_path: std::env::current_dir().expect("could not get current dir"),
+            }),
+        }
     }
 
     pub fn new_with_linter(linter: Linter) -> Self {
-        Self { snapshot_suffix: None, server_linter: ServerLinter::new_with_linter(linter) }
+        Self::new_with_server_linter(ServerLinter::new_with_linter(
+            linter,
+            IsolatedLintHandlerOptions {
+                use_cross_module: false,
+                root_path: std::env::current_dir().expect("could not get current dir"),
+            },
+        ))
+    }
+
+    pub fn new_with_server_linter(server_linter: ServerLinter) -> Self {
+        Self { snapshot_suffix: None, server_linter }
     }
 
     pub fn with_snapshot_suffix(mut self, suffix: &'static str) -> Self {

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -16,6 +16,7 @@ description.workspace = true
 [features]
 default = []
 ruledocs = ["oxc_macros/ruledocs"] # Enables the `ruledocs` feature for conditional compilation
+language_server = ["oxc_data_structures/rope"] # For the Runtime to support needed information for the language server
 
 [lints]
 workspace = true
@@ -29,6 +30,7 @@ oxc_ast = { workspace = true }
 oxc_ast_visit = { workspace = true }
 oxc_cfg = { workspace = true }
 oxc_codegen = { workspace = true }
+oxc_data_structures = { workspace = true, optional = true }
 oxc_diagnostics = { workspace = true }
 oxc_ecmascript = { workspace = true }
 oxc_index = { workspace = true, features = ["serde"] }

--- a/crates/oxc_linter/src/fixer/fix.rs
+++ b/crates/oxc_linter/src/fixer/fix.rs
@@ -4,6 +4,9 @@ use bitflags::bitflags;
 use oxc_allocator::{Allocator, CloneIn};
 use oxc_span::{GetSpan, SPAN, Span};
 
+#[cfg(feature = "language_server")]
+use crate::service::offset_to_position::SpanPositionMessage;
+
 bitflags! {
     /// Flags describing an automatic code fix.
     ///
@@ -286,6 +289,12 @@ pub struct Fix<'a> {
     /// editors via code actions.
     pub message: Option<Cow<'a, str>>,
     pub span: Span,
+}
+
+#[cfg(feature = "language_server")]
+pub struct FixWithPosition<'a> {
+    pub content: Cow<'a, str>,
+    pub span: SpanPositionMessage<'a>,
 }
 
 impl<'new> CloneIn<'new> for Fix<'_> {

--- a/crates/oxc_linter/src/fixer/mod.rs
+++ b/crates/oxc_linter/src/fixer/mod.rs
@@ -6,6 +6,13 @@ use oxc_span::{GetSpan, Span};
 
 use crate::LintContext;
 
+#[cfg(feature = "language_server")]
+use crate::service::offset_to_position::SpanPositionMessage;
+#[cfg(feature = "language_server")]
+pub use fix::FixWithPosition;
+#[cfg(feature = "language_server")]
+use oxc_diagnostics::{OxcCode, Severity};
+
 mod fix;
 pub use fix::{CompositeFix, Fix, FixKind, RuleFix};
 use oxc_allocator::{Allocator, CloneIn};
@@ -223,6 +230,32 @@ pub struct Message<'a> {
     pub fix: Option<Fix<'a>>,
     span: Span,
     fixed: bool,
+}
+
+#[cfg(feature = "language_server")]
+pub struct MessageWithPosition<'a> {
+    pub message: Cow<'a, str>,
+    pub labels: Option<Vec<SpanPositionMessage<'a>>>,
+    pub help: Option<Cow<'a, str>>,
+    pub severity: Severity,
+    pub code: OxcCode,
+    pub url: Option<Cow<'a, str>>,
+    pub fix: Option<FixWithPosition<'a>>,
+}
+
+#[cfg(feature = "language_server")]
+impl From<OxcDiagnostic> for MessageWithPosition<'_> {
+    fn from(from: OxcDiagnostic) -> Self {
+        Self {
+            message: from.message.clone(),
+            labels: None,
+            help: from.help.clone(),
+            severity: from.severity,
+            code: from.code.clone(),
+            url: from.url.clone(),
+            fix: None,
+        }
+    }
 }
 
 impl<'new> CloneIn<'new> for Message<'_> {

--- a/crates/oxc_linter/src/lib.rs
+++ b/crates/oxc_linter/src/lib.rs
@@ -53,6 +53,9 @@ use crate::{
     utils::iter_possible_jest_call_node,
 };
 
+#[cfg(feature = "language_server")]
+pub use crate::fixer::{FixWithPosition, MessageWithPosition};
+
 #[cfg(target_pointer_width = "64")]
 #[test]
 fn size_asserts() {
@@ -62,7 +65,7 @@ fn size_asserts() {
     assert_eq!(size_of::<RuleEnum>(), 16);
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Linter {
     // rules: Vec<RuleWithSeverity>,
     options: LintOptions,

--- a/crates/oxc_linter/src/service/mod.rs
+++ b/crates/oxc_linter/src/service/mod.rs
@@ -11,6 +11,9 @@ use crate::Linter;
 
 mod runtime;
 
+#[cfg(feature = "language_server")]
+pub mod offset_to_position;
+
 pub struct LintServiceOptions {
     /// Current working directory
     cwd: Box<Path>,
@@ -87,15 +90,25 @@ impl LintService {
         tx_error.send(None).unwrap();
     }
 
+    #[cfg(feature = "language_server")]
+    pub fn run_source<'a>(
+        &mut self,
+        allocator: &'a oxc_allocator::Allocator,
+        path: &Arc<OsStr>,
+        source_text: &str,
+    ) -> Vec<crate::MessageWithPosition<'a>> {
+        self.runtime.run_source(allocator, path, source_text)
+    }
+
     /// For tests
     #[cfg(test)]
-    pub(crate) fn run_source<'a>(
+    pub(crate) fn run_test_source<'a>(
         &mut self,
         allocator: &'a oxc_allocator::Allocator,
         source_text: &str,
         check_syntax_errors: bool,
         tx_error: &DiagnosticSender,
     ) -> Vec<crate::Message<'a>> {
-        self.runtime.run_source(allocator, source_text, check_syntax_errors, tx_error)
+        self.runtime.run_test_source(allocator, source_text, check_syntax_errors, tx_error)
     }
 }

--- a/crates/oxc_linter/src/service/offset_to_position.rs
+++ b/crates/oxc_linter/src/service/offset_to_position.rs
@@ -1,0 +1,100 @@
+use oxc_data_structures::rope::{Rope, get_line_column};
+use std::borrow::Cow;
+
+#[derive(Clone)]
+pub struct SpanPositionMessage<'a> {
+    /// A brief suggestion message describing the fix. Will be shown in
+    /// editors via code actions.
+    message: Option<Cow<'a, str>>,
+
+    start: SpanPosition,
+    end: SpanPosition,
+}
+
+impl<'a> SpanPositionMessage<'a> {
+    pub fn new(start: SpanPosition, end: SpanPosition) -> Self {
+        Self { start, end, message: None }
+    }
+
+    pub fn with_message(mut self, message: Option<Cow<'a, str>>) -> Self {
+        self.message = message;
+        self
+    }
+
+    pub fn start(&self) -> &SpanPosition {
+        &self.start
+    }
+
+    pub fn end(&self) -> &SpanPosition {
+        &self.end
+    }
+
+    pub fn message(&self) -> Option<&Cow<'a, str>> {
+        self.message.as_ref()
+    }
+}
+
+#[derive(Clone)]
+pub struct SpanPosition {
+    pub line: u32,
+    pub character: u32,
+}
+
+impl SpanPosition {
+    pub fn new(line: u32, column: u32) -> Self {
+        Self { line, character: column }
+    }
+}
+
+pub fn offset_to_position(offset: u32, source_text: &str) -> SpanPosition {
+    // TODO(perf): share a single instance of `Rope`
+    let rope = Rope::from_str(source_text);
+    let (line, column) = get_line_column(&rope, offset, source_text);
+    SpanPosition::new(line, column)
+}
+
+#[cfg(test)]
+mod test {
+    use super::offset_to_position;
+
+    #[test]
+    fn single_line() {
+        let source = "foo.bar!;";
+        assert_position(source, 0, (0, 0));
+        assert_position(source, 4, (0, 4));
+        assert_position(source, 9, (0, 9));
+    }
+
+    #[test]
+    fn multi_line() {
+        let source = "console.log(\n  foo.bar!\n);";
+        assert_position(source, 0, (0, 0));
+        assert_position(source, 12, (0, 12));
+        assert_position(source, 13, (1, 0));
+        assert_position(source, 23, (1, 10));
+        assert_position(source, 24, (2, 0));
+        assert_position(source, 26, (2, 2));
+    }
+
+    #[test]
+    fn multi_byte() {
+        let source = "let foo = \n  '👍';";
+        assert_position(source, 10, (0, 10));
+        assert_position(source, 11, (1, 0));
+        assert_position(source, 14, (1, 3));
+        assert_position(source, 18, (1, 5));
+        assert_position(source, 19, (1, 6));
+    }
+
+    #[test]
+    #[should_panic(expected = "out of bounds")]
+    fn out_of_bounds() {
+        offset_to_position(100, "foo");
+    }
+
+    fn assert_position(source: &str, offset: u32, expected: (u32, u32)) {
+        let position = offset_to_position(offset, source);
+        assert_eq!(position.line, expected.0);
+        assert_eq!(position.character, expected.1);
+    }
+}

--- a/crates/oxc_linter/src/tester.rs
+++ b/crates/oxc_linter/src/tester.rs
@@ -486,7 +486,7 @@ impl Tester {
             LintServiceOptions::new(cwd, paths).with_cross_module(self.plugins.has_import());
         let mut lint_service = LintService::from_linter(linter, options);
         let (sender, _receiver) = mpsc::channel();
-        let result = lint_service.run_source(&allocator, source_text, false, &sender);
+        let result = lint_service.run_test_source(&allocator, source_text, false, &sender);
 
         if result.is_empty() {
             return TestResult::Passed;

--- a/editors/vscode/client/extension.spec.ts
+++ b/editors/vscode/client/extension.spec.ts
@@ -161,6 +161,59 @@ suite('E2E Diagnostics', () => {
     strictEqual(diagnostics[0].range.end.character, 17);
   });
 
+  test('cross module', async () => {
+    await loadFixture('cross_module');
+    const diagnostics = await getDiagnostics('dep-a.ts');
+
+    strictEqual(diagnostics.length, 1);
+    assert(typeof diagnostics[0].code == 'object');
+    strictEqual(diagnostics[0].code.target.authority, 'oxc.rs');
+    strictEqual(
+      diagnostics[0].message,
+      'Dependency cycle detected\nhelp: These paths form a cycle: \n-> ./dep-b.ts - diagnostic/dep-b.ts\n-> ./dep-a.ts - diagnostic/dep-a.ts',
+    );
+    strictEqual(diagnostics[0].severity, DiagnosticSeverity.Error);
+    strictEqual(diagnostics[0].range.start.line, 1);
+    strictEqual(diagnostics[0].range.start.character, 18);
+    strictEqual(diagnostics[0].range.end.line, 1);
+    strictEqual(diagnostics[0].range.end.character, 30);
+  });
+
+  test('cross module with nested config', async () => {
+    await loadFixture('cross_module_nested_config');
+    const diagnostics = await getDiagnostics('folder/folder-dep-a.ts');
+
+    strictEqual(diagnostics.length, 1);
+    assert(typeof diagnostics[0].code == 'object');
+    strictEqual(diagnostics[0].code.target.authority, 'oxc.rs');
+    strictEqual(
+      diagnostics[0].message,
+      'Dependency cycle detected\nhelp: These paths form a cycle: \n-> ./folder-dep-b.ts - diagnostic/folder/folder-dep-b.ts\n-> ./folder-dep-a.ts - diagnostic/folder/folder-dep-a.ts',
+    );
+    strictEqual(diagnostics[0].severity, DiagnosticSeverity.Error);
+    strictEqual(diagnostics[0].range.start.line, 1);
+    strictEqual(diagnostics[0].range.start.character, 18);
+    strictEqual(diagnostics[0].range.end.line, 1);
+    strictEqual(diagnostics[0].range.end.character, 37);
+  });
+
+  test('cross module with extended config', async () => {
+    await loadFixture('cross_module_extended_config');
+    const diagnostics = await getDiagnostics('dep-a.ts');
+
+    assert(typeof diagnostics[0].code == 'object');
+    strictEqual(diagnostics[0].code.target.authority, 'oxc.rs');
+    strictEqual(
+      diagnostics[0].message,
+      'Dependency cycle detected\nhelp: These paths form a cycle: \n-> ./dep-b.ts - diagnostic/dep-b.ts\n-> ./dep-a.ts - diagnostic/dep-a.ts',
+    );
+    strictEqual(diagnostics[0].severity, DiagnosticSeverity.Error);
+    strictEqual(diagnostics[0].range.start.line, 1);
+    strictEqual(diagnostics[0].range.start.character, 18);
+    strictEqual(diagnostics[0].range.end.line, 1);
+    strictEqual(diagnostics[0].range.end.character, 30);
+  });
+
   test('setting rule to error, will report the diagnostic as error', async () => {
     const edit = new WorkspaceEdit();
     edit.createFile(fileUri, {

--- a/editors/vscode/fixtures/cross_module/.oxlintrc.json
+++ b/editors/vscode/fixtures/cross_module/.oxlintrc.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "import"
+  ],
+  "rules": {
+    "import/no-cycle": "error"
+  }
+}

--- a/editors/vscode/fixtures/cross_module/debugger.ts
+++ b/editors/vscode/fixtures/cross_module/debugger.ts
@@ -1,0 +1,2 @@
+// Debugger should be shown as a warning
+debugger;

--- a/editors/vscode/fixtures/cross_module/dep-a.ts
+++ b/editors/vscode/fixtures/cross_module/dep-a.ts
@@ -1,0 +1,4 @@
+// should report cycle detected
+import { b } from './dep-b.ts';
+
+b();

--- a/editors/vscode/fixtures/cross_module/dep-b.ts
+++ b/editors/vscode/fixtures/cross_module/dep-b.ts
@@ -1,0 +1,4 @@
+// this file is also included in dep-a.ts and dep-a.ts should report a no-cycle diagnostic
+import './dep-a.ts';
+
+export function b() { /* ... */ }

--- a/editors/vscode/fixtures/cross_module_extended_config/.oxlintrc.json
+++ b/editors/vscode/fixtures/cross_module_extended_config/.oxlintrc.json
@@ -1,0 +1,5 @@
+{
+  "extends": [
+    "./config/.oxlintrc.json"
+  ]
+}

--- a/editors/vscode/fixtures/cross_module_extended_config/config/.oxlintrc.json
+++ b/editors/vscode/fixtures/cross_module_extended_config/config/.oxlintrc.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "import"
+  ],
+  "rules": {
+    "import/no-cycle": "error"
+  }
+}

--- a/editors/vscode/fixtures/cross_module_extended_config/dep-a.ts
+++ b/editors/vscode/fixtures/cross_module_extended_config/dep-a.ts
@@ -1,0 +1,4 @@
+// should report cycle detected
+import { b } from './dep-b.ts';
+
+b();

--- a/editors/vscode/fixtures/cross_module_extended_config/dep-b.ts
+++ b/editors/vscode/fixtures/cross_module_extended_config/dep-b.ts
@@ -1,0 +1,4 @@
+// this file is also included in dep-a.ts and dep-a.ts should report a no-cycle diagnostic
+import './dep-a.ts';
+
+export function b() { /* ... */ }

--- a/editors/vscode/fixtures/cross_module_nested_config/dep-a.ts
+++ b/editors/vscode/fixtures/cross_module_nested_config/dep-a.ts
@@ -1,0 +1,4 @@
+// should report cycle detected
+import { b } from './dep-b.ts';
+
+b();

--- a/editors/vscode/fixtures/cross_module_nested_config/dep-b.ts
+++ b/editors/vscode/fixtures/cross_module_nested_config/dep-b.ts
@@ -1,0 +1,4 @@
+// this file is also included in dep-a.ts and dep-a.ts should report a no-cycle diagnostic
+import './dep-a.ts';
+
+export function b() { /* ... */ }

--- a/editors/vscode/fixtures/cross_module_nested_config/folder/.oxlintrc.json
+++ b/editors/vscode/fixtures/cross_module_nested_config/folder/.oxlintrc.json
@@ -1,0 +1,8 @@
+{
+  "plugins": [
+    "import"
+  ],
+  "rules": {
+    "import/no-cycle": "error"
+  }
+}

--- a/editors/vscode/fixtures/cross_module_nested_config/folder/folder-dep-a.ts
+++ b/editors/vscode/fixtures/cross_module_nested_config/folder/folder-dep-a.ts
@@ -1,0 +1,4 @@
+// should report cycle detected
+import { b } from './folder-dep-b.ts';
+
+b();

--- a/editors/vscode/fixtures/cross_module_nested_config/folder/folder-dep-b.ts
+++ b/editors/vscode/fixtures/cross_module_nested_config/folder/folder-dep-b.ts
@@ -1,0 +1,4 @@
+// this file is also included in folder-dep-a.ts and folder-dep-a.ts should report a no-cycle diagnostic
+import './folder-dep-a.ts';
+
+export function b() { /* ... */ }


### PR DESCRIPTION
closes #7118

Added tests for:
- (language_server & VSCode) nested configuration
- (language_server & VSCode) nested configuration extends
- (language_server) without nested configuration

The implementation requires at the moment a feature flag for `oxc_linter`. I added documentation in `runtime.rs` to let others know why this is needed. Maybe someone can refactor it to avoid the flag. My first idea is a Trait for file system, but you guys know what to do <3 




![grafik](https://github.com/user-attachments/assets/9bb3aa67-c376-4f51-8474-1d0837d78338)
