### PR TITLE
refactor(ast)!: remove `trailing_commas` from `ArrayExpression` and `ObjectExpression`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -308,10 +308,6 @@ pub struct ThisExpression {
 pub struct ArrayExpression<'a> {
     pub span: Span,
     pub elements: Vec<'a, ArrayExpressionElement<'a>>,
-    /// Array trailing comma
-    /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#arrays>
-    #[estree(skip)]
-    pub trailing_comma: Option<Span>,
 }
 
 inherit_variants! {
@@ -328,7 +324,7 @@ pub enum ArrayExpressionElement<'a> {
     SpreadElement(Box<'a, SpreadElement<'a>>) = 64,
     /// `<empty>` in `const array = [1, , 2];`
     ///
-    /// Array hole for sparse arrays
+    /// Array hole for sparse arrays.
     /// <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Trailing_commas#arrays>
     Elision(Elision) = 65,
     // `Expression` variants added here by `inherit_variants!` macro
@@ -352,8 +348,6 @@ pub struct Elision {
 ///
 /// Represents an object literal, which can include properties, spread properties,
 /// or computed properties.
-///
-/// If the object literal has a trailing comma, `trailing_comma` contains the span of that comma.
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
@@ -361,8 +355,6 @@ pub struct ObjectExpression<'a> {
     pub span: Span,
     /// Properties declared in the object
     pub properties: Vec<'a, ObjectPropertyKind<'a>>,
-    #[estree(skip)]
-    pub trailing_comma: Option<Span>,
 }
 
 /// Represents a property in an object literal.
@@ -879,8 +871,6 @@ pub struct ArrayAssignmentTarget<'a> {
     pub elements: Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>,
     #[estree(append_to = "elements")]
     pub rest: Option<AssignmentTargetRest<'a>>,
-    #[estree(skip)]
-    pub trailing_comma: Option<Span>,
 }
 
 /// `{ foo }` in `({ foo } = obj);`

