### PR TITLE
feat(transformer/typescript): support `allowDeclareFields: false` for backward compatibility

### DIFF
--- a/crates/oxc_transformer/src/typescript/annotations.rs
+++ b/crates/oxc_transformer/src/typescript/annotations.rs
@@ -53,8 +53,8 @@ impl<'a, 'ctx> TypeScriptAnnotations<'a, 'ctx> {
             has_jsx_fragment: false,
             jsx_element_import_name,
             jsx_fragment_import_name,
-            remove_class_fields_without_initializer: options
-                .remove_class_fields_without_initializer,
+            remove_class_fields_without_initializer: !options.allow_declare_fields
+                || options.remove_class_fields_without_initializer,
         }
     }
 }

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -1,6 +1,6 @@
 commit: 578ac4df
 
-Passed: 153/249
+Passed: 154/250
 
 # All Passed:
 * babel-plugin-transform-class-static-block
@@ -44,7 +44,7 @@ after transform: SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), R
 rebuilt        : SymbolId(0): [ReferenceId(0), ReferenceId(2), ReferenceId(6), ReferenceId(10)]
 
 
-# babel-plugin-transform-typescript (6/22)
+# babel-plugin-transform-typescript (7/23)
 * class-property-definition/input.ts
 Unresolved references mismatch:
 after transform: ["const"]

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/allow-declare-fields-false/input.ts
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/allow-declare-fields-false/input.ts
@@ -1,0 +1,6 @@
+class Cls {
+	x: number;
+	y = 1;
+	@dce
+	z: string;
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/allow-declare-fields-false/options.json
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/allow-declare-fields-false/options.json
@@ -1,0 +1,10 @@
+{
+  "plugins": [
+    [
+      "transform-typescript",
+      {
+        "allowDeclareFields": false
+      }
+    ]
+  ]
+}

--- a/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/allow-declare-fields-false/output.js
+++ b/tasks/transform_conformance/tests/babel-plugin-transform-typescript/test/fixtures/allow-declare-fields-false/output.js
@@ -1,0 +1,5 @@
+class Cls {
+  y = 1;
+  @dce
+  z;
+}


### PR DESCRIPTION
Although `allow_declare_fields` is deprecated, we still need to support it for backward compatibility.