### PR TITLE
perf(transformer/typescript): reduce allocations renaming extensions

### DIFF
--- a/crates/oxc_transformer/src/typescript/rewrite_extensions.rs
+++ b/crates/oxc_transformer/src/typescript/rewrite_extensions.rs
@@ -5,9 +5,11 @@
 //!
 //! Based on Babel's [plugin-rewrite-ts-imports](https://github.com/babel/babel/blob/3bcfee232506a4cebe410f02042fb0f0adeeb0b1/packages/babel-preset-typescript/src/plugin-rewrite-ts-imports.ts)
 
+use oxc_allocator::String as ArenaString;
 use oxc_ast::ast::{
     ExportAllDeclaration, ExportNamedDeclaration, ImportDeclaration, StringLiteral,
 };
+use oxc_span::Atom;
 use oxc_traverse::{Traverse, TraverseCtx};
 
 use crate::TypeScriptOptions;
@@ -29,22 +31,21 @@ impl TypeScriptRewriteExtensions {
             return;
         }
 
-        let Some((_, extension)) = value.rsplit_once('.') else { return };
+        let Some((without_extension, extension)) = value.rsplit_once('.') else { return };
 
         let replace = match extension {
-            "mts" => "mjs",
-            "cts" => "cjs",
-            "ts" | "tsx" => "js",
-            _ => return, // do not  rewrite or remove other unknown extensions
+            "mts" => ".mjs",
+            "cts" => ".cjs",
+            "ts" | "tsx" => ".js",
+            _ => return, // do not rewrite or remove other unknown extensions
         };
 
-        let value = value.trim_end_matches(extension);
         source.value = if self.mode.is_remove() {
-            ctx.ast.atom(value.trim_end_matches('.'))
+            Atom::from(without_extension)
         } else {
-            let mut value = value.to_string();
-            value.push_str(replace);
-            ctx.ast.atom(&value)
+            let new_value =
+                ArenaString::from_strs_array_in([without_extension, replace], ctx.ast.allocator);
+            Atom::from(new_value)
         };
         source.raw = None;
     }


### PR DESCRIPTION
Small optimization. When replacing extensions in TypeScript transform, avoid allocations.

* In `Remove` mode, use a slice of the original string, instead of allocating a new `Atom`.
* In `Replace` mode, create an `ArenaString` directly in arena, without a temporary `String`.
