### PR TITLE
docs(transform): correct tsc's `--isolatedDeclarations` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ TypeScript and React transforms are complete. See [Milestone 2](https://github.c
 
 ### 🔸 Isolated Declarations
 
-[TypeScript Isolated Declarations Emit](https://devblogs.microsoft.com/typescript/announcing-typescript-5-5-beta/#isolated-declarations) without using the TypeScript compiler.
+[TypeScript Isolated Declarations Emit](https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#isolated-declarations) without using the TypeScript compiler.
 
 Our [benchmark](https://github.com/oxc-project/bench-transformer) indications that our implementation is at least 20 times faster than the TypeScript compiler.
 

--- a/napi/transform/README.md
+++ b/napi/transform/README.md
@@ -23,9 +23,9 @@ assert.equal(declaration, 'declare class A<T> {}\n');
 assert(errors.length == 0);
 ```
 
-## [Isolated Declarations for Standalone DTS Emit](https://devblogs.microsoft.com/typescript/announcing-typescript-5-5-beta/#isolated-declarations)
+## [Isolated Declarations for Standalone DTS Emit](https://devblogs.microsoft.com/typescript/announcing-typescript-5-5/#isolated-declarations)
 
-Conforms to TypeScript Compiler's `--isolated-declaration` `.d.ts` emit.
+Conforms to TypeScript compiler's `--isolatedDeclarations` `.d.ts` emit.
 
 ### Usage
 


### PR DESCRIPTION
This PR fixes a typo about isolated declarations CLI option in the docs. The correct option name is `--isolatedDeclarations` ([document link](https://www.typescriptlang.org/docs/handbook/compiler-options.html#:~:text=%2D%2DisolatedDeclarations)).

I also add some other tiny improvements to the docs.

