### PR TITLE
test(allocator): ignore a slow doc test

### DIFF
--- a/crates/oxc_allocator/src/allocator.rs
+++ b/crates/oxc_allocator/src/allocator.rs
@@ -105,7 +105,7 @@ use bumpalo::Bump;
 ///
 /// If workload is completely uniform, it reaches stable state on the 3rd round.
 ///
-/// ```
+/// ```ignore
 /// # use oxc_allocator::Allocator;
 /// let mut allocator = Allocator::new();
 ///


### PR DESCRIPTION
This doc test runs a few times `workload`, which is quite a heavy function. Ignore this test, we can save ~1.5s
https://github.com/oxc-project/oxc/blob/3503d708ad7221109bde34bea129149f7170d42c/crates/oxc_allocator/src/allocator.rs#L112-L117