### PR TITLE
perf(transformer/class-properties): re-use `InstanceInitializerVisitor`

### DIFF
--- a/crates/oxc_transformer/src/es2022/class_properties/instance_prop_init.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/instance_prop_init.rs
@@ -29,19 +29,21 @@ impl<'a> ClassProperties<'a, '_> {
         instance_inits_constructor_scope_id: Option<ScopeId>,
         ctx: &mut TraverseCtx<'a>,
     ) {
-        for init in inits {
-            if let Some(constructor_scope_id) = instance_inits_constructor_scope_id {
-                // Re-parent first-level scopes, and check for symbol clashes
-                let mut updater = InstanceInitializerVisitor::new(
-                    instance_inits_scope_id,
-                    constructor_scope_id,
-                    self,
-                    ctx,
-                );
+        if let Some(constructor_scope_id) = instance_inits_constructor_scope_id {
+            // Re-parent first-level scopes, and check for symbol clashes
+            let mut updater = InstanceInitializerVisitor::new(
+                instance_inits_scope_id,
+                constructor_scope_id,
+                self,
+                ctx,
+            );
+            for init in inits {
                 updater.visit_expression(init);
-            } else {
-                // No symbol clashes possible. Just re-parent first-level scopes (faster).
-                let mut updater = FastInstanceInitializerVisitor::new(instance_inits_scope_id, ctx);
+            }
+        } else {
+            // No symbol clashes possible. Just re-parent first-level scopes (faster).
+            let mut updater = FastInstanceInitializerVisitor::new(instance_inits_scope_id, ctx);
+            for init in inits {
                 updater.visit_expression(init);
             }
         }


### PR DESCRIPTION
Follow-on after #10495.

1. Branch on whether `instance_inits_constructor_scope_id` is `Some` only once, rather than on each turn of the loop.
2. Only create one `InstanceInitializerVisitor` for all the inits, rather than a new one for each init. `InstanceInitializerVisitor` contains a `Stack`, so ideal to re-use it, because `Stack` performs an allocation.

These are small optimizations. I doubt will register on benchmarks.
