### PR TITLE
fix(parser): Correctly handle `?` postfixed element type in `TupleType`

### DIFF
--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1,7 +1,6 @@
 use oxc_allocator::{Box, Vec};
 use oxc_ast::{NONE, ast::*};
 use oxc_diagnostics::Result;
-use oxc_span::GetSpan;
 use oxc_syntax::operator::UnaryOperator;
 
 use crate::{
@@ -928,7 +927,7 @@ impl<'a> ParserImpl<'a> {
         }
         let ty = self.parse_ts_type()?;
         if let TSType::JSDocNullableType(ty) = ty {
-            if ty.span.start == ty.type_annotation.span().start {
+            if ty.postfix {
                 Ok(self.ast.ts_tuple_element_optional_type(ty.span, ty.unbox().type_annotation))
             } else {
                 Ok(TSTupleElement::JSDocNullableType(ty))

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -2,7 +2,7 @@ commit: 15392346
 
 estree_typescript Summary:
 AST Parsed     : 10619/10725 (99.01%)
-Positive Passed: 8573/10725 (79.93%)
+Positive Passed: 8575/10725 (79.95%)
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/ClassDeclarationWithInvalidConstOnPropertyDeclaration.ts
 A class member cannot have the 'const' keyword.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractPropertyInConstructor.ts
@@ -1180,8 +1180,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictModeWordInExportD
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictModeWordInImportDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictNullEmptyDestructuring.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictNullNotNullIndexTypeNoLib.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictOptionalProperties1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictOptionalProperties2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringRawType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/styledComponentsInstantiaionLimitNotReached.ts
 tasks/coverage/typescript/tests/cases/compiler/subclassThisTypeAssignable01.ts


### PR DESCRIPTION
For example:

```ts
declare let tx4: [(string | undefined)?]
```

The current logic relied on the span position to determine whether `?` should mean `JSDocNullableType` or `OptionalType`.

Therefore, the parsing results seemed to change depending on whether the `preserveParens` option was enabled or not.