### PR TITLE
refactor(ast)!: move `type_parameters` field to before `extends` in `TSInterfaceDeclaration`

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -927,11 +927,11 @@ pub struct TSInterfaceDeclaration<'a> {
     pub span: Span,
     /// The identifier (name) of the interface.
     pub id: BindingIdentifier<'a>,
-    /// Other interfaces/types this interface extends.
-    #[scope(enter_before)]
-    pub extends: Vec<'a, TSInterfaceHeritage<'a>>,
     /// Type parameters that get bound to the interface.
+    #[scope(enter_before)]
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
+    /// Other interfaces/types this interface extends.
+    pub extends: Vec<'a, TSInterfaceHeritage<'a>>,
     pub body: Box<'a, TSInterfaceBody<'a>>,
     /// `true` for `declare interface Foo {}`
     pub declare: bool,

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -1130,8 +1130,8 @@ const _: () = {
     assert!(align_of::<TSInterfaceDeclaration>() == 8);
     assert!(offset_of!(TSInterfaceDeclaration, span) == 0);
     assert!(offset_of!(TSInterfaceDeclaration, id) == 8);
-    assert!(offset_of!(TSInterfaceDeclaration, extends) == 40);
-    assert!(offset_of!(TSInterfaceDeclaration, type_parameters) == 72);
+    assert!(offset_of!(TSInterfaceDeclaration, type_parameters) == 40);
+    assert!(offset_of!(TSInterfaceDeclaration, extends) == 48);
     assert!(offset_of!(TSInterfaceDeclaration, body) == 80);
     assert!(offset_of!(TSInterfaceDeclaration, declare) == 88);
     assert!(offset_of!(TSInterfaceDeclaration, scope_id) == 92);
@@ -2523,8 +2523,8 @@ const _: () = {
     assert!(align_of::<TSInterfaceDeclaration>() == 4);
     assert!(offset_of!(TSInterfaceDeclaration, span) == 0);
     assert!(offset_of!(TSInterfaceDeclaration, id) == 8);
-    assert!(offset_of!(TSInterfaceDeclaration, extends) == 28);
-    assert!(offset_of!(TSInterfaceDeclaration, type_parameters) == 44);
+    assert!(offset_of!(TSInterfaceDeclaration, type_parameters) == 28);
+    assert!(offset_of!(TSInterfaceDeclaration, extends) == 32);
     assert!(offset_of!(TSInterfaceDeclaration, body) == 48);
     assert!(offset_of!(TSInterfaceDeclaration, declare) == 52);
     assert!(offset_of!(TSInterfaceDeclaration, scope_id) == 56);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -4128,8 +4128,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `id`: The identifier (name) of the interface.
-    /// * `extends`: Other interfaces/types this interface extends.
     /// * `type_parameters`: Type parameters that get bound to the interface.
+    /// * `extends`: Other interfaces/types this interface extends.
     /// * `body`
     /// * `declare`: `true` for `declare interface Foo {}`
     #[inline]
@@ -4137,8 +4137,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         id: BindingIdentifier<'a>,
-        extends: Vec<'a, TSInterfaceHeritage<'a>>,
         type_parameters: T1,
+        extends: Vec<'a, TSInterfaceHeritage<'a>>,
         body: T2,
         declare: bool,
     ) -> Declaration<'a>
@@ -4149,8 +4149,8 @@ impl<'a> AstBuilder<'a> {
         Declaration::TSInterfaceDeclaration(self.alloc_ts_interface_declaration(
             span,
             id,
-            extends,
             type_parameters,
+            extends,
             body,
             declare,
         ))
@@ -4163,8 +4163,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `id`: The identifier (name) of the interface.
-    /// * `extends`: Other interfaces/types this interface extends.
     /// * `type_parameters`: Type parameters that get bound to the interface.
+    /// * `extends`: Other interfaces/types this interface extends.
     /// * `body`
     /// * `declare`: `true` for `declare interface Foo {}`
     /// * `scope_id`
@@ -4173,8 +4173,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         id: BindingIdentifier<'a>,
-        extends: Vec<'a, TSInterfaceHeritage<'a>>,
         type_parameters: T1,
+        extends: Vec<'a, TSInterfaceHeritage<'a>>,
         body: T2,
         declare: bool,
         scope_id: ScopeId,
@@ -4186,8 +4186,8 @@ impl<'a> AstBuilder<'a> {
         Declaration::TSInterfaceDeclaration(self.alloc_ts_interface_declaration_with_scope_id(
             span,
             id,
-            extends,
             type_parameters,
+            extends,
             body,
             declare,
             scope_id,
@@ -8132,8 +8132,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `id`: The identifier (name) of the interface.
-    /// * `extends`: Other interfaces/types this interface extends.
     /// * `type_parameters`: Type parameters that get bound to the interface.
+    /// * `extends`: Other interfaces/types this interface extends.
     /// * `body`
     /// * `declare`: `true` for `declare interface Foo {}`
     #[inline]
@@ -8141,8 +8141,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         id: BindingIdentifier<'a>,
-        extends: Vec<'a, TSInterfaceHeritage<'a>>,
         type_parameters: T1,
+        extends: Vec<'a, TSInterfaceHeritage<'a>>,
         body: T2,
         declare: bool,
     ) -> ExportDefaultDeclarationKind<'a>
@@ -8153,8 +8153,8 @@ impl<'a> AstBuilder<'a> {
         ExportDefaultDeclarationKind::TSInterfaceDeclaration(self.alloc_ts_interface_declaration(
             span,
             id,
-            extends,
             type_parameters,
+            extends,
             body,
             declare,
         ))
@@ -8167,8 +8167,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `id`: The identifier (name) of the interface.
-    /// * `extends`: Other interfaces/types this interface extends.
     /// * `type_parameters`: Type parameters that get bound to the interface.
+    /// * `extends`: Other interfaces/types this interface extends.
     /// * `body`
     /// * `declare`: `true` for `declare interface Foo {}`
     /// * `scope_id`
@@ -8177,8 +8177,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         id: BindingIdentifier<'a>,
-        extends: Vec<'a, TSInterfaceHeritage<'a>>,
         type_parameters: T1,
+        extends: Vec<'a, TSInterfaceHeritage<'a>>,
         body: T2,
         declare: bool,
         scope_id: ScopeId,
@@ -8191,8 +8191,8 @@ impl<'a> AstBuilder<'a> {
             self.alloc_ts_interface_declaration_with_scope_id(
                 span,
                 id,
-                extends,
                 type_parameters,
+                extends,
                 body,
                 declare,
                 scope_id,
@@ -12070,8 +12070,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `id`: The identifier (name) of the interface.
-    /// * `extends`: Other interfaces/types this interface extends.
     /// * `type_parameters`: Type parameters that get bound to the interface.
+    /// * `extends`: Other interfaces/types this interface extends.
     /// * `body`
     /// * `declare`: `true` for `declare interface Foo {}`
     #[inline]
@@ -12079,8 +12079,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         id: BindingIdentifier<'a>,
-        extends: Vec<'a, TSInterfaceHeritage<'a>>,
         type_parameters: T1,
+        extends: Vec<'a, TSInterfaceHeritage<'a>>,
         body: T2,
         declare: bool,
     ) -> TSInterfaceDeclaration<'a>
@@ -12091,8 +12091,8 @@ impl<'a> AstBuilder<'a> {
         TSInterfaceDeclaration {
             span,
             id,
-            extends,
             type_parameters: type_parameters.into_in(self.allocator),
+            extends,
             body: body.into_in(self.allocator),
             declare,
             scope_id: Default::default(),
@@ -12107,8 +12107,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `id`: The identifier (name) of the interface.
-    /// * `extends`: Other interfaces/types this interface extends.
     /// * `type_parameters`: Type parameters that get bound to the interface.
+    /// * `extends`: Other interfaces/types this interface extends.
     /// * `body`
     /// * `declare`: `true` for `declare interface Foo {}`
     #[inline]
@@ -12116,8 +12116,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         id: BindingIdentifier<'a>,
-        extends: Vec<'a, TSInterfaceHeritage<'a>>,
         type_parameters: T1,
+        extends: Vec<'a, TSInterfaceHeritage<'a>>,
         body: T2,
         declare: bool,
     ) -> Box<'a, TSInterfaceDeclaration<'a>>
@@ -12126,7 +12126,7 @@ impl<'a> AstBuilder<'a> {
         T2: IntoIn<'a, Box<'a, TSInterfaceBody<'a>>>,
     {
         Box::new_in(
-            self.ts_interface_declaration(span, id, extends, type_parameters, body, declare),
+            self.ts_interface_declaration(span, id, type_parameters, extends, body, declare),
             self.allocator,
         )
     }
@@ -12139,8 +12139,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `id`: The identifier (name) of the interface.
-    /// * `extends`: Other interfaces/types this interface extends.
     /// * `type_parameters`: Type parameters that get bound to the interface.
+    /// * `extends`: Other interfaces/types this interface extends.
     /// * `body`
     /// * `declare`: `true` for `declare interface Foo {}`
     /// * `scope_id`
@@ -12149,8 +12149,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         id: BindingIdentifier<'a>,
-        extends: Vec<'a, TSInterfaceHeritage<'a>>,
         type_parameters: T1,
+        extends: Vec<'a, TSInterfaceHeritage<'a>>,
         body: T2,
         declare: bool,
         scope_id: ScopeId,
@@ -12162,8 +12162,8 @@ impl<'a> AstBuilder<'a> {
         TSInterfaceDeclaration {
             span,
             id,
-            extends,
             type_parameters: type_parameters.into_in(self.allocator),
+            extends,
             body: body.into_in(self.allocator),
             declare,
             scope_id: Cell::new(Some(scope_id)),
@@ -12178,8 +12178,8 @@ impl<'a> AstBuilder<'a> {
     /// ## Parameters
     /// * `span`: The [`Span`] covering this node
     /// * `id`: The identifier (name) of the interface.
-    /// * `extends`: Other interfaces/types this interface extends.
     /// * `type_parameters`: Type parameters that get bound to the interface.
+    /// * `extends`: Other interfaces/types this interface extends.
     /// * `body`
     /// * `declare`: `true` for `declare interface Foo {}`
     /// * `scope_id`
@@ -12188,8 +12188,8 @@ impl<'a> AstBuilder<'a> {
         self,
         span: Span,
         id: BindingIdentifier<'a>,
-        extends: Vec<'a, TSInterfaceHeritage<'a>>,
         type_parameters: T1,
+        extends: Vec<'a, TSInterfaceHeritage<'a>>,
         body: T2,
         declare: bool,
         scope_id: ScopeId,
@@ -12202,8 +12202,8 @@ impl<'a> AstBuilder<'a> {
             self.ts_interface_declaration_with_scope_id(
                 span,
                 id,
-                extends,
                 type_parameters,
+                extends,
                 body,
                 declare,
                 scope_id,

--- a/crates/oxc_ast/src/generated/derive_clone_in.rs
+++ b/crates/oxc_ast/src/generated/derive_clone_in.rs
@@ -6884,8 +6884,8 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInterfaceDeclaration<'_> {
         TSInterfaceDeclaration {
             span: CloneIn::clone_in(&self.span, allocator),
             id: CloneIn::clone_in(&self.id, allocator),
-            extends: CloneIn::clone_in(&self.extends, allocator),
             type_parameters: CloneIn::clone_in(&self.type_parameters, allocator),
+            extends: CloneIn::clone_in(&self.extends, allocator),
             body: CloneIn::clone_in(&self.body, allocator),
             declare: CloneIn::clone_in(&self.declare, allocator),
             scope_id: Default::default(),
@@ -6896,8 +6896,8 @@ impl<'new_alloc> CloneIn<'new_alloc> for TSInterfaceDeclaration<'_> {
         TSInterfaceDeclaration {
             span: CloneIn::clone_in_with_semantic_ids(&self.span, allocator),
             id: CloneIn::clone_in_with_semantic_ids(&self.id, allocator),
-            extends: CloneIn::clone_in_with_semantic_ids(&self.extends, allocator),
             type_parameters: CloneIn::clone_in_with_semantic_ids(&self.type_parameters, allocator),
+            extends: CloneIn::clone_in_with_semantic_ids(&self.extends, allocator),
             body: CloneIn::clone_in_with_semantic_ids(&self.body, allocator),
             declare: CloneIn::clone_in_with_semantic_ids(&self.declare, allocator),
             scope_id: CloneIn::clone_in_with_semantic_ids(&self.scope_id, allocator),

--- a/crates/oxc_ast/src/generated/derive_content_eq.rs
+++ b/crates/oxc_ast/src/generated/derive_content_eq.rs
@@ -2115,8 +2115,8 @@ impl ContentEq for TSClassImplements<'_> {
 impl ContentEq for TSInterfaceDeclaration<'_> {
     fn content_eq(&self, other: &Self) -> bool {
         ContentEq::content_eq(&self.id, &other.id)
-            && ContentEq::content_eq(&self.extends, &other.extends)
             && ContentEq::content_eq(&self.type_parameters, &other.type_parameters)
+            && ContentEq::content_eq(&self.extends, &other.extends)
             && ContentEq::content_eq(&self.body, &other.body)
             && ContentEq::content_eq(&self.declare, &other.declare)
     }

--- a/crates/oxc_ast/src/generated/derive_dummy.rs
+++ b/crates/oxc_ast/src/generated/derive_dummy.rs
@@ -2345,8 +2345,8 @@ impl<'a> Dummy<'a> for TSInterfaceDeclaration<'a> {
         Self {
             span: Dummy::dummy(allocator),
             id: Dummy::dummy(allocator),
-            extends: Dummy::dummy(allocator),
             type_parameters: Dummy::dummy(allocator),
+            extends: Dummy::dummy(allocator),
             body: Dummy::dummy(allocator),
             declare: Dummy::dummy(allocator),
             scope_id: Dummy::dummy(allocator),

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -2865,8 +2865,8 @@ impl ESTree for TSInterfaceDeclaration<'_> {
         state.serialize_field("start", &self.span.start);
         state.serialize_field("end", &self.span.end);
         state.serialize_field("id", &self.id);
-        state.serialize_field("extends", &self.extends);
         state.serialize_field("typeParameters", &self.type_parameters);
+        state.serialize_field("extends", &self.extends);
         state.serialize_field("body", &self.body);
         state.serialize_field("declare", &self.declare);
         state.end();

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -3622,10 +3622,10 @@ pub mod walk {
         visitor.visit_span(&it.span);
         visitor.visit_binding_identifier(&it.id);
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
-        visitor.visit_ts_interface_heritages(&it.extends);
         if let Some(type_parameters) = &it.type_parameters {
             visitor.visit_ts_type_parameter_declaration(type_parameters);
         }
+        visitor.visit_ts_interface_heritages(&it.extends);
         visitor.visit_ts_interface_body(&it.body);
         visitor.leave_scope();
         visitor.leave_node(kind);

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -3819,10 +3819,10 @@ pub mod walk_mut {
         visitor.visit_span(&mut it.span);
         visitor.visit_binding_identifier(&mut it.id);
         visitor.enter_scope(ScopeFlags::empty(), &it.scope_id);
-        visitor.visit_ts_interface_heritages(&mut it.extends);
         if let Some(type_parameters) = &mut it.type_parameters {
             visitor.visit_ts_type_parameter_declaration(type_parameters);
         }
+        visitor.visit_ts_interface_heritages(&mut it.extends);
         visitor.visit_ts_interface_body(&mut it.body);
         visitor.leave_scope();
         visitor.leave_node(kind);

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -172,8 +172,8 @@ impl<'a> ParserImpl<'a> {
         Ok(self.ast.declaration_ts_interface(
             self.end_span(span),
             id,
-            extends,
             type_parameters,
+            extends,
             body,
             modifiers.contains_declare(),
         ))

--- a/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/extends-reference.snap
+++ b/crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaration/type-parameters/interface/extends-reference.snap
@@ -36,7 +36,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
                 "flags": "ReferenceFlags(Type)",
                 "id": 1,
                 "name": "T",
-                "node_id": 13
+                "node_id": 16
               }
             ]
           }
@@ -57,7 +57,7 @@ input_file: crates/oxc_semantic/tests/fixtures/typescript-eslint/type-declaratio
             "flags": "ReferenceFlags(Type)",
             "id": 0,
             "name": "A",
-            "node_id": 9
+            "node_id": 12
           }
         ]
       },

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -249,8 +249,8 @@ pub(crate) enum AncestorType {
     TSClassImplementsExpression = 226,
     TSClassImplementsTypeArguments = 227,
     TSInterfaceDeclarationId = 228,
-    TSInterfaceDeclarationExtends = 229,
-    TSInterfaceDeclarationTypeParameters = 230,
+    TSInterfaceDeclarationTypeParameters = 229,
+    TSInterfaceDeclarationExtends = 230,
     TSInterfaceDeclarationBody = 231,
     TSInterfaceBodyBody = 232,
     TSPropertySignatureKey = 233,
@@ -751,10 +751,10 @@ pub enum Ancestor<'a, 't> {
         AncestorType::TSClassImplementsTypeArguments as u16,
     TSInterfaceDeclarationId(TSInterfaceDeclarationWithoutId<'a, 't>) =
         AncestorType::TSInterfaceDeclarationId as u16,
-    TSInterfaceDeclarationExtends(TSInterfaceDeclarationWithoutExtends<'a, 't>) =
-        AncestorType::TSInterfaceDeclarationExtends as u16,
     TSInterfaceDeclarationTypeParameters(TSInterfaceDeclarationWithoutTypeParameters<'a, 't>) =
         AncestorType::TSInterfaceDeclarationTypeParameters as u16,
+    TSInterfaceDeclarationExtends(TSInterfaceDeclarationWithoutExtends<'a, 't>) =
+        AncestorType::TSInterfaceDeclarationExtends as u16,
     TSInterfaceDeclarationBody(TSInterfaceDeclarationWithoutBody<'a, 't>) =
         AncestorType::TSInterfaceDeclarationBody as u16,
     TSInterfaceBodyBody(TSInterfaceBodyWithoutBody<'a, 't>) =
@@ -1637,8 +1637,8 @@ impl<'a, 't> Ancestor<'a, 't> {
         matches!(
             self,
             Self::TSInterfaceDeclarationId(_)
-                | Self::TSInterfaceDeclarationExtends(_)
                 | Self::TSInterfaceDeclarationTypeParameters(_)
+                | Self::TSInterfaceDeclarationExtends(_)
                 | Self::TSInterfaceDeclarationBody(_)
         )
     }
@@ -2426,8 +2426,8 @@ impl<'a, 't> GetAddress for Ancestor<'a, 't> {
             Self::TSClassImplementsExpression(a) => a.address(),
             Self::TSClassImplementsTypeArguments(a) => a.address(),
             Self::TSInterfaceDeclarationId(a) => a.address(),
-            Self::TSInterfaceDeclarationExtends(a) => a.address(),
             Self::TSInterfaceDeclarationTypeParameters(a) => a.address(),
+            Self::TSInterfaceDeclarationExtends(a) => a.address(),
             Self::TSInterfaceDeclarationBody(a) => a.address(),
             Self::TSInterfaceBodyBody(a) => a.address(),
             Self::TSPropertySignatureKey(a) => a.address(),
@@ -12498,10 +12498,10 @@ impl<'a, 't> GetAddress for TSClassImplementsWithoutTypeArguments<'a, 't> {
 pub(crate) const OFFSET_TS_INTERFACE_DECLARATION_SPAN: usize =
     offset_of!(TSInterfaceDeclaration, span);
 pub(crate) const OFFSET_TS_INTERFACE_DECLARATION_ID: usize = offset_of!(TSInterfaceDeclaration, id);
-pub(crate) const OFFSET_TS_INTERFACE_DECLARATION_EXTENDS: usize =
-    offset_of!(TSInterfaceDeclaration, extends);
 pub(crate) const OFFSET_TS_INTERFACE_DECLARATION_TYPE_PARAMETERS: usize =
     offset_of!(TSInterfaceDeclaration, type_parameters);
+pub(crate) const OFFSET_TS_INTERFACE_DECLARATION_EXTENDS: usize =
+    offset_of!(TSInterfaceDeclaration, extends);
 pub(crate) const OFFSET_TS_INTERFACE_DECLARATION_BODY: usize =
     offset_of!(TSInterfaceDeclaration, body);
 pub(crate) const OFFSET_TS_INTERFACE_DECLARATION_DECLARE: usize =
@@ -12525,18 +12525,18 @@ impl<'a, 't> TSInterfaceDeclarationWithoutId<'a, 't> {
     }
 
     #[inline]
-    pub fn extends(self) -> &'t Vec<'a, TSInterfaceHeritage<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_EXTENDS)
-                as *const Vec<'a, TSInterfaceHeritage<'a>>)
-        }
-    }
-
-    #[inline]
     pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_TYPE_PARAMETERS)
                 as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn extends(self) -> &'t Vec<'a, TSInterfaceHeritage<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_EXTENDS)
+                as *const Vec<'a, TSInterfaceHeritage<'a>>)
         }
     }
 
@@ -12565,68 +12565,6 @@ impl<'a, 't> TSInterfaceDeclarationWithoutId<'a, 't> {
 }
 
 impl<'a, 't> GetAddress for TSInterfaceDeclarationWithoutId<'a, 't> {
-    #[inline]
-    fn address(&self) -> Address {
-        Address::from_ptr(self.0)
-    }
-}
-
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug)]
-pub struct TSInterfaceDeclarationWithoutExtends<'a, 't>(
-    pub(crate) *const TSInterfaceDeclaration<'a>,
-    pub(crate) PhantomData<&'t ()>,
-);
-
-impl<'a, 't> TSInterfaceDeclarationWithoutExtends<'a, 't> {
-    #[inline]
-    pub fn span(self) -> &'t Span {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_SPAN) as *const Span)
-        }
-    }
-
-    #[inline]
-    pub fn id(self) -> &'t BindingIdentifier<'a> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_ID)
-                as *const BindingIdentifier<'a>)
-        }
-    }
-
-    #[inline]
-    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_TYPE_PARAMETERS)
-                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
-        }
-    }
-
-    #[inline]
-    pub fn body(self) -> &'t Box<'a, TSInterfaceBody<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_BODY)
-                as *const Box<'a, TSInterfaceBody<'a>>)
-        }
-    }
-
-    #[inline]
-    pub fn declare(self) -> &'t bool {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_DECLARE) as *const bool)
-        }
-    }
-
-    #[inline]
-    pub fn scope_id(self) -> &'t Cell<Option<ScopeId>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_SCOPE_ID)
-                as *const Cell<Option<ScopeId>>)
-        }
-    }
-}
-
-impl<'a, 't> GetAddress for TSInterfaceDeclarationWithoutExtends<'a, 't> {
     #[inline]
     fn address(&self) -> Address {
         Address::from_ptr(self.0)
@@ -12697,6 +12635,68 @@ impl<'a, 't> GetAddress for TSInterfaceDeclarationWithoutTypeParameters<'a, 't> 
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug)]
+pub struct TSInterfaceDeclarationWithoutExtends<'a, 't>(
+    pub(crate) *const TSInterfaceDeclaration<'a>,
+    pub(crate) PhantomData<&'t ()>,
+);
+
+impl<'a, 't> TSInterfaceDeclarationWithoutExtends<'a, 't> {
+    #[inline]
+    pub fn span(self) -> &'t Span {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_SPAN) as *const Span)
+        }
+    }
+
+    #[inline]
+    pub fn id(self) -> &'t BindingIdentifier<'a> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_ID)
+                as *const BindingIdentifier<'a>)
+        }
+    }
+
+    #[inline]
+    pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_TYPE_PARAMETERS)
+                as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn body(self) -> &'t Box<'a, TSInterfaceBody<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_BODY)
+                as *const Box<'a, TSInterfaceBody<'a>>)
+        }
+    }
+
+    #[inline]
+    pub fn declare(self) -> &'t bool {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_DECLARE) as *const bool)
+        }
+    }
+
+    #[inline]
+    pub fn scope_id(self) -> &'t Cell<Option<ScopeId>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_SCOPE_ID)
+                as *const Cell<Option<ScopeId>>)
+        }
+    }
+}
+
+impl<'a, 't> GetAddress for TSInterfaceDeclarationWithoutExtends<'a, 't> {
+    #[inline]
+    fn address(&self) -> Address {
+        Address::from_ptr(self.0)
+    }
+}
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
 pub struct TSInterfaceDeclarationWithoutBody<'a, 't>(
     pub(crate) *const TSInterfaceDeclaration<'a>,
     pub(crate) PhantomData<&'t ()>,
@@ -12719,18 +12719,18 @@ impl<'a, 't> TSInterfaceDeclarationWithoutBody<'a, 't> {
     }
 
     #[inline]
-    pub fn extends(self) -> &'t Vec<'a, TSInterfaceHeritage<'a>> {
-        unsafe {
-            &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_EXTENDS)
-                as *const Vec<'a, TSInterfaceHeritage<'a>>)
-        }
-    }
-
-    #[inline]
     pub fn type_parameters(self) -> &'t Option<Box<'a, TSTypeParameterDeclaration<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_TYPE_PARAMETERS)
                 as *const Option<Box<'a, TSTypeParameterDeclaration<'a>>>)
