### PR TITLE
fix(ast/estree): fix start span of `Program` in TS-ESTree AST where first statement is `@dec export class C {}`

### DIFF
--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -37,11 +37,14 @@ function deserialize(buffer, sourceTextInput, sourceLenInput) {
 function deserializeProgram(pos) {
   const body = deserializeVecDirective(pos + 88);
   body.push(...deserializeVecStatement(pos + 120));
-  let start = deserializeU32(pos);
+
+  const start = deserializeU32(pos);
+  const end = deserializeU32(pos + 4);
+
   const program = {
     type: 'Program',
     start,
-    end: deserializeU32(pos + 4),
+    end,
     body,
     sourceType: deserializeModuleKind(pos + 9),
     hashbang: deserializeOptionHashbang(pos + 64),

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -2,7 +2,7 @@ commit: 15392346
 
 estree_typescript Summary:
 AST Parsed     : 10619/10725 (99.01%)
-Positive Passed: 9012/10725 (84.03%)
+Positive Passed: 9013/10725 (84.04%)
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/ClassDeclarationWithInvalidConstOnPropertyDeclaration.ts
 A class member cannot have the 'const' keyword.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessOverriddenBaseClassMember1.ts
@@ -1643,7 +1643,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es7/trailingC
 Unexpected trailing comma after rest element
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es7/trailingCommasInFunctionParametersAndArguments.ts
 A rest parameter must be last in a parameter list
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-commentPreservation.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classDeclaration/esDecorators-classDeclaration-parameterProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.17.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/esDecorators/classExpression/esDecorators-classExpression-missingEmitHelpers-classDecorator.5.ts


### PR DESCRIPTION
#10438 aligned the spans of `@dec export class C {}` and `@dec export default class {}` with TS-ESLint.

```ts
@dec export class C {}
     ^^^^^^^^^^^^^^^^^ ExportNamedDeclaration
            ^^^^^^^^^^ Class
^^^^                   Decorator

@dec export default class {}
     ^^^^^^^^^^^^^^^^^^^^^^^ ExportDefaultDeclaration
                    ^^^^^^^^ Class
^^^^                         Decorator
```

However, this causes a problem where one of these is the first statement in the file. In TS-ESTree, `Program` start is the start of the first token (excluding whitespace and comments). So we need to set `Program` start to the start of the decorator in these cases.
