### PR TITLE
fix(semantic): incorrect `SymbolFlags` of `TSModuleDeclaration`

### DIFF
--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -1030,7 +1030,14 @@ impl<'a> Declaration<'a> {
             Declaration::TSInterfaceDeclaration(decl) => Some(&decl.id),
             Declaration::TSEnumDeclaration(decl) => Some(&decl.id),
             Declaration::TSImportEqualsDeclaration(decl) => Some(&decl.id),
-            _ => None,
+            Declaration::TSModuleDeclaration(decl) => {
+                if let TSModuleDeclarationName::Identifier(ident) = &decl.id {
+                    Some(ident)
+                } else {
+                    None
+                }
+            }
+            Declaration::VariableDeclaration(_) => None,
         }
     }
 

--- a/crates/oxc_semantic/src/binder.rs
+++ b/crates/oxc_semantic/src/binder.rs
@@ -2,9 +2,11 @@
 
 use std::ptr;
 
+use oxc_allocator::{Address, GetAddress};
 use oxc_ast::{AstKind, ast::*};
 use oxc_ecmascript::{BoundNames, IsSimpleParameterList};
 use oxc_syntax::{
+    node::NodeId,
     scope::{ScopeFlags, ScopeId},
     symbol::SymbolFlags,
 };
@@ -382,25 +384,282 @@ impl<'a> Binder<'a> for TSEnumMember<'a> {
 }
 
 impl<'a> Binder<'a> for TSModuleDeclaration<'a> {
-    fn bind(&self, builder: &mut SemanticBuilder) {
+    fn bind(&self, builder: &mut SemanticBuilder<'a>) {
         // do not bind `global` for `declare global { ... }`
         if self.kind.is_global() {
             return;
         }
         let TSModuleDeclarationName::Identifier(id) = &self.id else { return };
+        let instantiated =
+            get_module_instance_state(builder, self, builder.current_node_id).is_instantiated();
+        let (includes, excludes) = if instantiated {
+            (SymbolFlags::ValueModule, SymbolFlags::ValueModuleExcludes)
+        } else {
+            (SymbolFlags::NameSpaceModule, SymbolFlags::NamespaceModuleExcludes)
+        };
 
         // At declaration time a module has no value declaration it is only when a value declaration
         // is made inside a the scope of a module that the symbol is modified
         let ambient = if self.declare { SymbolFlags::Ambient } else { SymbolFlags::None };
-        let symbol_id = builder.declare_symbol(
-            id.span,
-            &id.name,
-            SymbolFlags::NameSpaceModule | ambient,
-            SymbolFlags::None,
-        );
+        let symbol_id = builder.declare_symbol(id.span, &id.name, includes | ambient, excludes);
 
         id.set_symbol_id(symbol_id);
     }
+}
+
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
+pub enum ModuleInstanceState {
+    NonInstantiated,
+    Instantiated,
+    ConstEnumOnly,
+}
+
+impl ModuleInstanceState {
+    fn is_instantiated(self) -> bool {
+        self != ModuleInstanceState::NonInstantiated
+    }
+}
+
+/// Determines if a module is instantiated or not.
+///
+/// Based on `https://github.com/microsoft/TypeScript/blob/15392346d05045742e653eab5c87538ff2a3c863/src/compiler/binder.ts#L342-L474`
+fn get_module_instance_state<'a>(
+    builder: &mut SemanticBuilder<'a>,
+    decl: &TSModuleDeclaration<'a>,
+    current_node_id: NodeId,
+) -> ModuleInstanceState {
+    get_module_instance_state_impl(builder, decl, current_node_id, &mut Vec::new())
+}
+
+fn get_module_instance_state_impl<'a, 'b>(
+    builder: &mut SemanticBuilder<'a>,
+    decl: &'b TSModuleDeclaration<'a>,
+    current_node_id: NodeId,
+    module_declaration_stmts: &mut Vec<&'b Statement<'a>>,
+) -> ModuleInstanceState {
+    let address = Address::from_ptr(decl);
+
+    if let Some(state) = builder.module_instance_state_cache.get(&address) {
+        return *state;
+    }
+
+    let Some(body) = &decl.body else {
+        // For modules without a block, we consider them instantiated
+        return ModuleInstanceState::Instantiated;
+    };
+
+    // A module is uninstantiated if it contains only specific declarations
+    let state = match body {
+        TSModuleDeclarationBody::TSModuleBlock(block) => {
+            let mut child_state = ModuleInstanceState::NonInstantiated;
+            for stmt in &block.body {
+                module_declaration_stmts.extend(block.body.iter());
+                child_state = get_module_instance_state_for_statement(
+                    builder,
+                    stmt,
+                    current_node_id,
+                    module_declaration_stmts,
+                );
+                if child_state.is_instantiated() {
+                    break;
+                }
+            }
+            child_state
+        }
+        TSModuleDeclarationBody::TSModuleDeclaration(module) => {
+            get_module_instance_state(builder, module, current_node_id)
+        }
+    };
+
+    builder.module_instance_state_cache.insert(address, state);
+    state
+}
+
+fn get_module_instance_state_for_statement<'a, 'b>(
+    builder: &mut SemanticBuilder<'a>,
+    stmt: &'b Statement<'a>,
+    current_node_id: NodeId,
+    module_declaration_stmts: &mut Vec<&'b Statement<'a>>,
+) -> ModuleInstanceState {
+    let address = stmt.address();
+    if let Some(state) = builder.module_instance_state_cache.get(&address) {
+        return *state;
+    }
+
+    let state = match stmt {
+            // 1. interface declarations, type alias declarations
+            Statement::TSInterfaceDeclaration(_)
+            | Statement::TSTypeAliasDeclaration(_)
+            // 3. non-exported import declarations
+            | Statement::TSImportEqualsDeclaration(_) => {
+                ModuleInstanceState::NonInstantiated
+            }
+            // 2. const enum declarations
+            Statement::TSEnumDeclaration(enum_decl) => {
+                if enum_decl.r#const {
+                    ModuleInstanceState::ConstEnumOnly
+                } else {
+                    ModuleInstanceState::Instantiated
+                }
+            }
+            Statement::ExportDefaultDeclaration(export_decl)  => {
+                if matches!(export_decl.declaration, ExportDefaultDeclarationKind::TSInterfaceDeclaration(_)) {
+                    ModuleInstanceState::NonInstantiated
+                } else {
+                    ModuleInstanceState::Instantiated
+                }
+            }
+            Statement::ExportNamedDeclaration(export_decl) if export_decl.declaration.is_some() => {
+                match export_decl.declaration.as_ref().unwrap() {
+                    Declaration::TSModuleDeclaration(module_decl) => {
+                        get_module_instance_state_impl(builder, module_decl, current_node_id, module_declaration_stmts)
+                    }
+                    decl => if decl.is_type() {
+                        ModuleInstanceState::NonInstantiated
+                    } else {
+                        ModuleInstanceState::Instantiated
+                    }
+                }
+            }
+            // 4. Export alias declarations pointing at uninstantiated modules
+            Statement::ExportNamedDeclaration(export_decl) => {
+                if export_decl.source.is_none() {
+                    let mut export_state = ModuleInstanceState::NonInstantiated;
+                    for specifier in &export_decl.specifiers {
+                        export_state = get_module_instance_state_for_alias_target(builder, specifier, current_node_id, module_declaration_stmts.as_slice());
+                        if export_state.is_instantiated() {
+                            break;
+                        }
+                    }
+                    export_state
+                } else {
+                    ModuleInstanceState::Instantiated
+                }
+            }
+            // 5. other module declarations
+            Statement::TSModuleDeclaration(module_decl) => {
+                get_module_instance_state_impl(builder, module_decl, current_node_id, module_declaration_stmts)
+            }
+            // Any other type of statement means the module is instantiated
+            _ => ModuleInstanceState::Instantiated,
+        };
+
+    builder.module_instance_state_cache.insert(address, state);
+    state
+}
+
+// `module_declaration_stmts` is stored statements that are collected from the all ModuleBlocks.
+// The reason we need to collect and pass in this method is that we need to check export specifiers
+// whether they refer to a declaration that declared in the module block or not. And we can't use
+// `self.nodes.node(node_id)` to get the nested module block's statements since the child ModuleBlock
+// AstNode hasn't created yet.
+fn get_module_instance_state_for_alias_target<'a>(
+    builder: &mut SemanticBuilder<'a>,
+    specifier: &ExportSpecifier<'a>,
+    mut current_node_id: NodeId,
+    module_declaration_stmts: &[&Statement<'a>],
+) -> ModuleInstanceState {
+    let ModuleExportName::IdentifierReference(local) = &specifier.local else {
+        return ModuleInstanceState::Instantiated;
+    };
+
+    let name = local.name;
+    let mut current_block_stmts = module_declaration_stmts.to_vec();
+    loop {
+        let mut found = false;
+        for stmt in &current_block_stmts {
+            match stmt {
+                Statement::VariableDeclaration(decl) => {
+                    decl.bound_names(&mut |id| {
+                        if id.name == name {
+                            found = true;
+                        }
+                    });
+                }
+                match_declaration!(Statement) => {
+                    if stmt.to_declaration().id().is_some_and(|id| id.name == name) {
+                        found = true;
+                    }
+                }
+                Statement::ExportNamedDeclaration(decl) => match decl.declaration.as_ref() {
+                    Some(Declaration::VariableDeclaration(decl)) => {
+                        decl.bound_names(&mut |id| {
+                            if id.name == name {
+                                found = true;
+                            }
+                        });
+                    }
+                    Some(decl) => {
+                        if decl.id().is_some_and(|id| id.name == name) {
+                            found = true;
+                        }
+                    }
+                    None => {
+                        continue;
+                    }
+                },
+                Statement::ExportDefaultDeclaration(decl) => match &decl.declaration {
+                    ExportDefaultDeclarationKind::FunctionDeclaration(decl) => {
+                        if decl.id.as_ref().is_some_and(|id| id.name == name) {
+                            found = true;
+                        }
+                    }
+                    ExportDefaultDeclarationKind::ClassDeclaration(decl) => {
+                        if decl.id.as_ref().is_some_and(|id| id.name == name) {
+                            found = true;
+                        }
+                    }
+                    ExportDefaultDeclarationKind::TSInterfaceDeclaration(decl) => {
+                        if decl.id.name == name {
+                            found = true;
+                        }
+                    }
+                    _ => {}
+                },
+                _ => {}
+            }
+
+            if found {
+                if matches!(stmt, Statement::TSImportEqualsDeclaration(_)) {
+                    // Treat re-exports of import aliases as instantiated,
+                    // since they're ambiguous. This is consistent with
+                    // `export import x = mod.x` being treated as instantiated:
+                    //   import x = mod.x;
+                    //   export { x };
+                    return ModuleInstanceState::Instantiated;
+                }
+                return get_module_instance_state_for_statement(
+                    builder,
+                    stmt,
+                    current_node_id,
+                    &mut Vec::default(), // No need to check export specifier
+                );
+            }
+        }
+
+        let Some(node) = builder.nodes.ancestors(current_node_id).skip(1).find(|node| {
+            matches!(
+                node.kind(),
+                AstKind::Program(_) | AstKind::TSModuleBlock(_) | AstKind::BlockStatement(_)
+            )
+        }) else {
+            break;
+        };
+
+        current_node_id = node.id();
+        current_block_stmts.clear();
+        // Didn't find the declaration whose name matches export specifier
+        // in the current block, so we need to check the parent block.
+        current_block_stmts.extend(match node.kind() {
+            AstKind::Program(program) => program.body.iter(),
+            AstKind::TSModuleBlock(block) => block.body.iter(),
+            AstKind::BlockStatement(block) => block.body.iter(),
+            _ => unreachable!(),
+        });
+    }
+
+    // Not found in any of the statements
+    ModuleInstanceState::Instantiated
 }
 
 impl<'a> Binder<'a> for TSTypeParameter<'a> {

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -5,6 +5,7 @@ use std::{
     mem,
 };
 
+use oxc_allocator::Address;
 use oxc_data_structures::stack::Stack;
 use rustc_hash::FxHashMap;
 
