### PR TITLE
fix(transformer/typescript): variable declaration disappears when declaring type-alias/interface first and then declaring namespace

### DIFF
--- a/crates/oxc_transformer/src/typescript/namespace.rs
+++ b/crates/oxc_transformer/src/typescript/namespace.rs
@@ -430,7 +430,8 @@ impl<'a> TypeScriptNamespace<'a, '_> {
     fn is_redeclaration_namespace(id: &BindingIdentifier<'a>, ctx: &TraverseCtx<'a>) -> bool {
         let symbol_id = id.symbol_id();
         let redeclarations = ctx.scoping().symbol_redeclarations(symbol_id);
-        redeclarations.first().map_or_else(|| false, |rd| rd.span != id.span)
+        // Find first value declaration because only value declaration will emit JS code.
+        redeclarations.iter().find(|rd| rd.flags.is_value()).is_some_and(|rd| rd.span != id.span)
     }
 }
 

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -7226,7 +7226,10 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(1), ReferenceId(6)]
 rebuilt        : SymbolId(1): [ReferenceId(4), ReferenceId(6)]
 
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitEnumReferenceViaImportEquals.ts
-semantic error: Scope children mismatch:
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): []
+rebuilt        : ScopeId(0): ["Translation"]
+Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Bindings mismatch:
@@ -7235,27 +7238,30 @@ rebuilt        : ScopeId(1): ["TranslationKeyEnum", "_Translation"]
 Scope children mismatch:
 after transform: ScopeId(2): [ScopeId(3)]
 rebuilt        : ScopeId(1): []
+Symbol flags mismatch for "Translation":
+after transform: SymbolId(0): SymbolFlags(Interface | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Translation":
+after transform: SymbolId(0): Span { start: 17, end: 28 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "Translation":
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(4), ReferenceId(5)]
+rebuilt        : SymbolId(0): [ReferenceId(1), ReferenceId(2)]
+Symbol redeclarations mismatch for "Translation":
+after transform: SymbolId(0): [Span { start: 17, end: 28 }, Span { start: 101, end: 112 }]
+rebuilt        : SymbolId(0): []
 Symbol flags mismatch for "TranslationKeyEnum":
 after transform: SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable | TypeAlias)
-rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable | ConstVariable)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable | ConstVariable)
 Symbol span mismatch for "TranslationKeyEnum":
 after transform: SymbolId(1): Span { start: 129, end: 147 }
-rebuilt        : SymbolId(1): Span { start: 198, end: 216 }
+rebuilt        : SymbolId(2): Span { start: 198, end: 216 }
 Symbol reference IDs mismatch for "TranslationKeyEnum":
 after transform: SymbolId(1): [ReferenceId(1), ReferenceId(2)]
-rebuilt        : SymbolId(1): []
+rebuilt        : SymbolId(2): []
 Symbol redeclarations mismatch for "TranslationKeyEnum":
 after transform: SymbolId(1): [Span { start: 129, end: 147 }, Span { start: 198, end: 216 }]
-rebuilt        : SymbolId(1): []
-Reference symbol mismatch for "Translation":
-after transform: SymbolId(0) "Translation"
-rebuilt        : <None>
-Reference symbol mismatch for "Translation":
-after transform: SymbolId(0) "Translation"
-rebuilt        : <None>
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["Translation"]
+rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitExactOptionalPropertyTypesNodeNotReused.ts
 semantic error: Scope children mismatch:
