### PR TITLE
fix(ast/estree): serialize class constructor key as `Identifier` in TS-ESTree AST

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -2040,6 +2040,7 @@ pub struct MethodDefinition<'a> {
     pub r#type: MethodDefinitionType,
     #[ts]
     pub decorators: Vec<'a, Decorator<'a>>,
+    #[estree(via = MethodDefinitionKey)]
     pub key: PropertyKey<'a>,
     #[visit(args(flags = match self.kind {
         MethodDefinitionKind::Get => ScopeFlags::Function | ScopeFlags::GetAccessor,

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1514,7 +1514,7 @@ impl ESTree for MethodDefinition<'_> {
         state.serialize_field("end", &self.span.end);
         state.serialize_field("static", &self.r#static);
         state.serialize_field("computed", &self.computed);
-        state.serialize_field("key", &self.key);
+        state.serialize_field("key", &crate::serialize::MethodDefinitionKey(self));
         state.serialize_field("kind", &self.kind);
         state.serialize_field("value", &self.value);
         state.serialize_ts_field("decorators", &self.decorators);

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -932,14 +932,27 @@ function deserializeClassBody(pos) {
 }
 
 function deserializeMethodDefinition(pos) {
+  const kind = deserializeMethodDefinitionKind(pos + 72);
+  let key = deserializePropertyKey(pos + 48);
+  if (kind === 'constructor') {
+    key = {
+      type: 'Identifier',
+      start: key.start,
+      end: key.end,
+      name: 'constructor',
+      decorators: [],
+      optional: false,
+      typeAnnotation: null,
+    };
+  }
   return {
     type: deserializeMethodDefinitionType(pos + 8),
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     static: deserializeBool(pos + 74),
     computed: deserializeBool(pos + 73),
-    key: deserializePropertyKey(pos + 48),
-    kind: deserializeMethodDefinitionKind(pos + 72),
+    key,
+    kind,
     value: deserializeBoxFunction(pos + 64),
     decorators: deserializeVecDecorator(pos + 16),
     override: deserializeBool(pos + 75),

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -2,7 +2,7 @@ commit: 15392346
 
 estree_typescript Summary:
 AST Parsed     : 10619/10725 (99.01%)
-Positive Passed: 9037/10725 (84.26%)
+Positive Passed: 9038/10725 (84.27%)
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/ClassDeclarationWithInvalidConstOnPropertyDeclaration.ts
 A class member cannot have the 'const' keyword.
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/accessOverriddenBaseClassMember1.ts
@@ -1055,7 +1055,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorD
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorParameters/readonlyReadonly.ts
 readonly' modifier already seen.
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/constructorWithExpressionLessReturn.ts
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/quotedConstructors.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/superCalls/derivedClassParameterProperties.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/superCalls/derivedClassSuperCallsWithThisArg.ts
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/constructorDeclarations/superCalls/derivedClassSuperStatementPosition.ts


### PR DESCRIPTION
Part of #9705. Align with TS-ESTree for `class C { "constructor"() {} }`.

I think this is a bug in TS-ESLint, but for the moment, we follow their behavior.
https://github.com/typescript-eslint/typescript-eslint/issues/11084
