### PR TITLE
fix(estree): Rename `TSInstantiationExpression`.`type_parameters` to `type_arguments`

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1595,8 +1595,7 @@ pub struct TSNamespaceExportDeclaration<'a> {
 pub struct TSInstantiationExpression<'a> {
     pub span: Span,
     pub expression: Expression<'a>,
-    #[estree(rename = "typeArguments")]
-    pub type_parameters: Box<'a, TSTypeParameterInstantiation<'a>>,
+    pub type_arguments: Box<'a, TSTypeParameterInstantiation<'a>>,
 }
 
 /// See [TypeScript - Type-Only Imports and Exports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html)

--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1595,6 +1595,7 @@ pub struct TSNamespaceExportDeclaration<'a> {
 pub struct TSInstantiationExpression<'a> {
     pub span: Span,
     pub expression: Expression<'a>,
+    #[estree(rename = "typeArguments")]
     pub type_parameters: Box<'a, TSTypeParameterInstantiation<'a>>,
 }
 

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -1357,7 +1357,7 @@ const _: () = {
     assert!(align_of::<TSInstantiationExpression>() == 8);
     assert!(offset_of!(TSInstantiationExpression, span) == 0);
     assert!(offset_of!(TSInstantiationExpression, expression) == 8);
-    assert!(offset_of!(TSInstantiationExpression, type_parameters) == 24);
+    assert!(offset_of!(TSInstantiationExpression, type_arguments) == 24);
 
     assert!(size_of::<ImportOrExportKind>() == 1);
     assert!(align_of::<ImportOrExportKind>() == 1);
@@ -2748,7 +2748,7 @@ const _: () = {
     assert!(align_of::<TSInstantiationExpression>() == 4);
     assert!(offset_of!(TSInstantiationExpression, span) == 0);
     assert!(offset_of!(TSInstantiationExpression, expression) == 8);
-    assert!(offset_of!(TSInstantiationExpression, type_parameters) == 16);
+    assert!(offset_of!(TSInstantiationExpression, type_arguments) == 16);
 
     assert!(size_of::<ImportOrExportKind>() == 1);
     assert!(align_of::<ImportOrExportKind>() == 1);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -1181,13 +1181,13 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
-    /// * `type_parameters`
+    /// * `type_arguments`
     #[inline]
     pub fn expression_ts_instantiation<T1>(
         self,
         span: Span,
         expression: Expression<'a>,
-        type_parameters: T1,
+        type_arguments: T1,
     ) -> Expression<'a>
     where
         T1: IntoIn<'a, Box<'a, TSTypeParameterInstantiation<'a>>>,
@@ -1195,7 +1195,7 @@ impl<'a> AstBuilder<'a> {
         Expression::TSInstantiationExpression(self.alloc_ts_instantiation_expression(
             span,
             expression,
-            type_parameters,
+            type_arguments,
         ))
     }
 
@@ -14345,13 +14345,13 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
-    /// * `type_parameters`
+    /// * `type_arguments`
     #[inline]
     pub fn ts_instantiation_expression<T1>(
         self,
         span: Span,
         expression: Expression<'a>,
-        type_parameters: T1,
+        type_arguments: T1,
     ) -> TSInstantiationExpression<'a>
     where
         T1: IntoIn<'a, Box<'a, TSTypeParameterInstantiation<'a>>>,
@@ -14359,7 +14359,7 @@ impl<'a> AstBuilder<'a> {
         TSInstantiationExpression {
             span,
             expression,
-            type_parameters: type_parameters.into_in(self.allocator),
+            type_arguments: type_arguments.into_in(self.allocator),
         }
     }
 
@@ -14371,19 +14371,19 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `expression`
-    /// * `type_parameters`
+    /// * `type_arguments`
     #[inline]
     pub fn alloc_ts_instantiation_expression<T1>(
         self,
         span: Span,
         expression: Expression<'a>,
-        type_parameters: T1,
+        type_arguments: T1,
     ) -> Box<'a, TSInstantiationExpression<'a>>
     where
         T1: IntoIn<'a, Box<'a, TSTypeParameterInstantiation<'a>>>,
     {
         Box::new_in(
-            self.ts_instantiation_expression(span, expression, type_parameters),
+            self.ts_instantiation_expression(span, expression, type_arguments),
             self.allocator,
         )
     }

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -7727,7 +7727,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInstantiationExpression<'_> {
         TSInstantiationExpression {
             span: CloneIn::clone_in(&self.span, allocator),
             expression: CloneIn::clone_in(&self.expression, allocator),
-            type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
+            type_arguments: CloneIn::clone_in(&self.type_arguments, allocator),
         }
     }
 
@@ -7735,7 +7735,7 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInstantiationExpression<'_> {
         TSInstantiationExpression {
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             expression: CloneIn::clone_in_with_semantic_ids(&self.expression, allocator),
-            type_parameters: CloneIn::clone_in_with_semantic_ids(&self.type_parameters, allocator),
+            type_arguments: CloneIn::clone_in_with_semantic_ids(&self.type_arguments, allocator),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -2420,7 +2420,7 @@ impl ContentEq for TSNamespaceExportDeclaration<'_> {
 impl ContentEq for TSInstantiationExpression<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.expression, &other.expression)
-            && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
+            && ContentEq::content_eq(&self.type_arguments, &other.type_arguments)
     }
 }
 

