### PR TITLE
fix(ast): Box `this_param` in `TSCallSignatureDeclaration`

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1016,7 +1016,7 @@ pub struct TSCallSignatureDeclaration<'a> {
     pub span: Span,
     pub type_parameters: Option<Box<'a, TSTypeParameterDeclaration<'a>>>,
     #[estree(skip)]
-    pub this_param: Option<TSThisParameter<'a>>,
+    pub this_param: Option<Box<'a, TSThisParameter<'a>>>,
     #[estree(via = TSCallSignatureDeclarationFormalParameters)]
     pub params: Box<'a, FormalParameters<'a>>,
     pub return_type: Option<Box<'a, TSTypeAnnotation<'a>>>,

--- a/crates/oxc_ast/src/generated/assert_layouts.rs
+++ b/crates/oxc_ast/src/generated/assert_layouts.rs
@@ -1161,13 +1161,13 @@ const _: () = {
     assert!(offset_of!(TSIndexSignature, readonly) == 48);
     assert!(offset_of!(TSIndexSignature, r#static) == 49);
 
-    assert!(size_of::<TSCallSignatureDeclaration>() == 64);
+    assert!(size_of::<TSCallSignatureDeclaration>() == 40);
     assert!(align_of::<TSCallSignatureDeclaration>() == 8);
     assert!(offset_of!(TSCallSignatureDeclaration, span) == 0);
     assert!(offset_of!(TSCallSignatureDeclaration, type_parameters) == 8);
     assert!(offset_of!(TSCallSignatureDeclaration, this_param) == 16);
-    assert!(offset_of!(TSCallSignatureDeclaration, params) == 48);
-    assert!(offset_of!(TSCallSignatureDeclaration, return_type) == 56);
+    assert!(offset_of!(TSCallSignatureDeclaration, params) == 24);
+    assert!(offset_of!(TSCallSignatureDeclaration, return_type) == 32);
 
     assert!(size_of::<TSMethodSignatureKind>() == 1);
     assert!(align_of::<TSMethodSignatureKind>() == 1);
@@ -2554,13 +2554,13 @@ const _: () = {
     assert!(offset_of!(TSIndexSignature, readonly) == 28);
     assert!(offset_of!(TSIndexSignature, r#static) == 29);
 
-    assert!(size_of::<TSCallSignatureDeclaration>() == 44);
+    assert!(size_of::<TSCallSignatureDeclaration>() == 24);
     assert!(align_of::<TSCallSignatureDeclaration>() == 4);
     assert!(offset_of!(TSCallSignatureDeclaration, span) == 0);
     assert!(offset_of!(TSCallSignatureDeclaration, type_parameters) == 8);
     assert!(offset_of!(TSCallSignatureDeclaration, this_param) == 12);
-    assert!(offset_of!(TSCallSignatureDeclaration, params) == 36);
-    assert!(offset_of!(TSCallSignatureDeclaration, return_type) == 40);
+    assert!(offset_of!(TSCallSignatureDeclaration, params) == 16);
+    assert!(offset_of!(TSCallSignatureDeclaration, return_type) == 20);
 
     assert!(size_of::<TSMethodSignatureKind>() == 1);
     assert!(align_of::<TSMethodSignatureKind>() == 1);

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -12388,18 +12388,19 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     /// * `return_type`
     #[inline]
-    pub fn ts_signature_call_signature_declaration<T1, T2, T3>(
+    pub fn ts_signature_call_signature_declaration<T1, T2, T3, T4>(
         self,
         span: Span,
         type_parameters: T1,
-        this_param: Option<TSThisParameter<'a>>,
-        params: T2,
-        return_type: T3,
+        this_param: T2,
+        params: T3,
+        return_type: T4,
     ) -> TSSignature<'a>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         TSSignature::TSCallSignatureDeclaration(self.alloc_ts_call_signature_declaration(
             span,
@@ -12643,23 +12644,24 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     /// * `return_type`
     #[inline]
-    pub fn ts_call_signature_declaration<T1, T2, T3>(
+    pub fn ts_call_signature_declaration<T1, T2, T3, T4>(
         self,
         span: Span,
         type_parameters: T1,
-        this_param: Option<TSThisParameter<'a>>,
-        params: T2,
-        return_type: T3,
+        this_param: T2,
+        params: T3,
+        return_type: T4,
     ) -> TSCallSignatureDeclaration<'a>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         TSCallSignatureDeclaration {
             span,
             type_parameters: type_parameters.into_in(self.allocator),
-            this_param,
+            this_param: this_param.into_in(self.allocator),
             params: params.into_in(self.allocator),
             return_type: return_type.into_in(self.allocator),
         }
@@ -12677,18 +12679,19 @@ impl<'a> AstBuilder<'a> {
     /// * `params`
     /// * `return_type`
     #[inline]
-    pub fn alloc_ts_call_signature_declaration<T1, T2, T3>(
+    pub fn alloc_ts_call_signature_declaration<T1, T2, T3, T4>(
         self,
         span: Span,
         type_parameters: T1,
-        this_param: Option<TSThisParameter<'a>>,
-        params: T2,
-        return_type: T3,
+        this_param: T2,
+        params: T3,
+        return_type: T4,
     ) -> Box<'a, TSCallSignatureDeclaration<'a>>
     where
         T1: IntoIn<'a, Option<Box<'a, TSTypeParameterDeclaration<'a>>>>,
-        T2: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
-        T3: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
+        T2: IntoIn<'a, Option<Box<'a, TSThisParameter<'a>>>>,
+        T3: IntoIn<'a, Box<'a, FormalParameters<'a>>>,
+        T4: IntoIn<'a, Option<Box<'a, TSTypeAnnotation<'a>>>>,
     {
         Box::new_in(
             self.ts_call_signature_declaration(

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -1206,7 +1206,7 @@ pub struct TSCallSignatureDeclarationFormalParameters<'a, 'b>(
 impl ESTree for TSCallSignatureDeclarationFormalParameters<'_, '_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         let v = self.0;
-        serialize_formal_params_with_this_param(v.this_param.as_ref(), &v.params, serializer);
+        serialize_formal_params_with_this_param(v.this_param.as_deref(), &v.params, serializer);
     }
 }
 

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -13005,10 +13005,10 @@ impl<'a, 't> TSCallSignatureDeclarationWithoutTypeParameters<'a, 't> {
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<TSThisParameter<'a>> {
+    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_THIS_PARAM)
-                as *const Option<TSThisParameter<'a>>)
+                as *const Option<Box<'a, TSThisParameter<'a>>>)
         }
     }
 
@@ -13107,10 +13107,10 @@ impl<'a, 't> TSCallSignatureDeclarationWithoutParams<'a, 't> {
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<TSThisParameter<'a>> {
+    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_THIS_PARAM)
-                as *const Option<TSThisParameter<'a>>)
+                as *const Option<Box<'a, TSThisParameter<'a>>>)
         }
     }
 
@@ -13154,10 +13154,10 @@ impl<'a, 't> TSCallSignatureDeclarationWithoutReturnType<'a, 't> {
     }
 
     #[inline]
-    pub fn this_param(self) -> &'t Option<TSThisParameter<'a>> {
+    pub fn this_param(self) -> &'t Option<Box<'a, TSThisParameter<'a>>> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_CALL_SIGNATURE_DECLARATION_THIS_PARAM)
-                as *const Option<TSThisParameter<'a>>)
+                as *const Option<Box<'a, TSThisParameter<'a>>>)
         }
     }
 

--- a/crates/oxc_traverse/src/generated/walk.rs
+++ b/crates/oxc_traverse/src/generated/walk.rs
@@ -4758,10 +4758,10 @@ unsafe fn walk_ts_call_signature_declaration<'a, Tr: Traverse<'a>>(
     }
     if let Some(field) = &mut *((node as *mut u8)
         .add(ancestor::OFFSET_TS_CALL_SIGNATURE_DECLARATION_THIS_PARAM)
-        as *mut Option<TSThisParameter>)
+        as *mut Option<Box<TSThisParameter>>)
     {
         ctx.retag_stack(AncestorType::TSCallSignatureDeclarationThisParam);
-        walk_ts_this_parameter(traverser, field as *mut _, ctx);
+        walk_ts_this_parameter(traverser, (&mut **field) as *mut _, ctx);
     }
     ctx.retag_stack(AncestorType::TSCallSignatureDeclarationParams);
     walk_formal_parameters(

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -1682,7 +1682,7 @@ function deserializeTSIndexSignature(pos) {
 }
 
 function deserializeTSCallSignatureDeclaration(pos) {
-  const params = deserializeBoxFormalParameters(pos + 48);
+  const params = deserializeBoxFormalParameters(pos + 24);
   const thisParam = deserializeOptionBoxTSThisParameter(pos + 16);
   if (thisParam !== null) params.unshift(thisParam);
   return {
@@ -1691,7 +1691,7 @@ function deserializeTSCallSignatureDeclaration(pos) {
     end: deserializeU32(pos + 4),
     typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 8),
     params,
-    returnType: deserializeOptionBoxTSTypeAnnotation(pos + 56),
+    returnType: deserializeOptionBoxTSTypeAnnotation(pos + 32),
   };
 }
 
@@ -5490,11 +5490,6 @@ function deserializeVecTSIndexSignatureName(pos) {
     pos += 32;
   }
   return arr;
-}
-
-function deserializeOptionTSThisParameter(pos) {
-  if (uint8[pos] === 0) return null;
-  return deserializeTSThisParameter(pos + 8);
 }
 
 function deserializeOptionTSModuleDeclarationBody(pos) {

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -1830,7 +1830,7 @@ function deserializeTSIndexSignature(pos) {
 }
 
 function deserializeTSCallSignatureDeclaration(pos) {
-  const params = deserializeBoxFormalParameters(pos + 48);
+  const params = deserializeBoxFormalParameters(pos + 24);
   const thisParam = deserializeOptionBoxTSThisParameter(pos + 16);
   if (thisParam !== null) params.unshift(thisParam);
   return {
@@ -1839,7 +1839,7 @@ function deserializeTSCallSignatureDeclaration(pos) {
     end: deserializeU32(pos + 4),
     typeParameters: deserializeOptionBoxTSTypeParameterDeclaration(pos + 8),
     params,
-    returnType: deserializeOptionBoxTSTypeAnnotation(pos + 56),
+    returnType: deserializeOptionBoxTSTypeAnnotation(pos + 32),
   };
 }
 
@@ -5638,11 +5638,6 @@ function deserializeVecTSIndexSignatureName(pos) {
     pos += 32;
   }
   return arr;
-}
-
-function deserializeOptionTSThisParameter(pos) {
-  if (uint8[pos] === 0) return null;
-  return deserializeTSThisParameter(pos + 8);
 }
 
 function deserializeOptionTSModuleDeclarationBody(pos) {


### PR DESCRIPTION
All other types of `this_param` were alreadey `Box`ed, but only here it was not.

Because of this, `raw_deser` was behaving wrongly.

https://github.com/oxc-project/oxc/blob/2eb1f88a7d8f382a9a0d87f177e1a043eaf1e32b/crates/oxc_ast/src/serialize.rs#L1197
