### PR TITLE
fix(parser,linter): consider typescript declarations for named exports

### DIFF
--- a/crates/oxc_linter/fixtures/import/typescript-export-enum.ts
+++ b/crates/oxc_linter/fixtures/import/typescript-export-enum.ts
@@ -1,0 +1,3 @@
+export enum Foo {
+  BAR = 0,
+}

--- a/crates/oxc_linter/src/rules/import/namespace.rs
+++ b/crates/oxc_linter/src/rules/import/namespace.rs
@@ -485,6 +485,11 @@ fn test() {
         (r"import { a } from './oxc/indirect-export'; console.log(a.nothing)", None),
         // Issue: <https://github.com/oxc-project/oxc/issues/7696>
         (r"import * as acorn from 'acorn'; acorn.parse()", None),
+        // https://github.com/oxc-project/oxc/issues/10318
+        (
+            r#"import * as lib from "./typescript-export-enum"; export const bar = lib.Foo.BAR;"#,
+            None,
+        ),
     ];
 
     let fail = vec![

--- a/napi/parser/test/esm.test.ts
+++ b/napi/parser/test/esm.test.ts
@@ -85,16 +85,19 @@ describe('hasModuleSyntax', () => {
 
 describe('export type', () => {
   const code = [
-    "export type * from 'mod'",
-    "export type * as ns from 'mod'",
-    'export type { foo }',
-    'export { type foo }',
-    "export type { foo } from 'mod'",
+    { source: "export type * from 'mod'", isType: true },
+    { source: "export type * as ns from 'mod'", isType: true },
+    { source: 'export type { foo }', isType: true },
+    { source: 'export { type foo }', isType: true },
+    { source: "export type { foo } from 'mod'", isType: true },
+    { source: 'export type Foo = {}', isType: true },
+    { source: 'export interface Bar {}', isType: true },
+    { source: 'export namespace Baz {}', isType: true },
   ];
-  test.each(code)('%s', (s) => {
-    const ret = parseSync('test.ts', s);
+  test.each(code)('%s', (source, isType) => {
+    const ret = parseSync('test.ts', source);
     expect(ret.module.staticExports.length).toBe(1);
     expect(ret.module.staticExports[0].entries.length).toBe(1);
-    expect(ret.module.staticExports[0].entries[0].isType).toBe(true);
+    expect(ret.module.staticExports[0].entries[0].isType).toBe(isType);
   });
 });

--- a/napi/parser/test/esm.test.ts
+++ b/napi/parser/test/esm.test.ts
@@ -84,7 +84,7 @@ describe('hasModuleSyntax', () => {
 });
 
 describe('export type', () => {
-  const code = [
+  const inputs = [
     ["export type * from 'mod'", true],
     ["export type * as ns from 'mod'", true],
     ['export type { foo }', true],
@@ -92,9 +92,9 @@ describe('export type', () => {
     ["export type { foo } from 'mod'", true],
     ['export type Foo = {}', true],
     ['export interface Bar {}', true],
-    ['export namespace Baz {}', true],
+    ['export namespace Baz {}', false], // namespace isn't considered a typed export
   ];
-  test.each(code)('%s', (source, isType) => {
+  test.each(inputs)('%s', (source, isType) => {
     const ret = parseSync('test.ts', source);
     expect(ret.module.staticExports.length).toBe(1);
     expect(ret.module.staticExports[0].entries.length).toBe(1);

--- a/napi/parser/test/esm.test.ts
+++ b/napi/parser/test/esm.test.ts
@@ -93,7 +93,7 @@ describe('export type', () => {
     ['export type Foo = {}', true],
     ['export interface Bar {}', true],
     ['export namespace Baz {}', false], // namespace isn't considered a typed export
-  ];
+  ] as const;
   test.each(inputs)('%s', (source, isType) => {
     const ret = parseSync('test.ts', source);
     expect(ret.module.staticExports.length).toBe(1);

--- a/napi/parser/test/esm.test.ts
+++ b/napi/parser/test/esm.test.ts
@@ -85,14 +85,14 @@ describe('hasModuleSyntax', () => {
 
 describe('export type', () => {
   const code = [
-    { source: "export type * from 'mod'", isType: true },
-    { source: "export type * as ns from 'mod'", isType: true },
-    { source: 'export type { foo }', isType: true },
-    { source: 'export { type foo }', isType: true },
-    { source: "export type { foo } from 'mod'", isType: true },
-    { source: 'export type Foo = {}', isType: true },
-    { source: 'export interface Bar {}', isType: true },
-    { source: 'export namespace Baz {}', isType: true },
+    ["export type * from 'mod'", true],
+    ["export type * as ns from 'mod'", true],
+    ['export type { foo }', true],
+    ['export { type foo }', true],
+    ["export type { foo } from 'mod'", true],
+    ['export type Foo = {}', true],
+    ['export interface Bar {}', true],
+    ['export namespace Baz {}', true],
   ];
   test.each(code)('%s', (source, isType) => {
     const ret = parseSync('test.ts', source);

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -3,7 +3,7 @@ commit: 15392346
 parser_typescript Summary:
 AST Parsed     : 6523/6531 (99.88%)
 Positive Passed: 6511/6531 (99.69%)
-Negative Passed: 1308/5754 (22.73%)
+Negative Passed: 1309/5754 (22.75%)
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ClassDeclaration24.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/ExportAssignment7.ts
@@ -2539,8 +2539,6 @@ Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsdocTypeCas
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsdocTypeNongenericInstantiationAttempt.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsdocTypedefMissingType.ts
-
-Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsdocTypedefNoCrash2.ts
 
 Expect Syntax Error: tasks/coverage/typescript/tests/cases/compiler/jsxCallElaborationCheckNoCrash1.tsx
 
@@ -13414,6 +13412,20 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·        ▲
    ╰────
   help: Try insert a semicolon here
+
+  × Duplicated export 'foo'
+   ╭─[typescript/tests/cases/compiler/jsdocTypedefNoCrash2.ts:1:13]
+ 1 │ export type foo = 5;
+   ·             ─┬─
+   ·              ╰── Export has already been declared here
+ 2 │ /**
+   ╰────
+   ╭─[typescript/tests/cases/compiler/jsdocTypedefNoCrash2.ts:6:14]
+ 5 │  */
+ 6 │ export const foo = 5;
+   ·              ─┬─
+   ·               ╰── It cannot be redeclared here
+   ╰────
 
   × Unexpected token
    ╭─[typescript/tests/cases/compiler/jsxAttributeMissingInitializer.tsx:1:21]


### PR DESCRIPTION
Only VariableDeclaration, FunctionDeclaration and ClassDeclaration were considered when collecting named export declarations for the module record. Now the parser also considers TSTypeAliasDeclaration, TSInterfaceDeclaration, TSEnumDeclaration, TSImportEqualsDeclaration and TSModuleDeclaration named export declarations of the module.

Maybe the other `decl.declaration.is_typescript_syntax()` check in `module_record.rs` also needs to be removed?

Closes #10318
Closes #10556