--- a/crates/oxc_ast/src/ast_impl/js.rs
+++ b/crates/oxc_ast/src/ast_impl/js.rs
@@ -860,7 +860,7 @@ impl<'a> ArrayAssignmentTarget<'a> {
         span: Span,
         elements: Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>,
     ) -> Self {
-        Self { span, elements, rest: None, trailing_comma: None }
+        Self { span, elements, rest: None }
     }
 }
 

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -49,11 +49,10 @@ const _: () = {
     assert!(align_of::<ThisExpression>() == 8);
     assert!(offset_of!(ThisExpression, span) == 0);
 
-    assert!(size_of::<ArrayExpression>() == 56);
+    assert!(size_of::<ArrayExpression>() == 40);
     assert!(align_of::<ArrayExpression>() == 8);
     assert!(offset_of!(ArrayExpression, span) == 0);
     assert!(offset_of!(ArrayExpression, elements) == 8);
-    assert!(offset_of!(ArrayExpression, trailing_comma) == 40);
 
     assert!(size_of::<ArrayExpressionElement>() == 16);
     assert!(align_of::<ArrayExpressionElement>() == 8);
@@ -62,11 +61,10 @@ const _: () = {
     assert!(align_of::<Elision>() == 8);
     assert!(offset_of!(Elision, span) == 0);
 
-    assert!(size_of::<ObjectExpression>() == 56);
+    assert!(size_of::<ObjectExpression>() == 40);
     assert!(align_of::<ObjectExpression>() == 8);
     assert!(offset_of!(ObjectExpression, span) == 0);
     assert!(offset_of!(ObjectExpression, properties) == 8);
-    assert!(offset_of!(ObjectExpression, trailing_comma) == 40);
 
     assert!(size_of::<ObjectPropertyKind>() == 16);
     assert!(align_of::<ObjectPropertyKind>() == 8);
@@ -223,12 +221,11 @@ const _: () = {
     assert!(size_of::<AssignmentTargetPattern>() == 16);
     assert!(align_of::<AssignmentTargetPattern>() == 8);
 
-    assert!(size_of::<ArrayAssignmentTarget>() == 80);
+    assert!(size_of::<ArrayAssignmentTarget>() == 64);
     assert!(align_of::<ArrayAssignmentTarget>() == 8);
     assert!(offset_of!(ArrayAssignmentTarget, span) == 0);
     assert!(offset_of!(ArrayAssignmentTarget, elements) == 8);
     assert!(offset_of!(ArrayAssignmentTarget, rest) == 40);
-    assert!(offset_of!(ArrayAssignmentTarget, trailing_comma) == 64);
 
     assert!(size_of::<ObjectAssignmentTarget>() == 64);
     assert!(align_of::<ObjectAssignmentTarget>() == 8);
@@ -1445,11 +1442,10 @@ const _: () = {
     assert!(align_of::<ThisExpression>() == 4);
     assert!(offset_of!(ThisExpression, span) == 0);
 
-    assert!(size_of::<ArrayExpression>() == 36);
+    assert!(size_of::<ArrayExpression>() == 24);
     assert!(align_of::<ArrayExpression>() == 4);
     assert!(offset_of!(ArrayExpression, span) == 0);
     assert!(offset_of!(ArrayExpression, elements) == 8);
-    assert!(offset_of!(ArrayExpression, trailing_comma) == 24);
 
     assert!(size_of::<ArrayExpressionElement>() == 12);
     assert!(align_of::<ArrayExpressionElement>() == 4);
@@ -1458,11 +1454,10 @@ const _: () = {
     assert!(align_of::<Elision>() == 4);
     assert!(offset_of!(Elision, span) == 0);
 
-    assert!(size_of::<ObjectExpression>() == 36);
+    assert!(size_of::<ObjectExpression>() == 24);
     assert!(align_of::<ObjectExpression>() == 4);
     assert!(offset_of!(ObjectExpression, span) == 0);
     assert!(offset_of!(ObjectExpression, properties) == 8);
-    assert!(offset_of!(ObjectExpression, trailing_comma) == 24);
 
     assert!(size_of::<ObjectPropertyKind>() == 8);
     assert!(align_of::<ObjectPropertyKind>() == 4);
@@ -1619,12 +1614,11 @@ const _: () = {
     assert!(size_of::<AssignmentTargetPattern>() == 8);
     assert!(align_of::<AssignmentTargetPattern>() == 4);
 
-    assert!(size_of::<ArrayAssignmentTarget>() == 52);
+    assert!(size_of::<ArrayAssignmentTarget>() == 40);
     assert!(align_of::<ArrayAssignmentTarget>() == 4);
     assert!(offset_of!(ArrayAssignmentTarget, span) == 0);
     assert!(offset_of!(ArrayAssignmentTarget, elements) == 8);
     assert!(offset_of!(ArrayAssignmentTarget, rest) == 24);
-    assert!(offset_of!(ArrayAssignmentTarget, trailing_comma) == 40);
 
     assert!(size_of::<ObjectAssignmentTarget>() == 40);
     assert!(align_of::<ObjectAssignmentTarget>() == 4);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -319,15 +319,13 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `elements`
-    /// * `trailing_comma`: Array trailing comma
     #[inline]
     pub fn expression_array(
         self,
         span: Span,
         elements: Vec<'a, ArrayExpressionElement<'a>>,
-        trailing_comma: Option<Span>,
     ) -> Expression<'a> {
-        Expression::ArrayExpression(self.alloc_array_expression(span, elements, trailing_comma))
+        Expression::ArrayExpression(self.alloc_array_expression(span, elements))
     }
 
     /// Build an [`Expression::ArrowFunctionExpression`].
@@ -894,15 +892,13 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `properties`: Properties declared in the object
-    /// * `trailing_comma`
     #[inline]
     pub fn expression_object(
         self,
         span: Span,
         properties: Vec<'a, ObjectPropertyKind<'a>>,
-        trailing_comma: Option<Span>,
     ) -> Expression<'a> {
-        Expression::ObjectExpression(self.alloc_object_expression(span, properties, trailing_comma))
+        Expression::ObjectExpression(self.alloc_object_expression(span, properties))
     }
 
     /// Build an [`Expression::ParenthesizedExpression`].
@@ -1471,15 +1467,13 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `elements`
-    /// * `trailing_comma`: Array trailing comma
     #[inline]
     pub fn array_expression(
         self,
         span: Span,
         elements: Vec<'a, ArrayExpressionElement<'a>>,
-        trailing_comma: Option<Span>,
     ) -> ArrayExpression<'a> {
-        ArrayExpression { span, elements, trailing_comma }
+        ArrayExpression { span, elements }
     }
 
     /// Build an [`ArrayExpression`], and store it in the memory arena.
@@ -1490,15 +1484,13 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `elements`
-    /// * `trailing_comma`: Array trailing comma
     #[inline]
     pub fn alloc_array_expression(
         self,
         span: Span,
         elements: Vec<'a, ArrayExpressionElement<'a>>,
-        trailing_comma: Option<Span>,
     ) -> Box<'a, ArrayExpression<'a>> {
-        Box::new_in(self.array_expression(span, elements, trailing_comma), self.allocator)
+        Box::new_in(self.array_expression(span, elements), self.allocator)
     }
 
     /// Build an [`ArrayExpressionElement::SpreadElement`].
@@ -1543,15 +1535,13 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `properties`: Properties declared in the object
-    /// * `trailing_comma`
     #[inline]
     pub fn object_expression(
         self,
         span: Span,
         properties: Vec<'a, ObjectPropertyKind<'a>>,
-        trailing_comma: Option<Span>,
     ) -> ObjectExpression<'a> {
-        ObjectExpression { span, properties, trailing_comma }
+        ObjectExpression { span, properties }
     }
 
     /// Build an [`ObjectExpression`], and store it in the memory arena.
@@ -1562,15 +1552,13 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `properties`: Properties declared in the object
-    /// * `trailing_comma`
     #[inline]
     pub fn alloc_object_expression(
         self,
         span: Span,
         properties: Vec<'a, ObjectPropertyKind<'a>>,
-        trailing_comma: Option<Span>,
     ) -> Box<'a, ObjectExpression<'a>> {
-        Box::new_in(self.object_expression(span, properties, trailing_comma), self.allocator)
+        Box::new_in(self.object_expression(span, properties), self.allocator)
     }
 
     /// Build an [`ObjectPropertyKind::ObjectProperty`].
@@ -2772,21 +2760,16 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `elements`
     /// * `rest`
-    /// * `trailing_comma`
     #[inline]
     pub fn assignment_target_pattern_array_assignment_target(
         self,
         span: Span,
         elements: Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>,
         rest: Option<AssignmentTargetRest<'a>>,
-        trailing_comma: Option<Span>,
     ) -> AssignmentTargetPattern<'a> {
-        AssignmentTargetPattern::ArrayAssignmentTarget(self.alloc_array_assignment_target(
-            span,
-            elements,
-            rest,
-            trailing_comma,
-        ))
+        AssignmentTargetPattern::ArrayAssignmentTarget(
+            self.alloc_array_assignment_target(span, elements, rest),
+        )
     }
 
     /// Build an [`AssignmentTargetPattern::ObjectAssignmentTarget`].
@@ -2818,16 +2801,14 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `elements`
     /// * `rest`
-    /// * `trailing_comma`
     #[inline]
     pub fn array_assignment_target(
         self,
         span: Span,
         elements: Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>,
         rest: Option<AssignmentTargetRest<'a>>,
-        trailing_comma: Option<Span>,
     ) -> ArrayAssignmentTarget<'a> {
-        ArrayAssignmentTarget { span, elements, rest, trailing_comma }
+        ArrayAssignmentTarget { span, elements, rest }
     }
 
     /// Build an [`ArrayAssignmentTarget`], and store it in the memory arena.