+        }
+    }
+
+    #[inline]
+    pub fn extends(self) -> &'t Vec<'a, TSInterfaceHeritage<'a>> {
+        unsafe {
+            &*((self.0 as *const u8).add(OFFSET_TS_INTERFACE_DECLARATION_EXTENDS)
+                as *const Vec<'a, TSInterfaceHeritage<'a>>)
         }
     }
 

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -4622,18 +4622,18 @@ unsafe fn walk_ts_interface_declaration<'a, Tr: Traverse<'a>>(
         .get()
         .unwrap();
     ctx.set_current_scope_id(current_scope_id);
-    ctx.retag_stack(AncestorType::TSInterfaceDeclarationExtends);
-    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_INTERFACE_DECLARATION_EXTENDS)
-        as *mut Vec<TSInterfaceHeritage>)
-    {
-        walk_ts_interface_heritage(traverser, item as *mut _, ctx);
-    }
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_INTERFACE_DECLARATION_TYPE_PARAMETERS)
         as *mut Option<Box<TSTypeParameterDeclaration>>)
     {
         ctx.retag_stack(AncestorType::TSInterfaceDeclarationTypeParameters);
         walk_ts_type_parameter_declaration(traverser, (&mut **field) as *mut _, ctx);
+    }
+    ctx.retag_stack(AncestorType::TSInterfaceDeclarationExtends);
+    for item in &mut *((node as *mut u8).add(ancestor::OFFSET_TS_INTERFACE_DECLARATION_EXTENDS)
+        as *mut Vec<TSInterfaceHeritage>)
+    {
+        walk_ts_interface_heritage(traverser, item as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::TSInterfaceDeclarationBody);
     walk_ts_interface_body(

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -1639,8 +1639,8 @@ function deserializeTSInterfaceDeclaration(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     id: deserializeBindingIdentifier(pos + 8),
-    extends: deserializeVecTSInterfaceHeritage(pos + 40),
-    typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 72),
+    typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 40),
+    extends: deserializeVecTSInterfaceHeritage(pos + 48),
     body: deserializeBoxTSInterfaceBody(pos + 80),
     declare: deserializeBool(pos + 88),
   };

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -1766,8 +1766,8 @@ function deserializeTSInterfaceDeclaration(pos) {
     start: deserializeU32(pos),
     end: deserializeU32(pos + 4),
     id: deserializeBindingIdentifier(pos + 8),
-    extends: deserializeVecTSInterfaceHeritage(pos + 40),
-    typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 72),
+    typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 40),
+    extends: deserializeVecTSInterfaceHeritage(pos + 48),
     body: deserializeBoxTSInterfaceBody(pos + 80),
     declare: deserializeBool(pos + 88),
   };

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -1211,8 +1211,8 @@ export interface TSClassImplements extends Span {
 export interface TSInterfaceDeclaration extends Span {
   type: 'TSInterfaceDeclaration';
   id: BindingIdentifier;
-  extends: Array<TSInterfaceHeritage>;
   typeParameters: TSTypeParameterDeclaration | null;
+  extends: Array<TSInterfaceHeritage>;
   body: TSInterfaceBody;
   declare: boolean;
 }

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -1276,7 +1276,7 @@ semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3)]
 Symbol reference IDs mismatch for "Base":
