### PR TITLE
feat(parser): error for `const { ...a: b } = {}`

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -519,6 +519,12 @@ pub fn import_arguments(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Dynamic imports can only accept a module specifier and an optional set of attributes as arguments").with_label(span)
 }
 
+/// TS(2566)
+#[cold]
+pub fn rest_element_property_name(span: Span) -> OxcDiagnostic {
+    ts_error("2566", "A rest element cannot have a property name.").with_label(span)
+}
+
 // ================================= MODIFIERS =================================
 
 #[cold]

--- a/crates/oxc_parser/src/js/binding.rs
+++ b/crates/oxc_parser/src/js/binding.rs
@@ -91,6 +91,9 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_rest_binding(&mut self) -> Result<BindingRestElement<'a>> {
         let elem = self.parse_rest_element()?;
+        if let Some(ty) = &elem.argument.type_annotation {
+            self.error(diagnostics::rest_element_property_name(ty.span));
+        }
         if self.at(Kind::Comma) {
             if matches!(self.peek_kind(), Kind::RCurly | Kind::RBrack) {
                 let span = self.cur_token().span();

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -770,7 +770,8 @@ Unexpected estree file content error: 1 != 2
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/numberVsBigIntOperations.ts
 Missing initializer in const declaration
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectBindingPattern_restElementWithPropertyName.ts
+Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/objectBindingPattern_restElementWithPropertyName.ts
+A rest element cannot have a property name.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectCreationOfElementAccessExpression.ts
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/objectLiteralIndexerNoImplicitAny.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/objectLiteralMemberWithModifiers1.ts
@@ -865,7 +866,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/restParameterAssignment
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/restParameterNotLast.ts
 A rest parameter must be last in a parameter list
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/restParameterWithBindingPattern1.ts
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/restParameterWithBindingPattern3.ts
+Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/restParameterWithBindingPattern3.ts
+A rest element cannot have a property name.
 tasks/coverage/typescript/tests/cases/compiler/reuseTypeAnnotationImportTypeInGlobalThisTypeArgument.ts
 Unexpected estree file content error: 2 != 4
 

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: 15392346
 parser_typescript Summary:
 AST Parsed     : 6522/6531 (99.86%)
 Positive Passed: 6511/6531 (99.69%)
-Negative Passed: 1307/5754 (22.71%)
+Negative Passed: 1308/5754 (22.73%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration24.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment7.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment8.ts
@@ -1565,7 +1565,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/numericIndex
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/numericIndexerConstraint5.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/numericIndexerTyping1.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/numericIndexerTyping2.ts
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectBindingPattern_restElementWithPropertyName.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectCreate-errors.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectCreationOfElementAccessExpression.ts
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/objectFreeze.ts
@@ -10203,6 +10202,12 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  4 │ 1.+2.0 + 3. ;
    ╰────
 
+  × TS(2566): A rest element cannot have a property name.
+   ╭─[typescript/tests/cases/compiler/objectBindingPattern_restElementWithPropertyName.ts:1:13]
+ 1 │ const { ...a: b } = {};
+   ·             ───
+   ╰────
+
   × Unexpected token
    ╭─[typescript/tests/cases/compiler/objectCreationExpressionInFunctionParameter.ts:6:2]
  5 │ function foo(x = new A(123)) { //should error, 123 is not string
@@ -11913,6 +11918,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╭─[typescript/tests/cases/compiler/restParameterNotLast.ts:1:12]
  1 │ function f(...x, y) { }
    ·            ────
+   ╰────
+
+  × TS(2566): A rest element cannot have a property name.
+   ╭─[typescript/tests/cases/compiler/restParameterWithBindingPattern3.ts:9:46]
+ 8 │ 
+ 9 │ function e(...{0: a = 1, 1: b = true, ...rest: rest}: [boolean, string, number]) { }
+   ·                                              ──────
    ╰────
 
   × A rest parameter cannot have an initializer


### PR DESCRIPTION
Syntax error for

```ts
const { ...a: b } = {}
const [ ...a: b ] = []
```