@@ -2839,19 +2820,14 @@ impl<'a> AstBuilder<'a> {
     /// * `span`: The [`Span`] covering this node
     /// * `elements`
     /// * `rest`
-    /// * `trailing_comma`
     #[inline]
     pub fn alloc_array_assignment_target(
         self,
         span: Span,
         elements: Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>,
         rest: Option<AssignmentTargetRest<'a>>,
-        trailing_comma: Option<Span>,
     ) -> Box<'a, ArrayAssignmentTarget<'a>> {
-        Box::new_in(
-            self.array_assignment_target(span, elements, rest, trailing_comma),
-            self.allocator,
-        )
+        Box::new_in(self.array_assignment_target(span, elements, rest), self.allocator)
     }
 
     /// Build an [`ObjectAssignmentTarget`].

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -388,7 +388,6 @@ impl<'new_alloc> CloneIn<'new_alloc> for ArrayExpression<'_> {
         ArrayExpression {
             span: CloneIn::clone_in(&self.span, allocator),
             elements: CloneIn::clone_in(&self.elements, allocator),
-            trailing_comma: CloneIn::clone_in(&self.trailing_comma, allocator),
         }
     }
 
@@ -396,7 +395,6 @@ impl<'new_alloc> CloneIn<'new_alloc> for ArrayExpression<'_> {
         ArrayExpression {
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             elements: CloneIn::clone_in_with_semantic_ids(&self.elements, allocator),
-            trailing_comma: CloneIn::clone_in_with_semantic_ids(&self.trailing_comma, allocator),
         }
     }
 }
@@ -702,7 +700,6 @@ impl<'new_alloc> CloneIn<'new_alloc> for ObjectExpression<'_> {
         ObjectExpression {
             span: CloneIn::clone_in(&self.span, allocator),
             properties: CloneIn::clone_in(&self.properties, allocator),
-            trailing_comma: CloneIn::clone_in(&self.trailing_comma, allocator),
         }
     }
 
@@ -710,7 +707,6 @@ impl<'new_alloc> CloneIn<'new_alloc> for ObjectExpression<'_> {
         ObjectExpression {
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             properties: CloneIn::clone_in_with_semantic_ids(&self.properties, allocator),
-            trailing_comma: CloneIn::clone_in_with_semantic_ids(&self.trailing_comma, allocator),
         }
     }
 }
@@ -1881,7 +1877,6 @@ impl<'new_alloc> CloneIn<'new_alloc> for ArrayAssignmentTarget<'_> {
             span: CloneIn::clone_in(&self.span, allocator),
             elements: CloneIn::clone_in(&self.elements, allocator),
             rest: CloneIn::clone_in(&self.rest, allocator),
-            trailing_comma: CloneIn::clone_in(&self.trailing_comma, allocator),
         }
     }
 
@@ -1890,7 +1885,6 @@ impl<'new_alloc> CloneIn<'new_alloc> for ArrayAssignmentTarget<'_> {
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             elements: CloneIn::clone_in_with_semantic_ids(&self.elements, allocator),
             rest: CloneIn::clone_in_with_semantic_ids(&self.rest, allocator),
-            trailing_comma: CloneIn::clone_in_with_semantic_ids(&self.trailing_comma, allocator),
         }
     }
 }

--- a/crates/oxc_ast/src/generated/derive_dummy.rs
+++ b/crates/oxc_ast/src/generated/derive_dummy.rs
@@ -95,11 +95,7 @@ impl<'a> Dummy<'a> for ArrayExpression<'a> {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self {
-            span: Dummy::dummy(allocator),
-            elements: Dummy::dummy(allocator),
-            trailing_comma: Dummy::dummy(allocator),
-        }
+        Self { span: Dummy::dummy(allocator), elements: Dummy::dummy(allocator) }
     }
 }
 
@@ -126,11 +122,7 @@ impl<'a> Dummy<'a> for ObjectExpression<'a> {
     ///
     /// Does not allocate any data into arena.
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self {
-            span: Dummy::dummy(allocator),
-            properties: Dummy::dummy(allocator),
-            trailing_comma: Dummy::dummy(allocator),
-        }
+        Self { span: Dummy::dummy(allocator), properties: Dummy::dummy(allocator) }
     }
 }
 
@@ -461,7 +453,7 @@ impl<'a> Dummy<'a> for AssignmentTargetPattern<'a> {
     ///
     /// Has cost of making 1 allocation (64 bytes).
     fn dummy(allocator: &'a Allocator) -> Self {
-        Self::ObjectAssignmentTarget(Dummy::dummy(allocator))
+        Self::ArrayAssignmentTarget(Dummy::dummy(allocator))
     }
 }
 
@@ -474,7 +466,6 @@ impl<'a> Dummy<'a> for ArrayAssignmentTarget<'a> {
             span: Dummy::dummy(allocator),
             elements: Dummy::dummy(allocator),
             rest: Dummy::dummy(allocator),
-            trailing_comma: Dummy::dummy(allocator),
         }
     }
 }

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -1464,9 +1464,6 @@ pub mod walk {
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
         visitor.visit_array_expression_elements(&it.elements);
-        if let Some(trailing_comma) = &it.trailing_comma {
-            visitor.visit_span(trailing_comma);
-        }
         visitor.leave_node(kind);
     }
 
@@ -1501,9 +1498,6 @@ pub mod walk {
         visitor.enter_node(kind);
         visitor.visit_span(&it.span);
         visitor.visit_object_property_kinds(&it.properties);
-        if let Some(trailing_comma) = &it.trailing_comma {
-            visitor.visit_span(trailing_comma);
-        }
         visitor.leave_node(kind);
     }
 
@@ -1829,9 +1823,6 @@ pub mod walk {
         }
         if let Some(rest) = &it.rest {
             visitor.visit_assignment_target_rest(rest);
-        }
-        if let Some(trailing_comma) = &it.trailing_comma {
-            visitor.visit_span(trailing_comma);
         }
         visitor.leave_node(kind);
     }

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -1468,9 +1468,6 @@ pub mod walk_mut {
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
         visitor.visit_array_expression_elements(&mut it.elements);
-        if let Some(trailing_comma) = &mut it.trailing_comma {
-            visitor.visit_span(trailing_comma);
-        }
         visitor.leave_node(kind);
     }
 
