### PR TITLE
feat(language_server/vscode): support multi workspace folder setups

### DIFF
--- a/crates/oxc_language_server/README.md
+++ b/crates/oxc_language_server/README.md
@@ -53,6 +53,11 @@ The server will revalidate the diagnostics for all open files and send one or mo
 
 Note: When nested configuration is active, the client should send all `.oxlintrc.json` configurations to the server after the [initialized](#initialized) response.
 
+#### [workspace/didChangeWorkspaceFolders](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeWorkspaceFolders)
+
+The server expects this requests when adding or removing workspace folders.
+The server will requests the specific workspace, if the client support it.
+
 #### [workspace/executeCommand](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_executeCommand)
 
 Executes a [Command](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_executeCommand) if it exists. See [Server Capabilities](#server-capabilities)
@@ -86,3 +91,12 @@ Returns a list of [CodeAction](https://microsoft.github.io/language-server-proto
 #### [textDocument/publishDiagnostics](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_publishDiagnostics)
 
 Returns a [PublishDiagnostic object](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#publishDiagnosticsParams)
+
+## Optional LSP Specifications from Client
+
+### Workspace
+
+#### [workspace/configuration](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_configuration)
+
+Will be requested some workspace configurations. The server expect the order of receiving items will match the order of the items requested.
+Only will be requested when the `ClientCapabilities` has `workspace.configuration` set to true.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -19,21 +19,31 @@ This is the linter for Oxc. The currently supported features are listed below.
 - Command to fix all auto-fixable content within the current text editor.
 - Support for `source.fixAll.oxc` as a code action provider. Configure this in your settings `editor.codeActionsOnSave`
   to automatically apply fixes when saving the file.
+- Support for multi root workspaces
 
 ## Configuration
 
-Following configuration are supported via `settings.json`:
+### Window Configuration
+
+Following configuration are supported via `settings.json` and effect the window editor:
 
 | Key                | Default Value | Possible Values                  | Description                                                                 |
 | ------------------ | ------------- | -------------------------------- | --------------------------------------------------------------------------- |
-| `oxc.lint.run`     | `onType`      | `onSave` \| `onType`             | Run the linter on save (onSave) or on type (onType)                         |
 | `oxc.enable`       | `true`        | `true` \| `false`                | Enables the language server to receive lint diagnostics                     |
 | `oxc.trace.server` | `off`         | `off` \| `messages` \| `verbose` | races the communication between VS Code and the language server.            |
-| `oxc.configPath`   | `null`        | `null`\| `<string>`              | Path to ESlint configuration. Keep it empty to enable nested configuration. |
 | `oxc.path.server`  | -             | `<string>`                       | Path to Oxc language server binary. Mostly for testing the language server. |
-| `oxc.flags`        | -             | `Record<string, string>`         | Custom flags passed to the language server.                                 |
 
-### Flags
+### Workspace Configuration
+
+Following configuration are supported via `settings.json` and can be changed for each workspace:
+
+| Key              | Default Value | Possible Values          | Description                                                                 |
+| ---------------- | ------------- | ------------------------ | --------------------------------------------------------------------------- |
+| `oxc.lint.run`   | `onType`      | `onSave` \| `onType`     | Run the linter on save (onSave) or on type (onType)                         |
+| `oxc.configPath` | `null`        | `null`\| `<string>`      | Path to ESlint configuration. Keep it empty to enable nested configuration. |
+| `oxc.flags`      | -             | `Record<string, string>` | Custom flags passed to the language server.                                 |
+
+#### Flags
 
 - `key: disable_nested_config`: Disabled nested configuration and searches only for `configPath`
 - `key: fix_kind`: default: `"safe_fix"`, possible values `"safe_fix" | "safe_fix_or_suggestion" | "dangerous_fix" | "dangerous_fix_or_suggestion" | "none" | "all"`

--- a/editors/vscode/client/ConfigService.ts
+++ b/editors/vscode/client/ConfigService.ts
@@ -1,7 +1,7 @@
-import { ConfigurationChangeEvent, workspace } from 'vscode';
+import { ConfigurationChangeEvent, Uri, workspace, WorkspaceFolder } from 'vscode';
 import { IDisposable } from './types';
 import { VSCodeConfig } from './VSCodeConfig';
-import { WorkspaceConfig } from './WorkspaceConfig';
+import { oxlintConfigFileName, WorkspaceConfig, WorkspaceConfigInterface } from './WorkspaceConfig';
 
 export class ConfigService implements IDisposable {
   public static readonly namespace = 'oxc';
@@ -9,16 +9,20 @@ export class ConfigService implements IDisposable {
 
   public vsCodeConfig: VSCodeConfig;
 
-  private _workspaceConfig: WorkspaceConfig;
+  private workspaceConfigs: Map<string, WorkspaceConfig> = new Map();
 
   public onConfigChange:
     | ((this: ConfigService, config: ConfigurationChangeEvent) => Promise<void>)
     | undefined;
 
   constructor() {
-    const conf = workspace.getConfiguration(ConfigService.namespace);
-    this.vsCodeConfig = new VSCodeConfig(conf);
-    this._workspaceConfig = new WorkspaceConfig(conf);
+    this.vsCodeConfig = new VSCodeConfig();
+    const workspaceFolders = workspace.workspaceFolders;
+    if (workspaceFolders) {
+      for (const folder of workspaceFolders) {
+        this.addWorkspaceConfig(folder);
+      }
+    }
     this.onConfigChange = undefined;
 
     const disposeChangeListener = workspace.onDidChangeConfiguration(
@@ -27,19 +31,82 @@ export class ConfigService implements IDisposable {
     this._disposables.push(disposeChangeListener);
   }
 
-  public get rootServerConfig(): WorkspaceConfig {
-    return this._workspaceConfig;
+  // ToDo: refactor it so we do not rely on this function
+  // this is only used for the initialize options on the server which is a custom object between the client and server
+  // we can change it to support multiple workspaces and avoid sending `workspace/configuration` request to the client.
+  // Make sure to still support the old way on server side for other clients.
+  public get rootLanguageServerConfig(): WorkspaceConfigInterface {
+    // will be true when the user uses `code file.ts` in cli
+    if (workspace.workspaceFolders === undefined) {
+      // fallback to the default config
+      return {
+        configPath: null,
+        run: 'onType',
+        flags: {},
+      };
+    }
+
+    return this.workspaceConfigs.get(workspace.workspaceFolders[0].uri.path)!.toLanguageServerConfig();
   }
 
-  public refresh(): void {
-    const conf = workspace.getConfiguration(ConfigService.namespace);
-    this.vsCodeConfig.refresh(conf);
-    this.rootServerConfig.refresh(conf);
+  public addWorkspaceConfig(workspace: WorkspaceFolder): WorkspaceConfig {
+    let workspaceConfig = new WorkspaceConfig(workspace);
+    this.workspaceConfigs.set(workspace.uri.path, workspaceConfig);
+    return workspaceConfig;
+  }
+
+  public removeWorkspaceConfig(workspace: WorkspaceFolder): void {
+    this.workspaceConfigs.delete(workspace.uri.path);
+  }
+
+  public getWorkspaceConfig(workspace: Uri): WorkspaceConfig | undefined {
+    return this.workspaceConfigs.get(workspace.path);
+  }
+
+  public effectsWorkspaceConfigChange(event: ConfigurationChangeEvent): boolean {
+    for (const workspaceConfig of this.workspaceConfigs.values()) {
+      if (workspaceConfig.effectsConfigChange(event)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public effectsWorkspaceConfigPathChange(event: ConfigurationChangeEvent): boolean {
+    for (const workspaceConfig of this.workspaceConfigs.values()) {
+      if (workspaceConfig.effectsConfigPathChange(event)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public getOxlintCustomConfigs(): string[] {
+    const customConfigs: string[] = [];
+    for (const [path, config] of this.workspaceConfigs.entries()) {
+      if (config.configPath && config.configPath !== oxlintConfigFileName) {
+        customConfigs.push(`${path}/${config.configPath}`);
+      }
+    }
+    return customConfigs;
   }
 
   private async onVscodeConfigChange(event: ConfigurationChangeEvent): Promise<void> {
+    let isConfigChanged = false;
+
     if (event.affectsConfiguration(ConfigService.namespace)) {
-      this.refresh();
+      this.vsCodeConfig.refresh();
+      isConfigChanged = true;
+    }
+
+    for (const workspaceConfig of this.workspaceConfigs.values()) {
+      if (workspaceConfig.effectsConfigChange(event)) {
+        workspaceConfig.refresh();
+        isConfigChanged = true;
+      }
+    }
+
+    if (isConfigChanged) {
       await this.onConfigChange?.(event);
     }
   }

--- a/editors/vscode/client/VSCodeConfig.spec.ts
+++ b/editors/vscode/client/VSCodeConfig.spec.ts
@@ -4,7 +4,7 @@ import { VSCodeConfig } from './VSCodeConfig.js';
 
 const conf = workspace.getConfiguration('oxc');
 
-suite('Config', () => {
+suite('VSCodeConfig', () => {
   setup(async () => {
     const keys = ['enable', 'trace.server', 'path.server'];
 
@@ -20,7 +20,7 @@ suite('Config', () => {
   });
 
   test('default values on initialization', () => {
-    const config = new VSCodeConfig(conf);
+    const config = new VSCodeConfig();
 
     strictEqual(config.enable, true);
     strictEqual(config.trace, 'off');
@@ -28,7 +28,7 @@ suite('Config', () => {
   });
 
   test('updating values updates the workspace configuration', async () => {
-    const config = new VSCodeConfig(conf);
+    const config = new VSCodeConfig();
 
     await Promise.all([
       config.updateEnable(false),

--- a/editors/vscode/client/VSCodeConfig.ts
+++ b/editors/vscode/client/VSCodeConfig.ts
@@ -1,21 +1,23 @@
-import { workspace, WorkspaceConfiguration } from 'vscode';
+import { workspace } from 'vscode';
 import { ConfigService } from './ConfigService';
-
-export const oxlintConfigFileName = '.oxlintrc.json';
 
 export class VSCodeConfig implements VSCodeConfigInterface {
   private _enable!: boolean;
   private _trace!: TraceLevel;
   private _binPath: string | undefined;
 
-  constructor(configuration: WorkspaceConfiguration) {
-    this.refresh(configuration);
+  constructor() {
+    this.refresh();
   }
 
-  public refresh(configuration: WorkspaceConfiguration): void {
-    this._enable = configuration.get<boolean>('enable') ?? true;
-    this._trace = configuration.get<TraceLevel>('trace.server') || 'off';
-    this._binPath = configuration.get<string>('path.server');
+  private get configuration() {
+    return workspace.getConfiguration(ConfigService.namespace);
+  }
+
+  public refresh(): void {
+    this._enable = this.configuration.get<boolean>('enable') ?? true;
+    this._trace = this.configuration.get<TraceLevel>('trace.server') || 'off';
+    this._binPath = this.configuration.get<string>('path.server');
   }
 
   get enable(): boolean {
@@ -24,9 +26,7 @@ export class VSCodeConfig implements VSCodeConfigInterface {
 
   updateEnable(value: boolean): PromiseLike<void> {
     this._enable = value;
-    return workspace
-      .getConfiguration(ConfigService.namespace)
-      .update('enable', value);
+    return this.configuration.update('enable', value);
   }
 
   get trace(): TraceLevel {
@@ -35,9 +35,7 @@ export class VSCodeConfig implements VSCodeConfigInterface {
 
   updateTrace(value: TraceLevel): PromiseLike<void> {
     this._trace = value;
-    return workspace
-      .getConfiguration(ConfigService.namespace)
-      .update('trace.server', value);
+    return this.configuration.update('trace.server', value);
   }
 
   get binPath(): string | undefined {
@@ -46,9 +44,7 @@ export class VSCodeConfig implements VSCodeConfigInterface {
 
   updateBinPath(value: string | undefined): PromiseLike<void> {
     this._binPath = value;
-    return workspace
-      .getConfiguration(ConfigService.namespace)
-      .update('path.server', value);
+    return this.configuration.update('path.server', value);
   }
 }
 

--- a/editors/vscode/client/WorkspaceConfig.spec.ts
+++ b/editors/vscode/client/WorkspaceConfig.spec.ts
@@ -1,10 +1,12 @@
 import { deepStrictEqual, strictEqual } from 'assert';
 import { Uri, workspace, WorkspaceEdit } from 'vscode';
+import { WORKSPACE_FOLDER } from './test-helpers.js';
 import { WorkspaceConfig } from './WorkspaceConfig.js';
 
-suite('Config', () => {
+const uri = WORKSPACE_FOLDER;
+suite('WorkspaceConfig', () => {
   setup(async () => {
-    const wsConfig = workspace.getConfiguration('oxc');
+    const wsConfig = workspace.getConfiguration('oxc', uri);
     const keys = ['lint.run', 'configPath', 'flags'];
 
     await Promise.all(keys.map(key => wsConfig.update(key, undefined)));
@@ -19,36 +21,36 @@ suite('Config', () => {
   });
 
   test('default values on initialization', () => {
-    const config = new WorkspaceConfig(workspace.getConfiguration('oxc'));
+    const config = new WorkspaceConfig(uri);
     strictEqual(config.runTrigger, 'onType');
     strictEqual(config.configPath, null);
     deepStrictEqual(config.flags, {});
   });
 
   test('configPath defaults to null when using nested configs and configPath is empty', async () => {
-    const wsConfig = workspace.getConfiguration('oxc');
+    const wsConfig = workspace.getConfiguration('oxc', uri);
     await wsConfig.update('configPath', '');
     await wsConfig.update('flags', {});
 
-    const config = new WorkspaceConfig(workspace.getConfiguration('oxc'));
+    const config = new WorkspaceConfig(uri);
 
     deepStrictEqual(config.flags, {});
     strictEqual(config.configPath, null);
   });
 
   test('configPath defaults to .oxlintrc.json when not using nested configs and configPath is empty', async () => {
-    const wsConfig = workspace.getConfiguration('oxc');
+    const wsConfig = workspace.getConfiguration('oxc', uri);
     await wsConfig.update('configPath', undefined);
     await wsConfig.update('flags', { disable_nested_config: '' });
 
-    const config = new WorkspaceConfig(workspace.getConfiguration('oxc'));
+    const config = new WorkspaceConfig(uri);
 
     deepStrictEqual(config.flags, { disable_nested_config: '' });
     strictEqual(config.configPath, '.oxlintrc.json');
   });
 
   test('updating values updates the workspace configuration', async () => {
-    const config = new WorkspaceConfig(workspace.getConfiguration('oxc'));
+    const config = new WorkspaceConfig(uri);
 
     await Promise.all([
       config.updateRunTrigger('onSave'),
@@ -56,7 +58,7 @@ suite('Config', () => {
       config.updateFlags({ test: 'value' }),
     ]);
 
-    const wsConfig = workspace.getConfiguration('oxc');
+    const wsConfig = workspace.getConfiguration('oxc', uri);
 
     strictEqual(wsConfig.get('lint.run'), 'onSave');
     strictEqual(wsConfig.get('configPath'), './somewhere');

--- a/editors/vscode/client/extension.ts
+++ b/editors/vscode/client/extension.ts
@@ -4,21 +4,26 @@ import {
   commands,
   ExtensionContext,
   FileSystemWatcher,
-  RelativePattern,
   StatusBarAlignment,
   StatusBarItem,
   ThemeColor,
+  Uri,
   window,
   workspace,
 } from 'vscode';
 
-import { ExecuteCommandRequest, MessageType, ShowMessageNotification } from 'vscode-languageclient';
+import {
+  ConfigurationParams,
+  ExecuteCommandRequest,
+  MessageType,
+  ShowMessageNotification,
+} from 'vscode-languageclient';
 
 import { Executable, LanguageClient, LanguageClientOptions, ServerOptions } from 'vscode-languageclient/node';
 
 import { join } from 'node:path';
 import { ConfigService } from './ConfigService';
-import { oxlintConfigFileName } from './VSCodeConfig';
+import { oxlintConfigFileName } from './WorkspaceConfig';
 
 const languageClientName = 'oxc';
 const outputChannelName = 'Oxc';
@@ -117,7 +122,7 @@ export async function activate(context: ExtensionContext) {
   );
 
   const outputChannel = window.createOutputChannel(outputChannelName, { log: true });
-  const fileWatchers = createFileEventWatchers(configService.rootServerConfig.configPath);
+  const fileWatchers = createFileEventWatchers(configService.getOxlintCustomConfigs());
 
   context.subscriptions.push(
     applyAllFixesFile,
@@ -175,7 +180,7 @@ export async function activate(context: ExtensionContext) {
 
   const command = await findBinary();
   const run: Executable = {
-    command: command!,
+    command: command,
     options: {
       env: {
         ...process.env,
@@ -209,10 +214,28 @@ export async function activate(context: ExtensionContext) {
       fileEvents: fileWatchers,
     },
     initializationOptions: {
-      settings: configService.rootServerConfig.toLanguageServerConfig(),
+      settings: configService.rootLanguageServerConfig,
     },
     outputChannel,
     traceOutputChannel: outputChannel,
+    middleware: {
+      workspace: {
+        configuration: (
+          params: ConfigurationParams,
+        ) => {
+          return params.items.map(item => {
+            if (item.section !== 'oxc_language_server') {
+              return null;
+            }
+            if (item.scopeUri === undefined) {
+              return null;
+            }
+
+            return configService.getWorkspaceConfig(Uri.parse(item.scopeUri))?.toLanguageServerConfig() ?? null;
+          });
+        },
+      },
+    },
   };
 
   // Create the language client and start the client.
@@ -254,8 +277,40 @@ export async function activate(context: ExtensionContext) {
 
   context.subscriptions.push(onDeleteFilesDispose);
 
+  const onDidChangeWorkspaceFoldersDispose = workspace.onDidChangeWorkspaceFolders(async (event) => {
+    let needRestart = false;
+    for (const folder of event.added) {
+      const workspaceConfig = configService.addWorkspaceConfig(folder);
+
+      if (workspaceConfig.isCustomConfigPath) {
+        needRestart = true;
+      }
+    }
+    for (const folder of event.removed) {
+      const workspaceConfig = configService.getWorkspaceConfig(folder.uri);
+      if (workspaceConfig?.isCustomConfigPath) {
+        needRestart = true;
+      }
+      configService.removeWorkspaceConfig(folder);
+    }
+
+    if (client === undefined) {
+      return;
+    }
+
+    if (needRestart) {
+      client.clientOptions.synchronize = client.clientOptions.synchronize ?? {};
+      client.clientOptions.synchronize.fileEvents = createFileEventWatchers(configService.getOxlintCustomConfigs());
+
+      if (client.isRunning()) {
+        await client.restart();
+      }
+    }
+  });
+
+  context.subscriptions.push(onDidChangeWorkspaceFoldersDispose);
+
   configService.onConfigChange = async function onConfigChange(event) {
-    let settings = this.rootServerConfig.toLanguageServerConfig();
     updateStatsBar(this.vsCodeConfig.enable);
 
     if (client === undefined) {
@@ -263,17 +318,20 @@ export async function activate(context: ExtensionContext) {
     }
 
     // update the initializationOptions for a possible restart
-    client.clientOptions.initializationOptions = { settings };
+    client.clientOptions.initializationOptions = { settings: this.rootLanguageServerConfig };
 
-    if (event.affectsConfiguration('oxc.configPath')) {
+    // ToDo: do not restart all watchers, just replace the changed ones
+    if (this.effectsWorkspaceConfigPathChange(event)) {
       client.clientOptions.synchronize = client.clientOptions.synchronize ?? {};
-      client.clientOptions.synchronize.fileEvents = createFileEventWatchers(settings.configPath);
+      client.clientOptions.synchronize.fileEvents = createFileEventWatchers(this.getOxlintCustomConfigs());
 
+      // restart the server, so the new file watchers are registered for sending the requests
+      // ToDo: check if we should handle the file notification to the server manually with `client.sendNotification(DidChangeWatchedFilesNotification.type, params)`
       if (client.isRunning()) {
         await client.restart();
       }
-    } else if (client.isRunning()) {
-      await client.sendNotification('workspace/didChangeConfiguration', { settings });
+    } else if (this.effectsWorkspaceConfigChange(event) && client.isRunning()) {
+      await client.sendNotification('workspace/didChangeConfiguration', { settings: this.rootLanguageServerConfig });
     }
   };
 
@@ -312,22 +370,18 @@ export async function deactivate(): Promise<void> {
 }
 
 // FileSystemWatcher are not ready on the start and can take some seconds on bigger repositories
-function createFileEventWatchers(configRelativePath: string | null): FileSystemWatcher[] {
+function createFileEventWatchers(configAbsolutePaths: string[]): FileSystemWatcher[] {
   // cleanup old watchers
   globalWatchers.forEach((watcher) => watcher.dispose());
   globalWatchers.length = 0;
 
   // create new watchers
-  let localWatchers;
-  if (configRelativePath !== null) {
-    localWatchers = (workspace.workspaceFolders || []).map((workspaceFolder) =>
-      workspace.createFileSystemWatcher(new RelativePattern(workspaceFolder, configRelativePath))
-    );
-  } else {
-    localWatchers = [
-      workspace.createFileSystemWatcher(`**/${oxlintConfigFileName}`),
-    ];
+  let localWatchers: FileSystemWatcher[] = [];
+  if (configAbsolutePaths.length) {
+    localWatchers = configAbsolutePaths.map((path) => workspace.createFileSystemWatcher(path));
   }
+
+  localWatchers.push(workspace.createFileSystemWatcher(`**/${oxlintConfigFileName}`));
 
   // assign watchers to global variable, so we can cleanup them on next call
   globalWatchers.push(...localWatchers);

--- a/editors/vscode/client/test-helpers.ts
+++ b/editors/vscode/client/test-helpers.ts
@@ -29,7 +29,8 @@ export type OxlintConfig = {
   ignorePatterns?: OxlintConfigIgnorePatterns;
 };
 
-export const WORKSPACE_DIR = workspace.workspaceFolders![0].uri;
+export const WORKSPACE_FOLDER = workspace.workspaceFolders![0];
+export const WORKSPACE_DIR = WORKSPACE_FOLDER.uri;
 
 const rootOxlintConfigUri = Uri.joinPath(WORKSPACE_DIR, '.oxlintrc.json');
 
@@ -52,14 +53,15 @@ export async function createOxlintConfiguration(configuration: OxlintConfig): Pr
   });
   await workspace.applyEdit(edit);
 }
-export async function loadFixture(fixture: string): Promise<void> {
+
+export async function loadFixture(fixture: string, workspaceUri: Uri = WORKSPACE_DIR): Promise<void> {
   const absolutePath = path.resolve(`${__dirname}/../fixtures/${fixture}`);
   // do not copy directly into the workspace folder. FileWatcher will detect them as a deletion and stop itself.
-  await workspace.fs.copy(Uri.file(absolutePath), Uri.joinPath(WORKSPACE_DIR, 'fixtures'), { overwrite: true });
+  await workspace.fs.copy(Uri.file(absolutePath), Uri.joinPath(workspaceUri, 'fixtures'), { overwrite: true });
 }
 
-export async function getDiagnostics(file: string): Promise<Diagnostic[]> {
-  const fileUri = Uri.joinPath(WORKSPACE_DIR, 'fixtures', file);
+export async function getDiagnostics(file: string, workspaceUri: Uri = WORKSPACE_DIR): Promise<Diagnostic[]> {
+  const fileUri = Uri.joinPath(workspaceUri, 'fixtures', file);
   await window.showTextDocument(fileUri);
   await sleep(500);
   const diagnostics = languages.getDiagnostics(fileUri);

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -76,6 +76,7 @@
         "oxc.enable": {
           "type": "boolean",
           "default": true,
+          "scope": "window",
           "description": "enable oxc language server"
         },
         "oxc.trace.server": {
@@ -94,23 +95,23 @@
           "default": "off",
           "description": "Traces the communication between VS Code and the language server."
         },
-        "oxc.configPath": {
-          "type": [
-            "string",
-            "null"
-          ],
-          "scope": "window",
-          "default": null,
-          "description": "Path to ESlint configuration. Keep it empty to enable nested configuration."
-        },
         "oxc.path.server": {
           "type": "string",
           "scope": "window",
           "description": "Path to Oxc language server binary. Mostly for testing the language server."
         },
+        "oxc.configPath": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "scope": "resource",
+          "default": null,
+          "description": "Path to ESlint configuration. Keep it empty to enable nested configuration."
+        },
         "oxc.flags": {
           "type": "object",
-          "scope": "window",
+          "scope": "resource",
           "default": {},
           "description": "Specific Oxlint flags to pass to the language server."
         }


### PR DESCRIPTION
## Server Side Changes

As a Server, we need to make sure we follow the LSP specifications. So can not make changes in VSCode and implement them in the language server.

### initialize

Check if a custom configuration is passed with `initialization_options`. Not every Client will send a configuration and expect that the server will request them with `workspace/configuration`.

We still uses `root_uri` as a fallback for older clients which do not support workspace folders.

Every use case tries to have a good fallback when something is wrong.

### Change Configuration

The Client is sending a Custom Configuration to the Client. Not every Client will send it. So we request for the specific workspace configuration and update them.

### Workspace Folder Change

This is new and should be self explained. 

## Client (VSCode Side Changes)

### Changed Configuration scopes

This should reflect what the server will support.

![screenshot](https://github.com/user-attachments/assets/daf5053e-3a0a-4844-bcac-4c9f78b3f19f)

### `onConfigChange`

We are now making sure that we check for every possible configuration. Custom User Configuration we will ignore.

## Testing

Testing will be done with https://github.com/oxc-project/oxc/pull/10648.
We need to change the test structure to different between multi root setups and normal setups.
Not every test should be executed twice.

I tried to test every use case with VSCode possible and only found one problem.
When we add a workspace folder with an already defined `oxc.configPath`, we want to restart the server, but the `onConfigChange` event will already fire `workspace/didChangeConfiguration` request. This will result into a small error window, but still works perfectly.
We should avoid restarting the server when we need to create new file watchers. There are some workarounds that the server needs to support first. This is a task for later :) 