### PR TITLE
refactor(allocator)!: return `&'alloc str` rather than `&'alloc mut str` in `Allocator::alloc_str` method

### DIFF
--- a/crates/oxc_allocator/src/allocator.rs
+++ b/crates/oxc_allocator/src/allocator.rs
@@ -284,7 +284,7 @@ impl Allocator {
     // We always want it to be inlined.
     #[expect(clippy::inline_always)]
     #[inline(always)]
-    pub fn alloc_str<'alloc>(&'alloc self, src: &str) -> &'alloc mut str {
+    pub fn alloc_str<'alloc>(&'alloc self, src: &str) -> &'alloc str {
         self.bump.alloc_str(src)
     }
 

--- a/crates/oxc_span/src/atom.rs
+++ b/crates/oxc_span/src/atom.rs
@@ -88,7 +88,7 @@ impl<'alloc> FromIn<'alloc, &Atom<'alloc>> for Atom<'alloc> {
 
 impl<'alloc> FromIn<'alloc, &str> for Atom<'alloc> {
     fn from_in(s: &str, allocator: &'alloc Allocator) -> Self {
-        Self::from(&*allocator.alloc_str(s))
+        Self::from(allocator.alloc_str(s))
     }
 }
 


### PR DESCRIPTION
No reason we return a `mut str` in this method.