### PR TITLE
refactor(language_server): do not request for worspace configuration when the client does not support it

### DIFF
--- a/crates/oxc_language_server/src/capabilities.rs
+++ b/crates/oxc_language_server/src/capabilities.rs
@@ -7,11 +7,12 @@ use tower_lsp_server::lsp_types::{
 
 use crate::{code_actions::CODE_ACTION_KIND_SOURCE_FIX_ALL_OXC, commands::LSP_COMMANDS};
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct Capabilities {
     pub code_action_provider: bool,
     pub workspace_apply_edit: bool,
     pub workspace_execute_command: bool,
+    pub workspace_configuration: bool,
 }
 
 impl From<ClientCapabilities> for Capabilities {
@@ -28,8 +29,17 @@ impl From<ClientCapabilities> for Capabilities {
             value.workspace.as_ref().is_some_and(|workspace| workspace.apply_edit.is_some());
         let workspace_execute_command =
             value.workspace.as_ref().is_some_and(|workspace| workspace.execute_command.is_some());
+        let workspace_configuration = value
+            .workspace
+            .as_ref()
+            .is_some_and(|workspace| workspace.configuration.is_some_and(|config| config));
 
-        Self { code_action_provider, workspace_apply_edit, workspace_execute_command }
+        Self {
+            code_action_provider,
+            workspace_apply_edit,
+            workspace_execute_command,
+            workspace_configuration,
+        }
     }
 }
 


### PR DESCRIPTION
Currently working on supporting multiple workspace folder. `workspace/didChangeConfiguratoin` does not specific the Workspace, so some clients expect to request them. 
We need to check if the client support this or fallback to a global configuration change (changing all workspaces).

ChatGPT:

> what if workspace/configuration is not supported by the clinet
ChatGPT:
 Ah, good follow-up — if the client does not support workspace/configuration, things get more limited and require some careful handling.
🔧 First: Check If the Client Supports It
When your language server receives the initialize request from the client, it includes its capabilities. Look for:
```
"capabilities": {
  "workspace": {
    "configuration": true
  }
}
```
> If that configuration field is false or missing, then you cannot use workspace/configuration, and the client will only send global settings via workspace/didChangeConfiguration.