### PR TITLE
fix(ast/estree): add `optional` field to `AssignmentTargetProperty` in TS-ESTree AST

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -952,8 +952,8 @@ pub enum AssignmentTargetProperty<'a> {
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(
     rename = "Property",
-    add_fields(method = False, shorthand = True, computed = False, kind = Init),
-    field_order(span, method, shorthand, computed, binding, init, kind),
+    add_fields(method = False, shorthand = True, computed = False, kind = Init, optional = TsFalse),
+    field_order(span, method, shorthand, computed, binding, init, kind, optional),
 )]
 pub struct AssignmentTargetPropertyIdentifier<'a> {
     pub span: Span,
@@ -971,8 +971,8 @@ pub struct AssignmentTargetPropertyIdentifier<'a> {
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
 #[estree(
     rename = "Property",
-    add_fields(method = False, shorthand = False, kind = Init),
-    field_order(span, method, shorthand, computed, name, binding, kind),
+    add_fields(method = False, shorthand = False, kind = Init, optional = TsFalse),
+    field_order(span, method, shorthand, computed, name, binding, kind, optional),
 )]
 pub struct AssignmentTargetPropertyProperty<'a> {
     pub span: Span,

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -719,6 +719,7 @@ impl ESTree for AssignmentTargetPropertyIdentifier<'_> {
             &crate::serialize::AssignmentTargetPropertyIdentifierValue(self),
         );
         state.serialize_field("kind", &crate::serialize::Init(self));
+        state.serialize_ts_field("optional", &crate::serialize::TsFalse(self));
         state.end();
     }
 }
@@ -735,6 +736,7 @@ impl ESTree for AssignmentTargetPropertyProperty<'_> {
         state.serialize_field("key", &self.name);
         state.serialize_field("value", &self.binding);
         state.serialize_field("kind", &crate::serialize::Init(self));
+        state.serialize_ts_field("optional", &crate::serialize::TsFalse(self));
         state.end();
     }
 }

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -406,6 +406,7 @@ function deserializeAssignmentTargetPropertyIdentifier(pos) {
     key,
     value,
     kind: 'init',
+    optional: false,
   };
 }
 
@@ -420,6 +421,7 @@ function deserializeAssignmentTargetPropertyProperty(pos) {
     key: deserializePropertyKey(pos + 8),
     value: deserializeAssignmentTargetMaybeDefault(pos + 24),
     kind: 'init',
+    optional: false,
   };
 }
 

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -288,6 +288,7 @@ export interface AssignmentTargetPropertyIdentifier extends Span {
   key: IdentifierReference;
   value: IdentifierReference | AssignmentTargetWithDefault;
   kind: 'init';
+  optional?: false;
 }
 
 export interface AssignmentTargetPropertyProperty extends Span {
@@ -298,6 +299,7 @@ export interface AssignmentTargetPropertyProperty extends Span {
   key: PropertyKey;
   value: AssignmentTargetMaybeDefault;
   kind: 'init';
+  optional?: false;
 }
 
 export interface SequenceExpression extends Span {


### PR DESCRIPTION
Add `optional` field to `AssignmentTargetPropertyIdentifier` and `AssignmentTargetPropertyProperty` in TS-ESTree AST.

This doesn't pass any more tests because those test cases all also include mismatches on `ArrayPattern` or `ObjectPattern`, but it does reduce the size of mismatch diffs.