@@ -1508,9 +1505,6 @@ pub mod walk_mut {
         visitor.enter_node(kind);
         visitor.visit_span(&mut it.span);
         visitor.visit_object_property_kinds(&mut it.properties);
-        if let Some(trailing_comma) = &mut it.trailing_comma {
-            visitor.visit_span(trailing_comma);
-        }
         visitor.leave_node(kind);
     }
 
@@ -1860,9 +1854,6 @@ pub mod walk_mut {
         }
         if let Some(rest) = &mut it.rest {
             visitor.visit_assignment_target_rest(rest);
-        }
-        if let Some(trailing_comma) = &mut it.trailing_comma {
-            visitor.visit_span(trailing_comma);
         }
         visitor.leave_node(kind);
     }

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1931,24 +1931,22 @@ impl Gen for ArrayAssignmentTarget<'_> {
     fn r#gen(&self, p: &mut Codegen, ctx: Context) {
         p.add_source_mapping(self.span);
         p.print_ascii_byte(b'[');
-        for (index, item) in self.elements.iter().enumerate() {
-            if index != 0 {
+        for (i, item) in self.elements.iter().enumerate() {
+            if i != 0 {
                 p.print_comma();
                 p.print_soft_space();
             }
             if let Some(item) = item {
                 item.print(p, ctx);
             }
-        }
-        if let Some(target) = &self.rest {
-            if !self.elements.is_empty() {
+            if i == self.elements.len() - 1 && (item.is_none() || self.rest.is_some()) {
                 p.print_comma();
             }
+        }
+        if let Some(target) = &self.rest {
+            p.print_soft_space();
             p.add_source_mapping(self.span);
             target.print(p, ctx);
-        }
-        if self.trailing_comma.is_some() {
-            p.print_comma();
         }
         p.print_ascii_byte(b']');
         p.add_source_mapping_end(self.span);

--- a/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
+++ b/crates/oxc_linter/src/rules/oxc/no_map_spread.rs
@@ -501,7 +501,7 @@ fn fix_spread_to_object_assign<'a>(
             ObjectPropertyKind::SpreadProperty(spread) => {
                 if !curr_obj_properties.is_empty() {
                     let properties = std::mem::replace(&mut curr_obj_properties, ast.vec());
-                    let obj_arg = ast.expression_object(SPAN, properties, None);
+                    let obj_arg = ast.expression_object(SPAN, properties);
                     if is_first {
                         is_first = false;
                     } else {
@@ -524,7 +524,7 @@ fn fix_spread_to_object_assign<'a>(
             codegen.print_str(", ");
         }
         let properties = std::mem::replace(&mut curr_obj_properties, ast.vec());
-        let obj_arg = ast.expression_object(SPAN, properties, None);
+        let obj_arg = ast.expression_object(SPAN, properties);
         codegen.print_expression(&obj_arg);
     }
     codegen.print_ascii_byte(b')');

--- a/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
+++ b/crates/oxc_minifier/src/peephole/remove_unused_expression.rs
@@ -421,11 +421,8 @@ impl<'a> PeepholeOptimizations {
                 ObjectPropertyKind::ObjectProperty(prop) => {
                     if !pending_spread_elements.is_empty() {
                         // flush pending spread elements
-                        transformed_elements.push(ctx.ast.expression_object(
-                            prop.span(),
-                            pending_spread_elements,
-                            None,
-                        ));
+                        transformed_elements
+                            .push(ctx.ast.expression_object(prop.span(), pending_spread_elements));
                         pending_spread_elements = ctx.ast.vec();
                     }
 
@@ -450,11 +447,8 @@ impl<'a> PeepholeOptimizations {
         }
 
         if !pending_spread_elements.is_empty() {
-            transformed_elements.push(ctx.ast.expression_object(
-                object_expr.span,
-                pending_spread_elements,
-                None,
-            ));
+            transformed_elements
+                .push(ctx.ast.expression_object(object_expr.span, pending_spread_elements));
         }
 
         if transformed_elements.is_empty() {
@@ -704,7 +698,6 @@ impl<'a> PeepholeOptimizations {
                 Argument::SpreadElement(e) => ctx.ast.expression_array(
                     e.span,
                     ctx.ast.vec1(ArrayExpressionElement::SpreadElement(e)),
-                    None,
                 ),
                 match_expression!(Argument) => arg.into_expression(),
             };

--- a/crates/oxc_minifier/src/peephole/replace_known_methods.rs
+++ b/crates/oxc_minifier/src/peephole/replace_known_methods.rs
@@ -956,7 +956,6 @@ impl<'a> PeepholeOptimizations {
         Some(ctx.ast.expression_array(
             span,
             ctx.ast.vec_from_iter(arguments.drain(..).map(ArrayExpressionElement::from)),
-            None,
         ))
     }
 

--- a/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
+++ b/crates/oxc_minifier/src/peephole/substitute_alternate_syntax.rs
@@ -756,18 +756,16 @@ impl<'a> PeepholeOptimizations {
         ctx: Ctx<'a, '_>,
     ) -> Option<Expression<'a>> {
         match name {
-            "Object" if args.is_empty() => {
-                Some(ctx.ast.expression_object(span, ctx.ast.vec(), None))
-            }
+            "Object" if args.is_empty() => Some(ctx.ast.expression_object(span, ctx.ast.vec())),
             "Array" => {
                 // `new Array` -> `[]`
                 if args.is_empty() {
-                    Some(ctx.ast.expression_array(span, ctx.ast.vec(), None))
+                    Some(ctx.ast.expression_array(span, ctx.ast.vec()))
                 } else if args.len() == 1 {
                     let arg = args[0].as_expression_mut()?;
                     // `new Array(0)` -> `[]`
                     if arg.is_number_0() {
-                        Some(ctx.ast.expression_array(span, ctx.ast.vec(), None))
+                        Some(ctx.ast.expression_array(span, ctx.ast.vec()))
                     }
                     // `new Array(8)` -> `Array(8)`
                     else if let Expression::NumericLiteral(n) = arg {
@@ -782,11 +780,9 @@ impl<'a> PeepholeOptimizations {
                                     ArrayExpressionElement::Elision(ctx.ast.elision(n.span))
                                 })
                                 .take(n_int);
-                                return Some(ctx.ast.expression_array(
-                                    span,
-                                    ctx.ast.vec_from_iter(elisions),
-                                    None,
-                                ));
+                                return Some(
+                                    ctx.ast.expression_array(span, ctx.ast.vec_from_iter(elisions)),
+                                );
                             }
                         }
                         let callee = ctx.ast.expression_identifier(n.span, "Array");
@@ -798,7 +794,7 @@ impl<'a> PeepholeOptimizations {
                         let elements = ctx
                             .ast
                             .vec1(ArrayExpressionElement::from(arg.take_in(ctx.ast.allocator)));
-                        Some(ctx.ast.expression_array(span, elements, None))
+                        Some(ctx.ast.expression_array(span, elements))
                     }
                     // `new Array(x)` -> `Array(x)`
                     else {
@@ -813,7 +809,7 @@ impl<'a> PeepholeOptimizations {
                             ArrayExpressionElement::from(arg.take_in(ctx.ast.allocator))
                         }),
                     );
