### PR TITLE
refactor(ast)!: improve pluralization of `TSClassImplements`

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -897,6 +897,7 @@ pub enum TSAccessibility {
 #[ast(visit)]
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, ContentEq, ESTree)]
+#[plural(TSClassImplementsList)]
 pub struct TSClassImplements<'a> {
     pub span: Span,
     pub expression: TSTypeName<'a>,

--- a/crates/oxc_ast_visit/src/generated/utf8_to_utf16_converter.rs
+++ b/crates/oxc_ast_visit/src/generated/utf8_to_utf16_converter.rs
@@ -1247,7 +1247,7 @@ impl Utf8ToUtf16Converter<'_> {
         if let Some(super_type_arguments) = &mut class.super_type_arguments {
             self.visit_ts_type_parameter_instantiation(super_type_arguments);
         }
-        self.visit_ts_class_implementses(&mut class.implements);
+        self.visit_ts_class_implements_list(&mut class.implements);
         self.visit_class_body(&mut class.body);
         // Process span end of `Class` and export statement
         self.convert_offset(&mut class.span.end);

--- a/crates/oxc_ast_visit/src/generated/visit.rs
+++ b/crates/oxc_ast_visit/src/generated/visit.rs
@@ -1254,8 +1254,8 @@ pub trait Visit<'a>: Sized {
     }
 
     #[inline]
-    fn visit_ts_class_implementses(&mut self, it: &Vec<'a, TSClassImplements<'a>>) {
-        walk_ts_class_implementses(self, it);
+    fn visit_ts_class_implements_list(&mut self, it: &Vec<'a, TSClassImplements<'a>>) {
+        walk_ts_class_implements_list(self, it);
     }
 
     #[inline]
@@ -2542,7 +2542,7 @@ pub mod walk {
         if let Some(super_type_arguments) = &it.super_type_arguments {
             visitor.visit_ts_type_parameter_instantiation(super_type_arguments);
         }
-        visitor.visit_ts_class_implementses(&it.implements);
+        visitor.visit_ts_class_implements_list(&it.implements);
         visitor.visit_class_body(&it.body);
         visitor.leave_scope();
         visitor.leave_node(kind);
@@ -4239,7 +4239,7 @@ pub mod walk {
     }
 
     #[inline]
-    pub fn walk_ts_class_implementses<'a, V: Visit<'a>>(
+    pub fn walk_ts_class_implements_list<'a, V: Visit<'a>>(
         visitor: &mut V,
         it: &Vec<'a, TSClassImplements<'a>>,
     ) {

--- a/crates/oxc_ast_visit/src/generated/visit_mut.rs
+++ b/crates/oxc_ast_visit/src/generated/visit_mut.rs
@@ -1249,8 +1249,8 @@ pub trait VisitMut<'a>: Sized {
     }
 
     #[inline]
-    fn visit_ts_class_implementses(&mut self, it: &mut Vec<'a, TSClassImplements<'a>>) {
-        walk_ts_class_implementses(self, it);
+    fn visit_ts_class_implements_list(&mut self, it: &mut Vec<'a, TSClassImplements<'a>>) {
+        walk_ts_class_implements_list(self, it);
     }
 
     #[inline]
@@ -2628,7 +2628,7 @@ pub mod walk_mut {
         if let Some(super_type_arguments) = &mut it.super_type_arguments {
             visitor.visit_ts_type_parameter_instantiation(super_type_arguments);
         }
-        visitor.visit_ts_class_implementses(&mut it.implements);
+        visitor.visit_ts_class_implements_list(&mut it.implements);
         visitor.visit_class_body(&mut it.body);
         visitor.leave_scope();
         visitor.leave_node(kind);
@@ -4472,7 +4472,7 @@ pub mod walk_mut {
     }
 
     #[inline]
-    pub fn walk_ts_class_implementses<'a, V: VisitMut<'a>>(
+    pub fn walk_ts_class_implements_list<'a, V: VisitMut<'a>>(
         visitor: &mut V,
         it: &mut Vec<'a, TSClassImplements<'a>>,
     ) {

--- a/crates/oxc_semantic/src/builder.rs
+++ b/crates/oxc_semantic/src/builder.rs
@@ -707,7 +707,7 @@ impl<'a> Visit<'a> for SemanticBuilder<'a> {
         if let Some(super_type_parameters) = &class.super_type_arguments {
             self.visit_ts_type_parameter_instantiation(super_type_parameters);
         }
-        self.visit_ts_class_implementses(&class.implements);
+        self.visit_ts_class_implements_list(&class.implements);
         self.visit_class_body(&class.body);
 
         self.leave_scope();

--- a/tasks/ast_tools/src/generators/utf8_to_utf16.rs
+++ b/tasks/ast_tools/src/generators/utf8_to_utf16.rs
@@ -300,7 +300,7 @@ fn generate(schema: &Schema, codegen: &Codegen) -> TokenStream {
                 if let Some(super_type_arguments) = &mut class.super_type_arguments {
                     self.visit_ts_type_parameter_instantiation(super_type_arguments);
                 }
-                self.visit_ts_class_implementses(&mut class.implements);
+                self.visit_ts_class_implements_list(&mut class.implements);
                 self.visit_class_body(&mut class.body);
 
                 ///@ Process span end of `Class` and export statement


### PR DESCRIPTION
`visit_ts_class_implementses` is weird. Change to `visit_ts_class_implements_list`, following the convention of singular `FormalParameter` -> plural `FormalParameterList`.
