### PR TITLE
refactor(napi/parser): refactor `wrap` files

### DIFF
--- a/napi/parser/wrap.cjs
+++ b/napi/parser/wrap.cjs
@@ -1,29 +1,11 @@
+// Note: This code is repeated in `wrap.mjs`.
+// Any changes should be applied in that file too.
+
 module.exports.wrap = function wrap(result) {
   let program, module, comments, errors;
   return {
     get program() {
-      if (!program) {
-        // Note: This code is repeated in `crates/oxc-wasm/update-bindings.mjs` and `napi/parser/wrap.cjs`.
-        // Any changes should be applied in those 2 scripts too.
-        program = JSON.parse(result.program, function(key, value) {
-          // Set `value` field of `Literal`s for `BigInt`s and `RegExp`s.
-          // This is not possible to do on Rust side, as neither can be represented correctly in JSON.
-          if (value === null && key === 'value' && Object.hasOwn(this, 'type') && this.type === 'Literal') {
-            if (Object.hasOwn(this, 'bigint')) {
-              return BigInt(this.bigint);
-            }
-            if (Object.hasOwn(this, 'regex')) {
-              const { regex } = this;
-              try {
-                return RegExp(regex.pattern, regex.flags);
-              } catch (_err) {
-                // Invalid regexp, or valid regexp using syntax not supported by this version of NodeJS
-              }
-            }
-          }
-          return value;
-        });
-      }
+      if (!program) program = jsonParseAst(result.program);
       return program;
     },
     get module() {
@@ -40,3 +22,26 @@ module.exports.wrap = function wrap(result) {
     },
   };
 };
+
+function jsonParseAst(program) {
+  return JSON.parse(program, transform);
+}
+
+function transform(key, value) {
+  // Set `value` field of `Literal`s for `BigInt`s and `RegExp`s.
+  // This is not possible to do on Rust side, as neither can be represented correctly in JSON.
+  if (value === null && key === 'value' && Object.hasOwn(this, 'type') && this.type === 'Literal') {
+    if (Object.hasOwn(this, 'bigint')) {
+      return BigInt(this.bigint);
+    }
+    if (Object.hasOwn(this, 'regex')) {
+      const { regex } = this;
+      try {
+        return RegExp(regex.pattern, regex.flags);
+      } catch (_err) {
+        // Invalid regexp, or valid regexp using syntax not supported by this version of NodeJS
+      }
+    }
+  }
+  return value;
+}


### PR DESCRIPTION
Refactor `wrap.cjs` and `wrap.mjs` in `napi/parser` package.

* Update outdated comments.
* Move JSON transform function to top level to avoid creating a new closure each time `jsonParseAst` is called.
* Make the 2 files as similar as possible so it's easier to keep them both in sync.
