### PR TITLE
fix(estree): Add missing fields for `RestElement` raw deser

### DIFF
--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -593,6 +593,8 @@ impl ESTree for ElisionConverter<'_> {
                     POS_OFFSET<BindingRestElement>.argument.type_annotation
                 ),
                 optional: DESER[bool]( POS_OFFSET<BindingRestElement>.argument.optional ),
+                decorators: [],
+                value: null,
                 /* END_IF_TS */
             });
         }

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -860,6 +860,8 @@ function deserializeFormalParameters(pos) {
         pos + 24,
       ),
       optional: deserializeBool(pos + 32),
+      decorators: [],
+      value: null,
     });
   }
   return params;


### PR DESCRIPTION
I happened to find this when checking #10548 👀 

(It might not have been necessary to fix it right away, but since I found it 😅)