### PR TITLE
fix(ast/estree): add fields to `AssignmentTargetPattern` in TS-ESTree AST

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -870,7 +870,10 @@ pub use match_assignment_target_pattern;
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "ArrayPattern")]
+#[estree(
+    rename = "ArrayPattern",
+    add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull),
+)]
 pub struct ArrayAssignmentTarget<'a> {
     pub span: Span,
     pub elements: Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>,
@@ -886,7 +889,10 @@ pub struct ArrayAssignmentTarget<'a> {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
-#[estree(rename = "ObjectPattern")]
+#[estree(
+    rename = "ObjectPattern",
+    add_fields(decorators = TsEmptyArray, optional = TsFalse, typeAnnotation = TsNull),
+)]
 pub struct ObjectAssignmentTarget<'a> {
     pub span: Span,
     pub properties: Vec<'a, AssignmentTargetProperty<'a>>,

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -636,6 +636,9 @@ impl ESTree for ArrayAssignmentTarget<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("elements", &AppendTo { array: &self.elements, after: &self.rest });
+        state.serialize_ts_field("decorators", &crate::serialize::TsEmptyArray(self));
+        state.serialize_ts_field("optional", &crate::serialize::TsFalse(self));
+        state.serialize_ts_field("typeAnnotation", &crate::serialize::TsNull(self));
         state.end();
     }
 }
@@ -650,6 +653,9 @@ impl ESTree for ObjectAssignmentTarget<'_> {
             "properties",
             &AppendTo { array: &self.properties, after: &self.rest },
         );
+        state.serialize_ts_field("decorators", &crate::serialize::TsEmptyArray(self));
+        state.serialize_ts_field("optional", &crate::serialize::TsFalse(self));
+        state.serialize_ts_field("typeAnnotation", &crate::serialize::TsNull(self));
         state.end();
     }
 }

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -347,6 +347,9 @@ function deserializeArrayAssignmentTarget(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     elements,
+    decorators: [],
+    optional: false,
+    typeAnnotation: null,
   };
 }
 
