### PR TITLE
perf(parser): pass span starts (u32) around instead of Span (2x u32)

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -20,16 +20,15 @@ pub struct ParserCheckpoint<'a> {
 
 impl<'a> ParserImpl<'a> {
     #[inline]
-    pub(crate) fn start_span(&self) -> Span {
-        let token = self.cur_token();
-        Span::new(token.start, 0)
+    pub(crate) fn start_span(&self) -> u32 {
+        self.token.start
     }
 
     #[inline]
-    pub(crate) fn end_span(&self, mut span: Span) -> Span {
-        span.end = self.prev_token_end;
-        debug_assert!(span.end >= span.start);
-        span
+    pub(crate) fn end_span(&self, start: u32) -> Span {
+        let end = self.prev_token_end;
+        debug_assert!(end >= start);
+        Span::new(start, end)
     }
 
     /// Get current token

--- a/crates/oxc_parser/src/js/arrow.rs
+++ b/crates/oxc_parser/src/js/arrow.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::Box;
 use oxc_ast::{NONE, ast::*};
 use oxc_diagnostics::Result;
-use oxc_span::{GetSpan, Span};
+use oxc_span::GetSpan;
 use oxc_syntax::precedence::Precedence;
 
 use super::Tristate;
@@ -12,7 +12,7 @@ struct ArrowFunctionHead<'a> {
     params: Box<'a, FormalParameters<'a>>,
     return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,
     r#async: bool,
-    span: Span,
+    span: u32,
     has_return_colon: bool,
 }
 
@@ -213,7 +213,7 @@ impl<'a> ParserImpl<'a> {
 
     pub(crate) fn parse_simple_arrow_function_expression(
         &mut self,
-        span: Span,
+        span: u32,
         ident: Expression<'a>,
         r#async: bool,
         allow_return_type_in_arrow_function: bool,
@@ -229,7 +229,7 @@ impl<'a> ParserImpl<'a> {
                 }
                 _ => unreachable!(),
             };
-            let params_span = self.end_span(ident.span);
+            let params_span = self.end_span(ident.span.start);
             let ident = BindingPatternKind::BindingIdentifier(ident);
             let pattern = self.ast.binding_pattern(ident, NONE, false);
             let formal_parameter = self.ast.plain_formal_parameter(params_span, pattern);

--- a/crates/oxc_parser/src/js/binding.rs
+++ b/crates/oxc_parser/src/js/binding.rs
@@ -1,6 +1,6 @@
 use oxc_ast::{NONE, ast::*};
 use oxc_diagnostics::Result;
-use oxc_span::{GetSpan, Span};
+use oxc_span::GetSpan;
 
 use crate::{Context, ParserImpl, diagnostics, lexer::Kind};
 
@@ -165,7 +165,7 @@ impl<'a> ParserImpl<'a> {
     ///   = `AssignmentExpression`[?In, ?Yield, ?Await]
     fn parse_initializer(
         &mut self,
-        span: Span,
+        span: u32,
         left: BindingPattern<'a>,
     ) -> Result<BindingPattern<'a>> {
         if self.eat(Kind::Eq) {

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -19,7 +19,7 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_class_statement(
         &mut self,
         stmt_ctx: StatementContext,
-        start_span: Span,
+        start_span: u32,
     ) -> Result<Statement<'a>> {
         let modifiers = self.parse_modifiers(
             /* allow_decorators */ true, /* permit_const_as_modifier */ false,
@@ -40,7 +40,7 @@ impl<'a> ParserImpl<'a> {
     /// Section 15.7 Class Definitions
     pub(crate) fn parse_class_declaration(
         &mut self,
-        start_span: Span,
+        start_span: u32,
         modifiers: &Modifiers<'a>,
     ) -> Result<Box<'a, Class<'a>>> {
         self.parse_class(start_span, ClassType::ClassDeclaration, modifiers)
@@ -57,14 +57,14 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_class(
         &mut self,
-        start_span: Span,
+        start_span: u32,
         r#type: ClassType,
         modifiers: &Modifiers<'a>,
     ) -> Result<Box<'a, Class<'a>>> {
         self.bump_any(); // advance `class`
 
         let decorators = self.consume_decorators();
-        let start_span = decorators.iter().next().map_or(start_span, |d| d.span);
+        let start_span = decorators.iter().next().map_or(start_span, |d| d.span.start);
 
         let id = if self.cur_kind().is_binding_identifier() && !self.at(Kind::Implements) {
             Some(self.parse_binding_identifier()?)
@@ -391,7 +391,7 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_class_method_definition(
         &mut self,
-        span: Span,
+        span: u32,
         kind: MethodDefinitionKind,
         key: PropertyKey<'a>,
         computed: bool,
@@ -455,7 +455,7 @@ impl<'a> ParserImpl<'a> {
     /// `FieldDefinition`[?Yield, ?Await] ;
     fn parse_class_property_definition(
         &mut self,
-        span: Span,
+        span: u32,
         key: PropertyKey<'a>,
         computed: bool,
         r#static: bool,
@@ -497,7 +497,7 @@ impl<'a> ParserImpl<'a> {
 
     /// `ClassStaticBlockStatementList` :
     ///    `StatementList`[~Yield, +Await, ~Return]
-    fn parse_class_static_block(&mut self, span: Span) -> Result<ClassElement<'a>> {
+    fn parse_class_static_block(&mut self, span: u32) -> Result<ClassElement<'a>> {
         let block =
             self.context(Context::Await, Context::Yield | Context::Return, Self::parse_block)?;
         Ok(self.ast.class_element_static_block(self.end_span(span), block.unbox().body))
@@ -506,7 +506,7 @@ impl<'a> ParserImpl<'a> {
     /// <https://github.com/tc39/proposal-decorators>
     fn parse_class_accessor_property(
         &mut self,
-        span: Span,
+        span: u32,
         key: PropertyKey<'a>,
         computed: bool,
         r#static: bool,

--- a/crates/oxc_parser/src/js/declaration.rs
+++ b/crates/oxc_parser/src/js/declaration.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::Box;
 use oxc_ast::{NONE, ast::*};
 use oxc_diagnostics::Result;
-use oxc_span::{GetSpan, Span};
+use oxc_span::GetSpan;
 
 use super::VariableDeclarationParent;
 use crate::{
@@ -36,13 +36,13 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_using_statement(&mut self) -> Result<Statement<'a>> {
         let mut decl = self.parse_using_declaration(StatementContext::StatementList)?;
         self.asi()?;
-        decl.span = self.end_span(decl.span);
+        decl.span = self.end_span(decl.span.start);
         Ok(Statement::VariableDeclaration(self.alloc(decl)))
     }
 
     pub(crate) fn parse_variable_declaration(
         &mut self,
-        start_span: Span,
+        start_span: u32,
         decl_parent: VariableDeclarationParent,
         modifiers: &Modifiers<'a>,
     ) -> Result<Box<'a, VariableDeclaration<'a>>> {

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -197,7 +197,7 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
-    fn parse_parenthesized_expression(&mut self, span: Span) -> Result<Expression<'a>> {
+    fn parse_parenthesized_expression(&mut self, span: u32) -> Result<Expression<'a>> {
         self.expect(Kind::LParen)?;
         let expr_span = self.start_span();
         let mut expressions = self.context(Context::In, Context::Decorator, |p| {
@@ -436,7 +436,7 @@ impl<'a> ParserImpl<'a> {
         if self.at(Kind::Comma) {
             let comma_span = self.start_span();
             self.bump_any();
-            self.state.trailing_commas.insert(span.start, self.end_span(comma_span));
+            self.state.trailing_commas.insert(span, self.end_span(comma_span));
         }
         self.expect(Kind::RBrack)?;
         Ok(self.ast.expression_array(self.end_span(span), elements))
@@ -510,7 +510,7 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_tagged_template(
         &mut self,
-        span: Span,
+        span: u32,
         lhs: Expression<'a>,
         in_optional_chain: bool,
         type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
@@ -708,7 +708,7 @@ impl<'a> ParserImpl<'a> {
     /// parse rhs of a member expression, starting from lhs
     fn parse_member_expression_rest(
         &mut self,
-        lhs_span: Span,
+        lhs_span: u32,
         lhs: Expression<'a>,
         in_optional_chain: &mut bool,
     ) -> Result<Expression<'a>> {
@@ -784,7 +784,7 @@ impl<'a> ParserImpl<'a> {
     /// static member `a.b`
     fn parse_static_member_expression(
         &mut self,
-        lhs_span: Span,
+        lhs_span: u32,
         lhs: Expression<'a>,
         optional: bool,
     ) -> Result<Expression<'a>> {
@@ -809,7 +809,7 @@ impl<'a> ParserImpl<'a> {
     ///   `MemberExpression`[?Yield, ?Await] [ Expression[+In, ?Yield, ?Await] ]
     fn parse_computed_member_expression(
         &mut self,
-        lhs_span: Span,
+        lhs_span: u32,
         lhs: Expression<'a>,
         optional: bool,
     ) -> Result<Expression<'a>> {
@@ -882,7 +882,7 @@ impl<'a> ParserImpl<'a> {
     /// Section 13.3 Call Expression
     fn parse_call_expression_rest(
         &mut self,
-        lhs_span: Span,
+        lhs_span: u32,
         lhs: Expression<'a>,
         in_optional_chain: &mut bool,
     ) -> Result<Expression<'a>> {
@@ -923,7 +923,7 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_call_arguments(
         &mut self,
-        lhs_span: Span,
+        lhs_span: u32,
         lhs: Expression<'a>,
         optional: bool,
         type_parameters: Option<Box<'a, TSTypeParameterInstantiation<'a>>>,
@@ -958,7 +958,7 @@ impl<'a> ParserImpl<'a> {
     }
 
     /// Section 13.4 Update Expression
-    fn parse_update_expression(&mut self, lhs_span: Span) -> Result<Expression<'a>> {
+    fn parse_update_expression(&mut self, lhs_span: u32) -> Result<Expression<'a>> {
         let kind = self.cur_kind();
         // ++ -- prefix update expressions
         if kind.is_update_operator() {
@@ -996,7 +996,7 @@ impl<'a> ParserImpl<'a> {
     /// Section 13.5 Unary Expression
     pub(crate) fn parse_unary_expression_or_higher(
         &mut self,
-        lhs_span: Span,
+        lhs_span: u32,
     ) -> Result<Expression<'a>> {
         // ++ -- prefix update expressions
         if self.is_update_expression() {
@@ -1007,7 +1007,7 @@ impl<'a> ParserImpl<'a> {
 
     pub(crate) fn parse_simple_unary_expression(
         &mut self,
-        lhs_span: Span,
+        lhs_span: u32,
     ) -> Result<Expression<'a>> {
         match self.cur_kind() {
             kind if kind.is_unary_operator() => self.parse_unary_expression(),
@@ -1066,7 +1066,7 @@ impl<'a> ParserImpl<'a> {
     /// Section 13.6 - 13.13 Binary Expression
     fn parse_binary_expression_rest(
         &mut self,
-        lhs_span: Span,
+        lhs_span: u32,
         lhs: Expression<'a>,
         min_precedence: Precedence,
     ) -> Result<Expression<'a>> {
@@ -1143,7 +1143,7 @@ impl<'a> ParserImpl<'a> {
     ///     `ShortCircuitExpression`[?In, ?Yield, ?Await] ? `AssignmentExpression`[+In, ?Yield, ?Await] : `AssignmentExpression`[?In, ?Yield, ?Await]
     fn parse_conditional_expression_rest(
         &mut self,
-        lhs_span: Span,
+        lhs_span: u32,
         lhs: Expression<'a>,
         allow_return_type_in_arrow_function: bool,
     ) -> Result<Expression<'a>> {
@@ -1284,7 +1284,7 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_assignment_expression_recursive(
         &mut self,
-        span: Span,
+        span: u32,
         lhs: Expression<'a>,
         allow_return_type_in_arrow_function: bool,
     ) -> Result<Expression<'a>> {
@@ -1305,7 +1305,7 @@ impl<'a> ParserImpl<'a> {
     /// Section 13.16 Sequence Expression
     fn parse_sequence_expression(
         &mut self,
-        span: Span,
+        span: u32,
         first_expression: Expression<'a>,
     ) -> Result<Expression<'a>> {
         let mut expressions = self.ast.vec1(first_expression);
@@ -1318,7 +1318,7 @@ impl<'a> ParserImpl<'a> {
 
     /// ``AwaitExpression`[Yield]` :
     ///     await `UnaryExpression`[?Yield, +Await]
-    fn parse_await_expression(&mut self, lhs_span: Span) -> Result<Expression<'a>> {
+    fn parse_await_expression(&mut self, lhs_span: u32) -> Result<Expression<'a>> {
         let span = self.start_span();
         if !self.ctx.has_await() {
             self.error(diagnostics::await_expression(self.cur_token().span()));

--- a/crates/oxc_parser/src/js/function.rs
+++ b/crates/oxc_parser/src/js/function.rs
@@ -111,7 +111,7 @@ impl<'a> ParserImpl<'a> {
 
     pub(crate) fn parse_function(
         &mut self,
-        span: Span,
+        span: u32,
         id: Option<BindingIdentifier<'a>>,
         r#async: bool,
         generator: bool,
@@ -232,7 +232,7 @@ impl<'a> ParserImpl<'a> {
     /// at `function`
     pub(crate) fn parse_ts_function_impl(
         &mut self,
-        start_span: Span,
+        start_span: u32,
         func_kind: FunctionKind,
         modifiers: &Modifiers<'a>,
     ) -> Result<Box<'a, Function<'a>>> {
@@ -254,7 +254,7 @@ impl<'a> ParserImpl<'a> {
     /// [Function Expression](https://tc39.es/ecma262/#prod-FunctionExpression)
     pub(crate) fn parse_function_expression(
         &mut self,
-        span: Span,
+        span: u32,
         r#async: bool,
     ) -> Result<Expression<'a>> {
         let func_kind = FunctionKind::Expression;
@@ -309,7 +309,7 @@ impl<'a> ParserImpl<'a> {
 
         let has_yield = self.ctx.has_yield();
         if !has_yield {
-            self.error(diagnostics::yield_expression(Span::new(span.start, span.start + 5)));
+            self.error(diagnostics::yield_expression(Span::new(span, span + 5)));
         }
 
         let mut delegate = false;

--- a/crates/oxc_parser/src/js/module.rs
+++ b/crates/oxc_parser/src/js/module.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::{Box, Vec};
 use oxc_ast::{NONE, ast::*};
 use oxc_diagnostics::Result;
-use oxc_span::{GetSpan, Span};
+use oxc_span::GetSpan;
 use rustc_hash::FxHashMap;
 
 use super::FunctionKind;
@@ -12,7 +12,7 @@ impl<'a> ParserImpl<'a> {
     /// `ImportCall` : import ( `AssignmentExpression` )
     pub(crate) fn parse_import_expression(
         &mut self,
-        span: Span,
+        span: u32,
         phase: Option<ImportPhase>,
     ) -> Result<Expression<'a>> {
         self.expect(Kind::LParen)?;
@@ -212,7 +212,7 @@ impl<'a> ParserImpl<'a> {
 
     pub(crate) fn parse_ts_export_assignment_declaration(
         &mut self,
-        start_span: Span,
+        start_span: u32,
     ) -> Result<Box<'a, TSExportAssignment<'a>>> {
         self.expect(Kind::Eq)?;
         let expression = self.parse_assignment_expression_or_higher()?;
@@ -222,7 +222,7 @@ impl<'a> ParserImpl<'a> {
 
     pub(crate) fn parse_ts_export_namespace(
         &mut self,
-        start_span: Span,
+        start_span: u32,
     ) -> Result<Box<'a, TSNamespaceExportDeclaration<'a>>> {
         self.expect(Kind::As)?;
         self.expect(Kind::Namespace)?;
@@ -278,7 +278,7 @@ impl<'a> ParserImpl<'a> {
     //   ModuleExportName as ModuleExportName
     fn parse_export_named_specifiers(
         &mut self,
-        span: Span,
+        span: u32,
     ) -> Result<Box<'a, ExportNamedDeclaration<'a>>> {
         let export_kind = self.parse_import_or_export_kind();
         self.expect(Kind::LCurly)?;
@@ -351,7 +351,7 @@ impl<'a> ParserImpl<'a> {
     // export Declaration
     fn parse_export_named_declaration(
         &mut self,
-        span: Span,
+        span: u32,
     ) -> Result<Box<'a, ExportNamedDeclaration<'a>>> {
         let decl_span = self.start_span();
         // For tc39/proposal-decorators
@@ -384,7 +384,7 @@ impl<'a> ParserImpl<'a> {
     // export default AssignmentExpression[+In, ~Yield, +Await] ;
     fn parse_export_default_declaration(
         &mut self,
-        span: Span,
+        span: u32,
     ) -> Result<Box<'a, ExportDefaultDeclaration<'a>>> {
         let exported = self.parse_keyword_identifier(Kind::Default);
         let decl_span = self.start_span();
@@ -440,7 +440,7 @@ impl<'a> ParserImpl<'a> {
     //   NamedExports
     fn parse_export_all_declaration(
         &mut self,
-        span: Span,
+        span: u32,
     ) -> Result<Box<'a, ExportAllDeclaration<'a>>> {
         let export_kind = self.parse_import_or_export_kind();
         self.bump_any(); // bump `star`

--- a/crates/oxc_parser/src/js/object.rs
+++ b/crates/oxc_parser/src/js/object.rs
@@ -1,7 +1,6 @@
 use oxc_allocator::Box;
 use oxc_ast::ast::*;
 use oxc_diagnostics::Result;
-use oxc_span::Span;
 use oxc_syntax::operator::AssignmentOperator;
 
 use crate::{Context, ParserImpl, diagnostics, lexer::Kind, modifiers::Modifier};
@@ -138,7 +137,7 @@ impl<'a> ParserImpl<'a> {
                 left,
                 right,
             );
-            self.state.cover_initialized_name.insert(span.start, expr);
+            self.state.cover_initialized_name.insert(span, expr);
         }
         Ok(self.ast.alloc_object_property(
             self.end_span(span),
@@ -155,7 +154,7 @@ impl<'a> ParserImpl<'a> {
     ///   `PropertyName`[?Yield, ?Await] : `AssignmentExpression`[+In, ?Yield, ?Await]
     fn parse_property_definition_assignment(
         &mut self,
-        span: Span,
+        span: u32,
         key: PropertyKey<'a>,
         computed: bool,
     ) -> Result<Box<'a, ObjectProperty<'a>>> {

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -240,7 +240,7 @@ impl<'a> ParserImpl<'a> {
     /// Section 14.5 Expression Statement
     pub(crate) fn parse_expression_statement(
         &mut self,
-        span: Span,
+        span: u32,
         expression: Expression<'a>,
     ) -> Result<Statement<'a>> {
         self.asi()?;
@@ -349,7 +349,7 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_variable_declaration_for_statement(
         &mut self,
-        span: Span,
+        span: u32,
         r#await: bool,
     ) -> Result<Statement<'a>> {
         let start_span = self.start_span();
@@ -370,7 +370,7 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_using_declaration_for_statement(
         &mut self,
-        span: Span,
+        span: u32,
         r#await: bool,
     ) -> Result<Statement<'a>> {
         let using_decl = self.parse_using_declaration(StatementContext::For)?;
@@ -398,7 +398,7 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_for_loop(
         &mut self,
-        span: Span,
+        span: u32,
         init: Option<ForStatementInit<'a>>,
         r#await: bool,
     ) -> Result<Statement<'a>> {
@@ -429,7 +429,7 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_for_in_or_of_loop(
         &mut self,
-        span: Span,
+        span: u32,
         r#await: bool,
         left: ForStatementLeft<'a>,
     ) -> Result<Statement<'a>> {
@@ -489,8 +489,8 @@ impl<'a> ParserImpl<'a> {
         };
         if !self.ctx.has_return() {
             self.error(diagnostics::return_statement_only_in_function_body(Span::new(
-                span.start,
-                span.start + 6,
+                span,
+                span + 6,
             )));
         }
         Ok(self.ast.statement_return(self.end_span(span), argument))

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::Box;
 use oxc_ast::ast::*;
 use oxc_diagnostics::Result;
-use oxc_span::{GetSpan, Span};
+use oxc_span::GetSpan;
 
 use crate::{
     ParserImpl, diagnostics,
@@ -20,7 +20,7 @@ impl<'a> ParserImpl<'a> {
     /// `https://www.typescriptlang.org/docs/handbook/enums.html`
     pub(crate) fn parse_ts_enum_declaration(
         &mut self,
-        span: Span,
+        span: u32,
         modifiers: &Modifiers<'a>,
     ) -> Result<Declaration<'a>> {
         self.bump_any(); // bump `enum`
@@ -113,7 +113,7 @@ impl<'a> ParserImpl<'a> {
 
     pub(crate) fn parse_ts_type_alias_declaration(
         &mut self,
-        span: Span,
+        span: u32,
         modifiers: &Modifiers<'a>,
     ) -> Result<Declaration<'a>> {
         self.expect(Kind::Type)?;
@@ -152,7 +152,7 @@ impl<'a> ParserImpl<'a> {
 
     pub(crate) fn parse_ts_interface_declaration(
         &mut self,
-        span: Span,
+        span: u32,
         modifiers: &Modifiers<'a>,
     ) -> Result<Declaration<'a>> {
         self.expect(Kind::Interface)?; // bump interface
@@ -283,7 +283,7 @@ impl<'a> ParserImpl<'a> {
 
     pub(crate) fn parse_ts_namespace_or_module_declaration_body(
         &mut self,
-        span: Span,
+        span: u32,
         kind: TSModuleDeclarationKind,
         modifiers: &Modifiers<'a>,
     ) -> Result<Box<'a, TSModuleDeclaration<'a>>> {
@@ -332,7 +332,7 @@ impl<'a> ParserImpl<'a> {
 
     pub(crate) fn parse_ts_declaration_statement(
         &mut self,
-        start_span: Span,
+        start_span: u32,
     ) -> Result<Statement<'a>> {
         let reserved_ctx = self.ctx;
         let modifiers = self.eat_modifiers_before_declaration()?;
@@ -347,7 +347,7 @@ impl<'a> ParserImpl<'a> {
 
     pub(crate) fn parse_declaration(
         &mut self,
-        start_span: Span,
+        start_span: u32,
         modifiers: &Modifiers<'a>,
     ) -> Result<Declaration<'a>> {
         match self.cur_kind() {
@@ -407,7 +407,7 @@ impl<'a> ParserImpl<'a> {
 
     pub(crate) fn parse_ts_declare_function(
         &mut self,
-        start_span: Span,
+        start_span: u32,
         modifiers: &Modifiers<'a>,
     ) -> Result<Box<'a, Function<'a>>> {
         let r#async = modifiers.contains(ModifierKind::Async);
@@ -437,7 +437,7 @@ impl<'a> ParserImpl<'a> {
 
     pub(crate) fn parse_ts_import_equals_declaration(
         &mut self,
-        span: Span,
+        span: u32,
     ) -> Result<Declaration<'a>> {
         let import_kind = if !self.peek_at(Kind::Eq) && self.eat(Kind::Type) {
             ImportOrExportKind::Type

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -648,7 +648,7 @@ impl<'a> ParserImpl<'a> {
     }
 
     fn parse_this_type_predicate(&mut self, this_ty: TSThisType) -> Result<TSType<'a>> {
-        let span = this_ty.span;
+        let span = this_ty.span.start;
         self.bump_any(); // bump `is`
         // TODO: this should go through the ast builder.
         let parameter_name = TSTypePredicateName::This(this_ty);
@@ -1230,7 +1230,7 @@ impl<'a> ParserImpl<'a> {
 
     pub(crate) fn parse_index_signature_declaration(
         &mut self,
-        span: Span,
+        span: u32,
         modifiers: &Modifiers<'a>,
     ) -> Result<TSIndexSignature<'a>> {
         self.verify_modifiers(


### PR DESCRIPTION
It it useless to pass around the end span, because it's always empty.

Pass `Span`s around when it definitely contains an end span.

This should reduce a bit of stack usage.