### PR TITLE
perf(codegen): speed up printing `Directive`s

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -77,20 +77,20 @@ impl Gen for Directive<'_> {
         // See https://github.com/babel/babel/blob/v7.26.2/packages/babel-generator/src/generators/base.ts#L64
         let directive = self.directive.as_str();
 
-        let mut chars = directive.chars();
+        let mut bytes = directive.as_bytes().iter();
         let mut quote = p.quote;
-        while let Some(c) = chars.next() {
-            match c {
-                '"' => {
+        while let Some(&b) = bytes.next() {
+            match b {
+                b'"' => {
                     quote = Quote::Single;
                     break;
                 }
-                '\'' => {
+                b'\'' => {
                     quote = Quote::Double;
                     break;
                 }
-                '\\' => {
-                    chars.next();
+                b'\\' => {
+                    bytes.next();
                 }
                 _ => {}
             }


### PR DESCRIPTION
Speed up printing `Directive`s by iterating over bytes instead of `char`s.