### PR TITLE
feat(semantic): add `SymbolFlags::Ambient` for declaration with `declare` modifier

### DIFF
--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class-deco-with-object-param.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/class-deco-with-object-param.snap
@@ -41,7 +41,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/decorators/clas
     "node": "Program",
     "symbols": [
       {
-        "flags": "SymbolFlags(Function)",
+        "flags": "SymbolFlags(Function | Ambient)",
         "id": 0,
         "name": "deco",
         "node": "Function(deco)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/this-jsxidentifier.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/this-jsxidentifier.snap
@@ -33,7 +33,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/jsx/this-jsxide
     "node": "Program",
     "symbols": [
       {
-        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable)",
+        "flags": "SymbolFlags(BlockScopedVariable | ConstVariable | Ambient)",
         "id": 0,
         "name": "React",
         "node": "VariableDeclarator(React)",

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type3.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/literal-type3.snap
@@ -68,7 +68,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
         ]
       },
       {
-        "flags": "SymbolFlags(Function)",
+        "flags": "SymbolFlags(Function | Ambient)",
         "id": 2,
         "name": "setAlignment",
         "node": "Function(setAlignment)",

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -125,7 +125,12 @@ bitflags! {
         const TypeParameter           = 1 << 13;
         const NameSpaceModule         = 1 << 14;
         const ValueModule             = 1 << 15;
-        // In a dts file or there is a declare flag
+        /// Declared with `declare` modifier, like `declare function x() {}`.
+        //
+        // This flag is not part of TypeScript's `SymbolFlags`, it comes from TypeScript's `NodeFlags`. We introduced it into
+        // here because `NodeFlags` is incomplete and we only can access to `NodeFlags` in the Semantic, but we also need to
+        // access it in the Transformer.
+        // https://github.com/microsoft/TypeScript/blob/15392346d05045742e653eab5c87538ff2a3c863/src/compiler/types.ts#L819-L820
         const Ambient                 = 1 << 16;
 
         const Enum = Self::ConstEnum.bits() | Self::RegularEnum.bits();
@@ -243,6 +248,11 @@ impl SymbolFlags {
     #[inline]
     pub fn is_type_import(&self) -> bool {
         self.contains(Self::TypeImport)
+    }
+
+    #[inline]
+    pub fn is_ambient(&self) -> bool {
+        self.contains(Self::Ambient)
     }
 
     /// If true, then the symbol can be referenced by a type reference

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -1458,7 +1458,7 @@ semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol flags mismatch for "C":
-after transform: SymbolId(0): SymbolFlags(Class | Function)
+after transform: SymbolId(0): SymbolFlags(Class | Function | Ambient)
 rebuilt        : SymbolId(0): SymbolFlags(Function)
 Symbol span mismatch for "C":
 after transform: SymbolId(0): Span { start: 14, end: 15 }

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -379,7 +379,7 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol flags mismatch for "D":
-after transform: SymbolId(3): SymbolFlags(Class | ValueModule)
+after transform: SymbolId(3): SymbolFlags(Class | ValueModule | Ambient)
 rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "D":
 after transform: SymbolId(3): Span { start: 97, end: 98 }
@@ -398,7 +398,7 @@ semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol flags mismatch for "foo":
-after transform: SymbolId(0): SymbolFlags(Class | Function)
+after transform: SymbolId(0): SymbolFlags(Class | Function | Ambient)
 rebuilt        : SymbolId(0): SymbolFlags(Function)
 Symbol span mismatch for "foo":
 after transform: SymbolId(0): Span { start: 14, end: 17 }
@@ -46653,6 +46653,9 @@ tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuite.tsx
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["Child", "Component", "Composite", "Composite2", "Namespace", "React", "_jsxFileName", "_objectSpread", "_reactJsxRuntime", "bar", "foo", "hasOwnProperty", "x", "y", "z"]
 rebuilt        : ScopeId(0): ["_jsxFileName", "_objectSpread", "_reactJsxRuntime", "x"]
+Symbol flags mismatch for "x":
+after transform: SymbolId(9): SymbolFlags(FunctionScopedVariable | Ambient)
+rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
 Symbol span mismatch for "x":
 after transform: SymbolId(9): Span { start: 231, end: 236 }
 rebuilt        : SymbolId(3): Span { start: 537, end: 538 }

--- a/tasks/transform_conformance/snapshots/babel.snap.md
+++ b/tasks/transform_conformance/snapshots/babel.snap.md
@@ -1705,7 +1705,7 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
 Symbol flags mismatch for "Signal":
-after transform: SymbolId(0): SymbolFlags(Class | Function)
+after transform: SymbolId(0): SymbolFlags(Class | Function | Ambient)
 rebuilt        : SymbolId(0): SymbolFlags(Function)
 Symbol span mismatch for "Signal":
 after transform: SymbolId(0): Span { start: 14, end: 20 }
@@ -1717,7 +1717,7 @@ Symbol redeclarations mismatch for "Signal":
 after transform: SymbolId(0): [Span { start: 14, end: 20 }, Span { start: 54, end: 60 }]
 rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "Signal2":
-after transform: SymbolId(3): SymbolFlags(Class | Function)
+after transform: SymbolId(3): SymbolFlags(Class | Function | Ambient)
 rebuilt        : SymbolId(2): SymbolFlags(Function)
 Symbol reference IDs mismatch for "Signal2":
 after transform: SymbolId(3): [ReferenceId(4), ReferenceId(7)]


### PR DESCRIPTION
Part of https://github.com/oxc-project/oxc/issues/7951.

After we have a `SymbolFlags::Ambient` within a Symbol that is declared by the `declare` modifier,  we can determine whether to remove an `ExportSpecifier` by tracing its referent and examining its `SymbolFlags`.
