### PR TITLE
refactor(syntax): move `CloneIn` impls

### DIFF
--- a/crates/oxc_syntax/src/reference.rs
+++ b/crates/oxc_syntax/src/reference.rs
@@ -19,6 +19,19 @@ use oxc_ast_macros::ast;
 #[estree(skip)]
 pub struct ReferenceId(NonMaxU32);
 
+impl Idx for ReferenceId {
+    #[expect(clippy::cast_possible_truncation)]
+    fn from_usize(idx: usize) -> Self {
+        assert!(idx < u32::MAX as usize);
+        // SAFETY: We just checked `idx` is a legal value for `NonMaxU32`
+        Self(unsafe { NonMaxU32::new_unchecked(idx as u32) })
+    }
+
+    fn index(self) -> usize {
+        self.0.get() as usize
+    }
+}
+
 impl<'alloc> CloneIn<'alloc> for ReferenceId {
     type Cloned = Self;
 
@@ -31,19 +44,6 @@ impl<'alloc> CloneIn<'alloc> for ReferenceId {
     #[inline(always)]
     fn clone_in_with_semantic_ids(&self, _: &'alloc Allocator) -> Self {
         *self
-    }
-}
-
-impl Idx for ReferenceId {
-    #[expect(clippy::cast_possible_truncation)]
-    fn from_usize(idx: usize) -> Self {
-        assert!(idx < u32::MAX as usize);
-        // SAFETY: We just checked `idx` is a legal value for `NonMaxU32`
-        Self(unsafe { NonMaxU32::new_unchecked(idx as u32) })
-    }
-
-    fn index(self) -> usize {
-        self.0.get() as usize
     }
 }
 

--- a/crates/oxc_syntax/src/scope.rs
+++ b/crates/oxc_syntax/src/scope.rs
@@ -16,21 +16,6 @@ use oxc_ast_macros::ast;
 #[estree(skip)]
 pub struct ScopeId(NonMaxU32);
 
-impl<'alloc> CloneIn<'alloc> for ScopeId {
-    type Cloned = Self;
-
-    fn clone_in(&self, _: &'alloc Allocator) -> Self {
-        // `clone_in` should never reach this, because `CloneIn` skips scope_id field
-        unreachable!();
-    }
-
-    #[expect(clippy::inline_always)]
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, _: &'alloc Allocator) -> Self {
-        *self
-    }
-}
-
 impl ScopeId {
     /// Create `ScopeId` from `u32`.
     ///
@@ -63,6 +48,21 @@ impl Idx for ScopeId {
 
     fn index(self) -> usize {
         self.0.get() as usize
+    }
+}
+
+impl<'alloc> CloneIn<'alloc> for ScopeId {
+    type Cloned = Self;
+
+    fn clone_in(&self, _: &'alloc Allocator) -> Self {
+        // `clone_in` should never reach this, because `CloneIn` skips scope_id field
+        unreachable!();
+    }
+
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
+    fn clone_in_with_semantic_ids(&self, _: &'alloc Allocator) -> Self {
+        *self
     }
 }
 

--- a/crates/oxc_syntax/src/symbol.rs
+++ b/crates/oxc_syntax/src/symbol.rs
@@ -16,21 +16,6 @@ use oxc_ast_macros::ast;
 #[estree(skip)]
 pub struct SymbolId(NonMaxU32);
 
-impl<'alloc> CloneIn<'alloc> for SymbolId {
-    type Cloned = Self;
-
-    fn clone_in(&self, _: &'alloc Allocator) -> Self {
-        // `clone_in` should never reach this, because `CloneIn` skips symbol_id field
-        unreachable!();
-    }
-
-    #[expect(clippy::inline_always)]
-    #[inline(always)]
-    fn clone_in_with_semantic_ids(&self, _: &'alloc Allocator) -> Self {
-        *self
-    }
-}
-
 impl SymbolId {
     /// Create `SymbolId` from `u32`.
     ///
@@ -63,6 +48,21 @@ impl Idx for SymbolId {
 
     fn index(self) -> usize {
         self.0.get() as usize
+    }
+}
+
+impl<'alloc> CloneIn<'alloc> for SymbolId {
+    type Cloned = Self;
+
+    fn clone_in(&self, _: &'alloc Allocator) -> Self {
+        // `clone_in` should never reach this, because `CloneIn` skips symbol_id field
+        unreachable!();
+    }
+
+    #[expect(clippy::inline_always)]
+    #[inline(always)]
+    fn clone_in_with_semantic_ids(&self, _: &'alloc Allocator) -> Self {
+        *self
     }
 }
 


### PR DESCRIPTION
Pure refactor. Move `CloneIn` impls lower down. It's conventional to have core methods before trait impls.