@@ -359,6 +362,9 @@ function deserializeObjectAssignmentTarget(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     properties,
+    decorators: [],
+    optional: false,
+    typeAnnotation: null,
   };
 }
 

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -258,11 +258,17 @@ export type AssignmentTargetPattern = ArrayAssignmentTarget | ObjectAssignmentTa
 export interface ArrayAssignmentTarget extends Span {
   type: 'ArrayPattern';
   elements: Array<AssignmentTargetMaybeDefault | AssignmentTargetRest | null>;
+  decorators?: [];
+  optional?: false;
+  typeAnnotation?: null;
 }
 
 export interface ObjectAssignmentTarget extends Span {
   type: 'ObjectPattern';
   properties: Array<AssignmentTargetProperty | AssignmentTargetRest>;
+  decorators?: [];
+  optional?: false;
+  typeAnnotation?: null;
 }
 
 export interface AssignmentTargetRest extends Span {

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -2,10 +2,9 @@ commit: 15392346
 
 estree_typescript Summary:
 AST Parsed     : 10619/10725 (99.01%)
-Positive Passed: 8915/10725 (83.12%)
+Positive Passed: 8970/10725 (83.64%)
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/ClassDeclarationWithInvalidConstOnPropertyDeclaration.ts
 A class member cannot have the 'const' keyword.
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/abstractPropertyInConstructor.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessOverriddenBaseClassMember1.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/accessorBodyInTypeContext.ts
 Unexpected token
@@ -60,21 +59,17 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/assignmentToPare
 Cannot assign to this expression
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/asyncFunctionsAndStrictNullChecks.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/autoAsiForStaticsInClassDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/autoTypeAssignedUsingDestructuringFromNeverNoCrash.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/autolift4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/avoidCycleWithVoidExpressionReturnedFromArrow.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/awaitInNonAsyncFunction.ts
 `await` is only allowed within async functions and at the top levels of modules
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/awaitLiteralValues.ts
 `await` is only allowed within async functions and at the top levels of modules
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/awaitedType.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/awaitedTypeStrictNull.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/baseCheck.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigintWithLib.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigintWithoutLib.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bluebirdStaticThis.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bom-utf8.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop12.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop9.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/capturedLetConstInLoop9_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/castParentheses.ts
@@ -158,8 +153,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/commentsemitComments.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/comparabilityTypeParametersRelatedByUnion.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/complicatedPrivacy.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/compositeGenericFunction.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertiesInDestructuring1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/computedPropertiesInDestructuring1_ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/conditionalTypeRelaxingConstraintAssignability.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/constDeclarationShadowedByVarDeclaration3.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/constDeclarations-errors.ts
@@ -258,11 +251,7 @@ serde_json::from_str(oxc_json) error: number out of range at line 28 column 25
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringAssignmentWithDefault.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringAssignmentWithDefault2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringAssignmentWithExportedName.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringAssignmentWithStrictNullChecks.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringAssignment_private.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringPropertyAssignmentNameIsNotAssignmentTarget.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringTempOccursAfterPrologue.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringTuple.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/destructuringUnspreadableIntoRest.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/doNotEmitDetachedComments.ts
@@ -315,7 +304,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSuperCallBeforeEmit
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSuperCallBeforeEmitPropertyDeclarationAndParameterPropertyDeclaration1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitSuperCallBeforeEmitPropertyDeclarationAndParameterPropertyDeclaration1ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitTopOfFileTripleSlashCommentOnNotEmittedNodeIfRemoveCommentsIsFalse.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/emptyArrayDestructuringExpressionVisitedByTransformer.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/enumIdentifierLiterals.ts
 An enum member cannot have a numeric name.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/enumUsedBeforeDeclaration.ts
@@ -490,12 +478,10 @@ Unexpected token
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/indexerSignatureWithRestParam.ts
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferFromAnnotatedReturn1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferTypePredicates.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceDoesntCompareAgainstUninstantiatedTypeParameter.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferenceOuterResultNotIncorrectlyInstantiatedWithInnerResult.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentialTypingUsingApparentType3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/inferentiallyTypingAnEmptyArray.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/initializePropertiesWithRenamedLet.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instanceAndStaticDeclarations1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/instantiateContextuallyTypedGenericThis.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/interfaceDeclaration3.ts
@@ -782,7 +768,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyParameters
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyParametersInInterface.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyParametersInModule.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noImplicitAnyReferencingDeclaredInterface.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUnusedLocals_destructuringAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUnusedLocals_writeOnly.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/noUsedBeforeDefinedErrorInAmbientContext1.ts
 tasks/coverage/typescript/tests/cases/compiler/nodeNextImportModeImplicitIndexResolution2.ts
@@ -866,7 +851,6 @@ Unexpected estree file content error: 1 != 2
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursiveSpecializationOfSignatures.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/recursivelySpecializedConstructorDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/referenceSatisfiesExpression.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/regularExpressionScanning.ts
 Unexpected flag a in regular expression literal
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/regularExpressionWithNonBMPFlags.ts
@@ -920,11 +904,9 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidat
 Unexpected token
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForArrayBindingPattern2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForArrayBindingPatternDefaultValues2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForObjectBindingPattern2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForObjectBindingPatternDefaultValues2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForOfArrayBindingPattern2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForOfArrayBindingPatternDefaultValues2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForOfObjectBindingPattern2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringForOfObjectBindingPatternDefaultValues2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementArrayBindingPattern3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDestructuringVariableStatementArrayBindingPattern4.ts
@@ -950,7 +932,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictModeReservedWordI
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictModeUseContextualKeyword.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictModeWordInExportDeclaration.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictModeWordInImportDeclaration.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictNullEmptyDestructuring.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/stringRawType.ts
 tasks/coverage/typescript/tests/cases/compiler/subclassThisTypeAssignable01.ts
 Unexpected estree file content error: 1 != 2
@@ -965,8 +946,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatD
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallFromClassThatHasNoBaseType1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superCallWithCommentEmit01.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/superNewCall1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule13.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/systemModule8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateStringsArrayTypeDefinedInES5Mode.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateStringsArrayTypeNotDefinedES5Mode.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/templateStringsArrayTypeRedefinedInES6Mode.ts
@@ -1034,8 +1013,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShort
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/ambient/ambientShorthand_reExport.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction5_es2017.ts
 Cannot use `await` as an identifier in an async context
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncMethodWithSuperConflict_es6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/asyncMethodWithSuper_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/await_incorrectThisType.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/await_unaryExpression_es2017.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es2017/await_unaryExpression_es2017_1.ts
@@ -1046,7 +1023,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es2017/
 Cannot use `await` as an identifier in an async context
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction5_es5.ts
 Cannot use `await` as an identifier in an async context
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es5/asyncMethodWithSuper_es5.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration12_es5.ts
 Cannot use `await` as an identifier in an async context
 tasks/coverage/typescript/tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration16_es5.ts
@@ -1056,7 +1032,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es5/fun
 Cannot use `await` as an identifier in an async context
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction5_es6.ts
 Cannot use `await` as an identifier in an async context
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/asyncMethodWithSuper_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/await_unaryExpression_es6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/await_unaryExpression_es6_1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/async/es6/await_unaryExpression_es6_2.ts
@@ -1120,9 +1095,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/membe
 Unexpected token
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameInObjectLiteral-3.ts
 Unexpected token
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameMethodAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticFieldDestructuredBinding.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameStaticMethodAssignment.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateWriteOnlyAccessorRead.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesAnnotated.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/mixinClassesAnonymous.ts
@@ -1308,7 +1281,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/defaultParameter
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/defaultParameters/emitDefaultParametersFunctionPropertyES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/defaultParameters/emitDefaultParametersMethod.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/defaultParameters/emitDefaultParametersMethodES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/arrayAssignmentPatternWithAny.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/declarationWithNoInitializer.ts
 Missing initializer in destructuring declaration
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts
@@ -1316,7 +1288,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/de
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment1ES5iterable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment1ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringControlFlow.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringObjectAssignmentPatternWithNestedSpread.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment1ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment1ES6.ts
@@ -1337,37 +1308,19 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/de
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringParameterProperties3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringParameterProperties4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringReassignsRightHandSide.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringSameNames.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration1ES5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration1ES5iterable.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration1ES6.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration2.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns01_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns01_ES5iterable.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns01_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns02_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns02_ES5iterable.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns02_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns03_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns03_ES5iterable.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns03_ES6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns04_ES5.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns04_ES5iterable.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyAssignmentPatterns04_ES6.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyVariableDeclarationBindingPatterns02_ES5.ts
 Missing initializer in destructuring declaration
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyVariableDeclarationBindingPatterns02_ES5iterable.ts
 Missing initializer in destructuring declaration
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/emptyVariableDeclarationBindingPatterns02_ES6.ts
 Missing initializer in destructuring declaration
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern23.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern24.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern6.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern7.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/iterableArrayPattern8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/nonIterableRestElement1.ts
@@ -1711,15 +1664,11 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es7/trailingC
 Unexpected trailing comma after rest element
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es7/trailingCommasInFunctionParametersAndArguments.ts
 A rest parameter must be last in a parameter list
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classSuper/esDecorators-classDeclaration-classSuper.3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/classSuper/esDecorators-classDeclaration-classSuper.5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-commentPreservation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-commonjs-classNamespaceMerge.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-commonjs.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-parameterProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-setFunctionName.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/classSuper/esDecorators-classExpression-classSuper.3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/classSuper/esDecorators-classExpression-classSuper.5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.17.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.5.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.7.ts
@@ -2373,7 +2322,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
 A 'return' statement can only be used within a function body.
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/ReturnStatements/parserReturnStatement2.ts
 A 'return' statement can only be used within a function body.
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserForStatement5.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserReturnStatement1.d.ts
 A 'return' statement can only be used within a function body.
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/Statements/parserWithStatement2.ts
@@ -2508,8 +2456,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableS
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithLegacyClassDecorators.4.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithLegacyClassDecorators.8.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/VariableStatements/usingDeclarations/usingDeclarationsWithLegacyClassDecorators.9.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring3.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring4.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of12.ts
 Unexpected token
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/statements/for-ofStatements/ES5For-of20.ts
@@ -2612,7 +2558,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/na
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/tuple/readonlyArraysAndTuples.ts
 'readonly' type modifier is only permitted on array and tuple literal types.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/restTupleElements1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/unionsOfTupleTypes1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/variadicTuples1.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/constraintSatisfactionWithAny.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/typeParameters/typeArgumentLists/constraintSatisfactionWithEmptyObject.ts


### PR DESCRIPTION
Add missing fields to `ArrayAssignmentTarget` and `ObjectAssignmentTarget` in TS-ESTree AST.
