### PR TITLE
test(transformer/class-properties): overrides a few tests that contain class properties without initializer usages

### DIFF
--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/compile-to-class/constructor-collision-ignores-types-loose/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/compile-to-class/constructor-collision-ignores-types-loose/output.js
@@ -1,0 +1,6 @@
+class C {
+  constructor(T) {
+    this.x = void 0;
+    this.y = 0;
+  }
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public-loose/instance-undefined/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public-loose/instance-undefined/output.js
@@ -1,0 +1,5 @@
+class Foo {
+  constructor() {
+    this.bar = void 0;
+  }
+}

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public-loose/preserve-comments/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public-loose/preserve-comments/output.js
@@ -1,0 +1,6 @@
+class C {
+  constructor() {
+    this.a = void 0;
+  }
+}
+C.b = void 0;

--- a/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public-loose/static-undefined/output.js
+++ b/tasks/transform_conformance/overrides/babel-plugin-transform-class-properties/test/fixtures/public-loose/static-undefined/output.js
@@ -1,0 +1,2 @@
+class Foo {}
+Foo.bar = void 0;


### PR DESCRIPTION
Prepare for #10491. Since #10491 aligns the transforming behavior of properties without an initializer with `TypeScript`, these tests' output needs to be tweaked. To avoid producing an unreadable diff, we override the tests first, and then we can see only the changed parts from the diff in #10491.