@@ -7637,18 +7643,24 @@ tasks/coverage/typescript/tests/cases/compiler/declarationEmitNameConflictsWithA
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitNamespaceMergedWithInterfaceNestedFunction.ts
-semantic error: Scope children mismatch:
+semantic error: Bindings mismatch:
+after transform: ScopeId(0): []
+rebuilt        : ScopeId(0): ["Bar"]
+Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
-Reference symbol mismatch for "Bar":
-after transform: SymbolId(1) "Bar"
-rebuilt        : <None>
-Reference symbol mismatch for "Bar":
-after transform: SymbolId(1) "Bar"
-rebuilt        : <None>
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["Bar"]
+Symbol flags mismatch for "Bar":
+after transform: SymbolId(1): SymbolFlags(Interface | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Bar":
+after transform: SymbolId(1): Span { start: 51, end: 54 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "Bar":
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(3), ReferenceId(4)]
+rebuilt        : SymbolId(0): [ReferenceId(2), ReferenceId(3)]
+Symbol redeclarations mismatch for "Bar":
+after transform: SymbolId(1): [Span { start: 51, end: 54 }, Span { start: 87, end: 90 }]
+rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/declarationEmitNestedAnonymousMappedType.ts
 semantic error: Scope children mismatch:
@@ -17506,7 +17518,10 @@ after transform: ["A"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces1.ts
-semantic error: Scope flags mismatch:
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["_A"]
+rebuilt        : ScopeId(1): ["B", "_A"]
+Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
@@ -17521,18 +17536,27 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Reference symbol mismatch for "B":
-after transform: SymbolId(1) "B"
-rebuilt        : <None>
-Reference symbol mismatch for "B":
-after transform: SymbolId(1) "B"
-rebuilt        : <None>
+Symbol flags mismatch for "B":
+after transform: SymbolId(1): SymbolFlags(Interface | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(1): Span { start: 33, end: 34 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "B":
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(5), ReferenceId(7)]
+rebuilt        : SymbolId(2): [ReferenceId(2), ReferenceId(3)]
+Symbol redeclarations mismatch for "B":
+after transform: SymbolId(1): [Span { start: 33, end: 34 }, Span { start: 107, end: 108 }]
+rebuilt        : SymbolId(2): []
 Unresolved references mismatch:
 after transform: ["A"]
-rebuilt        : ["B"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces2.ts
-semantic error: Scope flags mismatch:
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["_A"]
+rebuilt        : ScopeId(1): ["B", "_A"]
+Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
@@ -17547,15 +17571,21 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Reference symbol mismatch for "B":
-after transform: SymbolId(1) "B"
-rebuilt        : <None>
-Reference symbol mismatch for "B":
-after transform: SymbolId(1) "B"
-rebuilt        : <None>
+Symbol flags mismatch for "B":
+after transform: SymbolId(1): SymbolFlags(Interface | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(1): Span { start: 33, end: 34 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "B":
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(4), ReferenceId(5)]
+rebuilt        : SymbolId(2): [ReferenceId(2), ReferenceId(3)]
+Symbol redeclarations mismatch for "B":
+after transform: SymbolId(1): [Span { start: 33, end: 34 }, Span { start: 100, end: 101 }]
+rebuilt        : SymbolId(2): []
 Unresolved references mismatch:
 after transform: ["A"]
-rebuilt        : ["B"]
+rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces3.ts
 semantic error: Bindings mismatch:
@@ -17622,7 +17652,10 @@ after transform: SymbolId(1): [Span { start: 30, end: 31 }, Span { start: 134, e
 rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/compiler/interMixingModulesInterfaces5.ts
-semantic error: Scope flags mismatch:
+semantic error: Bindings mismatch:
+after transform: ScopeId(1): ["_A"]
+rebuilt        : ScopeId(1): ["B", "_A"]
+Scope flags mismatch:
 after transform: ScopeId(1): ScopeFlags(StrictMode | Function)
 rebuilt        : ScopeId(1): ScopeFlags(Function)
 Scope children mismatch:
@@ -17637,15 +17670,15 @@ rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
 Symbol span mismatch for "A":
 after transform: SymbolId(0): Span { start: 7, end: 8 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
-Reference symbol mismatch for "B":
-after transform: SymbolId(1) "B"
-rebuilt        : <None>
-Reference symbol mismatch for "B":
-after transform: SymbolId(1) "B"
-rebuilt        : <None>
-Unresolved references mismatch:
-after transform: []
-rebuilt        : ["B"]
+Symbol flags mismatch for "B":
+after transform: SymbolId(1): SymbolFlags(Interface | ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(1): Span { start: 26, end: 27 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "B":
+after transform: SymbolId(1): [Span { start: 26, end: 27 }, Span { start: 100, end: 101 }]
+rebuilt        : SymbolId(2): []
 
 tasks/coverage/typescript/tests/cases/compiler/interface0.ts
 semantic error: Scope children mismatch:

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 578ac4df
 
-Passed: 150/243
+Passed: 150/245
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -44,7 +44,7 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), R
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(10)]
 
 
-# babel-plugin-transform-typescript (4/17)
+# babel-plugin-transform-typescript (4/19)
 * class-property-definition/input.ts
 Unresolved references mismatch:
 after transform: ["const"]
@@ -286,6 +286,49 @@ rebuilt        : SymbolId(3): SymbolFlags(FunctionScopedVariable)
 Symbol redeclarations mismatch for "y":
 after transform: SymbolId(2): [Span { start: 59, end: 60 }, Span { start: 83, end: 84 }]
 rebuilt        : SymbolId(3): []
+
+* namespace/redeclaration-with-interface/input.ts
+Bindings mismatch:
+after transform: ScopeId(0): []
+rebuilt        : ScopeId(0): ["Foo"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "Foo":
+after transform: SymbolId(0): SymbolFlags(Interface | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Foo":
+after transform: SymbolId(0): Span { start: 17, end: 20 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "Foo":
+after transform: SymbolId(0): [Span { start: 17, end: 20 }, Span { start: 41, end: 44 }]
+rebuilt        : SymbolId(0): []
+
+* namespace/redeclaration-with-type-alias/input.ts
+Bindings mismatch:
+after transform: ScopeId(0): []
+rebuilt        : ScopeId(0): ["Foo"]
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Symbol flags mismatch for "Foo":
+after transform: SymbolId(0): SymbolFlags(TypeAlias | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Foo":
+after transform: SymbolId(0): Span { start: 12, end: 15 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "Foo":
+after transform: SymbolId(0): [Span { start: 12, end: 15 }, Span { start: 39, end: 42 }, Span { start: 87, end: 90 }]
+rebuilt        : SymbolId(0): []
 
 * preserve-import-=/input.js
 Symbol reference IDs mismatch for "Foo":

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/namespace/redeclaration-with-interface/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/namespace/redeclaration-with-interface/input.ts
@@ -1,0 +1,4 @@
+export interface Foo {}
+export namespace Foo {
+  export const Bar = 1;
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/namespace/redeclaration-with-interface/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/namespace/redeclaration-with-interface/output.js
@@ -1,0 +1,5 @@
+export let Foo;
+
+(function(_Foo) {
+  const Bar = _Foo.Bar = 1;
+})(Foo || (Foo = {}));

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/namespace/redeclaration-with-type-alias/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/namespace/redeclaration-with-type-alias/input.ts
@@ -1,0 +1,7 @@
+export type Foo = {};
+export namespace Foo {
+	export const Bar = 0;
+}
+export namespace Foo {
+	export const Zoo = 1;
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/namespace/redeclaration-with-type-alias/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/namespace/redeclaration-with-type-alias/output.js
@@ -1,0 +1,9 @@
+export let Foo;
+
+(function(_Foo) {
+  const Bar = _Foo.Bar = 0;
+})(Foo || (Foo = {}));
+
+(function(_Foo2) {
+  const Zoo = _Foo2.Zoo = 1;
+})(Foo || (Foo = {}));


### PR DESCRIPTION
- close https://github.com/rolldown/rolldown/issues/4198

We need to find the first value declaration to skip `TSTypeAliasDeclaration` and `TSInterfaceDeclaration` to check if it is a redeclaration, because `TSTypeAliasDeclaration` and `TSInterfaceDeclaration` are not emited JS code.

