### PR TITLE
fix(transformer/jsx): do not report "duplicate __source/__self prop found" error when `development` is disabled

### DIFF
--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -582,10 +582,18 @@ impl<'a> JsxImpl<'a, '_> {
                     JSXAttributeItem::Attribute(attr) => {
                         let JSXAttribute { span, name, value } = attr.unbox();
                         match &name {
-                            JSXAttributeName::Identifier(ident) if ident.name == "__self" => {
+                            JSXAttributeName::Identifier(ident)
+                                if self.options.development
+                                    && self.options.jsx_self_plugin
+                                    && ident.name == "__self" =>
+                            {
                                 self.jsx_self.report_error(ident.span);
                             }
-                            JSXAttributeName::Identifier(ident) if ident.name == "__source" => {
+                            JSXAttributeName::Identifier(ident)
+                                if self.options.development
+                                    && self.options.jsx_source_plugin
+                                    && ident.name == "__source" =>
+                            {
                                 self.jsx_source.report_error(ident.span);
                             }
                             JSXAttributeName::Identifier(ident) if ident.name == "key" => {

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 578ac4df
 
-Passed: 148/241
+Passed: 150/243
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -15,6 +15,7 @@ Passed: 148/241
 * babel-plugin-transform-exponentiation-operator
 * babel-plugin-transform-arrow-functions
 * babel-preset-typescript
+* babel-plugin-transform-react-jsx-self
 * babel-plugin-transform-react-jsx-source
 * regexp
 

--- a/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx-self/test/fixtures/react-source/duplicate-self-prop/input.jsx
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx-self/test/fixtures/react-source/duplicate-self-prop/input.jsx
@@ -1,0 +1,1 @@
+<div __self={this} />

--- a/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx-self/test/fixtures/react-source/duplicate-self-prop/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx-self/test/fixtures/react-source/duplicate-self-prop/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-react-jsx", "transform-react-jsx-self"]
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx-self/test/fixtures/react-source/duplicate-self-prop/output.jsx
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx-self/test/fixtures/react-source/duplicate-self-prop/output.jsx
@@ -1,0 +1,2 @@
+var _reactJsxRuntime = require("react/jsx-runtime");
+/* @__PURE__ */ _reactJsxRuntime.jsx("div", { __self: this }, this);

--- a/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/duplicate-source-prop/input.jsx
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/duplicate-source-prop/input.jsx
@@ -1,0 +1,1 @@
+<div __source="custom" />

--- a/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/duplicate-source-prop/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/duplicate-source-prop/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["transform-react-jsx", "transform-react-jsx-source"]
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/duplicate-source-prop/output.jsx
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/duplicate-source-prop/output.jsx
@@ -1,0 +1,7 @@
+var _reactJsxRuntime = require("react/jsx-runtime");
+var _jsxFileName = "<CWD>/tests/babel-plugin-transform-react-jsx-source/test/fixtures/react-source/duplicate-source-prop/input.jsx";
+/* @__PURE__ */ _reactJsxRuntime.jsx("div", { __source: "custom" }, {
+  fileName: _jsxFileName,
+  lineNumber: 1,
+  columnNumber: 1
+});


### PR DESCRIPTION
close: #10391
