### PR TITLE
fix(language_server): workspace edits as one batch when `source.fixAll.oxc` is the context

### DIFF
--- a/editors/vscode/client/test-helpers.ts
+++ b/editors/vscode/client/test-helpers.ts
@@ -31,8 +31,7 @@ export type OxlintConfig = {
 
 export const WORKSPACE_DIR = workspace.workspaceFolders![0].uri;
 
-const rootOxlintConfigPath = WORKSPACE_DIR + '/.oxlintrc.json';
-const rootOxlintConfigUri = Uri.parse(rootOxlintConfigPath);
+const rootOxlintConfigUri = Uri.joinPath(WORKSPACE_DIR, '.oxlintrc.json');
 
 export async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -53,15 +52,14 @@ export async function createOxlintConfiguration(configuration: OxlintConfig): Pr
   });
   await workspace.applyEdit(edit);
 }
-
 export async function loadFixture(fixture: string): Promise<void> {
   const absolutePath = path.resolve(`${__dirname}/../fixtures/${fixture}`);
   // do not copy directly into the workspace folder. FileWatcher will detect them as a deletion and stop itself.
-  await workspace.fs.copy(Uri.file(absolutePath), Uri.joinPath(WORKSPACE_DIR, 'diagnostic'), { overwrite: true });
+  await workspace.fs.copy(Uri.file(absolutePath), Uri.joinPath(WORKSPACE_DIR, 'fixtures'), { overwrite: true });
 }
 
 export async function getDiagnostics(file: string): Promise<Diagnostic[]> {
-  const fileUri = Uri.joinPath(WORKSPACE_DIR, 'diagnostic', file);
+  const fileUri = Uri.joinPath(WORKSPACE_DIR, 'fixtures', file);
   await window.showTextDocument(fileUri);
   await sleep(500);
   const diagnostics = languages.getDiagnostics(fileUri);

--- a/editors/vscode/fixtures/fixall_with_code_actions_on_save/.oxlintrc.json
+++ b/editors/vscode/fixtures/fixall_with_code_actions_on_save/.oxlintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+      "unicorn/switch-case-braces": "warn"
+  }
+}

--- a/editors/vscode/fixtures/fixall_with_code_actions_on_save/expected.txt
+++ b/editors/vscode/fixtures/fixall_with_code_actions_on_save/expected.txt
@@ -1,0 +1,72 @@
+ export function processChanges(changeHistory, maxChangesToShow) {
+  if (!changeHistory || !changeHistory.changes) {
+      return [];
+  }
+
+  const { patch = [] } = changeHistory.changes;
+  const summaryItems = [];
+  const processedPaths = new Set();
+  let totalChanges = 0;
+
+  // Process patch operations
+  patch.forEach(({ op, path, value }) => {
+      totalChanges++;
+
+      // Skip if we've reached the display limit
+      if (summaryItems.length >= maxChangesToShow) return;
+
+      // Format path for display
+      const displayPath = formatPathForDisplay(path);
+
+      // Skip duplicates or paths we've already processed
+      if (processedPaths.has(displayPath)) return;
+      processedPaths.add(displayPath);
+
+      // Handle different operation types
+      switch (op) {
+          case 'add': {if (path.match(/^\/references\/\d+$/)) {
+                  if (value && typeof value === 'object' && 'key' in value) {
+                      summaryItems.push({
+                          label: 'References.' + value.key,
+                          displayValue: <span className='text-green-600 font-medium'>Added</span>
+                      });
+                  }
+              } else {
+                  summaryItems.push({
+                      label: displayPath,
+                      displayValue: <span className='text-green-600 font-medium'>Added</span>
+                  });
+              }
+              break;
+          }
+
+          case 'remove': {
+              summaryItems.push({
+                  label: displayPath,
+                  displayValue: <span className='text-red-600 font-medium'>Removed</span>
+              });
+              break;
+          }
+
+          case 'replace': {if (path === '/version') return;
+              summaryItems.push({
+                  label: displayPath,
+                  displayValue: <span className='text-blue-600 font-medium'>Updated</span>
+              });
+              break;
+          }
+
+          default: {
+              summaryItems.push({
+                  label: displayPath,
+                  displayValue: <span className='text-gray-600'>{op}</span>
+              });
+          }
+      }
+  });
+
+  // Add metadata about more changes
+  summaryItems.moreChangesCount = Math.max(0, totalChanges - maxChangesToShow);
+
+  return summaryItems;
+}

--- a/editors/vscode/fixtures/fixall_with_code_actions_on_save/file.js
+++ b/editors/vscode/fixtures/fixall_with_code_actions_on_save/file.js
@@ -1,0 +1,73 @@
+export function processChanges(changeHistory, maxChangesToShow) {
+  if (!changeHistory || !changeHistory.changes) {
+      return [];
+  }
+
+  const { patch = [] } = changeHistory.changes;
+  const summaryItems = [];
+  const processedPaths = new Set();
+  let totalChanges = 0;
+
+  // Process patch operations
+  patch.forEach(({ op, path, value }) => {
+      totalChanges++;
+
+      // Skip if we've reached the display limit
+      if (summaryItems.length >= maxChangesToShow) return;
+
+      // Format path for display
+      const displayPath = formatPathForDisplay(path);
+
+      // Skip duplicates or paths we've already processed
+      if (processedPaths.has(displayPath)) return;
+      processedPaths.add(displayPath);
+
+      // Handle different operation types
+      switch (op) {
+          case 'add':
+              // Special handling for references
+              if (path.match(/^\/references\/\d+$/)) {
+                  if (value && typeof value === 'object' && 'key' in value) {
+                      summaryItems.push({
+                          label: 'References.' + value.key,
+                          displayValue: <span className='text-green-600 font-medium'>Added</span>
+                      });
+                  }
+              } else {
+                  summaryItems.push({
+                      label: displayPath,
+                      displayValue: <span className='text-green-600 font-medium'>Added</span>
+                  });
+              }
+              break;
+
+          case 'remove':
+              summaryItems.push({
+                  label: displayPath,
+                  displayValue: <span className='text-red-600 font-medium'>Removed</span>
+              });
+              break;
+
+          case 'replace':
+              // Skip version changes as we display them separately
+              if (path === '/version') return;
+
+              summaryItems.push({
+                  label: displayPath,
+                  displayValue: <span className='text-blue-600 font-medium'>Updated</span>
+              });
+              break;
+
+          default:
+              summaryItems.push({
+                  label: displayPath,
+                  displayValue: <span className='text-gray-600'>{op}</span>
+              });
+      }
+  });
+
+  // Add metadata about more changes
+  summaryItems.moreChangesCount = Math.max(0, totalChanges - maxChangesToShow);
+
+  return summaryItems;
+}


### PR DESCRIPTION
closes #10422 