--- a/crates/oxc_ast/src/generated/derive_dummy.rs
+++ b/crates/oxc_ast/src/generated/derive_dummy.rs
@@ -2810,7 +2810,7 @@ impl<'a> Dummy<'a> for TSInstantiationExpression<'a> {
         Self {
             span: Dummy::dummy(allocator),
             expression: Dummy::dummy(allocator),
-            type_parameters: Dummy::dummy(allocator),
+            type_arguments: Dummy::dummy(allocator),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -3298,7 +3298,7 @@ impl ESTree for TSInstantiationExpression<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
-        state.serialize_field("typeArguments", &self.type_parameters);
+        state.serialize_field("typeArguments", &self.type_arguments);
         state.end();
     }
 }

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -3298,7 +3298,7 @@ impl ESTree for TSInstantiationExpression<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("expression", &self.expression);
-        state.serialize_field("typeParameters", &self.type_parameters);
+        state.serialize_field("typeArguments", &self.type_parameters);
         state.end();
     }
 }

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -4084,7 +4084,7 @@ pub mod walk {
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
         visitor.visit_expression(&it.expression);
-        visitor.visit_ts_type_parameter_instantiation(&it.type_parameters);
+        visitor.visit_ts_type_parameter_instantiation(&it.type_arguments);
         visitor.leave_node(kind);
     }
 

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -4308,7 +4308,7 @@ pub mod walk_mut {
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
         visitor.visit_expression(&mut it.expression);
-        visitor.visit_ts_type_parameter_instantiation(&mut it.type_parameters);
+        visitor.visit_ts_type_parameter_instantiation(&mut it.type_arguments);
         visitor.leave_node(kind);
     }
 

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -2273,7 +2273,7 @@ impl GenExpr for TSNonNullExpression<'_> {
 impl GenExpr for TSInstantiationExpression<'_> {
     fn gen_expr(&self, p: &mut Codegen, precedence: Precedence, ctx: Context) {
         self.expression.print_expr(p, precedence, ctx);
-        self.type_parameters.print(p, ctx);
+        self.type_arguments.print(p, ctx);
         if p.options.minify {
             p.print_hard_space();
         }

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -142,7 +142,7 @@ impl<'a> ParserImpl<'a> {
             if let Expression::TSInstantiationExpression(expr) = extend {
                 let expr = expr.unbox();
                 extend = expr.expression;
-                type_argument = Some(expr.type_parameters);
+                type_argument = Some(expr.type_arguments);
             } else {
                 type_argument = self.try_parse_type_arguments()?;
             }

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -755,7 +755,7 @@ impl<'a> ParserImpl<'a> {
                     let (expr, type_parameters) =
                         if let Expression::TSInstantiationExpression(instantiation_expr) = lhs {
                             let expr = instantiation_expr.unbox();
-                            (expr.expression, Some(expr.type_parameters))
+                            (expr.expression, Some(expr.type_arguments))
                         } else {
                             (lhs, None)
                         };
@@ -844,7 +844,7 @@ impl<'a> ParserImpl<'a> {
         let mut type_parameter = None;
         if let Expression::TSInstantiationExpression(instantiation_expr) = callee {
             let instantiation_expr = instantiation_expr.unbox();
-            type_parameter.replace(instantiation_expr.type_parameters);
+            type_parameter.replace(instantiation_expr.type_arguments);
             callee = instantiation_expr.expression;
         }
 
@@ -907,7 +907,7 @@ impl<'a> ParserImpl<'a> {
             if type_arguments.is_some() || self.at(Kind::LParen) {
                 if let Expression::TSInstantiationExpression(expr) = lhs {
                     let expr = expr.unbox();
-                    type_arguments.replace(expr.type_parameters);
+                    type_arguments.replace(expr.type_arguments);
                     lhs = expr.expression;
                 }
 

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -311,7 +311,7 @@ pub(crate) enum AncestorType {
     TSExportAssignmentExpression = 288,
     TSNamespaceExportDeclarationId = 289,
     TSInstantiationExpressionExpression = 290,
-    TSInstantiationExpressionTypeParameters = 291,
+    TSInstantiationExpressionTypeArguments = 291,
     JSDocNullableTypeTypeAnnotation = 292,
     JSDocNonNullableTypeTypeAnnotation = 293,
 }
@@ -878,8 +878,8 @@ pub enum Ancestor<'a, 't> {
         AncestorType::TSNamespaceExportDeclarationId as u16,
     TSInstantiationExpressionExpression(TSInstantiationExpressionWithoutExpression<'a, 't>) =
         AncestorType::TSInstantiationExpressionExpression as u16,
-    TSInstantiationExpressionTypeParameters(TSInstantiationExpressionWithoutTypeParameters<'a, 't>) =
-        AncestorType::TSInstantiationExpressionTypeParameters as u16,
+    TSInstantiationExpressionTypeArguments(TSInstantiationExpressionWithoutTypeArguments<'a, 't>) =
+        AncestorType::TSInstantiationExpressionTypeArguments as u16,
     JSDocNullableTypeTypeAnnotation(JSDocNullableTypeWithoutTypeAnnotation<'a, 't>) =
         AncestorType::JSDocNullableTypeTypeAnnotation as u16,
     JSDocNonNullableTypeTypeAnnotation(JSDocNonNullableTypeWithoutTypeAnnotation<'a, 't>) =
@@ -1837,7 +1837,7 @@ impl<'a, 't> Ancestor<'a, 't> {
         matches!(
             self,
             Self::TSInstantiationExpressionExpression(_)
-                | Self::TSInstantiationExpressionTypeParameters(_)
+                | Self::TSInstantiationExpressionTypeArguments(_)
         )
     }
 
@@ -2481,7 +2481,7 @@ impl<'a, 't> GetAddress for Ancestor<'a, 't> {
             Self::TSExportAssignmentExpression(a) => a.address(),
             Self::TSNamespaceExportDeclarationId(a) => a.address(),
             Self::TSInstantiationExpressionExpression(a) => a.address(),
-            Self::TSInstantiationExpressionTypeParameters(a) => a.address(),
+            Self::TSInstantiationExpressionTypeArguments(a) => a.address(),
             Self::JSDocNullableTypeTypeAnnotation(a) => a.address(),
             Self::JSDocNonNullableTypeTypeAnnotation(a) => a.address(),
         }
@@ -15423,8 +15423,8 @@ pub(crate) const OFFSET_TS_INSTANTIATION_EXPRESSION_SPAN: usize =
     offset_of!(TSInstantiationExpression, span);
 pub(crate) const OFFSET_TS_INSTANTIATION_EXPRESSION_EXPRESSION: usize =
     offset_of!(TSInstantiationExpression, expression);
-pub(crate) const OFFSET_TS_INSTANTIATION_EXPRESSION_TYPE_PARAMETERS: usize =
-    offset_of!(TSInstantiationExpression, type_parameters);
+pub(crate) const OFFSET_TS_INSTANTIATION_EXPRESSION_TYPE_ARGUMENTS: usize =
+    offset_of!(TSInstantiationExpression, type_arguments);
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -15442,9 +15442,9 @@ impl<'a, 't> TSInstantiationExpressionWithoutExpression<'a, 't> {
     }
 
     #[inline]
-    pub fn type_parameters(self) -> &'t Box<'a, TSTypeParameterInstantiation<'a>> {
+    pub fn type_arguments(self) -> &'t Box<'a, TSTypeParameterInstantiation<'a>> {
         unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_INSTANTIATION_EXPRESSION_TYPE_PARAMETERS)
+            &*((self.0 as *const u8).add(OFFSET_TS_INSTANTIATION_EXPRESSION_TYPE_ARGUMENTS)
                 as *const Box<'a, TSTypeParameterInstantiation<'a>>)
         }
     }
@@ -15459,12 +15459,12 @@ impl<'a, 't> GetAddress for TSInstantiationExpressionWithoutExpression<'a, 't> {
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
-pub struct TSInstantiationExpressionWithoutTypeParameters<'a, 't>(
+pub struct TSInstantiationExpressionWithoutTypeArguments<'a, 't>(
     pub(crate) *const TSInstantiationExpression<'a>,
     pub(crate) PhantomData<&'t ()>,
 );
 
-impl<'a, 't> TSInstantiationExpressionWithoutTypeParameters<'a, 't> {
+impl<'a, 't> TSInstantiationExpressionWithoutTypeArguments<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe {
@@ -15481,7 +15481,7 @@ impl<'a, 't> TSInstantiationExpressionWithoutTypeParameters<'a, 't> {
     }
 }
 
-impl<'a, 't> GetAddress for TSInstantiationExpressionWithoutTypeParameters<'a, 't> {
+impl<'a, 't> GetAddress for TSInstantiationExpressionWithoutTypeArguments<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -5519,10 +5519,10 @@ unsafe fn walk_ts_instantiation_expression<'a, Tr: Traverse<'a>>(
             as *mut Expression,
         ctx,
     );
-    ctx.retag_stack(AncestorType::TSInstantiationExpressionTypeParameters);
+    ctx.retag_stack(AncestorType::TSInstantiationExpressionTypeArguments);
     walk_ts_type_parameter_instantiation(
         traverser,
-        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_INSTANTIATION_EXPRESSION_TYPE_PARAMETERS)
+        (&mut **((node as *mut u8).add(ancestor::OFFSET_TS_INSTANTIATION_EXPRESSION_TYPE_ARGUMENTS)
             as *mut Box<TSTypeParameterInstantiation>)) as *mut _,
         ctx,
     );

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -1952,7 +1952,7 @@ function deserializeTSInstantiationExpression(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     expression: deserializeExpression(pos + 8),
-    typeParameters: deserializeBoxTSTypeParameterInstantiation(pos + 24),
+    typeArguments: deserializeBoxTSTypeParameterInstantiation(pos + 24),
   };
 }
 

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -2028,7 +2028,7 @@ function deserializeTSInstantiationExpression(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     expression: deserializeExpression(pos + 8),
-    typeParameters: deserializeBoxTSTypeParameterInstantiation(pos + 24),
+    typeArguments: deserializeBoxTSTypeParameterInstantiation(pos + 24),
   };
 }
 

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -1413,7 +1413,7 @@ export interface TSNamespaceExportDeclaration extends Span {
 export interface TSInstantiationExpression extends Span {
   type: 'TSInstantiationExpression';
   expression: Expression;
-  typeParameters: TSTypeParameterInstantiation;
+  typeArguments: TSTypeParameterInstantiation;
 }
 
 export type ImportOrExportKind = 'value' | 'type';

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -2,7 +2,7 @@ commit: 15392346
 
 estree_typescript Summary:
 AST Parsed     : 10618/10725 (99.00%)
-Positive Passed: 8047/10725 (75.03%)
+Positive Passed: 8050/10725 (75.06%)
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/ClassDeclarationWithInvalidConstOnPropertyDeclaration.ts
 A class member cannot have the 'const' keyword.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractPropertyInConstructor.ts
@@ -819,7 +819,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/initializersInAmbientEn
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inlineMappedTypeModifierDeclarationEmit.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/innerExtern.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceAndStaticDeclarations1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceofOnInstantiationExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiateContextuallyTypedGenericThis.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiationExpressionErrorNoCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceAssignmentCompat.ts
@@ -2365,7 +2364,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classEx
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-contextualTypes.2.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-decoratorExpression.1.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-decoratorExpression.2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiteralInference.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiterals2ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/arrayLiterals/arrayLiterals2ES6.ts
@@ -3447,7 +3445,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/variadic
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeAliases/typeAliases.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/constraintSatisfactionWithAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/constraintSatisfactionWithEmptyObject.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiationExpressions.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/wrappedAndRecursiveConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiers.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeParameterLists/typeParameterConstModifiersReverseMappedTypes.ts

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -2,7 +2,7 @@ commit: 15392346
 
 estree_typescript Summary:
 AST Parsed     : 10618/10725 (99.00%)
-Positive Passed: 8059/10725 (75.14%)
+Positive Passed: 8062/10725 (75.17%)
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/ClassDeclarationWithInvalidConstOnPropertyDeclaration.ts
 A class member cannot have the 'const' keyword.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractPropertyInConstructor.ts


### PR DESCRIPTION
Part of #9705 

~~There seemed to be other nodes that originally has the `type_arguments` property.~~
~~Is it OK to just apply `estree(rename)` here...?~~