### PR TITLE
fix(parser): fix `using` asi

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -436,16 +436,6 @@ pub fn jsx_expressions_may_not_use_the_comma_operator(span: Span) -> OxcDiagnost
 }
 
 #[cold]
-pub fn line_terminator_before_using_declaration(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Line terminator not permitted before using declaration.").with_label(span)
-}
-
-#[cold]
-pub fn await_in_using_declaration(span: Span) -> OxcDiagnostic {
-    OxcDiagnostic::error("Await is not allowed in using declarations.").with_label(span)
-}
-
-#[cold]
 pub fn invalid_identifier_in_using_declaration(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Using declarations may not have binding patterns.").with_label(span)
 }

--- a/crates/oxc_parser/src/js/declaration.rs
+++ b/crates/oxc_parser/src/js/declaration.rs
@@ -143,19 +143,6 @@ impl<'a> ParserImpl<'a> {
 
         self.expect(Kind::Using)?;
 
-        // `[no LineTerminator here]`
-        if self.cur_token().is_on_new_line {
-            self.error(diagnostics::line_terminator_before_using_declaration(
-                self.cur_token().span(),
-            ));
-        }
-
-        // [lookahead ≠ await]
-        if self.cur_kind() == Kind::Await {
-            self.error(diagnostics::await_in_using_declaration(self.cur_token().span()));
-            self.eat(Kind::Await);
-        }
-
         // BindingList[?In, ?Yield, ?Await, ~Pattern]
         let mut declarations: oxc_allocator::Vec<'_, VariableDeclarator<'_>> = self.ast.vec();
         loop {

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -12,11 +12,6 @@ use crate::{
 
 impl<'a> ParserImpl<'a> {
     /* ------------------- Enum ------------------ */
-
-    pub(crate) fn is_at_enum_declaration(&mut self) -> bool {
-        self.at(Kind::Enum) || (self.at(Kind::Const) && self.peek_at(Kind::Enum))
-    }
-
     /// `https://www.typescriptlang.org/docs/handbook/enums.html`
     pub(crate) fn parse_ts_enum_declaration(
         &mut self,

--- a/tasks/coverage/misc/pass/oxc-10503.ts
+++ b/tasks/coverage/misc/pass/oxc-10503.ts
@@ -1,0 +1,5 @@
+using
+foo = bar();
+
+await using
+foo = bar();

--- a/tasks/coverage/snapshots/codegen_misc.snap
+++ b/tasks/coverage/snapshots/codegen_misc.snap
@@ -1,3 +1,3 @@
 codegen_misc Summary:
-AST Parsed     : 34/34 (100.00%)
-Positive Passed: 34/34 (100.00%)
+AST Parsed     : 35/35 (100.00%)
+Positive Passed: 35/35 (100.00%)

--- a/tasks/coverage/snapshots/parser_misc.snap
+++ b/tasks/coverage/snapshots/parser_misc.snap
@@ -1,6 +1,6 @@
 parser_misc Summary:
-AST Parsed     : 34/34 (100.00%)
-Positive Passed: 34/34 (100.00%)
+AST Parsed     : 35/35 (100.00%)
+Positive Passed: 35/35 (100.00%)
 Negative Passed: 31/31 (100.00%)
 
   × Identifier `b` has already been declared

--- a/tasks/coverage/snapshots/semantic_misc.snap
+++ b/tasks/coverage/snapshots/semantic_misc.snap
@@ -1,6 +1,6 @@
 semantic_misc Summary:
-AST Parsed     : 34/34 (100.00%)
-Positive Passed: 19/34 (55.88%)
+AST Parsed     : 35/35 (100.00%)
+Positive Passed: 20/35 (57.14%)
 tasks/coverage/misc/pass/oxc-1288.ts
 semantic error: Bindings mismatch:
 after transform: ScopeId(0): ["from"]

--- a/tasks/coverage/snapshots/transformer_misc.snap
+++ b/tasks/coverage/snapshots/transformer_misc.snap
@@ -1,3 +1,3 @@
 transformer_misc Summary:
-AST Parsed     : 34/34 (100.00%)
-Positive Passed: 34/34 (100.00%)
+AST Parsed     : 35/35 (100.00%)
+Positive Passed: 35/35 (100.00%)


### PR DESCRIPTION
fixes #10503

```ts
using
foo = bar()

await using
foo = bar()
```

should be parsed as

```ts
using;
foo = bar()

await using;
foo = bar()
```

not

```ts
using foo = bar()

await using foo = bar()
```