### PR TITLE
test(transformer/typescript): override namespace/empty-removed test

### DIFF
--- a/tasks/transform_conformance/overrides/babel-plugin-transform-typescript/test/fixtures/namespace/empty-removed/output.mjs
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-typescript/test/fixtures/namespace/empty-removed/output.mjs
@@ -1,0 +1,37 @@
+let a;
+(function(_a) {
+  let c;
+  (function(_c) {
+    var x;
+  })(c || (c = {}));
+})(a || (a = {}));
+let WithTypes;
+(function(_WithTypes) {
+  let d;
+  (function(_d2) {})(d || (d = {}));
+})(WithTypes || (WithTypes = {}));
+let WithValues;
+(function(_WithValues) {
+  let a;
+  (function(_a3) {
+    class A {}
+  })(a || (a = {}));
+  let b;
+  (function(_b3) {
+    let B = /* @__PURE__ */ function(B) {
+      return B;
+    }({});
+  })(b || (b = {}));
+  let c;
+  (function(_c3) {
+    function C() {}
+  })(c || (c = {}));
+  let d;
+  (function(_d3) {
+    var D;
+  })(d || (d = {}));
+  let e;
+  (function(_e2) {
+    E;
+  })(e || (e = {}));
+})(WithValues || (WithValues = {}));


### PR DESCRIPTION
Just override the test without any changes to prepare for #10366.