### PR TITLE
refactor(ast/estree): simplify serialization for `JSXOpeningFragment`

### DIFF
--- a/crates/oxc_ast/src/ast/jsx.rs
+++ b/crates/oxc_ast/src/ast/jsx.rs
@@ -128,7 +128,7 @@ pub struct JSXFragment<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(via = JSXOpeningFragmentConverter, add_fields(attributes = JSXOpeningFragmentAttributes, selfClosing = TsFalse))]
+#[estree(via = JSXOpeningFragmentConverter, add_fields(attributes = TsEmptyArray, selfClosing = TsFalse))]
 pub struct JSXOpeningFragment {
     /// Node location in source code
     pub span: Span,

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -870,17 +870,6 @@ impl ESTree for JSXOpeningElementSelfClosing<'_, '_> {
     }
 }
 
-#[ast_meta]
-#[estree(ts_type = "Array<JSXAttributeItem>", raw_deser = "[]")]
-#[ts]
-pub struct JSXOpeningFragmentAttributes<'b>(#[expect(dead_code)] pub &'b JSXOpeningFragment);
-
-impl ESTree for JSXOpeningFragmentAttributes<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) {
-        [(); 0].serialize(serializer);
-    }
-}
-
 /// Serializer for `IdentifierReference` variant of `JSXElementName` and `JSXMemberExpressionObject`.
 ///
 /// Convert to `JSXIdentifier`.
@@ -919,10 +908,14 @@ impl ESTree for JSXElementThisExpression<'_> {
     }
 }
 
-/// Serializer for `JSXOpeningFragment`.
+/// Converter for `JSXOpeningFragment`.
 ///
 /// Add `attributes` and `selfClosing` fields in JS AST, but not in TS AST.
 /// Acorn-JSX has these fields, but TS-ESLint parser does not.
+///
+/// The extra fields are added to the type as `TsEmptyArray` and `TsFalse`,
+/// which are incorrect, as these fields appear only in the *JS* AST, not the TS one.
+/// But that results in the fields being optional in TS type definition.
 //
 // TODO: Find a better way to do this.
 #[ast_meta]

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -858,7 +858,7 @@ export interface JSXFragment extends Span {
 
 export interface JSXOpeningFragment extends Span {
   type: 'JSXOpeningFragment';
-  attributes?: Array<JSXAttributeItem>;
+  attributes?: [];
   selfClosing?: false;
 }
 


### PR DESCRIPTION
Follow-on after #10208.

We can remove the `JSXOpeningFragmentAttributes` serializer, and use `TsEmptyArray` instead.

This results in `attributes?: []` in the TS type def, which seems reasonable since a JSX fragment can't have attributes. Really this field shouldn't exist at all! It can probably be considered a mistake in `acorn-jsx` that it does.
