### PR TITLE
perf(linter): use `binary_search` for arrays with more than `7` elements

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
+++ b/crates/oxc_linter/src/rules/eslint/array_callback_return/mod.rs
@@ -196,7 +196,7 @@ pub fn get_array_method_name<'a>(node: &AstNode<'a>, ctx: &LintContext<'a>) -> O
                 // "methods",
                 let array_method = callee.static_property_name()?;
 
-                if TARGET_METHODS.contains(&array_method)
+                if TARGET_METHODS.binary_search(&array_method).is_ok()
                     // Check that current node is parent's first argument
                     && call.arguments.len() == 1
                     && is_nth_argument(call, current_node_arg, 0)

--- a/crates/oxc_linter/src/rules/eslint/func_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/func_names.rs
@@ -388,7 +388,7 @@ const INVALID_NAMES: [&str; 9] =
     ["arguments", "async", "await", "constructor", "default", "eval", "null", "undefined", "yield"];
 
 fn is_valid_identifier_name(name: &str) -> bool {
-    !INVALID_NAMES.contains(&name) && is_identifier_name(name)
+    INVALID_NAMES.binary_search(&name).is_err() && is_identifier_name(name)
 }
 
 #[test]

--- a/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_shadow_restricted_names.rs
@@ -6,7 +6,7 @@ use oxc_syntax::symbol::SymbolId;
 
 use crate::{context::LintContext, rule::Rule};
 
