### PR TITLE
feat(parser): set `pure` on typescript wrapped AST nodes

### DIFF
--- a/crates/oxc_codegen/tests/integration/comments.rs
+++ b/crates/oxc_codegen/tests/integration/comments.rs
@@ -436,6 +436,12 @@ void /* @__PURE__ */ function() {}();
 typeof /* @__PURE__ */ function() {}();
 ! /* @__PURE__ */ function() {}();
 delete /* @__PURE__ */ (() => {})();",
+            "const Foo = /* @__PURE__ */ (((() => {})()))",
+            "const Foo = /* @__PURE__ */ (() => { })() as unknown as { new (): any }",
+            "const Foo = /* @__PURE__ */ (() => {})() satisfies X",
+            "const Foo = /* @__PURE__ */ (() => {})()<X>",
+            "const Foo = /* @__PURE__ */ <Foo>(() => {})()!",
+            "const Foo = /* @__PURE__ */ <Foo>(() => {})()! as X satisfies Y",
         ];
 
         snapshot("pure_comments", &cases);

--- a/crates/oxc_codegen/tests/integration/snapshots/pure_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/pure_comments.snap
@@ -435,3 +435,35 @@ void /* @__PURE__ */ function() {}();
 typeof /* @__PURE__ */ function() {}();
 !/* @__PURE__ */ function() {}();
 delete /* @__PURE__ */ (() => {})();
+
+########## 25
+const Foo = /* @__PURE__ */ (((() => {})()))
+----------
+const Foo = /* @__PURE__ */ (() => {})();
+
+########## 26
+const Foo = /* @__PURE__ */ (() => { })() as unknown as { new (): any }
+----------
+const Foo = (/* @__PURE__ */ (() => {})() as unknown) as {
+	new (): any
+};
+
+########## 27
+const Foo = /* @__PURE__ */ (() => {})() satisfies X
+----------
+const Foo = ((/* @__PURE__ */ (() => {})()) satisfies X);
+
+########## 28
+const Foo = /* @__PURE__ */ (() => {})()<X>
+----------
+const Foo = /* @__PURE__ */ (() => {})()<X>;
+
+########## 29
+const Foo = /* @__PURE__ */ <Foo>(() => {})()!
+----------
+const Foo = (<Foo>(/* @__PURE__ */ (() => {})())!);
+
+########## 30
+const Foo = /* @__PURE__ */ <Foo>(() => {})()! as X satisfies Y
+----------
+const Foo = (((<Foo>(/* @__PURE__ */ (() => {})())!) as X) satisfies Y);

--- a/crates/oxc_parser/src/js/expression.rs
+++ b/crates/oxc_parser/src/js/expression.rs
@@ -1247,7 +1247,7 @@ impl<'a> ParserImpl<'a> {
     }
 
     fn set_pure_on_call_or_new_expr(expr: &mut Expression<'a>) {
-        match &mut expr.without_parentheses_mut() {
+        match &mut expr.get_inner_expression_mut() {
             Expression::CallExpression(call_expr) => {
                 call_expr.pure = true;
             }


### PR DESCRIPTION
Fixes https://github.com/rolldown/rolldown/issues/4166

Previously these inner call expressions were not annotated with `pure`.

```js
const Foo = /* @__PURE__ */ (((() => {})()))
const Foo = /* @__PURE__ */ (() => { })() as unknown as { new (): any };
const Foo = /* @__PURE__ */ (() => {})() satisfies X"
const Foo = /* @__PURE__ */ (() => {})()<X>"
const Foo = /* @__PURE__ */ <Foo>(() => {})()!
const Foo = /* @__PURE__ */ <Foo>(() => {})()! as X satisfies Y
```