### PR TITLE
feat(tasks/transforme_conformance): support `--override` for tests have been passed

### DIFF
--- a/tasks/transform_conformance/src/lib.rs
+++ b/tasks/transform_conformance/src/lib.rs
@@ -146,6 +146,14 @@ impl TestRunner {
             let num_of_tests = test_cases.len();
             total += num_of_tests;
 
+            // `--override` option will override the output of test cases
+            // and write it down to `../overrides` folder.
+            for test_case in &test_cases {
+                if self.options.r#override {
+                    test_case.write_override_output();
+                }
+            }
+
             // Run the test
             let (passed, failed): (Vec<TestCase>, Vec<TestCase>) =
                 test_cases.into_iter().partition(|test_case| test_case.errors.is_empty());
@@ -157,9 +165,6 @@ impl TestRunner {
             } else {
                 writeln!(snapshot, "# {case} ({}/{})", passed.len(), num_of_tests).unwrap();
                 for test_case in failed {
-                    if self.options.r#override {
-                        test_case.write_override_output();
-                    }
                     snapshot.push_str("* ");
                     snapshot.push_str(&normalize_path(
                         test_case.path.strip_prefix(&case_root).unwrap(),


### PR DESCRIPTION
Before, we could only override the failed tests, now we support `--override` for the passed tests. This is useful for fixing the Babel itself bugs/misalignments. See #10538 and #10491