-const PRE_DEFINE_VAR: [&str; 5] = ["undefined", "Infinity", "NaN", "eval", "arguments"];
+const PRE_DEFINE_VAR: [&str; 5] = ["Infinity", "NaN", "arguments", "eval", "undefined"];
 
 fn no_shadow_restricted_names_diagnostic(shadowed_name: &str, span: Span) -> OxcDiagnostic {
     OxcDiagnostic::warn("Shadowing of global properties such as 'undefined' is not allowed.")

--- a/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
+++ b/crates/oxc_linter/src/rules/eslint/valid_typeof.rs
@@ -117,7 +117,7 @@ impl Rule for ValidTypeof {
         };
 
         if let Expression::StringLiteral(lit) = sibling {
-            if !VALID_TYPES.contains(&lit.value.as_str()) {
+            if VALID_TYPES.binary_search(&lit.value.as_str()).is_err() {
                 ctx.diagnostic(invalid_value(None, sibling.span()));
             }
             return;
@@ -125,7 +125,10 @@ impl Rule for ValidTypeof {
 
         if let Expression::TemplateLiteral(template) = sibling {
             if template.expressions.is_empty() {
-                if template.quasi().is_some_and(|value| !VALID_TYPES.contains(&value.as_str())) {
+                if template
+                    .quasi()
+                    .is_some_and(|value| VALID_TYPES.binary_search(&value.as_str()).is_err())
+                {
                     ctx.diagnostic(invalid_value(None, sibling.span()));
                 }
                 return;
@@ -174,7 +177,7 @@ impl Rule for ValidTypeof {
 }
 
 const VALID_TYPES: [&str; 8] =
-    ["symbol", "undefined", "object", "boolean", "number", "string", "function", "bigint"];
+    ["bigint", "boolean", "function", "number", "object", "string", "symbol", "undefined"];
 
 #[test]
 fn test() {

--- a/crates/oxc_linter/src/rules/jsdoc/empty_tags.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/empty_tags.rs
@@ -68,17 +68,17 @@ const EMPTY_TAGS: [&str; 18] = [
     "global",
     "hideconstructor",
     "ignore",
+    "inheritDoc",
     "inner",
     "instance",
-    "override",
-    "readonly",
-    "inheritDoc",
     "internal",
+    "override",
     "overload",
     "package",
     "private",
     "protected",
     "public",
+    "readonly",
     "static",
 ];
 
@@ -101,7 +101,7 @@ impl Rule for EmptyTags {
         let settings = &ctx.settings().jsdoc;
 
         let is_empty_tag_kind = |tag_name: &str| {
-            if EMPTY_TAGS.contains(&tag_name) {
+            if EMPTY_TAGS.binary_search(&tag_name).is_ok() {
                 return true;
             }
             if !self.0.tags.is_empty() && self.0.tags.contains(&tag_name.to_string()) {

--- a/crates/oxc_linter/src/rules/jsx_a11y/aria_unsupported_elements.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/aria_unsupported_elements.rs
@@ -50,7 +50,7 @@ impl Rule for AriaUnsupportedElements {
     fn run<'a>(&self, node: &AstNode<'a>, ctx: &LintContext<'a>) {
         if let AstKind::JSXOpeningElement(jsx_el) = node.kind() {
             let el_type = get_element_type(ctx, jsx_el);
-            if RESERVED_HTML_TAG.contains(&el_type.as_ref()) {
+            if RESERVED_HTML_TAG.binary_search(&el_type.as_ref()).is_ok() {
                 for attr in &jsx_el.attributes {
                     let attr = match attr {
                         JSXAttributeItem::Attribute(attr) => attr,

--- a/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
+++ b/crates/oxc_linter/src/rules/jsx_a11y/no_noninteractive_tabindex.rs
@@ -132,7 +132,7 @@ impl Rule for NoNoninteractiveTabindex {
 
         let component = &get_element_type(ctx, jsx_el);
 
-        if INTERACTIVE_HTML_ELEMENTS.contains(&component.as_ref()) {
+        if INTERACTIVE_HTML_ELEMENTS.binary_search(&component.as_ref()).is_ok() {
             return;
         }
 
@@ -152,7 +152,7 @@ impl Rule for NoNoninteractiveTabindex {
             return;
         };
 
-        if !INTERACTIVE_HTML_ROLES.contains(&role.value.as_str())
+        if INTERACTIVE_HTML_ROLES.binary_search(&role.value.as_str()).is_err()
             && !self.0.roles.contains(&CompactStr::new(role.value.as_str()))
         {
             ctx.diagnostic(no_noninteractive_tabindex_diagnostic(tabindex_attr.span));

--- a/crates/oxc_linter/src/rules/promise/no_new_statics.rs
+++ b/crates/oxc_linter/src/rules/promise/no_new_statics.rs
@@ -65,7 +65,7 @@ impl Rule for NoNewStatics {
             return;
         };
 
-        if PROMISE_STATIC_METHODS.contains(&prop_name) {
+        if PROMISE_STATIC_METHODS.binary_search(&prop_name).is_ok() {
             ctx.diagnostic_with_fix(
                 static_promise_diagnostic(
                     prop_name,

--- a/crates/oxc_linter/src/rules/promise/spec_only.rs
+++ b/crates/oxc_linter/src/rules/promise/spec_only.rs
@@ -78,7 +78,7 @@ impl Rule for SpecOnly {
             return;
         };
 
-        if PROMISE_STATIC_METHODS.contains(&prop_name) {
+        if PROMISE_STATIC_METHODS.binary_search(&prop_name).is_ok() {
             return;
         }
 

--- a/crates/oxc_linter/src/rules/react/iframe_missing_sandbox.rs
+++ b/crates/oxc_linter/src/rules/react/iframe_missing_sandbox.rs
@@ -175,7 +175,7 @@ fn validate_sandbox_value(literal: &StringLiteral, ctx: &LintContext) {
     let mut has_allow_same_origin = false;
     let mut has_allow_scripts = false;
     for trimmed_atr in attrs.into_iter().map(str::trim) {
-        if !ALLOWED_VALUES.contains(&trimmed_atr) {
+        if ALLOWED_VALUES.binary_search(&trimmed_atr).is_err() {
             ctx.diagnostic(invalid_sandbox_prop(literal.span, trimmed_atr));
         }
         if trimmed_atr == "allow-scripts" {

--- a/crates/oxc_linter/src/rules/react/no_array_index_key.rs
+++ b/crates/oxc_linter/src/rules/react/no_array_index_key.rs
@@ -128,7 +128,7 @@ fn find_index_param_name<'a>(node: &'a AstNode, ctx: &'a LintContext) -> Option<
                 return None;
             };
 
-            if SECOND_INDEX_METHODS.contains(&expr.property.name.as_str()) {
+            if SECOND_INDEX_METHODS.binary_search(&expr.property.name.as_str()).is_ok() {
                 return find_index_param_name_by_position(call_expr, 1);
             }
 
@@ -156,24 +156,9 @@ fn find_index_param_name_by_position<'a>(
     })
 }
 
-const SECOND_INDEX_METHODS: [&str; 8] = [
-    // things.map((thing, index) => (<Hello key={index} />));
-    "map",
-    // things.forEach((thing, index) => {otherThings.push(<Hello key={index} />);});
-    "forEach",
-    // things.filter((thing, index) => {otherThings.push(<Hello key={index} />);});
-    "filter",
-    // things.some((thing, index) => {otherThings.push(<Hello key={index} />);});
-    "some",
-    // things.every((thing, index) => {otherThings.push(<Hello key={index} />);});
-    "every",
-    // things.find((thing, index) => {otherThings.push(<Hello key={index} />);});
-    "find",
-    // things.findIndex((thing, index) => {otherThings.push(<Hello key={index} />);});
-    "findIndex",
-    // things.flatMap((thing, index) => (<Hello key={index} />));
-    "flatMap",
-];
+// things[`${method_name}`]((thing, index) => (<Hello key={index} />));
+const SECOND_INDEX_METHODS: [&str; 8] =
+    ["every", "filter", "find", "findIndex", "flatMap", "forEach", "map", "some"];
 
 const THIRD_INDEX_METHODS: [&str; 2] = [
     // things.reduce((collection, thing, index) => (collection.concat(<Hello key={index} />)), []);

--- a/crates/oxc_linter/src/utils/promise.rs
+++ b/crates/oxc_linter/src/utils/promise.rs
@@ -2,7 +2,7 @@ use oxc_ast::ast::CallExpression;
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise
 pub const PROMISE_STATIC_METHODS: [&str; 7] =
-    ["resolve", "reject", "all", "allSettled", "race", "any", "withResolvers"];
+    ["all", "allSettled", "any", "race", "reject", "resolve", "withResolvers"];
 
 pub fn is_promise(call_expr: &CallExpression) -> Option<String> {
     let member_expr = call_expr.callee.get_member_expr()?;
@@ -13,7 +13,8 @@ pub fn is_promise(call_expr: &CallExpression) -> Option<String> {
         return Some(prop_name.into());
     }
 
-    if member_expr.object().is_specific_id("Promise") && PROMISE_STATIC_METHODS.contains(&prop_name)
+    if member_expr.object().is_specific_id("Promise")
+        && PROMISE_STATIC_METHODS.binary_search(&prop_name).is_ok()
     {
         return Some(prop_name.into());
     }


### PR DESCRIPTION
Related to #10076 

Based on recent conclusions, replace the use of `contains` with `binary_search` to improve lookup performance for collections where `phf_set` was replaced with `array` before.