### PR TITLE
refactor(transformer/class-properties): debug assert `private_field_count` is 0 at end of transform

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/mod.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/mod.rs
@@ -323,6 +323,12 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
 }
 
 impl<'a> Traverse<'a> for ClassProperties<'a, '_> {
+    #[expect(clippy::inline_always)]
+    #[inline(always)] // Because this is a no-op in release mode
+    fn exit_program(&mut self, _program: &mut Program<'a>, _ctx: &mut TraverseCtx<'a>) {
+        debug_assert_eq!(self.private_field_count, 0);
+    }
+
     fn enter_class_body(&mut self, body: &mut ClassBody<'a>, ctx: &mut TraverseCtx<'a>) {
         self.transform_class_body_on_entry(body, ctx);
     }

--- a/crates/oxc_transformer/src/es2022/mod.rs
+++ b/crates/oxc_transformer/src/es2022/mod.rs
@@ -37,6 +37,13 @@ impl<'a, 'ctx> ES2022<'a, 'ctx> {
 }
 
 impl<'a> Traverse<'a> for ES2022<'a, '_> {
+    #[inline] // Because this is a no-op in release mode
+    fn exit_program(&mut self, program: &mut Program<'a>, ctx: &mut TraverseCtx<'a>) {
+        if let Some(class_properties) = &mut self.class_properties {
+            class_properties.exit_program(program, ctx);
+        }
+    }
+
     fn enter_expression(&mut self, expr: &mut Expression<'a>, ctx: &mut TraverseCtx<'a>) {
         if let Some(class_properties) = &mut self.class_properties {
             class_properties.enter_expression(expr, ctx);

--- a/crates/oxc_transformer/src/lib.rs
+++ b/crates/oxc_transformer/src/lib.rs
@@ -201,6 +201,7 @@ impl<'a> Traverse<'a> for TransformerImpl<'a, '_> {
         if let Some(typescript) = self.x0_typescript.as_mut() {
             typescript.exit_program(program, ctx);
         }
+        self.x2_es2022.exit_program(program, ctx);
         self.x2_es2018.exit_program(program, ctx);
         self.common.exit_program(program, ctx);
     }


### PR DESCRIPTION
`private_field_count` is incremented when entering a class with private properties/methods and decremented when leaving it. Make sure this is working correctly by ensuring `private_field_count == 0` at the end of the transform.

As suggested in https://github.com/oxc-project/oxc/pull/10447#pullrequestreview-2772743492.
