### PR TITLE
refactor(language_server): make linter independent of `Backend`

### DIFF
--- a/crates/oxc_language_server/src/capabilities.rs
+++ b/crates/oxc_language_server/src/capabilities.rs
@@ -5,7 +5,7 @@ use tower_lsp_server::lsp_types::{
     WorkspaceServerCapabilities,
 };
 
-use crate::{code_actions::CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC, commands::LSP_COMMANDS};
+use crate::{code_actions::CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC, commands::FIX_ALL_COMMAND_ID};
 
 #[derive(Clone, Default)]
 pub struct Capabilities {
@@ -45,11 +45,6 @@ impl From<ClientCapabilities> for Capabilities {
 
 impl From<Capabilities> for ServerCapabilities {
     fn from(value: Capabilities) -> Self {
-        let commands = LSP_COMMANDS
-            .iter()
-            .filter_map(|c| if c.available(value.clone()) { Some(c.command_id()) } else { None })
-            .collect();
-
         Self {
             text_document_sync: Some(TextDocumentSyncCapability::Kind(TextDocumentSyncKind::FULL)),
             workspace: Some(WorkspaceServerCapabilities {
@@ -74,7 +69,10 @@ impl From<Capabilities> for ServerCapabilities {
                 None
             },
             execute_command_provider: if value.workspace_execute_command {
-                Some(ExecuteCommandOptions { commands, ..Default::default() })
+                Some(ExecuteCommandOptions {
+                    commands: vec![FIX_ALL_COMMAND_ID.to_string()],
+                    ..Default::default()
+                })
             } else {
                 None
             },

--- a/crates/oxc_language_server/src/commands.rs
+++ b/crates/oxc_language_server/src/commands.rs
@@ -1,118 +1,21 @@
-use std::str::FromStr;
-
-use log::error;
 use serde::Deserialize;
-use tower_lsp_server::{
-    jsonrpc::{self, Error},
-    lsp_types::{
-        ApplyWorkspaceEditParams, TextEdit, Uri, WorkspaceEdit, request::ApplyWorkspaceEdit,
-    },
-};
 
-use crate::{Backend, capabilities::Capabilities};
-
-pub const LSP_COMMANDS: [WorkspaceCommands; 1] = [WorkspaceCommands::FixAll(FixAllCommand)];
-
-pub trait WorkspaceCommand {
-    fn command_id(&self) -> String;
-    fn available(&self, cap: Capabilities) -> bool;
-    type CommandArgs<'a>: serde::Deserialize<'a>;
-    async fn execute(
-        &self,
-        backend: &Backend,
-        args: Self::CommandArgs<'_>,
-    ) -> jsonrpc::Result<Option<serde_json::Value>>;
-}
-
-pub enum WorkspaceCommands {
-    FixAll(FixAllCommand),
-}
-
-impl WorkspaceCommands {
-    pub fn command_id(&self) -> String {
-        match self {
-            WorkspaceCommands::FixAll(c) => c.command_id(),
-        }
-    }
-    pub fn available(&self, cap: Capabilities) -> bool {
-        match self {
-            WorkspaceCommands::FixAll(c) => c.available(cap),
-        }
-    }
-    pub async fn execute(
-        &self,
-        backend: &Backend,
-        args: Vec<serde_json::Value>,
-    ) -> jsonrpc::Result<Option<serde_json::Value>> {
-        match self {
-            WorkspaceCommands::FixAll(c) => {
-                let arg: Result<
-                    <FixAllCommand as WorkspaceCommand>::CommandArgs<'_>,
-                    serde_json::Error,
-                > = serde_json::from_value(serde_json::Value::Array(args));
-                if let Err(e) = arg {
-                    error!("Invalid args passed to {:?}: {e}", c.command_id());
-                    return Err(Error::invalid_request());
-                }
-                let arg = arg.unwrap();
-
-                c.execute(backend, arg).await
-            }
-        }
-    }
-}
-
-pub struct FixAllCommand;
+pub const FIX_ALL_COMMAND_ID: &str = "oxc.fixAll";
 
 #[derive(Deserialize)]
-pub struct FixAllCommandArg {
-    uri: String,
+pub struct FixAllCommandArgs {
+    pub uri: String,
 }
 
-impl WorkspaceCommand for FixAllCommand {
-    fn command_id(&self) -> String {
-        "oxc.fixAll".into()
-    }
-    fn available(&self, cap: Capabilities) -> bool {
-        cap.workspace_apply_edit
-    }
-    type CommandArgs<'a> = (FixAllCommandArg,);
+impl TryFrom<Vec<serde_json::Value>> for FixAllCommandArgs {
+    type Error = &'static str;
 
-    async fn execute(
-        &self,
-        backend: &Backend,
-        args: Self::CommandArgs<'_>,
-    ) -> jsonrpc::Result<Option<serde_json::Value>> {
-        let url = Uri::from_str(&args.0.uri);
-        if let Err(e) = url {
-            error!("Invalid uri passed to {:?}: {e}", self.command_id());
-            return Err(Error::invalid_request());
-        }
-        let url = url.unwrap();
-
-        let mut edits = vec![];
-        if let Some(value) = backend.diagnostics_report_map.pin_owned().get(&url.to_string()) {
-            for report in value {
-                if let Some(fixed) = &report.fixed_content {
-                    edits.push(TextEdit { range: fixed.range, new_text: fixed.code.clone() });
-                }
-            }
-            let _ = backend
-                .client
-                .send_request::<ApplyWorkspaceEdit>(ApplyWorkspaceEditParams {
-                    label: Some(match edits.len() {
-                        1 => "Oxlint: 1 fix applied".into(),
-                        n => format!("Oxlint: {n} fixes applied"),
-                    }),
-                    edit: WorkspaceEdit {
-                        #[expect(clippy::disallowed_types)]
-                        changes: Some(std::collections::HashMap::from([(url, edits)])),
-                        ..WorkspaceEdit::default()
-                    },
-                })
-                .await;
+    fn try_from(value: Vec<serde_json::Value>) -> Result<Self, Self::Error> {
+        if value.len() != 1 {
+            return Err("Expected exactly one argument for FixAllCommandArgs");
         }
 
-        Ok(None)
+        let first_value = value.into_iter().next().ok_or("Missing argument")?;
+        serde_json::from_value(first_value).map_err(|_| "Failed to parse FixAllCommandArgs")
     }
 }

--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use tower_lsp_server::{UriExt, lsp_types::Uri};
 
-use oxc_linter::{ConfigStoreBuilder, FixKind, LintOptions, Linter};
+use oxc_linter::Linter;
 
 use crate::linter::error_with_position::DiagnosticReport;
 use crate::linter::isolated_lint_handler::IsolatedLintHandler;
@@ -15,7 +15,10 @@ pub struct ServerLinter {
 }
 
 impl ServerLinter {
+    #[cfg(test)]
     pub fn new(options: IsolatedLintHandlerOptions) -> Self {
+        use oxc_linter::{ConfigStoreBuilder, FixKind, LintOptions};
+
         let config_store =
             ConfigStoreBuilder::default().build().expect("Failed to build config store");
         let linter = Linter::new(LintOptions::default(), config_store).with_fix(FixKind::SafeFix);
@@ -42,7 +45,7 @@ mod test {
 
     use super::*;
     use crate::linter::tester::Tester;
-    use oxc_linter::{LintFilter, LintFilterKind, Oxlintrc};
+    use oxc_linter::{ConfigStoreBuilder, LintFilter, LintFilterKind, LintOptions, Oxlintrc};
     use rustc_hash::FxHashMap;
 
     #[test]

--- a/crates/oxc_language_server/src/main.rs
+++ b/crates/oxc_language_server/src/main.rs
@@ -1,42 +1,32 @@
-use code_actions::{
-    CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC, apply_all_fix_code_action, apply_fix_code_action,
-    ignore_this_line_code_action, ignore_this_rule_code_action,
-};
-use commands::LSP_COMMANDS;
+use code_actions::CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC;
+use commands::{FIX_ALL_COMMAND_ID, FixAllCommandArgs};
 use futures::future::join_all;
-use globset::Glob;
-use ignore::gitignore::Gitignore;
-use linter::{config_walker::ConfigWalker, isolated_lint_handler::IsolatedLintHandlerOptions};
-use log::{debug, error, info, warn};
-use oxc_linter::{ConfigStore, ConfigStoreBuilder, FixKind, LintOptions, Linter, Oxlintrc};
+use log::{debug, info};
+use oxc_linter::FixKind;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use serde::{Deserialize, Serialize};
-use std::{
-    fmt::Debug,
-    path::{Path, PathBuf},
-    str::FromStr,
-};
-use tokio::sync::{Mutex, OnceCell, RwLock, SetError};
+use std::{fmt::Debug, str::FromStr};
+use tokio::sync::{Mutex, OnceCell, SetError};
 use tower_lsp_server::{
-    Client, LanguageServer, LspService, Server, UriExt,
+    Client, LanguageServer, LspService, Server,
     jsonrpc::{Error, ErrorCode, Result},
     lsp_types::{
-        CodeActionOrCommand, CodeActionParams, CodeActionResponse, ConfigurationItem, Diagnostic,
+        CodeActionParams, CodeActionResponse, ConfigurationItem, Diagnostic,
         DidChangeConfigurationParams, DidChangeTextDocumentParams, DidChangeWatchedFilesParams,
         DidCloseTextDocumentParams, DidOpenTextDocumentParams, DidSaveTextDocumentParams,
-        ExecuteCommandParams, FileChangeType, InitializeParams, InitializeResult,
-        InitializedParams, Range, ServerInfo, Uri,
+        ExecuteCommandParams, InitializeParams, InitializeResult, InitializedParams, ServerInfo,
+        Uri, WorkspaceEdit,
     },
 };
+use worker::WorkspaceWorker;
 
 use crate::capabilities::Capabilities;
-use crate::linter::error_with_position::DiagnosticReport;
-use crate::linter::server_linter::ServerLinter;
 
 mod capabilities;
 mod code_actions;
 mod commands;
 mod linter;
+mod worker;
 
 type ConcurrentHashMap<K, V> = papaya::HashMap<K, V, FxBuildHasher>;
 
@@ -44,17 +34,17 @@ const OXC_CONFIG_FILE: &str = ".oxlintrc.json";
 
 struct Backend {
     client: Client,
-    root_uri: OnceCell<Option<Uri>>,
+    // Each Workspace has it own worker with Linter (and in the future the formatter).
+    // We must respect each program inside with its own root folder
+    // and can not use shared programmes across multiple workspaces.
+    // Each Workspace can have its own server configuration and program root configuration.
+    workspace_workers: Mutex<Vec<WorkspaceWorker>>,
     capabilities: OnceCell<Capabilities>,
-    server_linter: RwLock<ServerLinter>,
-    diagnostics_report_map: ConcurrentHashMap<String, Vec<DiagnosticReport>>,
-    options: Mutex<Options>,
-    gitignore_glob: Mutex<Vec<Gitignore>>,
-    nested_configs: ConcurrentHashMap<PathBuf, ConfigStore>,
 }
-#[derive(Debug, Serialize, Deserialize, Default, PartialEq, PartialOrd, Clone, Copy)]
+
+#[derive(Debug, Serialize, Deserialize, Default, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "camelCase")]
-enum Run {
+pub enum Run {
     OnSave,
     #[default]
     OnType,
@@ -91,16 +81,21 @@ impl Options {
 impl LanguageServer for Backend {
     #[expect(deprecated)] // TODO: FIXME
     async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
-        self.init(params.root_uri)?;
         let options = params.initialization_options.and_then(|mut value| {
             let settings = value.get_mut("settings")?.take();
             serde_json::from_value::<Options>(settings).ok()
         });
 
+        // ToDo: add support for multiple workspace folders
+        // maybe fallback when the client does not support it
+        let root_worker =
+            WorkspaceWorker::new(&params.root_uri.unwrap(), options.clone().unwrap_or_default());
+
+        *self.workspace_workers.lock().await = vec![root_worker];
+
         if let Some(value) = options {
             info!("initialize: {value:?}");
             info!("language server version: {:?}", env!("CARGO_PKG_VERSION"));
-            *self.options.lock().await = value;
         }
 
         let capabilities = Capabilities::from(params.capabilities);
@@ -115,9 +110,6 @@ impl LanguageServer for Backend {
             Error { code: ErrorCode::ParseError, message, data: None }
         })?;
 
-        self.init_nested_configs().await;
-        let oxlintrc = self.init_linter_config().await;
-        self.init_ignore_glob(oxlintrc).await;
         Ok(InitializeResult {
             server_info: Some(ServerInfo { name: "oxc".into(), version: None }),
             offset_encoding: None,
@@ -126,103 +118,91 @@ impl LanguageServer for Backend {
     }
 
     async fn did_change_configuration(&self, params: DidChangeConfigurationParams) {
-        let changed_options =
-            if let Ok(options) = serde_json::from_value::<Options>(params.settings) {
-                options
-            } else if self
-                .capabilities
-                .get()
-                .is_some_and(|capabilities| capabilities.workspace_configuration)
-            {
-                // Fallback if some client didn't took changed configuration in params of `workspace/configuration`
-                let Some(options) = self
-                    .client
-                    .configuration(vec![ConfigurationItem {
-                        scope_uri: None,
-                        section: Some("oxc_language_server".into()),
-                    }])
-                    .await
-                    .ok()
-                    .and_then(|mut config| config.first_mut().map(serde_json::Value::take))
-                    .and_then(|value| serde_json::from_value::<Options>(value).ok())
-                else {
-                    error!("Can't fetch `oxc_language_server` configuration");
-                    return;
+        let workers = self.workspace_workers.lock().await;
+
+        // when we have only workspace folder, apply to it
+        // ToDo: check if this is really safe because the client could still pass an empty settings
+        if workers.len() == 1 {
+            let worker = workers.first().unwrap();
+            worker.did_change_configuration(params.settings).await;
+
+        // else check if the client support workspace configuration requests so we can only restart only the needed workers
+        } else if self
+            .capabilities
+            .get()
+            .is_some_and(|capabilities| capabilities.workspace_configuration)
+        {
+            let mut config_items = vec![];
+            for worker in workers.iter() {
+                let Some(uri) = worker.get_root_uri() else {
+                    continue;
                 };
-                options
-            } else {
-                // the client did not give os changes to the configuration and he is not able to respond to `workspace/configuration`
-                // so we fallback to the current configuration
-                self.options.lock().await.clone()
+                // ToDo: this is broken in VSCode. Check how we can get the language server configuration from the client
+                // changing `section` to `oxc` will return the client configuration.
+                config_items.push(ConfigurationItem {
+                    scope_uri: Some(uri),
+                    section: Some("oxc_language_server".into()),
+                });
+            }
+
+            let Ok(configs) = self.client.configuration(config_items).await else {
+                debug!("failed to get configuration");
+                return;
             };
 
-        let current_option = &self.options.lock().await.clone();
+            // we expect that the client is sending all the configuration items in order and completed
+            // this is a LSP specification and errors should be reported on the client side
+            for (index, worker) in workers.iter().enumerate() {
+                let config = &configs[index];
+                worker.did_change_configuration(config.clone()).await;
+            }
 
-        debug!(
-            "
-        configuration changed:
-        incoming: {changed_options:?}
-        current: {current_option:?}
-        "
-        );
-
-        *self.options.lock().await = changed_options.clone();
-
-        if changed_options.use_nested_configs() != current_option.use_nested_configs() {
-            self.nested_configs.pin().clear();
-            self.init_nested_configs().await;
-        }
-
-        if Self::needs_linter_restart(current_option, &changed_options) {
-            self.init_linter_config().await;
-            self.revalidate_open_files().await;
+            // we have multiple workspace folders and the client does not support workspace configuration requests
+            // we assume that every workspace is under effect
+        } else {
+            for worker in workers.iter() {
+                worker.did_change_configuration(params.settings.clone()).await;
+            }
         }
     }
 
     async fn did_change_watched_files(&self, params: DidChangeWatchedFilesParams) {
+        let workers = self.workspace_workers.lock().await;
+        // ToDo: what if an empty changes flag is passed?
         debug!("watched file did change");
-        if self.options.lock().await.use_nested_configs() {
-            let nested_configs = self.nested_configs.pin();
+        let all_diagnostics: papaya::HashMap<String, Vec<Diagnostic>, FxBuildHasher> =
+            ConcurrentHashMap::default();
+        for file_event in &params.changes {
+            // We do not expect multiple changes from the same workspace folder.
+            // If we should consider it, we need to map the events to the workers first,
+            // to only restart the internal linter / diagnostics for once
+            let Some(worker) =
+                workers.iter().find(|worker| worker.is_responsible_for_uri(&file_event.uri))
+            else {
+                continue;
+            };
+            let Some(diagnostics) = worker.did_change_watched_files(file_event).await else {
+                continue;
+            };
 
-            params.changes.iter().for_each(|x| {
-                let Some(file_path) = x.uri.to_file_path() else {
-                    info!("Unable to convert {:?} to a file path", x.uri);
-                    return;
-                };
-                let Some(file_name) = file_path.file_name() else {
-                    info!("Unable to retrieve file name from {file_path:?}");
-                    return;
-                };
-
-                if file_name != OXC_CONFIG_FILE {
-                    return;
-                }
-
-                let Some(dir_path) = file_path.parent() else {
-                    info!("Unable to retrieve parent from {file_path:?}");
-                    return;
-                };
-
-                // spellchecker:off -- "typ" is accurate
-                if x.typ == FileChangeType::CREATED || x.typ == FileChangeType::CHANGED {
-                    // spellchecker:on
-                    let oxlintrc =
-                        Oxlintrc::from_file(&file_path).expect("Failed to parse config file");
-                    let config_store_builder = ConfigStoreBuilder::from_oxlintrc(false, oxlintrc)
-                        .expect("Failed to create config store builder");
-                    let config_store =
-                        config_store_builder.build().expect("Failed to build config store");
-                    nested_configs.insert(dir_path.to_path_buf(), config_store);
-                // spellchecker:off -- "typ" is accurate
-                } else if x.typ == FileChangeType::DELETED {
-                    // spellchecker:on
-                    nested_configs.remove(&dir_path.to_path_buf());
-                }
-            });
+            for (key, value) in &diagnostics.pin() {
+                all_diagnostics
+                    .pin()
+                    .insert(key.clone(), value.iter().map(|d| d.diagnostic.clone()).collect());
+            }
         }
 
-        self.init_linter_config().await;
-        self.revalidate_open_files().await;
+        if all_diagnostics.is_empty() {
+            return;
+        }
+
+        let x = &all_diagnostics
+            .pin()
+            .into_iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect::<Vec<_>>();
+
+        self.publish_all_diagnostics(x).await;
     }
 
     async fn initialized(&self, _params: InitializedParams) {
@@ -236,337 +216,150 @@ impl LanguageServer for Backend {
 
     async fn did_save(&self, params: DidSaveTextDocumentParams) {
         debug!("oxc server did save");
-        // drop as fast as possible
-        let run_level = { self.options.lock().await.run };
-        if run_level != Run::OnSave {
+        let uri = &params.text_document.uri;
+        let workers = self.workspace_workers.lock().await;
+        let Some(worker) = workers.iter().find(|worker| worker.is_responsible_for_uri(uri)) else {
+            return;
+        };
+        if !worker.should_lint_on_run_type(Run::OnSave).await {
             return;
         }
-        let uri = params.text_document.uri;
-        if self.is_ignored(&uri).await {
-            return;
+        if let Some(diagnostics) = worker.lint_file(uri, None).await {
+            self.client
+                .publish_diagnostics(
+                    uri.clone(),
+                    diagnostics.clone().into_iter().map(|d| d.diagnostic).collect(),
+                    None,
+                )
+                .await;
         }
-        self.handle_file_update(uri, None, None).await;
     }
 
     /// When the document changed, it may not be written to disk, so we should
     /// get the file context from the language client
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
-        let run_level = { self.options.lock().await.run };
-        if run_level != Run::OnType {
-            return;
-        }
-
         let uri = &params.text_document.uri;
-        if self.is_ignored(uri).await {
+        let workers = self.workspace_workers.lock().await;
+        let Some(worker) = workers.iter().find(|worker| worker.is_responsible_for_uri(uri)) else {
+            return;
+        };
+        if !worker.should_lint_on_run_type(Run::OnType).await {
             return;
         }
         let content = params.content_changes.first().map(|c| c.text.clone());
-        self.handle_file_update(
-            params.text_document.uri,
-            content,
-            Some(params.text_document.version),
-        )
-        .await;
+        if let Some(diagnostics) = worker.lint_file(uri, content).await {
+            self.client
+                .publish_diagnostics(
+                    uri.clone(),
+                    diagnostics.clone().into_iter().map(|d| d.diagnostic).collect(),
+                    Some(params.text_document.version),
+                )
+                .await;
+        }
     }
 
     async fn did_open(&self, params: DidOpenTextDocumentParams) {
-        if self.is_ignored(&params.text_document.uri).await {
+        let uri = &params.text_document.uri;
+        let workers = self.workspace_workers.lock().await;
+        let Some(worker) = workers.iter().find(|worker| worker.is_responsible_for_uri(uri)) else {
             return;
+        };
+
+        let content = params.text_document.text;
+        if let Some(diagnostics) = worker.lint_file(uri, Some(content)).await {
+            self.client
+                .publish_diagnostics(
+                    uri.clone(),
+                    diagnostics.clone().into_iter().map(|d| d.diagnostic).collect(),
+                    Some(params.text_document.version),
+                )
+                .await;
         }
-        self.handle_file_update(params.text_document.uri, None, Some(params.text_document.version))
-            .await;
     }
 
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
-        let uri = params.text_document.uri.to_string();
-        self.diagnostics_report_map.pin().remove(&uri);
+        let uri = &params.text_document.uri;
+        let workers = self.workspace_workers.lock().await;
+        let Some(worker) = workers.iter().find(|worker| worker.is_responsible_for_uri(uri)) else {
+            return;
+        };
+        worker.remove_diagnostics(&params.text_document.uri).await;
     }
 
     async fn code_action(&self, params: CodeActionParams) -> Result<Option<CodeActionResponse>> {
         let uri = &params.text_document.uri;
-        let report_map = self.diagnostics_report_map.pin();
-        let Some(value) = report_map.get(&uri.to_string()) else {
+        let workers = self.workspace_workers.lock().await;
+        let Some(worker) = workers.iter().find(|worker| worker.is_responsible_for_uri(uri)) else {
             return Ok(None);
         };
-
-        let reports = value.iter().filter(|r| {
-            r.diagnostic.range == params.range || range_overlaps(params.range, r.diagnostic.range)
-        });
 
         let is_source_fix_all_oxc = params
             .context
             .only
             .is_some_and(|only| only.contains(&CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC));
 
-        if is_source_fix_all_oxc {
-            return Ok(apply_all_fix_code_action(reports, uri)
-                .map(|code_actions| vec![CodeActionOrCommand::CodeAction(code_actions)]));
-        }
+        let code_actions =
+            worker.get_code_actions_or_commands(uri, &params.range, is_source_fix_all_oxc).await;
 
-        let mut code_actions_vec: Vec<CodeActionOrCommand> = vec![];
-
-        for report in reports {
-            if let Some(fix_action) = apply_fix_code_action(report, uri) {
-                code_actions_vec.push(CodeActionOrCommand::CodeAction(fix_action));
-            }
-
-            code_actions_vec
-                .push(CodeActionOrCommand::CodeAction(ignore_this_line_code_action(report, uri)));
-
-            code_actions_vec
-                .push(CodeActionOrCommand::CodeAction(ignore_this_rule_code_action(report, uri)));
-        }
-
-        if code_actions_vec.is_empty() {
+        if code_actions.is_empty() {
             return Ok(None);
         }
 
-        Ok(Some(code_actions_vec))
+        Ok(Some(code_actions))
     }
 
     async fn execute_command(
         &self,
         params: ExecuteCommandParams,
     ) -> Result<Option<serde_json::Value>> {
-        let command = LSP_COMMANDS.iter().find(|c| c.command_id() == params.command);
-        match command {
-            Some(c) => c.execute(self, params.arguments).await,
-            None => Err(Error::invalid_request()),
+        if params.command == FIX_ALL_COMMAND_ID {
+            if !self.capabilities.get().unwrap().workspace_apply_edit {
+                return Err(Error::invalid_params("client does not support workspace apply edit"));
+            }
+
+            let args =
+                FixAllCommandArgs::try_from(params.arguments).map_err(Error::invalid_params)?;
+
+            let uri = &Uri::from_str(&args.uri).unwrap();
+            let workers = self.workspace_workers.lock().await;
+            let Some(worker) = workers.iter().find(|worker| worker.is_responsible_for_uri(uri))
+            else {
+                return Ok(None);
+            };
+
+            let text_edits = worker.get_diagnostic_text_edits(uri).await;
+
+            self.client
+                .apply_edit(WorkspaceEdit {
+                    #[expect(clippy::disallowed_types)]
+                    changes: Some(std::collections::HashMap::from([(uri.clone(), text_edits)])),
+                    document_changes: None,
+                    change_annotations: None,
+                })
+                .await?;
+
+            return Ok(None);
         }
+
+        Err(Error::invalid_request())
     }
 }
 
 impl Backend {
-    fn init(&self, root_uri: Option<Uri>) -> Result<()> {
-        self.root_uri.set(root_uri).map_err(|err| {
-            let message = match err {
-                SetError::AlreadyInitializedError(_) => "root uri already initialized".into(),
-                SetError::InitializingError(_) => "initializing error".into(),
-            };
-
-            Error { code: ErrorCode::ParseError, message, data: None }
-        })?;
-
-        Ok(())
-    }
-
-    async fn init_ignore_glob(&self, oxlintrc: Option<Oxlintrc>) {
-        let uri = self
-            .root_uri
-            .get()
-            .expect("The root uri should be initialized already")
-            .as_ref()
-            .expect("should get uri");
-        let mut builder = globset::GlobSetBuilder::new();
-        // Collecting all ignore files
-        builder.add(Glob::new("**/.eslintignore").unwrap());
-        builder.add(Glob::new("**/.gitignore").unwrap());
-
-        let ignore_file_glob_set = builder.build().unwrap();
-
-        let walk = ignore::WalkBuilder::new(uri.to_file_path().unwrap())
-            .ignore(true)
-            .hidden(false)
-            .git_global(false)
-            .build()
-            .flatten();
-
-        let mut gitignore_globs = self.gitignore_glob.lock().await;
-        for entry in walk {
-            let ignore_file_path = entry.path();
-            if !ignore_file_glob_set.is_match(ignore_file_path) {
-                continue;
-            }
-
-            if let Some(ignore_file_dir) = ignore_file_path.parent() {
-                let mut builder = ignore::gitignore::GitignoreBuilder::new(ignore_file_dir);
-                builder.add(ignore_file_path);
-                if let Ok(gitignore) = builder.build() {
-                    gitignore_globs.push(gitignore);
-                }
-            }
-        }
-
-        if let Some(oxlintrc) = oxlintrc {
-            if !oxlintrc.ignore_patterns.is_empty() {
-                let mut builder =
-                    ignore::gitignore::GitignoreBuilder::new(oxlintrc.path.parent().unwrap());
-                for entry in &oxlintrc.ignore_patterns {
-                    builder.add_line(None, entry).expect("Failed to add ignore line");
-                }
-                gitignore_globs.push(builder.build().unwrap());
-            }
-        }
-    }
-
+    // clears all diagnostics for workspace folders
     async fn clear_all_diagnostics(&self) {
-        let cleared_diagnostics = self
-            .diagnostics_report_map
-            .pin()
-            .keys()
-            .map(|uri| (uri.clone(), vec![]))
-            .collect::<Vec<_>>();
+        let mut cleared_diagnostics = vec![];
+        for worker in self.workspace_workers.lock().await.iter() {
+            cleared_diagnostics.extend(worker.get_clear_diagnostics().await);
+        }
         self.publish_all_diagnostics(&cleared_diagnostics).await;
     }
 
-    #[expect(clippy::ptr_arg)]
-    async fn publish_all_diagnostics(&self, result: &Vec<(String, Vec<Diagnostic>)>) {
+    async fn publish_all_diagnostics(&self, result: &[(String, Vec<Diagnostic>)]) {
         join_all(result.iter().map(|(path, diagnostics)| {
             self.client.publish_diagnostics(Uri::from_str(path).unwrap(), diagnostics.clone(), None)
         }))
         .await;
-    }
-
-    async fn revalidate_open_files(&self) {
-        join_all(self.diagnostics_report_map.pin_owned().keys().map(|key| {
-            let url = Uri::from_str(key).expect("should convert to path");
-
-            self.handle_file_update(url, None, None)
-        }))
-        .await;
-    }
-
-    fn needs_linter_restart(old_options: &Options, new_options: &Options) -> bool {
-        old_options.config_path != new_options.config_path
-            || old_options.use_nested_configs() != new_options.use_nested_configs()
-            || old_options.fix_kind() != new_options.fix_kind()
-    }
-
-    /// Searches inside root_uri recursively for the default oxlint config files
-    /// and insert them inside the nested configuration
-    async fn init_nested_configs(&self) {
-        let Some(Some(uri)) = self.root_uri.get() else {
-            return;
-        };
-        let Some(root_path) = uri.to_file_path() else {
-            return;
-        };
-
-        // nested config is disabled, no need to search for configs
-        if !self.options.lock().await.use_nested_configs() {
-            return;
-        }
-
-        let paths = ConfigWalker::new(&root_path).paths();
-        let nested_configs = self.nested_configs.pin();
-
-        for path in paths {
-            let file_path = Path::new(&path);
-            let Some(dir_path) = file_path.parent() else {
-                continue;
-            };
-
-            let oxlintrc = Oxlintrc::from_file(file_path).expect("Failed to parse config file");
-            let config_store_builder = ConfigStoreBuilder::from_oxlintrc(false, oxlintrc)
-                .expect("Failed to create config store builder");
-            let config_store = config_store_builder.build().expect("Failed to build config store");
-            nested_configs.insert(dir_path.to_path_buf(), config_store);
-        }
-    }
-
-    async fn init_linter_config(&self) -> Option<Oxlintrc> {
-        let Some(Some(uri)) = self.root_uri.get() else {
-            return None;
-        };
-        let root_path = uri.to_file_path()?;
-        let relative_config_path = self.options.lock().await.config_path.clone();
-        let oxlintrc = if relative_config_path.is_some() {
-            let config = root_path.join(relative_config_path.unwrap());
-            if config.try_exists().expect("Could not get fs metadata for config") {
-                if let Ok(oxlintrc) = Oxlintrc::from_file(&config) {
-                    oxlintrc
-                } else {
-                    warn!("Failed to initialize oxlintrc config: {}", config.to_string_lossy());
-                    Oxlintrc::default()
-                }
-            } else {
-                warn!(
-                    "Config file not found: {}, fallback to default config",
-                    config.to_string_lossy()
-                );
-                Oxlintrc::default()
-            }
-        } else {
-            Oxlintrc::default()
-        };
-
-        // clone because we are returning it for ignore builder
-        let config_builder =
-            ConfigStoreBuilder::from_oxlintrc(false, oxlintrc.clone()).unwrap_or_default();
-
-        // TODO(refactor): pull this into a shared function, because in oxlint we have the same functionality.
-        let use_nested_config = self.options.lock().await.use_nested_configs();
-
-        let use_cross_module = if use_nested_config {
-            self.nested_configs.pin().values().any(|config| config.plugins().has_import())
-        } else {
-            config_builder.plugins().has_import()
-        };
-
-        let config_store = config_builder.build().expect("Failed to build config store");
-
-        let lint_options =
-            LintOptions { fix: self.options.lock().await.fix_kind(), ..Default::default() };
-
-        let linter = if use_nested_config {
-            let nested_configs = self.nested_configs.pin();
-            let nested_configs_copy: FxHashMap<PathBuf, ConfigStore> = nested_configs
-                .iter()
-                .map(|(key, value)| (key.clone(), value.clone()))
-                .collect::<FxHashMap<_, _>>();
-
-            Linter::new_with_nested_configs(lint_options, config_store, nested_configs_copy)
-        } else {
-            Linter::new(lint_options, config_store)
-        };
-
-        *self.server_linter.write().await = ServerLinter::new_with_linter(
-            linter,
-            IsolatedLintHandlerOptions { use_cross_module, root_path: root_path.to_path_buf() },
-        );
-
-        Some(oxlintrc)
-    }
-
-    async fn handle_file_update(&self, uri: Uri, content: Option<String>, version: Option<i32>) {
-        if let Some(Some(_root_uri)) = self.root_uri.get() {
-            let diagnostics = self.server_linter.read().await.run_single(&uri, content);
-            if let Some(diagnostics) = diagnostics {
-                self.client
-                    .publish_diagnostics(
-                        uri.clone(),
-                        diagnostics.clone().into_iter().map(|d| d.diagnostic).collect(),
-                        version,
-                    )
-                    .await;
-
-                self.diagnostics_report_map.pin().insert(uri.to_string(), diagnostics);
-            }
-        }
-    }
-
-    async fn is_ignored(&self, uri: &Uri) -> bool {
-        let Some(Some(root_uri)) = self.root_uri.get() else {
-            return false;
-        };
-
-        // The file is not under current workspace
-        if !uri.to_file_path().unwrap().starts_with(root_uri.to_file_path().unwrap()) {
-            return false;
-        }
-        let gitignore_globs = &(*self.gitignore_glob.lock().await);
-        for gitignore in gitignore_globs {
-            if let Some(uri_path) = uri.to_file_path() {
-                if !uri_path.starts_with(gitignore.path()) {
-                    continue;
-                }
-                if gitignore.matched_path_or_any_parents(&uri_path, uri_path.is_dir()).is_ignore() {
-                    debug!("ignored: {uri:?}");
-                    return true;
-                }
-            }
-        }
-        false
     }
 }
 
@@ -577,27 +370,12 @@ async fn main() {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
 
-    let server_linter = ServerLinter::new(IsolatedLintHandlerOptions {
-        use_cross_module: false,
-        root_path: PathBuf::new(),
-    });
-    let diagnostics_report_map = ConcurrentHashMap::default();
-
     let (service, socket) = LspService::build(|client| Backend {
         client,
-        root_uri: OnceCell::new(),
+        workspace_workers: Mutex::new(vec![]),
         capabilities: OnceCell::new(),
-        server_linter: RwLock::new(server_linter),
-        diagnostics_report_map,
-        options: Mutex::new(Options::default()),
-        gitignore_glob: Mutex::new(vec![]),
-        nested_configs: ConcurrentHashMap::default(),
     })
     .finish();
 
     Server::new(stdin, stdout, socket).serve(service).await;
-}
-
-fn range_overlaps(a: Range, b: Range) -> bool {
-    a.start <= b.end && a.end >= b.start
 }

--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -1,0 +1,492 @@
+use std::{
+    path::{Path, PathBuf},
+    str::FromStr,
+    vec,
+};
+
+use globset::Glob;
+use ignore::gitignore::Gitignore;
+use log::{debug, info, warn};
+use oxc_linter::{ConfigStore, ConfigStoreBuilder, LintOptions, Linter, Oxlintrc};
+use rustc_hash::{FxBuildHasher, FxHashMap};
+use tokio::sync::{Mutex, OnceCell, RwLock};
+use tower_lsp_server::{
+    UriExt,
+    lsp_types::{CodeActionOrCommand, Diagnostic, FileChangeType, FileEvent, Range, TextEdit, Uri},
+};
+
+use crate::{
+    ConcurrentHashMap, OXC_CONFIG_FILE, Options, Run,
+    code_actions::{
+        apply_all_fix_code_action, apply_fix_code_action, ignore_this_line_code_action,
+        ignore_this_rule_code_action,
+    },
+    linter::{
+        config_walker::ConfigWalker, error_with_position::DiagnosticReport,
+        isolated_lint_handler::IsolatedLintHandlerOptions, server_linter::ServerLinter,
+    },
+};
+
+pub struct WorkspaceWorker {
+    root_uri: OnceCell<Uri>,
+    server_linter: RwLock<ServerLinter>,
+    diagnostics_report_map: RwLock<ConcurrentHashMap<String, Vec<DiagnosticReport>>>,
+    options: Mutex<Options>,
+    gitignore_glob: Mutex<Vec<Gitignore>>,
+    nested_configs: RwLock<ConcurrentHashMap<PathBuf, ConfigStore>>,
+}
+
+impl WorkspaceWorker {
+    pub fn new(root_uri: &Uri, options: Options) -> Self {
+        let root_uri_cell = OnceCell::new();
+        root_uri_cell.set(root_uri.clone()).unwrap();
+
+        let nested_configs = Self::init_nested_configs(root_uri, &options);
+        let (server_linter, oxlintrc) =
+            Self::init_linter_config(root_uri, &options, &nested_configs);
+
+        Self {
+            root_uri: root_uri_cell,
+            server_linter: RwLock::new(server_linter),
+            diagnostics_report_map: RwLock::new(ConcurrentHashMap::default()),
+            options: Mutex::new(options),
+            gitignore_glob: Mutex::new(Self::init_ignore_glob(root_uri, &oxlintrc)),
+            nested_configs: RwLock::const_new(nested_configs),
+        }
+    }
+
+    pub fn get_root_uri(&self) -> Option<Uri> {
+        self.root_uri.get().cloned()
+    }
+
+    pub fn is_responsible_for_uri(&self, uri: &Uri) -> bool {
+        if let Some(root_uri) = self.root_uri.get() {
+            if let Some(path) = uri.to_file_path() {
+                return path.starts_with(root_uri.to_file_path().unwrap());
+            }
+        }
+        false
+    }
+
+    pub async fn remove_diagnostics(&self, uri: &Uri) {
+        self.diagnostics_report_map.read().await.pin().remove(&uri.to_string());
+    }
+
+    /// Searches inside root_uri recursively for the default oxlint config files
+    /// and insert them inside the nested configuration
+    fn init_nested_configs(
+        root_uri: &Uri,
+        options: &Options,
+    ) -> ConcurrentHashMap<PathBuf, ConfigStore> {
+        // nested config is disabled, no need to search for configs
+        if options.use_nested_configs() {
+            return ConcurrentHashMap::default();
+        }
+
+        let root_path = root_uri.to_file_path().expect("Failed to convert URI to file path");
+
+        let paths = ConfigWalker::new(&root_path).paths();
+        let nested_configs =
+            ConcurrentHashMap::with_capacity_and_hasher(paths.capacity(), FxBuildHasher);
+
+        for path in paths {
+            let file_path = Path::new(&path);
+            let Some(dir_path) = file_path.parent() else {
+                continue;
+            };
+
+            let oxlintrc = Oxlintrc::from_file(file_path).expect("Failed to parse config file");
+            let config_store_builder = ConfigStoreBuilder::from_oxlintrc(false, oxlintrc)
+                .expect("Failed to create config store builder");
+            let config_store = config_store_builder.build().expect("Failed to build config store");
+            nested_configs.pin().insert(dir_path.to_path_buf(), config_store);
+        }
+
+        nested_configs
+    }
+
+    async fn refresh_nested_configs(&self) {
+        let options = self.options.lock().await;
+        let nested_configs = Self::init_nested_configs(self.root_uri.get().unwrap(), &options);
+
+        *self.nested_configs.write().await = nested_configs;
+    }
+
+    fn init_linter_config(
+        root_uri: &Uri,
+        options: &Options,
+        nested_configs: &ConcurrentHashMap<PathBuf, ConfigStore>,
+    ) -> (ServerLinter, Oxlintrc) {
+        let root_path = root_uri.to_file_path().unwrap();
+        let relative_config_path = options.config_path.clone();
+        let oxlintrc = if relative_config_path.is_some() {
+            let config = root_path.join(relative_config_path.unwrap());
+            if config.try_exists().expect("Could not get fs metadata for config") {
+                if let Ok(oxlintrc) = Oxlintrc::from_file(&config) {
+                    oxlintrc
+                } else {
+                    warn!("Failed to initialize oxlintrc config: {}", config.to_string_lossy());
+                    Oxlintrc::default()
+                }
+            } else {
+                warn!(
+                    "Config file not found: {}, fallback to default config",
+                    config.to_string_lossy()
+                );
+                Oxlintrc::default()
+            }
+        } else {
+            Oxlintrc::default()
+        };
+
+        // clone because we are returning it for ignore builder
+        let config_builder =
+            ConfigStoreBuilder::from_oxlintrc(false, oxlintrc.clone()).unwrap_or_default();
+
+        // TODO(refactor): pull this into a shared function, because in oxlint we have the same functionality.
+        let use_nested_config = options.use_nested_configs();
+
+        let use_cross_module = if use_nested_config {
+            nested_configs.pin().values().any(|config| config.plugins().has_import())
+        } else {
+            config_builder.plugins().has_import()
+        };
+
+        let config_store = config_builder.build().expect("Failed to build config store");
+
+        let lint_options = LintOptions { fix: options.fix_kind(), ..Default::default() };
+
+        let linter = if use_nested_config {
+            let nested_configs = nested_configs.pin();
+            let nested_configs_copy: FxHashMap<PathBuf, ConfigStore> = nested_configs
+                .iter()
+                .map(|(key, value)| (key.clone(), value.clone()))
+                .collect::<FxHashMap<_, _>>();
+
+            Linter::new_with_nested_configs(lint_options, config_store, nested_configs_copy)
+        } else {
+            Linter::new(lint_options, config_store)
+        };
+
+        let server_linter = ServerLinter::new_with_linter(
+            linter,
+            IsolatedLintHandlerOptions { use_cross_module, root_path: root_path.to_path_buf() },
+        );
+
+        (server_linter, oxlintrc)
+    }
+
+    async fn refresh_linter_config(&self) {
+        let options = self.options.lock().await;
+        let nested_configs = self.nested_configs.read().await;
+        let (server_linter, _) =
+            Self::init_linter_config(self.root_uri.get().unwrap(), &options, &nested_configs);
+
+        *self.server_linter.write().await = server_linter;
+    }
+
+    fn init_ignore_glob(root_uri: &Uri, oxlintrc: &Oxlintrc) -> Vec<Gitignore> {
+        let mut builder = globset::GlobSetBuilder::new();
+        // Collecting all ignore files
+        builder.add(Glob::new("**/.eslintignore").unwrap());
+        builder.add(Glob::new("**/.gitignore").unwrap());
+
+        let ignore_file_glob_set = builder.build().unwrap();
+
+        let walk = ignore::WalkBuilder::new(root_uri.to_file_path().unwrap())
+            .ignore(true)
+            .hidden(false)
+            .git_global(false)
+            .build()
+            .flatten();
+
+        let mut gitignore_globs = vec![];
+        for entry in walk {
+            let ignore_file_path = entry.path();
+            if !ignore_file_glob_set.is_match(ignore_file_path) {
+                continue;
+            }
+
+            if let Some(ignore_file_dir) = ignore_file_path.parent() {
+                let mut builder = ignore::gitignore::GitignoreBuilder::new(ignore_file_dir);
+                builder.add(ignore_file_path);
+                if let Ok(gitignore) = builder.build() {
+                    gitignore_globs.push(gitignore);
+                }
+            }
+        }
+
+        if !oxlintrc.ignore_patterns.is_empty() {
+            let mut builder =
+                ignore::gitignore::GitignoreBuilder::new(oxlintrc.path.parent().unwrap());
+            for entry in &oxlintrc.ignore_patterns {
+                builder.add_line(None, entry).expect("Failed to add ignore line");
+            }
+            gitignore_globs.push(builder.build().unwrap());
+        }
+
+        gitignore_globs
+    }
+
+    fn needs_linter_restart(old_options: &Options, new_options: &Options) -> bool {
+        old_options.config_path != new_options.config_path
+            || old_options.use_nested_configs() != new_options.use_nested_configs()
+            || old_options.fix_kind() != new_options.fix_kind()
+    }
+
+    pub async fn should_lint_on_run_type(&self, current_run: Run) -> bool {
+        let run_level = { self.options.lock().await.run };
+
+        run_level == current_run
+    }
+
+    pub async fn lint_file(
+        &self,
+        uri: &Uri,
+        content: Option<String>,
+    ) -> Option<Vec<DiagnosticReport>> {
+        if self.is_ignored(uri).await {
+            return None;
+        }
+
+        Some(self.update_diagnostics(uri, content).await)
+    }
+
+    async fn update_diagnostics(
+        &self,
+        uri: &Uri,
+        content: Option<String>,
+    ) -> Vec<DiagnosticReport> {
+        let diagnostics = self.server_linter.read().await.run_single(uri, content);
+        if let Some(diagnostics) = diagnostics {
+            self.diagnostics_report_map
+                .read()
+                .await
+                .pin()
+                .insert(uri.to_string(), diagnostics.clone());
+
+            return diagnostics;
+        }
+
+        vec![]
+    }
+
+    async fn revalidate_diagnostics(&self) -> ConcurrentHashMap<String, Vec<DiagnosticReport>> {
+        let diagnostics_map = ConcurrentHashMap::with_capacity_and_hasher(
+            self.diagnostics_report_map.read().await.len(),
+            FxBuildHasher,
+        );
+        let linter = self.server_linter.read().await;
+        for uri in self.diagnostics_report_map.read().await.pin().keys() {
+            if let Some(diagnostics) = linter.run_single(&Uri::from_str(uri).unwrap(), None) {
+                diagnostics_map.pin().insert(uri.clone(), diagnostics);
+            }
+        }
+
+        *self.diagnostics_report_map.write().await = diagnostics_map.clone();
+
+        diagnostics_map
+    }
+
+    pub async fn get_clear_diagnostics(&self) -> Vec<(String, Vec<Diagnostic>)> {
+        self.diagnostics_report_map
+            .read()
+            .await
+            .pin()
+            .keys()
+            .map(|uri| (uri.clone(), vec![]))
+            .collect::<Vec<_>>()
+    }
+
+    pub async fn get_code_actions_or_commands(
+        &self,
+        uri: &Uri,
+        range: &Range,
+        is_source_fix_all_oxc: bool,
+    ) -> Vec<CodeActionOrCommand> {
+        let report_map = self.diagnostics_report_map.read().await;
+        let report_map_ref = report_map.pin();
+        let Some(value) = report_map_ref.get(&uri.to_string()) else {
+            return vec![];
+        };
+
+        let reports = value
+            .iter()
+            .filter(|r| r.diagnostic.range == *range || range_overlaps(*range, r.diagnostic.range));
+
+        if is_source_fix_all_oxc {
+            return apply_all_fix_code_action(reports, uri).map_or(vec![], |code_actions| {
+                vec![CodeActionOrCommand::CodeAction(code_actions)]
+            });
+        }
+
+        let mut code_actions_vec: Vec<CodeActionOrCommand> = vec![];
+
+        for report in reports {
+            if let Some(fix_action) = apply_fix_code_action(report, uri) {
+                code_actions_vec.push(CodeActionOrCommand::CodeAction(fix_action));
+            }
+
+            code_actions_vec
+                .push(CodeActionOrCommand::CodeAction(ignore_this_line_code_action(report, uri)));
+
+            code_actions_vec
+                .push(CodeActionOrCommand::CodeAction(ignore_this_rule_code_action(report, uri)));
+        }
+
+        code_actions_vec
+    }
+
+    pub async fn get_diagnostic_text_edits(&self, uri: &Uri) -> Vec<TextEdit> {
+        let report_map = self.diagnostics_report_map.read().await;
+        let report_map_ref = report_map.pin();
+        let Some(value) = report_map_ref.get(&uri.to_string()) else {
+            return vec![];
+        };
+
+        let mut text_edits = vec![];
+
+        for report in value {
+            if let Some(fixed_content) = &report.fixed_content {
+                text_edits.push(TextEdit {
+                    range: fixed_content.range,
+                    new_text: fixed_content.code.clone(),
+                });
+            }
+        }
+
+        text_edits
+    }
+
+    pub async fn did_change_watched_files(
+        &self,
+        file_event: &FileEvent,
+    ) -> Option<ConcurrentHashMap<String, Vec<DiagnosticReport>>> {
+        if self.options.lock().await.use_nested_configs() {
+            let nested_configs = self.nested_configs.read().await;
+            let nested_configs = nested_configs.pin();
+            let Some(file_path) = file_event.uri.to_file_path() else {
+                info!("Unable to convert {:?} to a file path", file_event.uri);
+                return None;
+            };
+            let Some(file_name) = file_path.file_name() else {
+                info!("Unable to retrieve file name from {file_path:?}");
+                return None;
+            };
+
+            if file_name != OXC_CONFIG_FILE {
+                return None;
+            }
+
+            let Some(dir_path) = file_path.parent() else {
+                info!("Unable to retrieve parent from {file_path:?}");
+                return None;
+            };
+
+            // spellchecker:off -- "typ" is accurate
+            if file_event.typ == FileChangeType::CREATED
+                || file_event.typ == FileChangeType::CHANGED
+            {
+                // spellchecker:on
+                let oxlintrc =
+                    Oxlintrc::from_file(&file_path).expect("Failed to parse config file");
+                let config_store_builder = ConfigStoreBuilder::from_oxlintrc(false, oxlintrc)
+                    .expect("Failed to create config store builder");
+                let config_store =
+                    config_store_builder.build().expect("Failed to build config store");
+                nested_configs.insert(dir_path.to_path_buf(), config_store);
+            // spellchecker:off -- "typ" is accurate
+            } else if file_event.typ == FileChangeType::DELETED {
+                // spellchecker:on
+                nested_configs.remove(&dir_path.to_path_buf());
+            }
+        }
+
+        self.refresh_linter_config().await;
+        Some(self.revalidate_diagnostics().await)
+    }
+
+    pub async fn did_change_configuration(
+        &self,
+        options: serde_json::value::Value,
+    ) -> Option<ConcurrentHashMap<String, Vec<DiagnosticReport>>> {
+        let changed_options = serde_json::from_value::<Options>(options).unwrap_or_default();
+
+        let current_option = &self.options.lock().await.clone();
+
+        debug!(
+            "
+        configuration changed:
+        incoming: {changed_options:?}
+        current: {current_option:?}
+        "
+        );
+
+        *self.options.lock().await = changed_options.clone();
+
+        if changed_options.use_nested_configs() != current_option.use_nested_configs() {
+            self.refresh_nested_configs().await;
+        }
+
+        if Self::needs_linter_restart(current_option, &changed_options) {
+            self.refresh_linter_config().await;
+            return Some(self.revalidate_diagnostics().await);
+        }
+
+        None
+    }
+
+    async fn is_ignored(&self, uri: &Uri) -> bool {
+        let gitignore_globs = &(*self.gitignore_glob.lock().await);
+        for gitignore in gitignore_globs {
+            if let Some(uri_path) = uri.to_file_path() {
+                if !uri_path.starts_with(gitignore.path()) {
+                    continue;
+                }
+                if gitignore.matched_path_or_any_parents(&uri_path, uri_path.is_dir()).is_ignore() {
+                    debug!("ignored: {uri:?}");
+                    return true;
+                }
+            }
+        }
+        false
+    }
+}
+
+fn range_overlaps(a: Range, b: Range) -> bool {
+    a.start <= b.end && a.end >= b.start
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_root_uri() {
+        let worker = WorkspaceWorker::new(
+            &Uri::from_file_path("/path/to/root").unwrap(),
+            Options::default(),
+        );
+
+        assert_eq!(worker.get_root_uri(), Some(Uri::from_file_path("/path/to/root").unwrap()));
+    }
+    #[test]
+    fn test_is_responsible() {
+        let worker = WorkspaceWorker::new(
+            &Uri::from_file_path("/path/to/root").unwrap(),
+            Options::default(),
+        );
+
+        assert!(
+            worker.is_responsible_for_uri(&Uri::from_file_path("/path/to/root/file.js").unwrap())
+        );
+        assert!(
+            worker.is_responsible_for_uri(
+                &Uri::from_file_path("/path/to/root/folder/file.js").unwrap()
+            )
+        );
+        assert!(
+            !worker.is_responsible_for_uri(&Uri::from_file_path("/path/to/other/file.js").unwrap())
+        );
+    }
+}


### PR DESCRIPTION
This PR will refactor the language server, so the Linter is independent of the language server.
The changes are needed to support multiple workspaces in the upstream PR. 
There, every linter will get its own root Uri, and will report back to the `Backend`.

The `Backend` collects the different outputs from the workers and return them to the client when needed.