### PR TITLE
fix(transformer/typescript): namespaces disappeared and do not transform when a type-only namespace followed by a value module namespace

### DIFF
--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -260,6 +260,11 @@ impl SymbolFlags {
         self.contains(Self::NameSpaceModule)
     }
 
+    #[inline]
+    pub fn is_value_module(&self) -> bool {
+        self.contains(Self::ValueModule)
+    }
+
     /// If true, then the symbol can be referenced by a type reference
     #[inline]
     pub fn can_be_referenced_by_type(&self) -> bool {

--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -1165,6 +1165,7 @@ Namespaces exporting non-const are not supported by Babel. Change to const or se
 
 tasks/coverage/typescript/tests/cases/compiler/augmentedTypesModules4.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
+Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/autonumberingInEnums.ts
 semantic error: Bindings mismatch:
@@ -2394,7 +2395,10 @@ rebuilt        : ["$"]
 tasks/coverage/typescript/tests/cases/compiler/cloduleWithPriorUninstantiatedModule.ts
 semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5)]
-rebuilt        : ScopeId(0): [ScopeId(1)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
 Symbol flags mismatch for "Moclodule":
 after transform: SymbolId(0): SymbolFlags(Class | NameSpaceModule | ValueModule)
 rebuilt        : SymbolId(0): SymbolFlags(Class)
@@ -6275,14 +6279,83 @@ rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/declFileGenericType2.ts
 semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["templa"]
-rebuilt        : ScopeId(0): []
+after transform: ScopeId(0): ["_defineProperty", "templa"]
+rebuilt        : ScopeId(0): ["_defineProperty"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(7), ScopeId(10), ScopeId(15), ScopeId(19), ScopeId(24)]
-rebuilt        : ScopeId(0): []
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(6)]
+Scope flags mismatch:
+after transform: ScopeId(19): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(20): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(21): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(24): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(25): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(7): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(26): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(8): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(27): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(9): ScopeFlags(Function)
+Symbol flags mismatch for "dom":
+after transform: SymbolId(16): SymbolFlags(ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "dom":
+after transform: SymbolId(16): Span { start: 643, end: 646 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "mvc":
+after transform: SymbolId(17): SymbolFlags(ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "mvc":
+after transform: SymbolId(17): Span { start: 647, end: 650 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
+Symbol flags mismatch for "dom":
+after transform: SymbolId(20): SymbolFlags(ValueModule)
+rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "dom":
+after transform: SymbolId(20): Span { start: 913, end: 916 }
+rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
+Symbol flags mismatch for "mvc":
+after transform: SymbolId(21): SymbolFlags(ValueModule)
+rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "mvc":
+after transform: SymbolId(21): Span { start: 917, end: 920 }
+rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
+Symbol flags mismatch for "composite":
+after transform: SymbolId(22): SymbolFlags(ValueModule)
+rebuilt        : SymbolId(12): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "composite":
+after transform: SymbolId(22): Span { start: 921, end: 930 }
+rebuilt        : SymbolId(12): Span { start: 0, end: 0 }
+Reference symbol mismatch for "templa":
+after transform: SymbolId(0) "templa"
+rebuilt        : <None>
+Reference symbol mismatch for "templa":
+after transform: SymbolId(0) "templa"
+rebuilt        : <None>
+Reference symbol mismatch for "templa":
+after transform: SymbolId(0) "templa"
+rebuilt        : <None>
+Reference symbol mismatch for "templa":
+after transform: SymbolId(0) "templa"
+rebuilt        : <None>
+Reference symbol mismatch for "templa":
+after transform: SymbolId(0) "templa"
+rebuilt        : <None>
+Reference symbol mismatch for "templa":
+after transform: SymbolId(0) "templa"
+rebuilt        : <None>
 Unresolved references mismatch:
-after transform: ["IElementController", "mvc"]
-rebuilt        : []
+after transform: ["IElementController", "mvc", "require"]
+rebuilt        : ["require", "templa"]
 
 tasks/coverage/typescript/tests/cases/compiler/declFileImportChainInExportAssignment.ts
 semantic error: Symbol flags mismatch for "m":
@@ -6352,12 +6425,42 @@ after transform: SymbolId(0): Span { start: 7, end: 9 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/declFileModuleContinuation.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): []
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Scope flags mismatch:
+after transform: ScopeId(4): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Symbol flags mismatch for "A":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "A":
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(11), ReferenceId(12)]
+rebuilt        : SymbolId(0): [ReferenceId(10), ReferenceId(11)]
+Symbol redeclarations mismatch for "A":
+after transform: SymbolId(0): [Span { start: 7, end: 8 }, Span { start: 54, end: 55 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch for "B":
+after transform: SymbolId(3): SymbolFlags(ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(3): Span { start: 56, end: 57 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "C":
+after transform: SymbolId(4): SymbolFlags(ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "C":
+after transform: SymbolId(4): Span { start: 58, end: 59 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/declFileModuleWithPropertyOfTypeModule.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -6853,31 +6956,151 @@ after transform: ["EventManager", "require"]
 rebuilt        : ["A", "EventManager", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause1.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["X"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(5)]
-rebuilt        : ScopeId(0): []
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Bindings mismatch:
+after transform: ScopeId(8): ["A", "W", "_C"]
+rebuilt        : ScopeId(4): ["W", "_C"]
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Scope children mismatch:
+after transform: ScopeId(8): [ScopeId(9), ScopeId(10)]
+rebuilt        : ScopeId(4): [ScopeId(5)]
+Symbol flags mismatch for "X":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "X":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "X":
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(15), ReferenceId(16)]
+rebuilt        : SymbolId(0): [ReferenceId(14), ReferenceId(15)]
+Symbol redeclarations mismatch for "X":
+after transform: SymbolId(0): [Span { start: 7, end: 8 }, Span { start: 55, end: 56 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch for "A":
+after transform: SymbolId(4): SymbolFlags(ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(4): Span { start: 57, end: 58 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "B":
+after transform: SymbolId(5): SymbolFlags(ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(5): Span { start: 59, end: 60 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
+Symbol flags mismatch for "C":
+after transform: SymbolId(6): SymbolFlags(ValueModule)
+rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "C":
+after transform: SymbolId(6): Span { start: 61, end: 62 }
+rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["X"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(10)]
-rebuilt        : ScopeId(0): []
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Symbol flags mismatch for "X":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "X":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "X":
+after transform: SymbolId(0): [Span { start: 7, end: 8 }, Span { start: 55, end: 56 }, Span { start: 152, end: 153 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch for "A":
+after transform: SymbolId(4): SymbolFlags(ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(4): Span { start: 57, end: 58 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "B":
+after transform: SymbolId(5): SymbolFlags(ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(5): Span { start: 59, end: 60 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
+Symbol flags mismatch for "C":
+after transform: SymbolId(6): SymbolFlags(ValueModule)
+rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "C":
+after transform: SymbolId(6): Span { start: 61, end: 62 }
+rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 Unresolved references mismatch:
 after transform: ["A"]
 rebuilt        : []
 
 tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause3.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["X"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(10)]
-rebuilt        : ScopeId(0): []
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(7): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(3): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(8): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(4): ScopeFlags(Function)
+Symbol flags mismatch for "X":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "X":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "X":
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(15), ReferenceId(16)]
+rebuilt        : SymbolId(0): [ReferenceId(14), ReferenceId(15)]
+Symbol redeclarations mismatch for "X":
+after transform: SymbolId(0): [Span { start: 7, end: 8 }, Span { start: 55, end: 56 }, Span { start: 179, end: 180 }]
+rebuilt        : SymbolId(0): []
+Symbol flags mismatch for "A":
+after transform: SymbolId(4): SymbolFlags(ValueModule)
+rebuilt        : SymbolId(2): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "A":
+after transform: SymbolId(4): Span { start: 57, end: 58 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
+Symbol flags mismatch for "B":
+after transform: SymbolId(5): SymbolFlags(ValueModule)
+rebuilt        : SymbolId(4): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "B":
+after transform: SymbolId(5): Span { start: 59, end: 60 }
+rebuilt        : SymbolId(4): Span { start: 0, end: 0 }
+Symbol flags mismatch for "C":
+after transform: SymbolId(6): SymbolFlags(ValueModule)
+rebuilt        : SymbolId(6): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "C":
+after transform: SymbolId(6): Span { start: 61, end: 62 }
+rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
 
 tasks/coverage/typescript/tests/cases/compiler/declInput-2.ts
 semantic error: Scope flags mismatch:
@@ -14796,26 +15019,92 @@ after transform: SymbolId(0): [ReferenceId(0)]
 rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["EndGate"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(9)]
-rebuilt        : ScopeId(0): []
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Symbol flags mismatch for "EndGate":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule | Ambient)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "EndGate":
+after transform: SymbolId(0): Span { start: 15, end: 22 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "EndGate":
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(13), ReferenceId(14), ReferenceId(21), ReferenceId(22)]
+rebuilt        : SymbolId(1): [ReferenceId(9), ReferenceId(10), ReferenceId(19), ReferenceId(20)]
+Symbol redeclarations mismatch for "EndGate":
+after transform: SymbolId(0): [Span { start: 15, end: 22 }, Span { start: 146, end: 153 }, Span { start: 335, end: 342 }]
+rebuilt        : SymbolId(1): []
+Symbol flags mismatch for "Tweening":
+after transform: SymbolId(3): SymbolFlags(ValueModule)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Tweening":
+after transform: SymbolId(3): Span { start: 154, end: 162 }
+rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Tweening":
+after transform: SymbolId(7): SymbolFlags(ValueModule)
+rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Tweening":
+after transform: SymbolId(7): Span { start: 343, end: 351 }
+rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 Unresolved references mismatch:
-after transform: ["ICloneable", "Tween"]
-rebuilt        : []
+after transform: ["ICloneable", "Tween", "require"]
+rebuilt        : ["Tween", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/genericConstraintOnExtendedBuiltinTypes2.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["EndGate"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(4), ScopeId(5), ScopeId(9)]
-rebuilt        : ScopeId(0): []
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(5)]
+Scope flags mismatch:
+after transform: ScopeId(5): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(6): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(2): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(9): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(5): ScopeFlags(Function)
+Scope flags mismatch:
+after transform: ScopeId(10): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(6): ScopeFlags(Function)
+Symbol flags mismatch for "EndGate":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "EndGate":
+after transform: SymbolId(0): Span { start: 7, end: 14 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
+Symbol reference IDs mismatch for "EndGate":
+after transform: SymbolId(0): [ReferenceId(0), ReferenceId(14), ReferenceId(15), ReferenceId(22), ReferenceId(23)]
+rebuilt        : SymbolId(1): [ReferenceId(9), ReferenceId(10), ReferenceId(19), ReferenceId(20)]
+Symbol redeclarations mismatch for "EndGate":
+after transform: SymbolId(0): [Span { start: 7, end: 14 }, Span { start: 138, end: 145 }, Span { start: 326, end: 333 }]
+rebuilt        : SymbolId(1): []
+Symbol flags mismatch for "Tweening":
+after transform: SymbolId(3): SymbolFlags(ValueModule)
+rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Tweening":
+after transform: SymbolId(3): Span { start: 146, end: 154 }
+rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
+Symbol flags mismatch for "Tweening":
+after transform: SymbolId(7): SymbolFlags(ValueModule)
+rebuilt        : SymbolId(8): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Tweening":
+after transform: SymbolId(7): Span { start: 334, end: 342 }
+rebuilt        : SymbolId(8): Span { start: 0, end: 0 }
 Unresolved references mismatch:
-after transform: ["ICloneable", "Tween"]
-rebuilt        : []
+after transform: ["ICloneable", "Tween", "require"]
+rebuilt        : ["Tween", "require"]
 
 tasks/coverage/typescript/tests/cases/compiler/genericConstructSignatureInInterface.ts
 semantic error: Scope children mismatch:
@@ -17787,12 +18076,24 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(4), ScopeId(6), Sc
 rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(3), ScopeId(5), ScopeId(8), ScopeId(10), ScopeId(12)]
 
 tasks/coverage/typescript/tests/cases/compiler/interfaceInReopenedModule.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["m"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Scope flags mismatch:
+after transform: ScopeId(2): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Scope children mismatch:
+after transform: ScopeId(2): [ScopeId(3), ScopeId(4)]
+rebuilt        : ScopeId(1): [ScopeId(2)]
+Symbol flags mismatch for "m":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(1): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "m":
+after transform: SymbolId(0): Span { start: 7, end: 8 }
+rebuilt        : SymbolId(1): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "m":
+after transform: SymbolId(0): [Span { start: 7, end: 8 }, Span { start: 93, end: 94 }]
+rebuilt        : SymbolId(1): []
 
 tasks/coverage/typescript/tests/cases/compiler/interfaceInheritance2.ts
 semantic error: Scope children mismatch:
@@ -18065,15 +18366,7 @@ tasks/coverage/typescript/tests/cases/compiler/internalAliasVarInsideTopLevelMod
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/internalAliasWithDottedNameEmit.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["a"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(4)]
-rebuilt        : ScopeId(0): []
-Unresolved references mismatch:
-after transform: ["b"]
-rebuilt        : []
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/compiler/internalImportInstantiatedModuleMergedWithClassNotReferencingInstanceNoConflict.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
@@ -29453,12 +29746,18 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 
 tasks/coverage/typescript/tests/cases/compiler/systemModule7.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["M"]
-rebuilt        : ScopeId(0): []
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
-rebuilt        : ScopeId(0): []
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Symbol flags mismatch for "M":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "M":
+after transform: SymbolId(0): Span { start: 49, end: 50 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "M":
+after transform: SymbolId(0): [Span { start: 49, end: 50 }, Span { start: 123, end: 124 }]
+rebuilt        : SymbolId(0): []
 
 tasks/coverage/typescript/tests/cases/compiler/systemModuleAmbientDeclarations.ts
 semantic error: Bindings mismatch:
@@ -44450,12 +44749,9 @@ after transform: []
 rebuilt        : ["foo"]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/es6/es6modulekindWithES5Target12.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["C", "E", "F", "N"]
-rebuilt        : ScopeId(0): ["C", "E", "F"]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
 Bindings mismatch:
 after transform: ScopeId(3): ["E", "w"]
 rebuilt        : ScopeId(3): ["E"]
@@ -44480,12 +44776,21 @@ rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "E":
 after transform: SymbolId(2): [Span { start: 80, end: 81 }, Span { start: 109, end: 110 }, Span { start: 143, end: 144 }, Span { start: 191, end: 192 }]
 rebuilt        : SymbolId(3): []
+Symbol flags mismatch for "N":
+after transform: SymbolId(7): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N":
+after transform: SymbolId(7): Span { start: 239, end: 240 }
+rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "N":
+after transform: SymbolId(7): [Span { start: 239, end: 240 }, Span { start: 263, end: 264 }]
+rebuilt        : SymbolId(10): []
 Symbol flags mismatch for "F":
 after transform: SymbolId(9): SymbolFlags(Function | ValueModule)
-rebuilt        : SymbolId(10): SymbolFlags(Function)
+rebuilt        : SymbolId(13): SymbolFlags(Function)
 Symbol redeclarations mismatch for "F":
 after transform: SymbolId(9): [Span { start: 310, end: 311 }, Span { start: 336, end: 337 }]
-rebuilt        : SymbolId(10): []
+rebuilt        : SymbolId(13): []
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/es6/es6modulekindWithES5Target3.ts
 semantic error: Bindings mismatch:
@@ -44585,12 +44890,9 @@ after transform: []
 rebuilt        : ["foo"]
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/esnext/esnextmodulekindWithES5Target12.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["C", "E", "F", "N"]
-rebuilt        : ScopeId(0): ["C", "E", "F"]
-Scope children mismatch:
+semantic error: Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9), ScopeId(10)]
-rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8)]
+rebuilt        : ScopeId(0): [ScopeId(1), ScopeId(2), ScopeId(3), ScopeId(4), ScopeId(5), ScopeId(6), ScopeId(7), ScopeId(8), ScopeId(9)]
 Bindings mismatch:
 after transform: ScopeId(3): ["E", "w"]
 rebuilt        : ScopeId(3): ["E"]
@@ -44615,12 +44917,21 @@ rebuilt        : SymbolId(3): SymbolFlags(BlockScopedVariable)
 Symbol redeclarations mismatch for "E":
 after transform: SymbolId(2): [Span { start: 80, end: 81 }, Span { start: 109, end: 110 }, Span { start: 143, end: 144 }, Span { start: 191, end: 192 }]
 rebuilt        : SymbolId(3): []
+Symbol flags mismatch for "N":
+after transform: SymbolId(7): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(10): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "N":
+after transform: SymbolId(7): Span { start: 239, end: 240 }
+rebuilt        : SymbolId(10): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "N":
+after transform: SymbolId(7): [Span { start: 239, end: 240 }, Span { start: 263, end: 264 }]
+rebuilt        : SymbolId(10): []
 Symbol flags mismatch for "F":
 after transform: SymbolId(9): SymbolFlags(Function | ValueModule)
-rebuilt        : SymbolId(10): SymbolFlags(Function)
+rebuilt        : SymbolId(13): SymbolFlags(Function)
 Symbol redeclarations mismatch for "F":
 after transform: SymbolId(9): [Span { start: 310, end: 311 }, Span { start: 336, end: 337 }]
-rebuilt        : SymbolId(10): []
+rebuilt        : SymbolId(13): []
 
 tasks/coverage/typescript/tests/cases/conformance/externalModules/esnext/esnextmodulekindWithES5Target3.ts
 semantic error: Bindings mismatch:
@@ -46100,18 +46411,7 @@ tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarat
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/nestedModules.ts
-semantic error: Bindings mismatch:
-after transform: ScopeId(0): ["A", "M2", "m", "p", "point"]
-rebuilt        : ScopeId(0): ["m", "p", "point"]
-Scope children mismatch:
-after transform: ScopeId(0): [ScopeId(1), ScopeId(5), ScopeId(7), ScopeId(10)]
-rebuilt        : ScopeId(0): []
-Reference symbol mismatch for "M2":
-after transform: SymbolId(6) "M2"
-rebuilt        : <None>
-Unresolved references mismatch:
-after transform: ["C"]
-rebuilt        : ["M2"]
+semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript
 
 tasks/coverage/typescript/tests/cases/conformance/internalModules/moduleDeclarations/nonInstantiatedModule.ts
 semantic error: Namespaces exporting non-const are not supported by Babel. Change to const or see: https://babeljs.io/docs/en/babel-plugin-transform-typescript

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 578ac4df
 
-Passed: 150/245
+Passed: 150/246
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -44,7 +44,7 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), R
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(10)]
 
 
-# babel-plugin-transform-typescript (4/19)
+# babel-plugin-transform-typescript (4/20)
 * class-property-definition/input.ts
 Unresolved references mismatch:
 after transform: ["const"]
@@ -328,6 +328,23 @@ after transform: SymbolId(0): Span { start: 12, end: 15 }
 rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
 Symbol redeclarations mismatch for "Foo":
 after transform: SymbolId(0): [Span { start: 12, end: 15 }, Span { start: 39, end: 42 }, Span { start: 87, end: 90 }]
+rebuilt        : SymbolId(0): []
+
+* namespace/redeclaration-with-type-only-namespace/input.ts
+Scope children mismatch:
+after transform: ScopeId(0): [ScopeId(1), ScopeId(3)]
+rebuilt        : ScopeId(0): [ScopeId(1)]
+Scope flags mismatch:
+after transform: ScopeId(3): ScopeFlags(StrictMode | Function)
+rebuilt        : ScopeId(1): ScopeFlags(Function)
+Symbol flags mismatch for "Foo":
+after transform: SymbolId(0): SymbolFlags(NameSpaceModule | ValueModule)
+rebuilt        : SymbolId(0): SymbolFlags(BlockScopedVariable)
+Symbol span mismatch for "Foo":
+after transform: SymbolId(0): Span { start: 17, end: 20 }
+rebuilt        : SymbolId(0): Span { start: 0, end: 0 }
+Symbol redeclarations mismatch for "Foo":
+after transform: SymbolId(0): [Span { start: 17, end: 20 }, Span { start: 62, end: 65 }]
 rebuilt        : SymbolId(0): []
 
 * preserve-import-=/input.js

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/namespace/redeclaration-with-type-only-namespace/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/namespace/redeclaration-with-type-only-namespace/input.ts
@@ -1,0 +1,6 @@
+export namespace Foo {
+	export type T = 0;
+}
+export namespace Foo {
+	export const Bar = 1;
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/namespace/redeclaration-with-type-only-namespace/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/namespace/redeclaration-with-type-only-namespace/output.js
@@ -1,0 +1,5 @@
+export let Foo;
+
+(function(_Foo) {
+  const Bar = _Foo.Bar = 1;
+})(Foo || (Foo = {}));


### PR DESCRIPTION
Input:
```ts
// SymbolFlags: NameSpaceModule
export namespace Foo {
	 export type T = 0;
}
// SymbolFlags: ValueModule
export namespace Foo {
	 export const Bar = 1;
}
```

Before output:
```js
expot {}
```

After Output:
```js
// SymbolFlags: ValueModule
export let Foo;
(function(_Foo) {
  const Bar = _Foo.Bar = 1;
})(Foo || (Foo = {}));
```

When both `NameSpaceModule` and `ValueModule` are present, we need to check the current
declaration flags. If the current declaration is `NameSpaceModule`, we can return early
because it's a type-only namespace and doesn't emit any JS code, otherwise we need to
continue transforming it.