### PR TITLE
feat(parser): a rest parameter cannot have an initializer

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -525,6 +525,11 @@ pub fn rest_element_property_name(span: Span) -> OxcDiagnostic {
     ts_error("2566", "A rest element cannot have a property name.").with_label(span)
 }
 
+#[cold]
+pub fn a_rest_element_cannot_have_an_initializer(span: Span) -> OxcDiagnostic {
+    OxcDiagnostic::error("A rest element cannot have an initializer.").with_label(span)
+}
+
 // ================================= MODIFIERS =================================
 
 #[cold]

--- a/crates/oxc_semantic/src/checker/javascript.rs
+++ b/crates/oxc_semantic/src/checker/javascript.rs
@@ -973,28 +973,6 @@ pub fn check_object_property(prop: &ObjectProperty, ctx: &SemanticBuilder<'_>) {
     }
 }
 
-fn a_rest_parameter_cannot_have_an_initializer(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("A rest parameter cannot have an initializer").with_label(span)
-}
-
-pub fn check_formal_parameters(params: &FormalParameters, ctx: &SemanticBuilder<'_>) {
-    if let Some(rest) = &params.rest {
-        if let BindingPatternKind::AssignmentPattern(pat) = &rest.argument.kind {
-            ctx.error(a_rest_parameter_cannot_have_an_initializer(pat.span));
-        }
-    }
-}
-
-pub fn check_array_pattern(pattern: &ArrayPattern, ctx: &SemanticBuilder<'_>) {
-    // function foo([...x = []]) { }
-    //                    ^^^^ A rest element cannot have an initializer
-    if let Some(rest) = &pattern.rest {
-        if let BindingPatternKind::AssignmentPattern(pat) = &rest.argument.kind {
-            ctx.error(a_rest_parameter_cannot_have_an_initializer(pat.span));
-        }
-    }
-}
-
 fn assignment_is_not_simple(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Invalid left-hand side in assignment").with_label(span)
 }

--- a/crates/oxc_semantic/src/checker/mod.rs
+++ b/crates/oxc_semantic/src/checker/mod.rs
@@ -96,11 +96,9 @@ pub fn check<'a>(node: &AstNode<'a>, ctx: &SemanticBuilder<'a>) {
         AstKind::Super(sup) => js::check_super(sup, node, ctx),
 
         AstKind::FormalParameters(params) => {
-            js::check_formal_parameters(params, ctx);
             ts::check_formal_parameters(params, ctx);
         }
         AstKind::ArrayPattern(pat) => {
-            js::check_array_pattern(pat, ctx);
             ts::check_array_pattern(pat, ctx);
         }
 

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -867,7 +867,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/restParameterNot
 A rest parameter must be last in a parameter list
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/restParameterWithBindingPattern1.ts
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/restParameterWithBindingPattern3.ts
-A rest element cannot have a property name.
+A rest element cannot have an initializer.
 tasks/coverage/typescript/tests/cases/compiler/reuseTypeAnnotationImportTypeInGlobalThisTypeArgument.ts
 Unexpected estree file content error: 2 != 4
 
@@ -1304,7 +1304,8 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/re
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/restElementWithAssignmentPattern2.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/restElementWithAssignmentPattern3.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/restElementWithAssignmentPattern4.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/restElementWithInitializer1.ts
+Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/restElementWithInitializer1.ts
+A rest element cannot have an initializer.
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/restElementWithInitializer2.ts
 Cannot assign to this expression
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/destructuring/restPropertyWithBindingPattern.ts
@@ -2257,7 +2258,8 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmasc
 Unexpected token
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList1.ts
 A rest parameter must be last in a parameter list
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList10.ts
+Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList10.ts
+A rest element cannot have an initializer.
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList11.ts
 A rest parameter cannot be optional
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList9.ts

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -4373,6 +4373,12 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·               ────
    ╰────
 
+  × A rest element cannot have an initializer.
+   ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/278/input.js:1:18]
+ 1 │ function f(a, ...b = 0)
+   ·                  ─────
+   ╰────
+
   × Unexpected token
    ╭─[babel/packages/babel-parser/test/fixtures/es2015/uncategorised/278/input.js:1:24]
  1 │ function f(a, ...b = 0)
@@ -5794,12 +5800,24 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·      ─────
    ╰────
 
+  × A rest element cannot have an initializer.
+   ╭─[babel/packages/babel-parser/test/fixtures/es2018/object-rest-spread/22/input.js:1:9]
+ 1 │ var {...x = 1} = {}
+   ·         ─────
+   ╰────
+
   × Invalid rest element
    ╭─[babel/packages/babel-parser/test/fixtures/es2018/object-rest-spread/22/input.js:1:9]
  1 │ var {...x = 1} = {}
    ·         ─────
    ╰────
   help: Expected identifier in rest element
+
+  × A rest element cannot have an initializer.
+   ╭─[babel/packages/babel-parser/test/fixtures/es2018/object-rest-spread/23/input.js:1:19]
+ 1 │ function test({...x = 1}) {}
+   ·                   ─────
+   ╰────
 
   × Invalid rest element
    ╭─[babel/packages/babel-parser/test/fixtures/es2018/object-rest-spread/23/input.js:1:19]
@@ -11225,7 +11243,7 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·               ────
    ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0260/input.js:1:15]
  1 │ function x(...a = 1){}
    ·               ─────

