### PR TITLE
docs(linter): fix wording in the eqeqeq docs

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
+++ b/crates/oxc_linter/src/rules/eslint/eqeqeq.rs
@@ -39,7 +39,7 @@ declare_oxc_lint!(
     /// const b = true;
     /// a == b
     /// ```
-    /// The above will evaluate to `true`, but almost surely not want you want.
+    /// The above will evaluate to `true`, but that is almost surely not what you want.
     ///
     /// Examples of **correct** code for this rule:
     ///


### PR DESCRIPTION
Fixes a small typo in the docs for `eqeqeq`. 