-                    Some(ctx.ast.expression_array(span, elements, None))
+                    Some(ctx.ast.expression_array(span, elements))
                 }
             }
             _ => None,

--- a/crates/oxc_minifier/tests/ecmascript/array_join.rs
+++ b/crates/oxc_minifier/tests/ecmascript/array_join.rs
@@ -26,11 +26,11 @@ fn test() {
         "42n",
         BigintBase::Decimal,
     ))));
-    let array = ast.array_expression(SPAN, elements.clone_in(&allocator), None);
+    let array = ast.array_expression(SPAN, elements.clone_in(&allocator));
     let mut array2 = array.clone_in(&allocator);
     array2.elements.push(ArrayExpressionElement::ArrayExpression(ast.alloc(array)));
     array2.elements.push(ArrayExpressionElement::ObjectExpression(
-        ast.alloc(ast.object_expression(SPAN, ast.vec(), None)),
+        ast.alloc(ast.object_expression(SPAN, ast.vec())),
     ));
     let joined = array2.array_join(&WithoutGlobalReferenceInformation {}, Some("_"));
     assert_eq!(joined, Some("__42_foo_true_42_,,42,foo,true,42_[object Object]".to_string()));

--- a/crates/oxc_minifier/tests/ecmascript/to_number.rs
+++ b/crates/oxc_minifier/tests/ecmascript/to_number.rs
@@ -27,7 +27,7 @@ fn test() {
     let global_undefined_number =
         undefined.to_number(&GlobalReferenceInformation { is_undefined_shadowed: false });
 
-    let empty_object = ast.expression_object(SPAN, ast.vec(), None);
+    let empty_object = ast.expression_object(SPAN, ast.vec());
     let object_with_to_string = ast.expression_object(
         SPAN,
         ast.vec1(ast.object_property_kind_object_property(
@@ -39,7 +39,6 @@ fn test() {
             false,
             false,
         )),
-        None,
     );
     let empty_object_number = empty_object.to_number(&WithoutGlobalReferenceInformation {});
     let object_with_to_string_number =

--- a/crates/oxc_minifier/tests/ecmascript/to_string.rs
+++ b/crates/oxc_minifier/tests/ecmascript/to_string.rs
@@ -27,7 +27,7 @@ fn test() {
     let global_undefined_string =
         undefined.to_js_string(&GlobalReferenceInformation { is_undefined_shadowed: false });
 
-    let empty_object = ast.expression_object(SPAN, ast.vec(), None);
+    let empty_object = ast.expression_object(SPAN, ast.vec());
     let object_with_to_string = ast.expression_object(
         SPAN,
         ast.vec1(ast.object_property_kind_object_property(
@@ -39,7 +39,6 @@ fn test() {
             false,
             false,
         )),
-        None,
     );
     let empty_object_string = empty_object.to_js_string(&WithoutGlobalReferenceInformation {});
     let object_with_to_string_string =

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -433,13 +433,13 @@ impl<'a> ParserImpl<'a> {
                 Self::parse_array_expression_element,
             )
         })?;
-        let trailing_comma = self.at(Kind::Comma).then(|| {
-            let span = self.start_span();
+        if self.at(Kind::Comma) {
+            let comma_span = self.start_span();
             self.bump_any();
-            self.end_span(span)
-        });
+            self.state.trailing_commas.insert(span.start, self.end_span(comma_span));
+        }
         self.expect(Kind::RBrack)?;
-        Ok(self.ast.expression_array(self.end_span(span), elements, trailing_comma))
+        Ok(self.ast.expression_array(self.end_span(span), elements))
     }
 
     fn parse_array_expression_element(&mut self) -> Result<ArrayExpressionElement<'a>> {

--- a/crates/oxc_parser/src/js/grammar.rs
+++ b/crates/oxc_parser/src/js/grammar.rs
@@ -81,8 +81,8 @@ impl<'a> CoverGrammar<'a, ArrayExpression<'a>> for ArrayAssignmentTarget<'a> {
                             elem.span,
                             AssignmentTarget::cover(elem.unbox().argument, p)?,
                         ));
-                        if let Some(span) = expr.trailing_comma {
-                            p.error(diagnostics::binding_rest_element_trailing_comma(span));
+                        if let Some(span) = p.state.trailing_commas.get(&expr.span.start) {
+                            p.error(diagnostics::binding_rest_element_trailing_comma(*span));
                         }
                     } else {
                         return Err(diagnostics::spread_last_element(elem.span));
@@ -92,7 +92,7 @@ impl<'a> CoverGrammar<'a, ArrayExpression<'a>> for ArrayAssignmentTarget<'a> {
             }
         }
 
-        Ok(p.ast.array_assignment_target(expr.span, elements, rest, expr.trailing_comma))
+        Ok(p.ast.array_assignment_target(expr.span, elements, rest))
     }
 }
 

