### PR TITLE
fix(codegen): fix spaces before `AssignmentTargetRest`

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1944,7 +1944,9 @@ impl Gen for ArrayAssignmentTarget<'_> {
             }
         }
         if let Some(target) = &self.rest {
-            p.print_soft_space();
+            if !self.elements.is_empty() {
+                p.print_soft_space();
+            }
             p.add_source_mapping(self.span);
             target.print(p, ctx);
         }
@@ -1961,6 +1963,7 @@ impl Gen for ObjectAssignmentTarget<'_> {
         if let Some(target) = &self.rest {
             if !self.properties.is_empty() {
                 p.print_comma();
+                p.print_soft_space();
             }
             p.add_source_mapping(self.span);
             target.print(p, ctx);

--- a/crates/oxc_codegen/tests/integration/unit.rs
+++ b/crates/oxc_codegen/tests/integration/unit.rs
@@ -188,6 +188,10 @@ fn comma() {
 #[test]
 fn assignment() {
     test("(let[0] = 100);", "(let)[0] = 100;\n");
+    test("[a, ...rest] = arr;", "[a, ...rest] = arr;\n");
+    test("[...rest] = arr;", "[...rest] = arr;\n");
+    test("({a, ...rest} = obj);", "({a, ...rest} = obj);\n");
+    test("({...rest} = obj);", "({...rest} = obj);\n");
     test_minify("a = b ? c : d", "a=b?c:d;");
     test_minify("[a,b] = (1, 2)", "[a,b]=(1,2);");
     // `{a,b}` is a block, must wrap the whole expression to be an assignment expression


### PR DESCRIPTION
Follow-on after #10431.

* Don't print space before `...rest` in `[...rest] = arr;`.
* Do print space before `...rest` in `({a, ...rest} = obj;`.
