### PR TITLE
feat(napi/transform): support enabling `removeClassFieldsWithoutInitializer`

### DIFF
--- a/napi/transform/index.d.ts
+++ b/napi/transform/index.d.ts
@@ -428,6 +428,41 @@ export interface TypeScriptOptions {
   allowNamespaces?: boolean
   allowDeclareFields?: boolean
   /**
+   * When enabled, class fields without initializers are removed.
+   *
+   * For example:
+   * ```ts
+   * class Foo {
+   *    x: number;
+   *    y: number = 0;
+   * }
+   * ```
+   * // transform into
+   * ```js
+   * class Foo {
+   *    x: number;
+   * }
+   * ```
+   *
+   * The option is used to align with the behavior of TypeScript's `useDefineForClassFields: false` option.
+   * When you want to enable this, you also need to set [`crate::CompilerAssumptions::set_public_class_fields`]
+   * to `true`. The `set_public_class_fields: true` + `remove_class_fields_without_initializer: true` is
+   * equivalent to `useDefineForClassFields: false` in TypeScript.
+   *
+   * When `set_public_class_fields` is true and class-properties plugin is enabled, the above example transforms into:
+   *
+   * ```js
+   * class Foo {
+   *   constructor() {
+   *     this.y = 0;
+   *   }
+   * }
+   * ```
+   *
+   * Defaults to `false`.
+   */
+  removeClassFieldsWithoutInitializer?: boolean
+  /**
    * Also generate a `.d.ts` declaration file for TypeScript files.
    *
    * The source file must be compliant with all

--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -220,6 +220,39 @@ pub struct TypeScriptOptions {
     pub only_remove_type_imports: Option<bool>,
     pub allow_namespaces: Option<bool>,
     pub allow_declare_fields: Option<bool>,
+    /// When enabled, class fields without initializers are removed.
+    ///
+    /// For example:
+    /// ```ts
+    /// class Foo {
+    ///    x: number;
+    ///    y: number = 0;
+    /// }
+    /// ```
+    /// // transform into
+    /// ```js
+    /// class Foo {
+    ///    x: number;
+    /// }
+    /// ```
+    ///
+    /// The option is used to align with the behavior of TypeScript's `useDefineForClassFields: false` option.
+    /// When you want to enable this, you also need to set [`crate::CompilerAssumptions::set_public_class_fields`]
+    /// to `true`. The `set_public_class_fields: true` + `remove_class_fields_without_initializer: true` is
+    /// equivalent to `useDefineForClassFields: false` in TypeScript.
+    ///
+    /// When `set_public_class_fields` is true and class-properties plugin is enabled, the above example transforms into:
+    ///
+    /// ```js
+    /// class Foo {
+    ///   constructor() {
+    ///     this.y = 0;
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// Defaults to `false`.
+    pub remove_class_fields_without_initializer: Option<bool>,
     /// Also generate a `.d.ts` declaration file for TypeScript files.
     ///
     /// The source file must be compliant with all
@@ -252,8 +285,9 @@ impl From<TypeScriptOptions> for oxc::transformer::TypeScriptOptions {
             allow_namespaces: options.allow_namespaces.unwrap_or(ops.allow_namespaces),
             allow_declare_fields: options.allow_declare_fields.unwrap_or(ops.allow_declare_fields),
             optimize_const_enums: false,
-            // TODO: Implement
-            remove_class_fields_without_initializer: false,
+            remove_class_fields_without_initializer: options
+                .remove_class_fields_without_initializer
+                .unwrap_or(ops.remove_class_fields_without_initializer),
             rewrite_import_extensions: options.rewrite_import_extensions.and_then(|value| {
                 match value {
                     Either::A(v) => {


### PR DESCRIPTION
Support passing `removeClassFieldsWithoutInitializer` by `oxc-transform` usage