### PR TITLE
fix(isolated-declarations): leading comments of `ExportDefaultDeclaration` and `TSExportAssignment` appear in incorrect places

### DIFF
--- a/crates/oxc_isolated_declarations/tests/fixtures/export-default2.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/export-default2.ts
@@ -1,0 +1,6 @@
+/**
+ * comment should be a leading comment of the arrow function
+ */
+export default () => {
+	return 0;
+};

--- a/crates/oxc_isolated_declarations/tests/fixtures/ts-export-assignment.ts
+++ b/crates/oxc_isolated_declarations/tests/fixtures/ts-export-assignment.ts
@@ -1,5 +1,8 @@
 const Res = 0;
 
+/**
+ * comment should be a leading comment of the function Foo
+ */
 export = function Foo(): typeof Res {
-  return Res;
-}
+	return Res;
+};

--- a/crates/oxc_isolated_declarations/tests/snapshots/export-default2.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/export-default2.snap
@@ -1,0 +1,12 @@
+---
+source: crates/oxc_isolated_declarations/tests/mod.rs
+input_file: crates/oxc_isolated_declarations/tests/fixtures/export-default2.ts
+---
+```
+==================== .D.TS ====================
+
+/**
+* comment should be a leading comment of the arrow function
+*/
+declare const _default: () => number;
+export default _default;

--- a/crates/oxc_isolated_declarations/tests/snapshots/ts-export-assignment.snap
+++ b/crates/oxc_isolated_declarations/tests/snapshots/ts-export-assignment.snap
@@ -6,5 +6,8 @@ input_file: crates/oxc_isolated_declarations/tests/fixtures/ts-export-assignment
 ==================== .D.TS ====================
 
 declare const Res = 0;
+/**
+* comment should be a leading comment of the function Foo
+*/
 declare const _default: () => typeof Res;
 export = _default;


### PR DESCRIPTION
close: #10535


https://www.typescriptlang.org/play/?#code/PQKhCgAIUgTBTAZgQwK4BsAul4A8AOA9gE6ZQjDh5GlxJpaQCMADOOKBNJACoDKAUQIlMAQQDO4gJYBzAHYBbeHLLRKVYbQC8kRKjkBjTFMJzdhQgAoAlJADekYvEypiZlgF8gA