### PR TITLE
refactor(transformer/class-properties): streamline handling scope of instance property initializer

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/instance_prop_init.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/instance_prop_init.rs
@@ -25,15 +25,22 @@ impl<'a> ClassProperties<'a, '_> {
     pub(super) fn transform_instance_initializer(
         &mut self,
         value: &Expression<'a>,
+        instance_inits_scope_id: ScopeId,
+        instance_inits_constructor_scope_id: Option<ScopeId>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        if let Some(constructor_scope_id) = self.instance_inits_constructor_scope_id {
+        if let Some(constructor_scope_id) = instance_inits_constructor_scope_id {
             // Re-parent first-level scopes, and check for symbol clashes
-            let mut updater = InstanceInitializerVisitor::new(constructor_scope_id, self, ctx);
+            let mut updater = InstanceInitializerVisitor::new(
+                instance_inits_scope_id,
+                constructor_scope_id,
+                self,
+                ctx,
+            );
             updater.visit_expression(value);
         } else {
             // No symbol clashes possible. Just re-parent first-level scopes (faster).
-            let mut updater = FastInstanceInitializerVisitor::new(self, ctx);
+            let mut updater = FastInstanceInitializerVisitor::new(instance_inits_scope_id, ctx);
             updater.visit_expression(value);
         }
     }
@@ -58,6 +65,7 @@ struct InstanceInitializerVisitor<'a, 'v> {
 
 impl<'a, 'v> InstanceInitializerVisitor<'a, 'v> {
     fn new(
+        instance_inits_scope_id: ScopeId,
         constructor_scope_id: ScopeId,
         class_properties: &'v mut ClassProperties<'a, '_>,
         ctx: &'v mut TraverseCtx<'a>,
@@ -66,7 +74,7 @@ impl<'a, 'v> InstanceInitializerVisitor<'a, 'v> {
             // Most initializers don't contain any scopes, so best default is 0 capacity
             // to avoid an allocation in most cases
             scope_ids_stack: Stack::new(),
-            parent_scope_id: class_properties.instance_inits_scope_id,
+            parent_scope_id: instance_inits_scope_id,
             constructor_scope_id,
             clashing_symbols: &mut class_properties.clashing_constructor_symbols,
             ctx,
@@ -154,8 +162,8 @@ struct FastInstanceInitializerVisitor<'a, 'v> {
 }
 
 impl<'a, 'v> FastInstanceInitializerVisitor<'a, 'v> {
-    fn new(class_properties: &'v ClassProperties<'a, '_>, ctx: &'v mut TraverseCtx<'a>) -> Self {
-        Self { parent_scope_id: class_properties.instance_inits_scope_id, ctx }
+    fn new(instance_inits_scope_id: ScopeId, ctx: &'v mut TraverseCtx<'a>) -> Self {
+        Self { parent_scope_id: instance_inits_scope_id, ctx }
     }
 }
 

--- a/crates/oxc_transformer/src/es2022/class_properties/mod.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/mod.rs
@@ -203,7 +203,7 @@ use serde::Deserialize;
 
 use oxc_ast::ast::*;
 use oxc_span::Atom;
-use oxc_syntax::{scope::ScopeId, symbol::SymbolId};
+use oxc_syntax::symbol::SymbolId;
 use oxc_traverse::{Traverse, TraverseCtx};
 
 use crate::TransformCtx;
@@ -266,15 +266,6 @@ pub struct ClassProperties<'a, 'ctx> {
 
     // ----- State used only during enter phase -----
     //
-    /// Scope that instance property initializers will be inserted into.
-    /// This is usually class constructor, but can also be a `_super` function which is created.
-    instance_inits_scope_id: ScopeId,
-    /// Scope of class constructor, if instance property initializers will be inserted into constructor.
-    /// Used for checking for variable name clashes.
-    /// e.g. `class C { prop = x(); constructor(x) {} }`
-    /// - `x` in constructor needs to be renamed when `x()` is moved into constructor body.
-    /// `None` if class has no existing constructor, as then there can't be any clashes.
-    instance_inits_constructor_scope_id: Option<ScopeId>,
     /// Symbols in constructor which clash with instance prop initializers.
     /// Keys are symbols' IDs.
     /// Values are initially the original name of binding, later on the name of new UID name.
@@ -310,9 +301,6 @@ impl<'a, 'ctx> ClassProperties<'a, 'ctx> {
             ctx,
             classes_stack: ClassesStack::new(),
             private_field_count: 0,
-            // Temporary values - overwritten when entering class
-            instance_inits_scope_id: ScopeId::new(0),
-            instance_inits_constructor_scope_id: None,
             // `Vec`s and `FxHashMap`s which are reused for every class being transformed
             clashing_constructor_symbols: FxHashMap::default(),
             insert_before: vec![],

--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -2,6 +2,7 @@
 //! Transform of class property declarations (instance or static properties).
 
 use oxc_ast::{NONE, ast::*};
+use oxc_semantic::ScopeId;
 use oxc_span::SPAN;
 use oxc_syntax::reference::ReferenceFlags;
 use oxc_traverse::TraverseCtx;
@@ -21,12 +22,19 @@ impl<'a> ClassProperties<'a, '_> {
         &mut self,
         prop: &mut PropertyDefinition<'a>,
         instance_inits: &mut Vec<Expression<'a>>,
+        instance_inits_scope_id: ScopeId,
+        instance_inits_constructor_scope_id: Option<ScopeId>,
         ctx: &mut TraverseCtx<'a>,
     ) {
         // Get value
         let value = match prop.value.take() {
             Some(value) => {
-                self.transform_instance_initializer(&value, ctx);
+                self.transform_instance_initializer(
+                    &value,
+                    instance_inits_scope_id,
+                    instance_inits_constructor_scope_id,
+                    ctx,
+                );
                 value
             }
             None => ctx.ast.void_0(SPAN),


### PR DESCRIPTION
Move the `instance_inits_scope_id` and `instance_inits_constructor_scope_id` fields from the `ClassProperties` struct to local variables.

Using struct-level fields as temporary variables is unnecessary within three function depths, and you also need to consider when to reset the states, otherwise, you may cause a bug due to using previous temporary information. Moreover, I think it also improves a bit readability.

NOTE: This is not only a refactor, but also along with #10495 and #10493 to prepare #10491.