### PR TITLE
refactor(transformer/class-properties): defer re-parenting initializers scopes until all instance properties are transformed

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/class.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/class.rs
@@ -309,13 +309,7 @@ impl<'a> ClassProperties<'a, '_> {
             match element {
                 ClassElement::PropertyDefinition(prop) => {
                     if !prop.r#static {
-                        self.convert_instance_property(
-                            prop,
-                            &mut instance_inits,
-                            instance_inits_scope_id,
-                            instance_inits_constructor_scope_id,
-                            ctx,
-                        );
+                        self.convert_instance_property(prop, &mut instance_inits, ctx);
                     }
                 }
                 ClassElement::MethodDefinition(method) => {
@@ -331,6 +325,14 @@ impl<'a> ClassProperties<'a, '_> {
                 ClassElement::StaticBlock(_) => {}
             }
         }
+
+        // Reparent property initializers scope to `instance_inits_scope_id`.
+        self.reparent_initializers_scope(
+            instance_inits.as_slice(),
+            instance_inits_scope_id,
+            instance_inits_constructor_scope_id,
+            ctx,
+        );
 
         // Insert instance initializers into constructor.
         // Create a constructor if there isn't one.

--- a/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/prop_decl.rs
@@ -2,7 +2,6 @@
 //! Transform of class property declarations (instance or static properties).
 
 use oxc_ast::{NONE, ast::*};
-use oxc_semantic::ScopeId;
 use oxc_span::SPAN;
 use oxc_syntax::reference::ReferenceFlags;
 use oxc_traverse::TraverseCtx;
@@ -22,23 +21,10 @@ impl<'a> ClassProperties<'a, '_> {
         &mut self,
         prop: &mut PropertyDefinition<'a>,
         instance_inits: &mut Vec<Expression<'a>>,
-        instance_inits_scope_id: ScopeId,
-        instance_inits_constructor_scope_id: Option<ScopeId>,
         ctx: &mut TraverseCtx<'a>,
     ) {
         // Get value
-        let value = match prop.value.take() {
-            Some(value) => {
-                self.transform_instance_initializer(
-                    &value,
-                    instance_inits_scope_id,
-                    instance_inits_constructor_scope_id,
-                    ctx,
-                );
-                value
-            }
-            None => ctx.ast.void_0(SPAN),
-        };
+        let value = prop.value.take().unwrap_or_else(|| ctx.ast.void_0(SPAN));
 
         let init_expr = if let PropertyKey::PrivateIdentifier(ident) = &mut prop.key {
             self.create_private_instance_init_assignment(ident, value, ctx)


### PR DESCRIPTION
Re-parenting the initializers' scope after all instance properties are transformed, which is preparing for #10493. And rename `transform_instance_initializer` to `reparent_initializers_scope` because the previous name confused me; the implementation only affects scope data.

Moreover, there is a drawback to this change. The `reparent_initializers_scope` method now processes initializers that have been transformed, so that it will visit many unrelated AST nodes. See the transformer/pdf.js benchmark, it shows `0.1ms` slower than before. It may not matter; we will get it back in the follow-up changes.