### PR TITLE
fix(estree): Rename `JSDocXxxType` to `TSJSDocXxxType`

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1629,6 +1629,7 @@ pub enum ImportOrExportKind {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[estree(rename = "TSJSDocNullableType")]
 pub struct JSDocNullableType<'a> {
     pub span: Span,
     pub type_annotation: TSType<'a>,
@@ -1640,6 +1641,7 @@ pub struct JSDocNullableType<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[estree(rename = "TSJSDocNonNullableType")]
 pub struct JSDocNonNullableType<'a> {
     pub span: Span,
     pub type_annotation: TSType<'a>,
@@ -1649,6 +1651,7 @@ pub struct JSDocNonNullableType<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[estree(rename = "TSJSDocUnknownType")]
 pub struct JSDocUnknownType {
     pub span: Span,
 }

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -3328,7 +3328,7 @@ impl ESTree for ImportOrExportKind {
 impl ESTree for JSDocNullableType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", &JsonSafeString("JSDocNullableType"));
+        state.serialize_field("type", &JsonSafeString("TSJSDocNullableType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeAnnotation", &self.type_annotation);
@@ -3340,7 +3340,7 @@ impl ESTree for JSDocNullableType<'_> {
 impl ESTree for JSDocNonNullableType<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", &JsonSafeString("JSDocNonNullableType"));
+        state.serialize_field("type", &JsonSafeString("TSJSDocNonNullableType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("typeAnnotation", &self.type_annotation);
@@ -3352,7 +3352,7 @@ impl ESTree for JSDocNonNullableType<'_> {
 impl ESTree for JSDocUnknownType {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let mut state = serializer.serialize_struct();
-        state.serialize_field("type", &JsonSafeString("JSDocUnknownType"));
+        state.serialize_field("type", &JsonSafeString("TSJSDocUnknownType"));
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.end();

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -1964,7 +1964,7 @@ function deserializeTSInstantiationExpression(pos) {
 
 function deserializeJSDocNullableType(pos) {
   return {
-    type: 'JSDocNullableType',
+    type: 'TSJSDocNullableType',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     typeAnnotation: deserializeTSType(pos + 8),
@@ -1974,7 +1974,7 @@ function deserializeJSDocNullableType(pos) {
 
 function deserializeJSDocNonNullableType(pos) {
   return {
-    type: 'JSDocNonNullableType',
+    type: 'TSJSDocNonNullableType',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     typeAnnotation: deserializeTSType(pos + 8),
@@ -1984,7 +1984,7 @@ function deserializeJSDocNonNullableType(pos) {
 
 function deserializeJSDocUnknownType(pos) {
   return {
-    type: 'JSDocUnknownType',
+    type: 'TSJSDocUnknownType',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -2040,7 +2040,7 @@ function deserializeTSInstantiationExpression(pos) {
 
 function deserializeJSDocNullableType(pos) {
   return {
-    type: 'JSDocNullableType',
+    type: 'TSJSDocNullableType',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     typeAnnotation: deserializeTSType(pos + 8),
@@ -2050,7 +2050,7 @@ function deserializeJSDocNullableType(pos) {
 
 function deserializeJSDocNonNullableType(pos) {
   return {
-    type: 'JSDocNonNullableType',
+    type: 'TSJSDocNonNullableType',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     typeAnnotation: deserializeTSType(pos + 8),
@@ -2060,7 +2060,7 @@ function deserializeJSDocNonNullableType(pos) {
 
 function deserializeJSDocUnknownType(pos) {
   return {
-    type: 'JSDocUnknownType',
+    type: 'TSJSDocUnknownType',
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
   };

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -1420,19 +1420,19 @@ export interface TSInstantiationExpression extends Span {
 export type ImportOrExportKind = 'value' | 'type';
 
 export interface JSDocNullableType extends Span {
-  type: 'JSDocNullableType';
+  type: 'TSJSDocNullableType';
   typeAnnotation: TSType;
   postfix: boolean;
 }
 
 export interface JSDocNonNullableType extends Span {
-  type: 'JSDocNonNullableType';
+  type: 'TSJSDocNonNullableType';
   typeAnnotation: TSType;
   postfix: boolean;
 }
 
 export interface JSDocUnknownType extends Span {
-  type: 'JSDocUnknownType';
+  type: 'TSJSDocUnknownType';
 }
 
 export type AssignmentOperator =


### PR DESCRIPTION
Part of #9705 

Just renamed them, no difference appeared in the coverage ATM.

From my understanding, there is a problem with the parser logic for now. I'll try to fix it later.