### PR TITLE
perf(linter): replace `phf_set` with `array` in `jsdoc/check-access`

### DIFF
--- a/crates/oxc_linter/src/rules/jsdoc/check_access.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/check_access.rs
@@ -1,7 +1,6 @@
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
-use phf::phf_set;
 use rustc_hash::FxHashSet;
 
 use crate::{context::LintContext, rule::Rule, utils::should_ignore_as_internal};
@@ -57,12 +56,7 @@ declare_oxc_lint!(
     restriction
 );
 
-const ACCESS_LEVELS: phf::Set<&'static str> = phf_set! {
-    "package",
-    "private",
-    "protected",
-    "public",
-};
+const ACCESS_LEVELS: [&str; 4] = ["package", "private", "protected", "public"];
 
 impl Rule for CheckAccess {
     fn run_once(&self, ctx: &LintContext) {
@@ -89,7 +83,7 @@ impl Rule for CheckAccess {
                 // Has valid access level?
                 let comment = tag.comment();
                 if tag_name == resolved_access_tag_name
-                    && !ACCESS_LEVELS.contains(&comment.parsed())
+                    && !ACCESS_LEVELS.contains(&comment.parsed().as_str())
                 {
                     ctx.diagnostic(invalid_access_level(comment.span_trimmed_first_line()));
                 }


### PR DESCRIPTION
Related to #10076 