--- a/crates/oxc_parser/src/js/object.rs
+++ b/crates/oxc_parser/src/js/object.rs
@@ -23,17 +23,9 @@ impl<'a> ParserImpl<'a> {
                 Self::parse_object_expression_property,
             )
         })?;
-        let trailing_comma = self.at(Kind::Comma).then(|| {
-            let span = self.start_span();
-            self.bump_any();
-            self.end_span(span)
-        });
+        self.eat(Kind::Comma); // Trailing Comma
         self.expect(Kind::RCurly)?;
-        Ok(self.ast.alloc_object_expression(
-            self.end_span(span),
-            object_expression_properties,
-            trailing_comma,
-        ))
+        Ok(self.ast.alloc_object_expression(self.end_span(span), object_expression_properties))
     }
 
     fn parse_object_expression_property(&mut self) -> Result<ObjectPropertyKind<'a>> {

--- a/crates/oxc_parser/src/state.rs
+++ b/crates/oxc_parser/src/state.rs
@@ -1,6 +1,7 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use oxc_ast::ast::{AssignmentExpression, Decorator};
+use oxc_span::Span;
 
 #[derive(Default)]
 pub struct ParserState<'a> {
@@ -11,4 +12,10 @@ pub struct ParserState<'a> {
     /// Temporary storage for `CoverInitializedName` `({ foo = bar })`.
     /// Keyed by `ObjectProperty`'s span.start.
     pub cover_initialized_name: FxHashMap<u32, AssignmentExpression<'a>>,
+
+    /// Trailing comma spans for `ArrayExpression`.
+    /// Used for error reporting.
+    /// Keyed by start span of `ArrayExpression`.
+    /// Valued by position of the trailing_comma.
+    pub trailing_commas: FxHashMap<u32, Span>,
 }

--- a/crates/oxc_transformer/src/decorator/legacy/metadata.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/metadata.rs
@@ -308,7 +308,7 @@ impl<'a> LegacyDecoratorMetadata<'a, '_> {
                 self.serialize_type_annotation(rest.argument.type_annotation.as_ref(), ctx),
             ));
         }
-        ctx.ast.expression_array(SPAN, elements, None)
+        ctx.ast.expression_array(SPAN, elements)
     }
 
     /// Serializes the return type of a node for use with decorator type metadata.

--- a/crates/oxc_transformer/src/decorator/legacy/mod.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/mod.rs
@@ -741,7 +741,7 @@ impl<'a> LegacyDecorator<'a, '_> {
         let decorations = ctx.ast.vec_from_iter(
             decorators_iter.map(|decorator| ArrayExpressionElement::from(decorator.expression)),
         );
-        ctx.ast.expression_array(SPAN, decorations, None)
+        ctx.ast.expression_array(SPAN, decorations)
     }
 
     /// Get all decorators of a class method.
@@ -787,7 +787,7 @@ impl<'a> LegacyDecorator<'a, '_> {
             self.transform_decorators_of_parameters(&mut decorations, params, ctx);
         }
 
-        Some(ctx.ast.expression_array(SPAN, decorations, None))
+        Some(ctx.ast.expression_array(SPAN, decorations))
     }
 
     /// * class_alias_binding is `Some`: `Class = _Class = expr`

--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -514,12 +514,12 @@ impl<'a, 'ctx> ObjectRestSpread<'a, 'ctx> {
         ctx: &mut TraverseCtx<'a>,
     ) {
         let had_props = !props.is_empty();
-        let obj = ctx.ast.expression_object(SPAN, ctx.ast.vec_from_iter(props.drain(..)), None);
+        let obj = ctx.ast.expression_object(SPAN, ctx.ast.vec_from_iter(props.drain(..)));
         let arguments = if let Some(call_expr) = expr.take() {
             let arg = Expression::CallExpression(ctx.ast.alloc(call_expr));
             let arg = Argument::from(arg);
             if had_props {
-                let empty_object = ctx.ast.expression_object(SPAN, ctx.ast.vec(), None);
+                let empty_object = ctx.ast.expression_object(SPAN, ctx.ast.vec());
                 ctx.ast.vec_from_array([arg, Argument::from(empty_object), Argument::from(obj)])
             } else {
                 ctx.ast.vec1(arg)
@@ -1069,11 +1069,9 @@ impl<'a> SpreadPair<'a> {
             // `function _objectDestructuringEmpty(t) { if (null == t) throw new TypeError("Cannot destructure " + t); }`
             let mut arguments = ctx.ast.vec();
             // Add `{}`.
-            arguments.push(Argument::ObjectExpression(ctx.ast.alloc_object_expression(
-                SPAN,
-                ctx.ast.vec(),
-                None,
-            )));
+            arguments.push(Argument::ObjectExpression(
+                ctx.ast.alloc_object_expression(SPAN, ctx.ast.vec()),
+            ));
             // Add `(_objectDestructuringEmpty(b), b);`
             arguments.push(Argument::SequenceExpression(ctx.ast.alloc_sequence_expression(
                 SPAN,
@@ -1095,7 +1093,7 @@ impl<'a> SpreadPair<'a> {
             // / `_objectWithoutProperties(_z, ["a", "b"])`
             let mut arguments =
                 ctx.ast.vec1(Argument::from(reference_builder.create_read_expression(ctx)));
-            let key_expression = ctx.ast.expression_array(SPAN, self.keys, None);
+            let key_expression = ctx.ast.expression_array(SPAN, self.keys);
 
             let key_expression = if self.all_primitives
                 && ctx.scoping.current_scope_id() != ctx.scoping().root_scope_id()

--- a/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/private_field.rs
@@ -2007,7 +2007,6 @@ impl<'a> ClassProperties<'a, '_> {
                 ArrayExpressionElement::from(prop_ident),
                 ArrayExpressionElement::from(object),
             ]),
-            None,
         );
         let arguments = ctx.ast.vec_from_array([
             Argument::from(self.ctx.helper_load(Helper::ClassPrivateFieldSet2, ctx)),

--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -184,7 +184,7 @@ impl<'a> ClassProperties<'a, '_> {
             false,
             false,
         );
-        let obj = ctx.ast.expression_object(SPAN, ctx.ast.vec1(property), None);
+        let obj = ctx.ast.expression_object(SPAN, ctx.ast.vec1(property));
 
         // Insert after class
         let class_details = self.current_class();
@@ -350,7 +350,6 @@ impl<'a> ClassProperties<'a, '_> {
                     false,
                 ),
             ]),
-            None,
         );
 
         let private_props = self.current_class().private_props.as_ref().unwrap();

--- a/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/super_converter.rs
@@ -145,7 +145,7 @@ impl<'a> ClassPropertiesSuperConverter<'a, '_, '_> {
     ) {
         let elements = arguments.drain(..).map(ArrayExpressionElement::from);
         let elements = ctx.ast.vec_from_iter(elements);
-        let array = ctx.ast.expression_array(SPAN, elements, None);
+        let array = ctx.ast.expression_array(SPAN, elements);
         arguments.push(Argument::from(array));
     }
 

--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -655,7 +655,7 @@ impl<'a> JsxImpl<'a, '_> {
                     need_jsxs = true;
                     let elements = children.into_iter().map(ArrayExpressionElement::from);
                     let elements = ctx.ast.vec_from_iter(elements);
-                    ctx.ast.expression_array(SPAN, elements, None)
+                    ctx.ast.expression_array(SPAN, elements)
                 };
                 let children = ctx.ast.property_key_static_identifier(SPAN, "children");
                 let kind = PropertyKind::Init;
@@ -666,7 +666,7 @@ impl<'a> JsxImpl<'a, '_> {
             }
 
             // If runtime is automatic that means we always to add `{ .. }` as the second argument even if it's empty