--- a/tasks/coverage/snapshots/parser_test262.snap
+++ b/tasks/coverage/snapshots/parser_test262.snap
@@ -3020,7 +3020,7 @@ Negative Passed: 4519/4519 (100.00%)
  60 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/arrow-function/dflt-params-rest.js:63:8]
  62 │ 
  63 │ 0, (...x = []) => {
@@ -3028,7 +3028,7 @@ Negative Passed: 4519/4519 (100.00%)
  64 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/arrow-function/dstr/ary-ptrn-rest-init-ary.js:53:10]
  52 │ var f;
  53 │ f = ([...[ x ] = []]) => {
@@ -3036,7 +3036,7 @@ Negative Passed: 4519/4519 (100.00%)
  54 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/arrow-function/dstr/ary-ptrn-rest-init-id.js:53:10]
  52 │ var f;
  53 │ f = ([...x = []]) => {
@@ -3044,7 +3044,7 @@ Negative Passed: 4519/4519 (100.00%)
  54 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/arrow-function/dstr/ary-ptrn-rest-init-obj.js:53:10]
  52 │ var f;
  53 │ f = ([...{ x } = []]) => {
@@ -3076,7 +3076,7 @@ Negative Passed: 4519/4519 (100.00%)
  54 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/arrow-function/dstr/dflt-ary-ptrn-rest-init-ary.js:53:10]
  52 │ var f;
  53 │ f = ([...[ x ] = []] = []) => {
@@ -3084,7 +3084,7 @@ Negative Passed: 4519/4519 (100.00%)
  54 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/arrow-function/dstr/dflt-ary-ptrn-rest-init-id.js:53:10]
  52 │ var f;
  53 │ f = ([...x = []] = []) => {
@@ -3092,7 +3092,7 @@ Negative Passed: 4519/4519 (100.00%)
  54 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/arrow-function/dstr/dflt-ary-ptrn-rest-init-obj.js:53:10]
  52 │ var f;
  53 │ f = ([...{ x } = []] = []) => {
@@ -6652,7 +6652,7 @@ Negative Passed: 4519/4519 (100.00%)
  52 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/async-arrow-function/dflt-params-rest.js:55:12]
  54 │ 
  55 │ (async (...x = []) => {
@@ -7008,7 +7008,7 @@ Negative Passed: 4519/4519 (100.00%)
  38 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/async-function/named-dflt-params-rest.js:41:22]
  40 │ 
  41 │ (async function f(...x = []) {
@@ -7058,7 +7058,7 @@ Negative Passed: 4519/4519 (100.00%)
  38 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/async-function/nameless-dflt-params-rest.js:41:20]
  40 │ 
  41 │ (async function(...x = []) {
@@ -7172,7 +7172,7 @@ Negative Passed: 4519/4519 (100.00%)
  41 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/async-generator/dflt-params-rest.js:44:23]
  43 │ 
  44 │ 0, async function*(...x = []) {
@@ -7180,7 +7180,7 @@ Negative Passed: 4519/4519 (100.00%)
  45 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/async-generator/dstr/ary-ptrn-rest-init-ary.js:34:25]
  33 │ var f;
  34 │ f = async function*([...[ x ] = []]) {
@@ -7188,7 +7188,7 @@ Negative Passed: 4519/4519 (100.00%)
  35 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/async-generator/dstr/ary-ptrn-rest-init-id.js:34:25]
  33 │ var f;
  34 │ f = async function*([...x = []]) {
@@ -7196,7 +7196,7 @@ Negative Passed: 4519/4519 (100.00%)
  35 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/async-generator/dstr/ary-ptrn-rest-init-obj.js:34:25]
  33 │ var f;
  34 │ f = async function*([...{ x } = []]) {
@@ -7228,7 +7228,7 @@ Negative Passed: 4519/4519 (100.00%)
  35 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/async-generator/dstr/dflt-ary-ptrn-rest-init-ary.js:34:25]
  33 │ var f;
  34 │ f = async function*([...[ x ] = []] = []) {
@@ -7236,7 +7236,7 @@ Negative Passed: 4519/4519 (100.00%)
  35 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/async-generator/dstr/dflt-ary-ptrn-rest-init-id.js:34:25]
  33 │ var f;
  34 │ f = async function*([...x = []] = []) {
@@ -7244,7 +7244,7 @@ Negative Passed: 4519/4519 (100.00%)
  35 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/async-generator/dstr/dflt-ary-ptrn-rest-init-obj.js:34:25]
  33 │ var f;
  34 │ f = async function*([...{ x } = []] = []) {
@@ -7276,7 +7276,7 @@ Negative Passed: 4519/4519 (100.00%)
  35 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/async-generator/dstr/named-ary-ptrn-rest-init-ary.js:34:27]
  33 │ var f;
  34 │ f = async function* h([...[ x ] = []]) {
@@ -7284,7 +7284,7 @@ Negative Passed: 4519/4519 (100.00%)
  35 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/async-generator/dstr/named-ary-ptrn-rest-init-id.js:34:27]
  33 │ var f;
  34 │ f = async function* h([...x = []]) {
@@ -7292,7 +7292,7 @@ Negative Passed: 4519/4519 (100.00%)
  35 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/async-generator/dstr/named-ary-ptrn-rest-init-obj.js:34:27]
  33 │ var f;
  34 │ f = async function* h([...{ x } = []]) {
@@ -7324,7 +7324,7 @@ Negative Passed: 4519/4519 (100.00%)
  35 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/async-generator/dstr/named-dflt-ary-ptrn-rest-init-ary.js:34:27]
  33 │ var f;
  34 │ f = async function* h([...[ x ] = []] = []) {
@@ -7332,7 +7332,7 @@ Negative Passed: 4519/4519 (100.00%)
  35 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/async-generator/dstr/named-dflt-ary-ptrn-rest-init-id.js:34:27]
  33 │ var f;
  34 │ f = async function* h([...x = []] = []) {
@@ -7340,7 +7340,7 @@ Negative Passed: 4519/4519 (100.00%)
  35 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/async-generator/dstr/named-dflt-ary-ptrn-rest-init-obj.js:34:27]
  33 │ var f;
  34 │ f = async function* h([...{ x } = []] = []) {
@@ -7632,7 +7632,7 @@ Negative Passed: 4519/4519 (100.00%)
  41 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/async-generator/named-dflt-params-rest.js:44:25]
  43 │ 
  44 │ 0, async function* g(...x = []) {
@@ -8013,7 +8013,7 @@ Negative Passed: 4519/4519 (100.00%)
  65 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/async-gen-method/dflt-params-rest.js:68:20]
  67 │ 0, class {
  68 │   async *method(...x = []) {
@@ -8233,7 +8233,7 @@ Negative Passed: 4519/4519 (100.00%)
  65 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/async-gen-method-static/dflt-params-rest.js:68:27]
  67 │ 0, class {
  68 │   static async *method(...x = []) {
@@ -8453,7 +8453,7 @@ Negative Passed: 4519/4519 (100.00%)
  63 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/async-method/dflt-params-rest.js:66:26]
  65 │ var C = class {
  66 │   static async method(...x = []) {
@@ -8567,7 +8567,7 @@ Negative Passed: 4519/4519 (100.00%)
  63 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/async-method-static/dflt-params-rest.js:66:26]
  65 │ var C = class {
  66 │   static async method(...x = []) {
@@ -8669,7 +8669,7 @@ Negative Passed: 4519/4519 (100.00%)
     ·               ─────
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-rest-init-ary.js:58:21]
  57 │ var C = class {
  58 │   async *method([...[ x ] = []]) {
@@ -8677,7 +8677,7 @@ Negative Passed: 4519/4519 (100.00%)
  59 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-rest-init-id.js:58:21]
  57 │ var C = class {
  58 │   async *method([...x = []]) {
@@ -8685,7 +8685,7 @@ Negative Passed: 4519/4519 (100.00%)
  59 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/async-gen-meth-ary-ptrn-rest-init-obj.js:58:21]
  57 │ var C = class {
  58 │   async *method([...{ x } = []]) {
@@ -8717,7 +8717,7 @@ Negative Passed: 4519/4519 (100.00%)
  59 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-ary.js:58:21]
  57 │ var C = class {
  58 │   async *method([...[ x ] = []] = []) {
@@ -8725,7 +8725,7 @@ Negative Passed: 4519/4519 (100.00%)
  59 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-id.js:58:21]
  57 │ var C = class {
  58 │   async *method([...x = []] = []) {
@@ -8733,7 +8733,7 @@ Negative Passed: 4519/4519 (100.00%)
  59 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-obj.js:58:21]
  57 │ var C = class {
  58 │   async *method([...{ x } = []] = []) {
@@ -8765,7 +8765,7 @@ Negative Passed: 4519/4519 (100.00%)
  59 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-rest-init-ary.js:58:28]
  57 │ var C = class {
  58 │   static async *method([...[ x ] = []]) {
@@ -8773,7 +8773,7 @@ Negative Passed: 4519/4519 (100.00%)
  59 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-rest-init-id.js:58:28]
  57 │ var C = class {
  58 │   static async *method([...x = []]) {
@@ -8781,7 +8781,7 @@ Negative Passed: 4519/4519 (100.00%)
  59 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/async-gen-meth-static-ary-ptrn-rest-init-obj.js:58:28]
  57 │ var C = class {
  58 │   static async *method([...{ x } = []]) {
@@ -8813,7 +8813,7 @@ Negative Passed: 4519/4519 (100.00%)
  59 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-init-ary.js:58:28]
  57 │ var C = class {
  58 │   static async *method([...[ x ] = []] = []) {
@@ -8821,7 +8821,7 @@ Negative Passed: 4519/4519 (100.00%)
  59 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-init-id.js:58:28]
  57 │ var C = class {
  58 │   static async *method([...x = []] = []) {
@@ -8829,7 +8829,7 @@ Negative Passed: 4519/4519 (100.00%)
  59 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-init-obj.js:58:28]
  57 │ var C = class {
  58 │   static async *method([...{ x } = []] = []) {
@@ -8861,7 +8861,7 @@ Negative Passed: 4519/4519 (100.00%)
  59 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-rest-init-ary.js:58:23]
  57 │ var C = class {
  58 │   async * #method([...[ x ] = []]) {
@@ -8869,7 +8869,7 @@ Negative Passed: 4519/4519 (100.00%)
  59 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-rest-init-id.js:58:23]
  57 │ var C = class {
  58 │   async * #method([...x = []]) {
@@ -8877,7 +8877,7 @@ Negative Passed: 4519/4519 (100.00%)
  59 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/async-private-gen-meth-ary-ptrn-rest-init-obj.js:58:23]
  57 │ var C = class {
  58 │   async * #method([...{ x } = []]) {
@@ -8909,7 +8909,7 @@ Negative Passed: 4519/4519 (100.00%)
  59 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-init-ary.js:58:23]
  57 │ var C = class {
  58 │   async * #method([...[ x ] = []] = []) {
@@ -8917,7 +8917,7 @@ Negative Passed: 4519/4519 (100.00%)
  59 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-init-id.js:58:23]
  57 │ var C = class {
  58 │   async * #method([...x = []] = []) {
@@ -8925,7 +8925,7 @@ Negative Passed: 4519/4519 (100.00%)
  59 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-init-obj.js:58:23]
  57 │ var C = class {
  58 │   async * #method([...{ x } = []] = []) {
@@ -8957,7 +8957,7 @@ Negative Passed: 4519/4519 (100.00%)
  59 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-init-ary.js:58:30]
  57 │ var C = class {
  58 │   static async * #method([...[ x ] = []]) {
@@ -8965,7 +8965,7 @@ Negative Passed: 4519/4519 (100.00%)
  59 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-init-id.js:58:30]
  57 │ var C = class {
  58 │   static async * #method([...x = []]) {
@@ -8973,7 +8973,7 @@ Negative Passed: 4519/4519 (100.00%)
  59 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-init-obj.js:58:30]
  57 │ var C = class {
  58 │   static async * #method([...{ x } = []]) {
@@ -9005,7 +9005,7 @@ Negative Passed: 4519/4519 (100.00%)
  59 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-init-ary.js:58:30]
  57 │ var C = class {
  58 │   static async * #method([...[ x ] = []] = []) {
@@ -9013,7 +9013,7 @@ Negative Passed: 4519/4519 (100.00%)
  59 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-init-id.js:58:30]
  57 │ var C = class {
  58 │   static async * #method([...x = []] = []) {
@@ -9021,7 +9021,7 @@ Negative Passed: 4519/4519 (100.00%)
  59 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-init-obj.js:58:30]
  57 │ var C = class {
  58 │   static async * #method([...{ x } = []] = []) {
@@ -9053,7 +9053,7 @@ Negative Passed: 4519/4519 (100.00%)
  59 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/gen-meth-ary-ptrn-rest-init-ary.js:77:15]
  76 │ var C = class {
  77 │   *method([...[ x ] = []]) {
@@ -9061,7 +9061,7 @@ Negative Passed: 4519/4519 (100.00%)
  78 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/gen-meth-ary-ptrn-rest-init-id.js:77:15]
  76 │ var C = class {
  77 │   *method([...x = []]) {
@@ -9069,7 +9069,7 @@ Negative Passed: 4519/4519 (100.00%)
  78 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/gen-meth-ary-ptrn-rest-init-obj.js:77:15]
  76 │ var C = class {
  77 │   *method([...{ x } = []]) {
@@ -9101,7 +9101,7 @@ Negative Passed: 4519/4519 (100.00%)
  78 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/gen-meth-dflt-ary-ptrn-rest-init-ary.js:77:15]
  76 │ var C = class {
  77 │   *method([...[ x ] = []] = []) {
@@ -9109,7 +9109,7 @@ Negative Passed: 4519/4519 (100.00%)
  78 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/gen-meth-dflt-ary-ptrn-rest-init-id.js:77:15]
  76 │ var C = class {
  77 │   *method([...x = []] = []) {
@@ -9117,7 +9117,7 @@ Negative Passed: 4519/4519 (100.00%)
  78 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/gen-meth-dflt-ary-ptrn-rest-init-obj.js:77:15]
  76 │ var C = class {
  77 │   *method([...{ x } = []] = []) {
@@ -9149,7 +9149,7 @@ Negative Passed: 4519/4519 (100.00%)
  78 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/gen-meth-static-ary-ptrn-rest-init-ary.js:77:22]
  76 │ var C = class {
  77 │   static *method([...[ x ] = []]) {
@@ -9157,7 +9157,7 @@ Negative Passed: 4519/4519 (100.00%)
  78 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/gen-meth-static-ary-ptrn-rest-init-id.js:77:22]
  76 │ var C = class {
  77 │   static *method([...x = []]) {
@@ -9165,7 +9165,7 @@ Negative Passed: 4519/4519 (100.00%)
  78 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/gen-meth-static-ary-ptrn-rest-init-obj.js:77:22]
  76 │ var C = class {
  77 │   static *method([...{ x } = []]) {
@@ -9197,7 +9197,7 @@ Negative Passed: 4519/4519 (100.00%)
  78 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/gen-meth-static-dflt-ary-ptrn-rest-init-ary.js:77:22]
  76 │ var C = class {
  77 │   static *method([...[ x ] = []] = []) {
@@ -9205,7 +9205,7 @@ Negative Passed: 4519/4519 (100.00%)
  78 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/gen-meth-static-dflt-ary-ptrn-rest-init-id.js:77:22]
  76 │ var C = class {
  77 │   static *method([...x = []] = []) {
@@ -9213,7 +9213,7 @@ Negative Passed: 4519/4519 (100.00%)
  78 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/gen-meth-static-dflt-ary-ptrn-rest-init-obj.js:77:22]
  76 │ var C = class {
  77 │   static *method([...{ x } = []] = []) {
@@ -9245,7 +9245,7 @@ Negative Passed: 4519/4519 (100.00%)
  78 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/meth-ary-ptrn-rest-init-ary.js:74:14]
  73 │ var C = class {
  74 │   method([...[ x ] = []]) {
@@ -9253,7 +9253,7 @@ Negative Passed: 4519/4519 (100.00%)
  75 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/meth-ary-ptrn-rest-init-id.js:74:14]
  73 │ var C = class {
  74 │   method([...x = []]) {
@@ -9261,7 +9261,7 @@ Negative Passed: 4519/4519 (100.00%)
  75 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/meth-ary-ptrn-rest-init-obj.js:74:14]
  73 │ var C = class {
  74 │   method([...{ x } = []]) {
@@ -9293,7 +9293,7 @@ Negative Passed: 4519/4519 (100.00%)
  75 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/meth-dflt-ary-ptrn-rest-init-ary.js:74:14]
  73 │ var C = class {
  74 │   method([...[ x ] = []] = []) {
@@ -9301,7 +9301,7 @@ Negative Passed: 4519/4519 (100.00%)
  75 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/meth-dflt-ary-ptrn-rest-init-id.js:74:14]
  73 │ var C = class {
  74 │   method([...x = []] = []) {
@@ -9309,7 +9309,7 @@ Negative Passed: 4519/4519 (100.00%)
  75 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/meth-dflt-ary-ptrn-rest-init-obj.js:74:14]
  73 │ var C = class {
  74 │   method([...{ x } = []] = []) {
@@ -9341,7 +9341,7 @@ Negative Passed: 4519/4519 (100.00%)
  75 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/meth-static-ary-ptrn-rest-init-ary.js:74:21]
  73 │ var C = class {
  74 │   static method([...[ x ] = []]) {
@@ -9349,7 +9349,7 @@ Negative Passed: 4519/4519 (100.00%)
  75 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/meth-static-ary-ptrn-rest-init-id.js:74:21]
  73 │ var C = class {
  74 │   static method([...x = []]) {
@@ -9357,7 +9357,7 @@ Negative Passed: 4519/4519 (100.00%)
  75 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/meth-static-ary-ptrn-rest-init-obj.js:74:21]
  73 │ var C = class {
  74 │   static method([...{ x } = []]) {
@@ -9389,7 +9389,7 @@ Negative Passed: 4519/4519 (100.00%)
  75 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/meth-static-dflt-ary-ptrn-rest-init-ary.js:74:21]
  73 │ var C = class {
  74 │   static method([...[ x ] = []] = []) {
@@ -9397,7 +9397,7 @@ Negative Passed: 4519/4519 (100.00%)
  75 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/meth-static-dflt-ary-ptrn-rest-init-id.js:74:21]
  73 │ var C = class {
  74 │   static method([...x = []] = []) {
@@ -9405,7 +9405,7 @@ Negative Passed: 4519/4519 (100.00%)
  75 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/meth-static-dflt-ary-ptrn-rest-init-obj.js:74:21]
  73 │ var C = class {
  74 │   static method([...{ x } = []] = []) {
@@ -9437,7 +9437,7 @@ Negative Passed: 4519/4519 (100.00%)
  75 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/private-gen-meth-ary-ptrn-rest-init-ary.js:77:17]
  76 │ var C = class {
  77 │   * #method([...[ x ] = []]) {
@@ -9445,7 +9445,7 @@ Negative Passed: 4519/4519 (100.00%)
  78 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/private-gen-meth-ary-ptrn-rest-init-id.js:77:17]
  76 │ var C = class {
  77 │   * #method([...x = []]) {
@@ -9453,7 +9453,7 @@ Negative Passed: 4519/4519 (100.00%)
  78 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/private-gen-meth-ary-ptrn-rest-init-obj.js:77:17]
  76 │ var C = class {
  77 │   * #method([...{ x } = []]) {
@@ -9485,7 +9485,7 @@ Negative Passed: 4519/4519 (100.00%)
  78 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/private-gen-meth-dflt-ary-ptrn-rest-init-ary.js:77:17]
  76 │ var C = class {
  77 │   * #method([...[ x ] = []] = []) {
@@ -9493,7 +9493,7 @@ Negative Passed: 4519/4519 (100.00%)
  78 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/private-gen-meth-dflt-ary-ptrn-rest-init-id.js:77:17]
  76 │ var C = class {
  77 │   * #method([...x = []] = []) {
@@ -9501,7 +9501,7 @@ Negative Passed: 4519/4519 (100.00%)
  78 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/private-gen-meth-dflt-ary-ptrn-rest-init-obj.js:77:17]
  76 │ var C = class {
  77 │   * #method([...{ x } = []] = []) {
@@ -9533,7 +9533,7 @@ Negative Passed: 4519/4519 (100.00%)
  78 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/private-gen-meth-static-ary-ptrn-rest-init-ary.js:77:24]
  76 │ var C = class {
  77 │   static * #method([...[ x ] = []]) {
@@ -9541,7 +9541,7 @@ Negative Passed: 4519/4519 (100.00%)
  78 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/private-gen-meth-static-ary-ptrn-rest-init-id.js:77:24]
  76 │ var C = class {
  77 │   static * #method([...x = []]) {
@@ -9549,7 +9549,7 @@ Negative Passed: 4519/4519 (100.00%)
  78 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/private-gen-meth-static-ary-ptrn-rest-init-obj.js:77:24]
  76 │ var C = class {
  77 │   static * #method([...{ x } = []]) {
@@ -9581,7 +9581,7 @@ Negative Passed: 4519/4519 (100.00%)
  78 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/private-gen-meth-static-dflt-ary-ptrn-rest-init-ary.js:77:24]
  76 │ var C = class {
  77 │   static * #method([...[ x ] = []] = []) {
@@ -9589,7 +9589,7 @@ Negative Passed: 4519/4519 (100.00%)
  78 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/private-gen-meth-static-dflt-ary-ptrn-rest-init-id.js:77:24]
  76 │ var C = class {
  77 │   static * #method([...x = []] = []) {
@@ -9597,7 +9597,7 @@ Negative Passed: 4519/4519 (100.00%)
  78 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/private-gen-meth-static-dflt-ary-ptrn-rest-init-obj.js:77:24]
  76 │ var C = class {
  77 │   static * #method([...{ x } = []] = []) {
@@ -9629,7 +9629,7 @@ Negative Passed: 4519/4519 (100.00%)
  78 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/private-meth-ary-ptrn-rest-init-ary.js:74:15]
  73 │ var C = class {
  74 │   #method([...[ x ] = []]) {
@@ -9637,7 +9637,7 @@ Negative Passed: 4519/4519 (100.00%)
  75 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/private-meth-ary-ptrn-rest-init-id.js:74:15]
  73 │ var C = class {
  74 │   #method([...x = []]) {
@@ -9645,7 +9645,7 @@ Negative Passed: 4519/4519 (100.00%)
  75 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/private-meth-ary-ptrn-rest-init-obj.js:74:15]
  73 │ var C = class {
  74 │   #method([...{ x } = []]) {
@@ -9677,7 +9677,7 @@ Negative Passed: 4519/4519 (100.00%)
  75 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/private-meth-dflt-ary-ptrn-rest-init-ary.js:74:15]
  73 │ var C = class {
  74 │   #method([...[ x ] = []] = []) {
@@ -9685,7 +9685,7 @@ Negative Passed: 4519/4519 (100.00%)
  75 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/private-meth-dflt-ary-ptrn-rest-init-id.js:74:15]
  73 │ var C = class {
  74 │   #method([...x = []] = []) {
@@ -9693,7 +9693,7 @@ Negative Passed: 4519/4519 (100.00%)
  75 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/private-meth-dflt-ary-ptrn-rest-init-obj.js:74:15]
  73 │ var C = class {
  74 │   #method([...{ x } = []] = []) {
@@ -9725,7 +9725,7 @@ Negative Passed: 4519/4519 (100.00%)
  75 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/private-meth-static-ary-ptrn-rest-init-ary.js:74:22]
  73 │ var C = class {
  74 │   static #method([...[ x ] = []]) {
@@ -9733,7 +9733,7 @@ Negative Passed: 4519/4519 (100.00%)
  75 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/private-meth-static-ary-ptrn-rest-init-id.js:74:22]
  73 │ var C = class {
  74 │   static #method([...x = []]) {
@@ -9741,7 +9741,7 @@ Negative Passed: 4519/4519 (100.00%)
  75 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/private-meth-static-ary-ptrn-rest-init-obj.js:74:22]
  73 │ var C = class {
  74 │   static #method([...{ x } = []]) {
@@ -9773,7 +9773,7 @@ Negative Passed: 4519/4519 (100.00%)
  75 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/private-meth-static-dflt-ary-ptrn-rest-init-ary.js:74:22]
  73 │ var C = class {
  74 │   static #method([...[ x ] = []] = []) {
@@ -9781,7 +9781,7 @@ Negative Passed: 4519/4519 (100.00%)
  75 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/private-meth-static-dflt-ary-ptrn-rest-init-id.js:74:22]
  73 │ var C = class {
  74 │   static #method([...x = []] = []) {
@@ -9789,7 +9789,7 @@ Negative Passed: 4519/4519 (100.00%)
  75 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/dstr/private-meth-static-dflt-ary-ptrn-rest-init-obj.js:74:22]
  73 │ var C = class {
  74 │   static #method([...{ x } = []] = []) {
@@ -13580,7 +13580,7 @@ Negative Passed: 4519/4519 (100.00%)
  86 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/gen-method/dflt-params-rest.js:89:14]
  88 │ 0, class {
  89 │   *method(...x = []) {
@@ -13745,7 +13745,7 @@ Negative Passed: 4519/4519 (100.00%)
  86 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/gen-method-static/dflt-params-rest.js:89:21]
  88 │ 0, class {
  89 │   static *method(...x = []) {
@@ -13908,7 +13908,7 @@ Negative Passed: 4519/4519 (100.00%)
  82 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/method/dflt-params-rest.js:85:13]
  84 │ 0, class {
  85 │   method(...x = []) {
@@ -13966,7 +13966,7 @@ Negative Passed: 4519/4519 (100.00%)
  82 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/class/method-static/dflt-params-rest.js:85:20]
  84 │ 0, class {
  85 │   static method(...x = []) {
@@ -16880,7 +16880,7 @@ Negative Passed: 4519/4519 (100.00%)
  61 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/function/dflt-params-rest.js:64:16]
  63 │ 
  64 │ 0, function(...x = []) {
@@ -16888,7 +16888,7 @@ Negative Passed: 4519/4519 (100.00%)
  65 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/function/dstr/ary-ptrn-rest-init-ary.js:54:18]
  53 │ var f;
  54 │ f = function([...[ x ] = []]) {
@@ -16896,7 +16896,7 @@ Negative Passed: 4519/4519 (100.00%)
  55 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/function/dstr/ary-ptrn-rest-init-id.js:54:18]
  53 │ var f;
  54 │ f = function([...x = []]) {
@@ -16904,7 +16904,7 @@ Negative Passed: 4519/4519 (100.00%)
  55 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/function/dstr/ary-ptrn-rest-init-obj.js:54:18]
  53 │ var f;
  54 │ f = function([...{ x } = []]) {
@@ -16936,7 +16936,7 @@ Negative Passed: 4519/4519 (100.00%)
  55 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/function/dstr/dflt-ary-ptrn-rest-init-ary.js:54:18]
  53 │ var f;
  54 │ f = function([...[ x ] = []] = []) {
@@ -16944,7 +16944,7 @@ Negative Passed: 4519/4519 (100.00%)
  55 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/function/dstr/dflt-ary-ptrn-rest-init-id.js:54:18]
  53 │ var f;
  54 │ f = function([...x = []] = []) {
@@ -16952,7 +16952,7 @@ Negative Passed: 4519/4519 (100.00%)
  55 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/function/dstr/dflt-ary-ptrn-rest-init-obj.js:54:18]
  53 │ var f;
  54 │ f = function([...{ x } = []] = []) {
@@ -17207,7 +17207,7 @@ Negative Passed: 4519/4519 (100.00%)
  62 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/generators/dflt-params-rest.js:65:17]
  64 │ 
  65 │ 0, function*(...x = []) {
@@ -17215,7 +17215,7 @@ Negative Passed: 4519/4519 (100.00%)
  66 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/generators/dstr/ary-ptrn-rest-init-ary.js:54:19]
  53 │ var f;
  54 │ f = function*([...[ x ] = []]) {
@@ -17223,7 +17223,7 @@ Negative Passed: 4519/4519 (100.00%)
  55 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/generators/dstr/ary-ptrn-rest-init-id.js:54:19]
  53 │ var f;
  54 │ f = function*([...x = []]) {
@@ -17231,7 +17231,7 @@ Negative Passed: 4519/4519 (100.00%)
  55 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/generators/dstr/ary-ptrn-rest-init-obj.js:54:19]
  53 │ var f;
  54 │ f = function*([...{ x } = []]) {
@@ -17263,7 +17263,7 @@ Negative Passed: 4519/4519 (100.00%)
  55 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/generators/dstr/dflt-ary-ptrn-rest-init-ary.js:54:19]
  53 │ var f;
  54 │ f = function*([...[ x ] = []] = []) {
@@ -17271,7 +17271,7 @@ Negative Passed: 4519/4519 (100.00%)
  55 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/generators/dstr/dflt-ary-ptrn-rest-init-id.js:54:19]
  53 │ var f;
  54 │ f = function*([...x = []] = []) {
@@ -17279,7 +17279,7 @@ Negative Passed: 4519/4519 (100.00%)
  55 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/generators/dstr/dflt-ary-ptrn-rest-init-obj.js:54:19]
  53 │ var f;
  54 │ f = function*([...{ x } = []] = []) {
@@ -17899,7 +17899,7 @@ Negative Passed: 4519/4519 (100.00%)
     ╰────
   help: Did you mean to use a ':'? An '=' can only follow a property name when the containing object literal is part of a destructuring pattern.
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-rest-init-ary.js:39:21]
  38 │ var obj = {
  39 │   async *method([...[ x ] = []]) {
@@ -17907,7 +17907,7 @@ Negative Passed: 4519/4519 (100.00%)
  40 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-rest-init-id.js:39:21]
  38 │ var obj = {
  39 │   async *method([...x = []]) {
@@ -17915,7 +17915,7 @@ Negative Passed: 4519/4519 (100.00%)
  40 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/object/dstr/async-gen-meth-ary-ptrn-rest-init-obj.js:39:21]
  38 │ var obj = {
  39 │   async *method([...{ x } = []]) {
@@ -17947,7 +17947,7 @@ Negative Passed: 4519/4519 (100.00%)
  40 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-ary.js:39:21]
  38 │ var obj = {
  39 │   async *method([...[ x ] = []] = []) {
@@ -17955,7 +17955,7 @@ Negative Passed: 4519/4519 (100.00%)
  40 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-id.js:39:21]
  38 │ var obj = {
  39 │   async *method([...x = []] = []) {
@@ -17963,7 +17963,7 @@ Negative Passed: 4519/4519 (100.00%)
  40 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/object/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-obj.js:39:21]
  38 │ var obj = {
  39 │   async *method([...{ x } = []] = []) {
@@ -17995,7 +17995,7 @@ Negative Passed: 4519/4519 (100.00%)
  40 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/object/dstr/gen-meth-ary-ptrn-rest-init-ary.js:59:15]
  58 │ var obj = {
  59 │   *method([...[ x ] = []]) {
@@ -18003,7 +18003,7 @@ Negative Passed: 4519/4519 (100.00%)
  60 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/object/dstr/gen-meth-ary-ptrn-rest-init-id.js:59:15]
  58 │ var obj = {
  59 │   *method([...x = []]) {
@@ -18011,7 +18011,7 @@ Negative Passed: 4519/4519 (100.00%)
  60 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/object/dstr/gen-meth-ary-ptrn-rest-init-obj.js:59:15]
  58 │ var obj = {
  59 │   *method([...{ x } = []]) {
@@ -18043,7 +18043,7 @@ Negative Passed: 4519/4519 (100.00%)
  60 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/object/dstr/gen-meth-dflt-ary-ptrn-rest-init-ary.js:59:15]
  58 │ var obj = {
  59 │   *method([...[ x ] = []] = []) {
@@ -18051,7 +18051,7 @@ Negative Passed: 4519/4519 (100.00%)
  60 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/object/dstr/gen-meth-dflt-ary-ptrn-rest-init-id.js:59:15]
  58 │ var obj = {
  59 │   *method([...x = []] = []) {
@@ -18059,7 +18059,7 @@ Negative Passed: 4519/4519 (100.00%)
  60 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/object/dstr/gen-meth-dflt-ary-ptrn-rest-init-obj.js:59:15]
  58 │ var obj = {
  59 │   *method([...{ x } = []] = []) {
@@ -18091,7 +18091,7 @@ Negative Passed: 4519/4519 (100.00%)
  60 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/object/dstr/meth-ary-ptrn-rest-init-ary.js:56:14]
  55 │ var obj = {
  56 │   method([...[ x ] = []]) {
@@ -18099,7 +18099,7 @@ Negative Passed: 4519/4519 (100.00%)
  57 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/object/dstr/meth-ary-ptrn-rest-init-id.js:56:14]
  55 │ var obj = {
  56 │   method([...x = []]) {
@@ -18107,7 +18107,7 @@ Negative Passed: 4519/4519 (100.00%)
  57 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/object/dstr/meth-ary-ptrn-rest-init-obj.js:56:14]
  55 │ var obj = {
  56 │   method([...{ x } = []]) {
@@ -18139,7 +18139,7 @@ Negative Passed: 4519/4519 (100.00%)
  57 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/object/dstr/meth-dflt-ary-ptrn-rest-init-ary.js:56:14]
  55 │ var obj = {
  56 │   method([...[ x ] = []] = []) {
@@ -18147,7 +18147,7 @@ Negative Passed: 4519/4519 (100.00%)
  57 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/object/dstr/meth-dflt-ary-ptrn-rest-init-id.js:56:14]
  55 │ var obj = {
  56 │   method([...x = []] = []) {
@@ -18155,7 +18155,7 @@ Negative Passed: 4519/4519 (100.00%)
  57 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/object/dstr/meth-dflt-ary-ptrn-rest-init-obj.js:56:14]
  55 │ var obj = {
  56 │   method([...{ x } = []] = []) {
@@ -18458,7 +18458,7 @@ Negative Passed: 4519/4519 (100.00%)
  46 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/object/method-definition/async-gen-meth-dflt-params-rest.js:49:20]
  48 │ 0, {
  49 │   async *method(...x = []) {
@@ -18622,7 +18622,7 @@ Negative Passed: 4519/4519 (100.00%)
  39 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/object/method-definition/async-meth-dflt-params-rest.js:42:20]
  41 │ ({
  42 │   async *method(...x = []) {
@@ -18838,7 +18838,7 @@ Negative Passed: 4519/4519 (100.00%)
  68 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/object/method-definition/gen-meth-dflt-params-rest.js:71:14]
  70 │ 0, {
  71 │   *method(...x = []) {
@@ -19059,7 +19059,7 @@ Negative Passed: 4519/4519 (100.00%)
  64 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/expressions/object/method-definition/meth-dflt-params-rest.js:67:13]
  66 │ 0, {
  67 │   method(...x = []) {
@@ -25396,7 +25396,7 @@ Negative Passed: 4519/4519 (100.00%)
  38 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/async-function/dflt-params-rest.js:41:21]
  40 │ 
  41 │ async function f(...x = []) {
@@ -25631,7 +25631,7 @@ Negative Passed: 4519/4519 (100.00%)
  41 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/async-generator/dflt-params-rest.js:44:22]
  43 │ 
  44 │ async function* f(...x = []) {
@@ -25639,7 +25639,7 @@ Negative Passed: 4519/4519 (100.00%)
  45 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/async-generator/dstr/ary-ptrn-rest-init-ary.js:33:23]
  32 │ var callCount = 0;
  33 │ async function* f([...[ x ] = []]) {
@@ -25647,7 +25647,7 @@ Negative Passed: 4519/4519 (100.00%)
  34 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/async-generator/dstr/ary-ptrn-rest-init-id.js:33:23]
  32 │ var callCount = 0;
  33 │ async function* f([...x = []]) {
@@ -25655,7 +25655,7 @@ Negative Passed: 4519/4519 (100.00%)
  34 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/async-generator/dstr/ary-ptrn-rest-init-obj.js:33:23]
  32 │ var callCount = 0;
  33 │ async function* f([...{ x } = []]) {
@@ -25687,7 +25687,7 @@ Negative Passed: 4519/4519 (100.00%)
  34 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/async-generator/dstr/dflt-ary-ptrn-rest-init-ary.js:33:23]
  32 │ var callCount = 0;
  33 │ async function* f([...[ x ] = []] = []) {
@@ -25695,7 +25695,7 @@ Negative Passed: 4519/4519 (100.00%)
  34 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/async-generator/dstr/dflt-ary-ptrn-rest-init-id.js:33:23]
  32 │ var callCount = 0;
  33 │ async function* f([...x = []] = []) {
@@ -25703,7 +25703,7 @@ Negative Passed: 4519/4519 (100.00%)
  34 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/async-generator/dstr/dflt-ary-ptrn-rest-init-obj.js:33:23]
  32 │ var callCount = 0;
  33 │ async function* f([...{ x } = []] = []) {
@@ -26187,7 +26187,7 @@ Negative Passed: 4519/4519 (100.00%)
  64 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/async-gen-method/dflt-params-rest.js:67:20]
  66 │ class C {
  67 │   async *method(...x = []) {
@@ -26407,7 +26407,7 @@ Negative Passed: 4519/4519 (100.00%)
  65 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/async-gen-method-static/dflt-params-rest.js:68:27]
  67 │ class C {
  68 │   static async *method(...x = []) {
@@ -26635,7 +26635,7 @@ Negative Passed: 4519/4519 (100.00%)
  63 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/async-method/dflt-params-rest.js:66:19]
  65 │ class C {
  66 │   async method(...x = []) {
@@ -26749,7 +26749,7 @@ Negative Passed: 4519/4519 (100.00%)
  62 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/async-method-static/dflt-params-rest.js:65:26]
  64 │ class C {
  65 │   static async method(...x = []) {
@@ -27001,7 +27001,7 @@ Negative Passed: 4519/4519 (100.00%)
     ╰────
   help: Try insert a semicolon here
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-rest-init-ary.js:57:21]
  56 │ class C {
  57 │   async *method([...[ x ] = []]) {
@@ -27009,7 +27009,7 @@ Negative Passed: 4519/4519 (100.00%)
  58 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-rest-init-id.js:57:21]
  56 │ class C {
  57 │   async *method([...x = []]) {
@@ -27017,7 +27017,7 @@ Negative Passed: 4519/4519 (100.00%)
  58 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/async-gen-meth-ary-ptrn-rest-init-obj.js:57:21]
  56 │ class C {
  57 │   async *method([...{ x } = []]) {
@@ -27049,7 +27049,7 @@ Negative Passed: 4519/4519 (100.00%)
  58 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-ary.js:57:21]
  56 │ class C {
  57 │   async *method([...[ x ] = []] = []) {
@@ -27057,7 +27057,7 @@ Negative Passed: 4519/4519 (100.00%)
  58 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-id.js:57:21]
  56 │ class C {
  57 │   async *method([...x = []] = []) {
@@ -27065,7 +27065,7 @@ Negative Passed: 4519/4519 (100.00%)
  58 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/async-gen-meth-dflt-ary-ptrn-rest-init-obj.js:57:21]
  56 │ class C {
  57 │   async *method([...{ x } = []] = []) {
@@ -27097,7 +27097,7 @@ Negative Passed: 4519/4519 (100.00%)
  58 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-rest-init-ary.js:57:28]
  56 │ class C {
  57 │   static async *method([...[ x ] = []]) {
@@ -27105,7 +27105,7 @@ Negative Passed: 4519/4519 (100.00%)
  58 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-rest-init-id.js:57:28]
  56 │ class C {
  57 │   static async *method([...x = []]) {
@@ -27113,7 +27113,7 @@ Negative Passed: 4519/4519 (100.00%)
  58 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/async-gen-meth-static-ary-ptrn-rest-init-obj.js:57:28]
  56 │ class C {
  57 │   static async *method([...{ x } = []]) {
@@ -27145,7 +27145,7 @@ Negative Passed: 4519/4519 (100.00%)
  58 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-init-ary.js:57:28]
  56 │ class C {
  57 │   static async *method([...[ x ] = []] = []) {
@@ -27153,7 +27153,7 @@ Negative Passed: 4519/4519 (100.00%)
  58 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-init-id.js:57:28]
  56 │ class C {
  57 │   static async *method([...x = []] = []) {
@@ -27161,7 +27161,7 @@ Negative Passed: 4519/4519 (100.00%)
  58 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/async-gen-meth-static-dflt-ary-ptrn-rest-init-obj.js:57:28]
  56 │ class C {
  57 │   static async *method([...{ x } = []] = []) {
@@ -27193,7 +27193,7 @@ Negative Passed: 4519/4519 (100.00%)
  58 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-rest-init-ary.js:57:23]
  56 │ class C {
  57 │   async * #method([...[ x ] = []]) {
@@ -27201,7 +27201,7 @@ Negative Passed: 4519/4519 (100.00%)
  58 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-rest-init-id.js:57:23]
  56 │ class C {
  57 │   async * #method([...x = []]) {
@@ -27209,7 +27209,7 @@ Negative Passed: 4519/4519 (100.00%)
  58 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/async-private-gen-meth-ary-ptrn-rest-init-obj.js:57:23]
  56 │ class C {
  57 │   async * #method([...{ x } = []]) {
@@ -27241,7 +27241,7 @@ Negative Passed: 4519/4519 (100.00%)
  58 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-init-ary.js:57:23]
  56 │ class C {
  57 │   async * #method([...[ x ] = []] = []) {
@@ -27249,7 +27249,7 @@ Negative Passed: 4519/4519 (100.00%)
  58 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-init-id.js:57:23]
  56 │ class C {
  57 │   async * #method([...x = []] = []) {
@@ -27257,7 +27257,7 @@ Negative Passed: 4519/4519 (100.00%)
  58 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/async-private-gen-meth-dflt-ary-ptrn-rest-init-obj.js:57:23]
  56 │ class C {
  57 │   async * #method([...{ x } = []] = []) {
@@ -27289,7 +27289,7 @@ Negative Passed: 4519/4519 (100.00%)
  58 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-init-ary.js:57:30]
  56 │ class C {
  57 │   static async * #method([...[ x ] = []]) {
@@ -27297,7 +27297,7 @@ Negative Passed: 4519/4519 (100.00%)
  58 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-init-id.js:57:30]
  56 │ class C {
  57 │   static async * #method([...x = []]) {
@@ -27305,7 +27305,7 @@ Negative Passed: 4519/4519 (100.00%)
  58 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/async-private-gen-meth-static-ary-ptrn-rest-init-obj.js:57:30]
  56 │ class C {
  57 │   static async * #method([...{ x } = []]) {
@@ -27337,7 +27337,7 @@ Negative Passed: 4519/4519 (100.00%)
  58 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-init-ary.js:57:30]
  56 │ class C {
  57 │   static async * #method([...[ x ] = []] = []) {
@@ -27345,7 +27345,7 @@ Negative Passed: 4519/4519 (100.00%)
  58 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-init-id.js:57:30]
  56 │ class C {
  57 │   static async * #method([...x = []] = []) {
@@ -27353,7 +27353,7 @@ Negative Passed: 4519/4519 (100.00%)
  58 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/async-private-gen-meth-static-dflt-ary-ptrn-rest-init-obj.js:57:30]
  56 │ class C {
  57 │   static async * #method([...{ x } = []] = []) {
@@ -27385,7 +27385,7 @@ Negative Passed: 4519/4519 (100.00%)
  58 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/gen-meth-ary-ptrn-rest-init-ary.js:75:15]
  74 │ class C {
  75 │   *method([...[ x ] = []]) {
@@ -27393,7 +27393,7 @@ Negative Passed: 4519/4519 (100.00%)
  76 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/gen-meth-ary-ptrn-rest-init-id.js:75:15]
  74 │ class C {
  75 │   *method([...x = []]) {
@@ -27401,7 +27401,7 @@ Negative Passed: 4519/4519 (100.00%)
  76 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/gen-meth-ary-ptrn-rest-init-obj.js:75:15]
  74 │ class C {
  75 │   *method([...{ x } = []]) {
@@ -27433,7 +27433,7 @@ Negative Passed: 4519/4519 (100.00%)
  76 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/gen-meth-dflt-ary-ptrn-rest-init-ary.js:75:15]
  74 │ class C {
  75 │   *method([...[ x ] = []] = []) {
@@ -27441,7 +27441,7 @@ Negative Passed: 4519/4519 (100.00%)
  76 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/gen-meth-dflt-ary-ptrn-rest-init-id.js:75:15]
  74 │ class C {
  75 │   *method([...x = []] = []) {
@@ -27449,7 +27449,7 @@ Negative Passed: 4519/4519 (100.00%)
  76 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/gen-meth-dflt-ary-ptrn-rest-init-obj.js:75:15]
  74 │ class C {
  75 │   *method([...{ x } = []] = []) {
@@ -27481,7 +27481,7 @@ Negative Passed: 4519/4519 (100.00%)
  76 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/gen-meth-static-ary-ptrn-rest-init-ary.js:75:22]
  74 │ class C {
  75 │   static *method([...[ x ] = []]) {
@@ -27489,7 +27489,7 @@ Negative Passed: 4519/4519 (100.00%)
  76 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/gen-meth-static-ary-ptrn-rest-init-id.js:75:22]
  74 │ class C {
  75 │   static *method([...x = []]) {
@@ -27497,7 +27497,7 @@ Negative Passed: 4519/4519 (100.00%)
  76 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/gen-meth-static-ary-ptrn-rest-init-obj.js:75:22]
  74 │ class C {
  75 │   static *method([...{ x } = []]) {
@@ -27529,7 +27529,7 @@ Negative Passed: 4519/4519 (100.00%)
  76 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/gen-meth-static-dflt-ary-ptrn-rest-init-ary.js:75:22]
  74 │ class C {
  75 │   static *method([...[ x ] = []] = []) {
@@ -27537,7 +27537,7 @@ Negative Passed: 4519/4519 (100.00%)
  76 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/gen-meth-static-dflt-ary-ptrn-rest-init-id.js:75:22]
  74 │ class C {
  75 │   static *method([...x = []] = []) {
@@ -27545,7 +27545,7 @@ Negative Passed: 4519/4519 (100.00%)
  76 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/gen-meth-static-dflt-ary-ptrn-rest-init-obj.js:75:22]
  74 │ class C {
  75 │   static *method([...{ x } = []] = []) {
@@ -27577,7 +27577,7 @@ Negative Passed: 4519/4519 (100.00%)
  76 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/meth-ary-ptrn-rest-init-ary.js:73:14]
  72 │ class C {
  73 │   method([...[ x ] = []]) {
@@ -27585,7 +27585,7 @@ Negative Passed: 4519/4519 (100.00%)
  74 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/meth-ary-ptrn-rest-init-id.js:73:14]
  72 │ class C {
  73 │   method([...x = []]) {
@@ -27593,7 +27593,7 @@ Negative Passed: 4519/4519 (100.00%)
  74 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/meth-ary-ptrn-rest-init-obj.js:73:14]
  72 │ class C {
  73 │   method([...{ x } = []]) {
@@ -27625,7 +27625,7 @@ Negative Passed: 4519/4519 (100.00%)
  74 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/meth-dflt-ary-ptrn-rest-init-ary.js:73:14]
  72 │ class C {
  73 │   method([...[ x ] = []] = []) {
@@ -27633,7 +27633,7 @@ Negative Passed: 4519/4519 (100.00%)
  74 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/meth-dflt-ary-ptrn-rest-init-id.js:73:14]
  72 │ class C {
  73 │   method([...x = []] = []) {
@@ -27641,7 +27641,7 @@ Negative Passed: 4519/4519 (100.00%)
  74 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/meth-dflt-ary-ptrn-rest-init-obj.js:73:14]
  72 │ class C {
  73 │   method([...{ x } = []] = []) {
@@ -27673,7 +27673,7 @@ Negative Passed: 4519/4519 (100.00%)
  74 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/meth-static-ary-ptrn-rest-init-ary.js:73:21]
  72 │ class C {
  73 │   static method([...[ x ] = []]) {
@@ -27681,7 +27681,7 @@ Negative Passed: 4519/4519 (100.00%)
  74 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/meth-static-ary-ptrn-rest-init-id.js:73:21]
  72 │ class C {
  73 │   static method([...x = []]) {
@@ -27689,7 +27689,7 @@ Negative Passed: 4519/4519 (100.00%)
  74 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/meth-static-ary-ptrn-rest-init-obj.js:73:21]
  72 │ class C {
  73 │   static method([...{ x } = []]) {
@@ -27721,7 +27721,7 @@ Negative Passed: 4519/4519 (100.00%)
  74 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/meth-static-dflt-ary-ptrn-rest-init-ary.js:73:21]
  72 │ class C {
  73 │   static method([...[ x ] = []] = []) {
@@ -27729,7 +27729,7 @@ Negative Passed: 4519/4519 (100.00%)
  74 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/meth-static-dflt-ary-ptrn-rest-init-id.js:73:21]
  72 │ class C {
  73 │   static method([...x = []] = []) {
@@ -27737,7 +27737,7 @@ Negative Passed: 4519/4519 (100.00%)
  74 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/meth-static-dflt-ary-ptrn-rest-init-obj.js:73:21]
  72 │ class C {
  73 │   static method([...{ x } = []] = []) {
@@ -27769,7 +27769,7 @@ Negative Passed: 4519/4519 (100.00%)
  74 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/private-gen-meth-ary-ptrn-rest-init-ary.js:75:17]
  74 │ class C {
  75 │   * #method([...[ x ] = []]) {
@@ -27777,7 +27777,7 @@ Negative Passed: 4519/4519 (100.00%)
  76 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/private-gen-meth-ary-ptrn-rest-init-id.js:75:17]
  74 │ class C {
  75 │   * #method([...x = []]) {
@@ -27785,7 +27785,7 @@ Negative Passed: 4519/4519 (100.00%)
  76 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/private-gen-meth-ary-ptrn-rest-init-obj.js:75:17]
  74 │ class C {
  75 │   * #method([...{ x } = []]) {
@@ -27817,7 +27817,7 @@ Negative Passed: 4519/4519 (100.00%)
  76 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/private-gen-meth-dflt-ary-ptrn-rest-init-ary.js:75:17]
  74 │ class C {
  75 │   * #method([...[ x ] = []] = []) {
@@ -27825,7 +27825,7 @@ Negative Passed: 4519/4519 (100.00%)
  76 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/private-gen-meth-dflt-ary-ptrn-rest-init-id.js:75:17]
  74 │ class C {
  75 │   * #method([...x = []] = []) {
@@ -27833,7 +27833,7 @@ Negative Passed: 4519/4519 (100.00%)
  76 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/private-gen-meth-dflt-ary-ptrn-rest-init-obj.js:75:17]
  74 │ class C {
  75 │   * #method([...{ x } = []] = []) {
@@ -27865,7 +27865,7 @@ Negative Passed: 4519/4519 (100.00%)
  76 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/private-gen-meth-static-ary-ptrn-rest-init-ary.js:75:24]
  74 │ class C {
  75 │   static * #method([...[ x ] = []]) {
@@ -27873,7 +27873,7 @@ Negative Passed: 4519/4519 (100.00%)
  76 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/private-gen-meth-static-ary-ptrn-rest-init-id.js:75:24]
  74 │ class C {
  75 │   static * #method([...x = []]) {
@@ -27881,7 +27881,7 @@ Negative Passed: 4519/4519 (100.00%)
  76 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/private-gen-meth-static-ary-ptrn-rest-init-obj.js:75:24]
  74 │ class C {
  75 │   static * #method([...{ x } = []]) {
@@ -27913,7 +27913,7 @@ Negative Passed: 4519/4519 (100.00%)
  76 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/private-gen-meth-static-dflt-ary-ptrn-rest-init-ary.js:75:24]
  74 │ class C {
  75 │   static * #method([...[ x ] = []] = []) {
@@ -27921,7 +27921,7 @@ Negative Passed: 4519/4519 (100.00%)
  76 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/private-gen-meth-static-dflt-ary-ptrn-rest-init-id.js:75:24]
  74 │ class C {
  75 │   static * #method([...x = []] = []) {
@@ -27929,7 +27929,7 @@ Negative Passed: 4519/4519 (100.00%)
  76 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/private-gen-meth-static-dflt-ary-ptrn-rest-init-obj.js:75:24]
  74 │ class C {
  75 │   static * #method([...{ x } = []] = []) {
@@ -27961,7 +27961,7 @@ Negative Passed: 4519/4519 (100.00%)
  76 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/private-meth-ary-ptrn-rest-init-ary.js:73:15]
  72 │ class C {
  73 │   #method([...[ x ] = []]) {
@@ -27969,7 +27969,7 @@ Negative Passed: 4519/4519 (100.00%)
  74 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/private-meth-ary-ptrn-rest-init-id.js:73:15]
  72 │ class C {
  73 │   #method([...x = []]) {
@@ -27977,7 +27977,7 @@ Negative Passed: 4519/4519 (100.00%)
  74 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/private-meth-ary-ptrn-rest-init-obj.js:73:15]
  72 │ class C {
  73 │   #method([...{ x } = []]) {
@@ -28009,7 +28009,7 @@ Negative Passed: 4519/4519 (100.00%)
  74 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/private-meth-dflt-ary-ptrn-rest-init-ary.js:73:15]
  72 │ class C {
  73 │   #method([...[ x ] = []] = []) {
@@ -28017,7 +28017,7 @@ Negative Passed: 4519/4519 (100.00%)
  74 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/private-meth-dflt-ary-ptrn-rest-init-id.js:73:15]
  72 │ class C {
  73 │   #method([...x = []] = []) {
@@ -28025,7 +28025,7 @@ Negative Passed: 4519/4519 (100.00%)
  74 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/private-meth-dflt-ary-ptrn-rest-init-obj.js:73:15]
  72 │ class C {
  73 │   #method([...{ x } = []] = []) {
@@ -28057,7 +28057,7 @@ Negative Passed: 4519/4519 (100.00%)
  74 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/private-meth-static-ary-ptrn-rest-init-ary.js:73:22]
  72 │ class C {
  73 │   static #method([...[ x ] = []]) {
@@ -28065,7 +28065,7 @@ Negative Passed: 4519/4519 (100.00%)
  74 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/private-meth-static-ary-ptrn-rest-init-id.js:73:22]
  72 │ class C {
  73 │   static #method([...x = []]) {
@@ -28073,7 +28073,7 @@ Negative Passed: 4519/4519 (100.00%)
  74 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/private-meth-static-ary-ptrn-rest-init-obj.js:73:22]
  72 │ class C {
  73 │   static #method([...{ x } = []]) {
@@ -28105,7 +28105,7 @@ Negative Passed: 4519/4519 (100.00%)
  74 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/private-meth-static-dflt-ary-ptrn-rest-init-ary.js:73:22]
  72 │ class C {
  73 │   static #method([...[ x ] = []] = []) {
@@ -28113,7 +28113,7 @@ Negative Passed: 4519/4519 (100.00%)
  74 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/private-meth-static-dflt-ary-ptrn-rest-init-id.js:73:22]
  72 │ class C {
  73 │   static #method([...x = []] = []) {
@@ -28121,7 +28121,7 @@ Negative Passed: 4519/4519 (100.00%)
  74 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/dstr/private-meth-static-dflt-ary-ptrn-rest-init-obj.js:73:22]
  72 │ class C {
  73 │   static #method([...{ x } = []] = []) {
@@ -31973,7 +31973,7 @@ Negative Passed: 4519/4519 (100.00%)
  84 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/gen-method/dflt-params-rest.js:87:14]
  86 │ class C {
  87 │   *method(...x = []) {
@@ -32138,7 +32138,7 @@ Negative Passed: 4519/4519 (100.00%)
  84 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/gen-method-static/dflt-params-rest.js:87:21]
  86 │ class C {
  87 │   static *method(...x = []) {
@@ -32301,7 +32301,7 @@ Negative Passed: 4519/4519 (100.00%)
  81 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/method/dflt-params-rest.js:84:13]
  83 │ class C {
  84 │   method(...x = []) {
@@ -32359,7 +32359,7 @@ Negative Passed: 4519/4519 (100.00%)
  81 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/class/method-static/dflt-params-rest.js:84:20]
  83 │ class C {
  84 │   static method(...x = []) {
@@ -32593,7 +32593,7 @@ Negative Passed: 4519/4519 (100.00%)
  26 │ }
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/const/dstr/ary-ptrn-rest-init-ary.js:31:11]
  30 │ 
  31 │ const [...[ x ] = []] = [];
@@ -32601,7 +32601,7 @@ Negative Passed: 4519/4519 (100.00%)
  32 │ 
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/const/dstr/ary-ptrn-rest-init-id.js:31:11]
  30 │ 
  31 │ const [...x = []] = [];
@@ -32609,7 +32609,7 @@ Negative Passed: 4519/4519 (100.00%)
  32 │ 
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/const/dstr/ary-ptrn-rest-init-obj.js:31:11]
  30 │ 
  31 │ const [...{ x } = []] = [];
@@ -33372,7 +33372,7 @@ Negative Passed: 4519/4519 (100.00%)
     ╰────
   help: Try insert a semicolon here
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for/dstr/const-ary-ptrn-rest-init-ary.js:52:16]
  51 │ 
  52 │ for (const [...[ x ] = []] = []; iterCount < 1; ) {
@@ -33380,7 +33380,7 @@ Negative Passed: 4519/4519 (100.00%)
  53 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for/dstr/const-ary-ptrn-rest-init-id.js:52:16]
  51 │ 
  52 │ for (const [...x = []] = []; iterCount < 1; ) {
@@ -33388,7 +33388,7 @@ Negative Passed: 4519/4519 (100.00%)
  53 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for/dstr/const-ary-ptrn-rest-init-obj.js:52:16]
  51 │ 
  52 │ for (const [...{ x } = []] = []; iterCount < 1; ) {
@@ -33420,7 +33420,7 @@ Negative Passed: 4519/4519 (100.00%)
  53 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for/dstr/let-ary-ptrn-rest-init-ary.js:52:14]
  51 │ 
  52 │ for (let [...[ x ] = []] = []; iterCount < 1; ) {
@@ -33428,7 +33428,7 @@ Negative Passed: 4519/4519 (100.00%)
  53 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for/dstr/let-ary-ptrn-rest-init-id.js:52:14]
  51 │ 
  52 │ for (let [...x = []] = []; iterCount < 1; ) {
@@ -33436,7 +33436,7 @@ Negative Passed: 4519/4519 (100.00%)
  53 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for/dstr/let-ary-ptrn-rest-init-obj.js:52:14]
  51 │ 
  52 │ for (let [...{ x } = []] = []; iterCount < 1; ) {
@@ -33468,7 +33468,7 @@ Negative Passed: 4519/4519 (100.00%)
  53 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for/dstr/var-ary-ptrn-rest-init-ary.js:46:14]
  45 │ 
  46 │ for (var [...[ x ] = []] = []; iterCount < 1; ) {
@@ -33476,7 +33476,7 @@ Negative Passed: 4519/4519 (100.00%)
  47 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for/dstr/var-ary-ptrn-rest-init-id.js:46:14]
  45 │ 
  46 │ for (var [...x = []] = []; iterCount < 1; ) {
@@ -33484,7 +33484,7 @@ Negative Passed: 4519/4519 (100.00%)
  47 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for/dstr/var-ary-ptrn-rest-init-obj.js:46:14]
  45 │ 
  46 │ for (var [...{ x } = []] = []; iterCount < 1; ) {
@@ -33636,7 +33636,7 @@ Negative Passed: 4519/4519 (100.00%)
  35 │ }
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-init-ary.js:53:24]
  52 │ async function fn() {
  53 │   for await (const [...[ x ] = []] of [[]]) {
@@ -33644,7 +33644,7 @@ Negative Passed: 4519/4519 (100.00%)
  54 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-init-id.js:53:24]
  52 │ async function fn() {
  53 │   for await (const [...x = []] of [[]]) {
@@ -33652,7 +33652,7 @@ Negative Passed: 4519/4519 (100.00%)
  54 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-func-dstr-const-ary-ptrn-rest-init-obj.js:53:24]
  52 │ async function fn() {
  53 │   for await (const [...{ x } = []] of [[]]) {
@@ -33684,7 +33684,7 @@ Negative Passed: 4519/4519 (100.00%)
  54 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-init-ary.js:56:24]
  55 │ async function fn() {
  56 │   for await (const [...[ x ] = []] of asyncIter) {
@@ -33692,7 +33692,7 @@ Negative Passed: 4519/4519 (100.00%)
  57 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-init-id.js:56:24]
  55 │ async function fn() {
  56 │   for await (const [...x = []] of asyncIter) {
@@ -33700,7 +33700,7 @@ Negative Passed: 4519/4519 (100.00%)
  57 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-func-dstr-const-async-ary-ptrn-rest-init-obj.js:56:24]
  55 │ async function fn() {
  56 │   for await (const [...{ x } = []] of asyncIter) {
@@ -33732,7 +33732,7 @@ Negative Passed: 4519/4519 (100.00%)
  57 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-init-ary.js:53:22]
  52 │ async function fn() {
  53 │   for await (let [...[ x ] = []] of [[]]) {
@@ -33740,7 +33740,7 @@ Negative Passed: 4519/4519 (100.00%)
  54 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-init-id.js:53:22]
  52 │ async function fn() {
  53 │   for await (let [...x = []] of [[]]) {
@@ -33748,7 +33748,7 @@ Negative Passed: 4519/4519 (100.00%)
  54 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-func-dstr-let-ary-ptrn-rest-init-obj.js:53:22]
  52 │ async function fn() {
  53 │   for await (let [...{ x } = []] of [[]]) {
@@ -33780,7 +33780,7 @@ Negative Passed: 4519/4519 (100.00%)
  54 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-init-ary.js:56:22]
  55 │ async function fn() {
  56 │   for await (let [...[ x ] = []] of asyncIter) {
@@ -33788,7 +33788,7 @@ Negative Passed: 4519/4519 (100.00%)
  57 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-init-id.js:56:22]
  55 │ async function fn() {
  56 │   for await (let [...x = []] of asyncIter) {
@@ -33796,7 +33796,7 @@ Negative Passed: 4519/4519 (100.00%)
  57 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-func-dstr-let-async-ary-ptrn-rest-init-obj.js:56:22]
  55 │ async function fn() {
  56 │   for await (let [...{ x } = []] of asyncIter) {
@@ -33828,7 +33828,7 @@ Negative Passed: 4519/4519 (100.00%)
  57 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-init-ary.js:50:22]
  49 │ async function fn() {
  50 │   for await (var [...[ x ] = []] of [[]]) {
@@ -33836,7 +33836,7 @@ Negative Passed: 4519/4519 (100.00%)
  51 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-init-id.js:50:22]
  49 │ async function fn() {
  50 │   for await (var [...x = []] of [[]]) {
@@ -33844,7 +33844,7 @@ Negative Passed: 4519/4519 (100.00%)
  51 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-func-dstr-var-ary-ptrn-rest-init-obj.js:50:22]
  49 │ async function fn() {
  50 │   for await (var [...{ x } = []] of [[]]) {
@@ -33876,7 +33876,7 @@ Negative Passed: 4519/4519 (100.00%)
  51 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-init-ary.js:56:22]
  55 │ async function fn() {
  56 │   for await (var [...[ x ] = []] of asyncIter) {
@@ -33884,7 +33884,7 @@ Negative Passed: 4519/4519 (100.00%)
  57 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-init-id.js:56:22]
  55 │ async function fn() {
  56 │   for await (var [...x = []] of asyncIter) {
@@ -33892,7 +33892,7 @@ Negative Passed: 4519/4519 (100.00%)
  57 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-func-dstr-var-async-ary-ptrn-rest-init-obj.js:56:22]
  55 │ async function fn() {
  56 │   for await (var [...{ x } = []] of asyncIter) {
@@ -33932,7 +33932,7 @@ Negative Passed: 4519/4519 (100.00%)
  21 │ }
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-init-ary.js:53:24]
  52 │ async function *fn() {
  53 │   for await (const [...[ x ] = []] of [[]]) {
@@ -33940,7 +33940,7 @@ Negative Passed: 4519/4519 (100.00%)
  54 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-init-id.js:53:24]
  52 │ async function *fn() {
  53 │   for await (const [...x = []] of [[]]) {
@@ -33948,7 +33948,7 @@ Negative Passed: 4519/4519 (100.00%)
  54 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-gen-dstr-const-ary-ptrn-rest-init-obj.js:53:24]
  52 │ async function *fn() {
  53 │   for await (const [...{ x } = []] of [[]]) {
@@ -33980,7 +33980,7 @@ Negative Passed: 4519/4519 (100.00%)
  54 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-init-ary.js:56:24]
  55 │ async function *fn() {
  56 │   for await (const [...[ x ] = []] of asyncIter) {
@@ -33988,7 +33988,7 @@ Negative Passed: 4519/4519 (100.00%)
  57 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-init-id.js:56:24]
  55 │ async function *fn() {
  56 │   for await (const [...x = []] of asyncIter) {
@@ -33996,7 +33996,7 @@ Negative Passed: 4519/4519 (100.00%)
  57 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-gen-dstr-const-async-ary-ptrn-rest-init-obj.js:56:24]
  55 │ async function *fn() {
  56 │   for await (const [...{ x } = []] of asyncIter) {
@@ -34044,7 +34044,7 @@ Negative Passed: 4519/4519 (100.00%)
  21 │ }
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-init-ary.js:53:22]
  52 │ async function *fn() {
  53 │   for await (let [...[ x ] = []] of [[]]) {
@@ -34052,7 +34052,7 @@ Negative Passed: 4519/4519 (100.00%)
  54 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-init-id.js:53:22]
  52 │ async function *fn() {
  53 │   for await (let [...x = []] of [[]]) {
@@ -34060,7 +34060,7 @@ Negative Passed: 4519/4519 (100.00%)
  54 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-gen-dstr-let-ary-ptrn-rest-init-obj.js:53:22]
  52 │ async function *fn() {
  53 │   for await (let [...{ x } = []] of [[]]) {
@@ -34092,7 +34092,7 @@ Negative Passed: 4519/4519 (100.00%)
  54 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-init-ary.js:56:22]
  55 │ async function *fn() {
  56 │   for await (let [...[ x ] = []] of asyncIter) {
@@ -34100,7 +34100,7 @@ Negative Passed: 4519/4519 (100.00%)
  57 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-init-id.js:56:22]
  55 │ async function *fn() {
  56 │   for await (let [...x = []] of asyncIter) {
@@ -34108,7 +34108,7 @@ Negative Passed: 4519/4519 (100.00%)
  57 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-gen-dstr-let-async-ary-ptrn-rest-init-obj.js:56:22]
  55 │ async function *fn() {
  56 │   for await (let [...{ x } = []] of asyncIter) {
@@ -34156,7 +34156,7 @@ Negative Passed: 4519/4519 (100.00%)
  21 │ }
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-init-ary.js:50:22]
  49 │ async function *fn() {
  50 │   for await (var [...[ x ] = []] of [[]]) {
@@ -34164,7 +34164,7 @@ Negative Passed: 4519/4519 (100.00%)
  51 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-init-id.js:50:22]
  49 │ async function *fn() {
  50 │   for await (var [...x = []] of [[]]) {
@@ -34172,7 +34172,7 @@ Negative Passed: 4519/4519 (100.00%)
  51 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-gen-dstr-var-ary-ptrn-rest-init-obj.js:50:22]
  49 │ async function *fn() {
  50 │   for await (var [...{ x } = []] of [[]]) {
@@ -34204,7 +34204,7 @@ Negative Passed: 4519/4519 (100.00%)
  51 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-init-ary.js:56:22]
  55 │ async function *fn() {
  56 │   for await (var [...[ x ] = []] of asyncIter) {
@@ -34212,7 +34212,7 @@ Negative Passed: 4519/4519 (100.00%)
  57 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-init-id.js:56:22]
  55 │ async function *fn() {
  56 │   for await (var [...x = []] of asyncIter) {
@@ -34220,7 +34220,7 @@ Negative Passed: 4519/4519 (100.00%)
  57 │     
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-await-of/async-gen-dstr-var-async-ary-ptrn-rest-init-obj.js:56:22]
  55 │ async function *fn() {
  56 │   for await (var [...{ x } = []] of asyncIter) {
@@ -35036,7 +35036,7 @@ Negative Passed: 4519/4519 (100.00%)
     ·      ─────────────
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-of/dstr/const-ary-ptrn-rest-init-ary.js:52:16]
  51 │ 
  52 │ for (const [...[ x ] = []] of [[]]) {
@@ -35044,7 +35044,7 @@ Negative Passed: 4519/4519 (100.00%)
  53 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-of/dstr/const-ary-ptrn-rest-init-id.js:52:16]
  51 │ 
  52 │ for (const [...x = []] of [[]]) {
@@ -35052,7 +35052,7 @@ Negative Passed: 4519/4519 (100.00%)
  53 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-of/dstr/const-ary-ptrn-rest-init-obj.js:52:16]
  51 │ 
  52 │ for (const [...{ x } = []] of [[]]) {
@@ -35098,7 +35098,7 @@ Negative Passed: 4519/4519 (100.00%)
     ·      ───────────
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-of/dstr/let-ary-ptrn-rest-init-ary.js:52:14]
  51 │ 
  52 │ for (let [...[ x ] = []] of [[]]) {
@@ -35106,7 +35106,7 @@ Negative Passed: 4519/4519 (100.00%)
  53 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-of/dstr/let-ary-ptrn-rest-init-id.js:52:14]
  51 │ 
  52 │ for (let [...x = []] of [[]]) {
@@ -35114,7 +35114,7 @@ Negative Passed: 4519/4519 (100.00%)
  53 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-of/dstr/let-ary-ptrn-rest-init-obj.js:52:14]
  51 │ 
  52 │ for (let [...{ x } = []] of [[]]) {
@@ -35263,7 +35263,7 @@ Negative Passed: 4519/4519 (100.00%)
     ·      ───────────
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-of/dstr/var-ary-ptrn-rest-init-ary.js:49:14]
  48 │ 
  49 │ for (var [...[ x ] = []] of [[]]) {
@@ -35271,7 +35271,7 @@ Negative Passed: 4519/4519 (100.00%)
  50 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-of/dstr/var-ary-ptrn-rest-init-id.js:49:14]
  48 │ 
  49 │ for (var [...x = []] of [[]]) {
@@ -35279,7 +35279,7 @@ Negative Passed: 4519/4519 (100.00%)
  50 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/for-of/dstr/var-ary-ptrn-rest-init-obj.js:49:14]
  48 │ 
  49 │ for (var [...{ x } = []] of [[]]) {
@@ -35594,7 +35594,7 @@ Negative Passed: 4519/4519 (100.00%)
  62 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/function/dflt-params-rest.js:65:15]
  64 │ 
  65 │ function f(...x = []) {
@@ -35602,7 +35602,7 @@ Negative Passed: 4519/4519 (100.00%)
  66 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/function/dstr/ary-ptrn-rest-init-ary.js:54:16]
  53 │ var callCount = 0;
  54 │ function f([...[ x ] = []]) {
@@ -35610,7 +35610,7 @@ Negative Passed: 4519/4519 (100.00%)
  55 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/function/dstr/ary-ptrn-rest-init-id.js:54:16]
  53 │ var callCount = 0;
  54 │ function f([...x = []]) {
@@ -35618,7 +35618,7 @@ Negative Passed: 4519/4519 (100.00%)
  55 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/function/dstr/ary-ptrn-rest-init-obj.js:54:16]
  53 │ var callCount = 0;
  54 │ function f([...{ x } = []]) {
@@ -35650,7 +35650,7 @@ Negative Passed: 4519/4519 (100.00%)
  55 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/function/dstr/dflt-ary-ptrn-rest-init-ary.js:54:16]
  53 │ var callCount = 0;
  54 │ function f([...[ x ] = []] = []) {
@@ -35658,7 +35658,7 @@ Negative Passed: 4519/4519 (100.00%)
  55 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/function/dstr/dflt-ary-ptrn-rest-init-id.js:54:16]
  53 │ var callCount = 0;
  54 │ function f([...x = []] = []) {
@@ -35666,7 +35666,7 @@ Negative Passed: 4519/4519 (100.00%)
  55 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/function/dstr/dflt-ary-ptrn-rest-init-obj.js:54:16]
  53 │ var callCount = 0;
  54 │ function f([...{ x } = []] = []) {
@@ -36027,7 +36027,7 @@ Negative Passed: 4519/4519 (100.00%)
  62 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/generators/dflt-params-rest.js:65:16]
  64 │ 
  65 │ function* f(...x = []) {
@@ -36035,7 +36035,7 @@ Negative Passed: 4519/4519 (100.00%)
  66 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/generators/dstr/ary-ptrn-rest-init-ary.js:53:17]
  52 │ var callCount = 0;
  53 │ function* f([...[ x ] = []]) {
@@ -36043,7 +36043,7 @@ Negative Passed: 4519/4519 (100.00%)
  54 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/generators/dstr/ary-ptrn-rest-init-id.js:53:17]
  52 │ var callCount = 0;
  53 │ function* f([...x = []]) {
@@ -36051,7 +36051,7 @@ Negative Passed: 4519/4519 (100.00%)
  54 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/generators/dstr/ary-ptrn-rest-init-obj.js:53:17]
  52 │ var callCount = 0;
  53 │ function* f([...{ x } = []]) {
@@ -36083,7 +36083,7 @@ Negative Passed: 4519/4519 (100.00%)
  54 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/generators/dstr/dflt-ary-ptrn-rest-init-ary.js:53:17]
  52 │ var callCount = 0;
  53 │ function* f([...[ x ] = []] = []) {
@@ -36091,7 +36091,7 @@ Negative Passed: 4519/4519 (100.00%)
  54 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/generators/dstr/dflt-ary-ptrn-rest-init-id.js:53:17]
  52 │ var callCount = 0;
  53 │ function* f([...x = []] = []) {
@@ -36099,7 +36099,7 @@ Negative Passed: 4519/4519 (100.00%)
  54 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/generators/dstr/dflt-ary-ptrn-rest-init-obj.js:53:17]
  52 │ var callCount = 0;
  53 │ function* f([...{ x } = []] = []) {
@@ -36946,7 +36946,7 @@ Negative Passed: 4519/4519 (100.00%)
     · ─────
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/let/dstr/ary-ptrn-rest-init-ary.js:31:9]
  30 │ 
  31 │ let [...[ x ] = []] = [];
@@ -36954,7 +36954,7 @@ Negative Passed: 4519/4519 (100.00%)
  32 │ 
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/let/dstr/ary-ptrn-rest-init-id.js:31:9]
  30 │ 
  31 │ let [...x = []] = [];
@@ -36962,7 +36962,7 @@ Negative Passed: 4519/4519 (100.00%)
  32 │ 
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/let/dstr/ary-ptrn-rest-init-obj.js:31:9]
  30 │ 
  31 │ let [...{ x } = []] = [];
@@ -38017,7 +38017,7 @@ Negative Passed: 4519/4519 (100.00%)
     ·                ────
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/try/dstr/ary-ptrn-rest-init-ary.js:33:14]
  32 │   throw [];
  33 │ } catch ([...[ x ] = []]) {
@@ -38025,7 +38025,7 @@ Negative Passed: 4519/4519 (100.00%)
  34 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/try/dstr/ary-ptrn-rest-init-id.js:33:14]
  32 │   throw [];
  33 │ } catch ([...x = []]) {
@@ -38033,7 +38033,7 @@ Negative Passed: 4519/4519 (100.00%)
  34 │   
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/try/dstr/ary-ptrn-rest-init-obj.js:33:14]
  32 │   throw [];
  33 │ } catch ([...{ x } = []]) {
@@ -38362,7 +38362,7 @@ Negative Passed: 4519/4519 (100.00%)
  26 │   }
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/variable/dstr/ary-ptrn-rest-init-ary.js:30:9]
  29 │ 
  30 │ var [...[ x ] = []] = [];
@@ -38370,7 +38370,7 @@ Negative Passed: 4519/4519 (100.00%)
  31 │ 
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/variable/dstr/ary-ptrn-rest-init-id.js:30:9]
  29 │ 
  30 │ var [...x = []] = [];
@@ -38378,7 +38378,7 @@ Negative Passed: 4519/4519 (100.00%)
  31 │ 
     ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
     ╭─[test262/test/language/statements/variable/dstr/ary-ptrn-rest-init-obj.js:30:9]
  29 │ 
  30 │ var [...{ x } = []] = [];

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -8194,19 +8194,19 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │ (...arg) => 103;
    ╰────
 
-  × A required parameter cannot follow an optional parameter.
-   ╭─[typescript/tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors1.ts:1:9]
- 1 │ (arg1?, arg2) => 101;
-   ·         ────
- 2 │ (...arg?) => 102;
-   ╰────
-
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
    ╭─[typescript/tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors1.ts:4:5]
  3 │ (...arg) => 103;
  4 │ (...arg:number [] = []) => 104;
    ·     ──────────────────
  5 │ 
+   ╰────
+
+  × A required parameter cannot follow an optional parameter.
+   ╭─[typescript/tests/cases/compiler/fatarrowfunctionsOptionalArgsErrors1.ts:1:9]
+ 1 │ (arg1?, arg2) => 101;
+   ·         ────
+ 2 │ (...arg?) => 102;
    ╰────
 
   × Expected a semicolon or an implicit semicolon after a statement, but found none
@@ -11890,7 +11890,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  2 │ function f2(...x = []) { }
    ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
    ╭─[typescript/tests/cases/compiler/restParamAsOptional.ts:2:16]
  1 │ function f(...x?) { }
  2 │ function f2(...x = []) { }
@@ -11920,19 +11920,19 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·            ────
    ╰────
 
-  × TS(2566): A rest element cannot have a property name.
-   ╭─[typescript/tests/cases/compiler/restParameterWithBindingPattern3.ts:9:46]
- 8 │ 
- 9 │ function e(...{0: a = 1, 1: b = true, ...rest: rest}: [boolean, string, number]) { }
-   ·                                              ──────
-   ╰────
-
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
    ╭─[typescript/tests/cases/compiler/restParameterWithBindingPattern3.ts:3:19]
  2 │ 
  3 │ function b(...[...foo = []]: string[]) { }
    ·                   ────────
  4 │ 
+   ╰────
+
+  × TS(2566): A rest element cannot have a property name.
+   ╭─[typescript/tests/cases/compiler/restParameterWithBindingPattern3.ts:9:46]
+ 8 │ 
+ 9 │ function e(...{0: a = 1, 1: b = true, ...rest: rest}: [boolean, string, number]) { }
+   ·                                              ──────
    ╰────
 
   × Identifier `v` has already been declared
@@ -16708,6 +16708,14 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  15 │ function a4(...b = [1,2,3]) { }   // Error, can't have initializer
     ╰────
 
+  × A rest element cannot have an initializer.
+    ╭─[typescript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration4.ts:15:16]
+ 14 │ function a3(...b?) { }            // Error, can't be optional
+ 15 │ function a4(...b = [1,2,3]) { }   // Error, can't have initializer
+    ·                ───────────
+ 16 │ function a5([a, b, [[c]]]) { }
+    ╰────
+
   × Unexpected token
     ╭─[typescript/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration4.ts:29:24]
  28 │ class C {
@@ -16974,7 +16982,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·                ─────
    ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
    ╭─[typescript/tests/cases/conformance/es6/destructuring/restElementWithInitializer1.ts:2:9]
  1 │ var a: number[];
  2 │ var [...x = a] = a;  // Error, rest element cannot have initializer
@@ -22341,7 +22349,7 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │ }
    ╰────
 
-  × A rest parameter cannot have an initializer
+  × A rest element cannot have an initializer.
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList10.ts:2:11]
  1 │ class C {
  2 │    foo(...bar = 0) { }


### PR DESCRIPTION
```js
function b(...[...foo = []]: string[]) { }
                      ^^^^
```