### PR TITLE
test(linter): ensure complex fixes have messages

### DIFF
--- a/crates/oxc_linter/src/context/mod.rs
+++ b/crates/oxc_linter/src/context/mod.rs
@@ -353,6 +353,19 @@ impl<'a> LintContext<'a> {
         };
         if self.parent.fix.can_apply(rule_fix.kind()) && !rule_fix.is_empty() {
             let fix = rule_fix.into_fix(self.source_text());
+            #[cfg(debug_assertions)]
+            {
+                if fix.span.size() > 1 {
+                    assert!(
+                        fix.message.as_ref().is_some_and(|msg| !msg.is_empty()),
+                        "Rule `{}/{}` fix should have a message for a complex fix. Did you forget to add a message?\n   Source text: {:?}\n    Fixed text: {:?}\nhelp: You can add a message to a fix with `RuleFix.with_message()`",
+                        self.current_plugin_name,
+                        self.current_rule_name,
+                        self.source_range(fix.span),
+                        fix.content
+                    );
+                }
+            }
             self.add_diagnostic(Message::new(diagnostic, Some(fix)));
         } else {
             self.diagnostic(diagnostic);

--- a/crates/oxc_linter/src/fixer/fix.rs
+++ b/crates/oxc_linter/src/fixer/fix.rs
@@ -237,8 +237,15 @@ impl<'a> RuleFix<'a> {
 
     #[inline]
     pub fn into_fix(self, source_text: &str) -> Fix<'a> {
+        // If there is only one fix, use the message from that fix.
+        let message = match &self.fix {
+            CompositeFix::Single(fix) if fix.message.as_ref().is_some_and(|m| !m.is_empty()) => {
+                fix.message.clone()
+            }
+            _ => self.message,
+        };
         let mut fix = self.fix.normalize_fixes(source_text);
-        fix.message = self.message;
+        fix.message = message;
         fix
     }
 


### PR DESCRIPTION
- related to https://github.com/oxc-project/oxc/issues/10038

This adds an assertion which ensures that fixes which change more than a single character have a fix message associated with them.