-            let mut object_expression = ctx.ast.expression_object(SPAN, properties, None);
+            let mut object_expression = ctx.ast.expression_object(SPAN, properties);
             if let Some(options) = self.object_rest_spread_options {
                 ObjectRestSpread::transform_object_expression(
                     options,
@@ -722,7 +722,7 @@ impl<'a> JsxImpl<'a, '_> {
             }
 
             if !properties.is_empty() {
-                let mut object_expression = ctx.ast.expression_object(SPAN, properties, None);
+                let mut object_expression = ctx.ast.expression_object(SPAN, properties);
                 if let Some(options) = self.object_rest_spread_options {
                     ObjectRestSpread::transform_object_expression(
                         options,
@@ -898,7 +898,7 @@ impl<'a> JsxImpl<'a, '_> {
             let JSXSpreadChild { span, expression } = e.unbox();
             let spread_element = ctx.ast.array_expression_element_spread_element(span, expression);
             let elements = ctx.ast.vec1(spread_element);
-            Some(ctx.ast.expression_array(span, elements, None))
+            Some(ctx.ast.expression_array(span, elements))
         } else {
             self.transform_jsx_child(child, ctx)
         }

--- a/crates/oxc_transformer/src/jsx/jsx_source.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_source.rs
@@ -174,7 +174,7 @@ impl<'a> JsxSource<'a, '_> {
         };
 
         let properties = ctx.ast.vec_from_array([filename, line_number, column_number]);
-        ctx.ast.expression_object(SPAN, properties, None)
+        ctx.ast.expression_object(SPAN, properties)
     }
 
     pub fn get_filename_var_statement(&self, ctx: &TraverseCtx<'a>) -> Option<Statement<'a>> {

--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -589,7 +589,7 @@ impl<'a> ReactRefresh<'a, '_> {
                 ctx.ast.vec(),
                 ctx.ast.vec1(ctx.ast.statement_return(
                     SPAN,
-                    Some(ctx.ast.expression_array(SPAN, custom_hooks_in_scope, None)),
+                    Some(ctx.ast.expression_array(SPAN, custom_hooks_in_scope)),
                 )),
             );
             let scope_id = ctx.create_child_scope_of_current(ScopeFlags::Function);

--- a/crates/oxc_transformer/src/plugins/module_runner_transform.rs
+++ b/crates/oxc_transformer/src/plugins/module_runner_transform.rs
@@ -660,7 +660,7 @@ impl<'a> ModuleRunnerTransform<'a> {
         elements: ArenaVec<'a, ArrayExpressionElement<'a>>,
         ctx: &TraverseCtx<'a>,
     ) -> Argument<'a> {
-        let value = ctx.ast.expression_array(SPAN, elements, None);
+        let value = ctx.ast.expression_array(SPAN, elements);
         let key = ctx.ast.property_key_static_identifier(SPAN, Atom::from("importedNames"));
         let imported_names = ctx.ast.object_property_kind_object_property(
             SPAN,
@@ -671,7 +671,7 @@ impl<'a> ModuleRunnerTransform<'a> {
             false,
             false,
         );
-        Argument::from(ctx.ast.expression_object(SPAN, ctx.ast.vec1(imported_names), None))
+        Argument::from(ctx.ast.expression_object(SPAN, ctx.ast.vec1(imported_names)))
     }
 
     // `const __vite_ssr_import_0__ = await __vite_ssr_import__('vue', { importedNames: ['foo'] });`
@@ -763,7 +763,6 @@ impl<'a> ModuleRunnerTransform<'a> {
                 Self::create_object_property("configurable", None, ctx),
                 Self::create_object_property("get", Some(getter), ctx),
             ]),
-            None,
         );
 
         let arguments = ctx.ast.vec_from_array([

--- a/crates/oxc_transformer/src/typescript/enum.rs
+++ b/crates/oxc_transformer/src/typescript/enum.rs
@@ -137,7 +137,7 @@ impl<'a> TypeScriptEnum<'a> {
 
         let arguments = if (is_export || is_not_top_scope) && !is_already_declared {
             // }({});
-            let object_expr = ast.expression_object(SPAN, ast.vec(), None);
+            let object_expr = ast.expression_object(SPAN, ast.vec());
             ast.vec1(Argument::from(object_expr))
         } else {
             // }(Foo || {});
@@ -148,7 +148,7 @@ impl<'a> TypeScriptEnum<'a> {
                 enum_symbol_id,
                 ReferenceFlags::Read,
             );
-            let right = ast.expression_object(SPAN, ast.vec(), None);
+            let right = ast.expression_object(SPAN, ast.vec());
             let expression = ast.expression_logical(SPAN, left, op, right);
             ast.vec1(Argument::from(expression))
         };

--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -307,7 +307,7 @@ impl<'a> TypeScriptNamespace<'a, '_> {
                     binding.create_write_target(ctx)
                 };
 
-                let assign_right = ctx.ast.expression_object(SPAN, ctx.ast.vec(), None);
+                let assign_right = ctx.ast.expression_object(SPAN, ctx.ast.vec());
                 let op = AssignmentOperator::Assign;
                 let assign_expr =
                     ctx.ast.expression_assignment(SPAN, op, assign_left, assign_right);

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -2680,8 +2680,6 @@ impl<'a, 't> GetAddress for ProgramWithoutBody<'a, 't> {
 
 pub(crate) const OFFSET_ARRAY_EXPRESSION_SPAN: usize = offset_of!(ArrayExpression, span);
 pub(crate) const OFFSET_ARRAY_EXPRESSION_ELEMENTS: usize = offset_of!(ArrayExpression, elements);
-pub(crate) const OFFSET_ARRAY_EXPRESSION_TRAILING_COMMA: usize =
-    offset_of!(ArrayExpression, trailing_comma);
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -2695,14 +2693,6 @@ impl<'a, 't> ArrayExpressionWithoutElements<'a, 't> {
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_ARRAY_EXPRESSION_SPAN) as *const Span) }
     }
