### PR TITLE
fix(ast/estree): fix raw deser for `FormalParameter`

### DIFF
--- a/crates/oxc_ast/src/ast/js.rs
+++ b/crates/oxc_ast/src/ast/js.rs
@@ -1793,8 +1793,15 @@ pub struct FormalParameters<'a> {
 #[plural(FormalParameterList)]
 #[estree(
     no_type,
+    via = FormalParameterConverter,
     add_ts_def = "
-        interface TSParameterProperty extends Span {
+        type FormalParameter =
+            & ({
+                decorators?: Array<Decorator>;
+            })
+            & BindingPattern;
+
+        export interface TSParameterProperty extends Span {
             type: 'TSParameterProperty';
             accessibility: TSAccessibility | null;
             decorators: Array<Decorator>;

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -1392,12 +1392,7 @@ impl ESTree for FormalParameters<'_> {
 
 impl ESTree for FormalParameter<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        let mut state = serializer.serialize_struct();
-        self.pattern.kind.serialize(FlatStructSerializer(&mut state));
-        state.serialize_ts_field("typeAnnotation", &self.pattern.type_annotation);
-        state.serialize_ts_field("optional", &self.pattern.optional);
-        state.serialize_ts_field("decorators", &self.decorators);
-        state.end();
+        crate::serialize::FormalParameterConverter(self).serialize(serializer)
     }
 }
 

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -760,7 +760,6 @@ function deserializeBindingRestElement(pos) {
 
 function deserializeFunction(pos) {
   const params = deserializeBoxFormalParameters(pos + 72);
-  // TODO: Serialize items, rest
   return {
     type: deserializeFunctionType(pos + 8),
     start: deserializeU32(pos),
@@ -776,7 +775,6 @@ function deserializeFunction(pos) {
 
 function deserializeFormalParameters(pos) {
   const params = deserializeVecFormalParameter(pos + 16);
-  // TODO: Serialize items
   if (uint32[(pos + 48) >> 2] !== 0 && uint32[(pos + 52) >> 2] !== 0) {
     pos = uint32[(pos + 48) >> 2];
     params.push({
@@ -790,9 +788,7 @@ function deserializeFormalParameters(pos) {
 }
 
 function deserializeFormalParameter(pos) {
-  return {
-    ...deserializeBindingPatternKind(pos + 40),
-  };
+  return deserializeBindingPatternKind(pos + 40);
 }
 
 function deserializeFunctionBody(pos) {
@@ -1703,7 +1699,6 @@ function deserializeTSMethodSignature(pos) {
   const params = deserializeBoxFormalParameters(pos + 48);
   const thisParam = deserializeOptionBoxTSThisParameter(pos + 40);
   if (thisParam !== null) params.unshift(thisParam);
-  // TODO: Serialize items, rest
   return {
     type: 'TSMethodSignature',
     start: deserializeU32(pos),
@@ -1834,7 +1829,6 @@ function deserializeTSFunctionType(pos) {
   const params = deserializeBoxFormalParameters(pos + 24);
   const thisParam = deserializeOptionBoxTSThisParameter(pos + 16);
   if (thisParam !== null) params.unshift(thisParam);
-  // TODO: Serialize items, rest
   return {
     type: 'TSFunctionType',
     start: deserializeU32(pos),


### PR DESCRIPTION
Follow-on after #10534. Fix the raw deser implementation for `FormalParameter` to handle `TSParameterProperty`.

This involves moving some of the logic into a converter for `FormalParameter`, instead of doing it all in `FormalParameters` converter.