@@ -25,7 +26,7 @@ use oxc_syntax::{
 
 use crate::{
     JSDocFinder, Semantic,
-    binder::Binder,
+    binder::{Binder, ModuleInstanceState},
     checker,
     class::ClassTableBuilder,
     diagnostics::redeclaration,
@@ -67,11 +68,7 @@ pub struct SemanticBuilder<'a> {
     pub(crate) current_scope_id: ScopeId,
     /// Stores current `AstKind::Function` and `AstKind::ArrowFunctionExpression` during AST visit
     pub(crate) function_stack: Stack<NodeId>,
-    // To make a namespace/module value like
-    // we need the to know the modules we are inside
-    // and when we reach a value declaration we set it
-    // to value like
-    pub(crate) namespace_stack: Vec<Option<SymbolId>>,
+    pub(crate) module_instance_state_cache: FxHashMap<Address, ModuleInstanceState>,
     current_reference_flags: ReferenceFlags,
     pub(crate) hoisting_variables: FxHashMap<ScopeId, FxHashMap<Atom<'a>, SymbolId>>,
 
@@ -125,7 +122,7 @@ impl<'a> SemanticBuilder<'a> {
             current_reference_flags: ReferenceFlags::empty(),
             current_scope_id,
             function_stack: Stack::with_capacity(16),
-            namespace_stack: vec![],
+            module_instance_state_cache: FxHashMap::default(),
             nodes: AstNodes::default(),
             hoisting_variables: FxHashMap::default(),
             scoping,
@@ -1964,25 +1961,21 @@ impl<'a> SemanticBuilder<'a> {
             }
             AstKind::VariableDeclarator(decl) => {
                 decl.bind(self);
-                self.make_all_namespaces_valuelike();
             }
             AstKind::Function(func) => {
                 self.function_stack.push(self.current_node_id);
                 if func.is_declaration() {
                     func.bind(self);
                 }
-                self.make_all_namespaces_valuelike();
             }
             AstKind::ArrowFunctionExpression(_) => {
                 self.function_stack.push(self.current_node_id);
-                self.make_all_namespaces_valuelike();
             }
             AstKind::Class(class) => {
                 self.current_node_flags |= NodeFlags::Class;
                 if class.is_declaration() {
                     class.bind(self);
                 }
-                self.make_all_namespaces_valuelike();
             }
             AstKind::ClassBody(body) => {
                 self.class_table_builder.declare_class_body(
@@ -2009,11 +2002,6 @@ impl<'a> SemanticBuilder<'a> {
             }
             AstKind::TSModuleDeclaration(module_declaration) => {
                 module_declaration.bind(self);
-                let symbol_id = match &module_declaration.id {
-                    TSModuleDeclarationName::Identifier(ident) => ident.symbol_id.get(),
-                    TSModuleDeclarationName::StringLiteral(_) => None,
-                };
-                self.namespace_stack.push(symbol_id);
             }
             AstKind::TSTypeAliasDeclaration(type_alias_declaration) => {
                 type_alias_declaration.bind(self);
@@ -2024,7 +2012,6 @@ impl<'a> SemanticBuilder<'a> {
             AstKind::TSEnumDeclaration(enum_declaration) => {
                 enum_declaration.bind(self);
                 // TODO: const enum?
-                self.make_all_namespaces_valuelike();
             }
             AstKind::TSEnumMember(enum_member) => {
                 enum_member.bind(self);
@@ -2111,9 +2098,6 @@ impl<'a> SemanticBuilder<'a> {
             AstKind::CatchParameter(_) => {
                 self.resolve_references_for_current_scope();
             }
-            AstKind::TSModuleDeclaration(_) => {
-                self.namespace_stack.pop();
-            }
             AstKind::TSTypeName(_) => {
                 self.current_reference_flags -= ReferenceFlags::Type;
             }
@@ -2124,20 +2108,6 @@ impl<'a> SemanticBuilder<'a> {
             }
             AstKind::LabeledStatement(_) => self.unused_labels.mark_unused(self.current_node_id),
             _ => {}
-        }
-    }
-
-    fn make_all_namespaces_valuelike(&mut self) {
-        for symbol_id in self.namespace_stack.iter().copied() {
-            let Some(symbol_id) = symbol_id else {
-                continue;
-            };
-
-            // Ambient modules cannot be value modules
-            if self.scoping.symbol_flags(symbol_id).intersects(SymbolFlags::Ambient) {
-                continue;
-            }
-            self.scoping.union_symbol_flag(symbol_id, SymbolFlags::ValueModule);
         }
     }
 

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/class-namespace.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/class-namespace.snap
@@ -33,7 +33,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
     "node": "Program",
     "symbols": [
       {
-        "flags": "SymbolFlags(Class | NameSpaceModule | ValueModule)",
+        "flags": "SymbolFlags(Class | ValueModule)",
         "id": 0,
         "name": "Foo",
         "node": "Class(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/function-namespace.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/declaration-merging/function-namespace.snap
@@ -33,7 +33,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/decla
     "node": "Program",
     "symbols": [
       {
-        "flags": "SymbolFlags(Function | NameSpaceModule | ValueModule)",
+        "flags": "SymbolFlags(Function | ValueModule)",
         "id": 0,
         "name": "Foo",
         "node": "Function(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/external-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/external-ref.snap
@@ -26,7 +26,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/exter
     "node": "Program",
     "symbols": [
       {
-        "flags": "SymbolFlags(NameSpaceModule | ValueModule)",
+        "flags": "SymbolFlags(ValueModule)",
         "id": 0,
         "name": "Foo",
         "node": "TSModuleDeclaration(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-shadowed-in-body.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-shadowed-in-body.snap
@@ -26,7 +26,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/name-
     "node": "Program",
     "symbols": [
       {
-        "flags": "SymbolFlags(NameSpaceModule | ValueModule)",
+        "flags": "SymbolFlags(ValueModule)",
         "id": 0,
         "name": "Foo",
         "node": "TSModuleDeclaration(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/namespace.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/namespace.snap
@@ -26,7 +26,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/names
     "node": "Program",
     "symbols": [
       {
-        "flags": "SymbolFlags(NameSpaceModule | ValueModule)",
+        "flags": "SymbolFlags(ValueModule)",
         "id": 0,
         "name": "Foo",
         "node": "TSModuleDeclaration(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/scope.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/scope.snap
@@ -26,7 +26,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/scope
     "node": "Program",
     "symbols": [
       {
-        "flags": "SymbolFlags(NameSpaceModule | ValueModule)",
+        "flags": "SymbolFlags(ValueModule)",
         "id": 0,
         "name": "Foo",
         "node": "TSModuleDeclaration(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/self-ref.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/self-ref.snap
@@ -26,7 +26,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/ts-module/self-
     "node": "Program",
     "symbols": [
       {
-        "flags": "SymbolFlags(NameSpaceModule | ValueModule)",
+        "flags": "SymbolFlags(ValueModule)",
         "id": 0,
         "name": "Foo",
         "node": "TSModuleDeclaration(Foo)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface-heritage2.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/interface-heritage2.snap
@@ -59,7 +59,14 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         "id": 1,
         "name": "Member",
         "node": "TSModuleDeclaration(Member)",
-        "references": []
+        "references": [
+          {
+            "flags": "ReferenceFlags(Type)",
+            "id": 0,
+            "name": "Member",
+            "node_id": 16
+          }
+        ]
       },
       {
         "flags": "SymbolFlags(Interface)",

--- a/crates/oxc_semantic/tests/integration/symbols.rs
+++ b/crates/oxc_semantic/tests/integration/symbols.rs
@@ -415,10 +415,15 @@ fn test_tagged_templates() {
 fn test_module_like_declarations() {
     SemanticTester::ts("namespace A { export const x = 1; }")
         .has_root_symbol("A")
-        .contains_flags(SymbolFlags::NameSpaceModule)
+        .contains_flags(SymbolFlags::ValueModule)
         .test();
 
     SemanticTester::ts("module A { export const x = 1; }")
+        .has_root_symbol("A")
+        .contains_flags(SymbolFlags::ValueModule)
+        .test();
+
+    SemanticTester::ts("module A { export type x = 1; }")
         .has_root_symbol("A")
         .contains_flags(SymbolFlags::NameSpaceModule)
         .test();

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -152,6 +152,8 @@ bitflags! {
         const InterfaceExcludes = Self::Type.bits() & !(Self::Interface.bits() | Self::Class.bits());
         const TypeParameterExcludes = Self::Type.bits() & !Self::TypeParameter.bits();
         const ConstEnumExcludes = (Self::Type.bits() | Self::Value.bits()) & !Self::ConstEnum.bits();
+        const ValueModuleExcludes = Self::Value.bits() & !(Self::Function.bits() | Self::Class.bits() | Self::RegularEnum.bits() | Self::ValueModule.bits());
+        const NamespaceModuleExcludes = 0;
         // TODO: include value module in regular enum excludes
         const RegularEnumExcludes = (Self::Value.bits() | Self::Type.bits()) & !(Self::RegularEnum.bits() | Self::ValueModule.bits() );
         const EnumMemberExcludes = Self::EnumMember.bits();
@@ -214,6 +216,11 @@ impl SymbolFlags {
     }
 
     #[inline]
+    pub fn is_const_enum(&self) -> bool {
+        self.intersects(Self::ConstEnum)
+    }
+
+    #[inline]
     pub fn is_enum_member(&self) -> bool {
         self.contains(Self::EnumMember)
     }
@@ -241,7 +248,7 @@ impl SymbolFlags {
     /// If true, then the symbol can be referenced by a type reference
     #[inline]
     pub fn can_be_referenced_by_type(&self) -> bool {
-        self.intersects(Self::Type | Self::TypeImport | Self::Import)
+        self.intersects(Self::Type | Self::TypeImport | Self::Import | Self::NameSpaceModule)
     }
 
     /// If true, then the symbol can be referenced by a value reference

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: 15392346
 parser_typescript Summary:
 AST Parsed     : 6522/6531 (99.86%)
 Positive Passed: 6511/6531 (99.69%)
-Negative Passed: 1295/5754 (22.51%)
+Negative Passed: 1298/5754 (22.56%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration24.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment7.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment8.ts
@@ -403,7 +403,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constDeclara
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-useBeforeDefinition.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-useBeforeDefinition2.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constEnumBadPropertyNames.ts
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constEnumErrors.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constWithNonNull.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constantEnumAssert.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/constraintErrors1.ts
@@ -1437,8 +1436,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleVisibi
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleVisibilityTest4.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleWithNoValuesAsType.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/moduleWithValuesAsType.ts
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/module_augmentExistingAmbientVariable.ts
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/module_augmentExistingVariable.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/multiLineContextDiagnosticWithPretty.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/multiLineErrors.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/multipleBaseInterfaesWithIncompatibleProperties.ts
@@ -5575,6 +5572,30 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  22 │ 
     ╰────
 
+  × Identifier `x6a` has already been declared
+    ╭─[typescript/tests/cases/compiler/augmentedTypesVar.ts:27:5]
+ 26 │ 
+ 27 │ var x6a = 1; // error
+    ·     ─┬─
+    ·      ╰── `x6a` has already been declared here
+ 28 │ module x6a { var y = 2; } // error since instantiated
+    ·        ─┬─
+    ·         ╰── It can not be redeclared here
+ 29 │ 
+    ╰────
+
+  × Identifier `x6b` has already been declared
+    ╭─[typescript/tests/cases/compiler/augmentedTypesVar.ts:30:5]
+ 29 │ 
+ 30 │ var x6b = 1; // error
+    ·     ─┬─
+    ·      ╰── `x6b` has already been declared here
+ 31 │ module x6b { export var y = 2; } // error
+    ·        ─┬─
+    ·         ╰── It can not be redeclared here
+ 32 │ 
+    ╰────
+
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[typescript/tests/cases/compiler/autoLift2.ts:5:17]
  4 │     constructor() {
@@ -6871,6 +6892,21 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
     · ────
  19 │     const c5 = 0;
     ╰────
+
+  × Identifier `E` has already been declared
+   ╭─[typescript/tests/cases/compiler/constEnumErrors.ts:1:12]
+ 1 │ const enum E {
+   ·            ┬
+   ·            ╰── `E` has already been declared here
+ 2 │     A
+   ╰────
+   ╭─[typescript/tests/cases/compiler/constEnumErrors.ts:5:8]
+ 4 │ 
+ 5 │ module E {
+   ·        ┬
+   ·        ╰── It can not be redeclared here
+ 6 │     var x = 1;
+   ╰────
 
   × TS(1248): A class member cannot have the 'const' keyword.
    ╭─[typescript/tests/cases/compiler/constInClassExpression.ts:2:11]
@@ -9869,6 +9905,30 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  12 │ 
     ╰────
 
+  × Identifier `console` has already been declared
+   ╭─[typescript/tests/cases/compiler/module_augmentExistingAmbientVariable.ts:1:13]
+ 1 │ declare var console: any;
+   ·             ──────┬─────
+   ·                   ╰── `console` has already been declared here
+ 2 │ 
+ 3 │ module console {
+   ·        ───┬───
+   ·           ╰── It can not be redeclared here
+ 4 │     export var x = 2;
+   ╰────
+
+  × Identifier `console` has already been declared
+   ╭─[typescript/tests/cases/compiler/module_augmentExistingVariable.ts:1:5]
+ 1 │ var console: any;
+   ·     ──────┬─────
+   ·           ╰── `console` has already been declared here
+ 2 │ 
+ 3 │ module console {
+   ·        ───┬───
+   ·           ╰── It can not be redeclared here
+ 4 │     export var x = 2;
+   ╰────
+
   × TS(1108): A 'return' statement can only be used within a function body.
    ╭─[typescript/tests/cases/compiler/multiLinePropertyAccessAndArrowFunctionIndent1.ts:1:1]
  1 │ return this.edit(role)
@@ -9893,6 +9953,19 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  4 │     static static p3;
    ╰────
   help: Remove the duplicate modifier.
+
+  × Identifier `x` has already been declared
+   ╭─[typescript/tests/cases/compiler/nameCollisions.ts:2:9]
+ 1 │ module T {
+ 2 │     var x = 2;
+   ·         ┬
+   ·         ╰── `x` has already been declared here
+ 3 │ 
+ 4 │     module x { // error
+   ·            ┬
+   ·            ╰── It can not be redeclared here
+ 5 │         export class Bar {
+   ╰────
 
   × Identifier `z` has already been declared
     ╭─[typescript/tests/cases/compiler/nameCollisions.ts:10:12]

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -931,7 +931,7 @@ rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/export/nested-same-name/input.ts
 semantic error: Symbol flags mismatch for "N":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "N":
 after transform: SymbolId(1): Span { start: 37, end: 38 }
@@ -1277,7 +1277,7 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/module-namespace/body/input.ts
 semantic error: Symbol flags mismatch for "N":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "N":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
@@ -1587,9 +1587,6 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["N"]
-rebuilt        : []
 
 tasks/coverage/babel/packages/babel-parser/test/fixtures/typescript/scope/export-type-after/input.ts
 semantic error: Scope children mismatch:

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -232,14 +232,14 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2)]
 rebuilt        : ScopeId(1): []
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Unresolved references mismatch:
-after transform: ["M", "N"]
-rebuilt        : ["N"]
+Symbol reference IDs mismatch for "M":
+after transform: SymbolId(0): [ReferenceId(1), ReferenceId(4), ReferenceId(5)]
+rebuilt        : SymbolId(0): [ReferenceId(3), ReferenceId(4)]
 
 tasks/coverage/typescript/tests/cases/compiler/accessorsEmit.ts
 semantic error: Symbol reference IDs mismatch for "Result":
@@ -272,7 +272,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2)]
 rebuilt        : ScopeId(1): []
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -286,13 +286,13 @@ Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "N":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "N":
 after transform: SymbolId(1): Span { start: 22, end: 23 }
@@ -379,7 +379,7 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol flags mismatch for "D":
-after transform: SymbolId(3): SymbolFlags(Class | NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "D":
 after transform: SymbolId(3): Span { start: 97, end: 98 }
@@ -496,6 +496,27 @@ rebuilt        : ScopeId(0): ["c", "c2"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
 rebuilt        : ScopeId(0): []
+Reference symbol mismatch for "Foo":
+after transform: SymbolId(0) "Foo"
+rebuilt        : <None>
+Reference symbol mismatch for "Foo":
+after transform: SymbolId(0) "Foo"
+rebuilt        : <None>
+Reference symbol mismatch for "Foo":
+after transform: SymbolId(0) "Foo"
+rebuilt        : <None>
+Reference symbol mismatch for "Foo2":
+after transform: SymbolId(5) "Foo2"
+rebuilt        : <None>
+Reference symbol mismatch for "Foo2":
+after transform: SymbolId(5) "Foo2"
+rebuilt        : <None>
+Reference symbol mismatch for "Foo2":
+after transform: SymbolId(5) "Foo2"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["Foo", "Foo2"]
 
 tasks/coverage/typescript/tests/cases/compiler/ambientModuleWithClassDeclarationWithExtends.ts
 semantic error: Bindings mismatch:
@@ -512,6 +533,24 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
+Reference symbol mismatch for "Foo":
+after transform: SymbolId(0) "Foo"
+rebuilt        : <None>
+Reference symbol mismatch for "Foo":
+after transform: SymbolId(0) "Foo"
+rebuilt        : <None>
+Reference symbol mismatch for "Foo":
+after transform: SymbolId(0) "Foo"
+rebuilt        : <None>
+Reference symbol mismatch for "Foo":
+after transform: SymbolId(0) "Foo"
+rebuilt        : <None>
+Reference symbol mismatch for "Foo":
+after transform: SymbolId(0) "Foo"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["Foo"]
 
 tasks/coverage/typescript/tests/cases/compiler/ambientModules.ts
 semantic error: Bindings mismatch:
@@ -520,6 +559,12 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
+Reference symbol mismatch for "Foo":
+after transform: SymbolId(0) "Foo"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["Foo"]
 
 tasks/coverage/typescript/tests/cases/compiler/ambientNameRestrictions.ts
 semantic error: Bindings mismatch:
@@ -583,7 +628,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -644,7 +689,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(7)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
 Symbol flags mismatch for "Test":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Test":
 after transform: SymbolId(0): Span { start: 7, end: 11 }
@@ -675,7 +720,7 @@ Scope children mismatch:
 after transform: ScopeId(17): [ScopeId(18), ScopeId(19), ScopeId(20), ScopeId(21), ScopeId(22)]
 rebuilt        : ScopeId(15): [ScopeId(16), ScopeId(17)]
 Symbol flags mismatch for "EmptyTypes":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "EmptyTypes":
 after transform: SymbolId(0): Span { start: 7, end: 17 }
@@ -684,7 +729,7 @@ Symbol reference IDs mismatch for "base":
 after transform: SymbolId(2): [ReferenceId(2), ReferenceId(9), ReferenceId(11), ReferenceId(12), ReferenceId(14), ReferenceId(15), ReferenceId(17), ReferenceId(23)]
 rebuilt        : SymbolId(3): [ReferenceId(1), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(18)]
 Symbol flags mismatch for "NonEmptyTypes":
-after transform: SymbolId(28): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(28): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(23): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "NonEmptyTypes":
 after transform: SymbolId(28): Span { start: 2225, end: 2238 }
@@ -776,7 +821,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -857,7 +902,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2)]
 rebuilt        : ScopeId(1): []
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -1034,7 +1079,7 @@ Reference symbol mismatch for "resolve2":
 after transform: SymbolId(15) "resolve2"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Promise", "Windows", "arguments", "require"]
+after transform: ["Promise", "arguments", "require"]
 rebuilt        : ["arguments", "require", "resolve1", "resolve2"]
 
 tasks/coverage/typescript/tests/cases/compiler/asyncYieldStarContextualType.ts
@@ -1303,7 +1348,7 @@ Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Test":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Test":
 after transform: SymbolId(1): Span { start: 42, end: 46 }
@@ -1336,7 +1381,7 @@ rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/blockScopedNamespaceDifferentFile.ts
 semantic error: Symbol flags mismatch for "C":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "C":
 after transform: SymbolId(0): Span { start: 66, end: 67 }
@@ -1751,7 +1796,7 @@ rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/chainedImportAlias.ts
 semantic error: Symbol flags mismatch for "m":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m":
 after transform: SymbolId(0): Span { start: 14, end: 15 }
@@ -1901,7 +1946,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch for "maker":
-after transform: SymbolId(1): SymbolFlags(Function | NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(Function | ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(Function)
 Symbol reference IDs mismatch for "maker":
 after transform: SymbolId(1): [ReferenceId(0), ReferenceId(1), ReferenceId(5), ReferenceId(6)]
@@ -1995,7 +2040,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -2067,7 +2112,7 @@ Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "M2":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M2":
 after transform: SymbolId(2): Span { start: 68, end: 70 }
@@ -2231,19 +2276,19 @@ Scope children mismatch:
 after transform: ScopeId(35): [ScopeId(36), ScopeId(37), ScopeId(38)]
 rebuilt        : ScopeId(22): [ScopeId(23)]
 Symbol flags mismatch for "m1":
-after transform: SymbolId(9): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(9): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(9): Span { start: 594, end: 596 }
 rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
-after transform: SymbolId(13): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(13): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(13): Span { start: 690, end: 692 }
 rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m3":
-after transform: SymbolId(14): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(14): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m3":
 after transform: SymbolId(14): Span { start: 714, end: 716 }
@@ -2266,7 +2311,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3)]
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -2313,7 +2358,7 @@ Scope children mismatch:
 after transform: ScopeId(3): [ScopeId(4), ScopeId(6)]
 rebuilt        : ScopeId(3): [ScopeId(4)]
 Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol reference IDs mismatch for "Foo":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(3), ReferenceId(4)]
@@ -2327,7 +2372,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Symbol flags mismatch for "Service":
-after transform: SymbolId(2): SymbolFlags(Class | NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(Class)
 Symbol reference IDs mismatch for "Service":
 after transform: SymbolId(2): [ReferenceId(2), ReferenceId(4), ReferenceId(5)]
@@ -2754,7 +2799,7 @@ Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(0x0)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 7, end: 9 }
@@ -2774,13 +2819,13 @@ Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 7, end: 9 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(3): Span { start: 73, end: 75 }
@@ -2794,7 +2839,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
 Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 7, end: 9 }
@@ -2817,7 +2862,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 7, end: 9 }
@@ -2828,7 +2873,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüßAbcd123":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüß才能ソЫⅨ蒤郳र\u{94d}क\u{94d}ड\u{94d}राüışğİliيونيكودöÄüßAbcd123":
 after transform: SymbolId(0): Span { start: 7, end: 170 }
@@ -2864,7 +2909,7 @@ Scope children mismatch:
 after transform: ScopeId(6): [ScopeId(7), ScopeId(8)]
 rebuilt        : ScopeId(1): []
 Symbol flags mismatch for "m2":
-after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(5): Span { start: 187, end: 189 }
@@ -2887,7 +2932,7 @@ Scope children mismatch:
 after transform: ScopeId(6): [ScopeId(7), ScopeId(8)]
 rebuilt        : ScopeId(1): []
 Symbol flags mismatch for "m4":
-after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m4":
 after transform: SymbolId(5): Span { start: 169, end: 171 }
@@ -2907,7 +2952,7 @@ Scope children mismatch:
 after transform: ScopeId(16): [ScopeId(17), ScopeId(20)]
 rebuilt        : ScopeId(3): []
 Symbol flags mismatch for "m2":
-after transform: SymbolId(15): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(15): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(15): Span { start: 524, end: 526 }
@@ -2927,7 +2972,7 @@ Bindings mismatch:
 after transform: ScopeId(2): ["_m", "a", "exports", "require"]
 rebuilt        : ScopeId(1): ["_m", "a"]
 Symbol flags mismatch for "m2":
-after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(5): Span { start: 151, end: 153 }
@@ -2941,13 +2986,13 @@ Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 Symbol flags mismatch for "m3":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m3":
 after transform: SymbolId(2): Span { start: 89, end: 91 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m4":
-after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m4":
 after transform: SymbolId(5): Span { start: 209, end: 211 }
@@ -2964,19 +3009,19 @@ Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Symbol flags mismatch for "mOfGloalFile":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "mOfGloalFile":
 after transform: SymbolId(0): Span { start: 7, end: 19 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m1":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(4): Span { start: 155, end: 157 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
-after transform: SymbolId(7): SymbolFlags(NameSpaceModule)
+after transform: SymbolId(7): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(7): Span { start: 282, end: 284 }
@@ -2989,9 +3034,6 @@ rebuilt        : ScopeId(0): ["foo", "foo2"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(6)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Unresolved references mismatch:
-after transform: ["exports", "require"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/collisionRestParameterClassConstructor.ts
 semantic error: Bindings mismatch:
@@ -3175,7 +3217,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "_this":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "_this":
 after transform: SymbolId(0): Span { start: 7, end: 12 }
@@ -3231,7 +3273,7 @@ Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "foo":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "foo":
 after transform: SymbolId(1): Span { start: 37, end: 40 }
@@ -3258,19 +3300,19 @@ Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch for "hello":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "hello":
 after transform: SymbolId(0): Span { start: 10, end: 15 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "hi":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "hi":
 after transform: SymbolId(1): Span { start: 16, end: 18 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "world":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "world":
 after transform: SymbolId(2): Span { start: 19, end: 24 }
@@ -3432,13 +3474,13 @@ rebuilt        : SymbolId(23): []
 
 tasks/coverage/typescript/tests/cases/compiler/commentsDottedModuleName.ts
 semantic error: Symbol flags mismatch for "outerModule":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "outerModule":
 after transform: SymbolId(0): Span { start: 49, end: 60 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "InnerModule":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "InnerModule":
 after transform: SymbolId(1): Span { start: 61, end: 72 }
@@ -3478,7 +3520,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "m":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -3503,7 +3545,7 @@ Namespaces exporting non-const are not supported by Babel. Change to const or se
 
 tasks/coverage/typescript/tests/cases/compiler/commentsMultiModuleMultiFile.ts
 semantic error: Symbol flags mismatch for "multiM":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "multiM":
 after transform: SymbolId(0): Span { start: 49, end: 55 }
@@ -3520,7 +3562,7 @@ Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Symbol flags mismatch for "multiM":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "multiM":
 after transform: SymbolId(0): Span { start: 42, end: 48 }
@@ -3615,7 +3657,7 @@ Scope flags mismatch:
 after transform: ScopeId(18): ScopeFlags(0x0)
 rebuilt        : ScopeId(11): ScopeFlags(Function)
 Symbol flags mismatch for "m1":
-after transform: SymbolId(12): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(12): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(12): Span { start: 1256, end: 1258 }
@@ -3647,7 +3689,7 @@ Scope children mismatch:
 after transform: ScopeId(14): [ScopeId(15), ScopeId(17)]
 rebuilt        : ScopeId(8): [ScopeId(9)]
 Symbol flags mismatch for "m1":
-after transform: SymbolId(12): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(12): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(12): Span { start: 1256, end: 1258 }
@@ -3718,7 +3760,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Foo":
 after transform: SymbolId(0): Span { start: 7, end: 10 }
@@ -3820,7 +3862,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "NS":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "NS":
 after transform: SymbolId(0): Span { start: 10, end: 12 }
@@ -4053,7 +4095,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 19, end: 20 }
@@ -4098,7 +4140,7 @@ Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "foo":
-after transform: SymbolId(0): SymbolFlags(Function | NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(Function | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Function)
 Symbol redeclarations mismatch for "foo":
 after transform: SymbolId(0): [Span { start: 9, end: 12 }, Span { start: 25, end: 28 }]
@@ -4115,7 +4157,7 @@ Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "foo":
-after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol redeclarations mismatch for "foo":
 after transform: SymbolId(0): [Span { start: 6, end: 9 }, Span { start: 20, end: 23 }]
@@ -4138,7 +4180,7 @@ Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(3): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "foo":
-after transform: SymbolId(0): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(RegularEnum | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "foo":
 after transform: SymbolId(0): [Span { start: 5, end: 8 }, Span { start: 22, end: 25 }]
@@ -4155,7 +4197,7 @@ Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "foo":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "foo":
 after transform: SymbolId(0): Span { start: 7, end: 10 }
@@ -4175,7 +4217,7 @@ Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "foo":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "foo":
 after transform: SymbolId(0): Span { start: 7, end: 10 }
@@ -4203,7 +4245,7 @@ Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "ConstEnumOnlyModule":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "ConstEnumOnlyModule":
 after transform: SymbolId(0): Span { start: 14, end: 33 }
@@ -4396,7 +4438,7 @@ Symbol reference IDs mismatch for "Comments":
 after transform: SymbolId(31): [ReferenceId(85), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(90), ReferenceId(91), ReferenceId(92), ReferenceId(93), ReferenceId(226)]
 rebuilt        : SymbolId(3): [ReferenceId(83), ReferenceId(208), ReferenceId(209), ReferenceId(210), ReferenceId(211), ReferenceId(212), ReferenceId(213), ReferenceId(214)]
 Symbol flags mismatch for "A":
-after transform: SymbolId(39): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(39): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(39): Span { start: 717, end: 718 }
@@ -4405,13 +4447,13 @@ Symbol redeclarations mismatch for "A":
 after transform: SymbolId(39): [Span { start: 717, end: 718 }, Span { start: 905, end: 906 }]
 rebuilt        : SymbolId(5): []
 Symbol flags mismatch for "B":
-after transform: SymbolId(40): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(40): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "B":
 after transform: SymbolId(40): Span { start: 739, end: 740 }
 rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 Symbol flags mismatch for "C":
-after transform: SymbolId(41): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(41): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "C":
 after transform: SymbolId(41): Span { start: 765, end: 766 }
@@ -4420,13 +4462,13 @@ Symbol flags mismatch for "E":
 after transform: SymbolId(42): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "B":
-after transform: SymbolId(45): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(45): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "B":
 after transform: SymbolId(45): Span { start: 927, end: 928 }
 rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 Symbol flags mismatch for "C":
-after transform: SymbolId(46): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(46): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "C":
 after transform: SymbolId(46): Span { start: 953, end: 954 }
@@ -4435,19 +4477,19 @@ Symbol flags mismatch for "E":
 after transform: SymbolId(47): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "A1":
-after transform: SymbolId(50): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(50): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A1":
 after transform: SymbolId(50): Span { start: 1114, end: 1116 }
 rebuilt        : SymbolId(20): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
-after transform: SymbolId(51): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(51): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(22): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "B":
 after transform: SymbolId(51): Span { start: 1137, end: 1138 }
 rebuilt        : SymbolId(22): Span { start: 0, end: 0 }
 Symbol flags mismatch for "C":
-after transform: SymbolId(52): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(52): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(24): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "C":
 after transform: SymbolId(52): Span { start: 1163, end: 1164 }
@@ -4456,19 +4498,19 @@ Symbol flags mismatch for "E":
 after transform: SymbolId(53): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(26): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "A2":
-after transform: SymbolId(56): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(56): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(28): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A2":
 after transform: SymbolId(56): Span { start: 1292, end: 1294 }
 rebuilt        : SymbolId(28): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
-after transform: SymbolId(57): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(57): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(30): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "B":
 after transform: SymbolId(57): Span { start: 1315, end: 1316 }
 rebuilt        : SymbolId(30): Span { start: 0, end: 0 }
 Symbol flags mismatch for "C":
-after transform: SymbolId(58): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(58): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(32): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "C":
 after transform: SymbolId(58): Span { start: 1341, end: 1342 }
@@ -4610,7 +4652,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(5)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4)]
 Symbol flags mismatch for "Test":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Test":
 after transform: SymbolId(0): Span { start: 7, end: 11 }
@@ -4805,6 +4847,15 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
+Reference symbol mismatch for "app":
+after transform: SymbolId(0) "app"
+rebuilt        : <None>
+Reference symbol mismatch for "app":
+after transform: SymbolId(0) "app"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["app"]
 
 tasks/coverage/typescript/tests/cases/compiler/contextualReturnTypeOfIIFE3.ts
 semantic error: Bindings mismatch:
@@ -4813,6 +4864,15 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
+Reference symbol mismatch for "app":
+after transform: SymbolId(0) "app"
+rebuilt        : <None>
+Reference symbol mismatch for "app":
+after transform: SymbolId(0) "app"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["app"]
 
 tasks/coverage/typescript/tests/cases/compiler/contextualSigInstantiationRestParams.ts
 semantic error: Bindings mismatch:
@@ -5231,7 +5291,7 @@ Reference symbol mismatch for "App4":
 after transform: SymbolId(42) "App4"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["JSX", "require", "undefined"]
+after transform: ["require", "undefined"]
 rebuilt        : ["App4", "app", "app2", "app3", "foo", "require", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/contextualTypingOfTooShortOverloads.ts
@@ -5388,11 +5448,8 @@ Reference symbol mismatch for "DropdownMenu":
 after transform: SymbolId(1) "DropdownMenu"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["DropdownMenu", "JSX"]
+after transform: ["JSX"]
 rebuilt        : ["DropdownMenu"]
-Unresolved reference IDs mismatch for "DropdownMenu":
-after transform: [ReferenceId(7)]
-rebuilt        : [ReferenceId(1), ReferenceId(9)]
 
 tasks/coverage/typescript/tests/cases/compiler/contextuallyTypedOptionalProperty.ts
 semantic error: Bindings mismatch:
@@ -5908,7 +5965,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4)]
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -6088,13 +6145,13 @@ rebuilt        : ["Foo", "module"]
 
 tasks/coverage/typescript/tests/cases/compiler/declFileExportImportChain.ts
 semantic error: Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 7, end: 9 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(1): Span { start: 30, end: 32 }
@@ -6102,13 +6159,13 @@ rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/declFileExportImportChain2.ts
 semantic error: Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 7, end: 9 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(1): Span { start: 30, end: 32 }
@@ -6193,7 +6250,7 @@ semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(12), ScopeId(13), ScopeId(14)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(12), ScopeId(13)]
 Symbol flags mismatch for "C":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "C":
 after transform: SymbolId(0): Span { start: 14, end: 15 }
@@ -6237,31 +6294,31 @@ Scope flags mismatch:
 after transform: ScopeId(27): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(9): ScopeFlags(Function)
 Symbol flags mismatch for "dom":
-after transform: SymbolId(16): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(16): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "dom":
 after transform: SymbolId(16): Span { start: 643, end: 646 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "mvc":
-after transform: SymbolId(17): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(17): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "mvc":
 after transform: SymbolId(17): Span { start: 647, end: 650 }
 rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol flags mismatch for "dom":
-after transform: SymbolId(20): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(20): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "dom":
 after transform: SymbolId(20): Span { start: 913, end: 916 }
 rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 Symbol flags mismatch for "mvc":
-after transform: SymbolId(21): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(21): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "mvc":
 after transform: SymbolId(21): Span { start: 917, end: 920 }
 rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 Symbol flags mismatch for "composite":
-after transform: SymbolId(22): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(22): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "composite":
 after transform: SymbolId(22): Span { start: 921, end: 930 }
@@ -6278,22 +6335,25 @@ rebuilt        : <None>
 Reference symbol mismatch for "templa":
 after transform: SymbolId(0) "templa"
 rebuilt        : <None>
+Reference symbol mismatch for "templa":
+after transform: SymbolId(0) "templa"
+rebuilt        : <None>
+Reference symbol mismatch for "templa":
+after transform: SymbolId(0) "templa"
+rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["IElementController", "mvc", "require", "templa"]
+after transform: ["IElementController", "mvc", "require"]
 rebuilt        : ["require", "templa"]
-Unresolved reference IDs mismatch for "templa":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(7), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(15), ReferenceId(16), ReferenceId(18), ReferenceId(19)]
-rebuilt        : [ReferenceId(1), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(30), ReferenceId(31)]
 
 tasks/coverage/typescript/tests/cases/compiler/declFileImportChainInExportAssignment.ts
 semantic error: Symbol flags mismatch for "m":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "c":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "c":
 after transform: SymbolId(1): Span { start: 29, end: 30 }
@@ -6309,12 +6369,12 @@ rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(0): Span { start: 7, end: 9 }
 rebuilt        : SymbolId(0): Span { start: 229, end: 322 }
+Symbol reference IDs mismatch for "m2":
+after transform: SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
+rebuilt        : SymbolId(0): [ReferenceId(1)]
 Symbol redeclarations mismatch for "m2":
 after transform: SymbolId(0): [Span { start: 7, end: 9 }, Span { start: 229, end: 322 }]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["m2", "module"]
-rebuilt        : ["module"]
 
 tasks/coverage/typescript/tests/cases/compiler/declFileImportedTypeUseInTypeArgPosition.ts
 semantic error: Scope children mismatch:
@@ -6346,7 +6406,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 7, end: 9 }
@@ -6369,13 +6429,13 @@ Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch for "B":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "B":
 after transform: SymbolId(3): Span { start: 56, end: 57 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol flags mismatch for "C":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "C":
 after transform: SymbolId(4): Span { start: 58, end: 59 }
@@ -6386,9 +6446,9 @@ rebuilt        : <None>
 Reference symbol mismatch for "A":
 after transform: SymbolId(0) "A"
 rebuilt        : <None>
-Unresolved reference IDs mismatch for "A":
-after transform: [ReferenceId(0)]
-rebuilt        : [ReferenceId(10), ReferenceId(11)]
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["A"]
 
 tasks/coverage/typescript/tests/cases/compiler/declFileModuleWithPropertyOfTypeModule.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -6434,7 +6494,7 @@ Symbol reference IDs mismatch for "c":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(12), ReferenceId(13), ReferenceId(14)]
 rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7), ReferenceId(14), ReferenceId(15)]
 Symbol flags mismatch for "m":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m":
 after transform: SymbolId(1): Span { start: 19, end: 20 }
@@ -6468,7 +6528,7 @@ Symbol reference IDs mismatch for "c":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(7), ReferenceId(10)]
 rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(11)]
 Symbol flags mismatch for "m":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m":
 after transform: SymbolId(1): Span { start: 19, end: 20 }
@@ -6498,7 +6558,7 @@ Symbol reference IDs mismatch for "g":
 after transform: SymbolId(1): [ReferenceId(1), ReferenceId(7), ReferenceId(8)]
 rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "m":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m":
 after transform: SymbolId(3): Span { start: 34, end: 35 }
@@ -6515,7 +6575,7 @@ Symbol reference IDs mismatch for "c":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7)]
 Symbol flags mismatch for "m":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m":
 after transform: SymbolId(1): Span { start: 19, end: 20 }
@@ -6535,7 +6595,7 @@ Symbol reference IDs mismatch for "c":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7)]
 Symbol flags mismatch for "m":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m":
 after transform: SymbolId(1): Span { start: 19, end: 20 }
@@ -6558,7 +6618,7 @@ Symbol reference IDs mismatch for "c":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(4), ReferenceId(8), ReferenceId(11), ReferenceId(14)]
 rebuilt        : SymbolId(1): [ReferenceId(11), ReferenceId(13), ReferenceId(17), ReferenceId(20)]
 Symbol flags mismatch for "m":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m":
 after transform: SymbolId(1): Span { start: 42, end: 43 }
@@ -6578,7 +6638,7 @@ Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Symbol flags mismatch for "m":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -6590,7 +6650,7 @@ Symbol reference IDs mismatch for "public1":
 after transform: SymbolId(2): [ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(22)]
 rebuilt        : SymbolId(3): [ReferenceId(1), ReferenceId(8), ReferenceId(9)]
 Symbol flags mismatch for "m2":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(3): Span { start: 84, end: 86 }
@@ -6607,7 +6667,7 @@ Scope flags mismatch:
 after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(12): ScopeFlags(Function)
 Symbol flags mismatch for "m":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -6619,7 +6679,7 @@ Symbol reference IDs mismatch for "public1":
 after transform: SymbolId(2): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(13)]
 rebuilt        : SymbolId(3): [ReferenceId(1), ReferenceId(8), ReferenceId(11)]
 Symbol flags mismatch for "m2":
-after transform: SymbolId(19): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(19): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(19): Span { start: 534, end: 536 }
@@ -6636,7 +6696,7 @@ Scope flags mismatch:
 after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(12): ScopeFlags(Function)
 Symbol flags mismatch for "m":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -6648,7 +6708,7 @@ Symbol reference IDs mismatch for "public1":
 after transform: SymbolId(2): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(13)]
 rebuilt        : SymbolId(3): [ReferenceId(1), ReferenceId(8), ReferenceId(11)]
 Symbol flags mismatch for "m2":
-after transform: SymbolId(11): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(11): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(11): Span { start: 613, end: 615 }
@@ -6737,7 +6797,7 @@ Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(0x0)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 7, end: 9 }
@@ -6782,7 +6842,7 @@ Scope flags mismatch:
 after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(9): ScopeFlags(Function)
 Symbol flags mismatch for "X":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "X":
 after transform: SymbolId(4): Span { start: 82, end: 83 }
@@ -6791,35 +6851,41 @@ Symbol redeclarations mismatch for "X":
 after transform: SymbolId(4): [Span { start: 82, end: 83 }, Span { start: 172, end: 173 }]
 rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "Y":
-after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Y":
 after transform: SymbolId(5): Span { start: 84, end: 85 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol flags mismatch for "base":
-after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "base":
 after transform: SymbolId(6): Span { start: 86, end: 90 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Y":
-after transform: SymbolId(8): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(8): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Y":
 after transform: SymbolId(8): Span { start: 174, end: 175 }
 rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 Symbol flags mismatch for "base":
-after transform: SymbolId(9): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(9): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "base":
 after transform: SymbolId(9): Span { start: 176, end: 180 }
 rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Z":
-after transform: SymbolId(10): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(10): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Z":
 after transform: SymbolId(10): Span { start: 181, end: 182 }
 rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
+Reference symbol mismatch for "A":
+after transform: SymbolId(0) "A"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: ["require"]
+rebuilt        : ["A", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/declFileWithExtendsClauseThatHasItsContainerNameConflict.ts
 semantic error: Bindings mismatch:
@@ -6844,19 +6910,19 @@ Scope flags mismatch:
 after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
 Symbol flags mismatch for "B":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "B":
 after transform: SymbolId(4): Span { start: 55, end: 56 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
-after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "B":
 after transform: SymbolId(6): Span { start: 130, end: 131 }
 rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol flags mismatch for "C":
-after transform: SymbolId(7): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(7): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "C":
 after transform: SymbolId(7): Span { start: 132, end: 133 }
@@ -6903,19 +6969,19 @@ Scope children mismatch:
 after transform: ScopeId(8): [ScopeId(9), ScopeId(10)]
 rebuilt        : ScopeId(4): [ScopeId(5)]
 Symbol flags mismatch for "A":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(4): Span { start: 57, end: 58 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
-after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "B":
 after transform: SymbolId(5): Span { start: 59, end: 60 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol flags mismatch for "C":
-after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "C":
 after transform: SymbolId(6): Span { start: 61, end: 62 }
@@ -6926,9 +6992,9 @@ rebuilt        : <None>
 Reference symbol mismatch for "X":
 after transform: SymbolId(0) "X"
 rebuilt        : <None>
-Unresolved reference IDs mismatch for "X":
-after transform: [ReferenceId(0)]
-rebuilt        : [ReferenceId(14), ReferenceId(15)]
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["X"]
 
 tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause2.ts
 semantic error: Bindings mismatch:
@@ -6950,19 +7016,19 @@ Scope flags mismatch:
 after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Symbol flags mismatch for "A":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(4): Span { start: 57, end: 58 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
-after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "B":
 after transform: SymbolId(5): Span { start: 59, end: 60 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol flags mismatch for "C":
-after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "C":
 after transform: SymbolId(6): Span { start: 61, end: 62 }
@@ -6997,19 +7063,19 @@ Scope flags mismatch:
 after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Symbol flags mismatch for "A":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(4): Span { start: 57, end: 58 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
-after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "B":
 after transform: SymbolId(5): Span { start: 59, end: 60 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol flags mismatch for "C":
-after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "C":
 after transform: SymbolId(6): Span { start: 61, end: 62 }
@@ -7020,9 +7086,9 @@ rebuilt        : <None>
 Reference symbol mismatch for "X":
 after transform: SymbolId(0) "X"
 rebuilt        : <None>
-Unresolved reference IDs mismatch for "X":
-after transform: [ReferenceId(0)]
-rebuilt        : [ReferenceId(14), ReferenceId(15)]
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["X"]
 
 tasks/coverage/typescript/tests/cases/compiler/declInput-2.ts
 semantic error: Scope flags mismatch:
@@ -7032,7 +7098,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -7080,7 +7146,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -7483,7 +7549,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
 Symbol flags mismatch for "Test":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Test":
 after transform: SymbolId(0): Span { start: 10, end: 14 }
@@ -7635,7 +7701,7 @@ Reference symbol mismatch for "dual":
 after transform: SymbolId(58) "dual"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Array", "IArguments", "Iterable", "Parameters", "Types"]
+after transform: ["Array", "IArguments", "Iterable", "Parameters"]
 rebuilt        : ["dual"]
 
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitImportInExportAssignmentModule.ts
@@ -7759,7 +7825,7 @@ rebuilt        : ["x", "y"]
 
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflicts.ts
 semantic error: Symbol flags mismatch for "f":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "f":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -7933,9 +7999,6 @@ rebuilt        : ScopeId(0): ["o"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
-after transform: ["N"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitPartialReuseComputedProperty.ts
 semantic error: Symbol reference IDs mismatch for "n":
@@ -8299,7 +8362,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "foo":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "foo":
 after transform: SymbolId(0): Span { start: 10, end: 13 }
@@ -8329,12 +8392,12 @@ rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(0): Span { start: 7, end: 9 }
 rebuilt        : SymbolId(0): Span { start: 230, end: 323 }
+Symbol reference IDs mismatch for "m2":
+after transform: SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
+rebuilt        : SymbolId(0): [ReferenceId(1)]
 Symbol redeclarations mismatch for "m2":
 after transform: SymbolId(0): [Span { start: 7, end: 9 }, Span { start: 230, end: 323 }]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["m2", "module"]
-rebuilt        : ["module"]
 
 tasks/coverage/typescript/tests/cases/compiler/declarationMerging1.ts
 semantic error: Scope children mismatch:
@@ -8399,6 +8462,15 @@ rebuilt        : ScopeId(0): ["D", "E", "ab"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Reference symbol mismatch for "A":
+after transform: SymbolId(0) "A"
+rebuilt        : <None>
+Reference symbol mismatch for "A":
+after transform: SymbolId(0) "A"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["A"]
 
 tasks/coverage/typescript/tests/cases/compiler/declareDottedModuleName.ts
 semantic error: Bindings mismatch:
@@ -8426,12 +8498,12 @@ rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(0): Span { start: 7, end: 9 }
 rebuilt        : SymbolId(0): Span { start: 230, end: 323 }
+Symbol reference IDs mismatch for "m2":
+after transform: SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
+rebuilt        : SymbolId(0): [ReferenceId(1)]
 Symbol redeclarations mismatch for "m2":
 after transform: SymbolId(0): [Span { start: 7, end: 9 }, Span { start: 230, end: 323 }]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["m2", "module"]
-rebuilt        : ["module"]
 
 tasks/coverage/typescript/tests/cases/compiler/declareFileExportAssignmentWithVarFromVariableStatement.ts
 semantic error: Scope children mismatch:
@@ -8443,12 +8515,12 @@ rebuilt        : SymbolId(1): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(0): Span { start: 7, end: 9 }
 rebuilt        : SymbolId(1): Span { start: 238, end: 331 }
+Symbol reference IDs mismatch for "m2":
+after transform: SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(4), ReferenceId(5)]
+rebuilt        : SymbolId(1): [ReferenceId(1)]
 Symbol redeclarations mismatch for "m2":
 after transform: SymbolId(0): [Span { start: 7, end: 9 }, Span { start: 238, end: 331 }]
 rebuilt        : SymbolId(1): []
-Unresolved references mismatch:
-after transform: ["m2", "module"]
-rebuilt        : ["module"]
 
 tasks/coverage/typescript/tests/cases/compiler/declareModifierOnTypeAlias.ts
 semantic error: Scope children mismatch:
@@ -8773,7 +8845,7 @@ Scope children mismatch:
 after transform: ScopeId(2): [ScopeId(3)]
 rebuilt        : ScopeId(1): []
 Symbol flags mismatch for "Something":
-after transform: SymbolId(10): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(10): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Something":
 after transform: SymbolId(10): Span { start: 294, end: 303 }
@@ -9540,19 +9612,19 @@ Namespaces exporting non-const are not supported by Babel. Change to const or se
 
 tasks/coverage/typescript/tests/cases/compiler/dottedNamesInSystem.ts
 semantic error: Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 17, end: 18 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "B":
 after transform: SymbolId(1): Span { start: 19, end: 20 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "C":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "C":
 after transform: SymbolId(2): Span { start: 21, end: 22 }
@@ -9597,13 +9669,13 @@ Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
 Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(RegularEnum | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 5, end: 8 }, Span { start: 117, end: 120 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "Bar":
-after transform: SymbolId(6): SymbolFlags(Function | NameSpaceModule | ValueModule)
+after transform: SymbolId(6): SymbolFlags(Function | ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(Function)
 Symbol redeclarations mismatch for "Bar":
 after transform: SymbolId(6): [Span { start: 198, end: 201 }, Span { start: 235, end: 238 }]
@@ -9856,7 +9928,7 @@ Scope flags mismatch:
 after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(12): ScopeFlags(Function)
 Symbol flags mismatch for "F":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "F":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -9865,7 +9937,7 @@ Symbol redeclarations mismatch for "F":
 after transform: SymbolId(0): [Span { start: 7, end: 8 }, Span { start: 50, end: 51 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "Foo":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Foo":
 after transform: SymbolId(3): Span { start: 126, end: 129 }
@@ -9874,13 +9946,13 @@ Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(3): [Span { start: 126, end: 129 }, Span { start: 171, end: 174 }]
 rebuilt        : SymbolId(5): []
 Symbol flags mismatch for "Gar":
-after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Gar":
 after transform: SymbolId(6): Span { start: 249, end: 252 }
 rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Foo":
-after transform: SymbolId(7): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(7): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Foo":
 after transform: SymbolId(7): Span { start: 266, end: 269 }
@@ -9914,7 +9986,7 @@ semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol flags mismatch for "Shapes":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Shapes":
 after transform: SymbolId(1): Span { start: 42, end: 48 }
@@ -9962,7 +10034,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 71, end: 72 }
@@ -10075,19 +10147,19 @@ rebuilt        : ["dec"]
 
 tasks/coverage/typescript/tests/cases/compiler/emitMemberAccessExpression.ts
 semantic error: Symbol flags mismatch for "Microsoft":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Microsoft":
 after transform: SymbolId(0): Span { start: 82, end: 91 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "PeopleAtWork":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "PeopleAtWork":
 after transform: SymbolId(1): Span { start: 92, end: 104 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Model":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Model":
 after transform: SymbolId(2): Span { start: 105, end: 110 }
@@ -12372,7 +12444,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -12404,6 +12476,12 @@ rebuilt        : ScopeId(0): ["Bar"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
+Reference symbol mismatch for "M":
+after transform: SymbolId(0) "M"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["M"]
 
 tasks/coverage/typescript/tests/cases/compiler/es6ClassTest8.ts
 semantic error: Symbol reference IDs mismatch for "Vector":
@@ -12525,7 +12603,7 @@ rebuilt        : ScopeId(0): ["a", "a1", "a11", "b", "m", "x", "x1", "x11", "xxx
 
 tasks/coverage/typescript/tests/cases/compiler/es6ImportNamedImportInIndirectExportAssignment.ts
 semantic error: Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "a":
 after transform: SymbolId(0): Span { start: 14, end: 15 }
@@ -12543,13 +12621,13 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/es6ModuleClassDeclaration.ts
 semantic error: Symbol flags mismatch for "m1":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(2): Span { start: 538, end: 540 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
-after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(5): Span { start: 1240, end: 1242 }
@@ -12557,13 +12635,13 @@ rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/es6ModuleConst.ts
 semantic error: Symbol flags mismatch for "m1":
-after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(6): Span { start: 116, end: 118 }
 rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
-after transform: SymbolId(13): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(13): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(13): Span { start: 245, end: 247 }
@@ -12613,7 +12691,7 @@ Symbol flags mismatch for "e2":
 after transform: SymbolId(4): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "m1":
-after transform: SymbolId(10): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(10): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(10): Span { start: 125, end: 127 }
@@ -12625,7 +12703,7 @@ Symbol flags mismatch for "e4":
 after transform: SymbolId(15): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "m2":
-after transform: SymbolId(23): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(23): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(23): Span { start: 338, end: 340 }
@@ -12681,7 +12759,7 @@ Symbol flags mismatch for "e2":
 after transform: SymbolId(4): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "m1":
-after transform: SymbolId(10): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(10): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(10): Span { start: 125, end: 127 }
@@ -12693,7 +12771,7 @@ Symbol flags mismatch for "e4":
 after transform: SymbolId(15): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "m2":
-after transform: SymbolId(23): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(23): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(23): Span { start: 338, end: 340 }
@@ -12749,7 +12827,7 @@ Symbol flags mismatch for "e2":
 after transform: SymbolId(4): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "m1":
-after transform: SymbolId(10): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(10): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(10): Span { start: 113, end: 115 }
@@ -12761,7 +12839,7 @@ Symbol flags mismatch for "e4":
 after transform: SymbolId(15): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "m2":
-after transform: SymbolId(23): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(23): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(23): Span { start: 314, end: 316 }
@@ -12775,13 +12853,13 @@ rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
 
 tasks/coverage/typescript/tests/cases/compiler/es6ModuleFunctionDeclaration.ts
 semantic error: Symbol flags mismatch for "m1":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(2): Span { start: 76, end: 78 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
-after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(5): Span { start: 200, end: 202 }
@@ -12899,7 +12977,7 @@ semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(8), ScopeId(11), ScopeId(14)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(7), ScopeId(10), ScopeId(13)]
 Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(Function | NameSpaceModule | Ambient)
+after transform: SymbolId(0): SymbolFlags(Function | ValueModule | Ambient)
 rebuilt        : SymbolId(0): SymbolFlags(Function)
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 9, end: 12 }, Span { start: 44, end: 47 }]
@@ -12956,9 +13034,6 @@ rebuilt        : SymbolId(1): Span { start: 152, end: 158 }
 Symbol redeclarations mismatch for "server":
 after transform: SymbolId(2): [Span { start: 82, end: 88 }, Span { start: 152, end: 158 }]
 rebuilt        : SymbolId(1): []
-Unresolved references mismatch:
-after transform: ["Date", "http", "module"]
-rebuilt        : ["Date", "module"]
 Unresolved reference IDs mismatch for "Date":
 after transform: [ReferenceId(1), ReferenceId(2)]
 rebuilt        : [ReferenceId(0)]
@@ -13042,7 +13117,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 67, end: 68 }
@@ -13058,8 +13133,11 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
+Reference symbol mismatch for "Q":
+after transform: SymbolId(0) "Q"
+rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["Function", "Q"]
+after transform: ["Function"]
 rebuilt        : ["Q"]
 
 tasks/coverage/typescript/tests/cases/compiler/exportDefaultAsyncFunction.ts
@@ -13074,6 +13152,15 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
+Reference symbol mismatch for "m":
+after transform: SymbolId(0) "m"
+rebuilt        : <None>
+Reference flags mismatch for "m":
+after transform: ReferenceId(0): ReferenceFlags(Type)
+rebuilt        : ReferenceId(0): ReferenceFlags(Read | Type)
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["m"]
 
 tasks/coverage/typescript/tests/cases/compiler/exportDefaultImportedType.ts
 semantic error: Scope children mismatch:
@@ -13106,13 +13193,13 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/exportDefaultProperty.ts
 semantic error: Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
-after transform: SymbolId(1): SymbolFlags(Class | NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(Class)
 Symbol redeclarations mismatch for "B":
 after transform: SymbolId(1): [Span { start: 31, end: 32 }, Span { start: 84, end: 85 }]
@@ -13170,13 +13257,13 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/exportEqualsProperty.ts
 semantic error: Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
-after transform: SymbolId(1): SymbolFlags(Class | NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(Class)
 Symbol redeclarations mismatch for "B":
 after transform: SymbolId(1): [Span { start: 31, end: 32 }, Span { start: 84, end: 85 }]
@@ -13233,7 +13320,7 @@ Scope flags mismatch:
 after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(8): ScopeFlags(Function)
 Symbol flags mismatch for "MsPortalFx":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "MsPortalFx":
 after transform: SymbolId(0): Span { start: 7, end: 17 }
@@ -13242,13 +13329,13 @@ Symbol redeclarations mismatch for "MsPortalFx":
 after transform: SymbolId(0): [Span { start: 7, end: 17 }, Span { start: 526, end: 536 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "ViewModels":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "ViewModels":
 after transform: SymbolId(1): Span { start: 18, end: 28 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Dialogs":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Dialogs":
 after transform: SymbolId(2): Span { start: 29, end: 36 }
@@ -13260,7 +13347,7 @@ Symbol flags mismatch for "MessageBoxButtons":
 after transform: SymbolId(13): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "ViewModels":
-after transform: SymbolId(20): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(20): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "ViewModels":
 after transform: SymbolId(20): Span { start: 537, end: 547 }
@@ -13280,7 +13367,7 @@ Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "B":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "B":
 after transform: SymbolId(2): Span { start: 58, end: 59 }
@@ -13310,9 +13397,15 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
+Reference symbol mismatch for "X":
+after transform: SymbolId(0) "X"
+rebuilt        : <None>
 Reference flags mismatch for "X":
-after transform: ReferenceId(2): ReferenceFlags(Read | Type)
+after transform: ReferenceId(2): ReferenceFlags(Type)
 rebuilt        : ReferenceId(1): ReferenceFlags(Read)
+Unresolved references mismatch:
+after transform: ["module"]
+rebuilt        : ["X", "module"]
 
 tasks/coverage/typescript/tests/cases/compiler/exportPrivateType.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -13444,7 +13537,7 @@ Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -13453,7 +13546,7 @@ Symbol redeclarations mismatch for "M":
 after transform: SymbolId(0): [Span { start: 7, end: 8 }, Span { start: 104, end: 105 }]
 rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "N":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "N":
 after transform: SymbolId(4): Span { start: 156, end: 157 }
@@ -13506,8 +13599,11 @@ rebuilt        : ScopeId(0): ["ec", "x"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
+Reference symbol mismatch for "EM":
+after transform: SymbolId(0) "EM"
+rebuilt        : <None>
 Unresolved reference IDs mismatch for "EM":
-after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(3)]
+after transform: [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/compiler/externalModuleAssignToVar.ts
@@ -13562,7 +13658,7 @@ Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "X":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "X":
 after transform: SymbolId(3): Span { start: 62, end: 63 }
@@ -13582,7 +13678,7 @@ Symbol flags mismatch for "Foo":
 after transform: SymbolId(0): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "X":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "X":
 after transform: SymbolId(3): Span { start: 62, end: 63 }
@@ -13648,13 +13744,13 @@ Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Symbol flags mismatch for "Events":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Events":
 after transform: SymbolId(0): Span { start: 7, end: 13 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Consumer":
-after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Consumer":
 after transform: SymbolId(5): Span { start: 217, end: 225 }
@@ -13801,7 +13897,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Foo":
 after transform: SymbolId(0): Span { start: 7, end: 10 }
@@ -13962,7 +14058,7 @@ Symbol redeclarations mismatch for "overload1":
 after transform: SymbolId(31): [Span { start: 1000, end: 1009 }, Span { start: 1040, end: 1049 }, Span { start: 1080, end: 1089 }]
 rebuilt        : SymbolId(31): []
 Symbol flags mismatch for "m2":
-after transform: SymbolId(38): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(38): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(36): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(38): Span { start: 1207, end: 1209 }
@@ -13986,7 +14082,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 7, end: 9 }
@@ -14045,7 +14141,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Midori":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Midori":
 after transform: SymbolId(0): Span { start: 9, end: 15 }
@@ -14065,19 +14161,19 @@ Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 Symbol flags mismatch for "foo":
-after transform: SymbolId(0): SymbolFlags(Function | NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(Function | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Function)
 Symbol redeclarations mismatch for "foo":
 after transform: SymbolId(0): [Span { start: 9, end: 12 }, Span { start: 56, end: 59 }, Span { start: 108, end: 111 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "Bar":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Bar":
 after transform: SymbolId(3): Span { start: 60, end: 63 }
 rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Baz":
-after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Baz":
 after transform: SymbolId(5): Span { start: 112, end: 115 }
@@ -14473,7 +14569,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
 Symbol flags mismatch for "test":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "test":
 after transform: SymbolId(0): Span { start: 7, end: 11 }
@@ -14525,7 +14621,7 @@ Symbol reference IDs mismatch for "C":
 after transform: SymbolId(0): [ReferenceId(1)]
 rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "M":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(3): Span { start: 66, end: 67 }
@@ -14630,7 +14726,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4), ScopeId(6), ScopeId(7)]
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -14653,14 +14749,11 @@ Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "bar":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "bar":
 after transform: SymbolId(3): Span { start: 55, end: 58 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Unresolved references mismatch:
-after transform: ["foo"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/genericClassPropertyInheritanceSpecialization.ts
 semantic error: Bindings mismatch:
@@ -14691,49 +14784,52 @@ Scope flags mismatch:
 after transform: ScopeId(35): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(11): ScopeFlags(Function)
 Symbol flags mismatch for "Portal":
-after transform: SymbolId(10): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(10): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Portal":
 after transform: SymbolId(10): Span { start: 1075, end: 1081 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Controls":
-after transform: SymbolId(11): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(11): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Controls":
 after transform: SymbolId(11): Span { start: 1082, end: 1090 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Validators":
-after transform: SymbolId(12): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(12): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Validators":
 after transform: SymbolId(12): Span { start: 1091, end: 1101 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "PortalFx":
-after transform: SymbolId(17): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(17): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "PortalFx":
 after transform: SymbolId(17): Span { start: 1491, end: 1499 }
 rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 Symbol flags mismatch for "ViewModels":
-after transform: SymbolId(18): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(18): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "ViewModels":
 after transform: SymbolId(18): Span { start: 1500, end: 1510 }
 rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Controls":
-after transform: SymbolId(19): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(19): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Controls":
 after transform: SymbolId(19): Span { start: 1511, end: 1519 }
 rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Validators":
-after transform: SymbolId(20): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(20): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Validators":
 after transform: SymbolId(20): Span { start: 1520, end: 1530 }
 rebuilt        : SymbolId(16): Span { start: 0, end: 0 }
+Reference symbol mismatch for "ko":
+after transform: SymbolId(8) "ko"
+rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["PortalFx", "ko", "require"]
+after transform: ["PortalFx", "require"]
 rebuilt        : ["ko", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/genericClassWithStaticFactory.ts
@@ -14741,7 +14837,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Editor":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Editor":
 after transform: SymbolId(0): Span { start: 7, end: 13 }
@@ -14787,7 +14883,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Foo":
 after transform: SymbolId(0): Span { start: 7, end: 10 }
@@ -14846,13 +14942,13 @@ Scope flags mismatch:
 after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 Symbol flags mismatch for "Tweening":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Tweening":
 after transform: SymbolId(3): Span { start: 154, end: 162 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Tweening":
-after transform: SymbolId(7): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(7): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Tweening":
 after transform: SymbolId(7): Span { start: 343, end: 351 }
@@ -14870,11 +14966,8 @@ Reference symbol mismatch for "EndGate":
 after transform: SymbolId(0) "EndGate"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["EndGate", "ICloneable", "Tween", "require"]
+after transform: ["ICloneable", "Tween", "require"]
 rebuilt        : ["EndGate", "Tween", "require"]
-Unresolved reference IDs mismatch for "EndGate":
-after transform: [ReferenceId(0)]
-rebuilt        : [ReferenceId(9), ReferenceId(10), ReferenceId(19), ReferenceId(20)]
 
 tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes2.ts
 semantic error: Bindings mismatch:
@@ -14896,13 +14989,13 @@ Scope flags mismatch:
 after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 Symbol flags mismatch for "Tweening":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Tweening":
 after transform: SymbolId(3): Span { start: 146, end: 154 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Tweening":
-after transform: SymbolId(7): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(7): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Tweening":
 after transform: SymbolId(7): Span { start: 334, end: 342 }
@@ -14920,11 +15013,8 @@ Reference symbol mismatch for "EndGate":
 after transform: SymbolId(0) "EndGate"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["EndGate", "ICloneable", "Tween", "require"]
+after transform: ["ICloneable", "Tween", "require"]
 rebuilt        : ["EndGate", "Tween", "require"]
-Unresolved reference IDs mismatch for "EndGate":
-after transform: [ReferenceId(0)]
-rebuilt        : [ReferenceId(9), ReferenceId(10), ReferenceId(19), ReferenceId(20)]
 
 tasks/coverage/typescript/tests/cases/compiler/genericConstructSignatureInInterface.ts
 semantic error: Scope children mismatch:
@@ -15060,6 +15150,15 @@ rebuilt        : ScopeId(0): ["age_v", "name_v", "o", "rr_v", "x_v", "yy_v", "zz
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
+Reference symbol mismatch for "ko":
+after transform: SymbolId(0) "ko"
+rebuilt        : <None>
+Reference symbol mismatch for "ko":
+after transform: SymbolId(0) "ko"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["ko"]
 
 tasks/coverage/typescript/tests/cases/compiler/genericInferenceDefaultTypeParameter.ts
 semantic error: Bindings mismatch:
@@ -15172,13 +15271,13 @@ Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(3): Span { start: 45, end: 46 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "C":
-after transform: SymbolId(4): SymbolFlags(Class | NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(Class)
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(4): [ReferenceId(3), ReferenceId(8), ReferenceId(11), ReferenceId(13)]
@@ -15201,13 +15300,13 @@ Scope flags mismatch:
 after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(8): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(3): Span { start: 45, end: 46 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "C":
-after transform: SymbolId(4): SymbolFlags(Class | NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(Class)
 Symbol reference IDs mismatch for "C":
 after transform: SymbolId(4): [ReferenceId(3), ReferenceId(8), ReferenceId(11), ReferenceId(13)]
@@ -15216,7 +15315,7 @@ Symbol redeclarations mismatch for "C":
 after transform: SymbolId(4): [Span { start: 66, end: 67 }, Span { start: 100, end: 101 }]
 rebuilt        : SymbolId(4): []
 Symbol flags mismatch for "N":
-after transform: SymbolId(7): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(7): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "N":
 after transform: SymbolId(7): Span { start: 217, end: 218 }
@@ -15272,7 +15371,7 @@ Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(0x0)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "TypeScript2":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "TypeScript2":
 after transform: SymbolId(0): Span { start: 7, end: 18 }
@@ -15484,7 +15583,7 @@ Scope flags mismatch:
 after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "MyModule":
-after transform: SymbolId(14): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(14): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "MyModule":
 after transform: SymbolId(14): Span { start: 435, end: 443 }
@@ -15535,7 +15634,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -15791,7 +15890,7 @@ rebuilt        : ["getNumberIndexValue", "getStringIndexValue"]
 
 tasks/coverage/typescript/tests/cases/compiler/importAliasAnExternalModuleInsideAnInternalModule.ts
 semantic error: Symbol flags mismatch for "m":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m":
 after transform: SymbolId(0): Span { start: 14, end: 15 }
@@ -15805,13 +15904,13 @@ Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "My":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "My":
 after transform: SymbolId(0): Span { start: 10, end: 12 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Internal":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Internal":
 after transform: SymbolId(1): Span { start: 13, end: 21 }
@@ -16000,13 +16099,13 @@ rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/import_reference-exported-alias.ts
 semantic error: Symbol flags mismatch for "App":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "App":
 after transform: SymbolId(0): Span { start: 7, end: 10 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Services":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Services":
 after transform: SymbolId(1): Span { start: 31, end: 39 }
@@ -16014,13 +16113,13 @@ rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/import_reference-to-type-alias.ts
 semantic error: Symbol flags mismatch for "App":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "App":
 after transform: SymbolId(0): Span { start: 14, end: 17 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Services":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Services":
 after transform: SymbolId(1): Span { start: 38, end: 46 }
@@ -16041,25 +16140,25 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/importedAliasesInTypePositions.ts
 semantic error: Symbol flags mismatch for "elaborate":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "elaborate":
 after transform: SymbolId(0): Span { start: 14, end: 23 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "nested":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "nested":
 after transform: SymbolId(1): Span { start: 24, end: 30 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "mod":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "mod":
 after transform: SymbolId(2): Span { start: 31, end: 34 }
 rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol flags mismatch for "name":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "name":
 after transform: SymbolId(3): Span { start: 35, end: 39 }
@@ -16209,7 +16308,7 @@ Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(0x0)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -17182,13 +17281,13 @@ Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "N":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "N":
 after transform: SymbolId(4): Span { start: 69, end: 70 }
@@ -17314,13 +17413,13 @@ Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Symbol flags mismatch for "_provider":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "_provider":
 after transform: SymbolId(0): Span { start: 7, end: 16 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "consumer":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "consumer":
 after transform: SymbolId(2): Span { start: 171, end: 179 }
@@ -17337,7 +17436,7 @@ Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -17360,24 +17459,30 @@ Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "B":
 after transform: SymbolId(3): Span { start: 95, end: 96 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
+Reference symbol mismatch for "BB":
+after transform: SymbolId(1) "BB"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: ["require"]
+rebuilt        : ["BB", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/innerFunc.ts
 semantic error: Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(2): Span { start: 82, end: 83 }
@@ -17474,7 +17579,7 @@ Scope children mismatch:
 after transform: ScopeId(43): [ScopeId(44)]
 rebuilt        : ScopeId(9): []
 Symbol flags mismatch for "N1":
-after transform: SymbolId(51): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(51): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "N1":
 after transform: SymbolId(51): Span { start: 1772, end: 1774 }
@@ -17590,13 +17695,13 @@ Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
-after transform: SymbolId(1): SymbolFlags(Interface | NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(Interface | ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "B":
 after transform: SymbolId(1): Span { start: 30, end: 31 }
@@ -17622,7 +17727,7 @@ Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -17648,7 +17753,7 @@ Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -17677,13 +17782,13 @@ Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
-after transform: SymbolId(1): SymbolFlags(Interface | NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(Interface | ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "B":
 after transform: SymbolId(1): Span { start: 23, end: 24 }
@@ -17712,13 +17817,13 @@ Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
-after transform: SymbolId(1): SymbolFlags(Interface | NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(Interface | ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "B":
 after transform: SymbolId(1): Span { start: 30, end: 31 }
@@ -17738,7 +17843,7 @@ Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -17939,7 +18044,7 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 
 tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideTopLevelModuleWithExport.ts
 semantic error: Symbol flags mismatch for "x":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "x":
 after transform: SymbolId(0): Span { start: 14, end: 15 }
@@ -17947,7 +18052,7 @@ rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/internalAliasClassInsideTopLevelModuleWithoutExport.ts
 semantic error: Symbol flags mismatch for "x":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "x":
 after transform: SymbolId(0): Span { start: 14, end: 15 }
@@ -17970,7 +18075,7 @@ Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "a":
 after transform: SymbolId(0): Span { start: 14, end: 15 }
@@ -17990,7 +18095,7 @@ Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "a":
 after transform: SymbolId(0): Span { start: 14, end: 15 }
@@ -18015,7 +18120,7 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 
 tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideTopLevelModuleWithExport.ts
 semantic error: Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "a":
 after transform: SymbolId(0): Span { start: 14, end: 15 }
@@ -18023,7 +18128,7 @@ rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/internalAliasFunctionInsideTopLevelModuleWithoutExport.ts
 semantic error: Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "a":
 after transform: SymbolId(0): Span { start: 14, end: 15 }
@@ -18040,13 +18145,13 @@ semantic error: Namespaces exporting non-const are not supported by Babel. Chang
 
 tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideTopLevelModuleWithExport.ts
 semantic error: Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "a":
 after transform: SymbolId(0): Span { start: 14, end: 15 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "b":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "b":
 after transform: SymbolId(1): Span { start: 36, end: 37 }
@@ -18057,13 +18162,13 @@ rebuilt        : SymbolId(5): [ReferenceId(9)]
 
 tasks/coverage/typescript/tests/cases/compiler/internalAliasInitializedModuleInsideTopLevelModuleWithoutExport.ts
 semantic error: Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "a":
 after transform: SymbolId(0): Span { start: 14, end: 15 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "b":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "b":
 after transform: SymbolId(1): Span { start: 36, end: 37 }
@@ -18189,7 +18294,7 @@ Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "B":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "B":
 after transform: SymbolId(2): Span { start: 58, end: 59 }
@@ -18283,7 +18388,7 @@ Scope flags mismatch:
 after transform: ScopeId(29): ScopeFlags(0x0)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 Symbol flags mismatch for "enums":
-after transform: SymbolId(27): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(27): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "enums":
 after transform: SymbolId(27): Span { start: 1443, end: 1448 }
@@ -18416,9 +18521,6 @@ rebuilt        : ScopeId(0): ["p", "p2", "x"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(24)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
-after transform: ["Windows"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/ipromise3.ts
 semantic error: Scope children mismatch:
@@ -18432,9 +18534,6 @@ rebuilt        : ScopeId(0): ["p"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(24), ScopeId(25), ScopeId(26)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
-Unresolved references mismatch:
-after transform: ["Windows"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/isDeclarationVisibleNodeKinds.ts
 semantic error: Scope flags mismatch:
@@ -18483,7 +18582,7 @@ Scope children mismatch:
 after transform: ScopeId(25): [ScopeId(26)]
 rebuilt        : ScopeId(20): []
 Symbol flags mismatch for "schema":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "schema":
 after transform: SymbolId(0): Span { start: 25, end: 31 }
@@ -18768,9 +18867,6 @@ rebuilt        : ScopeId(0): ["ElemClass", "_jsxFileName", "_reactJsxRuntime", "
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(9)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Unresolved references mismatch:
-after transform: ["JSX", "require"]
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxElementsAsIdentifierNames.tsx
 semantic error: Bindings mismatch:
@@ -18802,14 +18898,11 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(7), ScopeId(10)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
 Symbol flags mismatch for "Element":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Element":
 after transform: SymbolId(2): Span { start: 358, end: 365 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Unresolved references mismatch:
-after transform: ["JSX", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxEmptyExpressionNotCountedAsChild.tsx
 semantic error: Scope children mismatch:
@@ -18837,14 +18930,11 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(7), ScopeId(10)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
 Symbol flags mismatch for "Element":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Element":
 after transform: SymbolId(2): Span { start: 358, end: 365 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Unresolved references mismatch:
-after transform: ["JSX", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxFactoryIdentifierAsParameter.ts
 semantic error: Bindings mismatch:
@@ -18862,14 +18952,11 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(7), ScopeId(10)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(4)]
 Symbol flags mismatch for "Element":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Element":
 after transform: SymbolId(2): Span { start: 358, end: 365 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Unresolved references mismatch:
-after transform: ["JSX", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxFragmentAndFactoryUsedOnFragmentUse.tsx
 semantic error: Bindings mismatch:
@@ -18922,11 +19009,14 @@ rebuilt        : <None>
 Reference symbol mismatch for "React":
 after transform: SymbolId(0) "React"
 rebuilt        : <None>
+Reference symbol mismatch for "React":
+after transform: SymbolId(0) "React"
+rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["React"]
 rebuilt        : ["React", "createComponentClass"]
 Unresolved reference IDs mismatch for "React":
-after transform: [ReferenceId(2), ReferenceId(4), ReferenceId(7)]
+after transform: [ReferenceId(2), ReferenceId(4)]
 rebuilt        : [ReferenceId(1), ReferenceId(2)]
 
 tasks/coverage/typescript/tests/cases/compiler/jsxInferenceProducesLiteralAsExpected.tsx
@@ -19015,7 +19105,7 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
-after transform: ["JSX", "Record"]
+after transform: ["Record"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/jsxNamespacedNameNotComparedToNonMatchingIndexSignature.tsx
@@ -19182,7 +19272,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "A":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(3): Span { start: 45, end: 46 }
@@ -19203,7 +19293,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Editor":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Editor":
 after transform: SymbolId(0): Span { start: 7, end: 13 }
@@ -19295,7 +19385,7 @@ Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch for "Keyboard":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Keyboard":
 after transform: SymbolId(0): Span { start: 7, end: 15 }
@@ -19304,7 +19394,7 @@ Symbol flags mismatch for "Key":
 after transform: SymbolId(1): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "App":
-after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "App":
 after transform: SymbolId(6): Span { start: 72, end: 75 }
@@ -19700,7 +19790,7 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/mergedModuleDeclarationCodeGen.ts
 semantic error: Symbol flags mismatch for "X":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "X":
 after transform: SymbolId(0): Span { start: 14, end: 15 }
@@ -19709,13 +19799,13 @@ Symbol redeclarations mismatch for "X":
 after transform: SymbolId(0): [Span { start: 14, end: 15 }, Span { start: 163, end: 164 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "Y":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Y":
 after transform: SymbolId(1): Span { start: 36, end: 37 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Y":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Y":
 after transform: SymbolId(4): Span { start: 185, end: 186 }
@@ -19738,7 +19828,7 @@ Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 Symbol flags mismatch for "my":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "my":
 after transform: SymbolId(0): Span { start: 7, end: 9 }
@@ -19747,19 +19837,19 @@ Symbol redeclarations mismatch for "my":
 after transform: SymbolId(0): [Span { start: 7, end: 9 }, Span { start: 60, end: 62 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "data":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "data":
 after transform: SymbolId(1): Span { start: 10, end: 14 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "foo":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "foo":
 after transform: SymbolId(2): Span { start: 15, end: 18 }
 rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol flags mismatch for "data":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "data":
 after transform: SymbolId(4): Span { start: 63, end: 67 }
@@ -19782,7 +19872,7 @@ Scope flags mismatch:
 after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 Symbol flags mismatch for "my":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "my":
 after transform: SymbolId(0): Span { start: 7, end: 9 }
@@ -19791,19 +19881,19 @@ Symbol redeclarations mismatch for "my":
 after transform: SymbolId(0): [Span { start: 7, end: 9 }, Span { start: 56, end: 58 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "data":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "data":
 after transform: SymbolId(1): Span { start: 10, end: 14 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "data":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "data":
 after transform: SymbolId(3): Span { start: 59, end: 63 }
 rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol flags mismatch for "foo":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "foo":
 after transform: SymbolId(4): Span { start: 64, end: 67 }
@@ -19835,19 +19925,19 @@ Scope flags mismatch:
 after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(9): ScopeFlags(Function)
 Symbol flags mismatch for "superContain":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "superContain":
 after transform: SymbolId(0): Span { start: 7, end: 19 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "contain":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "contain":
 after transform: SymbolId(1): Span { start: 40, end: 47 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "my":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "my":
 after transform: SymbolId(2): Span { start: 72, end: 74 }
@@ -19856,25 +19946,25 @@ Symbol redeclarations mismatch for "my":
 after transform: SymbolId(2): [Span { start: 72, end: 74 }, Span { start: 202, end: 204 }]
 rebuilt        : SymbolId(4): []
 Symbol flags mismatch for "buz":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "buz":
 after transform: SymbolId(3): Span { start: 75, end: 78 }
 rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol flags mismatch for "data":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "data":
 after transform: SymbolId(4): Span { start: 107, end: 111 }
 rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 Symbol flags mismatch for "buz":
-after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "buz":
 after transform: SymbolId(6): Span { start: 205, end: 208 }
 rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
 Symbol flags mismatch for "data":
-after transform: SymbolId(7): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(7): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "data":
 after transform: SymbolId(7): Span { start: 237, end: 241 }
@@ -19922,7 +20012,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "MyModule":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "MyModule":
 after transform: SymbolId(0): Span { start: 7, end: 15 }
@@ -20027,7 +20117,7 @@ Scope flags mismatch:
 after transform: ScopeId(16): ScopeFlags(0x0)
 rebuilt        : ScopeId(16): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(19): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(19): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(19): Span { start: 758, end: 759 }
@@ -20191,13 +20281,13 @@ Scope children mismatch:
 after transform: ScopeId(15): [ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19)]
 rebuilt        : ScopeId(7): []
 Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "My":
-after transform: SymbolId(1): SymbolFlags(Function | NameSpaceModule | Ambient)
+after transform: SymbolId(1): SymbolFlags(Function | ValueModule | Ambient)
 rebuilt        : SymbolId(2): SymbolFlags(Function)
 Symbol span mismatch for "My":
 after transform: SymbolId(1): Span { start: 30, end: 32 }
@@ -20206,13 +20296,13 @@ Symbol redeclarations mismatch for "My":
 after transform: SymbolId(1): [Span { start: 30, end: 32 }, Span { start: 84, end: 86 }]
 rebuilt        : SymbolId(2): []
 Symbol flags mismatch for "B":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "B":
 after transform: SymbolId(4): Span { start: 112, end: 113 }
 rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol flags mismatch for "My":
-after transform: SymbolId(5): SymbolFlags(Function | NameSpaceModule | Ambient)
+after transform: SymbolId(5): SymbolFlags(Function | ValueModule | Ambient)
 rebuilt        : SymbolId(6): SymbolFlags(Function)
 Symbol span mismatch for "My":
 after transform: SymbolId(5): Span { start: 135, end: 137 }
@@ -20221,19 +20311,19 @@ Symbol redeclarations mismatch for "My":
 after transform: SymbolId(5): [Span { start: 135, end: 137 }, Span { start: 189, end: 191 }, Span { start: 218, end: 220 }]
 rebuilt        : SymbolId(6): []
 Symbol flags mismatch for "C":
-after transform: SymbolId(9): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(9): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "C":
 after transform: SymbolId(9): Span { start: 243, end: 244 }
 rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 Symbol flags mismatch for "D":
-after transform: SymbolId(13): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(13): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "D":
 after transform: SymbolId(13): Span { start: 354, end: 355 }
 rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 Symbol flags mismatch for "E":
-after transform: SymbolId(18): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(18): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "E":
 after transform: SymbolId(18): Span { start: 499, end: 500 }
@@ -20246,6 +20336,12 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
+Reference symbol mismatch for "Q":
+after transform: SymbolId(0) "Q"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: []
+rebuilt        : ["Q"]
 
 tasks/coverage/typescript/tests/cases/compiler/modularizeLibrary_NoErrorDuplicateLibOptions1.ts
 semantic error: Bindings mismatch:
@@ -20312,7 +20408,7 @@ Scope flags mismatch:
 after transform: ScopeId(18): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(16): ScopeFlags(Function)
 Symbol flags mismatch for "_modes":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "_modes":
 after transform: SymbolId(0): Span { start: 7, end: 13 }
@@ -20321,25 +20417,25 @@ Symbol reference IDs mismatch for "_modes":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(5), ReferenceId(16), ReferenceId(17)]
 rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
 Symbol flags mismatch for "editor":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "editor":
 after transform: SymbolId(3): Span { start: 165, end: 171 }
 rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
 Symbol flags mismatch for "editor2":
-after transform: SymbolId(11): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(11): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "editor2":
 after transform: SymbolId(11): Span { start: 493, end: 500 }
 rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Foo":
-after transform: SymbolId(16): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(16): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Foo":
 after transform: SymbolId(16): Span { start: 685, end: 688 }
 rebuilt        : SymbolId(16): Span { start: 0, end: 0 }
 Symbol flags mismatch for "A1":
-after transform: SymbolId(21): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(21): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(22): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A1":
 after transform: SymbolId(21): Span { start: 799, end: 801 }
@@ -20348,7 +20444,7 @@ Symbol reference IDs mismatch for "A1":
 after transform: SymbolId(21): [ReferenceId(11), ReferenceId(28), ReferenceId(29)]
 rebuilt        : SymbolId(22): [ReferenceId(14), ReferenceId(15)]
 Symbol flags mismatch for "B1":
-after transform: SymbolId(24): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(24): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(25): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "B1":
 after transform: SymbolId(24): Span { start: 868, end: 870 }
@@ -20364,9 +20460,6 @@ rebuilt        : ScopeId(0): ["z", "z2"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["X"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceSharingName3.ts
 semantic error: Bindings mismatch:
@@ -20375,9 +20468,6 @@ rebuilt        : ScopeId(0): ["z", "z2"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["X"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/moduleAndInterfaceSharingName4.ts
 semantic error: Bindings mismatch:
@@ -20661,7 +20751,7 @@ Scope flags mismatch:
 after transform: ScopeId(17): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(15): ScopeFlags(Function)
 Symbol flags mismatch for "TypeScript":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "TypeScript":
 after transform: SymbolId(0): Span { start: 7, end: 17 }
@@ -20670,7 +20760,7 @@ Symbol redeclarations mismatch for "TypeScript":
 after transform: SymbolId(0): [Span { start: 7, end: 17 }, Span { start: 146, end: 156 }, Span { start: 535, end: 545 }, Span { start: 879, end: 889 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "Parser":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Parser":
 after transform: SymbolId(1): Span { start: 18, end: 24 }
@@ -20679,7 +20769,7 @@ Symbol reference IDs mismatch for "PositionedElement":
 after transform: SymbolId(5): [ReferenceId(3), ReferenceId(19)]
 rebuilt        : SymbolId(6): [ReferenceId(8)]
 Symbol flags mismatch for "Syntax":
-after transform: SymbolId(18): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(18): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(21): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Syntax":
 after transform: SymbolId(18): Span { start: 890, end: 896 }
@@ -20702,7 +20792,7 @@ Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 101, end: 102 }
@@ -20721,7 +20811,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Foo":
 after transform: SymbolId(0): Span { start: 7, end: 10 }
@@ -20734,9 +20824,6 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["outer"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/modulePreserve2.ts
 semantic error: Bindings mismatch:
@@ -20787,7 +20874,7 @@ Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -20810,7 +20897,7 @@ Scope children mismatch:
 after transform: ScopeId(3): [ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(3): [ScopeId(4)]
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -21020,13 +21107,13 @@ Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "X":
-after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "X":
 after transform: SymbolId(6): Span { start: 207, end: 208 }
@@ -21046,25 +21133,25 @@ Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
 Symbol flags mismatch for "Z":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Z":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(1): Span { start: 9, end: 10 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "A":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(3): Span { start: 75, end: 76 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(4): Span { start: 77, end: 78 }
@@ -21084,25 +21171,25 @@ Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
 Symbol flags mismatch for "Z":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Z":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(1): Span { start: 9, end: 10 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "A":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(3): Span { start: 75, end: 76 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(4): Span { start: 77, end: 78 }
@@ -21128,25 +21215,25 @@ Scope children mismatch:
 after transform: ScopeId(5): [ScopeId(6), ScopeId(7)]
 rebuilt        : ScopeId(5): [ScopeId(6)]
 Symbol flags mismatch for "Z":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Z":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(1): Span { start: 9, end: 10 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "A":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(3): Span { start: 75, end: 76 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(4): Span { start: 77, end: 78 }
@@ -21178,7 +21265,7 @@ Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
 Symbol flags mismatch for "Z":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Z":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -21187,19 +21274,19 @@ Symbol reference IDs mismatch for "Z":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(7), ReferenceId(8)]
 rebuilt        : SymbolId(0): [ReferenceId(6), ReferenceId(7)]
 Symbol flags mismatch for "M":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(1): Span { start: 9, end: 10 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "A":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(3): Span { start: 75, end: 76 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(4): Span { start: 77, end: 78 }
@@ -21230,20 +21317,11 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Symbol reference IDs mismatch for "M":
-after transform: SymbolId(0): [ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
-Reference symbol mismatch for "M":
-after transform: <None>
-rebuilt        : SymbolId(0) "M"
-Unresolved references mismatch:
-after transform: ["M"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/module_augmentUninstantiatedModule.ts
 semantic error: Scope children mismatch:
@@ -21260,9 +21338,9 @@ rebuilt        : ScopeId(0): []
 Reference symbol mismatch for "ng":
 after transform: SymbolId(0) "ng"
 rebuilt        : <None>
-Unresolved reference IDs mismatch for "ng":
-after transform: [ReferenceId(0)]
-rebuilt        : [ReferenceId(1)]
+Unresolved references mismatch:
+after transform: ["module"]
+rebuilt        : ["module", "ng"]
 
 tasks/coverage/typescript/tests/cases/compiler/moduledecl.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -21344,7 +21422,7 @@ Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -21358,7 +21436,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Variables":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Variables":
 after transform: SymbolId(0): Span { start: 7, end: 16 }
@@ -21371,9 +21449,6 @@ rebuilt        : ScopeId(0): ["x", "x2"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["X"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/namespaces2.ts
 semantic error: Scope flags mismatch:
@@ -21383,13 +21458,13 @@ Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "B":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "B":
 after transform: SymbolId(1): Span { start: 29, end: 30 }
@@ -21414,7 +21489,7 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
-after transform: ["Q", "Q2", "Q3", "Q4"]
+after transform: ["Q2", "Q4"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/narrowByBooleanComparison.ts
@@ -22021,13 +22096,13 @@ Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "a":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "b":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "b":
 after transform: SymbolId(2): Span { start: 45, end: 46 }
@@ -22058,7 +22133,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -22137,7 +22212,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -22183,7 +22258,7 @@ Symbol reference IDs mismatch for "cat":
 after transform: SymbolId(0): [ReferenceId(1)]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "Foo":
-after transform: SymbolId(1): SymbolFlags(Class | NameSpaceModule | Ambient)
+after transform: SymbolId(1): SymbolFlags(Class | ValueModule | Ambient)
 rebuilt        : SymbolId(1): SymbolFlags(Class)
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(1): [Span { start: 22, end: 25 }, Span { start: 61, end: 64 }]
@@ -23235,7 +23310,7 @@ Scope children mismatch:
 after transform: ScopeId(5): [ScopeId(6)]
 rebuilt        : ScopeId(5): []
 Symbol flags mismatch for "Bugs":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Bugs":
 after transform: SymbolId(0): Span { start: 7, end: 11 }
@@ -23249,7 +23324,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
 Symbol flags mismatch for "Bugs":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Bugs":
 after transform: SymbolId(0): Span { start: 7, end: 11 }
@@ -23461,7 +23536,7 @@ semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol flags mismatch for "foo":
-after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | Ambient)
+after transform: SymbolId(0): SymbolFlags(Class | ValueModule | Ambient)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol span mismatch for "foo":
 after transform: SymbolId(0): Span { start: 15, end: 18 }
@@ -23475,7 +23550,7 @@ semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol flags mismatch for "foo":
-after transform: SymbolId(0): SymbolFlags(Function | NameSpaceModule | Ambient)
+after transform: SymbolId(0): SymbolFlags(Function | ValueModule | Ambient)
 rebuilt        : SymbolId(0): SymbolFlags(Function)
 Symbol span mismatch for "foo":
 after transform: SymbolId(0): Span { start: 15, end: 18 }
@@ -23806,7 +23881,7 @@ Symbol reference IDs mismatch for "publicClass":
 after transform: SymbolId(1): [ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47)]
 rebuilt        : SymbolId(1): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15)]
 Symbol flags mismatch for "publicModule":
-after transform: SymbolId(34): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(34): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(34): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "publicModule":
 after transform: SymbolId(34): Span { start: 5395, end: 5407 }
@@ -23818,7 +23893,7 @@ Symbol reference IDs mismatch for "publicClass":
 after transform: SymbolId(36): [ReferenceId(68), ReferenceId(69), ReferenceId(70), ReferenceId(71), ReferenceId(72), ReferenceId(73), ReferenceId(74), ReferenceId(75), ReferenceId(84), ReferenceId(85), ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(90), ReferenceId(91), ReferenceId(96), ReferenceId(97), ReferenceId(98), ReferenceId(99), ReferenceId(104), ReferenceId(105), ReferenceId(106), ReferenceId(107), ReferenceId(181)]
 rebuilt        : SymbolId(37): [ReferenceId(21), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(38), ReferenceId(39), ReferenceId(40), ReferenceId(41)]
 Symbol flags mismatch for "privateModule":
-after transform: SymbolId(69): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(69): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(70): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "privateModule":
 after transform: SymbolId(69): Span { start: 11550, end: 11563 }
@@ -23851,7 +23926,7 @@ Scope children mismatch:
 after transform: ScopeId(3): [ScopeId(4)]
 rebuilt        : ScopeId(2): []
 Symbol flags mismatch for "Query":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Query":
 after transform: SymbolId(3): Span { start: 86, end: 91 }
@@ -23865,7 +23940,7 @@ Scope children mismatch:
 after transform: ScopeId(3): [ScopeId(4)]
 rebuilt        : ScopeId(2): []
 Symbol flags mismatch for "Q":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Q":
 after transform: SymbolId(3): Span { start: 92, end: 93 }
@@ -23948,13 +24023,13 @@ Scope children mismatch:
 after transform: ScopeId(19): [ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32), ScopeId(33), ScopeId(34), ScopeId(35), ScopeId(36)]
 rebuilt        : ScopeId(17): [ScopeId(18), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27), ScopeId(28), ScopeId(29), ScopeId(30), ScopeId(31), ScopeId(32)]
 Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 14, end: 16 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
-after transform: SymbolId(17): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(17): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(17): Span { start: 1045, end: 1047 }
@@ -23971,13 +24046,13 @@ Scope children mismatch:
 after transform: ScopeId(11): [ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19)]
 rebuilt        : ScopeId(9): [ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15)]
 Symbol flags mismatch for "publicModule":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "publicModule":
 after transform: SymbolId(0): Span { start: 14, end: 26 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "privateModule":
-after transform: SymbolId(10): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(10): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "privateModule":
 after transform: SymbolId(10): Span { start: 1050, end: 1063 }
@@ -24000,7 +24075,7 @@ Scope children mismatch:
 after transform: ScopeId(58): [ScopeId(59), ScopeId(60), ScopeId(61), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(65), ScopeId(66)]
 rebuilt        : ScopeId(54): [ScopeId(55), ScopeId(56), ScopeId(57), ScopeId(58), ScopeId(59), ScopeId(60), ScopeId(61)]
 Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 7, end: 9 }
@@ -24051,7 +24126,7 @@ Symbol reference IDs mismatch for "publicClass":
 after transform: SymbolId(1): [ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(18), ReferenceId(19), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(32), ReferenceId(33), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(49), ReferenceId(51), ReferenceId(53), ReferenceId(55), ReferenceId(57), ReferenceId(59), ReferenceId(69), ReferenceId(71)]
 rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "publicModule":
-after transform: SymbolId(76): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(76): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(58): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "publicModule":
 after transform: SymbolId(76): Span { start: 4743, end: 4755 }
@@ -24063,7 +24138,7 @@ Symbol reference IDs mismatch for "publicClass":
 after transform: SymbolId(78): [ReferenceId(81), ReferenceId(83), ReferenceId(85), ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(95), ReferenceId(96), ReferenceId(97), ReferenceId(98), ReferenceId(99), ReferenceId(107), ReferenceId(108), ReferenceId(109), ReferenceId(110), ReferenceId(111), ReferenceId(112), ReferenceId(113), ReferenceId(121), ReferenceId(122), ReferenceId(123), ReferenceId(124), ReferenceId(125), ReferenceId(126), ReferenceId(127), ReferenceId(129), ReferenceId(131), ReferenceId(133), ReferenceId(135), ReferenceId(137), ReferenceId(139), ReferenceId(149), ReferenceId(151), ReferenceId(241)]
 rebuilt        : SymbolId(61): [ReferenceId(13)]
 Symbol flags mismatch for "privateModule":
-after transform: SymbolId(153): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(153): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(118): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "privateModule":
 after transform: SymbolId(153): Span { start: 9961, end: 9974 }
@@ -24104,7 +24179,7 @@ Symbol reference IDs mismatch for "publicClass":
 after transform: SymbolId(1): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(24), ReferenceId(25), ReferenceId(26), ReferenceId(27), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(40), ReferenceId(41), ReferenceId(42), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(49), ReferenceId(51), ReferenceId(53), ReferenceId(55), ReferenceId(57), ReferenceId(59)]
 rebuilt        : SymbolId(1): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(12), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(17), ReferenceId(19)]
 Symbol flags mismatch for "publicModule":
-after transform: SymbolId(32): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(32): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "publicModule":
 after transform: SymbolId(32): Span { start: 6483, end: 6495 }
@@ -24116,7 +24191,7 @@ Symbol reference IDs mismatch for "publicClass":
 after transform: SymbolId(34): [ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(94), ReferenceId(95), ReferenceId(96), ReferenceId(97), ReferenceId(106), ReferenceId(107), ReferenceId(108), ReferenceId(109), ReferenceId(110), ReferenceId(111), ReferenceId(112), ReferenceId(113), ReferenceId(122), ReferenceId(123), ReferenceId(124), ReferenceId(125), ReferenceId(126), ReferenceId(127), ReferenceId(128), ReferenceId(129), ReferenceId(131), ReferenceId(133), ReferenceId(135), ReferenceId(137), ReferenceId(139), ReferenceId(141), ReferenceId(247)]
 rebuilt        : SymbolId(23): [ReferenceId(27), ReferenceId(34), ReferenceId(35), ReferenceId(36), ReferenceId(37), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(55), ReferenceId(59)]
 Symbol flags mismatch for "privateModule":
-after transform: SymbolId(65): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(65): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(42): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "privateModule":
 after transform: SymbolId(65): Span { start: 13824, end: 13837 }
@@ -24133,7 +24208,7 @@ rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/privacyGetter.ts
 semantic error: Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 14, end: 16 }
@@ -24145,7 +24220,7 @@ Symbol reference IDs mismatch for "C2_private":
 after transform: SymbolId(2): [ReferenceId(4), ReferenceId(5), ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(13), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17)]
 rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(5), ReferenceId(10), ReferenceId(11)]
 Symbol flags mismatch for "m2":
-after transform: SymbolId(13): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(13): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(13): Span { start: 1449, end: 1451 }
@@ -24174,7 +24249,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16), ScopeId(17), ScopeId(18)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16)]
 Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 7, end: 9 }
@@ -24200,7 +24275,7 @@ Scope children mismatch:
 after transform: ScopeId(132): [ScopeId(133), ScopeId(134), ScopeId(135), ScopeId(136), ScopeId(137), ScopeId(138), ScopeId(139), ScopeId(140), ScopeId(141), ScopeId(142), ScopeId(143), ScopeId(144), ScopeId(145), ScopeId(146), ScopeId(147)]
 rebuilt        : ScopeId(122): [ScopeId(123), ScopeId(124), ScopeId(125), ScopeId(126), ScopeId(127), ScopeId(128), ScopeId(129), ScopeId(130), ScopeId(131), ScopeId(132), ScopeId(133), ScopeId(134), ScopeId(135)]
 Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 14, end: 16 }
@@ -24212,7 +24287,7 @@ Symbol reference IDs mismatch for "C2_private":
 after transform: SymbolId(2): [ReferenceId(1), ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(9), ReferenceId(14), ReferenceId(15), ReferenceId(16), ReferenceId(17), ReferenceId(19), ReferenceId(22), ReferenceId(23), ReferenceId(26), ReferenceId(27), ReferenceId(32), ReferenceId(33), ReferenceId(34), ReferenceId(35), ReferenceId(38), ReferenceId(39), ReferenceId(42), ReferenceId(43), ReferenceId(46), ReferenceId(47), ReferenceId(52), ReferenceId(53), ReferenceId(54), ReferenceId(55)]
 rebuilt        : SymbolId(3): [ReferenceId(4), ReferenceId(5), ReferenceId(8), ReferenceId(9), ReferenceId(14), ReferenceId(15), ReferenceId(18), ReferenceId(19), ReferenceId(32), ReferenceId(33), ReferenceId(40), ReferenceId(41)]
 Symbol flags mismatch for "m2":
-after transform: SymbolId(43): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(43): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(40): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(43): Span { start: 3609, end: 3611 }
@@ -24235,7 +24310,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 7, end: 9 }
@@ -24280,7 +24355,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(14)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(4)]
 Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 7, end: 9 }
@@ -24347,7 +24422,7 @@ Scope children mismatch:
 after transform: ScopeId(23): [ScopeId(24), ScopeId(26), ScopeId(27), ScopeId(36)]
 rebuilt        : ScopeId(5): [ScopeId(6), ScopeId(8)]
 Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 14, end: 16 }
@@ -24359,7 +24434,7 @@ Symbol reference IDs mismatch for "C2_private":
 after transform: SymbolId(2): [ReferenceId(1), ReferenceId(3), ReferenceId(5), ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(13), ReferenceId(15), ReferenceId(17), ReferenceId(19), ReferenceId(21), ReferenceId(23), ReferenceId(25), ReferenceId(27), ReferenceId(29), ReferenceId(31), ReferenceId(33), ReferenceId(35)]
 rebuilt        : SymbolId(3): []
 Symbol flags mismatch for "m2":
-after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(5): Span { start: 1205, end: 1207 }
@@ -24384,9 +24459,6 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(11), ScopeId(20), ScopeId(21), ScopeId(22), ScopeId(23), ScopeId(24), ScopeId(25), ScopeId(26), ScopeId(27)]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["privateModule"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/privacyLocalInternalReferenceImportWithExport.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -24488,7 +24560,7 @@ Symbol reference IDs mismatch for "publicClass":
 after transform: SymbolId(1): [ReferenceId(6), ReferenceId(7), ReferenceId(8), ReferenceId(9), ReferenceId(10), ReferenceId(11), ReferenceId(18), ReferenceId(19), ReferenceId(20), ReferenceId(21), ReferenceId(22), ReferenceId(23), ReferenceId(28), ReferenceId(29), ReferenceId(30), ReferenceId(31), ReferenceId(36), ReferenceId(37), ReferenceId(38), ReferenceId(39), ReferenceId(41), ReferenceId(43), ReferenceId(44), ReferenceId(45), ReferenceId(46), ReferenceId(47), ReferenceId(48), ReferenceId(49)]
 rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "publicModule":
-after transform: SymbolId(86): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(86): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "publicModule":
 after transform: SymbolId(86): Span { start: 4738, end: 4750 }
@@ -24500,7 +24572,7 @@ Symbol reference IDs mismatch for "publicClass":
 after transform: SymbolId(88): [ReferenceId(74), ReferenceId(75), ReferenceId(76), ReferenceId(77), ReferenceId(78), ReferenceId(79), ReferenceId(86), ReferenceId(87), ReferenceId(88), ReferenceId(89), ReferenceId(90), ReferenceId(91), ReferenceId(96), ReferenceId(97), ReferenceId(98), ReferenceId(99), ReferenceId(104), ReferenceId(105), ReferenceId(106), ReferenceId(107), ReferenceId(109), ReferenceId(111), ReferenceId(112), ReferenceId(113), ReferenceId(114), ReferenceId(115), ReferenceId(116), ReferenceId(117), ReferenceId(187)]
 rebuilt        : SymbolId(21): [ReferenceId(1)]
 Symbol flags mismatch for "privateModule":
-after transform: SymbolId(173): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(173): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(38): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "privateModule":
 after transform: SymbolId(173): Span { start: 10023, end: 10036 }
@@ -24531,7 +24603,7 @@ Symbol reference IDs mismatch for "publicClass":
 after transform: SymbolId(1): [ReferenceId(4), ReferenceId(12)]
 rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "publicModule":
-after transform: SymbolId(26): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(26): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "publicModule":
 after transform: SymbolId(26): Span { start: 1169, end: 1181 }
@@ -24543,7 +24615,7 @@ Symbol reference IDs mismatch for "publicClassInPublicModule":
 after transform: SymbolId(28): [ReferenceId(34), ReferenceId(42), ReferenceId(83)]
 rebuilt        : SymbolId(21): [ReferenceId(9)]
 Symbol flags mismatch for "privateModule":
-after transform: SymbolId(53): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(53): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(38): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "privateModule":
 after transform: SymbolId(53): Span { start: 2605, end: 2618 }
@@ -24598,7 +24670,7 @@ Symbol reference IDs mismatch for "publicClassT":
 after transform: SymbolId(4): [ReferenceId(3), ReferenceId(9), ReferenceId(11), ReferenceId(16), ReferenceId(22), ReferenceId(24), ReferenceId(29), ReferenceId(35), ReferenceId(37), ReferenceId(42), ReferenceId(48), ReferenceId(50), ReferenceId(54), ReferenceId(58)]
 rebuilt        : SymbolId(3): []
 Symbol flags mismatch for "publicModule":
-after transform: SymbolId(22): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(22): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "publicModule":
 after transform: SymbolId(22): Span { start: 1973, end: 1985 }
@@ -24616,7 +24688,7 @@ Symbol reference IDs mismatch for "publicClassInPublicModuleT":
 after transform: SymbolId(27): [ReferenceId(65), ReferenceId(71), ReferenceId(73), ReferenceId(78), ReferenceId(84), ReferenceId(86), ReferenceId(91), ReferenceId(97), ReferenceId(99), ReferenceId(104), ReferenceId(110), ReferenceId(112), ReferenceId(116), ReferenceId(120), ReferenceId(187)]
 rebuilt        : SymbolId(9): [ReferenceId(3)]
 Symbol flags mismatch for "privateModule":
-after transform: SymbolId(45): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(45): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "privateModule":
 after transform: SymbolId(45): Span { start: 4805, end: 4818 }
@@ -24664,7 +24736,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Test":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Test":
 after transform: SymbolId(0): Span { start: 7, end: 11 }
@@ -25753,7 +25825,7 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(33), ScopeId(35)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
-after transform: ["NonNullable", "Parameters", "R", "Record", "ReturnType", "Tools"]
+after transform: ["NonNullable", "Parameters", "Record", "ReturnType"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/ramdaToolsNoInfinite2.ts
@@ -25929,7 +26001,7 @@ Scope children mismatch:
 after transform: ScopeId(2): [ScopeId(3)]
 rebuilt        : ScopeId(1): []
 Symbol flags mismatch for "Foo":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Foo":
 after transform: SymbolId(1): Span { start: 34, end: 37 }
@@ -25943,7 +26015,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -26016,7 +26088,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "TypeScript2":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "TypeScript2":
 after transform: SymbolId(0): Span { start: 7, end: 18 }
@@ -26117,9 +26189,6 @@ rebuilt        : ScopeId(0): ["s1", "s2", "x"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Test1", "Test2"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveGenericUnionType2.ts
 semantic error: Bindings mismatch:
@@ -26128,9 +26197,6 @@ rebuilt        : ScopeId(0): ["s1", "s2", "x"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Test1", "Test2"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveIdenticalAssignment.ts
 semantic error: Scope children mismatch:
@@ -26145,7 +26211,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -26173,7 +26239,7 @@ rebuilt        : ["a", "b", "c"]
 
 tasks/coverage/typescript/tests/cases/compiler/recursiveMods.ts
 semantic error: Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Foo":
 after transform: SymbolId(0): Span { start: 14, end: 17 }
@@ -26312,25 +26378,25 @@ Scope children mismatch:
 after transform: ScopeId(4): [ScopeId(5), ScopeId(6), ScopeId(8)]
 rebuilt        : ScopeId(4): [ScopeId(5), ScopeId(7)]
 Symbol flags mismatch for "MsPortal":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "MsPortal":
 after transform: SymbolId(0): Span { start: 7, end: 15 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Controls":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Controls":
 after transform: SymbolId(1): Span { start: 16, end: 24 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Base":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Base":
 after transform: SymbolId(2): Span { start: 25, end: 29 }
 rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 Symbol flags mismatch for "ItemList":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "ItemList":
 after transform: SymbolId(3): Span { start: 30, end: 38 }
@@ -26426,7 +26492,7 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/requireEmitSemicolon.ts
 semantic error: Symbol flags mismatch for "Models":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Models":
 after transform: SymbolId(0): Span { start: 14, end: 20 }
@@ -26555,12 +26621,12 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "foo":
 after transform: SymbolId(0): Span { start: 15, end: 18 }
 rebuilt        : SymbolId(0): Span { start: 56, end: 68 }
+Symbol reference IDs mismatch for "foo":
+after transform: SymbolId(0): [ReferenceId(0)]
+rebuilt        : SymbolId(0): []
 Symbol redeclarations mismatch for "foo":
 after transform: SymbolId(0): [Span { start: 15, end: 18 }, Span { start: 56, end: 68 }]
 rebuilt        : SymbolId(0): []
-Unresolved references mismatch:
-after transform: ["foo"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/resolveModuleNameWithSameLetDeclarationName2.ts
 semantic error: Scope children mismatch:
@@ -26695,13 +26761,13 @@ Scope children mismatch:
 after transform: ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
 rebuilt        : ScopeId(5): [ScopeId(6)]
 Symbol flags mismatch for "M1":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M1":
 after transform: SymbolId(0): Span { start: 7, end: 9 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M2":
-after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M2":
 after transform: SymbolId(6): Span { start: 149, end: 151 }
@@ -26948,7 +27014,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "X":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "X":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -27057,13 +27123,13 @@ Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "sas":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "sas":
 after transform: SymbolId(0): Span { start: 7, end: 10 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "tools":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "tools":
 after transform: SymbolId(1): Span { start: 11, end: 16 }
@@ -27077,7 +27143,7 @@ Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Shapes":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Shapes":
 after transform: SymbolId(1): Span { start: 75, end: 81 }
@@ -27099,7 +27165,7 @@ Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Foo":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Foo":
 after transform: SymbolId(3): Span { start: 104, end: 107 }
@@ -27116,7 +27182,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Q":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Q":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -27127,13 +27193,13 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Foo":
 after transform: SymbolId(0): Span { start: 7, end: 10 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Bar":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Bar":
 after transform: SymbolId(1): Span { start: 11, end: 14 }
@@ -28633,7 +28699,7 @@ rebuilt        : ["console"]
 
 tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationImport.ts
 semantic error: Symbol flags mismatch for "m":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m":
 after transform: SymbolId(0): Span { start: 14, end: 15 }
@@ -28653,7 +28719,7 @@ Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch for "m1":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(0): Span { start: 7, end: 9 }
@@ -28689,7 +28755,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -29052,7 +29118,7 @@ Symbol reference IDs mismatch for "ListWrapper2":
 after transform: SymbolId(5): [ReferenceId(5), ReferenceId(9), ReferenceId(12)]
 rebuilt        : SymbolId(5): [ReferenceId(7)]
 Symbol flags mismatch for "tessst":
-after transform: SymbolId(13): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(13): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "tessst":
 after transform: SymbolId(13): Span { start: 503, end: 509 }
@@ -29335,7 +29401,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -29490,7 +29556,7 @@ Scope children mismatch:
 after transform: ScopeId(5): [ScopeId(6)]
 rebuilt        : ScopeId(5): []
 Symbol flags mismatch for "test":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "test":
 after transform: SymbolId(0): Span { start: 7, end: 11 }
@@ -29697,7 +29763,7 @@ Symbol flags mismatch for "TopLevelConstEnum":
 after transform: SymbolId(2): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "M":
-after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(5): Span { start: 165, end: 166 }
@@ -29738,7 +29804,7 @@ Symbol flags mismatch for "TopLevelConstEnum":
 after transform: SymbolId(2): SymbolFlags(ConstEnum)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol flags mismatch for "M":
-after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(5): Span { start: 165, end: 166 }
@@ -29761,19 +29827,19 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(5): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "F":
-after transform: SymbolId(0): SymbolFlags(Function | NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(Function | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Function)
 Symbol redeclarations mismatch for "F":
 after transform: SymbolId(0): [Span { start: 16, end: 17 }, Span { start: 37, end: 38 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "C":
-after transform: SymbolId(2): SymbolFlags(Class | NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(Class)
 Symbol redeclarations mismatch for "C":
 after transform: SymbolId(2): [Span { start: 64, end: 65 }, Span { start: 83, end: 84 }]
 rebuilt        : SymbolId(3): []
 Symbol flags mismatch for "E":
-after transform: SymbolId(4): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(RegularEnum | ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "E":
 after transform: SymbolId(4): [Span { start: 109, end: 110 }, Span { start: 128, end: 129 }]
@@ -29793,7 +29859,7 @@ Scope flags mismatch:
 after transform: ScopeId(9): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(9): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "TopLevelModule":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "TopLevelModule":
 after transform: SymbolId(1): Span { start: 44, end: 58 }
@@ -29802,13 +29868,13 @@ Symbol flags mismatch for "TopLevelEnum":
 after transform: SymbolId(4): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "TopLevelModule2":
-after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "TopLevelModule2":
 after transform: SymbolId(6): Span { start: 156, end: 171 }
 rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 Symbol flags mismatch for "NonTopLevelModule":
-after transform: SymbolId(8): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(8): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "NonTopLevelModule":
 after transform: SymbolId(8): Span { start: 229, end: 246 }
@@ -29825,7 +29891,7 @@ Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "ns":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "ns":
 after transform: SymbolId(0): Span { start: 10, end: 12 }
@@ -29860,7 +29926,7 @@ rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/taggedTemplatesInModuleAndGlobal.ts
 semantic error: Symbol flags mismatch for "n":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "n":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
@@ -29978,7 +30044,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 35, end: 36 }
@@ -30018,7 +30084,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "bar":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "bar":
 after transform: SymbolId(0): Span { start: 7, end: 10 }
@@ -30076,7 +30142,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "ObjectLiteral":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "ObjectLiteral":
 after transform: SymbolId(0): Span { start: 7, end: 20 }
@@ -30237,7 +30303,7 @@ Reference symbol mismatch for "Comp":
 after transform: SymbolId(5) "Comp"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["JSX", "parseInt", "require", "undefined"]
+after transform: ["parseInt", "require", "undefined"]
 rebuilt        : ["Comp", "parseInt", "require", "undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/tsxFragmentChildrenCheck.ts
@@ -30258,9 +30324,6 @@ rebuilt        : ScopeId(0): ["ShouldInferFromData", "_jsxFileName", "_reactJsxR
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
-Unresolved references mismatch:
-after transform: ["JSX", "require"]
-rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/compiler/tsxReactPropsInferenceSucceedsOnIntersections.tsx
 semantic error: Bindings mismatch:
@@ -30313,9 +30376,6 @@ rebuilt        : ScopeId(0): ["AnimalComponent", "_jsx", "_jsxFileName", "_objec
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
-Unresolved references mismatch:
-after transform: ["JSX", "undefined"]
-rebuilt        : ["undefined"]
 
 tasks/coverage/typescript/tests/cases/compiler/tupleTypeInference.ts
 semantic error: Bindings mismatch:
@@ -30411,7 +30471,7 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
 Unresolved references mismatch:
-after transform: ["Function", "m"]
+after transform: ["Function"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/typeAliasExport.ts
@@ -30685,7 +30745,7 @@ rebuilt        : ["aIndex", "bIndex", "cIndex"]
 
 tasks/coverage/typescript/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty7.ts
 semantic error: Symbol flags mismatch for "Foo":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Foo":
 after transform: SymbolId(0): Span { start: 17, end: 20 }
@@ -30693,7 +30753,7 @@ rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/typeGuardOnContainerTypeNoHang.ts
 semantic error: Symbol flags mismatch for "TypeGuards":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "TypeGuards":
 after transform: SymbolId(0): Span { start: 17, end: 27 }
@@ -31186,19 +31246,19 @@ Scope children mismatch:
 after transform: ScopeId(17): [ScopeId(18), ScopeId(20), ScopeId(22), ScopeId(24), ScopeId(26)]
 rebuilt        : ScopeId(15): [ScopeId(16), ScopeId(18), ScopeId(20)]
 Symbol flags mismatch for "TopLevelModule1":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "TopLevelModule1":
 after transform: SymbolId(0): Span { start: 14, end: 29 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "SubModule1":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "SubModule1":
 after transform: SymbolId(1): Span { start: 50, end: 60 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "SubSubModule1":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "SubSubModule1":
 after transform: SymbolId(2): Span { start: 85, end: 98 }
@@ -31210,31 +31270,31 @@ Symbol reference IDs mismatch for "ClassB":
 after transform: SymbolId(13): [ReferenceId(8), ReferenceId(26), ReferenceId(57)]
 rebuilt        : SymbolId(16): [ReferenceId(22)]
 Symbol flags mismatch for "SubModule2":
-after transform: SymbolId(37): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(37): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(39): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "SubModule2":
 after transform: SymbolId(37): Span { start: 3617, end: 3627 }
 rebuilt        : SymbolId(39): Span { start: 0, end: 0 }
 Symbol flags mismatch for "SubSubModule2":
-after transform: SymbolId(38): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(38): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(41): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "SubSubModule2":
 after transform: SymbolId(38): Span { start: 3652, end: 3665 }
 rebuilt        : SymbolId(41): Span { start: 0, end: 0 }
 Symbol flags mismatch for "NotExportedModule":
-after transform: SymbolId(47): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(47): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(47): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "NotExportedModule":
 after transform: SymbolId(47): Span { start: 4231, end: 4248 }
 rebuilt        : SymbolId(47): Span { start: 0, end: 0 }
 Symbol flags mismatch for "TopLevelModule2":
-after transform: SymbolId(49): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(49): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(50): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "TopLevelModule2":
 after transform: SymbolId(49): Span { start: 4299, end: 4314 }
 rebuilt        : SymbolId(50): Span { start: 0, end: 0 }
 Symbol flags mismatch for "SubModule3":
-after transform: SymbolId(50): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(50): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(52): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "SubModule3":
 after transform: SymbolId(50): Span { start: 4335, end: 4345 }
@@ -31632,8 +31692,17 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch for "View":
 after transform: SymbolId(23) "View"
 rebuilt        : <None>
+Reference symbol mismatch for "_":
+after transform: SymbolId(0) "_"
+rebuilt        : <None>
+Reference symbol mismatch for "_":
+after transform: SymbolId(0) "_"
+rebuilt        : <None>
+Reference symbol mismatch for "_":
+after transform: SymbolId(0) "_"
+rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["_"]
+after transform: []
 rebuilt        : ["View", "_"]
 
 tasks/coverage/typescript/tests/cases/compiler/unexportedInstanceClassVariables.ts
@@ -31644,7 +31713,7 @@ Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -31965,7 +32034,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
 Symbol flags mismatch for "Validation":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Validation":
 after transform: SymbolId(0): Span { start: 10, end: 20 }
@@ -31993,7 +32062,7 @@ semantic error: Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2)]
 rebuilt        : ScopeId(1): []
 Symbol flags mismatch for "N":
-after transform: SymbolId(29): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(29): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(29): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "N":
 after transform: SymbolId(29): Span { start: 2046, end: 2047 }
@@ -32096,7 +32165,7 @@ rebuilt        : ["a", "b"]
 
 tasks/coverage/typescript/tests/cases/compiler/useBeforeDeclaration.ts
 semantic error: Symbol flags mismatch for "ts":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "ts":
 after transform: SymbolId(0): Span { start: 10, end: 12 }
@@ -32807,13 +32876,13 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5), ScopeId(6)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5)]
 Symbol flags mismatch for "m1":
-after transform: SymbolId(17): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(17): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(13): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(17): Span { start: 843, end: 845 }
 rebuilt        : SymbolId(13): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m3":
-after transform: SymbolId(21): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(21): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m3":
 after transform: SymbolId(21): Span { start: 980, end: 982 }
@@ -32824,7 +32893,7 @@ semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["anotherVar", "arrayVar", "b", "deckareVarWithType", "declareVar2", "declaredVar", "m1", "m3", "simpleFunction", "simpleVar", "varWithArrayType", "varWithInitialValue", "varWithSimpleType", "withComplicatedValue"]
 rebuilt        : ScopeId(0): ["anotherVar", "arrayVar", "b", "m1", "m3", "simpleFunction", "simpleVar", "varWithArrayType", "varWithInitialValue", "varWithSimpleType", "withComplicatedValue"]
 Symbol flags mismatch for "m1":
-after transform: SymbolId(11): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(11): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(11): Span { start: 504, end: 506 }
@@ -32865,8 +32934,14 @@ rebuilt        : ScopeId(0): []
 Reference symbol mismatch for "E3":
 after transform: SymbolId(39) "E3"
 rebuilt        : <None>
+Reference symbol mismatch for "M1":
+after transform: SymbolId(43) "M1"
+rebuilt        : <None>
+Reference symbol mismatch for "M1":
+after transform: SymbolId(43) "M1"
+rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["M1"]
+after transform: []
 rebuilt        : ["E3", "M1"]
 
 tasks/coverage/typescript/tests/cases/conformance/ambient/ambientDeclarationsExternal.ts
@@ -32912,7 +32987,7 @@ Scope children mismatch:
 after transform: ScopeId(6): [ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
 rebuilt        : ScopeId(1): []
 Symbol flags mismatch for "M2":
-after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M2":
 after transform: SymbolId(6): Span { start: 173, end: 175 }
@@ -32980,7 +33055,7 @@ Scope flags mismatch:
 after transform: ScopeId(59): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(55): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(19): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(19): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(33): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(19): Span { start: 913, end: 914 }
@@ -33446,7 +33521,7 @@ Scope flags mismatch:
 after transform: ScopeId(59): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(55): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(19): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(19): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(33): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(19): Span { start: 913, end: 914 }
@@ -33477,7 +33552,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "X":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "X":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
@@ -33943,7 +34018,7 @@ Scope flags mismatch:
 after transform: ScopeId(59): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(55): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(19): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(19): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(33): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(19): Span { start: 913, end: 914 }
@@ -34416,7 +34491,7 @@ Symbol redeclarations mismatch for "C":
 after transform: SymbolId(0): [Span { start: 6, end: 7 }, Span { start: 35, end: 36 }]
 rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "M":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(1): Span { start: 62, end: 63 }
@@ -34538,7 +34613,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(4): Span { start: 67, end: 68 }
@@ -34660,7 +34735,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Generic":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Generic":
 after transform: SymbolId(0): Span { start: 7, end: 14 }
@@ -34679,13 +34754,13 @@ Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 Symbol flags mismatch for "NonGeneric":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "NonGeneric":
 after transform: SymbolId(0): Span { start: 7, end: 17 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Generic":
-after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Generic":
 after transform: SymbolId(5): Span { start: 198, end: 205 }
@@ -35309,61 +35384,61 @@ Classes may not have a static property named prototype
 Classes may not have a static property named prototype
 Classes may not have a static property named prototype
 Symbol flags mismatch for "TestOnDefaultExportedClass_1":
-after transform: SymbolId(41): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(41): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(82): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "TestOnDefaultExportedClass_1":
 after transform: SymbolId(41): Span { start: 6217, end: 6245 }
 rebuilt        : SymbolId(82): Span { start: 0, end: 0 }
 Symbol flags mismatch for "TestOnDefaultExportedClass_2":
-after transform: SymbolId(44): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(44): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(86): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "TestOnDefaultExportedClass_2":
 after transform: SymbolId(44): Span { start: 6560, end: 6588 }
 rebuilt        : SymbolId(86): Span { start: 0, end: 0 }
 Symbol flags mismatch for "TestOnDefaultExportedClass_3":
-after transform: SymbolId(47): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(47): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(90): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "TestOnDefaultExportedClass_3":
 after transform: SymbolId(47): Span { start: 6901, end: 6929 }
 rebuilt        : SymbolId(90): Span { start: 0, end: 0 }
 Symbol flags mismatch for "TestOnDefaultExportedClass_4":
-after transform: SymbolId(50): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(50): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(94): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "TestOnDefaultExportedClass_4":
 after transform: SymbolId(50): Span { start: 7271, end: 7299 }
 rebuilt        : SymbolId(94): Span { start: 0, end: 0 }
 Symbol flags mismatch for "TestOnDefaultExportedClass_5":
-after transform: SymbolId(53): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(53): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(98): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "TestOnDefaultExportedClass_5":
 after transform: SymbolId(53): Span { start: 7642, end: 7670 }
 rebuilt        : SymbolId(98): Span { start: 0, end: 0 }
 Symbol flags mismatch for "TestOnDefaultExportedClass_6":
-after transform: SymbolId(56): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(56): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(102): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "TestOnDefaultExportedClass_6":
 after transform: SymbolId(56): Span { start: 7986, end: 8014 }
 rebuilt        : SymbolId(102): Span { start: 0, end: 0 }
 Symbol flags mismatch for "TestOnDefaultExportedClass_7":
-after transform: SymbolId(59): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(59): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(106): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "TestOnDefaultExportedClass_7":
 after transform: SymbolId(59): Span { start: 8328, end: 8356 }
 rebuilt        : SymbolId(106): Span { start: 0, end: 0 }
 Symbol flags mismatch for "TestOnDefaultExportedClass_8":
-after transform: SymbolId(62): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(62): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(110): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "TestOnDefaultExportedClass_8":
 after transform: SymbolId(62): Span { start: 8698, end: 8726 }
 rebuilt        : SymbolId(110): Span { start: 0, end: 0 }
 Symbol flags mismatch for "TestOnDefaultExportedClass_9":
-after transform: SymbolId(65): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(65): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(114): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "TestOnDefaultExportedClass_9":
 after transform: SymbolId(65): Span { start: 9069, end: 9097 }
 rebuilt        : SymbolId(114): Span { start: 0, end: 0 }
 Symbol flags mismatch for "TestOnDefaultExportedClass_10":
-after transform: SymbolId(68): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(68): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(118): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "TestOnDefaultExportedClass_10":
 after transform: SymbolId(68): Span { start: 9457, end: 9486 }
@@ -35836,7 +35911,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -36706,7 +36781,7 @@ rebuilt        : ["Function", "Object", "Service", "decorator"]
 
 tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorMetadataWithTypeOnlyImport2.ts
 semantic error: Symbol flags mismatch for "Services":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Services":
 after transform: SymbolId(0): Span { start: 17, end: 25 }
@@ -37478,7 +37553,7 @@ Scope flags mismatch:
 after transform: ScopeId(21): ScopeFlags(0x0)
 rebuilt        : ScopeId(21): ScopeFlags(Function)
 Symbol flags mismatch for "M1":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M1":
 after transform: SymbolId(0): Span { start: 183, end: 185 }
@@ -37496,7 +37571,7 @@ Symbol redeclarations mismatch for "EConst1":
 after transform: SymbolId(8): [Span { start: 290, end: 297 }, Span { start: 351, end: 358 }]
 rebuilt        : SymbolId(5): []
 Symbol flags mismatch for "M2":
-after transform: SymbolId(16): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(16): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M2":
 after transform: SymbolId(16): Span { start: 570, end: 572 }
@@ -37508,7 +37583,7 @@ Symbol redeclarations mismatch for "EComp2":
 after transform: SymbolId(17): [Span { start: 591, end: 597 }, Span { start: 684, end: 690 }]
 rebuilt        : SymbolId(11): []
 Symbol flags mismatch for "M3":
-after transform: SymbolId(25): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(25): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(15): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M3":
 after transform: SymbolId(25): Span { start: 950, end: 952 }
@@ -37520,7 +37595,7 @@ Symbol redeclarations mismatch for "EInit":
 after transform: SymbolId(26): [Span { start: 964, end: 969 }, Span { start: 1009, end: 1014 }]
 rebuilt        : SymbolId(17): []
 Symbol flags mismatch for "M4":
-after transform: SymbolId(32): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(32): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M4":
 after transform: SymbolId(32): Span { start: 1103, end: 1105 }
@@ -37529,7 +37604,7 @@ Symbol flags mismatch for "Color":
 after transform: SymbolId(33): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(22): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "M5":
-after transform: SymbolId(37): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(37): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(24): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M5":
 after transform: SymbolId(37): Span { start: 1160, end: 1162 }
@@ -37538,7 +37613,7 @@ Symbol flags mismatch for "Color":
 after transform: SymbolId(38): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(26): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "M6":
-after transform: SymbolId(42): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(42): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(28): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M6":
 after transform: SymbolId(42): Span { start: 1218, end: 1220 }
@@ -37547,7 +37622,7 @@ Symbol redeclarations mismatch for "M6":
 after transform: SymbolId(42): [Span { start: 1218, end: 1220 }, Span { start: 1277, end: 1279 }]
 rebuilt        : SymbolId(28): []
 Symbol flags mismatch for "A":
-after transform: SymbolId(43): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(43): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(30): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(43): Span { start: 1221, end: 1222 }
@@ -37556,7 +37631,7 @@ Symbol flags mismatch for "Color":
 after transform: SymbolId(44): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(32): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "A":
-after transform: SymbolId(48): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(48): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(35): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(48): Span { start: 1300, end: 1301 }
@@ -38090,7 +38165,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -38107,7 +38182,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -38124,7 +38199,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -38135,7 +38210,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(1): Span { start: 48, end: 49 }
@@ -38149,7 +38224,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(1): Span { start: 48, end: 49 }
@@ -39090,7 +39165,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -39112,7 +39187,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -42450,7 +42525,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(8): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(11): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(11): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(11): Span { start: 383, end: 384 }
@@ -44347,31 +44422,31 @@ Scope flags mismatch:
 after transform: ScopeId(18): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(18): ScopeFlags(Function)
 Symbol flags mismatch for "m":
-after transform: SymbolId(21): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(21): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(21): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m":
 after transform: SymbolId(21): Span { start: 1652, end: 1653 }
 rebuilt        : SymbolId(21): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
-after transform: SymbolId(23): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(23): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(24): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(23): Span { start: 1705, end: 1707 }
 rebuilt        : SymbolId(24): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m1":
-after transform: SymbolId(26): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(26): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(28): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m1":
 after transform: SymbolId(26): Span { start: 2016, end: 2018 }
 rebuilt        : SymbolId(28): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m2":
-after transform: SymbolId(28): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(28): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(31): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m2":
 after transform: SymbolId(28): Span { start: 2070, end: 2072 }
 rebuilt        : SymbolId(31): Span { start: 0, end: 0 }
 Symbol flags mismatch for "m3":
-after transform: SymbolId(29): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(29): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(33): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "m3":
 after transform: SymbolId(29): Span { start: 2073, end: 2075 }
@@ -44550,7 +44625,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "container":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "container":
 after transform: SymbolId(2): Span { start: 49, end: 58 }
@@ -44636,19 +44711,19 @@ Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "C":
-after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol redeclarations mismatch for "C":
 after transform: SymbolId(0): [Span { start: 13, end: 14 }, Span { start: 37, end: 38 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "E":
-after transform: SymbolId(2): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(RegularEnum | ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "E":
 after transform: SymbolId(2): [Span { start: 80, end: 81 }, Span { start: 109, end: 110 }, Span { start: 143, end: 144 }, Span { start: 191, end: 192 }]
 rebuilt        : SymbolId(3): []
 Symbol flags mismatch for "F":
-after transform: SymbolId(9): SymbolFlags(Function | NameSpaceModule | ValueModule)
+after transform: SymbolId(9): SymbolFlags(Function | ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(Function)
 Symbol redeclarations mismatch for "F":
 after transform: SymbolId(9): [Span { start: 310, end: 311 }, Span { start: 336, end: 337 }]
@@ -44711,7 +44786,7 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol flags mismatch for "N":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "N":
 after transform: SymbolId(0): Span { start: 17, end: 18 }
@@ -44780,19 +44855,19 @@ Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(4): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "C":
-after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol redeclarations mismatch for "C":
 after transform: SymbolId(0): [Span { start: 13, end: 14 }, Span { start: 37, end: 38 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "E":
-after transform: SymbolId(2): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(RegularEnum | ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "E":
 after transform: SymbolId(2): [Span { start: 80, end: 81 }, Span { start: 109, end: 110 }, Span { start: 143, end: 144 }, Span { start: 191, end: 192 }]
 rebuilt        : SymbolId(3): []
 Symbol flags mismatch for "F":
-after transform: SymbolId(9): SymbolFlags(Function | NameSpaceModule | ValueModule)
+after transform: SymbolId(9): SymbolFlags(Function | ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(Function)
 Symbol redeclarations mismatch for "F":
 after transform: SymbolId(9): [Span { start: 310, end: 311 }, Span { start: 336, end: 337 }]
@@ -44855,7 +44930,7 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol flags mismatch for "N":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "N":
 after transform: SymbolId(0): Span { start: 17, end: 18 }
@@ -44914,9 +44989,12 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
-Reference flags mismatch for "M1":
-after transform: ReferenceId(0): ReferenceFlags(Read | Type)
-rebuilt        : ReferenceId(1): ReferenceFlags(Read)
+Reference symbol mismatch for "M1":
+after transform: SymbolId(0) "M1"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: ["module"]
+rebuilt        : ["M1", "module"]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/exportNonVisibleType.ts
 semantic error: Scope children mismatch:
@@ -44987,9 +45065,6 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["foo"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/typeAndNamespaceExportMerge.ts
 semantic error: Scope children mismatch:
@@ -45059,7 +45134,7 @@ rebuilt        : ScopeId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/typeOnly/nestedNamespace.ts
 semantic error: Symbol flags mismatch for "types":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "types":
 after transform: SymbolId(0): Span { start: 17, end: 22 }
@@ -45250,7 +45325,7 @@ Scope flags mismatch:
 after transform: ScopeId(17): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(6): ScopeFlags(Function)
 Symbol flags mismatch for "Directive":
-after transform: SymbolId(12): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
+after transform: SymbolId(12): SymbolFlags(RegularEnum | ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "Directive":
 after transform: SymbolId(12): [ReferenceId(14), ReferenceId(16), ReferenceId(18), ReferenceId(51), ReferenceId(54), ReferenceId(64), ReferenceId(93), ReferenceId(94), ReferenceId(108)]
@@ -45259,7 +45334,7 @@ Symbol redeclarations mismatch for "Directive":
 after transform: SymbolId(12): [Span { start: 318, end: 327 }, Span { start: 381, end: 390 }]
 rebuilt        : SymbolId(3): []
 Symbol flags mismatch for "StepResult":
-after transform: SymbolId(28): SymbolFlags(TypeAlias | NameSpaceModule | ValueModule)
+after transform: SymbolId(28): SymbolFlags(TypeAlias | ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "StepResult":
 after transform: SymbolId(28): Span { start: 1257, end: 1267 }
@@ -45394,7 +45469,7 @@ Scope children mismatch:
 after transform: ScopeId(7): [ScopeId(8), ScopeId(9), ScopeId(10), ScopeId(11), ScopeId(12), ScopeId(13)]
 rebuilt        : ScopeId(1): []
 Symbol flags mismatch for "M":
-after transform: SymbolId(13): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(13): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(13): Span { start: 474, end: 475 }
@@ -45441,7 +45516,7 @@ Scope children mismatch:
 after transform: ScopeId(13): [ScopeId(14)]
 rebuilt        : ScopeId(8): []
 Symbol flags mismatch for "M2":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M2":
 after transform: SymbolId(0): Span { start: 113, end: 115 }
@@ -45450,19 +45525,19 @@ Symbol redeclarations mismatch for "M2":
 after transform: SymbolId(0): [Span { start: 113, end: 115 }, Span { start: 235, end: 237 }, Span { start: 518, end: 520 }, Span { start: 693, end: 695 }, Span { start: 892, end: 894 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "M3":
-after transform: SymbolId(10): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(10): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M3":
 after transform: SymbolId(10): Span { start: 541, end: 543 }
 rebuilt        : SymbolId(11): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M3":
-after transform: SymbolId(15): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(15): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(17): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M3":
 after transform: SymbolId(15): Span { start: 716, end: 718 }
 rebuilt        : SymbolId(17): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M3":
-after transform: SymbolId(21): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(21): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(24): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M3":
 after transform: SymbolId(21): Span { start: 915, end: 917 }
@@ -45479,7 +45554,7 @@ Scope children mismatch:
 after transform: ScopeId(5): [ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
 rebuilt        : ScopeId(1): []
 Symbol flags mismatch for "M":
-after transform: SymbolId(10): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(10): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(10): Span { start: 396, end: 397 }
@@ -45517,7 +45592,7 @@ Scope children mismatch:
 after transform: ScopeId(9): [ScopeId(10)]
 rebuilt        : ScopeId(6): []
 Symbol flags mismatch for "M2":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M2":
 after transform: SymbolId(0): Span { start: 113, end: 115 }
@@ -45526,13 +45601,13 @@ Symbol redeclarations mismatch for "M2":
 after transform: SymbolId(0): [Span { start: 113, end: 115 }, Span { start: 234, end: 236 }, Span { start: 412, end: 414 }, Span { start: 586, end: 588 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "M3":
-after transform: SymbolId(9): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(9): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M3":
 after transform: SymbolId(9): Span { start: 435, end: 437 }
 rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M3":
-after transform: SymbolId(14): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(14): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M3":
 after transform: SymbolId(14): Span { start: 609, end: 611 }
@@ -45568,7 +45643,7 @@ Symbol reference IDs mismatch for "C2":
 after transform: SymbolId(1): [ReferenceId(1)]
 rebuilt        : SymbolId(2): []
 Symbol flags mismatch for "M":
-after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(6): Span { start: 412, end: 413 }
@@ -45603,7 +45678,7 @@ Symbol reference IDs mismatch for "C4":
 after transform: SymbolId(3): [ReferenceId(3)]
 rebuilt        : SymbolId(4): []
 Symbol flags mismatch for "M":
-after transform: SymbolId(8): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(8): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(8): Span { start: 509, end: 510 }
@@ -45657,7 +45732,7 @@ Scope children mismatch:
 after transform: ScopeId(3): [ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(1): []
 Symbol flags mismatch for "G":
-after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "G":
 after transform: SymbolId(5): Span { start: 176, end: 177 }
@@ -45668,7 +45743,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "n":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "n":
 after transform: SymbolId(2): Span { start: 45, end: 46 }
@@ -45720,7 +45795,7 @@ Reference symbol mismatch for "Constructor":
 after transform: SymbolId(15) "Constructor"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["NX", "Partial", "Readonly", "require"]
+after transform: ["Partial", "Readonly", "require"]
 rebuilt        : ["Constructor", "require"]
 
 tasks/coverage/typescript/tests/cases/conformance/interfaces/interfaceDeclarations/interfaceThatHidesBaseProperty.ts
@@ -45785,7 +45860,7 @@ rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/AmbientModuleAndNonAmbientClassWithSameNameAndCommonRoot.ts
 semantic error: Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -45802,7 +45877,7 @@ Scope flags mismatch:
 after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(10): ScopeFlags(Function)
 Symbol flags mismatch for "Point":
-after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol reference IDs mismatch for "Point":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3)]
@@ -45811,13 +45886,13 @@ Symbol redeclarations mismatch for "Point":
 after transform: SymbolId(0): [Span { start: 6, end: 11 }, Span { start: 135, end: 140 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "A":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(4): Span { start: 226, end: 227 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Point":
-after transform: SymbolId(5): SymbolFlags(Class | NameSpaceModule | ValueModule)
+after transform: SymbolId(5): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(Class)
 Symbol reference IDs mismatch for "Point":
 after transform: SymbolId(5): [ReferenceId(1), ReferenceId(5), ReferenceId(6), ReferenceId(8)]
@@ -45837,7 +45912,7 @@ Scope flags mismatch:
 after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(7): ScopeFlags(Function)
 Symbol flags mismatch for "Point":
-after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(Class)
 Symbol reference IDs mismatch for "Point":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(3), ReferenceId(14)]
@@ -45846,13 +45921,13 @@ Symbol redeclarations mismatch for "Point":
 after transform: SymbolId(0): [Span { start: 6, end: 11 }, Span { start: 124, end: 129 }]
 rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "A":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(4): Span { start: 200, end: 201 }
 rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Point":
-after transform: SymbolId(5): SymbolFlags(Class | NameSpaceModule | ValueModule)
+after transform: SymbolId(5): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(Class)
 Symbol reference IDs mismatch for "Point":
 after transform: SymbolId(5): [ReferenceId(1), ReferenceId(5), ReferenceId(6), ReferenceId(8), ReferenceId(18)]
@@ -45872,7 +45947,7 @@ Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "enumdule":
-after transform: SymbolId(0): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(RegularEnum | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol reference IDs mismatch for "enumdule":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2), ReferenceId(5), ReferenceId(6), ReferenceId(12)]
@@ -45883,7 +45958,7 @@ rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/FunctionAndModuleWithSameNameAndDifferentCommonRoot.ts
 semantic error: Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -45900,7 +45975,7 @@ Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(0x0)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Symbol flags mismatch for "enumdule":
-after transform: SymbolId(0): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(RegularEnum | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "enumdule":
 after transform: SymbolId(0): Span { start: 7, end: 15 }
@@ -45938,7 +46013,7 @@ Scope flags mismatch:
 after transform: ScopeId(12): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(14): ScopeFlags(Function)
 Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -45947,7 +46022,7 @@ Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 7, end: 8 }, Span { start: 90, end: 91 }]
 rebuilt        : SymbolId(1): []
 Symbol flags mismatch for "X":
-after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "X":
 after transform: SymbolId(5): Span { start: 294, end: 295 }
@@ -45956,25 +46031,25 @@ Symbol redeclarations mismatch for "X":
 after transform: SymbolId(5): [Span { start: 294, end: 295 }, Span { start: 366, end: 367 }]
 rebuilt        : SymbolId(8): []
 Symbol flags mismatch for "Y":
-after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Y":
 after transform: SymbolId(6): Span { start: 296, end: 297 }
 rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Z":
-after transform: SymbolId(7): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(7): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Z":
 after transform: SymbolId(7): Span { start: 298, end: 299 }
 rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Y":
-after transform: SymbolId(9): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(9): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Y":
 after transform: SymbolId(9): Span { start: 388, end: 389 }
 rebuilt        : SymbolId(16): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Z":
-after transform: SymbolId(10): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(10): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Z":
 after transform: SymbolId(10): Span { start: 414, end: 415 }
@@ -45990,9 +46065,6 @@ rebuilt        : ScopeId(0): ["l", "p"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(8), ScopeId(13), ScopeId(17)]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["A", "X"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedAndNonExportedLocalVarsOfTheSameName.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -46004,9 +46076,6 @@ rebuilt        : ScopeId(0): ["l", "p"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(14), ScopeId(18)]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["A", "X"]
-rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/DeclarationMerging/TwoInternalModulesThatMergeEachWithExportedModulesOfTheSameName.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -46017,19 +46086,19 @@ semantic error: Scope children mismatch:
 after transform: ScopeId(2): [ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(2): [ScopeId(3)]
 Symbol flags mismatch for "Root":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Root":
 after transform: SymbolId(0): Span { start: 7, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "A":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(1): Span { start: 32, end: 33 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Utils":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Utils":
 after transform: SymbolId(3): Span { start: 148, end: 153 }
@@ -46040,13 +46109,13 @@ semantic error: Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
 Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Utils":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Utils":
 after transform: SymbolId(2): Span { start: 103, end: 108 }
@@ -46070,7 +46139,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(4)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
 Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -46085,7 +46154,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -46103,7 +46172,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -46120,7 +46189,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -46137,7 +46206,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -46213,7 +46282,7 @@ Scope children mismatch:
 after transform: ScopeId(8): [ScopeId(9)]
 rebuilt        : ScopeId(8): []
 Symbol flags mismatch for "moduleA":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "moduleA":
 after transform: SymbolId(0): Span { start: 7, end: 14 }
@@ -46222,7 +46291,7 @@ Symbol reference IDs mismatch for "moduleA":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(13), ReferenceId(14)]
 rebuilt        : SymbolId(1): [ReferenceId(5), ReferenceId(6)]
 Symbol flags mismatch for "clodule":
-after transform: SymbolId(6): SymbolFlags(Class | NameSpaceModule | ValueModule)
+after transform: SymbolId(6): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(Class)
 Symbol reference IDs mismatch for "clodule":
 after transform: SymbolId(6): [ReferenceId(4), ReferenceId(6), ReferenceId(15), ReferenceId(16)]
@@ -46243,7 +46312,7 @@ Symbol redeclarations mismatch for "Point":
 after transform: SymbolId(7): [Span { start: 288, end: 293 }, Span { start: 340, end: 352 }]
 rebuilt        : SymbolId(9): []
 Symbol flags mismatch for "fundule":
-after transform: SymbolId(9): SymbolFlags(Function | NameSpaceModule | ValueModule)
+after transform: SymbolId(9): SymbolFlags(Function | ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(Function)
 Symbol reference IDs mismatch for "fundule":
 after transform: SymbolId(9): [ReferenceId(8), ReferenceId(17), ReferenceId(18)]
@@ -46278,7 +46347,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "container":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "container":
 after transform: SymbolId(2): Span { start: 49, end: 58 }
@@ -46303,8 +46372,14 @@ rebuilt        : ScopeId(0): ["test1", "test2"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(5)]
 rebuilt        : ScopeId(0): []
+Reference symbol mismatch for "pack2":
+after transform: SymbolId(2) "pack2"
+rebuilt        : <None>
+Reference symbol mismatch for "mod2":
+after transform: SymbolId(7) "mod2"
+rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["mod1", "mod2", "pack1", "pack2"]
+after transform: ["mod1"]
 rebuilt        : ["mod2", "pack2"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsdoc/declarations/jsDeclarationsClassImplementsGenericsSerialization.ts
@@ -46699,12 +46774,12 @@ rebuilt        : ScopeId(0): [ScopeId(1)]
 Reference symbol mismatch for "React":
 after transform: SymbolId(2) "React"
 rebuilt        : <None>
+Reference symbol mismatch for "React":
+after transform: SymbolId(2) "React"
+rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["JSX", "React"]
+after transform: []
 rebuilt        : ["React"]
-Unresolved reference IDs mismatch for "React":
-after transform: [ReferenceId(2)]
-rebuilt        : [ReferenceId(0), ReferenceId(1)]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxDefaultAttributesResolution1.tsx
 semantic error: Scope children mismatch:
@@ -46743,7 +46818,7 @@ Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch for "Dotted":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Dotted":
 after transform: SymbolId(4): Span { start: 161, end: 167 }
@@ -47036,6 +47111,12 @@ rebuilt        : ScopeId(0): ["_jsxFileName", "_reactJsxRuntime"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): []
+Reference symbol mismatch for "A":
+after transform: SymbolId(2) "A"
+rebuilt        : <None>
+Unresolved references mismatch:
+after transform: ["require"]
+rebuilt        : ["A", "require"]
 
 tasks/coverage/typescript/tests/cases/conformance/jsx/tsxParseTests1.tsx
 semantic error: Bindings mismatch:
@@ -47932,7 +48013,7 @@ Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "Shapes":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Shapes":
 after transform: SymbolId(1): Span { start: 75, end: 81 }
@@ -48049,8 +48130,11 @@ rebuilt        : ScopeId(0): ["x"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
+Reference symbol mismatch for "string":
+after transform: SymbolId(0) "string"
+rebuilt        : <None>
 Unresolved reference IDs mismatch for "string":
-after transform: [ReferenceId(0), ReferenceId(1)]
+after transform: [ReferenceId(1)]
 rebuilt        : [ReferenceId(0)]
 
 tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModuleDeclaration12.ts
@@ -48354,7 +48438,7 @@ Symbol reference IDs mismatch for "F":
 after transform: SymbolId(4): [ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25)]
 rebuilt        : SymbolId(3): [ReferenceId(21), ReferenceId(22)]
 Symbol flags mismatch for "M":
-after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(6): Span { start: 198, end: 199 }
@@ -48383,7 +48467,7 @@ Symbol reference IDs mismatch for "D":
 after transform: SymbolId(2): [ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(13)]
 rebuilt        : SymbolId(2): [ReferenceId(18)]
 Symbol flags mismatch for "M":
-after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(6): Span { start: 198, end: 199 }
@@ -49004,7 +49088,7 @@ Symbol reference IDs mismatch for "F":
 after transform: SymbolId(4): [ReferenceId(22), ReferenceId(23), ReferenceId(24), ReferenceId(25)]
 rebuilt        : SymbolId(3): [ReferenceId(21), ReferenceId(22)]
 Symbol flags mismatch for "M":
-after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(6): Span { start: 198, end: 199 }
@@ -49105,7 +49189,7 @@ Symbol reference IDs mismatch for "D":
 after transform: SymbolId(2): [ReferenceId(2), ReferenceId(4), ReferenceId(5), ReferenceId(21), ReferenceId(42)]
 rebuilt        : SymbolId(2): [ReferenceId(26), ReferenceId(46)]
 Symbol flags mismatch for "M":
-after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(6): Span { start: 212, end: 213 }
@@ -49362,7 +49446,7 @@ semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(10)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Unresolved references mismatch:
-after transform: ["Bar", "Baz", "require"]
+after transform: ["Bar", "require"]
 rebuilt        : ["require"]
 
 tasks/coverage/typescript/tests/cases/conformance/types/import/importTypeAmdBundleRewrite.ts
@@ -51392,7 +51476,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "M":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "M":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
@@ -51691,13 +51775,13 @@ Symbol redeclarations mismatch for "getFalsyPrimitive":
 after transform: SymbolId(1): [Span { start: 64, end: 81 }, Span { start: 113, end: 130 }, Span { start: 162, end: 179 }, Span { start: 213, end: 230 }, Span { start: 284, end: 301 }, Span { start: 355, end: 372 }, Span { start: 424, end: 441 }, Span { start: 515, end: 532 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "Consts1":
-after transform: SymbolId(10): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(10): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Consts1":
 after transform: SymbolId(10): Span { start: 807, end: 814 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Consts2":
-after transform: SymbolId(21): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(21): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Consts2":
 after transform: SymbolId(21): Span { start: 1271, end: 1278 }
@@ -51720,13 +51804,13 @@ Symbol redeclarations mismatch for "getFalsyPrimitive":
 after transform: SymbolId(0): [Span { start: 9, end: 26 }, Span { start: 58, end: 75 }, Span { start: 107, end: 124 }, Span { start: 158, end: 175 }, Span { start: 229, end: 246 }, Span { start: 300, end: 317 }, Span { start: 369, end: 386 }, Span { start: 460, end: 477 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "Consts1":
-after transform: SymbolId(9): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(9): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Consts1":
 after transform: SymbolId(9): Span { start: 745, end: 752 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Consts2":
-after transform: SymbolId(20): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(20): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Consts2":
 after transform: SymbolId(20): Span { start: 1178, end: 1185 }
@@ -52174,7 +52258,7 @@ semantic error: Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "container":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "container":
 after transform: SymbolId(3): Span { start: 42, end: 51 }
@@ -52555,7 +52639,7 @@ Scope children mismatch:
 after transform: ScopeId(6): [ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
 rebuilt        : ScopeId(6): [ScopeId(7), ScopeId(9)]
 Symbol flags mismatch for "SimpleTypes":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "SimpleTypes":
 after transform: SymbolId(0): Span { start: 146, end: 157 }
@@ -52567,7 +52651,7 @@ Symbol reference IDs mismatch for "T":
 after transform: SymbolId(2): [ReferenceId(1)]
 rebuilt        : SymbolId(4): []
 Symbol flags mismatch for "ObjectTypes":
-after transform: SymbolId(13): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(13): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(13): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "ObjectTypes":
 after transform: SymbolId(13): Span { start: 700, end: 711 }
@@ -52860,7 +52944,7 @@ Symbol reference IDs mismatch for "Base":
 after transform: SymbolId(14): [ReferenceId(1), ReferenceId(2), ReferenceId(3), ReferenceId(27), ReferenceId(32), ReferenceId(47), ReferenceId(91), ReferenceId(92), ReferenceId(113)]
 rebuilt        : SymbolId(15): [ReferenceId(3), ReferenceId(6)]
 Symbol flags mismatch for "Derived":
-after transform: SymbolId(15): SymbolFlags(Class | NameSpaceModule | ValueModule)
+after transform: SymbolId(15): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(16): SymbolFlags(Class)
 Symbol reference IDs mismatch for "Derived":
 after transform: SymbolId(15): [ReferenceId(4), ReferenceId(30), ReferenceId(31), ReferenceId(48), ReferenceId(69), ReferenceId(70), ReferenceId(116), ReferenceId(117)]
@@ -52872,7 +52956,7 @@ Symbol reference IDs mismatch for "Derived2":
 after transform: SymbolId(16): [ReferenceId(5)]
 rebuilt        : SymbolId(18): []
 Symbol flags mismatch for "WithContextualType":
-after transform: SymbolId(30): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(30): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(34): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "WithContextualType":
 after transform: SymbolId(30): Span { start: 1461, end: 1479 }
@@ -53160,7 +53244,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(9), ScopeId(10), ScopeId(11)]
 rebuilt        : ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 Symbol flags mismatch for "CallSignature":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "CallSignature":
 after transform: SymbolId(0): Span { start: 7, end: 20 }
@@ -53329,7 +53413,7 @@ Scope children mismatch:
 after transform: ScopeId(68): [ScopeId(69), ScopeId(71), ScopeId(72), ScopeId(73), ScopeId(75), ScopeId(76)]
 rebuilt        : ScopeId(34): [ScopeId(35), ScopeId(36)]
 Symbol flags mismatch for "Errors":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Errors":
 after transform: SymbolId(0): Span { start: 168, end: 174 }
@@ -53344,7 +53428,7 @@ Symbol reference IDs mismatch for "Derived2":
 after transform: SymbolId(3): [ReferenceId(7), ReferenceId(24), ReferenceId(36), ReferenceId(52), ReferenceId(60), ReferenceId(111), ReferenceId(115)]
 rebuilt        : SymbolId(6): []
 Symbol flags mismatch for "WithGenericSignaturesInBaseType":
-after transform: SymbolId(122): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(122): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(81): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "WithGenericSignaturesInBaseType":
 after transform: SymbolId(122): Span { start: 4321, end: 4352 }
@@ -53471,7 +53555,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(1): []
 Symbol flags mismatch for "ConstructSignature":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "ConstructSignature":
 after transform: SymbolId(0): Span { start: 7, end: 25 }
@@ -53586,7 +53670,7 @@ Scope children mismatch:
 after transform: ScopeId(38): [ScopeId(39), ScopeId(40), ScopeId(41), ScopeId(42)]
 rebuilt        : ScopeId(10): []
 Symbol flags mismatch for "Errors":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Errors":
 after transform: SymbolId(0): Span { start: 168, end: 174 }
@@ -53601,7 +53685,7 @@ Symbol reference IDs mismatch for "Derived2":
 after transform: SymbolId(3): [ReferenceId(7), ReferenceId(24), ReferenceId(36), ReferenceId(53), ReferenceId(61), ReferenceId(112), ReferenceId(116)]
 rebuilt        : SymbolId(6): []
 Symbol flags mismatch for "WithGenericSignaturesInBaseType":
-after transform: SymbolId(82): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(82): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(53): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "WithGenericSignaturesInBaseType":
 after transform: SymbolId(82): Span { start: 4469, end: 4500 }
@@ -53735,7 +53819,7 @@ Scope children mismatch:
 after transform: ScopeId(10): [ScopeId(11), ScopeId(12), ScopeId(13), ScopeId(14), ScopeId(15), ScopeId(16)]
 rebuilt        : ScopeId(1): []
 Symbol flags mismatch for "TwoLevels":
-after transform: SymbolId(12): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(12): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "TwoLevels":
 after transform: SymbolId(12): Span { start: 1157, end: 1166 }
@@ -59156,7 +59240,7 @@ Scope children mismatch:
 after transform: ScopeId(17): [ScopeId(18), ScopeId(19)]
 rebuilt        : ScopeId(6): []
 Symbol flags mismatch for "NonGenericParameter":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "NonGenericParameter":
 after transform: SymbolId(0): Span { start: 193, end: 212 }
@@ -59165,7 +59249,7 @@ Symbol reference IDs mismatch for "a":
 after transform: SymbolId(1): [ReferenceId(0), ReferenceId(3)]
 rebuilt        : SymbolId(2): [ReferenceId(2)]
 Symbol flags mismatch for "GenericParameter":
-after transform: SymbolId(8): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(8): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "GenericParameter":
 after transform: SymbolId(8): Span { start: 457, end: 473 }
@@ -59179,7 +59263,7 @@ Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)
 Symbol flags mismatch for "NonGenericParameter":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "NonGenericParameter":
 after transform: SymbolId(0): Span { start: 193, end: 212 }
@@ -59188,7 +59272,7 @@ Symbol reference IDs mismatch for "a":
 after transform: SymbolId(1): [ReferenceId(0), ReferenceId(3)]
 rebuilt        : SymbolId(2): [ReferenceId(2)]
 Symbol flags mismatch for "GenericParameter":
-after transform: SymbolId(10): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(10): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "GenericParameter":
 after transform: SymbolId(10): Span { start: 452, end: 468 }
@@ -59214,7 +59298,7 @@ Symbol reference IDs mismatch for "X":
 after transform: SymbolId(2): [ReferenceId(1), ReferenceId(3), ReferenceId(7), ReferenceId(9), ReferenceId(20), ReferenceId(22), ReferenceId(34), ReferenceId(36), ReferenceId(39), ReferenceId(41), ReferenceId(52), ReferenceId(54)]
 rebuilt        : SymbolId(3): [ReferenceId(6), ReferenceId(7), ReferenceId(23), ReferenceId(24)]
 Symbol flags mismatch for "Class":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Class":
 after transform: SymbolId(4): Span { start: 214, end: 219 }
@@ -59226,7 +59310,7 @@ Symbol reference IDs mismatch for "G2":
 after transform: SymbolId(16): [ReferenceId(26)]
 rebuilt        : SymbolId(15): []
 Symbol flags mismatch for "Interface":
-after transform: SymbolId(23): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(23): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Interface":
 after transform: SymbolId(23): Span { start: 749, end: 758 }
@@ -59758,11 +59842,32 @@ rebuilt        : <None>
 Reference symbol mismatch for "f":
 after transform: SymbolId(69) "f"
 rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
+rebuilt        : <None>
 Reference symbol mismatch for "f":
 after transform: SymbolId(69) "f"
 rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
+rebuilt        : <None>
 Reference symbol mismatch for "s":
 after transform: SymbolId(65) "s"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "s":
+after transform: SymbolId(65) "s"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
 rebuilt        : <None>
 Reference symbol mismatch for "s":
 after transform: SymbolId(65) "s"
@@ -59782,8 +59887,20 @@ rebuilt        : <None>
 Reference symbol mismatch for "s":
 after transform: SymbolId(65) "s"
 rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
+rebuilt        : <None>
 Reference symbol mismatch for "s":
 after transform: SymbolId(65) "s"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
 rebuilt        : <None>
 Reference symbol mismatch for "s":
 after transform: SymbolId(65) "s"
@@ -59803,11 +59920,20 @@ rebuilt        : <None>
 Reference symbol mismatch for "s":
 after transform: SymbolId(65) "s"
 rebuilt        : <None>
-Reference symbol mismatch for "s":
-after transform: SymbolId(65) "s"
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
 rebuilt        : <None>
 Reference symbol mismatch for "s":
 after transform: SymbolId(65) "s"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
 rebuilt        : <None>
 Reference symbol mismatch for "o":
 after transform: SymbolId(68) "o"
@@ -59818,9 +59944,15 @@ rebuilt        : <None>
 Reference symbol mismatch for "o":
 after transform: SymbolId(68) "o"
 rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
+rebuilt        : <None>
 Reference symbol mismatch for "o":
 after transform: SymbolId(68) "o"
 rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
+rebuilt        : <None>
 Reference symbol mismatch for "f":
 after transform: SymbolId(69) "f"
 rebuilt        : <None>
@@ -59830,8 +59962,14 @@ rebuilt        : <None>
 Reference symbol mismatch for "f":
 after transform: SymbolId(69) "f"
 rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
+rebuilt        : <None>
 Reference symbol mismatch for "f":
 after transform: SymbolId(69) "f"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
 rebuilt        : <None>
 Reference symbol mismatch for "g":
 after transform: SymbolId(72) "g"
@@ -59842,17 +59980,44 @@ rebuilt        : <None>
 Reference symbol mismatch for "g":
 after transform: SymbolId(72) "g"
 rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
+rebuilt        : <None>
 Reference symbol mismatch for "g":
 after transform: SymbolId(72) "g"
 rebuilt        : <None>
-Reference symbol mismatch for "s":
-after transform: SymbolId(65) "s"
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
 rebuilt        : <None>
 Reference symbol mismatch for "s":
 after transform: SymbolId(65) "s"
 rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
+rebuilt        : <None>
 Reference symbol mismatch for "s":
 after transform: SymbolId(65) "s"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "s":
+after transform: SymbolId(65) "s"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(66) "N"
 rebuilt        : <None>
 Reference symbol mismatch for "s":
 after transform: SymbolId(65) "s"
@@ -59876,11 +60041,8 @@ Reference symbol mismatch for "s":
 after transform: SymbolId(65) "s"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["AsyncIterableIterator", "IterableIterator", "Math", "N", "Promise", "Symbol", "arguments", "require"]
+after transform: ["AsyncIterableIterator", "IterableIterator", "Math", "Promise", "Symbol", "arguments", "require"]
 rebuilt        : ["Math", "N", "Promise", "Symbol", "arguments", "c", "constType", "f", "g", "i", "l", "o", "require", "s"]
-Unresolved reference IDs mismatch for "N":
-after transform: [ReferenceId(86), ReferenceId(90), ReferenceId(94), ReferenceId(96), ReferenceId(98), ReferenceId(99), ReferenceId(101), ReferenceId(102), ReferenceId(110), ReferenceId(111), ReferenceId(113), ReferenceId(114), ReferenceId(116), ReferenceId(117), ReferenceId(119), ReferenceId(120), ReferenceId(130), ReferenceId(132), ReferenceId(137), ReferenceId(138), ReferenceId(140), ReferenceId(141), ReferenceId(145), ReferenceId(147), ReferenceId(149), ReferenceId(150), ReferenceId(154), ReferenceId(156), ReferenceId(158), ReferenceId(160), ReferenceId(162)]
-rebuilt        : [ReferenceId(115), ReferenceId(117), ReferenceId(119), ReferenceId(120), ReferenceId(122), ReferenceId(123), ReferenceId(135), ReferenceId(137), ReferenceId(141), ReferenceId(143), ReferenceId(157), ReferenceId(160), ReferenceId(166), ReferenceId(169), ReferenceId(173), ReferenceId(175), ReferenceId(179), ReferenceId(181), ReferenceId(185), ReferenceId(187), ReferenceId(189), ReferenceId(190), ReferenceId(194), ReferenceId(196), ReferenceId(198), ReferenceId(200), ReferenceId(202)]
 Unresolved reference IDs mismatch for "Promise":
 after transform: [ReferenceId(82), ReferenceId(164)]
 rebuilt        : [ReferenceId(109)]
@@ -59964,11 +60126,32 @@ rebuilt        : <None>
 Reference symbol mismatch for "f":
 after transform: SymbolId(68) "f"
 rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
+rebuilt        : <None>
 Reference symbol mismatch for "f":
 after transform: SymbolId(68) "f"
 rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
+rebuilt        : <None>
 Reference symbol mismatch for "s":
 after transform: SymbolId(64) "s"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "s":
+after transform: SymbolId(64) "s"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
 rebuilt        : <None>
 Reference symbol mismatch for "s":
 after transform: SymbolId(64) "s"
@@ -59988,8 +60171,20 @@ rebuilt        : <None>
 Reference symbol mismatch for "s":
 after transform: SymbolId(64) "s"
 rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
+rebuilt        : <None>
 Reference symbol mismatch for "s":
 after transform: SymbolId(64) "s"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
 rebuilt        : <None>
 Reference symbol mismatch for "s":
 after transform: SymbolId(64) "s"
@@ -60009,11 +60204,20 @@ rebuilt        : <None>
 Reference symbol mismatch for "s":
 after transform: SymbolId(64) "s"
 rebuilt        : <None>
-Reference symbol mismatch for "s":
-after transform: SymbolId(64) "s"
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
 rebuilt        : <None>
 Reference symbol mismatch for "s":
 after transform: SymbolId(64) "s"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
 rebuilt        : <None>
 Reference symbol mismatch for "o":
 after transform: SymbolId(67) "o"
@@ -60024,9 +60228,15 @@ rebuilt        : <None>
 Reference symbol mismatch for "o":
 after transform: SymbolId(67) "o"
 rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
+rebuilt        : <None>
 Reference symbol mismatch for "o":
 after transform: SymbolId(67) "o"
 rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
+rebuilt        : <None>
 Reference symbol mismatch for "f":
 after transform: SymbolId(68) "f"
 rebuilt        : <None>
@@ -60036,8 +60246,14 @@ rebuilt        : <None>
 Reference symbol mismatch for "f":
 after transform: SymbolId(68) "f"
 rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
+rebuilt        : <None>
 Reference symbol mismatch for "f":
 after transform: SymbolId(68) "f"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
 rebuilt        : <None>
 Reference symbol mismatch for "g":
 after transform: SymbolId(71) "g"
@@ -60048,17 +60264,44 @@ rebuilt        : <None>
 Reference symbol mismatch for "g":
 after transform: SymbolId(71) "g"
 rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
+rebuilt        : <None>
 Reference symbol mismatch for "g":
 after transform: SymbolId(71) "g"
 rebuilt        : <None>
-Reference symbol mismatch for "s":
-after transform: SymbolId(64) "s"
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
 rebuilt        : <None>
 Reference symbol mismatch for "s":
 after transform: SymbolId(64) "s"
 rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
+rebuilt        : <None>
 Reference symbol mismatch for "s":
 after transform: SymbolId(64) "s"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "s":
+after transform: SymbolId(64) "s"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
+rebuilt        : <None>
+Reference symbol mismatch for "N":
+after transform: SymbolId(65) "N"
 rebuilt        : <None>
 Reference symbol mismatch for "s":
 after transform: SymbolId(64) "s"
@@ -60082,11 +60325,8 @@ Reference symbol mismatch for "s":
 after transform: SymbolId(64) "s"
 rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["AsyncIterableIterator", "IterableIterator", "Math", "N", "Promise", "Symbol", "arguments", "require"]
+after transform: ["AsyncIterableIterator", "IterableIterator", "Math", "Promise", "Symbol", "arguments", "require"]
 rebuilt        : ["Math", "N", "Promise", "Symbol", "arguments", "c", "constType", "f", "g", "i", "l", "o", "require", "s"]
-Unresolved reference IDs mismatch for "N":
-after transform: [ReferenceId(86), ReferenceId(90), ReferenceId(94), ReferenceId(96), ReferenceId(98), ReferenceId(99), ReferenceId(101), ReferenceId(102), ReferenceId(110), ReferenceId(111), ReferenceId(113), ReferenceId(114), ReferenceId(116), ReferenceId(117), ReferenceId(119), ReferenceId(120), ReferenceId(130), ReferenceId(132), ReferenceId(137), ReferenceId(138), ReferenceId(140), ReferenceId(141), ReferenceId(145), ReferenceId(147), ReferenceId(149), ReferenceId(150), ReferenceId(154), ReferenceId(156), ReferenceId(158), ReferenceId(160), ReferenceId(162)]
-rebuilt        : [ReferenceId(115), ReferenceId(117), ReferenceId(119), ReferenceId(120), ReferenceId(122), ReferenceId(123), ReferenceId(135), ReferenceId(137), ReferenceId(141), ReferenceId(143), ReferenceId(157), ReferenceId(160), ReferenceId(166), ReferenceId(169), ReferenceId(173), ReferenceId(175), ReferenceId(179), ReferenceId(181), ReferenceId(185), ReferenceId(187), ReferenceId(189), ReferenceId(190), ReferenceId(194), ReferenceId(196), ReferenceId(198), ReferenceId(200), ReferenceId(202)]
 Unresolved reference IDs mismatch for "Promise":
 after transform: [ReferenceId(82), ReferenceId(164)]
 rebuilt        : [ReferenceId(109)]

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1980,13 +1980,16 @@ rebuilt        : ScopeId(0): []
 Symbol reference IDs mismatch for "AliasModule":
 after transform: SymbolId(8): [ReferenceId(2), ReferenceId(3), ReferenceId(4)]
 rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(2)]
+Reference symbol mismatch for "LongNameModule":
+after transform: SymbolId(0) "LongNameModule"
+rebuilt        : <None>
 Unresolved reference IDs mismatch for "LongNameModule":
-after transform: [ReferenceId(1), ReferenceId(5)]
+after transform: [ReferenceId(5)]
 rebuilt        : [ReferenceId(0)]
 
 * namespace/clobber-class/input.ts
 Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 6, end: 7 }, Span { start: 22, end: 23 }]
@@ -2000,7 +2003,7 @@ Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(1): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(RegularEnum | NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(RegularEnum | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 5, end: 6 }, Span { start: 30, end: 31 }]
@@ -2008,7 +2011,7 @@ rebuilt        : SymbolId(0): []
 
 * namespace/clobber-export/input.ts
 Symbol flags mismatch for "N":
-after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol redeclarations mismatch for "N":
 after transform: SymbolId(0): [Span { start: 13, end: 14 }, Span { start: 35, end: 36 }]
@@ -2016,211 +2019,211 @@ rebuilt        : SymbolId(0): []
 
 * namespace/contentious-names/input.ts
 Symbol flags mismatch for "N":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "N":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "N":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "N":
 after transform: SymbolId(1): Span { start: 26, end: 27 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "constructor":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "constructor":
 after transform: SymbolId(3): Span { start: 50, end: 61 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "length":
-after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "length":
 after transform: SymbolId(5): Span { start: 84, end: 90 }
 rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 Symbol flags mismatch for "concat":
-after transform: SymbolId(7): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(7): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "concat":
 after transform: SymbolId(7): Span { start: 113, end: 119 }
 rebuilt        : SymbolId(11): Span { start: 0, end: 0 }
 Symbol flags mismatch for "copyWithin":
-after transform: SymbolId(9): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(9): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "copyWithin":
 after transform: SymbolId(9): Span { start: 142, end: 152 }
 rebuilt        : SymbolId(14): Span { start: 0, end: 0 }
 Symbol flags mismatch for "fill":
-after transform: SymbolId(11): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(11): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(17): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "fill":
 after transform: SymbolId(11): Span { start: 175, end: 179 }
 rebuilt        : SymbolId(17): Span { start: 0, end: 0 }
 Symbol flags mismatch for "find":
-after transform: SymbolId(13): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(13): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(20): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "find":
 after transform: SymbolId(13): Span { start: 202, end: 206 }
 rebuilt        : SymbolId(20): Span { start: 0, end: 0 }
 Symbol flags mismatch for "findIndex":
-after transform: SymbolId(15): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(15): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(23): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "findIndex":
 after transform: SymbolId(15): Span { start: 229, end: 238 }
 rebuilt        : SymbolId(23): Span { start: 0, end: 0 }
 Symbol flags mismatch for "lastIndexOf":
-after transform: SymbolId(17): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(17): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(26): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "lastIndexOf":
 after transform: SymbolId(17): Span { start: 261, end: 272 }
 rebuilt        : SymbolId(26): Span { start: 0, end: 0 }
 Symbol flags mismatch for "pop":
-after transform: SymbolId(19): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(19): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(29): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "pop":
 after transform: SymbolId(19): Span { start: 295, end: 298 }
 rebuilt        : SymbolId(29): Span { start: 0, end: 0 }
 Symbol flags mismatch for "push":
-after transform: SymbolId(21): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(21): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(32): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "push":
 after transform: SymbolId(21): Span { start: 321, end: 325 }
 rebuilt        : SymbolId(32): Span { start: 0, end: 0 }
 Symbol flags mismatch for "reverse":
-after transform: SymbolId(23): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(23): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(35): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "reverse":
 after transform: SymbolId(23): Span { start: 348, end: 355 }
 rebuilt        : SymbolId(35): Span { start: 0, end: 0 }
 Symbol flags mismatch for "shift":
-after transform: SymbolId(25): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(25): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(38): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "shift":
 after transform: SymbolId(25): Span { start: 378, end: 383 }
 rebuilt        : SymbolId(38): Span { start: 0, end: 0 }
 Symbol flags mismatch for "unshift":
-after transform: SymbolId(27): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(27): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(41): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "unshift":
 after transform: SymbolId(27): Span { start: 406, end: 413 }
 rebuilt        : SymbolId(41): Span { start: 0, end: 0 }
 Symbol flags mismatch for "slice":
-after transform: SymbolId(29): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(29): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(44): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "slice":
 after transform: SymbolId(29): Span { start: 436, end: 441 }
 rebuilt        : SymbolId(44): Span { start: 0, end: 0 }
 Symbol flags mismatch for "sort":
-after transform: SymbolId(31): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(31): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(47): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "sort":
 after transform: SymbolId(31): Span { start: 464, end: 468 }
 rebuilt        : SymbolId(47): Span { start: 0, end: 0 }
 Symbol flags mismatch for "splice":
-after transform: SymbolId(33): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(33): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(50): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "splice":
 after transform: SymbolId(33): Span { start: 491, end: 497 }
 rebuilt        : SymbolId(50): Span { start: 0, end: 0 }
 Symbol flags mismatch for "includes":
-after transform: SymbolId(35): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(35): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(53): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "includes":
 after transform: SymbolId(35): Span { start: 520, end: 528 }
 rebuilt        : SymbolId(53): Span { start: 0, end: 0 }
 Symbol flags mismatch for "indexOf":
-after transform: SymbolId(37): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(37): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(56): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "indexOf":
 after transform: SymbolId(37): Span { start: 551, end: 558 }
 rebuilt        : SymbolId(56): Span { start: 0, end: 0 }
 Symbol flags mismatch for "join":
-after transform: SymbolId(39): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(39): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(59): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "join":
 after transform: SymbolId(39): Span { start: 581, end: 585 }
 rebuilt        : SymbolId(59): Span { start: 0, end: 0 }
 Symbol flags mismatch for "keys":
-after transform: SymbolId(41): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(41): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(62): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "keys":
 after transform: SymbolId(41): Span { start: 608, end: 612 }
 rebuilt        : SymbolId(62): Span { start: 0, end: 0 }
 Symbol flags mismatch for "entries":
-after transform: SymbolId(43): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(43): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(65): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "entries":
 after transform: SymbolId(43): Span { start: 635, end: 642 }
 rebuilt        : SymbolId(65): Span { start: 0, end: 0 }
 Symbol flags mismatch for "values":
-after transform: SymbolId(45): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(45): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(68): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "values":
 after transform: SymbolId(45): Span { start: 665, end: 671 }
 rebuilt        : SymbolId(68): Span { start: 0, end: 0 }
 Symbol flags mismatch for "forEach":
-after transform: SymbolId(47): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(47): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(71): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "forEach":
 after transform: SymbolId(47): Span { start: 694, end: 701 }
 rebuilt        : SymbolId(71): Span { start: 0, end: 0 }
 Symbol flags mismatch for "filter":
-after transform: SymbolId(49): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(49): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(74): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "filter":
 after transform: SymbolId(49): Span { start: 724, end: 730 }
 rebuilt        : SymbolId(74): Span { start: 0, end: 0 }
 Symbol flags mismatch for "map":
-after transform: SymbolId(51): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(51): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(77): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "map":
 after transform: SymbolId(51): Span { start: 753, end: 756 }
 rebuilt        : SymbolId(77): Span { start: 0, end: 0 }
 Symbol flags mismatch for "every":
-after transform: SymbolId(53): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(53): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(80): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "every":
 after transform: SymbolId(53): Span { start: 779, end: 784 }
 rebuilt        : SymbolId(80): Span { start: 0, end: 0 }
 Symbol flags mismatch for "some":
-after transform: SymbolId(55): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(55): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(83): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "some":
 after transform: SymbolId(55): Span { start: 807, end: 811 }
 rebuilt        : SymbolId(83): Span { start: 0, end: 0 }
 Symbol flags mismatch for "reduce":
-after transform: SymbolId(57): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(57): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(86): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "reduce":
 after transform: SymbolId(57): Span { start: 834, end: 840 }
 rebuilt        : SymbolId(86): Span { start: 0, end: 0 }
 Symbol flags mismatch for "reduceRight":
-after transform: SymbolId(59): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(59): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(89): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "reduceRight":
 after transform: SymbolId(59): Span { start: 863, end: 874 }
 rebuilt        : SymbolId(89): Span { start: 0, end: 0 }
 Symbol flags mismatch for "toLocaleString":
-after transform: SymbolId(61): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(61): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(92): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "toLocaleString":
 after transform: SymbolId(61): Span { start: 897, end: 911 }
 rebuilt        : SymbolId(92): Span { start: 0, end: 0 }
 Symbol flags mismatch for "toString":
-after transform: SymbolId(63): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(63): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(95): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "toString":
 after transform: SymbolId(63): Span { start: 934, end: 942 }
 rebuilt        : SymbolId(95): Span { start: 0, end: 0 }
 Symbol flags mismatch for "flat":
-after transform: SymbolId(65): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(65): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(98): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "flat":
 after transform: SymbolId(65): Span { start: 965, end: 969 }
 rebuilt        : SymbolId(98): Span { start: 0, end: 0 }
 Symbol flags mismatch for "flatMap":
-after transform: SymbolId(67): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(67): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(101): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "flatMap":
 after transform: SymbolId(67): Span { start: 992, end: 999 }
@@ -2234,7 +2237,7 @@ Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(1): []
 Symbol flags mismatch for "N":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "N":
 after transform: SymbolId(0): Span { start: 17, end: 18 }
@@ -2245,7 +2248,7 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Symbol flags mismatch for "X":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "X":
 after transform: SymbolId(2): Span { start: 70, end: 71 }
@@ -2274,7 +2277,7 @@ Scope flags mismatch:
 after transform: ScopeId(18): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(9): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "a":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "a":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
@@ -2283,37 +2286,37 @@ Symbol reference IDs mismatch for "a":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4), ReferenceId(5)]
 rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
 Symbol flags mismatch for "c":
-after transform: SymbolId(2): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(2): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "c":
 after transform: SymbolId(2): Span { start: 43, end: 44 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "WithTypes":
-after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "WithTypes":
 after transform: SymbolId(6): Span { start: 107, end: 116 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "d":
-after transform: SymbolId(13): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(13): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "d":
 after transform: SymbolId(13): Span { start: 224, end: 225 }
 rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 Symbol flags mismatch for "WithValues":
-after transform: SymbolId(15): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(15): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "WithValues":
 after transform: SymbolId(15): Span { start: 262, end: 272 }
 rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
 Symbol flags mismatch for "a":
-after transform: SymbolId(16): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(16): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "a":
 after transform: SymbolId(16): Span { start: 287, end: 288 }
 rebuilt        : SymbolId(11): Span { start: 0, end: 0 }
 Symbol flags mismatch for "b":
-after transform: SymbolId(18): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(18): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "b":
 after transform: SymbolId(18): Span { start: 316, end: 317 }
@@ -2322,19 +2325,19 @@ Symbol flags mismatch for "B":
 after transform: SymbolId(19): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(16): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "c":
-after transform: SymbolId(20): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(20): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(18): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "c":
 after transform: SymbolId(20): Span { start: 344, end: 345 }
 rebuilt        : SymbolId(18): Span { start: 0, end: 0 }
 Symbol flags mismatch for "d":
-after transform: SymbolId(22): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(22): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(21): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "d":
 after transform: SymbolId(22): Span { start: 378, end: 379 }
 rebuilt        : SymbolId(21): Span { start: 0, end: 0 }
 Symbol flags mismatch for "e":
-after transform: SymbolId(24): SymbolFlags(NameSpaceModule)
+after transform: SymbolId(24): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(24): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "e":
 after transform: SymbolId(24): Span { start: 402, end: 403 }
@@ -2342,7 +2345,7 @@ rebuilt        : SymbolId(24): Span { start: 0, end: 0 }
 
 * namespace/export/input.ts
 Symbol flags mismatch for "N":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "N":
 after transform: SymbolId(0): Span { start: 17, end: 18 }
@@ -2355,25 +2358,22 @@ rebuilt        : ScopeId(0): []
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1)]
 rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["Platform"]
-rebuilt        : []
 
 * namespace/module-nested/input.ts
 Symbol flags mismatch for "src":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "src":
 after transform: SymbolId(0): Span { start: 7, end: 10 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "ns1":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "ns1":
 after transform: SymbolId(1): Span { start: 32, end: 35 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "ns2":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "ns2":
 after transform: SymbolId(3): Span { start: 113, end: 116 }
@@ -2381,19 +2381,19 @@ rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 
 * namespace/module-nested-export/input.ts
 Symbol flags mismatch for "src":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "src":
 after transform: SymbolId(0): Span { start: 14, end: 17 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "ns1":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "ns1":
 after transform: SymbolId(1): Span { start: 39, end: 42 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "ns2":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "ns2":
 after transform: SymbolId(3): Span { start: 120, end: 123 }
@@ -2401,7 +2401,7 @@ rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 
 * namespace/multiple/input.ts
 Symbol flags mismatch for "N":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "N":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
@@ -2447,25 +2447,25 @@ Scope flags mismatch:
 after transform: ScopeId(13): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(13): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
 Symbol redeclarations mismatch for "A":
 after transform: SymbolId(0): [Span { start: 6, end: 7 }, Span { start: 22, end: 23 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "C":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "C":
 after transform: SymbolId(1): Span { start: 45, end: 46 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "M":
-after transform: SymbolId(4): SymbolFlags(Function | NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(Function | ValueModule)
 rebuilt        : SymbolId(6): SymbolFlags(Function)
 Symbol redeclarations mismatch for "M":
 after transform: SymbolId(4): [Span { start: 110, end: 111 }, Span { start: 129, end: 130 }]
 rebuilt        : SymbolId(6): []
 Symbol flags mismatch for "D":
-after transform: SymbolId(6): SymbolFlags(Function | NameSpaceModule | ValueModule)
+after transform: SymbolId(6): SymbolFlags(Function | ValueModule)
 rebuilt        : SymbolId(9): SymbolFlags(Function)
 Symbol redeclarations mismatch for "D":
 after transform: SymbolId(6): [Span { start: 181, end: 182 }, Span { start: 207, end: 208 }]
@@ -2474,13 +2474,13 @@ Symbol flags mismatch for "H":
 after transform: SymbolId(8): SymbolFlags(RegularEnum)
 rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
 Symbol flags mismatch for "F":
-after transform: SymbolId(12): SymbolFlags(Class | NameSpaceModule | ValueModule)
+after transform: SymbolId(12): SymbolFlags(Class | ValueModule)
 rebuilt        : SymbolId(14): SymbolFlags(Class)
 Symbol redeclarations mismatch for "F":
 after transform: SymbolId(12): [Span { start: 308, end: 309 }, Span { start: 325, end: 326 }]
 rebuilt        : SymbolId(14): []
 Symbol flags mismatch for "G":
-after transform: SymbolId(14): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(14): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(17): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "G":
 after transform: SymbolId(14): Span { start: 350, end: 351 }
@@ -2503,7 +2503,7 @@ Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(2): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "A":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 17, end: 18 }
@@ -2514,37 +2514,37 @@ rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 
 * namespace/nested-shorthand/input.ts
 Symbol flags mismatch for "X":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "X":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "Y":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Y":
 after transform: SymbolId(1): Span { start: 12, end: 13 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "proj":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "proj":
 after transform: SymbolId(3): Span { start: 51, end: 55 }
 rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol flags mismatch for "data":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(7): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "data":
 after transform: SymbolId(4): Span { start: 56, end: 60 }
 rebuilt        : SymbolId(7): Span { start: 0, end: 0 }
 Symbol flags mismatch for "util":
-after transform: SymbolId(5): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(5): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(9): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "util":
 after transform: SymbolId(5): Span { start: 61, end: 65 }
 rebuilt        : SymbolId(9): Span { start: 0, end: 0 }
 Symbol flags mismatch for "api":
-after transform: SymbolId(6): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(6): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "api":
 after transform: SymbolId(6): Span { start: 66, end: 69 }
@@ -2555,19 +2555,19 @@ Scope flags mismatch:
 after transform: ScopeId(8): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(8): ScopeFlags(StrictMode | Function)
 Symbol flags mismatch for "N":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "N":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol flags mismatch for "_N7":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "_N7":
 after transform: SymbolId(1): Span { start: 26, end: 29 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol flags mismatch for "N":
-after transform: SymbolId(3): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(3): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "N":
 after transform: SymbolId(3): Span { start: 59, end: 60 }
@@ -2581,7 +2581,7 @@ rebuilt        : SymbolId(11): SymbolFlags(BlockScopedVariable)
 
 * namespace/undeclared/input.ts
 Symbol flags mismatch for "N":
-after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(0): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "N":
 after transform: SymbolId(0): Span { start: 10, end: 11 }

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -174,7 +174,7 @@ Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
 Symbol flags mismatch for "Name":
-after transform: SymbolId(7): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(7): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "Name":
 after transform: SymbolId(7): Span { start: 116, end: 120 }
@@ -202,7 +202,7 @@ Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Symbol flags mismatch for "N1":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "N1":
 after transform: SymbolId(1): Span { start: 31, end: 33 }
@@ -222,13 +222,13 @@ Symbol reference IDs mismatch for "A":
 after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1)]
 rebuilt        : SymbolId(0): [ReferenceId(2)]
 Symbol flags mismatch for "N1":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "N1":
 after transform: SymbolId(1): Span { start: 31, end: 33 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol flags mismatch for "N2":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "N2":
 after transform: SymbolId(4): Span { start: 130, end: 132 }
@@ -242,13 +242,13 @@ Scope flags mismatch:
 after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "N1":
-after transform: SymbolId(1): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(1): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "N1":
 after transform: SymbolId(1): Span { start: 34, end: 36 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 Symbol flags mismatch for "N2":
-after transform: SymbolId(4): SymbolFlags(NameSpaceModule | ValueModule)
+after transform: SymbolId(4): SymbolFlags(ValueModule)
 rebuilt        : SymbolId(5): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "N2":
 after transform: SymbolId(4): Span { start: 145, end: 147 }
@@ -274,7 +274,7 @@ Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
 Symbol flags mismatch for "x":
-after transform: SymbolId(0): SymbolFlags(RegularEnum | NameSpaceModule)
+after transform: SymbolId(0): SymbolFlags(RegularEnum | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "x":
 after transform: SymbolId(0): Span { start: 10, end: 11 }
@@ -283,7 +283,7 @@ Symbol redeclarations mismatch for "x":
 after transform: SymbolId(0): [Span { start: 10, end: 11 }, Span { start: 39, end: 40 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "y":
-after transform: SymbolId(2): SymbolFlags(RegularEnum | NameSpaceModule)
+after transform: SymbolId(2): SymbolFlags(RegularEnum | ValueModule)
 rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "y":
 after transform: SymbolId(2): [Span { start: 59, end: 60 }, Span { start: 83, end: 84 }]


### PR DESCRIPTION
Based on TypeScript's [implementation](https://github.com/microsoft/TypeScript/blob/15392346d05045742e653eab5c87538ff2a3c863/src/compiler/binder.ts#L2384-L2393) to correct `SymbolFlags` of `TSModuleDeclaration`.

The `SymbolFlags::NamespaceModule` and `SymbolFlags::ValueModule` have a significant difference,

`NamespaceModule`: can only be referenced as a type.
`ValueModule`: can only be referenced as a value.

Let's take an example to see:

```ts
namespace NamespaceModule {
  export type A = string
}
namespace ValueModule {
  export const A = 0;
}
```

The following code is the JS output of the above example.

```js
"use strict";
var ValueModule;
(function (ValueModule) {
    ValueModule.A = 0;
})(ValueModule || (ValueModule = {}));
```

Only `ValueModule` will be preserved and transformed. 

That means whether a `TSModuleDeclaration`  needs to be transformed or removed directly, we can determine by its `SymbolFlags`. We can use it to simplify the current `TSModuleDeclaration` transformation later.