### PR TITLE
chore(oxlint): improve feature and build command

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -9,7 +9,7 @@ minsize = "run -p oxc_minsize --profile coverage --"
 rule = "run -p rulegen"
 
 # Build oxlint in release mode
-oxlint = "build --release --bin oxlint --features allocator"
+oxlint = "build --release -p oxlint --bin oxlint --features allocator"
 
 # Fix napi breaking in test environment <https://github.com/napi-rs/napi-rs/issues/1005#issuecomment-1011034770>
 # To be able to run unit tests on macOS, support compilation to 'x86_64-apple-darwin'.

--- a/.github/workflows/release_oxlint.yml
+++ b/.github/workflows/release_oxlint.yml
@@ -105,8 +105,8 @@ jobs:
         env:
           CC: clang # for mimalloc
         run: |
-          cross build --release --target=${{ matrix.target }} --bin oxlint --features allocator
-          cross build -p oxc_language_server --bin oxc_language_server --release --target=${{ matrix.target }}
+          cross build --release -p oxlint --bin oxlint --features allocator --target=${{ matrix.target }}
+          cross build --release -p oxc_language_server --bin oxc_language_server --target=${{ matrix.target }}
 
       # The binaries are zipped to fix permission loss https://github.com/actions/upload-artifact#permission-loss
       - name: Archive Binaries

--- a/crates/oxc_linter/Cargo.toml
+++ b/crates/oxc_linter/Cargo.toml
@@ -14,6 +14,7 @@ rust-version.workspace = true
 description.workspace = true
 
 [features]
+default = []
 ruledocs = ["oxc_macros/ruledocs"] # Enables the `ruledocs` feature for conditional compilation
 
 [lints]


### PR DESCRIPTION
Binary size reduced from `6.3M` to `5.8M` with this change.