### PR TITLE
feat(transformer, napi/transform): deprecate `allowDeclareFields` option

### DIFF
--- a/crates/oxc_transformer/src/typescript/options.rs
+++ b/crates/oxc_transformer/src/typescript/options.rs
@@ -40,7 +40,12 @@ pub struct TypeScriptOptions {
     #[serde(default = "default_as_true")]
     pub allow_namespaces: bool,
 
-    // When enabled, type-only class fields are only removed if they are prefixed with the declare modifier:
+    /// When enabled, type-only class fields are only removed if they are prefixed with the declare modifier:
+    ///
+    /// ## Deprecated
+    ///
+    /// Allowing `declare` fields is built-in support in Oxc without any option. If you want to remove class fields
+    /// without initializer, you can use `remove_class_fields_without_initializer: true` instead.
     #[serde(default = "default_as_true")]
     pub allow_declare_fields: bool,
 

--- a/napi/transform/index.d.ts
+++ b/napi/transform/index.d.ts
@@ -467,6 +467,14 @@ export interface TypeScriptOptions {
   jsxPragmaFrag?: string
   onlyRemoveTypeImports?: boolean
   allowNamespaces?: boolean
+  /**
+   * When enabled, type-only class fields are only removed if they are prefixed with the declare modifier:
+   *
+   * @deprecated
+   *
+   * Allowing `declare` fields is built-in support in Oxc without any option. If you want to remove class fields
+   * without initializer, you can use `remove_class_fields_without_initializer: true` instead.
+   */
   allowDeclareFields?: boolean
   /**
    * When enabled, class fields without initializers are removed.

--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -258,6 +258,12 @@ pub struct TypeScriptOptions {
     pub jsx_pragma_frag: Option<String>,
     pub only_remove_type_imports: Option<bool>,
     pub allow_namespaces: Option<bool>,
+    /// When enabled, type-only class fields are only removed if they are prefixed with the declare modifier:
+    ///
+    /// @deprecated
+    ///
+    /// Allowing `declare` fields is built-in support in Oxc without any option. If you want to remove class fields
+    /// without initializer, you can use `remove_class_fields_without_initializer: true` instead.
     pub allow_declare_fields: Option<bool>,
     /// When enabled, class fields without initializers are removed.
     ///


### PR DESCRIPTION
After the `removeClassFieldsWithoutInitializer` option is supported, `allowDeclareFields` is no longer needed. More detail see https://github.com/oxc-project/oxc/pull/10491#issuecomment-2826008849