### PR TITLE
perf(parser): use `ArenaVec` to store decorators

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -1,6 +1,6 @@
 //! Code related to navigating `Token`s from the lexer
 
-use oxc_allocator::Vec;
+use oxc_allocator::{TakeIn, Vec};
 use oxc_ast::ast::{Decorator, RegExpFlags};
 use oxc_diagnostics::Result;
 use oxc_span::{GetSpan, Span};
@@ -327,8 +327,7 @@ impl<'a> ParserImpl<'a> {
     }
 
     pub(crate) fn consume_decorators(&mut self) -> Vec<'a, Decorator<'a>> {
-        let decorators = std::mem::take(&mut self.state.decorators);
-        self.ast.vec_from_iter(decorators)
+        self.state.decorators.take_in(self.ast.allocator)
     }
 
     pub(crate) fn parse_normal_list<F, T>(

--- a/crates/oxc_parser/src/lib.rs
+++ b/crates/oxc_parser/src/lib.rs
@@ -410,7 +410,7 @@ impl<'a> ParserImpl<'a> {
             errors: vec![],
             token: Token::default(),
             prev_token_end: 0,
-            state: ParserState::default(),
+            state: ParserState::new(allocator),
             ctx: Self::default_context(source_type, options),
             ast: AstBuilder::new(allocator),
             module_record_builder: ModuleRecordBuilder::new(allocator),

--- a/crates/oxc_parser/src/state.rs
+++ b/crates/oxc_parser/src/state.rs
@@ -1,13 +1,13 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 
+use oxc_allocator::{Allocator, Vec as ArenaVec};
 use oxc_ast::ast::{AssignmentExpression, Decorator};
 use oxc_span::Span;
 
-#[derive(Default)]
 pub struct ParserState<'a> {
     pub not_parenthesized_arrow: FxHashSet<u32>,
 
-    pub decorators: Vec<Decorator<'a>>,
+    pub decorators: ArenaVec<'a, Decorator<'a>>,
 
     /// Temporary storage for `CoverInitializedName` `({ foo = bar })`.
     /// Keyed by `ObjectProperty`'s span.start.
@@ -18,4 +18,15 @@ pub struct ParserState<'a> {
     /// Keyed by start span of `ArrayExpression`.
     /// Valued by position of the trailing_comma.
     pub trailing_commas: FxHashMap<u32, Span>,
+}
+
+impl<'a> ParserState<'a> {
+    pub fn new(allocator: &'a Allocator) -> Self {
+        Self {
+            not_parenthesized_arrow: FxHashSet::default(),
+            decorators: ArenaVec::new_in(allocator),
+            cover_initialized_name: FxHashMap::default(),
+            trailing_commas: FxHashMap::default(),
+        }
+    }
 }

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -491,7 +491,7 @@ impl<'a> ParserImpl<'a> {
             return Ok(());
         }
 
-        let mut decorators = vec![];
+        let mut decorators = self.ast.vec();
         while self.at(Kind::At) {
             let decorator = self.parse_decorator()?;
             decorators.push(decorator);


### PR DESCRIPTION
No performance changes show in the `CodeSpeed` because we don't have a benchmark that includes decorators. According to convention, we always store child/leaf ASTs used for building ASTs in an arena to avoid extra allocations. We have got many performances from this kind of change, so I think it is good!