### PR TITLE
refactor(linter): extract common logic from `jsdoc/require-yields` and `jsdoc/require-returns`

### DIFF
--- a/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
+++ b/crates/oxc_linter/src/rules/jsdoc/require_returns.rs
@@ -4,7 +4,7 @@ use oxc_ast::{
 };
 use oxc_diagnostics::OxcDiagnostic;
 use oxc_macros::declare_oxc_lint;
-use oxc_semantic::{JSDoc, JSDocTag};
+use oxc_semantic::JSDoc;
 use oxc_span::Span;
 use rustc_hash::FxHashMap;
 use serde::Deserialize;
@@ -13,7 +13,8 @@ use crate::{
     context::LintContext,
     rule::Rule,
     utils::{
-        default_true, get_function_nearest_jsdoc_node, should_ignore_as_avoid,
+        default_true, get_function_nearest_jsdoc_node, is_duplicated_special_tag,
+        is_missing_special_tag, should_ignore_as_avoid, should_ignore_as_custom_skip,
         should_ignore_as_internal, should_ignore_as_private,
     },
 };
@@ -229,45 +230,16 @@ impl Rule for RequireReturns {
             let jsdoc_tags = jsdocs.iter().flat_map(JSDoc::tags).collect::<Vec<_>>();
             let resolved_returns_tag_name = settings.resolve_tag_name("returns");
 
-            if is_missing_returns_tag(&jsdoc_tags, resolved_returns_tag_name) {
+            if is_missing_special_tag(&jsdoc_tags, resolved_returns_tag_name) {
                 ctx.diagnostic(missing_returns_diagnostic(*func_span));
                 continue;
             }
 
-            if let Some(span) = is_duplicated_returns_tag(&jsdoc_tags, resolved_returns_tag_name) {
+            if let Some(span) = is_duplicated_special_tag(&jsdoc_tags, resolved_returns_tag_name) {
                 ctx.diagnostic(duplicate_returns_diagnostic(span));
             }
         }
     }
-}
-
-const CUSTOM_SKIP_TAG_NAMES: [&str; 6] =
-    ["abstract", "virtual", "class", "constructor", "type", "interface"];
-
-fn should_ignore_as_custom_skip(jsdoc: &JSDoc) -> bool {
-    jsdoc.tags().iter().any(|tag| CUSTOM_SKIP_TAG_NAMES.contains(&tag.kind.parsed()))
-}
-
-fn is_missing_returns_tag(jsdoc_tags: &[&JSDocTag], resolved_returns_tag_name: &str) -> bool {
-    jsdoc_tags.iter().all(|tag| tag.kind.parsed() != resolved_returns_tag_name)
-}
-
-fn is_duplicated_returns_tag(
-    jsdoc_tags: &Vec<&JSDocTag>,
-    resolved_returns_tag_name: &str,
-) -> Option<Span> {
-    let mut returns_found = false;
-    for tag in jsdoc_tags {
-        if tag.kind.parsed() == resolved_returns_tag_name {
-            if returns_found {
-                return Some(tag.kind.span);
-            }
-
-            returns_found = true;
-        }
-    }
-
-    None
 }
 
 /// - Some(true): `Promise` with value

--- a/crates/oxc_linter/src/utils/jsdoc.rs
+++ b/crates/oxc_linter/src/utils/jsdoc.rs
@@ -2,11 +2,40 @@ use oxc_ast::{
     AstKind,
     ast::{BindingPattern, BindingPatternKind, Expression, FormalParameters},
 };
-use oxc_semantic::{JSDoc, Semantic};
+use oxc_semantic::{JSDoc, JSDocTag, Semantic};
 use oxc_span::Span;
 use rustc_hash::FxHashSet;
 
 use crate::{AstNode, config::JSDocPluginSettings};
+
+pub const CUSTOM_SKIP_TAG_NAMES: [&str; 6] =
+    ["abstract", "class", "constructor", "interface", "type", "virtual"];
+
+pub fn should_ignore_as_custom_skip(jsdoc: &JSDoc) -> bool {
+    jsdoc.tags().iter().any(|tag| CUSTOM_SKIP_TAG_NAMES.binary_search(&tag.kind.parsed()).is_ok())
+}
+
+pub fn is_missing_special_tag(jsdoc_tags: &[&JSDocTag], resolved_tag_name: &str) -> bool {
+    jsdoc_tags.iter().all(|tag| tag.kind.parsed() != resolved_tag_name)
+}
+
+pub fn is_duplicated_special_tag(
+    jsdoc_tags: &Vec<&JSDocTag>,
+    resolved_returns_tag_name: &str,
+) -> Option<Span> {
+    let mut returns_found = false;
+    for tag in jsdoc_tags {
+        if tag.kind.parsed() == resolved_returns_tag_name {
+            if returns_found {
+                return Some(tag.kind.span);
+            }
+
+            returns_found = true;
+        }
+    }
+
+    None
+}
 
 /// JSDoc is often attached on the parent node of a function.
 ///


### PR DESCRIPTION
The functions are duplicated, so we can extract the common logic.