### PR TITLE
fix(transformer/typescript): remove `StringLiteral::raw` when rewriting extensions

### DIFF
--- a/crates/oxc_transformer/src/typescript/rewrite_extensions.rs
+++ b/crates/oxc_transformer/src/typescript/rewrite_extensions.rs
@@ -46,6 +46,7 @@ impl TypeScriptRewriteExtensions {
             value.push_str(replace);
             ctx.ast.atom(&value)
         };
+        source.raw = None;
     }
 }
 


### PR DESCRIPTION
When altering `value` of a `StringLiteral`, `raw` should be set to `None` because it no longer represents the content of the string.