### PR TITLE
refactor(ast)!: remove `JSXOpeningElement::self_closing` field

### DIFF
--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -37,10 +37,13 @@ pub struct JSXElement<'a> {
     /// Node location in source code
     pub span: Span,
     /// Opening tag of the element.
+    #[estree(via = JSXElementOpening)]
     pub opening_element: Box<'a, JSXOpeningElement<'a>>,
-    /// Closing tag of the element. Will be [`None`] for self-closing tags.
+    /// Closing tag of the element.
+    /// [`None`] for self-closing tags.
     pub closing_element: Option<Box<'a, JSXClosingElement<'a>>>,
-    /// Children of the element. This can be text, other elements, or expressions.
+    /// Children of the element.
+    /// This can be text, other elements, or expressions.
     pub children: Vec<'a, JSXChild<'a>>,
 }
 
@@ -62,18 +65,13 @@ pub struct JSXElement<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(field_order(span, attributes, name, self_closing, type_arguments))]
+#[estree(
+    add_fields(selfClosing = JSXOpeningElementSelfClosing),
+    field_order(span, attributes, name, selfClosing, type_arguments),
+)]
 pub struct JSXOpeningElement<'a> {
     /// Node location in source code
     pub span: Span,
-    /// Is this tag self-closing?
-    ///
-    /// ## Examples
-    /// ```tsx
-    /// <Foo />  // <- self_closing = true
-    /// <Foo>    // <- self_closing = false
-    /// ```
-    pub self_closing: bool,
     /// The possibly-namespaced tag name, e.g. `Foo` in `<Foo />`.
     pub name: JSXElementName<'a>,
     /// List of JSX attributes. In React-like applications, these become props.

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -809,13 +809,12 @@ const _: () = {
     assert!(offset_of!(JSXElement, closing_element) == 16);
     assert!(offset_of!(JSXElement, children) == 24);
 
-    assert!(size_of::<JSXOpeningElement>() == 72);
+    assert!(size_of::<JSXOpeningElement>() == 64);
     assert!(align_of::<JSXOpeningElement>() == 8);
     assert!(offset_of!(JSXOpeningElement, span) == 0);
-    assert!(offset_of!(JSXOpeningElement, self_closing) == 8);
-    assert!(offset_of!(JSXOpeningElement, name) == 16);
-    assert!(offset_of!(JSXOpeningElement, attributes) == 32);
-    assert!(offset_of!(JSXOpeningElement, type_arguments) == 64);
+    assert!(offset_of!(JSXOpeningElement, name) == 8);
+    assert!(offset_of!(JSXOpeningElement, attributes) == 24);
+    assert!(offset_of!(JSXOpeningElement, type_arguments) == 56);
 
     assert!(size_of::<JSXClosingElement>() == 24);
     assert!(align_of::<JSXClosingElement>() == 8);
@@ -2201,13 +2200,12 @@ const _: () = {
     assert!(offset_of!(JSXElement, closing_element) == 12);
     assert!(offset_of!(JSXElement, children) == 16);
 
-    assert!(size_of::<JSXOpeningElement>() == 40);
+    assert!(size_of::<JSXOpeningElement>() == 36);
     assert!(align_of::<JSXOpeningElement>() == 4);
     assert!(offset_of!(JSXOpeningElement, span) == 0);
-    assert!(offset_of!(JSXOpeningElement, self_closing) == 8);
-    assert!(offset_of!(JSXOpeningElement, name) == 12);
-    assert!(offset_of!(JSXOpeningElement, attributes) == 20);
-    assert!(offset_of!(JSXOpeningElement, type_arguments) == 36);
+    assert!(offset_of!(JSXOpeningElement, name) == 8);
+    assert!(offset_of!(JSXOpeningElement, attributes) == 16);
+    assert!(offset_of!(JSXOpeningElement, type_arguments) == 32);
 
     assert!(size_of::<JSXClosingElement>() == 16);
     assert!(align_of::<JSXClosingElement>() == 4);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -1057,8 +1057,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     /// * `opening_element`: Opening tag of the element.
-    /// * `closing_element`: Closing tag of the element. Will be [`None`] for self-closing tags.
-    /// * `children`: Children of the element. This can be text, other elements, or expressions.
+    /// * `closing_element`: Closing tag of the element.
+    /// * `children`: Children of the element.
     #[inline]
     pub fn expression_jsx_element<T1, T2>(
         self,
@@ -8623,8 +8623,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     /// * `opening_element`: Opening tag of the element.
-    /// * `closing_element`: Closing tag of the element. Will be [`None`] for self-closing tags.
-    /// * `children`: Children of the element. This can be text, other elements, or expressions.
+    /// * `closing_element`: Closing tag of the element.
+    /// * `children`: Children of the element.
     #[inline]
     pub fn jsx_element<T1, T2>(
         self,
@@ -8653,8 +8653,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     /// * `opening_element`: Opening tag of the element.
-    /// * `closing_element`: Closing tag of the element. Will be [`None`] for self-closing tags.
-    /// * `children`: Children of the element. This can be text, other elements, or expressions.
+    /// * `closing_element`: Closing tag of the element.
+    /// * `children`: Children of the element.
     #[inline]
     pub fn alloc_jsx_element<T1, T2>(
         self,
@@ -8680,7 +8680,6 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
-    /// * `self_closing`: Is this tag self-closing?
     /// * `name`: The possibly-namespaced tag name, e.g. `Foo` in `<Foo />`.
     /// * `attributes`: List of JSX attributes. In React-like applications, these become props.
     /// * `type_arguments`: Type parameters for generic JSX elements.
@@ -8688,7 +8687,6 @@ impl<'a> AstBuilder<'a> {
     pub fn jsx_opening_element<T1>(
         self,
         span: Span,
-        self_closing: bool,
         name: JSXElementName<'a>,
         attributes: Vec<'a, JSXAttributeItem<'a>>,
         type_arguments: T1,
@@ -8698,7 +8696,6 @@ impl<'a> AstBuilder<'a> {
     {
         JSXOpeningElement {
             span,
-            self_closing,
             name,
             attributes,
             type_arguments: type_arguments.into_in(self.allocator),
@@ -8712,7 +8709,6 @@ impl<'a> AstBuilder<'a> {
     ///
     /// ## Parameters
     /// * `span`: Node location in source code
-    /// * `self_closing`: Is this tag self-closing?
     /// * `name`: The possibly-namespaced tag name, e.g. `Foo` in `<Foo />`.
     /// * `attributes`: List of JSX attributes. In React-like applications, these become props.
     /// * `type_arguments`: Type parameters for generic JSX elements.
@@ -8720,7 +8716,6 @@ impl<'a> AstBuilder<'a> {
     pub fn alloc_jsx_opening_element<T1>(
         self,
         span: Span,
-        self_closing: bool,
         name: JSXElementName<'a>,
         attributes: Vec<'a, JSXAttributeItem<'a>>,
         type_arguments: T1,
@@ -8729,7 +8724,7 @@ impl<'a> AstBuilder<'a> {
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterInstantiation<'a>>>>,
     {
         Box::new_in(
-            self.jsx_opening_element(span, self_closing, name, attributes, type_arguments),
+            self.jsx_opening_element(span, name, attributes, type_arguments),
             self.allocator,
         )
     }
@@ -9350,8 +9345,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     /// * `opening_element`: Opening tag of the element.
-    /// * `closing_element`: Closing tag of the element. Will be [`None`] for self-closing tags.
-    /// * `children`: Children of the element. This can be text, other elements, or expressions.
+    /// * `closing_element`: Closing tag of the element.
+    /// * `children`: Children of the element.
     #[inline]
     pub fn jsx_attribute_value_element<T1, T2>(
         self,
@@ -9452,8 +9447,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: Node location in source code
     /// * `opening_element`: Opening tag of the element.
-    /// * `closing_element`: Closing tag of the element. Will be [`None`] for self-closing tags.
-    /// * `children`: Children of the element. This can be text, other elements, or expressions.
+    /// * `closing_element`: Closing tag of the element.
+    /// * `children`: Children of the element.
     #[inline]
     pub fn jsx_child_element<T1, T2>(
         self,

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -4969,7 +4969,6 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXOpeningElement<'_> {
     fn clone_in(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXOpeningElement {
             span: CloneIn::clone_in(&self.span, allocator),
-            self_closing: CloneIn::clone_in(&self.self_closing, allocator),
             name: CloneIn::clone_in(&self.name, allocator),
             attributes: CloneIn::clone_in(&self.attributes, allocator),
             type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
@@ -4979,7 +4978,6 @@ impl<'new_alloc> CloneIn<'new_alloc> for JSXOpeningElement<'_> {
     fn clone_in_with_semantic_ids(&self, allocator: &'new_alloc Allocator) -> Self::Cloned {
         JSXOpeningElement {
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
-            self_closing: CloneIn::clone_in_with_semantic_ids(&self.self_closing, allocator),
             name: CloneIn::clone_in_with_semantic_ids(&self.name, allocator),
             attributes: CloneIn::clone_in_with_semantic_ids(&self.attributes, allocator),
             type_arguments: CloneIn::clone_in_with_semantic_ids(&self.type_arguments, allocator),

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -1505,8 +1505,7 @@ impl ContentEq for JSXElement<'_> {
 
 impl ContentEq for JSXOpeningElement<'_> {
     fn content_eq(&self, other: &Self) -> bool {
-        ContentEq::content_eq(&self.self_closing, &other.self_closing)
-            && ContentEq::content_eq(&self.name, &other.name)
+        ContentEq::content_eq(&self.name, &other.name)
             && ContentEq::content_eq(&self.attributes, &other.attributes)
             && ContentEq::content_eq(&self.type_arguments, &other.type_arguments)
     }

--- a/crates/oxc_ast/src/generated/derive_dummy.rs
+++ b/crates/oxc_ast/src/generated/derive_dummy.rs
@@ -1650,7 +1650,7 @@ impl<'a> Dummy<'a> for RegExpPattern<'a> {
 impl<'a> Dummy<'a> for JSXElement<'a> {
     /// Create a dummy [`JSXElement`].
     ///
-    /// Has cost of making 2 allocations (80 bytes).
+    /// Has cost of making 2 allocations (72 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
             span: Dummy::dummy(allocator),
@@ -1668,7 +1668,6 @@ impl<'a> Dummy<'a> for JSXOpeningElement<'a> {
     fn dummy(allocator: &'a Allocator) -> Self {
         Self {
             span: Dummy::dummy(allocator),
-            self_closing: Dummy::dummy(allocator),
             name: Dummy::dummy(allocator),
             attributes: Dummy::dummy(allocator),
             type_arguments: Dummy::dummy(allocator),

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1982,7 +1982,7 @@ impl ESTree for JSXElement<'_> {
         state.serialize_field("type", &JsonSafeString("JSXElement"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
-        state.serialize_field("openingElement", &self.opening_element);
+        state.serialize_field("openingElement", &crate::serialize::JSXElementOpening(self));
         state.serialize_field("closingElement", &self.closing_element);
         state.serialize_field("children", &self.children);
         state.end();
@@ -1997,7 +1997,7 @@ impl ESTree for JSXOpeningElement<'_> {
         state.serialize_field("end", &self.span.end);
         state.serialize_field("attributes", &self.attributes);
         state.serialize_field("name", &self.name);
-        state.serialize_field("selfClosing", &self.self_closing);
+        state.serialize_field("selfClosing", &crate::serialize::JSXOpeningElementSelfClosing(self));
         state.serialize_ts_field("typeArguments", &self.type_arguments);
         state.end();
     }

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -783,6 +783,52 @@ impl ESTree for ExportAllDeclarationWithClause<'_, '_> {
 // JSX
 // --------------------
 
+/// Serializer for `opening_element` field of `JSXElement`.
+///
+/// `selfClosing` field of `JSXOpeningElement` depends on whether `JSXElement` has a `closing_element`.
+#[ast_meta]
+#[estree(
+    ts_type = "JSXOpeningElement",
+    raw_deser = "
+        const openingElement = DESER[Box<JSXOpeningElement>](POS_OFFSET.opening_element);
+        if (THIS.closingElement === null) openingElement.selfClosing = true;
+        openingElement
+    "
+)]
+pub struct JSXElementOpening<'a, 'b>(pub &'b JSXElement<'a>);
+
+impl ESTree for JSXElementOpening<'_, '_> {
+    fn serialize<S: Serializer>(&self, serializer: S) {
+        let element = self.0;
+        let opening_element = element.opening_element.as_ref();
+
+        let mut state = serializer.serialize_struct();
+        state.serialize_field("type", &JsonSafeString("JSXOpeningElement"));
+        state.serialize_field("start", &opening_element.span.start);
+        state.serialize_field("end", &opening_element.span.end);
+        state.serialize_field("attributes", &opening_element.attributes);
+        state.serialize_field("name", &opening_element.name);
+        state.serialize_field("selfClosing", &element.closing_element.is_none());
+        state.serialize_ts_field("typeArguments", &opening_element.type_arguments);
+        state.end();
+    }
+}
+
+/// Converter for `selfClosing` field of `JSXOpeningElement`.
+///
+/// This converter is not used for serialization - `JSXElementOpening` above handles serialization.
+/// This type is only required to add `selfClosing: boolean` to TS type def,
+/// and provide default value of `false` for raw transfer deserializer.
+#[ast_meta]
+#[estree(ts_type = "boolean", raw_deser = "false")]
+pub struct JSXOpeningElementSelfClosing<'a, 'b>(#[expect(dead_code)] pub &'b JSXOpeningElement<'a>);
+
+impl ESTree for JSXOpeningElementSelfClosing<'_, '_> {
+    fn serialize<S: Serializer>(&self, _serializer: S) {
+        unreachable!()
+    }
+}
+
 /// Serializer for `IdentifierReference` variant of `JSXElementName` and `JSXMemberExpressionObject`.
 ///
 /// Convert to `JSXIdentifier`.

--- a/crates/oxc_linter/src/rules/react/self_closing_comp.rs
+++ b/crates/oxc_linter/src/rules/react/self_closing_comp.rs
@@ -84,7 +84,7 @@ impl Rule for SelfClosingComp {
             return;
         };
 
-        if jsx_el.opening_element.self_closing {
+        if jsx_el.closing_element.is_none() {
             return;
         }
 

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -10559,8 +10559,6 @@ impl<'a, 't> GetAddress for JSXElementWithoutChildren<'a, 't> {
 }
 
 pub(crate) const OFFSET_JSX_OPENING_ELEMENT_SPAN: usize = offset_of!(JSXOpeningElement, span);
-pub(crate) const OFFSET_JSX_OPENING_ELEMENT_SELF_CLOSING: usize =
-    offset_of!(JSXOpeningElement, self_closing);
 pub(crate) const OFFSET_JSX_OPENING_ELEMENT_NAME: usize = offset_of!(JSXOpeningElement, name);
 pub(crate) const OFFSET_JSX_OPENING_ELEMENT_ATTRIBUTES: usize =
     offset_of!(JSXOpeningElement, attributes);
@@ -10578,13 +10576,6 @@ impl<'a, 't> JSXOpeningElementWithoutName<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_SPAN) as *const Span) }
-    }
-
-    #[inline]
-    pub fn self_closing(self) -> &'t bool {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_SELF_CLOSING) as *const bool)
-        }
     }
 
     #[inline]
@@ -10625,13 +10616,6 @@ impl<'a, 't> JSXOpeningElementWithoutAttributes<'a, 't> {
     }
 
     #[inline]
-    pub fn self_closing(self) -> &'t bool {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_SELF_CLOSING) as *const bool)
-        }
-    }
-
-    #[inline]
     pub fn name(self) -> &'t JSXElementName<'a> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_NAME)
@@ -10666,13 +10650,6 @@ impl<'a, 't> JSXOpeningElementWithoutTypeArguments<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_SPAN) as *const Span) }
-    }
-
-    #[inline]
-    pub fn self_closing(self) -> &'t bool {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_JSX_OPENING_ELEMENT_SELF_CLOSING) as *const bool)
-        }
     }
 
     #[inline]

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -1133,12 +1133,15 @@ function deserializeRegExpFlags(pos) {
 }
 
 function deserializeJSXElement(pos) {
+  const closingElement = deserializeOptionBoxJSXClosingElement(pos + 16);
+  const openingElement = deserializeBoxJSXOpeningElement(pos + 8);
+  if (closingElement === null) openingElement.selfClosing = true;
   return {
     type: 'JSXElement',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    openingElement: deserializeBoxJSXOpeningElement(pos + 8),
-    closingElement: deserializeOptionBoxJSXClosingElement(pos + 16),
+    openingElement,
+    closingElement,
     children: deserializeVecJSXChild(pos + 24),
   };
 }
@@ -1148,9 +1151,9 @@ function deserializeJSXOpeningElement(pos) {
     type: 'JSXOpeningElement',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    attributes: deserializeVecJSXAttributeItem(pos + 32),
-    name: deserializeJSXElementName(pos + 16),
-    selfClosing: deserializeBool(pos + 8),
+    attributes: deserializeVecJSXAttributeItem(pos + 24),
+    name: deserializeJSXElementName(pos + 8),
+    selfClosing: false,
   };
 }
 

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -1207,12 +1207,15 @@ function deserializeRegExpFlags(pos) {
 }
 
 function deserializeJSXElement(pos) {
+  const closingElement = deserializeOptionBoxJSXClosingElement(pos + 16);
+  const openingElement = deserializeBoxJSXOpeningElement(pos + 8);
+  if (closingElement === null) openingElement.selfClosing = true;
   return {
     type: 'JSXElement',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    openingElement: deserializeBoxJSXOpeningElement(pos + 8),
-    closingElement: deserializeOptionBoxJSXClosingElement(pos + 16),
+    openingElement,
+    closingElement,
     children: deserializeVecJSXChild(pos + 24),
   };
 }
@@ -1222,10 +1225,10 @@ function deserializeJSXOpeningElement(pos) {
     type: 'JSXOpeningElement',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
-    attributes: deserializeVecJSXAttributeItem(pos + 32),
-    name: deserializeJSXElementName(pos + 16),
-    selfClosing: deserializeBool(pos + 8),
-    typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 64),
+    attributes: deserializeVecJSXAttributeItem(pos + 24),
+    name: deserializeJSXElementName(pos + 8),
+    selfClosing: false,
+    typeArguments: deserializeOptionBoxTSTypeParameterInstantiation(pos + 56),
   };
 }
 


### PR DESCRIPTION
Remove `self_closing` field from `JSXOpeningElement`. Whether the tag is self-closing can be determined by whether the `JSXElement` has a `closing_element` or not.

This is advantageous for 2 reasons:

1. Reduce size of `JSXOpeningElement` by 8 bytes.
2. Make it impossible for `self_closing` and `closing_element` fields to get out of sync. Only one source of truth.