-after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(3)]
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(2)]
 rebuilt        : SymbolId(1): [ReferenceId(2)]
 Symbol reference IDs mismatch for "Derived":
 after transform: SymbolId(1): [ReferenceId(6), ReferenceId(7)]
@@ -18622,7 +18622,7 @@ Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(6), ScopeId(10), ScopeId(12), ScopeId(13), ScopeId(16), ScopeId(17), ScopeId(18), ScopeId(19), ScopeId(21), ScopeId(23), ScopeId(25), ScopeId(27), ScopeId(29), ScopeId(31), ScopeId(33), ScopeId(35), ScopeId(37), ScopeId(39), ScopeId(40), ScopeId(42), ScopeId(44), ScopeId(45), ScopeId(46), ScopeId(48), ScopeId(50), ScopeId(52), ScopeId(54), ScopeId(56), ScopeId(58), ScopeId(60), ScopeId(62), ScopeId(63), ScopeId(64), ScopeId(66), ScopeId(68), ScopeId(69), ScopeId(71), ScopeId(74), ScopeId(75), ScopeId(76), ScopeId(77), ScopeId(78), ScopeId(79), ScopeId(84), ScopeId(85), ScopeId(86)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch for "React":
-after transform: SymbolId(0): [ReferenceId(17), ReferenceId(19), ReferenceId(44), ReferenceId(50), ReferenceId(54), ReferenceId(82), ReferenceId(85), ReferenceId(88), ReferenceId(102), ReferenceId(180), ReferenceId(195), ReferenceId(206), ReferenceId(209), ReferenceId(233), ReferenceId(236), ReferenceId(242)]
+after transform: SymbolId(0): [ReferenceId(17), ReferenceId(19), ReferenceId(44), ReferenceId(50), ReferenceId(54), ReferenceId(82), ReferenceId(85), ReferenceId(88), ReferenceId(102), ReferenceId(180), ReferenceId(196), ReferenceId(206), ReferenceId(209), ReferenceId(233), ReferenceId(236), ReferenceId(242)]
 rebuilt        : SymbolId(0): [ReferenceId(0)]
 Reference symbol mismatch for "ReactSelectClass":
 after transform: SymbolId(19) "ReactSelectClass"


### PR DESCRIPTION
```ts
interface Foo<T> extends Bar { }
```

Move `type_parameters` field (`<T>`) to before `extends` field (`Bar`), because it comes first.
