### PR TITLE
fix(parser): correct AST for `a<b>?.()`

### DIFF
--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -841,10 +841,10 @@ impl<'a> ParserImpl<'a> {
         let mut optional = false;
         let mut callee = self.parse_member_expression_or_higher(&mut optional)?;
 
-        let mut type_parameter = None;
+        let mut type_arguments = None;
         if let Expression::TSInstantiationExpression(instantiation_expr) = callee {
             let instantiation_expr = instantiation_expr.unbox();
-            type_parameter.replace(instantiation_expr.type_arguments);
+            type_arguments.replace(instantiation_expr.type_arguments);
             callee = instantiation_expr.expression;
         }
 
@@ -876,7 +876,7 @@ impl<'a> ParserImpl<'a> {
             self.error(diagnostics::new_optional_chain(span));
         }
 
-        Ok(self.ast.expression_new(span, callee, arguments, type_parameter))
+        Ok(self.ast.expression_new(span, callee, arguments, type_arguments))
     }
 
     /// Section 13.3 Call Expression
@@ -905,10 +905,12 @@ impl<'a> ParserImpl<'a> {
             }
 
             if type_arguments.is_some() || self.at(Kind::LParen) {
-                if let Expression::TSInstantiationExpression(expr) = lhs {
-                    let expr = expr.unbox();
-                    type_arguments.replace(expr.type_arguments);
-                    lhs = expr.expression;
+                if !optional_call {
+                    if let Expression::TSInstantiationExpression(expr) = lhs {
+                        let expr = expr.unbox();
+                        type_arguments.replace(expr.type_arguments);
+                        lhs = expr.expression;
+                    }
                 }
 
                 lhs =

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -2,7 +2,7 @@ commit: 15392346
 
 estree_typescript Summary:
 AST Parsed     : 10619/10725 (99.01%)
-Positive Passed: 9036/10725 (84.25%)
+Positive Passed: 9037/10725 (84.26%)
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/ClassDeclarationWithInvalidConstOnPropertyDeclaration.ts
 A class member cannot have the 'const' keyword.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessOverriddenBaseClassMember1.ts
@@ -780,7 +780,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/objectLiteralMem
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/objectLiteralMemberWithQuestionMark1.ts
 Expected `,` but found `?`
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectRestSpread.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalChainWithInstantiationExpression2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/optionalParameterProperty.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overloadsWithConstraints.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/overrideBaseIntersectionMethod.ts


### PR DESCRIPTION
Need to keep `TSInstantiationExpression` in optional callee.