### PR TITLE
refactor(transformer/class-properties): re-order fields and expand comments

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -385,6 +385,8 @@ impl<'a> ClassProperties<'a, '_> {
         if class_details.is_transform_required {
             self.transform_class_declaration_on_exit_impl(class, ctx);
         } else {
+            // Note: `is_transform_required` is `true` if class has any private properties/methods,
+            // so no need to touch `private_field_count` here
             debug_assert!(class_details.bindings.temp.is_none());
         }
         // Pop off stack. We're done!
@@ -446,6 +448,7 @@ impl<'a> ClassProperties<'a, '_> {
 
         if let Some(private_props) = &class_details.private_props {
             self.private_field_count -= private_props.len();
+
             if self.private_fields_as_properties {
                 let mut private_props = private_props
                     .iter()
@@ -536,6 +539,8 @@ impl<'a> ClassProperties<'a, '_> {
         if class_details.is_transform_required {
             self.transform_class_expression_on_exit_impl(expr, ctx);
         } else {
+            // Note: `is_transform_required` is `true` if class has any private properties/methods,
+            // so no need to touch `private_field_count` here
             debug_assert!(class_details.bindings.temp.is_none());
         }
 
@@ -591,6 +596,7 @@ impl<'a> ClassProperties<'a, '_> {
         // Also insert `var _prop;` temp var declarations for private static props.
         if let Some(private_props) = &class_details.private_props {
             self.private_field_count -= private_props.len();
+
             // Insert `var _prop;` declarations here rather than when binding was created to maintain
             // same order of `var` declarations as Babel.
             // `c = class C { #x = 1; static y = 2; }` -> `var _C, _x;`


### PR DESCRIPTION
Follow-on after #10418. Pure refactor.

`private_field_count` is accessed in both the entry and exit phases of the transform, so move that field up to be with the other fields which are in that same category.

Expand the comment which explains how this optimization works.

Also, when reviewing #10418, I had to trace through the logic to make sure that it wasn't possible for decreasing `private_field_count` on exit to get skipped if `is_transform_required` is `false`. Turns out it's not a problem - `is_transform_required` is always `true` if class has any private properties/methods. Add comments to clarify that.
