### PR TITLE
refactor(transformer/typescript): remove unnecessary specific handling of `TSModuleDeclaration` transformation

### DIFF
--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -307,16 +307,6 @@ impl<'a> Traverse<'a> for TransformerImpl<'a, '_> {
         self.x2_es2022.exit_static_block(block, ctx);
     }
 
-    fn enter_ts_module_declaration(
-        &mut self,
-        decl: &mut TSModuleDeclaration<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
-        if let Some(typescript) = self.x0_typescript.as_mut() {
-            typescript.enter_ts_module_declaration(decl, ctx);
-        }
-    }
-
     #[inline]
     fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         self.common.enter_expression(expr, ctx);

--- a/crates/oxc_transformer/src/typescript/mod.rs
+++ b/crates/oxc_transformer/src/typescript/mod.rs
@@ -118,14 +118,6 @@ impl<'a> Traverse<'a> for TypeScript<'a, '_> {
         self.annotations.enter_class_body(body, ctx);
     }
 
-    fn enter_ts_module_declaration(
-        &mut self,
-        decl: &mut TSModuleDeclaration<'a>,
-        ctx: &mut TraverseCtx<'a>,
-    ) {
-        self.annotations.enter_ts_module_declaration(decl, ctx);
-    }
-
     fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         self.annotations.enter_expression(expr, ctx);
     }

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -2095,9 +2095,6 @@ rebuilt        : ScopeId(0): ["M2"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
-after transform: ScopeId(4): ["C", "T", "_M"]
-rebuilt        : ScopeId(1): ["C", "_M"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
@@ -17964,9 +17961,6 @@ rebuilt        : ScopeId(0): ["B"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Bindings mismatch:
-after transform: ScopeId(3): ["A", "Y", "_B"]
-rebuilt        : ScopeId(1): ["A", "_B"]
 Scope flags mismatch:
 after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
@@ -20060,9 +20054,6 @@ rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(1): [ScopeId(2), ScopeId(3)]
 rebuilt        : ScopeId(1): [ScopeId(2)]
-Bindings mismatch:
-after transform: ScopeId(4): ["Bug", "_editor", "i", "modes"]
-rebuilt        : ScopeId(3): ["Bug", "_editor", "i"]
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(3): ScopeFlags(Function)
@@ -20078,9 +20069,6 @@ rebuilt        : ScopeId(14): ScopeFlags(Function)
 Scope children mismatch:
 after transform: ScopeId(15): [ScopeId(16), ScopeId(17)]
 rebuilt        : ScopeId(14): [ScopeId(15)]
-Bindings mismatch:
-after transform: ScopeId(18): ["A1Alias1", "_B", "c", "i"]
-rebuilt        : ScopeId(16): ["_B", "c", "i"]
 Scope flags mismatch:
 after transform: ScopeId(18): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(16): ScopeFlags(Function)
@@ -20926,9 +20914,6 @@ rebuilt        : ScopeId(2): ScopeFlags(Function)
 Scope flags mismatch:
 after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(4): ScopeFlags(Function)
-Bindings mismatch:
-after transform: ScopeId(5): ["M", "_M2", "bar"]
-rebuilt        : ScopeId(5): ["_M2", "bar"]
 Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(5): ScopeFlags(Function)

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -209,9 +209,6 @@ after transform: SymbolId(1): Span { start: 31, end: 33 }
 rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
 
 * namespace/import-=/input.ts
-Bindings mismatch:
-after transform: ScopeId(1): ["V", "X", "_N"]
-rebuilt        : ScopeId(1): ["V", "_N"]
 Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)


### PR DESCRIPTION
￼It seems that as ⁠`Semantic` gradually improves, many checks and special handling will no longer be necessary.
