### PR TITLE
refactor(linter): remove duplicate ARIA property lists

### DIFF
--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_unsupported_elements.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_unsupported_elements.rs
@@ -3,11 +3,10 @@ use oxc_ast::{AstKind, ast::JSXAttributeItem};
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
 use oxc_span::Span;
-use phf::phf_set;
 
 use crate::{
     AstNode, LintContext,
-    globals::RESERVED_HTML_TAG,
+    globals::{RESERVED_HTML_TAG, is_valid_aria_property},
     rule::Rule,
     utils::{get_element_type, get_jsx_attribute_name},
 };
@@ -59,7 +58,7 @@ impl Rule for AriaUnsupportedElements {
                     };
                     let attr_name = get_jsx_attribute_name(&attr.name);
                     let attr_name = attr_name.cow_to_ascii_lowercase();
-                    if INVALID_ATTRIBUTES.contains(&attr_name) {
+                    if attr_name == "role" || is_valid_aria_property(&attr_name) {
                         ctx.diagnostic_with_fix(
                             aria_unsupported_elements_diagnostic(attr.span, &attr_name),
                             |fixer| fixer.delete(&attr.span),
@@ -70,58 +69,6 @@ impl Rule for AriaUnsupportedElements {
         }
     }
 }
-
-const INVALID_ATTRIBUTES: phf::Set<&'static str> = phf_set! {
-    "aria-activedescendant",
-    "aria-atomic",
-    "aria-autocomplete",
-    "aria-busy",
-    "aria-checked",
-    "aria-colcount",
-    "aria-colindex",
-    "aria-colspan",
-    "aria-controls",
-    "aria-current",
-    "aria-describedby",
-    "aria-details",
-    "aria-disabled",
-    "aria-dropeffect",
-    "aria-errormessage",
-    "aria-expanded",
-    "aria-flowto",
-    "aria-grabbed",
-    "aria-haspopup",
-    "aria-hidden",
-    "aria-invalid",
-    "aria-keyshortcuts",
-    "aria-label",
-    "aria-labelledby",
-    "aria-level",
-    "aria-live",
-    "aria-modal",
-    "aria-multiline",
-    "aria-multiselectable",
-    "aria-orientation",
-    "aria-owns",
-    "aria-placeholder",
-    "aria-posinset",
-    "aria-pressed",
-    "aria-readonly",
-    "aria-relevant",
-    "aria-required",
-    "aria-roledescription",
-    "aria-rowcount",
-    "aria-rowindex",
-    "aria-rowspan",
-    "aria-selected",
-    "aria-setsize",
-    "aria-sort",
-    "aria-valuemax",
-    "aria-valuemin",
-    "aria-valuenow",
-    "aria-valuetext",
-    "role",
-};
 
 #[test]
 fn test() {

--- a/crates/oxc_linter/src/rules/react/no_unknown_property.rs
+++ b/crates/oxc_linter/src/rules/react/no_unknown_property.rs
@@ -16,6 +16,7 @@ use serde::Deserialize;
 use crate::{
     AstNode,
     context::{ContextHost, LintContext},
+    globals::is_valid_aria_property,
     rule::Rule,
     utils::get_jsx_attribute_name,
 };
@@ -308,23 +309,6 @@ const DOM_PROPERTIES_NAMES: Set<&'static str> = phf_set! {
     "onPointerUpCapture",
 };
 
-const ARIA_PROPERTIES: Set<&'static str> = phf_set! {
-    // See https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes
-    // Global attributes
-    "aria-atomic", "aria-braillelabel", "aria-brailleroledescription", "aria-busy", "aria-controls", "aria-current",
-    "aria-describedby", "aria-description", "aria-details",
-    "aria-disabled", "aria-dropeffect", "aria-errormessage", "aria-flowto", "aria-grabbed", "aria-haspopup",
-    "aria-hidden", "aria-invalid", "aria-keyshortcuts", "aria-label", "aria-labelledby", "aria-live",
-    "aria-owns", "aria-relevant", "aria-roledescription",
-    // Widget attributes
-    "aria-autocomplete", "aria-checked", "aria-expanded", "aria-level", "aria-modal", "aria-multiline", "aria-multiselectable",
-    "aria-orientation", "aria-placeholder", "aria-pressed", "aria-readonly", "aria-required", "aria-selected",
-    "aria-sort", "aria-valuemax", "aria-valuemin", "aria-valuenow", "aria-valuetext",
-    // Relationship attributes
-    "aria-activedescendant", "aria-colcount", "aria-colindex", "aria-colindextext", "aria-colspan",
-    "aria-posinset", "aria-rowcount", "aria-rowindex", "aria-rowindextext", "aria-rowspan", "aria-setsize",
-};
-
 const DOM_ATTRIBUTES_TO_CAMEL: Map<&'static str, &'static str> = phf_map! {
     "accept-charset" => "acceptCharset",
     "class" => "className",
@@ -527,7 +511,7 @@ impl Rule for NoUnknownProperty {
                     }
                     return;
                 }
-                if ARIA_PROPERTIES.contains(&actual_name) || !is_valid_html_tag {
+                if is_valid_aria_property(&actual_name) || !is_valid_html_tag {
                     return;
                 }
                 let name = normalize_attribute_case(&actual_name);


### PR DESCRIPTION
Removes some additional duplication of ARIA properties in other lint rules.