-
-    #[inline]
-    pub fn trailing_comma(self) -> &'t Option<Span> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_ARRAY_EXPRESSION_TRAILING_COMMA)
-                as *const Option<Span>)
-        }
-    }
 }
 
 impl<'a, 't> GetAddress for ArrayExpressionWithoutElements<'a, 't> {
@@ -2715,8 +2705,6 @@ impl<'a, 't> GetAddress for ArrayExpressionWithoutElements<'a, 't> {
 pub(crate) const OFFSET_OBJECT_EXPRESSION_SPAN: usize = offset_of!(ObjectExpression, span);
 pub(crate) const OFFSET_OBJECT_EXPRESSION_PROPERTIES: usize =
     offset_of!(ObjectExpression, properties);
-pub(crate) const OFFSET_OBJECT_EXPRESSION_TRAILING_COMMA: usize =
-    offset_of!(ObjectExpression, trailing_comma);
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -2729,14 +2717,6 @@ impl<'a, 't> ObjectExpressionWithoutProperties<'a, 't> {
     #[inline]
     pub fn span(self) -> &'t Span {
         unsafe { &*((self.0 as *const u8).add(OFFSET_OBJECT_EXPRESSION_SPAN) as *const Span) }
-    }
-
-    #[inline]
-    pub fn trailing_comma(self) -> &'t Option<Span> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_OBJECT_EXPRESSION_TRAILING_COMMA)
-                as *const Option<Span>)
-        }
     }
 }
 
@@ -4153,8 +4133,6 @@ pub(crate) const OFFSET_ARRAY_ASSIGNMENT_TARGET_ELEMENTS: usize =
     offset_of!(ArrayAssignmentTarget, elements);
 pub(crate) const OFFSET_ARRAY_ASSIGNMENT_TARGET_REST: usize =
     offset_of!(ArrayAssignmentTarget, rest);
-pub(crate) const OFFSET_ARRAY_ASSIGNMENT_TARGET_TRAILING_COMMA: usize =
-    offset_of!(ArrayAssignmentTarget, trailing_comma);
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
@@ -4174,14 +4152,6 @@ impl<'a, 't> ArrayAssignmentTargetWithoutElements<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARRAY_ASSIGNMENT_TARGET_REST)
                 as *const Option<AssignmentTargetRest<'a>>)
-        }
-    }
-
-    #[inline]
-    pub fn trailing_comma(self) -> &'t Option<Span> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_ARRAY_ASSIGNMENT_TARGET_TRAILING_COMMA)
-                as *const Option<Span>)
         }
     }
 }
@@ -4211,14 +4181,6 @@ impl<'a, 't> ArrayAssignmentTargetWithoutRest<'a, 't> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_ARRAY_ASSIGNMENT_TARGET_ELEMENTS)
                 as *const Vec<'a, Option<AssignmentTargetMaybeDefault<'a>>>)
-        }
-    }
-
-    #[inline]
-    pub fn trailing_comma(self) -> &'t Option<Span> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_ARRAY_ASSIGNMENT_TARGET_TRAILING_COMMA)
-                as *const Option<Span>)
         }
     }
 }

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -4539,11 +4539,6 @@ function deserializeVecArrayExpressionElement(pos) {
   return arr;
 }
 
-function deserializeOptionSpan(pos) {
-  if (uint8[pos] === 0) return null;
-  return deserializeSpan(pos + 8);
-}
-
 function deserializeBoxSpreadElement(pos) {
   return deserializeSpreadElement(uint32[pos >> 2]);
 }

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -4626,11 +4626,6 @@ function deserializeVecArrayExpressionElement(pos) {
   return arr;
 }
 
-function deserializeOptionSpan(pos) {
-  if (uint8[pos] === 0) return null;
-  return deserializeSpan(pos + 8);
-}
-
 function deserializeBoxSpreadElement(pos) {
   return deserializeSpreadElement(uint32[pos >> 2]);
 }


### PR DESCRIPTION
closes #10419

This change reduces the size of these AST nodes, saving a bit of memory.

`ArrayExpression`: 56 -> 40
`ObjectExpression`: 56 -> 40
`ArrayAssignmentTarget`: 80 -> 64

Also removes the annoying `None` argument from these AST node builders.