### PR TITLE
perf(parser): remove `-> Result<T>` from all parsing methods

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -28,9 +28,7 @@ impl<'a> ParserImpl<'a> {
 
     #[inline]
     pub(crate) fn end_span(&self, start: u32) -> Span {
-        let end = self.prev_token_end;
-        debug_assert!(end >= start);
-        Span::new(start, end)
+        Span::new(start, self.prev_token_end)
     }
 
     /// Get current token
@@ -168,16 +166,16 @@ impl<'a> ParserImpl<'a> {
 
     /// [Automatic Semicolon Insertion](https://tc39.es/ecma262/#sec-automatic-semicolon-insertion)
     /// # Errors
-    pub(crate) fn asi(&mut self) -> Result<()> {
+    pub(crate) fn asi(&mut self) {
         if !self.can_insert_semicolon() {
             let span = Span::new(self.prev_token_end, self.prev_token_end);
             let error = diagnostics::auto_semicolon_insertion(span);
-            return Err(self.set_fatal_error(error));
+            self.set_fatal_error(error);
+            return;
         }
         if self.at(Kind::Semicolon) {
             self.advance(Kind::Semicolon);
         }
-        Ok(())
     }
 
     pub(crate) fn can_insert_semicolon(&self) -> bool {
@@ -189,39 +187,35 @@ impl<'a> ParserImpl<'a> {
     }
 
     /// # Errors
-    pub(crate) fn expect_without_advance(&mut self, kind: Kind) -> Result<()> {
+    pub(crate) fn expect_without_advance(&mut self, kind: Kind) {
         if !self.at(kind) {
             let range = self.cur_token().span();
             let error = diagnostics::expect_token(kind.to_str(), self.cur_kind().to_str(), range);
-            return Err(self.set_fatal_error(error));
+            self.set_fatal_error(error);
         }
-        Ok(())
     }
 
     /// Expect a `Kind` or return error
     /// # Errors
     #[inline]
-    pub(crate) fn expect(&mut self, kind: Kind) -> Result<()> {
-        self.expect_without_advance(kind)?;
+    pub(crate) fn expect(&mut self, kind: Kind) {
+        self.expect_without_advance(kind);
         self.advance(kind);
-        Ok(())
     }
 
     /// Expect the next next token to be a `JsxChild`, i.e. `<` or `{` or `JSXText`
     /// # Errors
-    pub(crate) fn expect_jsx_child(&mut self, kind: Kind) -> Result<()> {
-        self.expect_without_advance(kind)?;
+    pub(crate) fn expect_jsx_child(&mut self, kind: Kind) {
+        self.expect_without_advance(kind);
         self.advance_for_jsx_child(kind);
-        Ok(())
     }
 
     /// Expect the next next token to be a `JsxString` or any other token
     /// # Errors
-    pub(crate) fn expect_jsx_attribute_value(&mut self, kind: Kind) -> Result<()> {
+    pub(crate) fn expect_jsx_attribute_value(&mut self, kind: Kind) {
         self.lexer.set_context(LexerContext::JsxAttributeValue);
-        self.expect(kind)?;
+        self.expect(kind);
         self.lexer.set_context(LexerContext::Regular);
-        Ok(())
     }
 
     /// Tell lexer to read a regex
@@ -296,16 +290,15 @@ impl<'a> ParserImpl<'a> {
         self.fatal_error = fatal_error;
     }
 
-    /// # Errors
     pub(crate) fn try_parse<T>(
         &mut self,
-        func: impl FnOnce(&mut ParserImpl<'a>) -> Result<T>,
+        func: impl FnOnce(&mut ParserImpl<'a>) -> T,
     ) -> Option<T> {
         let checkpoint = self.checkpoint();
         let ctx = self.ctx;
-        let result = func(self);
-        if let Ok(result) = result {
-            Some(result)
+        let node = func(self);
+        if self.fatal_error.is_none() {
+            Some(node)
         } else {
             self.ctx = ctx;
             self.rewind(checkpoint);
@@ -337,33 +330,28 @@ impl<'a> ParserImpl<'a> {
         self.state.decorators.take_in(self.ast.allocator)
     }
 
-    pub(crate) fn parse_normal_list<F, T>(
-        &mut self,
-        open: Kind,
-        close: Kind,
-        f: F,
-    ) -> Result<Vec<'a, T>>
+    pub(crate) fn parse_normal_list<F, T>(&mut self, open: Kind, close: Kind, f: F) -> Vec<'a, T>
     where
-        F: Fn(&mut Self) -> Result<Option<T>>,
+        F: Fn(&mut Self) -> Option<T>,
     {
-        self.expect(open)?;
+        self.expect(open);
         let mut list = self.ast.vec();
         loop {
             let kind = self.cur_kind();
             if kind == close || self.has_fatal_error() {
                 break;
             }
-            match f(self)? {
+            match f(self) {
                 Some(e) => {
                     list.push(e);
                 }
-                _ => {
+                None => {
                     break;
                 }
             }
         }
-        self.expect(close)?;
-        Ok(list)
+        self.expect(close);
+        list
     }
 
     pub(crate) fn parse_delimited_list<F, T>(
@@ -372,9 +360,9 @@ impl<'a> ParserImpl<'a> {
         separator: Kind,
         trailing_separator: bool,
         f: F,
-    ) -> Result<Vec<'a, T>>
+    ) -> Vec<'a, T>
     where
-        F: Fn(&mut Self) -> Result<T>,
+        F: Fn(&mut Self) -> T,
     {
         let mut list = self.ast.vec();
         let mut first = true;
@@ -389,14 +377,14 @@ impl<'a> ParserImpl<'a> {
                 if !trailing_separator && self.at(separator) && self.peek_at(close) {
                     break;
                 }
-                self.expect(separator)?;
+                self.expect(separator);
                 if self.at(close) {
                     break;
                 }
             }
-            list.push(f(self)?);
+            list.push(f(self));
         }
-        Ok(list)
+        list
     }
 
     pub(crate) fn parse_delimited_list_with_rest<E, R, A, B>(
@@ -404,10 +392,10 @@ impl<'a> ParserImpl<'a> {
         close: Kind,
         parse_element: E,
         parse_rest: R,
-    ) -> Result<(Vec<'a, A>, Option<B>)>
+    ) -> (Vec<'a, A>, Option<B>)
     where
-        E: Fn(&mut Self) -> Result<A>,
-        R: Fn(&mut Self) -> Result<B>,
+        E: Fn(&mut Self) -> A,
+        R: Fn(&mut Self) -> B,
         B: GetSpan,
     {
         let mut list = self.ast.vec();
@@ -421,20 +409,20 @@ impl<'a> ParserImpl<'a> {
             if first {
                 first = false;
             } else {
-                self.expect(Kind::Comma)?;
+                self.expect(Kind::Comma);
                 if self.at(close) {
                     break;
                 }
             }
 
             if self.at(Kind::Dot3) {
-                if let Some(r) = rest.replace(parse_rest(self)?) {
+                if let Some(r) = rest.replace(parse_rest(self)) {
                     self.error(diagnostics::binding_rest_element_last(r.span()));
                 }
             } else {
-                list.push(parse_element(self)?);
+                list.push(parse_element(self));
             }
         }
-        Ok((list, rest))
+        (list, rest)
     }
 }

--- a/crates/oxc_parser/src/js/binding.rs
+++ b/crates/oxc_parser/src/js/binding.rs
@@ -1,5 +1,4 @@
 use oxc_ast::{NONE, ast::*};
-use oxc_diagnostics::Result;
 use oxc_span::GetSpan;
 
 use crate::{Context, ParserImpl, diagnostics, lexer::Kind};
@@ -8,28 +7,25 @@ impl<'a> ParserImpl<'a> {
     /// `BindingElement`
     ///     `SingleNameBinding`
     ///     `BindingPattern`[?Yield, ?Await] `Initializer`[+In, ?Yield, ?Await]opt
-    pub(super) fn parse_binding_pattern_with_initializer(&mut self) -> Result<BindingPattern<'a>> {
+    pub(super) fn parse_binding_pattern_with_initializer(&mut self) -> BindingPattern<'a> {
         let span = self.start_span();
-        let pattern = self.parse_binding_pattern(true)?;
+        let pattern = self.parse_binding_pattern(true);
         self.context(Context::In, Context::empty(), |p| p.parse_initializer(span, pattern))
     }
 
-    pub(super) fn parse_binding_pattern(
-        &mut self,
-        allow_question: bool,
-    ) -> Result<BindingPattern<'a>> {
-        let mut kind = self.parse_binding_pattern_kind()?;
+    pub(super) fn parse_binding_pattern(&mut self, allow_question: bool) -> BindingPattern<'a> {
+        let mut kind = self.parse_binding_pattern_kind();
         let optional = if allow_question && self.is_ts { self.eat(Kind::Question) } else { false };
-        let type_annotation = self.parse_ts_type_annotation()?;
+        let type_annotation = self.parse_ts_type_annotation();
         if let Some(type_annotation) = &type_annotation {
             Self::extend_binding_pattern_span_end(type_annotation.span.end, &mut kind);
         } else if optional {
             Self::extend_binding_pattern_span_end(self.prev_token_end, &mut kind);
         }
-        Ok(self.ast.binding_pattern(kind, type_annotation, optional))
+        self.ast.binding_pattern(kind, type_annotation, optional)
     }
 
-    pub(crate) fn parse_binding_pattern_kind(&mut self) -> Result<BindingPatternKind<'a>> {
+    pub(crate) fn parse_binding_pattern_kind(&mut self) -> BindingPatternKind<'a> {
         match self.cur_kind() {
             Kind::LCurly => self.parse_object_binding_pattern(),
             Kind::LBrack => self.parse_array_binding_pattern(),
@@ -37,61 +33,61 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
-    fn parse_binding_pattern_identifier(&mut self) -> Result<BindingPatternKind<'a>> {
-        let ident = self.parse_binding_identifier()?;
-        Ok(BindingPatternKind::BindingIdentifier(self.alloc(ident)))
+    fn parse_binding_pattern_identifier(&mut self) -> BindingPatternKind<'a> {
+        let ident = self.parse_binding_identifier();
+        BindingPatternKind::BindingIdentifier(self.alloc(ident))
     }
 
     /// Section 14.3.3 Object Binding Pattern
-    fn parse_object_binding_pattern(&mut self) -> Result<BindingPatternKind<'a>> {
+    fn parse_object_binding_pattern(&mut self) -> BindingPatternKind<'a> {
         let span = self.start_span();
-        self.expect(Kind::LCurly)?;
+        self.expect(Kind::LCurly);
         let (list, rest) = self.parse_delimited_list_with_rest(
             Kind::RCurly,
             Self::parse_binding_property,
             Self::parse_rest_binding,
-        )?;
+        );
         if let Some(rest) = &rest {
             if !matches!(&rest.argument.kind, BindingPatternKind::BindingIdentifier(_)) {
                 let error = diagnostics::invalid_binding_rest_element(rest.argument.span());
-                return Err(self.set_fatal_error(error));
+                return self.fatal_error(error);
             }
         }
-        self.expect(Kind::RCurly)?;
-        Ok(self.ast.binding_pattern_kind_object_pattern(
+        self.expect(Kind::RCurly);
+        self.ast.binding_pattern_kind_object_pattern(
             self.end_span(span),
             list,
             rest.map(|r| self.alloc(r)),
-        ))
+        )
     }
 
     /// Section 14.3.3 Array Binding Pattern
-    fn parse_array_binding_pattern(&mut self) -> Result<BindingPatternKind<'a>> {
+    fn parse_array_binding_pattern(&mut self) -> BindingPatternKind<'a> {
         let span = self.start_span();
-        self.expect(Kind::LBrack)?;
+        self.expect(Kind::LBrack);
         let (list, rest) = self.parse_delimited_list_with_rest(
             Kind::RBrack,
             Self::parse_array_binding_element,
             Self::parse_rest_binding,
-        )?;
-        self.expect(Kind::RBrack)?;
-        Ok(self.ast.binding_pattern_kind_array_pattern(
+        );
+        self.expect(Kind::RBrack);
+        self.ast.binding_pattern_kind_array_pattern(
             self.end_span(span),
             list,
             rest.map(|r| self.alloc(r)),
-        ))
+        )
     }
 
-    fn parse_array_binding_element(&mut self) -> Result<Option<BindingPattern<'a>>> {
+    fn parse_array_binding_element(&mut self) -> Option<BindingPattern<'a>> {
         if self.at(Kind::Comma) {
-            Ok(None)
+            None
         } else {
-            self.parse_binding_pattern_with_initializer().map(Some)
+            Some(self.parse_binding_pattern_with_initializer())
         }
     }
 
-    fn parse_rest_binding(&mut self) -> Result<BindingRestElement<'a>> {
-        let elem = self.parse_rest_element()?;
+    fn parse_rest_binding(&mut self) -> BindingRestElement<'a> {
+        let elem = self.parse_rest_element();
         if let Some(ty) = &elem.argument.type_annotation {
             self.error(diagnostics::rest_element_property_name(ty.span));
         }
@@ -105,16 +101,16 @@ impl<'a> ParserImpl<'a> {
                 self.error(diagnostics::binding_rest_element_last(elem.span));
             }
         }
-        Ok(elem)
+        elem
     }
 
     /// Section 14.3.3 Binding Rest Property
-    pub(super) fn parse_rest_element(&mut self) -> Result<BindingRestElement<'a>> {
+    pub(super) fn parse_rest_element(&mut self) -> BindingRestElement<'a> {
         let span = self.start_span();
         self.bump_any(); // advance `...`
         let init_span = self.start_span();
 
-        let kind = self.parse_binding_pattern_kind()?;
+        let kind = self.parse_binding_pattern_kind();
         // Rest element does not allow `?`, checked in checker/typescript.rs
         if self.at(Kind::Question) && self.is_ts {
             let span = self.cur_token().span();
@@ -122,30 +118,30 @@ impl<'a> ParserImpl<'a> {
             self.error(diagnostics::a_rest_parameter_cannot_be_optional(span));
         }
         // The span is not extended to its type_annotation
-        let type_annotation = self.parse_ts_type_annotation()?;
+        let type_annotation = self.parse_ts_type_annotation();
         let pattern = self.ast.binding_pattern(kind, type_annotation, false);
 
         // Rest element does not allow `= initializer`
         // function foo([...x = []]) { }
         //                    ^^^^ A rest element cannot have an initializer
         let argument = self
-            .context(Context::In, Context::empty(), |p| p.parse_initializer(init_span, pattern))?;
+            .context(Context::In, Context::empty(), |p| p.parse_initializer(init_span, pattern));
         if let BindingPatternKind::AssignmentPattern(pat) = &argument.kind {
             self.error(diagnostics::a_rest_element_cannot_have_an_initializer(pat.span));
         }
 
-        Ok(self.ast.binding_rest_element(self.end_span(span), argument))
+        self.ast.binding_rest_element(self.end_span(span), argument)
     }
 
     /// `BindingProperty`[Yield, Await] :
     ///     `SingleNameBinding`[?Yield, ?Await]
     ///     `PropertyName`[?Yield, ?Await] : `BindingElement`[?Yield, ?Await]
-    pub(super) fn parse_binding_property(&mut self) -> Result<BindingProperty<'a>> {
+    pub(super) fn parse_binding_property(&mut self) -> BindingProperty<'a> {
         let span = self.start_span();
 
         let mut shorthand = false;
         let is_binding_identifier = self.cur_kind().is_binding_identifier();
-        let (key, computed) = self.parse_property_name()?;
+        let (key, computed) = self.parse_property_name();
 
         let value = if is_binding_identifier && !self.at(Kind::Colon) {
             // let { a = b } = c
@@ -156,36 +152,32 @@ impl<'a> ParserImpl<'a> {
                 let identifier =
                     self.ast.binding_pattern_kind_binding_identifier(ident.span, ident.name);
                 let left = self.ast.binding_pattern(identifier, NONE, false);
-                self.context(Context::In, Context::empty(), |p| p.parse_initializer(span, left))?
+                self.context(Context::In, Context::empty(), |p| p.parse_initializer(span, left))
             } else {
-                return Err(self.unexpected());
+                return self.unexpected();
             }
         } else {
             // let { a: b } = c
             //       ^ IdentifierReference
-            self.expect(Kind::Colon)?;
-            self.parse_binding_pattern_with_initializer()?
+            self.expect(Kind::Colon);
+            self.parse_binding_pattern_with_initializer()
         };
 
-        Ok(self.ast.binding_property(self.end_span(span), key, value, shorthand, computed))
+        self.ast.binding_property(self.end_span(span), key, value, shorthand, computed)
     }
 
     /// Initializer[In, Yield, Await] :
     ///   = `AssignmentExpression`[?In, ?Yield, ?Await]
-    fn parse_initializer(
-        &mut self,
-        span: u32,
-        left: BindingPattern<'a>,
-    ) -> Result<BindingPattern<'a>> {
+    fn parse_initializer(&mut self, span: u32, left: BindingPattern<'a>) -> BindingPattern<'a> {
         if self.eat(Kind::Eq) {
-            let expr = self.parse_assignment_expression_or_higher()?;
-            Ok(self.ast.binding_pattern(
+            let expr = self.parse_assignment_expression_or_higher();
+            self.ast.binding_pattern(
                 self.ast.binding_pattern_kind_assignment_pattern(self.end_span(span), left, expr),
                 NONE,
                 false,
-            ))
+            )
         } else {
-            Ok(left)
+            left
         }
     }
 

--- a/crates/oxc_parser/src/js/class.rs
+++ b/crates/oxc_parser/src/js/class.rs
@@ -1,6 +1,5 @@
 use oxc_allocator::{Box, Vec};
 use oxc_ast::ast::*;
-use oxc_diagnostics::Result;
 use oxc_ecmascript::PropName;
 use oxc_span::{GetSpan, Span};
 
@@ -20,12 +19,12 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         stmt_ctx: StatementContext,
         start_span: u32,
-    ) -> Result<Statement<'a>> {
+    ) -> Statement<'a> {
         let modifiers = self.parse_modifiers(
             /* allow_decorators */ true, /* permit_const_as_modifier */ false,
             /* stop_on_start_of_class_static_block */ true,
         );
-        let decl = self.parse_class_declaration(start_span, &modifiers)?;
+        let decl = self.parse_class_declaration(start_span, &modifiers);
 
         if stmt_ctx.is_single_statement() {
             self.error(diagnostics::class_declaration(Span::new(
@@ -34,7 +33,7 @@ impl<'a> ParserImpl<'a> {
             )));
         }
 
-        Ok(Statement::ClassDeclaration(decl))
+        Statement::ClassDeclaration(decl)
     }
 
     /// Section 15.7 Class Definitions
@@ -42,17 +41,17 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         start_span: u32,
         modifiers: &Modifiers<'a>,
-    ) -> Result<Box<'a, Class<'a>>> {
+    ) -> Box<'a, Class<'a>> {
         self.parse_class(start_span, ClassType::ClassDeclaration, modifiers)
     }
 
     /// Section [Class Definitions](https://tc39.es/ecma262/#prod-ClassExpression)
     /// `ClassExpression`[Yield, Await] :
     ///     class `BindingIdentifier`[?Yield, ?Await]opt `ClassTail`[?Yield, ?Await]
-    pub(crate) fn parse_class_expression(&mut self) -> Result<Expression<'a>> {
+    pub(crate) fn parse_class_expression(&mut self) -> Expression<'a> {
         let class =
-            self.parse_class(self.start_span(), ClassType::ClassExpression, &Modifiers::empty())?;
-        Ok(Expression::ClassExpression(class))
+            self.parse_class(self.start_span(), ClassType::ClassExpression, &Modifiers::empty());
+        Expression::ClassExpression(class)
     }
 
     fn parse_class(
@@ -60,7 +59,7 @@ impl<'a> ParserImpl<'a> {
         start_span: u32,
         r#type: ClassType,
         modifiers: &Modifiers<'a>,
-    ) -> Result<Box<'a, Class<'a>>> {
+    ) -> Box<'a, Class<'a>> {
         self.bump_any(); // advance `class`
 
         let decorators = self.consume_decorators();
@@ -74,13 +73,13 @@ impl<'a> ParserImpl<'a> {
         }
 
         let id = if self.cur_kind().is_binding_identifier() && !self.at(Kind::Implements) {
-            Some(self.parse_binding_identifier()?)
+            Some(self.parse_binding_identifier())
         } else {
             None
         };
 
-        let type_parameters = if self.is_ts { self.parse_ts_type_parameters()? } else { None };
-        let (extends, implements) = self.parse_heritage_clause()?;
+        let type_parameters = if self.is_ts { self.parse_ts_type_parameters() } else { None };
+        let (extends, implements) = self.parse_heritage_clause();
         let mut super_class = None;
         let mut super_type_parameters = None;
         if let Some(mut extends) = extends {
@@ -90,7 +89,7 @@ impl<'a> ParserImpl<'a> {
                 super_type_parameters = first_extends.1;
             }
         }
-        let body = self.parse_class_body()?;
+        let body = self.parse_class_body();
 
         self.verify_modifiers(
             modifiers,
@@ -98,7 +97,7 @@ impl<'a> ParserImpl<'a> {
             diagnostics::modifier_cannot_be_used_here,
         );
 
-        Ok(self.ast.alloc_class(
+        self.ast.alloc_class(
             self.end_span(start_span),
             r#type,
             decorators,
@@ -110,12 +109,12 @@ impl<'a> ParserImpl<'a> {
             body,
             modifiers.contains_abstract(),
             modifiers.contains_declare(),
-        ))
+        )
     }
 
     pub(crate) fn parse_heritage_clause(
         &mut self,
-    ) -> Result<(Option<Extends<'a>>, Vec<'a, TSClassImplements<'a>>)> {
+    ) -> (Option<Extends<'a>>, Vec<'a, TSClassImplements<'a>>) {
         let mut extends = None;
         let mut implements = self.ast.vec();
 
@@ -131,7 +130,7 @@ impl<'a> ParserImpl<'a> {
                             self.cur_token().span(),
                         ));
                     }
-                    extends = Some(self.parse_extends_clause()?);
+                    extends = Some(self.parse_extends_clause());
                 }
                 Kind::Implements => {
                     if !implements.is_empty() {
@@ -139,31 +138,31 @@ impl<'a> ParserImpl<'a> {
                             self.cur_token().span(),
                         ));
                     }
-                    implements.extend(self.parse_ts_implements_clause()?);
+                    implements.extend(self.parse_ts_implements_clause());
                 }
                 _ => break,
             }
         }
 
-        Ok((extends, implements))
+        (extends, implements)
     }
 
     /// `ClassHeritage`
     /// extends `LeftHandSideExpression`[?Yield, ?Await]
-    fn parse_extends_clause(&mut self) -> Result<Extends<'a>> {
+    fn parse_extends_clause(&mut self) -> Extends<'a> {
         self.bump_any(); // bump `extends`
 
         let mut extends = self.ast.vec();
         loop {
             let span = self.start_span();
-            let mut extend = self.parse_lhs_expression_or_higher()?;
+            let mut extend = self.parse_lhs_expression_or_higher();
             let type_argument;
             if let Expression::TSInstantiationExpression(expr) = extend {
                 let expr = expr.unbox();
                 extend = expr.expression;
                 type_argument = Some(expr.type_arguments);
             } else {
-                type_argument = self.try_parse_type_arguments()?;
+                type_argument = self.try_parse_type_arguments();
             }
 
             extends.push((extend, type_argument, self.end_span(span)));
@@ -173,23 +172,23 @@ impl<'a> ParserImpl<'a> {
             }
         }
 
-        Ok(extends)
+        extends
     }
 
-    fn parse_class_body(&mut self) -> Result<Box<'a, ClassBody<'a>>> {
+    fn parse_class_body(&mut self) -> Box<'a, ClassBody<'a>> {
         let span = self.start_span();
         let class_elements =
-            self.parse_normal_list(Kind::LCurly, Kind::RCurly, Self::parse_class_element)?;
-        Ok(self.ast.alloc_class_body(self.end_span(span), class_elements))
+            self.parse_normal_list(Kind::LCurly, Kind::RCurly, Self::parse_class_element);
+        self.ast.alloc_class_body(self.end_span(span), class_elements)
     }
 
-    pub(crate) fn parse_class_element(&mut self) -> Result<Option<ClassElement<'a>>> {
+    pub(crate) fn parse_class_element(&mut self) -> Option<ClassElement<'a>> {
         // skip empty class element `;`
         while self.at(Kind::Semicolon) {
             self.bump_any();
         }
         if self.at(Kind::RCurly) {
-            return Ok(None);
+            return None;
         }
 
         let span = self.start_span();
@@ -214,7 +213,7 @@ impl<'a> ParserImpl<'a> {
             // static { block }
             if self.peek_at(Kind::LCurly) {
                 self.bump(Kind::Static);
-                return self.parse_class_static_block(span).map(Some);
+                return Some(self.parse_class_static_block(span));
             }
 
             // static ...
@@ -222,7 +221,7 @@ impl<'a> ParserImpl<'a> {
                 self.bump(Kind::Static);
                 r#static = true;
             } else {
-                key_name = Some(self.parse_class_element_name()?);
+                key_name = Some(self.parse_class_element_name());
             }
         }
 
@@ -234,14 +233,13 @@ impl<'a> ParserImpl<'a> {
                 self.bump(Kind::Async);
                 r#async = true;
             } else {
-                key_name = Some(self.parse_class_element_name()?);
+                key_name = Some(self.parse_class_element_name());
             }
         }
 
         if self.is_at_ts_index_signature_member() {
-            return self
-                .parse_index_signature_declaration(span, &modifiers)
-                .map(|sig| Some(ClassElement::TSIndexSignature(self.alloc(sig))));
+            let decl = self.parse_index_signature_declaration(span, &modifiers);
+            return Some(ClassElement::TSIndexSignature(self.alloc(decl)));
         }
 
         // * ...
@@ -256,22 +254,20 @@ impl<'a> ParserImpl<'a> {
                 Kind::Get if peeked_class_element => {
                     self.bump(Kind::Get);
                     kind = MethodDefinitionKind::Get;
-                    Some(self.parse_class_element_name()?)
+                    Some(self.parse_class_element_name())
                 }
                 Kind::Set if peeked_class_element => {
                     self.bump(Kind::Set);
                     kind = MethodDefinitionKind::Set;
-                    Some(self.parse_class_element_name()?)
+                    Some(self.parse_class_element_name())
                 }
-                kind if kind.is_class_element_name_start() => {
-                    Some(self.parse_class_element_name()?)
-                }
-                _ => return Err(self.unexpected()),
+                kind if kind.is_class_element_name_start() => Some(self.parse_class_element_name()),
+                _ => return self.unexpected(),
             }
         }
 
         let (key, computed) =
-            if let Some(result) = key_name { result } else { self.parse_class_element_name()? };
+            if let Some(result) = key_name { result } else { self.parse_class_element_name() };
 
         let (optional, optional_span) = if self.at(Kind::Question) {
             let span = self.start_span();
@@ -308,7 +304,7 @@ impl<'a> ParserImpl<'a> {
             if optional {
                 self.error(diagnostics::optional_accessor_property(optional_span));
             }
-            self.parse_class_accessor_property(
+            Some(self.parse_class_accessor_property(
                 span,
                 key,
                 computed,
@@ -317,8 +313,7 @@ impl<'a> ParserImpl<'a> {
                 r#override,
                 definite,
                 accessibility,
-            )
-            .map(Some)
+            ))
         } else if self.at(Kind::LParen) || self.at(Kind::LAngle) || r#async || generator {
             if !computed {
                 if let Some((name, span)) = key.prop_name() {
@@ -352,12 +347,12 @@ impl<'a> ParserImpl<'a> {
                 r#abstract,
                 accessibility,
                 optional,
-            )?;
-            Ok(Some(definition))
+            );
+            Some(definition)
         } else {
             // getter and setter has no ts type annotation
             if !kind.is_method() {
-                return Err(self.unexpected());
+                return self.unexpected();
             }
             if !computed {
                 if let Some((name, span)) = key.prop_name() {
@@ -381,16 +376,16 @@ impl<'a> ParserImpl<'a> {
                 accessibility,
                 optional,
                 definite,
-            )?;
-            Ok(Some(definition))
+            );
+            Some(definition)
         }
     }
 
-    fn parse_class_element_name(&mut self) -> Result<(PropertyKey<'a>, bool)> {
+    fn parse_class_element_name(&mut self) -> (PropertyKey<'a>, bool) {
         match self.cur_kind() {
             Kind::PrivateIdentifier => {
                 let private_ident = self.parse_private_identifier();
-                Ok((PropertyKey::PrivateIdentifier(self.alloc(private_ident)), false))
+                (PropertyKey::PrivateIdentifier(self.alloc(private_ident)), false)
             }
             _ => self.parse_property_name(),
         }
@@ -409,7 +404,7 @@ impl<'a> ParserImpl<'a> {
         r#abstract: bool,
         accessibility: Option<TSAccessibility>,
         optional: bool,
-    ) -> Result<ClassElement<'a>> {
+    ) -> ClassElement<'a> {
         let kind = if !r#static
             && !computed
             && key.prop_name().is_some_and(|(name, _)| name == "constructor")
@@ -421,7 +416,7 @@ impl<'a> ParserImpl<'a> {
 
         let decorators = self.consume_decorators();
 
-        let value = self.parse_method(r#async, generator)?;
+        let value = self.parse_method(r#async, generator);
 
         if kind == MethodDefinitionKind::Constructor {
             if let Some(this_param) = &value.this_param {
@@ -444,7 +439,7 @@ impl<'a> ParserImpl<'a> {
         } else {
             MethodDefinitionType::MethodDefinition
         };
-        Ok(self.ast.class_element_method_definition(
+        self.ast.class_element_method_definition(
             self.end_span(span),
             r#type,
             decorators,
@@ -456,7 +451,7 @@ impl<'a> ParserImpl<'a> {
             r#override,
             optional,
             accessibility,
-        ))
+        )
     }
 
     /// `FieldDefinition`[?Yield, ?Await] ;
@@ -473,18 +468,18 @@ impl<'a> ParserImpl<'a> {
         accessibility: Option<TSAccessibility>,
         optional: bool,
         definite: bool,
-    ) -> Result<ClassElement<'a>> {
-        let type_annotation = if self.is_ts { self.parse_ts_type_annotation()? } else { None };
+    ) -> ClassElement<'a> {
+        let type_annotation = if self.is_ts { self.parse_ts_type_annotation() } else { None };
         let decorators = self.consume_decorators();
-        let value = if self.eat(Kind::Eq) { Some(self.parse_expr()?) } else { None };
-        self.asi()?;
+        let value = if self.eat(Kind::Eq) { Some(self.parse_expr()) } else { None };
+        self.asi();
 
         let r#type = if r#abstract {
             PropertyDefinitionType::TSAbstractPropertyDefinition
         } else {
             PropertyDefinitionType::PropertyDefinition
         };
-        Ok(self.ast.class_element_property_definition(
+        self.ast.class_element_property_definition(
             self.end_span(span),
             r#type,
             decorators,
@@ -499,15 +494,15 @@ impl<'a> ParserImpl<'a> {
             readonly,
             type_annotation,
             accessibility,
-        ))
+        )
     }
 
     /// `ClassStaticBlockStatementList` :
     ///    `StatementList`[~Yield, +Await, ~Return]
-    fn parse_class_static_block(&mut self, span: u32) -> Result<ClassElement<'a>> {
+    fn parse_class_static_block(&mut self, span: u32) -> ClassElement<'a> {
         let block =
-            self.context(Context::Await, Context::Yield | Context::Return, Self::parse_block)?;
-        Ok(self.ast.class_element_static_block(self.end_span(span), block.unbox().body))
+            self.context(Context::Await, Context::Yield | Context::Return, Self::parse_block);
+        self.ast.class_element_static_block(self.end_span(span), block.unbox().body)
     }
 
     /// <https://github.com/tc39/proposal-decorators>
@@ -521,18 +516,17 @@ impl<'a> ParserImpl<'a> {
         r#override: bool,
         definite: bool,
         accessibility: Option<TSAccessibility>,
-    ) -> Result<ClassElement<'a>> {
-        let type_annotation = if self.is_ts { self.parse_ts_type_annotation()? } else { None };
-        let value =
-            self.eat(Kind::Eq).then(|| self.parse_assignment_expression_or_higher()).transpose()?;
-        self.asi()?;
+    ) -> ClassElement<'a> {
+        let type_annotation = if self.is_ts { self.parse_ts_type_annotation() } else { None };
+        let value = self.eat(Kind::Eq).then(|| self.parse_assignment_expression_or_higher());
+        self.asi();
         let r#type = if r#abstract {
             AccessorPropertyType::TSAbstractAccessorProperty
         } else {
             AccessorPropertyType::AccessorProperty
         };
         let decorators = self.consume_decorators();
-        Ok(self.ast.class_element_accessor_property(
+        self.ast.class_element_accessor_property(
             self.end_span(span),
             r#type,
             decorators,
@@ -544,6 +538,6 @@ impl<'a> ParserImpl<'a> {
             definite,
             type_annotation,
             accessibility,
-        ))
+        )
     }
 }

--- a/crates/oxc_parser/src/js/declaration.rs
+++ b/crates/oxc_parser/src/js/declaration.rs
@@ -1,6 +1,5 @@
 use oxc_allocator::Box;
 use oxc_ast::{NONE, ast::*};
-use oxc_diagnostics::Result;
 use oxc_span::GetSpan;
 
 use super::VariableDeclarationParent;
@@ -11,33 +10,33 @@ use crate::{
 };
 
 impl<'a> ParserImpl<'a> {
-    pub(crate) fn parse_let(&mut self, stmt_ctx: StatementContext) -> Result<Statement<'a>> {
+    pub(crate) fn parse_let(&mut self, stmt_ctx: StatementContext) -> Statement<'a> {
         let span = self.start_span();
         let peeked = self.peek_kind();
         // let = foo, let instanceof x, let + 1
         if peeked.is_assignment_operator() || peeked.is_binary_operator() {
-            let expr = self.parse_assignment_expression_or_higher()?;
+            let expr = self.parse_assignment_expression_or_higher();
             self.parse_expression_statement(span, expr)
         // let.a = 1, let()[a] = 1
         } else if matches!(peeked, Kind::Dot | Kind::LParen) {
-            let expr = self.parse_expr()?;
-            Ok(self.ast.statement_expression(self.end_span(span), expr))
+            let expr = self.parse_expr();
+            self.ast.statement_expression(self.end_span(span), expr)
         // single statement let declaration: while (0) let
         } else if (stmt_ctx.is_single_statement() && peeked != Kind::LBrack)
             || peeked == Kind::Semicolon
         {
-            let expr = self.parse_identifier_expression()?;
+            let expr = self.parse_identifier_expression();
             self.parse_expression_statement(span, expr)
         } else {
             self.parse_variable_statement(stmt_ctx)
         }
     }
 
-    pub(crate) fn parse_using_statement(&mut self) -> Result<Statement<'a>> {
-        let mut decl = self.parse_using_declaration(StatementContext::StatementList)?;
-        self.asi()?;
+    pub(crate) fn parse_using_statement(&mut self) -> Statement<'a> {
+        let mut decl = self.parse_using_declaration(StatementContext::StatementList);
+        self.asi();
         decl.span = self.end_span(decl.span.start);
-        Ok(Statement::VariableDeclaration(self.alloc(decl)))
+        Statement::VariableDeclaration(self.alloc(decl))
     }
 
     pub(crate) fn parse_variable_declaration(
@@ -45,18 +44,18 @@ impl<'a> ParserImpl<'a> {
         start_span: u32,
         decl_parent: VariableDeclarationParent,
         modifiers: &Modifiers<'a>,
-    ) -> Result<Box<'a, VariableDeclaration<'a>>> {
+    ) -> Box<'a, VariableDeclaration<'a>> {
         let kind = match self.cur_kind() {
             Kind::Var => VariableDeclarationKind::Var,
             Kind::Const => VariableDeclarationKind::Const,
             Kind::Let => VariableDeclarationKind::Let,
-            _ => return Err(self.unexpected()),
+            _ => return self.unexpected(),
         };
         self.bump_any();
 
         let mut declarations = self.ast.vec();
         loop {
-            let declaration = self.parse_variable_declarator(decl_parent, kind)?;
+            let declaration = self.parse_variable_declarator(decl_parent, kind);
             declarations.push(declaration);
             if !self.eat(Kind::Comma) {
                 break;
@@ -64,7 +63,7 @@ impl<'a> ParserImpl<'a> {
         }
 
         if matches!(decl_parent, VariableDeclarationParent::Statement) {
-            self.asi()?;
+            self.asi();
         }
 
         self.verify_modifiers(
@@ -73,22 +72,22 @@ impl<'a> ParserImpl<'a> {
             diagnostics::modifier_cannot_be_used_here,
         );
 
-        Ok(self.ast.alloc_variable_declaration(
+        self.ast.alloc_variable_declaration(
             self.end_span(start_span),
             kind,
             declarations,
             modifiers.contains_declare(),
-        ))
+        )
     }
 
     fn parse_variable_declarator(
         &mut self,
         decl_parent: VariableDeclarationParent,
         kind: VariableDeclarationKind,
-    ) -> Result<VariableDeclarator<'a>> {
+    ) -> VariableDeclarator<'a> {
         let span = self.start_span();
 
-        let mut binding_kind = self.parse_binding_pattern_kind()?;
+        let mut binding_kind = self.parse_binding_pattern_kind();
 
         let (id, definite) = if self.is_ts {
             // const x!: number = 1
@@ -102,7 +101,7 @@ impl<'a> ParserImpl<'a> {
                 definite = true;
             }
             let optional = self.eat(Kind::Question); // not allowed, but checked in checker/typescript.rs
-            let type_annotation = self.parse_ts_type_annotation()?;
+            let type_annotation = self.parse_ts_type_annotation();
             if let Some(type_annotation) = &type_annotation {
                 Self::extend_binding_pattern_span_end(type_annotation.span.end, &mut binding_kind);
             }
@@ -110,13 +109,12 @@ impl<'a> ParserImpl<'a> {
         } else {
             (self.ast.binding_pattern(binding_kind, NONE, false), false)
         };
-        let init =
-            self.eat(Kind::Eq).then(|| self.parse_assignment_expression_or_higher()).transpose()?;
+        let init = self.eat(Kind::Eq).then(|| self.parse_assignment_expression_or_higher());
         let decl = self.ast.variable_declarator(self.end_span(span), kind, id, init, definite);
         if decl_parent == VariableDeclarationParent::Statement {
             self.check_missing_initializer(&decl);
         }
-        Ok(decl)
+        decl
     }
 
     pub(crate) fn check_missing_initializer(&mut self, decl: &VariableDeclarator<'a>) {
@@ -136,12 +134,12 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_using_declaration(
         &mut self,
         statement_ctx: StatementContext,
-    ) -> Result<VariableDeclaration<'a>> {
+    ) -> VariableDeclaration<'a> {
         let span = self.start_span();
 
         let is_await = self.eat(Kind::Await);
 
-        self.expect(Kind::Using)?;
+        self.expect(Kind::Using);
 
         // BindingList[?In, ?Yield, ?Await, ~Pattern]
         let mut declarations: oxc_allocator::Vec<'_, VariableDeclarator<'_>> = self.ast.vec();
@@ -153,7 +151,7 @@ impl<'a> ParserImpl<'a> {
                 } else {
                     VariableDeclarationKind::Using
                 },
-            )?;
+            );
 
             match declaration.id.kind {
                 BindingPatternKind::BindingIdentifier(_) => {}
@@ -182,6 +180,6 @@ impl<'a> ParserImpl<'a> {
         } else {
             VariableDeclarationKind::Using
         };
-        Ok(self.ast.variable_declaration(self.end_span(span), kind, declarations, false))
+        self.ast.variable_declaration(self.end_span(span), kind, declarations, false)
     }
 }

--- a/crates/oxc_parser/src/js/grammar.rs
+++ b/crates/oxc_parser/src/js/grammar.rs
@@ -1,69 +1,67 @@
 //! Cover Grammar for Destructuring Assignment
 
 use oxc_ast::ast::*;
-use oxc_diagnostics::Result;
 use oxc_span::GetSpan;
 
 use crate::{ParserImpl, diagnostics};
 
 pub trait CoverGrammar<'a, T>: Sized {
-    fn cover(value: T, p: &mut ParserImpl<'a>) -> Result<Self>;
+    fn cover(value: T, p: &mut ParserImpl<'a>) -> Self;
 }
 
 impl<'a> CoverGrammar<'a, Expression<'a>> for AssignmentTarget<'a> {
-    fn cover(expr: Expression<'a>, p: &mut ParserImpl<'a>) -> Result<Self> {
+    fn cover(expr: Expression<'a>, p: &mut ParserImpl<'a>) -> Self {
         match expr {
             Expression::ArrayExpression(array_expr) => {
-                ArrayAssignmentTarget::cover(array_expr.unbox(), p)
-                    .map(|pat| AssignmentTarget::ArrayAssignmentTarget(p.alloc(pat)))
+                let pat = ArrayAssignmentTarget::cover(array_expr.unbox(), p);
+                AssignmentTarget::ArrayAssignmentTarget(p.alloc(pat))
             }
             Expression::ObjectExpression(object_expr) => {
-                ObjectAssignmentTarget::cover(object_expr.unbox(), p)
-                    .map(|pat| AssignmentTarget::ObjectAssignmentTarget(p.alloc(pat)))
+                let pat = ObjectAssignmentTarget::cover(object_expr.unbox(), p);
+                AssignmentTarget::ObjectAssignmentTarget(p.alloc(pat))
             }
-            _ => SimpleAssignmentTarget::cover(expr, p).map(AssignmentTarget::from),
+            _ => AssignmentTarget::from(SimpleAssignmentTarget::cover(expr, p)),
         }
     }
 }
 
 impl<'a> CoverGrammar<'a, Expression<'a>> for SimpleAssignmentTarget<'a> {
-    #[expect(clippy::only_used_in_recursion)]
-    fn cover(expr: Expression<'a>, p: &mut ParserImpl<'a>) -> Result<Self> {
+    fn cover(expr: Expression<'a>, p: &mut ParserImpl<'a>) -> Self {
         match expr {
             Expression::Identifier(ident) => {
-                Ok(SimpleAssignmentTarget::AssignmentTargetIdentifier(ident))
+                SimpleAssignmentTarget::AssignmentTargetIdentifier(ident)
             }
             match_member_expression!(Expression) => {
                 let member_expr = expr.into_member_expression();
-                Ok(SimpleAssignmentTarget::from(member_expr))
+                SimpleAssignmentTarget::from(member_expr)
             }
             Expression::ParenthesizedExpression(expr) => {
                 let span = expr.span;
                 match expr.unbox().expression {
                     Expression::ObjectExpression(_) | Expression::ArrayExpression(_) => {
-                        Err(diagnostics::invalid_assignment(span))
+                        p.fatal_error(diagnostics::invalid_assignment(span))
                     }
                     expr => SimpleAssignmentTarget::cover(expr, p),
                 }
             }
-            Expression::TSAsExpression(expr) => Ok(SimpleAssignmentTarget::TSAsExpression(expr)),
+            Expression::TSAsExpression(expr) => SimpleAssignmentTarget::TSAsExpression(expr),
             Expression::TSSatisfiesExpression(expr) => {
-                Ok(SimpleAssignmentTarget::TSSatisfiesExpression(expr))
+                SimpleAssignmentTarget::TSSatisfiesExpression(expr)
             }
             Expression::TSNonNullExpression(expr) => {
-                Ok(SimpleAssignmentTarget::TSNonNullExpression(expr))
+                SimpleAssignmentTarget::TSNonNullExpression(expr)
             }
-            Expression::TSTypeAssertion(expr) => Ok(SimpleAssignmentTarget::TSTypeAssertion(expr)),
+            Expression::TSTypeAssertion(expr) => SimpleAssignmentTarget::TSTypeAssertion(expr),
             Expression::TSInstantiationExpression(expr) => {
-                Err(diagnostics::invalid_lhs_assignment(expr.span()))
+                p.fatal_error(diagnostics::invalid_lhs_assignment(expr.span()))
             }
-            expr => Err(diagnostics::invalid_assignment(expr.span())),
+            expr => p.fatal_error(diagnostics::invalid_assignment(expr.span())),
         }
     }
 }
 
 impl<'a> CoverGrammar<'a, ArrayExpression<'a>> for ArrayAssignmentTarget<'a> {
-    fn cover(expr: ArrayExpression<'a>, p: &mut ParserImpl<'a>) -> Result<Self> {
+    fn cover(expr: ArrayExpression<'a>, p: &mut ParserImpl<'a>) -> Self {
         let mut elements = p.ast.vec();
         let mut rest = None;
 
@@ -72,54 +70,54 @@ impl<'a> CoverGrammar<'a, ArrayExpression<'a>> for ArrayAssignmentTarget<'a> {
             match elem {
                 match_expression!(ArrayExpressionElement) => {
                     let expr = elem.into_expression();
-                    let target = AssignmentTargetMaybeDefault::cover(expr, p)?;
+                    let target = AssignmentTargetMaybeDefault::cover(expr, p);
                     elements.push(Some(target));
                 }
                 ArrayExpressionElement::SpreadElement(elem) => {
                     if i == len - 1 {
                         rest = Some(p.ast.assignment_target_rest(
                             elem.span,
-                            AssignmentTarget::cover(elem.unbox().argument, p)?,
+                            AssignmentTarget::cover(elem.unbox().argument, p),
                         ));
                         if let Some(span) = p.state.trailing_commas.get(&expr.span.start) {
                             p.error(diagnostics::binding_rest_element_trailing_comma(*span));
                         }
                     } else {
                         let error = diagnostics::spread_last_element(elem.span);
-                        return Err(p.set_fatal_error(error));
+                        return p.fatal_error(error);
                     }
                 }
                 ArrayExpressionElement::Elision(_) => elements.push(None),
             }
         }
 
-        Ok(p.ast.array_assignment_target(expr.span, elements, rest))
+        p.ast.array_assignment_target(expr.span, elements, rest)
     }
 }
 
 impl<'a> CoverGrammar<'a, Expression<'a>> for AssignmentTargetMaybeDefault<'a> {
-    fn cover(expr: Expression<'a>, p: &mut ParserImpl<'a>) -> Result<Self> {
+    fn cover(expr: Expression<'a>, p: &mut ParserImpl<'a>) -> Self {
         match expr {
             Expression::AssignmentExpression(assignment_expr) => {
-                let target = AssignmentTargetWithDefault::cover(assignment_expr.unbox(), p)?;
-                Ok(AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(p.alloc(target)))
+                let target = AssignmentTargetWithDefault::cover(assignment_expr.unbox(), p);
+                AssignmentTargetMaybeDefault::AssignmentTargetWithDefault(p.alloc(target))
             }
             expr => {
-                let target = AssignmentTarget::cover(expr, p)?;
-                Ok(AssignmentTargetMaybeDefault::from(target))
+                let target = AssignmentTarget::cover(expr, p);
+                AssignmentTargetMaybeDefault::from(target)
             }
         }
     }
 }
 
 impl<'a> CoverGrammar<'a, AssignmentExpression<'a>> for AssignmentTargetWithDefault<'a> {
-    fn cover(expr: AssignmentExpression<'a>, p: &mut ParserImpl<'a>) -> Result<Self> {
-        Ok(p.ast.assignment_target_with_default(expr.span, expr.left, expr.right))
+    fn cover(expr: AssignmentExpression<'a>, p: &mut ParserImpl<'a>) -> Self {
+        p.ast.assignment_target_with_default(expr.span, expr.left, expr.right)
     }
 }
 
 impl<'a> CoverGrammar<'a, ObjectExpression<'a>> for ObjectAssignmentTarget<'a> {
-    fn cover(expr: ObjectExpression<'a>, p: &mut ParserImpl<'a>) -> Result<Self> {
+    fn cover(expr: ObjectExpression<'a>, p: &mut ParserImpl<'a>) -> Self {
         let mut properties = p.ast.vec();
         let mut rest = None;
 
@@ -127,51 +125,51 @@ impl<'a> CoverGrammar<'a, ObjectExpression<'a>> for ObjectAssignmentTarget<'a> {
         for (i, elem) in expr.properties.into_iter().enumerate() {
             match elem {
                 ObjectPropertyKind::ObjectProperty(property) => {
-                    let target = AssignmentTargetProperty::cover(property.unbox(), p)?;
+                    let target = AssignmentTargetProperty::cover(property.unbox(), p);
                     properties.push(target);
                 }
                 ObjectPropertyKind::SpreadProperty(spread) => {
                     if i == len - 1 {
                         rest = Some(p.ast.assignment_target_rest(
                             spread.span,
-                            AssignmentTarget::cover(spread.unbox().argument, p)?,
+                            AssignmentTarget::cover(spread.unbox().argument, p),
                         ));
                     } else {
-                        return Err(diagnostics::spread_last_element(spread.span));
+                        return p.fatal_error(diagnostics::spread_last_element(spread.span));
                     }
                 }
             }
         }
 
-        Ok(p.ast.object_assignment_target(expr.span, properties, rest))
+        p.ast.object_assignment_target(expr.span, properties, rest)
     }
 }
 
 impl<'a> CoverGrammar<'a, ObjectProperty<'a>> for AssignmentTargetProperty<'a> {
-    fn cover(property: ObjectProperty<'a>, p: &mut ParserImpl<'a>) -> Result<Self> {
+    fn cover(property: ObjectProperty<'a>, p: &mut ParserImpl<'a>) -> Self {
         if property.shorthand {
             let binding = match property.key {
                 PropertyKey::StaticIdentifier(ident) => {
                     let ident = ident.unbox();
                     p.ast.identifier_reference(ident.span, ident.name)
                 }
-                _ => return Err(p.unexpected()),
+                _ => return p.unexpected(),
             };
             // convert `CoverInitializedName`
             let init = p.state.cover_initialized_name.remove(&property.span.start).map(|e| e.right);
-            Ok(p.ast.assignment_target_property_assignment_target_property_identifier(
+            p.ast.assignment_target_property_assignment_target_property_identifier(
                 property.span,
                 binding,
                 init,
-            ))
+            )
         } else {
-            let binding = AssignmentTargetMaybeDefault::cover(property.value, p)?;
-            Ok(p.ast.assignment_target_property_assignment_target_property_property(
+            let binding = AssignmentTargetMaybeDefault::cover(property.value, p);
+            p.ast.assignment_target_property_assignment_target_property_property(
                 property.span,
                 property.key,
                 binding,
                 property.computed,
-            ))
+            )
         }
     }
 }

--- a/crates/oxc_parser/src/js/object.rs
+++ b/crates/oxc_parser/src/js/object.rs
@@ -1,6 +1,5 @@
 use oxc_allocator::Box;
 use oxc_ast::ast::*;
-use oxc_diagnostics::Result;
 use oxc_syntax::operator::AssignmentOperator;
 
 use crate::{Context, ParserImpl, diagnostics, lexer::Kind, modifiers::Modifier};
@@ -11,9 +10,9 @@ impl<'a> ParserImpl<'a> {
     ///     { }
     ///     { `PropertyDefinitionList`[?Yield, ?Await] }
     ///     { `PropertyDefinitionList`[?Yield, ?Await] , }
-    pub(crate) fn parse_object_expression(&mut self) -> Result<Box<'a, ObjectExpression<'a>>> {
+    pub(crate) fn parse_object_expression(&mut self) -> Box<'a, ObjectExpression<'a>> {
         let span = self.start_span();
-        self.expect(Kind::LCurly)?;
+        self.expect(Kind::LCurly);
         let object_expression_properties = self.context(Context::In, Context::empty(), |p| {
             p.parse_delimited_list(
                 Kind::RCurly,
@@ -21,21 +20,21 @@ impl<'a> ParserImpl<'a> {
                 /* trailing_separator */ false,
                 Self::parse_object_expression_property,
             )
-        })?;
+        });
         self.eat(Kind::Comma); // Trailing Comma
-        self.expect(Kind::RCurly)?;
-        Ok(self.ast.alloc_object_expression(self.end_span(span), object_expression_properties))
+        self.expect(Kind::RCurly);
+        self.ast.alloc_object_expression(self.end_span(span), object_expression_properties)
     }
 
-    fn parse_object_expression_property(&mut self) -> Result<ObjectPropertyKind<'a>> {
+    fn parse_object_expression_property(&mut self) -> ObjectPropertyKind<'a> {
         match self.cur_kind() {
-            Kind::Dot3 => self.parse_spread_element().map(ObjectPropertyKind::SpreadProperty),
-            _ => self.parse_property_definition().map(ObjectPropertyKind::ObjectProperty),
+            Kind::Dot3 => ObjectPropertyKind::SpreadProperty(self.parse_spread_element()),
+            _ => ObjectPropertyKind::ObjectProperty(self.parse_property_definition()),
         }
     }
 
     /// `PropertyDefinition`[Yield, Await]
-    pub(crate) fn parse_property_definition(&mut self) -> Result<Box<'a, ObjectProperty<'a>>> {
+    pub(crate) fn parse_property_definition(&mut self) -> Box<'a, ObjectProperty<'a>> {
         let peek_kind = self.peek_kind();
         let class_element_name = peek_kind.is_class_element_name_start();
         match self.cur_kind() {
@@ -85,15 +84,15 @@ impl<'a> ParserImpl<'a> {
             }
             _ => {
                 let span = self.start_span();
-                let (key, computed) = self.parse_property_name()?;
+                let (key, computed) = self.parse_property_name();
 
                 if self.at(Kind::Colon) {
                     return self.parse_property_definition_assignment(span, key, computed);
                 }
 
                 if matches!(self.cur_kind(), Kind::LParen | Kind::LAngle | Kind::ShiftLeft) {
-                    let method = self.parse_method(false, false)?;
-                    return Ok(self.ast.alloc_object_property(
+                    let method = self.parse_method(false, false);
+                    return self.ast.alloc_object_property(
                         self.end_span(span),
                         PropertyKind::Init,
                         key,
@@ -101,35 +100,35 @@ impl<'a> ParserImpl<'a> {
                         /* method */ true,
                         /* shorthand */ false,
                         /* computed */ computed,
-                    ));
+                    );
                 }
 
-                Err(self.unexpected())
+                self.unexpected()
             }
         }
     }
 
     /// `PropertyDefinition`[Yield, Await] :
     ///   ... `AssignmentExpression`[+In, ?Yield, ?Await]
-    pub(crate) fn parse_spread_element(&mut self) -> Result<Box<'a, SpreadElement<'a>>> {
+    pub(crate) fn parse_spread_element(&mut self) -> Box<'a, SpreadElement<'a>> {
         let span = self.start_span();
         self.bump_any(); // advance `...`
-        let argument = self.parse_assignment_expression_or_higher()?;
-        Ok(self.ast.alloc_spread_element(self.end_span(span), argument))
+        let argument = self.parse_assignment_expression_or_higher();
+        self.ast.alloc_spread_element(self.end_span(span), argument)
     }
 
     /// `PropertyDefinition`[Yield, Await] :
     ///   `IdentifierReference`[?Yield, ?Await]
     ///   `CoverInitializedName`[?Yield, ?Await]
-    fn parse_property_definition_shorthand(&mut self) -> Result<Box<'a, ObjectProperty<'a>>> {
+    fn parse_property_definition_shorthand(&mut self) -> Box<'a, ObjectProperty<'a>> {
         let span = self.start_span();
-        let identifier = self.parse_identifier_reference()?;
+        let identifier = self.parse_identifier_reference();
         let key = self.ast.alloc_identifier_name(identifier.span, identifier.name);
         // IdentifierReference ({ foo })
         let value = Expression::Identifier(self.alloc(identifier.clone()));
         // CoverInitializedName ({ foo = bar })
         if self.eat(Kind::Eq) {
-            let right = self.parse_assignment_expression_or_higher()?;
+            let right = self.parse_assignment_expression_or_higher();
             let left = AssignmentTarget::AssignmentTargetIdentifier(self.alloc(identifier));
             let expr = self.ast.assignment_expression(
                 self.end_span(span),
@@ -139,7 +138,7 @@ impl<'a> ParserImpl<'a> {
             );
             self.state.cover_initialized_name.insert(span, expr);
         }
-        Ok(self.ast.alloc_object_property(
+        self.ast.alloc_object_property(
             self.end_span(span),
             PropertyKind::Init,
             PropertyKey::StaticIdentifier(key),
@@ -147,7 +146,7 @@ impl<'a> ParserImpl<'a> {
             /* method */ false,
             /* shorthand */ true,
             /* computed */ false,
-        ))
+        )
     }
 
     /// `PropertyDefinition`[Yield, Await] :
@@ -157,10 +156,10 @@ impl<'a> ParserImpl<'a> {
         span: u32,
         key: PropertyKey<'a>,
         computed: bool,
-    ) -> Result<Box<'a, ObjectProperty<'a>>> {
+    ) -> Box<'a, ObjectProperty<'a>> {
         self.bump_any(); // bump `:`
-        let value = self.parse_assignment_expression_or_higher()?;
-        Ok(self.ast.alloc_object_property(
+        let value = self.parse_assignment_expression_or_higher();
+        self.ast.alloc_object_property(
             self.end_span(span),
             PropertyKind::Init,
             key,
@@ -168,54 +167,54 @@ impl<'a> ParserImpl<'a> {
             /* method */ false,
             /* shorthand */ false,
             /* computed */ computed,
-        ))
+        )
     }
 
     /// `PropertyName`[Yield, Await] :
     ///    `LiteralPropertyName`
     ///    `ComputedPropertyName`[?Yield, ?Await]
-    pub(crate) fn parse_property_name(&mut self) -> Result<(PropertyKey<'a>, bool)> {
+    pub(crate) fn parse_property_name(&mut self) -> (PropertyKey<'a>, bool) {
         let mut computed = false;
         let key = match self.cur_kind() {
-            Kind::Str => self.parse_literal_expression().map(PropertyKey::from)?,
-            kind if kind.is_number() => self.parse_literal_expression().map(PropertyKey::from)?,
+            Kind::Str => PropertyKey::from(self.parse_literal_expression()),
+            kind if kind.is_number() => PropertyKey::from(self.parse_literal_expression()),
             // { [foo]() {} }
             Kind::LBrack => {
                 computed = true;
-                self.parse_computed_property_name().map(PropertyKey::from)?
+                PropertyKey::from(self.parse_computed_property_name())
             }
             _ => {
-                let ident = self.parse_identifier_name()?;
+                let ident = self.parse_identifier_name();
                 PropertyKey::StaticIdentifier(self.alloc(ident))
             }
         };
-        Ok((key, computed))
+        (key, computed)
     }
 
     /// `ComputedPropertyName`[Yield, Await] : [ `AssignmentExpression`[+In, ?Yield, ?Await] ]
-    pub(crate) fn parse_computed_property_name(&mut self) -> Result<Expression<'a>> {
+    pub(crate) fn parse_computed_property_name(&mut self) -> Expression<'a> {
         self.bump_any(); // advance `[`
 
         let expression = self.context(
             Context::In,
             Context::empty(),
             Self::parse_assignment_expression_or_higher,
-        )?;
+        );
 
-        self.expect(Kind::RBrack)?;
-        Ok(expression)
+        self.expect(Kind::RBrack);
+        expression
     }
 
     /// `PropertyDefinition`[Yield, Await] :
     ///   `MethodDefinition`[?Yield, ?Await]
-    fn parse_property_definition_method(&mut self) -> Result<Box<'a, ObjectProperty<'a>>> {
+    fn parse_property_definition_method(&mut self) -> Box<'a, ObjectProperty<'a>> {
         let span = self.start_span();
         let r#async = self.eat(Kind::Async);
         let generator = self.eat(Kind::Star);
-        let (key, computed) = self.parse_property_name()?;
-        let method = self.parse_method(r#async, generator)?;
+        let (key, computed) = self.parse_property_name();
+        let method = self.parse_method(r#async, generator);
         let value = Expression::FunctionExpression(method);
-        Ok(self.ast.alloc_object_property(
+        self.ast.alloc_object_property(
             self.end_span(span),
             PropertyKind::Init,
             key,
@@ -223,18 +222,18 @@ impl<'a> ParserImpl<'a> {
             /* method */ true,
             /* shorthand */ false,
             /* computed */ computed,
-        ))
+        )
     }
 
     /// `MethodDefinition`[Yield, Await] :
     ///   get `ClassElementName`[?Yield, ?Await] ( ) { `FunctionBody`[~Yield, ~Await] }
-    fn parse_method_getter(&mut self) -> Result<Box<'a, ObjectProperty<'a>>> {
+    fn parse_method_getter(&mut self) -> Box<'a, ObjectProperty<'a>> {
         let span = self.start_span();
-        self.expect(Kind::Get)?;
-        let (key, computed) = self.parse_property_name()?;
-        let method = self.parse_method(false, false)?;
+        self.expect(Kind::Get);
+        let (key, computed) = self.parse_property_name();
+        let method = self.parse_method(false, false);
         let value = Expression::FunctionExpression(method);
-        Ok(self.ast.alloc_object_property(
+        self.ast.alloc_object_property(
             self.end_span(span),
             PropertyKind::Get,
             key,
@@ -242,18 +241,18 @@ impl<'a> ParserImpl<'a> {
             /* method */ false,
             /* shorthand */ false,
             /* computed */ computed,
-        ))
+        )
     }
 
     /// `MethodDefinition`[Yield, Await] :
     /// set `ClassElementName`[?Yield, ?Await] ( `PropertySetParameterList` ) { `FunctionBody`[~Yield, ~Await] }
-    fn parse_method_setter(&mut self) -> Result<Box<'a, ObjectProperty<'a>>> {
+    fn parse_method_setter(&mut self) -> Box<'a, ObjectProperty<'a>> {
         let span = self.start_span();
-        self.expect(Kind::Set)?;
-        let (key, computed) = self.parse_property_name()?;
-        let method = self.parse_method(false, false)?;
+        self.expect(Kind::Set);
+        let (key, computed) = self.parse_property_name();
+        let method = self.parse_method(false, false);
 
-        Ok(self.ast.alloc_object_property(
+        self.ast.alloc_object_property(
             self.end_span(span),
             PropertyKind::Set,
             key,
@@ -261,6 +260,6 @@ impl<'a> ParserImpl<'a> {
             /* method */ false,
             /* shorthand */ false,
             /* computed */ computed,
-        ))
+        )
     }
 }

--- a/crates/oxc_parser/src/js/statement.rs
+++ b/crates/oxc_parser/src/js/statement.rs
@@ -1,6 +1,5 @@
 use oxc_allocator::{Box, Vec};
 use oxc_ast::ast::*;
-use oxc_diagnostics::Result;
 use oxc_span::{Atom, GetSpan, Span};
 
 use super::{VariableDeclarationParent, grammar::CoverGrammar};
@@ -31,7 +30,7 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_directives_and_statements(
         &mut self,
         is_top_level: bool,
-    ) -> Result<(Vec<'a, Directive<'a>>, Vec<'a, Statement<'a>>)> {
+    ) -> (Vec<'a, Directive<'a>>, Vec<'a, Statement<'a>>) {
         let mut directives = self.ast.vec();
         let mut statements = self.ast.vec();
 
@@ -40,7 +39,7 @@ impl<'a> ParserImpl<'a> {
             if !is_top_level && self.at(Kind::RCurly) {
                 break;
             }
-            let stmt = self.parse_statement_list_item(StatementContext::StatementList)?;
+            let stmt = self.parse_statement_list_item(StatementContext::StatementList);
 
             if is_top_level {
                 if let Some(module_decl) = stmt.as_module_declaration() {
@@ -70,7 +69,7 @@ impl<'a> ParserImpl<'a> {
             statements.push(stmt);
         }
 
-        Ok((directives, statements))
+        (directives, statements)
     }
 
     /// `StatementListItem`[Yield, Await, Return] :
@@ -79,14 +78,14 @@ impl<'a> ParserImpl<'a> {
     pub(crate) fn parse_statement_list_item(
         &mut self,
         stmt_ctx: StatementContext,
-    ) -> Result<Statement<'a>> {
+    ) -> Statement<'a> {
         let start_span = self.start_span();
 
         let has_no_side_effects_comment =
             self.lexer.trivia_builder.previous_token_has_no_side_effects_comment();
 
         if self.at(Kind::At) {
-            self.eat_decorators()?;
+            self.eat_decorators();
         }
 
         // For performance reasons, match orders are:
@@ -95,7 +94,7 @@ impl<'a> ParserImpl<'a> {
         // 3. peek token
         let mut stmt = match self.cur_kind() {
             Kind::LCurly => self.parse_block_statement(),
-            Kind::Semicolon => Ok(self.parse_empty_statement()),
+            Kind::Semicolon => self.parse_empty_statement(),
             Kind::If => self.parse_if_statement(),
             Kind::Do => self.parse_do_while_statement(),
             Kind::While => self.parse_while_statement(),
@@ -155,13 +154,13 @@ impl<'a> ParserImpl<'a> {
                 self.parse_ts_declaration_statement(start_span)
             }
             _ => self.parse_expression_or_labeled_statement(),
-        }?;
+        };
 
         if has_no_side_effects_comment {
             Self::set_pure_on_function_stmt(&mut stmt);
         }
 
-        Ok(stmt)
+        stmt
     }
 
     fn set_pure_on_function_stmt(stmt: &mut Statement<'a>) {
@@ -200,56 +199,53 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
-    fn parse_expression_or_labeled_statement(&mut self) -> Result<Statement<'a>> {
+    fn parse_expression_or_labeled_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
-        let expr = self.parse_expr()?;
+        let expr = self.parse_expr();
         if let Expression::Identifier(ident) = &expr {
             // Section 14.13 Labelled Statement
             // Avoids lookahead for a labeled statement, which is on a hot path
             if self.eat(Kind::Colon) {
                 let label = self.ast.label_identifier(ident.span, ident.name);
-                let body = self.parse_statement_list_item(StatementContext::Label)?;
-                return Ok(self.ast.statement_labeled(self.end_span(span), label, body));
+                let body = self.parse_statement_list_item(StatementContext::Label);
+                return self.ast.statement_labeled(self.end_span(span), label, body);
             }
         }
         self.parse_expression_statement(span, expr)
     }
 
     /// Section 14.2 Block Statement
-    pub(crate) fn parse_block(&mut self) -> Result<Box<'a, BlockStatement<'a>>> {
+    pub(crate) fn parse_block(&mut self) -> Box<'a, BlockStatement<'a>> {
         let span = self.start_span();
-        self.expect(Kind::LCurly)?;
+        self.expect(Kind::LCurly);
         let mut body = self.ast.vec();
         while !self.at(Kind::RCurly) && !self.has_fatal_error() {
-            let stmt = self.parse_statement_list_item(StatementContext::StatementList)?;
+            let stmt = self.parse_statement_list_item(StatementContext::StatementList);
             body.push(stmt);
         }
-        self.expect(Kind::RCurly)?;
-        Ok(self.ast.alloc_block_statement(self.end_span(span), body))
+        self.expect(Kind::RCurly);
+        self.ast.alloc_block_statement(self.end_span(span), body)
     }
 
-    pub(crate) fn parse_block_statement(&mut self) -> Result<Statement<'a>> {
-        let block = self.parse_block()?;
-        Ok(Statement::BlockStatement(block))
+    pub(crate) fn parse_block_statement(&mut self) -> Statement<'a> {
+        let block = self.parse_block();
+        Statement::BlockStatement(block)
     }
 
     /// Section 14.3.2 Variable Statement
-    pub(crate) fn parse_variable_statement(
-        &mut self,
-        stmt_ctx: StatementContext,
-    ) -> Result<Statement<'a>> {
+    pub(crate) fn parse_variable_statement(&mut self, stmt_ctx: StatementContext) -> Statement<'a> {
         let start_span = self.start_span();
         let decl = self.parse_variable_declaration(
             start_span,
             VariableDeclarationParent::Statement,
             &Modifiers::empty(),
-        )?;
+        );
 
         if stmt_ctx.is_single_statement() && decl.kind.is_lexical() {
             self.error(diagnostics::lexical_declaration_single_statement(decl.span));
         }
 
-        Ok(Statement::VariableDeclaration(decl))
+        Statement::VariableDeclaration(decl)
     }
 
     /// Section 14.4 Empty Statement
@@ -264,46 +260,44 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         span: u32,
         expression: Expression<'a>,
-    ) -> Result<Statement<'a>> {
-        self.asi()?;
-        Ok(self.ast.statement_expression(self.end_span(span), expression))
+    ) -> Statement<'a> {
+        self.asi();
+        self.ast.statement_expression(self.end_span(span), expression)
     }
 
     /// Section 14.6 If Statement
-    fn parse_if_statement(&mut self) -> Result<Statement<'a>> {
+    fn parse_if_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
         self.bump_any(); // bump `if`
-        let test = self.parse_paren_expression()?;
-        let consequent = self.parse_statement_list_item(StatementContext::If)?;
-        let alternate = self
-            .eat(Kind::Else)
-            .then(|| self.parse_statement_list_item(StatementContext::If))
-            .transpose()?;
-        Ok(self.ast.statement_if(self.end_span(span), test, consequent, alternate))
+        let test = self.parse_paren_expression();
+        let consequent = self.parse_statement_list_item(StatementContext::If);
+        let alternate =
+            self.eat(Kind::Else).then(|| self.parse_statement_list_item(StatementContext::If));
+        self.ast.statement_if(self.end_span(span), test, consequent, alternate)
     }
 
     /// Section 14.7.2 Do-While Statement
-    fn parse_do_while_statement(&mut self) -> Result<Statement<'a>> {
+    fn parse_do_while_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
         self.bump_any(); // advance `do`
-        let body = self.parse_statement_list_item(StatementContext::Do)?;
-        self.expect(Kind::While)?;
-        let test = self.parse_paren_expression()?;
+        let body = self.parse_statement_list_item(StatementContext::Do);
+        self.expect(Kind::While);
+        let test = self.parse_paren_expression();
         self.bump(Kind::Semicolon);
-        Ok(self.ast.statement_do_while(self.end_span(span), body, test))
+        self.ast.statement_do_while(self.end_span(span), body, test)
     }
 
     /// Section 14.7.3 While Statement
-    fn parse_while_statement(&mut self) -> Result<Statement<'a>> {
+    fn parse_while_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
         self.bump_any(); // bump `while`
-        let test = self.parse_paren_expression()?;
-        let body = self.parse_statement_list_item(StatementContext::While)?;
-        Ok(self.ast.statement_while(self.end_span(span), test, body))
+        let test = self.parse_paren_expression();
+        let body = self.parse_statement_list_item(StatementContext::While);
+        self.ast.statement_while(self.end_span(span), test, body)
     }
 
     /// Section 14.7.4 For Statement
-    fn parse_for_statement(&mut self) -> Result<Statement<'a>> {
+    fn parse_for_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
         self.bump_any(); // bump `for`
 
@@ -318,7 +312,7 @@ impl<'a> ParserImpl<'a> {
             false
         };
 
-        self.expect(Kind::LParen)?;
+        self.expect(Kind::LParen);
 
         // for (;..
         if self.at(Kind::Semicolon) {
@@ -349,13 +343,15 @@ impl<'a> ParserImpl<'a> {
             return self.parse_for_loop(span, None, r#await);
         }
 
-        let init_expression =
-            self.context(Context::empty(), Context::In, ParserImpl::parse_expr)?;
+        let init_expression = self.context(Context::empty(), Context::In, ParserImpl::parse_expr);
 
         // for (a.b in ...), for ([a] in ..), for ({a} in ..)
         if self.at(Kind::In) || self.at(Kind::Of) {
-            let target = AssignmentTarget::cover(init_expression, self)
-                .map_err(|_| diagnostics::unexpected_token(self.end_span(expr_span)))?;
+            let target = AssignmentTarget::cover(init_expression, self);
+            if self.fatal_error.is_some() {
+                let span = self.end_span(expr_span);
+                self.fatal_error.as_mut().unwrap().error = diagnostics::unexpected_token(span);
+            }
             let for_stmt_left = ForStatementLeft::from(target);
             if !r#await && is_async_of {
                 self.error(diagnostics::for_loop_async_of(self.end_span(expr_span)));
@@ -373,12 +369,12 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         span: u32,
         r#await: bool,
-    ) -> Result<Statement<'a>> {
+    ) -> Statement<'a> {
         let start_span = self.start_span();
         let init_declaration = self.context(Context::empty(), Context::In, |p| {
             let decl_ctx = VariableDeclarationParent::For;
             p.parse_variable_declaration(start_span, decl_ctx, &Modifiers::empty())
-        })?;
+        });
 
         // for (.. a in) for (.. a of)
         if matches!(self.cur_kind(), Kind::In | Kind::Of) {
@@ -390,12 +386,8 @@ impl<'a> ParserImpl<'a> {
         self.parse_for_loop(span, init, r#await)
     }
 
-    fn parse_using_declaration_for_statement(
-        &mut self,
-        span: u32,
-        r#await: bool,
-    ) -> Result<Statement<'a>> {
-        let using_decl = self.parse_using_declaration(StatementContext::For)?;
+    fn parse_using_declaration_for_statement(&mut self, span: u32, r#await: bool) -> Statement<'a> {
+        let using_decl = self.parse_using_declaration(StatementContext::For);
 
         if matches!(self.cur_kind(), Kind::In) {
             if using_decl.kind.is_await() {
@@ -423,30 +415,30 @@ impl<'a> ParserImpl<'a> {
         span: u32,
         init: Option<ForStatementInit<'a>>,
         r#await: bool,
-    ) -> Result<Statement<'a>> {
-        self.expect(Kind::Semicolon)?;
+    ) -> Statement<'a> {
+        self.expect(Kind::Semicolon);
         if let Some(ForStatementInit::VariableDeclaration(decl)) = &init {
             for d in &decl.declarations {
                 self.check_missing_initializer(d);
             }
         }
         let test = if !self.at(Kind::Semicolon) && !self.at(Kind::RParen) {
-            Some(self.context(Context::In, Context::empty(), ParserImpl::parse_expr)?)
+            Some(self.context(Context::In, Context::empty(), ParserImpl::parse_expr))
         } else {
             None
         };
-        self.expect(Kind::Semicolon)?;
+        self.expect(Kind::Semicolon);
         let update = if self.at(Kind::RParen) {
             None
         } else {
-            Some(self.context(Context::In, Context::empty(), ParserImpl::parse_expr)?)
+            Some(self.context(Context::In, Context::empty(), ParserImpl::parse_expr))
         };
-        self.expect(Kind::RParen)?;
+        self.expect(Kind::RParen);
         if r#await {
             self.error(diagnostics::for_await(self.end_span(span)));
         }
-        let body = self.parse_statement_list_item(StatementContext::For)?;
-        Ok(self.ast.statement_for(self.end_span(span), init, test, update, body))
+        let body = self.parse_statement_list_item(StatementContext::For);
+        self.ast.statement_for(self.end_span(span), init, test, update, body)
     }
 
     fn parse_for_in_or_of_loop(
@@ -454,43 +446,43 @@ impl<'a> ParserImpl<'a> {
         span: u32,
         r#await: bool,
         left: ForStatementLeft<'a>,
-    ) -> Result<Statement<'a>> {
+    ) -> Statement<'a> {
         let is_for_in = self.at(Kind::In);
         self.bump_any(); // bump `in` or `of`
         let right = if is_for_in {
             self.parse_expr()
         } else {
             self.parse_assignment_expression_or_higher()
-        }?;
-        self.expect(Kind::RParen)?;
+        };
+        self.expect(Kind::RParen);
 
         if r#await && is_for_in {
             self.error(diagnostics::for_await(self.end_span(span)));
         }
 
-        let body = self.parse_statement_list_item(StatementContext::For)?;
+        let body = self.parse_statement_list_item(StatementContext::For);
         let span = self.end_span(span);
 
         if is_for_in {
-            Ok(self.ast.statement_for_in(span, left, right, body))
+            self.ast.statement_for_in(span, left, right, body)
         } else {
-            Ok(self.ast.statement_for_of(span, r#await, left, right, body))
+            self.ast.statement_for_of(span, r#await, left, right, body)
         }
     }
 
     /// Section 14.8 Continue Statement
     /// Section 14.9 Break Statement
-    fn parse_break_or_continue_statement(&mut self) -> Result<Statement<'a>> {
+    fn parse_break_or_continue_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
         let kind = self.cur_kind();
         self.bump_any(); // bump `break` or `continue`
         let label =
-            if self.can_insert_semicolon() { None } else { Some(self.parse_label_identifier()?) };
-        self.asi()?;
+            if self.can_insert_semicolon() { None } else { Some(self.parse_label_identifier()) };
+        self.asi();
         let end_span = self.end_span(span);
         match kind {
-            Kind::Break => Ok(self.ast.statement_break(end_span, label)),
-            Kind::Continue => Ok(self.ast.statement_continue(end_span, label)),
+            Kind::Break => self.ast.statement_break(end_span, label),
+            Kind::Continue => self.ast.statement_continue(end_span, label),
             _ => unreachable!(),
         }
     }
@@ -499,14 +491,14 @@ impl<'a> ParserImpl<'a> {
     /// `ReturnStatement`[Yield, Await] :
     ///   return ;
     ///   return [no `LineTerminator` here] Expression[+In, ?Yield, ?Await] ;
-    fn parse_return_statement(&mut self) -> Result<Statement<'a>> {
+    fn parse_return_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
         self.bump_any(); // advance `return`
         let argument = if self.eat(Kind::Semicolon) || self.can_insert_semicolon() {
             None
         } else {
-            let expr = self.context(Context::In, Context::empty(), ParserImpl::parse_expr)?;
-            self.asi()?;
+            let expr = self.context(Context::In, Context::empty(), ParserImpl::parse_expr);
+            self.asi();
             Some(expr)
         };
         if !self.ctx.has_return() {
@@ -515,29 +507,29 @@ impl<'a> ParserImpl<'a> {
                 span + 6,
             )));
         }
-        Ok(self.ast.statement_return(self.end_span(span), argument))
+        self.ast.statement_return(self.end_span(span), argument)
     }
 
     /// Section 14.11 With Statement
-    fn parse_with_statement(&mut self) -> Result<Statement<'a>> {
+    fn parse_with_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
         self.bump_any(); // bump `with`
-        let object = self.parse_paren_expression()?;
-        let body = self.parse_statement_list_item(StatementContext::With)?;
+        let object = self.parse_paren_expression();
+        let body = self.parse_statement_list_item(StatementContext::With);
         let span = self.end_span(span);
-        Ok(self.ast.statement_with(span, object, body))
+        self.ast.statement_with(span, object, body)
     }
 
     /// Section 14.12 Switch Statement
-    fn parse_switch_statement(&mut self) -> Result<Statement<'a>> {
+    fn parse_switch_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
         self.bump_any(); // advance `switch`
-        let discriminant = self.parse_paren_expression()?;
-        let cases = self.parse_normal_list(Kind::LCurly, Kind::RCurly, Self::parse_switch_case)?;
-        Ok(self.ast.statement_switch(self.end_span(span), discriminant, cases))
+        let discriminant = self.parse_paren_expression();
+        let cases = self.parse_normal_list(Kind::LCurly, Kind::RCurly, Self::parse_switch_case);
+        self.ast.statement_switch(self.end_span(span), discriminant, cases)
     }
 
-    pub(crate) fn parse_switch_case(&mut self) -> Result<Option<SwitchCase<'a>>> {
+    pub(crate) fn parse_switch_case(&mut self) -> Option<SwitchCase<'a>> {
         let span = self.start_span();
         let test = match self.cur_kind() {
             Kind::Default => {
@@ -546,24 +538,24 @@ impl<'a> ParserImpl<'a> {
             }
             Kind::Case => {
                 self.bump_any();
-                let expression = self.parse_expr()?;
+                let expression = self.parse_expr();
                 Some(expression)
             }
-            _ => return Err(self.unexpected()),
+            _ => return self.unexpected(),
         };
-        self.expect(Kind::Colon)?;
+        self.expect(Kind::Colon);
         let mut consequent = self.ast.vec();
         while !matches!(self.cur_kind(), Kind::Case | Kind::Default | Kind::RCurly)
             && !self.has_fatal_error()
         {
-            let stmt = self.parse_statement_list_item(StatementContext::StatementList)?;
+            let stmt = self.parse_statement_list_item(StatementContext::StatementList);
             consequent.push(stmt);
         }
-        Ok(Some(self.ast.switch_case(self.end_span(span), test, consequent)))
+        Some(self.ast.switch_case(self.end_span(span), test, consequent))
     }
 
     /// Section 14.14 Throw Statement
-    fn parse_throw_statement(&mut self) -> Result<Statement<'a>> {
+    fn parse_throw_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
         self.bump_any(); // advance `throw`
         if self.cur_token().is_on_new_line {
@@ -573,50 +565,50 @@ impl<'a> ParserImpl<'a> {
                 self.cur_token().span(),
             ));
         }
-        let argument = self.parse_expr()?;
-        self.asi()?;
-        Ok(self.ast.statement_throw(self.end_span(span), argument))
+        let argument = self.parse_expr();
+        self.asi();
+        self.ast.statement_throw(self.end_span(span), argument)
     }
 
     /// Section 14.15 Try Statement
-    fn parse_try_statement(&mut self) -> Result<Statement<'a>> {
+    fn parse_try_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
         self.bump_any(); // bump `try`
 
-        let block = self.parse_block()?;
+        let block = self.parse_block();
 
-        let handler = self.at(Kind::Catch).then(|| self.parse_catch_clause()).transpose()?;
+        let handler = self.at(Kind::Catch).then(|| self.parse_catch_clause());
 
-        let finalizer = self.eat(Kind::Finally).then(|| self.parse_block()).transpose()?;
+        let finalizer = self.eat(Kind::Finally).then(|| self.parse_block());
 
         if handler.is_none() && finalizer.is_none() {
             let range = Span::new(block.span.end, block.span.end);
             self.error(diagnostics::expect_catch_finally(range));
         }
 
-        Ok(self.ast.statement_try(self.end_span(span), block, handler, finalizer))
+        self.ast.statement_try(self.end_span(span), block, handler, finalizer)
     }
 
-    fn parse_catch_clause(&mut self) -> Result<Box<'a, CatchClause<'a>>> {
+    fn parse_catch_clause(&mut self) -> Box<'a, CatchClause<'a>> {
         let span = self.start_span();
         self.bump_any(); // advance `catch`
         let pattern = if self.eat(Kind::LParen) {
-            let pattern = self.parse_binding_pattern(false)?;
-            self.expect(Kind::RParen)?;
+            let pattern = self.parse_binding_pattern(false);
+            self.expect(Kind::RParen);
             Some(pattern)
         } else {
             None
         };
-        let body = self.parse_block()?;
+        let body = self.parse_block();
         let param = pattern.map(|pattern| self.ast.catch_parameter(pattern.kind.span(), pattern));
-        Ok(self.ast.alloc_catch_clause(self.end_span(span), param, body))
+        self.ast.alloc_catch_clause(self.end_span(span), param, body)
     }
 
     /// Section 14.16 Debugger Statement
-    fn parse_debugger_statement(&mut self) -> Result<Statement<'a>> {
+    fn parse_debugger_statement(&mut self) -> Statement<'a> {
         let span = self.start_span();
         self.bump_any();
-        self.asi()?;
-        Ok(self.ast.statement_debugger(self.end_span(span)))
+        self.asi();
+        self.ast.statement_debugger(self.end_span(span))
     }
 }

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -1,54 +1,53 @@
 //! [JSX](https://facebook.github.io/jsx)
 
-use oxc_allocator::{Box, Vec};
+use oxc_allocator::{Box, Dummy, Vec};
 use oxc_ast::ast::*;
-use oxc_diagnostics::Result;
 use oxc_span::{Atom, GetSpan, Span};
 
 use crate::{Context, ParserImpl, diagnostics, lexer::Kind};
 
 impl<'a> ParserImpl<'a> {
-    pub(crate) fn parse_jsx_expression(&mut self) -> Result<Expression<'a>> {
+    pub(crate) fn parse_jsx_expression(&mut self) -> Expression<'a> {
         if self.peek_at(Kind::RAngle) {
-            self.parse_jsx_fragment(false).map(Expression::JSXFragment)
+            Expression::JSXFragment(self.parse_jsx_fragment(false))
         } else {
-            self.parse_jsx_element(false).map(Expression::JSXElement)
+            Expression::JSXElement(self.parse_jsx_element(false))
         }
     }
 
     /// `JSXFragment` :
     ///   < > `JSXChildren_opt` < / >
-    fn parse_jsx_fragment(&mut self, in_jsx_child: bool) -> Result<Box<'a, JSXFragment<'a>>> {
+    fn parse_jsx_fragment(&mut self, in_jsx_child: bool) -> Box<'a, JSXFragment<'a>> {
         let span = self.start_span();
-        let opening_fragment = self.parse_jsx_opening_fragment(span)?;
-        let children = self.parse_jsx_children()?;
-        let closing_fragment = self.parse_jsx_closing_fragment(in_jsx_child)?;
-        Ok(self.ast.alloc_jsx_fragment(
+        let opening_fragment = self.parse_jsx_opening_fragment(span);
+        let children = self.parse_jsx_children();
+        let closing_fragment = self.parse_jsx_closing_fragment(in_jsx_child);
+        self.ast.alloc_jsx_fragment(
             self.end_span(span),
             opening_fragment,
             closing_fragment,
             children,
-        ))
+        )
     }
 
     /// <>
-    fn parse_jsx_opening_fragment(&mut self, span: u32) -> Result<JSXOpeningFragment> {
-        self.expect(Kind::LAngle)?;
-        self.expect_jsx_child(Kind::RAngle)?;
-        Ok(self.ast.jsx_opening_fragment(self.end_span(span)))
+    fn parse_jsx_opening_fragment(&mut self, span: u32) -> JSXOpeningFragment {
+        self.expect(Kind::LAngle);
+        self.expect_jsx_child(Kind::RAngle);
+        self.ast.jsx_opening_fragment(self.end_span(span))
     }
 
     /// </>
-    fn parse_jsx_closing_fragment(&mut self, in_jsx_child: bool) -> Result<JSXClosingFragment> {
+    fn parse_jsx_closing_fragment(&mut self, in_jsx_child: bool) -> JSXClosingFragment {
         let span = self.start_span();
-        self.expect(Kind::LAngle)?;
-        self.expect(Kind::Slash)?;
+        self.expect(Kind::LAngle);
+        self.expect(Kind::Slash);
         if in_jsx_child {
-            self.expect_jsx_child(Kind::RAngle)?;
+            self.expect_jsx_child(Kind::RAngle);
         } else {
-            self.expect(Kind::RAngle)?;
+            self.expect(Kind::RAngle);
         }
-        Ok(self.ast.jsx_closing_fragment(self.end_span(span)))
+        self.ast.jsx_closing_fragment(self.end_span(span))
     }
 
     /// `JSXElement` :
@@ -57,14 +56,14 @@ impl<'a> ParserImpl<'a> {
     /// `in_jsx_child`:
     ///     used for telling `JSXClosingElement` to parse the next jsx child or not
     ///     true when inside jsx element, false when at top level expression
-    fn parse_jsx_element(&mut self, in_jsx_child: bool) -> Result<Box<'a, JSXElement<'a>>> {
+    fn parse_jsx_element(&mut self, in_jsx_child: bool) -> Box<'a, JSXElement<'a>> {
         let span = self.start_span();
-        let (opening_element, self_closing) = self.parse_jsx_opening_element(span, in_jsx_child)?;
-        let children = if self_closing { self.ast.vec() } else { self.parse_jsx_children()? };
+        let (opening_element, self_closing) = self.parse_jsx_opening_element(span, in_jsx_child);
+        let children = if self_closing { self.ast.vec() } else { self.parse_jsx_children() };
         let closing_element = if self_closing {
             None
         } else {
-            let closing_element = self.parse_jsx_closing_element(in_jsx_child)?;
+            let closing_element = self.parse_jsx_closing_element(in_jsx_child);
             if !Self::jsx_element_name_eq(&opening_element.name, &closing_element.name) {
                 self.error(diagnostics::jsx_element_no_match(
                     opening_element.name.span(),
@@ -74,12 +73,7 @@ impl<'a> ParserImpl<'a> {
             }
             Some(closing_element)
         };
-        Ok(self.ast.alloc_jsx_element(
-            self.end_span(span),
-            opening_element,
-            closing_element,
-            children,
-        ))
+        self.ast.alloc_jsx_element(self.end_span(span), opening_element, closing_element, children)
     }
 
     /// `JSXOpeningElement` :
@@ -88,20 +82,20 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         span: u32,
         in_jsx_child: bool,
-    ) -> Result<(
+    ) -> (
         Box<'a, JSXOpeningElement<'a>>,
         bool, // `true` if self-closing
-    )> {
-        self.expect(Kind::LAngle)?;
-        let name = self.parse_jsx_element_name()?;
+    ) {
+        self.expect(Kind::LAngle);
+        let name = self.parse_jsx_element_name();
         // <Component<TsType> for tsx
-        let type_parameters = if self.is_ts { self.try_parse_type_arguments()? } else { None };
-        let attributes = self.parse_jsx_attributes()?;
+        let type_parameters = if self.is_ts { self.try_parse_type_arguments() } else { None };
+        let attributes = self.parse_jsx_attributes();
         let self_closing = self.eat(Kind::Slash);
         if !self_closing || in_jsx_child {
-            self.expect_jsx_child(Kind::RAngle)?;
+            self.expect_jsx_child(Kind::RAngle);
         } else {
-            self.expect(Kind::RAngle)?;
+            self.expect(Kind::RAngle);
         }
         let elem = self.ast.alloc_jsx_opening_element(
             self.end_span(span),
@@ -109,48 +103,49 @@ impl<'a> ParserImpl<'a> {
             attributes,
             type_parameters,
         );
-        Ok((elem, self_closing))
+        (elem, self_closing)
     }
 
-    fn parse_jsx_closing_element(
-        &mut self,
-        in_jsx_child: bool,
-    ) -> Result<Box<'a, JSXClosingElement<'a>>> {
+    fn parse_jsx_closing_element(&mut self, in_jsx_child: bool) -> Box<'a, JSXClosingElement<'a>> {
         let span = self.start_span();
-        self.expect(Kind::LAngle)?;
-        self.expect(Kind::Slash)?;
-        let name = self.parse_jsx_element_name()?;
+        self.expect(Kind::LAngle);
+        self.expect(Kind::Slash);
+        let name = self.parse_jsx_element_name();
         if in_jsx_child {
-            self.expect_jsx_child(Kind::RAngle)?;
+            self.expect_jsx_child(Kind::RAngle);
         } else {
-            self.expect(Kind::RAngle)?;
+            self.expect(Kind::RAngle);
         }
-        Ok(self.ast.alloc_jsx_closing_element(self.end_span(span), name))
+        self.ast.alloc_jsx_closing_element(self.end_span(span), name)
     }
 
     /// `JSXElementName` :
     ///   `JSXIdentifier`
     ///   `JSXNamespacedName`
     ///   `JSXMemberExpression`
-    fn parse_jsx_element_name(&mut self) -> Result<JSXElementName<'a>> {
+    fn parse_jsx_element_name(&mut self) -> JSXElementName<'a> {
         let span = self.start_span();
-        let identifier = self.parse_jsx_identifier()?;
+        let identifier = self.parse_jsx_identifier();
 
         // <namespace:property />
         if self.eat(Kind::Colon) {
-            let property = self.parse_jsx_identifier()?;
-            return Ok(self.ast.jsx_element_name_namespaced_name(
+            let property = self.parse_jsx_identifier();
+            return self.ast.jsx_element_name_namespaced_name(
                 self.end_span(span),
                 identifier,
                 property,
-            ));
+            );
         }
 
         // <member.foo.bar />
         if self.at(Kind::Dot) {
-            return self
-                .parse_jsx_member_expression(span, &identifier)
-                .map(JSXElementName::MemberExpression);
+            return JSXElementName::MemberExpression(
+                self.parse_jsx_member_expression(span, &identifier),
+            );
+        }
+
+        if self.fatal_error.is_some() {
+            return JSXElementName::dummy(self.ast.allocator);
         }
 
         // References begin with a capital letter, `_` or `$` e.g. `<Foo>`, `<_foo>`, `<$foo>`.
@@ -175,7 +170,7 @@ impl<'a> ParserImpl<'a> {
         } else {
             JSXElementName::Identifier(self.alloc(identifier))
         };
-        Ok(element_name)
+        element_name
     }
 
     /// `JSXMemberExpression` :
@@ -185,7 +180,7 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         span: u32,
         object: &JSXIdentifier<'a>,
-    ) -> Result<Box<'a, JSXMemberExpression<'a>>> {
+    ) -> Box<'a, JSXMemberExpression<'a>> {
         let mut object = if object.name == "this" {
             self.ast.jsx_member_expression_object_this_expression(object.span)
         } else {
@@ -195,7 +190,7 @@ impl<'a> ParserImpl<'a> {
         let mut span = Span::new(span, 0);
         let mut property = None;
 
-        while self.eat(Kind::Dot) && !self.has_fatal_error() {
+        while self.eat(Kind::Dot) && self.fatal_error.is_none() {
             // <foo.bar.baz>
             if let Some(prop) = property {
                 object =
@@ -203,39 +198,39 @@ impl<'a> ParserImpl<'a> {
             }
 
             // <foo.bar>
-            let ident = self.parse_jsx_identifier()?;
+            let ident = self.parse_jsx_identifier();
             // `<foo.bar- />` is a syntax error.
             if ident.name.contains('-') {
                 let error = diagnostics::unexpected_token(ident.span);
-                return Err(self.set_fatal_error(error));
+                return self.fatal_error(error);
             }
             property = Some(ident);
             span = self.end_span(span.start);
         }
 
         if let Some(property) = property {
-            return Ok(self.ast.alloc_jsx_member_expression(
+            return self.ast.alloc_jsx_member_expression(
                 self.end_span(span.start),
                 object,
                 property,
-            ));
+            );
         }
 
-        Err(self.unexpected())
+        self.unexpected()
     }
 
     /// `JSXChildren` :
     ///   `JSXChild` `JSXChildren_opt`
-    fn parse_jsx_children(&mut self) -> Result<Vec<'a, JSXChild<'a>>> {
+    fn parse_jsx_children(&mut self) -> Vec<'a, JSXChild<'a>> {
         let mut children = self.ast.vec();
-        while !self.has_fatal_error() {
-            if let Some(child) = self.parse_jsx_child()? {
+        while self.fatal_error.is_none() {
+            if let Some(child) = self.parse_jsx_child() {
                 children.push(child);
             } else {
                 break;
             }
         }
-        Ok(children)
+        children
     }
 
     /// `JSXChild` :
@@ -243,31 +238,31 @@ impl<'a> ParserImpl<'a> {
     ///   `JSXElement`
     ///   `JSXFragment`
     ///   { `JSXChildExpression_opt` }
-    fn parse_jsx_child(&mut self) -> Result<Option<JSXChild<'a>>> {
+    fn parse_jsx_child(&mut self) -> Option<JSXChild<'a>> {
         match self.cur_kind() {
             // </ close fragment
-            Kind::LAngle if self.peek_at(Kind::Slash) => Ok(None),
+            Kind::LAngle if self.peek_at(Kind::Slash) => None,
             // <> open fragment
             Kind::LAngle if self.peek_at(Kind::RAngle) => {
-                self.parse_jsx_fragment(true).map(JSXChild::Fragment).map(Some)
+                Some(JSXChild::Fragment(self.parse_jsx_fragment(true)))
             }
             // <ident open element
             Kind::LAngle if self.peek_at(Kind::Ident) || self.peek_kind().is_all_keyword() => {
-                self.parse_jsx_element(true).map(JSXChild::Element).map(Some)
+                Some(JSXChild::Element(self.parse_jsx_element(true)))
             }
             // {...expr}
             Kind::LCurly if self.peek_at(Kind::Dot3) => {
-                self.parse_jsx_spread_child().map(JSXChild::Spread).map(Some)
+                Some(JSXChild::Spread(self.parse_jsx_spread_child()))
             }
             // {expr}
             Kind::LCurly => {
-                self.parse_jsx_expression_container(/* is_jsx_child */ true)
-                    .map(JSXChild::ExpressionContainer)
-                    .map(Some)
+                Some(JSXChild::ExpressionContainer(
+                    self.parse_jsx_expression_container(/* is_jsx_child */ true),
+                ))
             }
             // text
-            Kind::JSXText => Ok(Some(JSXChild::Text(self.parse_jsx_text()))),
-            _ => Err(self.unexpected()),
+            Kind::JSXText => Some(JSXChild::Text(self.parse_jsx_text())),
+            _ => self.unexpected(),
         }
     }
 
@@ -275,40 +270,40 @@ impl<'a> ParserImpl<'a> {
     fn parse_jsx_expression_container(
         &mut self,
         in_jsx_child: bool,
-    ) -> Result<Box<'a, JSXExpressionContainer<'a>>> {
+    ) -> Box<'a, JSXExpressionContainer<'a>> {
         let span = self.start_span();
         self.bump_any(); // bump `{`
 
         let expr = if self.at(Kind::RCurly) {
             if in_jsx_child {
-                self.expect_jsx_child(Kind::RCurly)
+                self.expect_jsx_child(Kind::RCurly);
             } else {
-                self.expect(Kind::RCurly)
-            }?;
+                self.expect(Kind::RCurly);
+            }
             let span = self.end_span(span);
             // Handle comment between curly braces (ex. `{/* comment */}`)
             //                                            ^^^^^^^^^^^^^ span
             let expr = self.ast.jsx_empty_expression(Span::new(span.start + 1, span.end - 1));
             JSXExpression::EmptyExpression(expr)
         } else {
-            let expr = self.parse_jsx_assignment_expression().map(JSXExpression::from)?;
+            let expr = JSXExpression::from(self.parse_jsx_assignment_expression());
             if in_jsx_child {
-                self.expect_jsx_child(Kind::RCurly)
+                self.expect_jsx_child(Kind::RCurly);
             } else {
-                self.expect(Kind::RCurly)
-            }?;
+                self.expect(Kind::RCurly);
+            }
             expr
         };
 
-        Ok(self.ast.alloc_jsx_expression_container(self.end_span(span), expr))
+        self.ast.alloc_jsx_expression_container(self.end_span(span), expr)
     }
 
-    fn parse_jsx_assignment_expression(&mut self) -> Result<Expression<'a>> {
+    fn parse_jsx_assignment_expression(&mut self) -> Expression<'a> {
         self.context(Context::default().and_await(self.ctx.has_await()), self.ctx, |p| {
             let expr = p.parse_expr();
-            if let Ok(Expression::SequenceExpression(seq)) = &expr {
+            if let Expression::SequenceExpression(seq) = &expr {
                 let error = diagnostics::jsx_expressions_may_not_use_the_comma_operator(seq.span);
-                return Err(p.set_fatal_error(error));
+                return p.fatal_error(error);
             }
             expr
         })
@@ -316,95 +311,96 @@ impl<'a> ParserImpl<'a> {
 
     /// `JSXChildExpression` :
     ///   { ... `AssignmentExpression` }
-    fn parse_jsx_spread_child(&mut self) -> Result<Box<'a, JSXSpreadChild<'a>>> {
+    fn parse_jsx_spread_child(&mut self) -> Box<'a, JSXSpreadChild<'a>> {
         let span = self.start_span();
         self.bump_any(); // bump `{`
-        self.expect(Kind::Dot3)?;
-        let expr = self.parse_jsx_assignment_expression()?;
-        self.expect_jsx_child(Kind::RCurly)?;
-        Ok(self.ast.alloc_jsx_spread_child(self.end_span(span), expr))
+        self.expect(Kind::Dot3);
+        let expr = self.parse_jsx_assignment_expression();
+        self.expect_jsx_child(Kind::RCurly);
+        self.ast.alloc_jsx_spread_child(self.end_span(span), expr)
     }
 
     /// `JSXAttributes` :
     ///   `JSXSpreadAttribute` `JSXAttributes_opt`
     ///   `JSXAttribute` `JSXAttributes_opt`
-    fn parse_jsx_attributes(&mut self) -> Result<Vec<'a, JSXAttributeItem<'a>>> {
+    fn parse_jsx_attributes(&mut self) -> Vec<'a, JSXAttributeItem<'a>> {
         let mut attributes = self.ast.vec();
         while !matches!(self.cur_kind(), Kind::LAngle | Kind::RAngle | Kind::Slash)
-            && !self.has_fatal_error()
+            && self.fatal_error.is_none()
         {
             let attribute = match self.cur_kind() {
                 Kind::LCurly => {
-                    self.parse_jsx_spread_attribute().map(JSXAttributeItem::SpreadAttribute)
+                    JSXAttributeItem::SpreadAttribute(self.parse_jsx_spread_attribute())
                 }
-                _ => self.parse_jsx_attribute().map(JSXAttributeItem::Attribute),
-            }?;
+                _ => JSXAttributeItem::Attribute(self.parse_jsx_attribute()),
+            };
             attributes.push(attribute);
         }
-        Ok(attributes)
+        attributes
     }
 
     /// `JSXAttribute` :
     ///   `JSXAttributeName` `JSXAttributeInitializer_opt`
-    fn parse_jsx_attribute(&mut self) -> Result<Box<'a, JSXAttribute<'a>>> {
+    fn parse_jsx_attribute(&mut self) -> Box<'a, JSXAttribute<'a>> {
         let span = self.start_span();
-        let name = self.parse_jsx_attribute_name()?;
+        let name = self.parse_jsx_attribute_name();
         let value = if self.at(Kind::Eq) {
-            self.expect_jsx_attribute_value(Kind::Eq)?;
-            Some(self.parse_jsx_attribute_value()?)
+            self.expect_jsx_attribute_value(Kind::Eq);
+            Some(self.parse_jsx_attribute_value())
         } else {
             None
         };
-        Ok(self.ast.alloc_jsx_attribute(self.end_span(span), name, value))
+        self.ast.alloc_jsx_attribute(self.end_span(span), name, value)
     }
 
     /// `JSXSpreadAttribute` :
     ///   { ... `AssignmentExpression` }
-    fn parse_jsx_spread_attribute(&mut self) -> Result<Box<'a, JSXSpreadAttribute<'a>>> {
+    fn parse_jsx_spread_attribute(&mut self) -> Box<'a, JSXSpreadAttribute<'a>> {
         let span = self.start_span();
         self.bump_any(); // bump `{`
-        self.expect(Kind::Dot3)?;
-        let argument = self.parse_jsx_assignment_expression()?;
-        self.expect(Kind::RCurly)?;
-        Ok(self.ast.alloc_jsx_spread_attribute(self.end_span(span), argument))
+        self.expect(Kind::Dot3);
+        let argument = self.parse_jsx_assignment_expression();
+        self.expect(Kind::RCurly);
+        self.ast.alloc_jsx_spread_attribute(self.end_span(span), argument)
     }
 
     /// `JSXAttributeName` :
     ///   `JSXIdentifier`
     ///   `JSXNamespacedName`
-    fn parse_jsx_attribute_name(&mut self) -> Result<JSXAttributeName<'a>> {
+    fn parse_jsx_attribute_name(&mut self) -> JSXAttributeName<'a> {
         let span = self.start_span();
-        let identifier = self.parse_jsx_identifier()?;
+        let identifier = self.parse_jsx_identifier();
 
         if self.eat(Kind::Colon) {
-            let property = self.parse_jsx_identifier()?;
-            return Ok(self.ast.jsx_attribute_name_namespaced_name(
+            let property = self.parse_jsx_identifier();
+            return self.ast.jsx_attribute_name_namespaced_name(
                 self.end_span(span),
                 identifier,
                 property,
-            ));
+            );
         }
 
-        Ok(JSXAttributeName::Identifier(self.alloc(identifier)))
+        JSXAttributeName::Identifier(self.alloc(identifier))
     }
 
-    fn parse_jsx_attribute_value(&mut self) -> Result<JSXAttributeValue<'a>> {
+    fn parse_jsx_attribute_value(&mut self) -> JSXAttributeValue<'a> {
         match self.cur_kind() {
-            Kind::Str => self
-                .parse_literal_string()
-                .map(|str_lit| JSXAttributeValue::StringLiteral(self.alloc(str_lit))),
+            Kind::Str => {
+                let str_lit = self.parse_literal_string();
+                JSXAttributeValue::StringLiteral(self.alloc(str_lit))
+            }
             Kind::LCurly => {
-                let expr = self.parse_jsx_expression_container(/* is_jsx_child */ false)?;
-                Ok(JSXAttributeValue::ExpressionContainer(expr))
+                let expr = self.parse_jsx_expression_container(/* is_jsx_child */ false);
+                JSXAttributeValue::ExpressionContainer(expr)
             }
             Kind::LAngle => {
                 if self.peek_at(Kind::RAngle) {
-                    self.parse_jsx_fragment(false).map(JSXAttributeValue::Fragment)
+                    JSXAttributeValue::Fragment(self.parse_jsx_fragment(false))
                 } else {
-                    self.parse_jsx_element(false).map(JSXAttributeValue::Element)
+                    JSXAttributeValue::Element(self.parse_jsx_element(false))
                 }
             }
-            _ => Err(self.unexpected()),
+            _ => self.unexpected(),
         }
     }
 
@@ -412,17 +408,17 @@ impl<'a> ParserImpl<'a> {
     ///   `IdentifierStart`
     ///   `JSXIdentifier` `IdentifierPart`
     ///   `JSXIdentifier` [no `WhiteSpace` or Comment here] -
-    fn parse_jsx_identifier(&mut self) -> Result<JSXIdentifier<'a>> {
+    fn parse_jsx_identifier(&mut self) -> JSXIdentifier<'a> {
         let span = self.start_span();
         if !self.at(Kind::Ident) && !self.cur_kind().is_all_keyword() {
-            return Err(self.unexpected());
+            return self.unexpected();
         }
         // Currently at a valid normal Ident or Keyword, keep on lexing for `-` in `<component-name />`
         self.continue_lex_jsx_identifier();
         self.bump_any();
         let span = self.end_span(span);
         let name = span.source_text(self.source_text);
-        Ok(self.ast.jsx_identifier(span, name))
+        self.ast.jsx_identifier(span, name)
     }
 
     fn parse_jsx_text(&mut self) -> Box<'a, JSXText<'a>> {

--- a/crates/oxc_parser/src/ts/statement.rs
+++ b/crates/oxc_parser/src/ts/statement.rs
@@ -1,6 +1,5 @@
 use oxc_allocator::Box;
 use oxc_ast::ast::*;
-use oxc_diagnostics::Result;
 use oxc_span::GetSpan;
 
 use crate::{
@@ -17,115 +16,123 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         span: u32,
         modifiers: &Modifiers<'a>,
-    ) -> Result<Declaration<'a>> {
+    ) -> Declaration<'a> {
         self.bump_any(); // bump `enum`
-        let id = self.parse_binding_identifier()?;
-        let body = self.parse_ts_enum_body()?;
+        let id = self.parse_binding_identifier();
+        let body = self.parse_ts_enum_body();
         let span = self.end_span(span);
         self.verify_modifiers(
             modifiers,
             ModifierFlags::DECLARE | ModifierFlags::CONST,
             diagnostics::modifier_cannot_be_used_here,
         );
-        Ok(self.ast.declaration_ts_enum(
+        self.ast.declaration_ts_enum(
             span,
             id,
             body,
             modifiers.contains_const(),
             modifiers.contains_declare(),
-        ))
+        )
     }
 
-    pub(crate) fn parse_ts_enum_body(&mut self) -> Result<TSEnumBody<'a>> {
+    pub(crate) fn parse_ts_enum_body(&mut self) -> TSEnumBody<'a> {
         let span = self.start_span();
-        self.expect(Kind::LCurly)?;
+        self.expect(Kind::LCurly);
         let members = self.parse_delimited_list(
             Kind::RCurly,
             Kind::Comma,
             /* trailing_separator */ true,
             Self::parse_ts_enum_member,
-        )?;
-        self.expect(Kind::RCurly)?;
-        Ok(self.ast.ts_enum_body(self.end_span(span), members))
+        );
+        self.expect(Kind::RCurly);
+        self.ast.ts_enum_body(self.end_span(span), members)
     }
 
-    pub(crate) fn parse_ts_enum_member(&mut self) -> Result<TSEnumMember<'a>> {
+    pub(crate) fn parse_ts_enum_member(&mut self) -> TSEnumMember<'a> {
         let span = self.start_span();
-        let id = self.parse_ts_enum_member_name()?;
+        let id = self.parse_ts_enum_member_name();
         let initializer = if self.eat(Kind::Eq) {
-            Some(self.parse_assignment_expression_or_higher()?)
+            Some(self.parse_assignment_expression_or_higher())
         } else {
             None
         };
-        Ok(self.ast.ts_enum_member(self.end_span(span), id, initializer))
+        self.ast.ts_enum_member(self.end_span(span), id, initializer)
     }
 
-    fn parse_ts_enum_member_name(&mut self) -> Result<TSEnumMemberName<'a>> {
+    fn parse_ts_enum_member_name(&mut self) -> TSEnumMemberName<'a> {
         match self.cur_kind() {
             Kind::Str => {
-                let literal = self.parse_literal_string()?;
-                Ok(TSEnumMemberName::String(self.alloc(literal)))
+                let literal = self.parse_literal_string();
+                TSEnumMemberName::String(self.alloc(literal))
             }
-            Kind::LBrack => match self.parse_computed_property_name()? {
-                Expression::StringLiteral(literal) => Ok(TSEnumMemberName::ComputedString(literal)),
+            Kind::LBrack => match self.parse_computed_property_name() {
+                Expression::StringLiteral(literal) => TSEnumMemberName::ComputedString(literal),
                 Expression::TemplateLiteral(template) if template.is_no_substitution_template() => {
-                    Ok(TSEnumMemberName::ComputedTemplateString(template))
+                    TSEnumMemberName::ComputedTemplateString(template)
                 }
                 Expression::NumericLiteral(literal) => {
-                    Err(diagnostics::enum_member_cannot_have_numeric_name(literal.span()))
+                    let error = diagnostics::enum_member_cannot_have_numeric_name(literal.span());
+                    self.fatal_error(error)
                 }
-                expr => Err(diagnostics::computed_property_names_not_allowed_in_enums(expr.span())),
+                expr => {
+                    let error =
+                        diagnostics::computed_property_names_not_allowed_in_enums(expr.span());
+                    self.fatal_error(error)
+                }
             },
-            Kind::NoSubstitutionTemplate | Kind::TemplateHead => Err(
-                diagnostics::computed_property_names_not_allowed_in_enums(self.cur_token().span()),
-            ),
+            Kind::NoSubstitutionTemplate | Kind::TemplateHead => {
+                let error = diagnostics::computed_property_names_not_allowed_in_enums(
+                    self.cur_token().span(),
+                );
+                self.fatal_error(error)
+            }
             kind if kind.is_number() => {
-                Err(diagnostics::enum_member_cannot_have_numeric_name(self.cur_token().span()))
+                let error =
+                    diagnostics::enum_member_cannot_have_numeric_name(self.cur_token().span());
+                self.fatal_error(error)
             }
             _ => {
-                let ident_name = self.parse_identifier_name()?;
-                Ok(TSEnumMemberName::Identifier(self.alloc(ident_name)))
+                let ident_name = self.parse_identifier_name();
+                TSEnumMemberName::Identifier(self.alloc(ident_name))
             }
         }
     }
 
     /* ------------------- Annotation ----------------- */
 
-    pub(crate) fn parse_ts_type_annotation(
-        &mut self,
-    ) -> Result<Option<Box<'a, TSTypeAnnotation<'a>>>> {
+    pub(crate) fn parse_ts_type_annotation(&mut self) -> Option<Box<'a, TSTypeAnnotation<'a>>> {
         if !self.is_ts {
-            return Ok(None);
+            return None;
         }
         if !self.at(Kind::Colon) {
-            return Ok(None);
+            return None;
         }
         let span = self.start_span();
         self.bump_any(); // bump ':'
-        let type_annotation = self.parse_ts_type()?;
-        Ok(Some(self.ast.alloc_ts_type_annotation(self.end_span(span), type_annotation)))
+        let type_annotation = self.parse_ts_type();
+        Some(self.ast.alloc_ts_type_annotation(self.end_span(span), type_annotation))
     }
 
     pub(crate) fn parse_ts_type_alias_declaration(
         &mut self,
         span: u32,
         modifiers: &Modifiers<'a>,
-    ) -> Result<Declaration<'a>> {
-        self.expect(Kind::Type)?;
+    ) -> Declaration<'a> {
+        self.expect(Kind::Type);
 
-        let id = self.parse_binding_identifier()?;
-        let params = self.parse_ts_type_parameters()?;
-        self.expect(Kind::Eq)?;
+        let id = self.parse_binding_identifier();
+        let params = self.parse_ts_type_parameters();
+        self.expect(Kind::Eq);
 
         let annotation = if self.at(Kind::Intrinsic) && !self.peek_at(Kind::Dot) {
             let span = self.start_span();
             self.bump_any();
             self.ast.ts_type_intrinsic_keyword(self.end_span(span))
         } else {
-            self.parse_ts_type()?
+            self.parse_ts_type()
         };
 
-        self.asi()?;
+        self.asi();
         let span = self.end_span(span);
 
         self.verify_modifiers(
@@ -134,13 +141,13 @@ impl<'a> ParserImpl<'a> {
             diagnostics::modifier_cannot_be_used_here,
         );
 
-        Ok(self.ast.declaration_ts_type_alias(
+        self.ast.declaration_ts_type_alias(
             span,
             id,
             params,
             annotation,
             modifiers.contains_declare(),
-        ))
+        )
     }
 
     /* ---------------------  Interface  ------------------------ */
@@ -149,12 +156,12 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         span: u32,
         modifiers: &Modifiers<'a>,
-    ) -> Result<Declaration<'a>> {
-        self.expect(Kind::Interface)?; // bump interface
-        let id = self.parse_binding_identifier()?;
-        let type_parameters = self.parse_ts_type_parameters()?;
-        let (extends, _) = self.parse_heritage_clause()?;
-        let body = self.parse_ts_interface_body()?;
+    ) -> Declaration<'a> {
+        self.expect(Kind::Interface); // bump interface
+        let id = self.parse_binding_identifier();
+        let type_parameters = self.parse_ts_type_parameters();
+        let (extends, _) = self.parse_heritage_clause();
+        let body = self.parse_ts_interface_body();
         let extends =
             extends.map_or_else(|| self.ast.vec(), |e| self.ast.ts_interface_heritages(e));
 
@@ -164,21 +171,22 @@ impl<'a> ParserImpl<'a> {
             diagnostics::modifier_cannot_be_used_here,
         );
 
-        Ok(self.ast.declaration_ts_interface(
+        self.ast.declaration_ts_interface(
             self.end_span(span),
             id,
             type_parameters,
             extends,
             body,
             modifiers.contains_declare(),
-        ))
+        )
     }
 
-    fn parse_ts_interface_body(&mut self) -> Result<Box<'a, TSInterfaceBody<'a>>> {
+    fn parse_ts_interface_body(&mut self) -> Box<'a, TSInterfaceBody<'a>> {
         let span = self.start_span();
-        let body_list =
-            self.parse_normal_list(Kind::LCurly, Kind::RCurly, Self::parse_ts_type_signature)?;
-        Ok(self.ast.alloc_ts_interface_body(self.end_span(span), body_list))
+        let body_list = self.parse_normal_list(Kind::LCurly, Kind::RCurly, |p| {
+            Some(Self::parse_ts_type_signature(p))
+        });
+        self.ast.alloc_ts_interface_body(self.end_span(span), body_list)
     }
 
     pub(crate) fn is_at_interface_declaration(&mut self) -> bool {
@@ -189,13 +197,12 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
-    pub(crate) fn parse_ts_type_signature(&mut self) -> Result<Option<TSSignature<'a>>> {
+    pub(crate) fn parse_ts_type_signature(&mut self) -> TSSignature<'a> {
         if self.is_at_ts_index_signature_member() {
             let span = self.start_span();
             let modifiers = self.parse_modifiers(false, false, false);
-            return self
-                .parse_index_signature_declaration(span, &modifiers)
-                .map(|sig| Some(TSSignature::TSIndexSignature(self.alloc(sig))));
+            let sig = self.parse_index_signature_declaration(span, &modifiers);
+            return TSSignature::TSIndexSignature(self.alloc(sig));
         }
 
         match self.cur_kind() {
@@ -211,7 +218,6 @@ impl<'a> ParserImpl<'a> {
             }
             _ => self.parse_ts_property_or_method_signature_member(),
         }
-        .map(Some)
     }
 
     /// Must be at `[ident:` or `<modifiers> [ident:`
@@ -268,13 +274,13 @@ impl<'a> ParserImpl<'a> {
 
     /* ----------------------- Namespace & Module ----------------------- */
 
-    fn parse_ts_module_block(&mut self) -> Result<Box<'a, TSModuleBlock<'a>>> {
+    fn parse_ts_module_block(&mut self) -> Box<'a, TSModuleBlock<'a>> {
         let span = self.start_span();
-        self.expect(Kind::LCurly)?;
+        self.expect(Kind::LCurly);
         let (directives, statements) =
-            self.parse_directives_and_statements(/* is_top_level */ false)?;
-        self.expect(Kind::RCurly)?;
-        Ok(self.ast.alloc_ts_module_block(self.end_span(span), directives, statements))
+            self.parse_directives_and_statements(/* is_top_level */ false);
+        self.expect(Kind::RCurly);
+        self.ast.alloc_ts_module_block(self.end_span(span), directives, statements)
     }
 
     pub(crate) fn parse_ts_namespace_or_module_declaration_body(
@@ -282,30 +288,27 @@ impl<'a> ParserImpl<'a> {
         span: u32,
         kind: TSModuleDeclarationKind,
         modifiers: &Modifiers<'a>,
-    ) -> Result<Box<'a, TSModuleDeclaration<'a>>> {
+    ) -> Box<'a, TSModuleDeclaration<'a>> {
         self.verify_modifiers(
             modifiers,
             ModifierFlags::DECLARE | ModifierFlags::EXPORT,
             diagnostics::modifier_cannot_be_used_here,
         );
         let id = match self.cur_kind() {
-            Kind::Str => self.parse_literal_string().map(TSModuleDeclarationName::StringLiteral),
-            _ => self.parse_binding_identifier().map(TSModuleDeclarationName::Identifier),
-        }?;
+            Kind::Str => TSModuleDeclarationName::StringLiteral(self.parse_literal_string()),
+            _ => TSModuleDeclarationName::Identifier(self.parse_binding_identifier()),
+        };
 
         let body = if self.eat(Kind::Dot) {
             let span = self.start_span();
-            let decl = self.parse_ts_namespace_or_module_declaration_body(
-                span,
-                kind,
-                &Modifiers::empty(),
-            )?;
+            let decl =
+                self.parse_ts_namespace_or_module_declaration_body(span, kind, &Modifiers::empty());
             Some(TSModuleDeclarationBody::TSModuleDeclaration(decl))
         } else if self.at(Kind::LCurly) {
-            let block = self.parse_ts_module_block()?;
+            let block = self.parse_ts_module_block();
             Some(TSModuleDeclarationBody::TSModuleBlock(block))
         } else {
-            self.asi()?;
+            self.asi();
             None
         };
 
@@ -315,89 +318,95 @@ impl<'a> ParserImpl<'a> {
             diagnostics::modifier_cannot_be_used_here,
         );
 
-        Ok(self.ast.alloc_ts_module_declaration(
+        self.ast.alloc_ts_module_declaration(
             self.end_span(span),
             id,
             body,
             kind,
             modifiers.contains_declare(),
-        ))
+        )
     }
 
     /* ----------------------- declare --------------------- */
 
-    pub(crate) fn parse_ts_declaration_statement(
-        &mut self,
-        start_span: u32,
-    ) -> Result<Statement<'a>> {
+    pub(crate) fn parse_ts_declaration_statement(&mut self, start_span: u32) -> Statement<'a> {
         let reserved_ctx = self.ctx;
-        let modifiers = self.eat_modifiers_before_declaration()?;
+        let modifiers = self.eat_modifiers_before_declaration();
         self.ctx = self
             .ctx
             .union_ambient_if(modifiers.contains_declare())
             .and_await(modifiers.contains_async());
-        let result = self.parse_declaration(start_span, &modifiers);
+        let decl = self.parse_declaration(start_span, &modifiers);
         self.ctx = reserved_ctx;
-        result.map(Statement::from)
+        Statement::from(decl)
     }
 
     pub(crate) fn parse_declaration(
         &mut self,
         start_span: u32,
         modifiers: &Modifiers<'a>,
-    ) -> Result<Declaration<'a>> {
+    ) -> Declaration<'a> {
         match self.cur_kind() {
             Kind::Namespace => {
                 let kind = TSModuleDeclarationKind::Namespace;
                 self.bump_any();
-                self.parse_ts_namespace_or_module_declaration_body(start_span, kind, modifiers)
-                    .map(Declaration::TSModuleDeclaration)
+                let decl =
+                    self.parse_ts_namespace_or_module_declaration_body(start_span, kind, modifiers);
+                Declaration::TSModuleDeclaration(decl)
             }
             Kind::Module => {
                 let kind = TSModuleDeclarationKind::Module;
                 self.bump_any();
-                self.parse_ts_namespace_or_module_declaration_body(start_span, kind, modifiers)
-                    .map(Declaration::TSModuleDeclaration)
+                let decl =
+                    self.parse_ts_namespace_or_module_declaration_body(start_span, kind, modifiers);
+                Declaration::TSModuleDeclaration(decl)
             }
             Kind::Global => {
                 // declare global { }
                 let kind = TSModuleDeclarationKind::Global;
-                self.parse_ts_namespace_or_module_declaration_body(start_span, kind, modifiers)
-                    .map(Declaration::TSModuleDeclaration)
+                let decl =
+                    self.parse_ts_namespace_or_module_declaration_body(start_span, kind, modifiers);
+                Declaration::TSModuleDeclaration(decl)
             }
             Kind::Type => self.parse_ts_type_alias_declaration(start_span, modifiers),
             Kind::Enum => self.parse_ts_enum_declaration(start_span, modifiers),
             Kind::Interface if self.is_at_interface_declaration() => {
                 self.parse_ts_interface_declaration(start_span, modifiers)
             }
-            Kind::Class => self
-                .parse_class_declaration(start_span, modifiers)
-                .map(Declaration::ClassDeclaration),
+            Kind::Class => {
+                let decl = self.parse_class_declaration(start_span, modifiers);
+                Declaration::ClassDeclaration(decl)
+            }
             Kind::Import => {
                 self.bump_any();
                 self.parse_ts_import_equals_declaration(start_span)
             }
-            kind if kind.is_variable_declaration() => self
-                .parse_variable_declaration(
+            kind if kind.is_variable_declaration() => {
+                let decl = self.parse_variable_declaration(
                     start_span,
                     VariableDeclarationParent::Statement,
                     modifiers,
-                )
-                .map(Declaration::VariableDeclaration),
+                );
+                Declaration::VariableDeclaration(decl)
+            }
             _ if self.at_function_with_async() => {
                 let declare = modifiers.contains(ModifierKind::Declare);
                 if declare {
-                    self.parse_ts_declare_function(start_span, modifiers)
-                        .map(Declaration::FunctionDeclaration)
+                    let decl = self.parse_ts_declare_function(start_span, modifiers);
+                    Declaration::FunctionDeclaration(decl)
                 } else if self.is_ts {
-                    self.parse_ts_function_impl(start_span, FunctionKind::Declaration, modifiers)
-                        .map(Declaration::FunctionDeclaration)
+                    let decl = self.parse_ts_function_impl(
+                        start_span,
+                        FunctionKind::Declaration,
+                        modifiers,
+                    );
+                    Declaration::FunctionDeclaration(decl)
                 } else {
-                    self.parse_function_impl(FunctionKind::Declaration)
-                        .map(Declaration::FunctionDeclaration)
+                    let decl = self.parse_function_impl(FunctionKind::Declaration);
+                    Declaration::FunctionDeclaration(decl)
                 }
             }
-            _ => Err(self.unexpected()),
+            _ => self.unexpected(),
         }
     }
 
@@ -405,11 +414,11 @@ impl<'a> ParserImpl<'a> {
         &mut self,
         start_span: u32,
         modifiers: &Modifiers<'a>,
-    ) -> Result<Box<'a, Function<'a>>> {
+    ) -> Box<'a, Function<'a>> {
         let r#async = modifiers.contains(ModifierKind::Async);
-        self.expect(Kind::Function)?;
+        self.expect(Kind::Function);
         let func_kind = FunctionKind::TSDeclaration;
-        let id = self.parse_function_id(func_kind, r#async, false)?;
+        let id = self.parse_function_id(func_kind, r#async, false);
         self.parse_function(
             start_span,
             id,
@@ -421,80 +430,76 @@ impl<'a> ParserImpl<'a> {
         )
     }
 
-    pub(crate) fn parse_ts_type_assertion(&mut self) -> Result<Expression<'a>> {
+    pub(crate) fn parse_ts_type_assertion(&mut self) -> Expression<'a> {
         let span = self.start_span();
-        self.expect(Kind::LAngle)?;
-        let type_annotation = self.parse_ts_type()?;
-        self.expect(Kind::RAngle)?;
+        self.expect(Kind::LAngle);
+        let type_annotation = self.parse_ts_type();
+        self.expect(Kind::RAngle);
         let lhs_span = self.start_span();
-        let expression = self.parse_simple_unary_expression(lhs_span)?;
-        Ok(self.ast.expression_ts_type_assertion(self.end_span(span), expression, type_annotation))
+        let expression = self.parse_simple_unary_expression(lhs_span);
+        self.ast.expression_ts_type_assertion(self.end_span(span), expression, type_annotation)
     }
 
-    pub(crate) fn parse_ts_import_equals_declaration(
-        &mut self,
-        span: u32,
-    ) -> Result<Declaration<'a>> {
+    pub(crate) fn parse_ts_import_equals_declaration(&mut self, span: u32) -> Declaration<'a> {
         let import_kind = if !self.peek_at(Kind::Eq) && self.eat(Kind::Type) {
             ImportOrExportKind::Type
         } else {
             ImportOrExportKind::Value
         };
 
-        let id = self.parse_binding_identifier()?;
+        let id = self.parse_binding_identifier();
 
-        self.expect(Kind::Eq)?;
+        self.expect(Kind::Eq);
 
         let reference_span = self.start_span();
         let module_reference = if self.eat(Kind::Require) {
-            self.expect(Kind::LParen)?;
-            let expression = self.parse_literal_string()?;
-            self.expect(Kind::RParen)?;
+            self.expect(Kind::LParen);
+            let expression = self.parse_literal_string();
+            self.expect(Kind::RParen);
             self.ast.ts_module_reference_external_module_reference(
                 self.end_span(reference_span),
                 expression,
             )
         } else {
-            let type_name = self.parse_ts_type_name()?;
+            let type_name = self.parse_ts_type_name();
             TSModuleReference::from(type_name)
         };
 
-        self.asi()?;
+        self.asi();
 
-        Ok(self.ast.declaration_ts_import_equals(
+        self.ast.declaration_ts_import_equals(
             self.end_span(span),
             id,
             module_reference,
             import_kind,
-        ))
+        )
     }
 
-    pub(crate) fn parse_ts_this_parameter(&mut self) -> Result<TSThisParameter<'a>> {
+    pub(crate) fn parse_ts_this_parameter(&mut self) -> TSThisParameter<'a> {
         let span = self.start_span();
         self.parse_class_element_modifiers(true);
-        self.eat_decorators()?;
+        self.eat_decorators();
 
         let this_span = self.start_span();
         self.bump_any();
         let this = self.end_span(this_span);
 
-        let type_annotation = self.parse_ts_type_annotation()?;
-        Ok(self.ast.ts_this_parameter(self.end_span(span), this, type_annotation))
+        let type_annotation = self.parse_ts_type_annotation();
+        self.ast.ts_this_parameter(self.end_span(span), this, type_annotation)
     }
 
-    pub(crate) fn eat_decorators(&mut self) -> Result<()> {
+    pub(crate) fn eat_decorators(&mut self) {
         if !self.at(Kind::At) {
-            return Ok(());
+            return;
         }
 
         let mut decorators = self.ast.vec();
         while self.at(Kind::At) {
-            let decorator = self.parse_decorator()?;
+            let decorator = self.parse_decorator();
             decorators.push(decorator);
         }
 
         self.state.decorators = decorators;
-        Ok(())
     }
 
     pub(crate) fn at_start_of_ts_declaration(&mut self) -> bool {

--- a/tasks/coverage/snapshots/parser_babel.snap
+++ b/tasks/coverage/snapshots/parser_babel.snap
@@ -1,8 +1,8 @@
 commit: 578ac4df
 
 parser_babel Summary:
-AST Parsed     : 2303/2322 (99.18%)
-Positive Passed: 2282/2322 (98.28%)
+AST Parsed     : 2306/2322 (99.31%)
+Positive Passed: 2285/2322 (98.41%)
 Negative Passed: 1557/1673 (93.07%)
 Expect Syntax Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/categorized/invalid-startindex-and-startline-specified-without-startcolumn/input.js
 
@@ -254,21 +254,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/core/o
    ╰────
   help: new.target is only allowed in constructors and functions invoked using thew `new` operator
 
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-private-properties/await-identifier-in-property-in-arguments-of-async-call/input.js
-
-  × Unexpected token
-   ╭─[babel/packages/babel-parser/test/fixtures/es2022/class-private-properties/await-identifier-in-property-in-arguments-of-async-call/input.js:1:31]
- 1 │ async( x = class { #x = await });
-   ·                               ─
-   ╰────
-
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-private-properties/await-in-private-property-in-params-of-async-arrow/input.js
 
-  × Unexpected token
-   ╭─[babel/packages/babel-parser/test/fixtures/es2022/class-private-properties/await-in-private-property-in-params-of-async-arrow/input.js:1:31]
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[babel/packages/babel-parser/test/fixtures/es2022/class-private-properties/await-in-private-property-in-params-of-async-arrow/input.js:1:33]
  1 │ async( x = class { #x = await }) => {}
-   ·                               ─
+   ·                                 ▲
    ╰────
+  help: Try insert a semicolon here
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-properties/arguments-in-key/input.js
 
@@ -280,29 +273,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022
  4 │   }
    ╰────
 
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-properties/await-identifier-in-computed-property-in-arguments-of-async-call/input.js
-
-  × Unexpected token
-   ╭─[babel/packages/babel-parser/test/fixtures/es2022/class-properties/await-identifier-in-computed-property-in-arguments-of-async-call/input.js:1:26]
- 1 │ async( x = class { [await] = x })
-   ·                          ─
-   ╰────
-
-Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-properties/await-identifier-in-property-in-arguments-of-async-call/input.js
-
-  × Unexpected token
-   ╭─[babel/packages/babel-parser/test/fixtures/es2022/class-properties/await-identifier-in-property-in-arguments-of-async-call/input.js:1:30]
- 1 │ async( x = class { x = await });
-   ·                              ─
-   ╰────
-
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-properties/await-in-property-in-params-of-async-arrow/input.js
 
-  × Unexpected token
-   ╭─[babel/packages/babel-parser/test/fixtures/es2022/class-properties/await-in-property-in-params-of-async-arrow/input.js:1:30]
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[babel/packages/babel-parser/test/fixtures/es2022/class-properties/await-in-property-in-params-of-async-arrow/input.js:1:32]
  1 │ async( x = class { x = await }) => {}
-   ·                              ─
+   ·                                ▲
    ╰────
+  help: Try insert a semicolon here
 
 Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-properties/new-target/input.js
 
@@ -1696,32 +1674,14 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
  1 │ 3e
    ╰────
 
-  × Invalid Number invalid float
-   ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/349/input.js:1:1]
- 1 │ 3e
-   · ──
-   ╰────
-
   × Unexpected end of file
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/350/input.js:1:4]
  1 │ 3e+
    ╰────
 
-  × Invalid Number invalid float
-   ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/350/input.js:1:1]
- 1 │ 3e+
-   · ───
-   ╰────
-
   × Unexpected end of file
    ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/351/input.js:1:4]
  1 │ 3e-
-   ╰────
-
-  × Invalid Number invalid float
-   ╭─[babel/packages/babel-parser/test/fixtures/core/uncategorised/351/input.js:1:1]
- 1 │ 3e-
-   · ───
    ╰────
 
   × Invalid characters after number
@@ -5718,11 +5678,26 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Try insert a semicolon here
 
-  × Unexpected token
-   ╭─[babel/packages/babel-parser/test/fixtures/es2017/async-functions/multiple-await-in-async-arrow-params/input.js:1:22]
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[babel/packages/babel-parser/test/fixtures/es2017/async-functions/multiple-await-in-async-arrow-params/input.js:1:41]
  1 │ async ({ x = [ await ], y = { await } }) => {}
-   ·                      ─
+   ·                                         ▲
    ╰────
+  help: Try insert a semicolon here
+
+  × Invalid assignment in object literal
+   ╭─[babel/packages/babel-parser/test/fixtures/es2017/async-functions/multiple-await-in-async-arrow-params/input.js:1:10]
+ 1 │ async ({ x = [ await ], y = { await } }) => {}
+   ·          ─────────────
+   ╰────
+  help: Did you mean to use a ':'? An '=' can only follow a property name when the containing object literal is part of a destructuring pattern.
+
+  × Invalid assignment in object literal
+   ╭─[babel/packages/babel-parser/test/fixtures/es2017/async-functions/multiple-await-in-async-arrow-params/input.js:1:25]
+ 1 │ async ({ x = [ await ], y = { await } }) => {}
+   ·                         ─────────────
+   ╰────
+  help: Did you mean to use a ':'? An '=' can only follow a property name when the containing object literal is part of a destructuring pattern.
 
   × Line terminator not permitted before arrow
    ╭─[babel/packages/babel-parser/test/fixtures/es2017/async-functions/newline-before-arrow/input.js:2:1]
@@ -8448,11 +8423,12 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ╰────
   help: Try insert a semicolon here
 
-  × Unexpected token
-   ╭─[babel/packages/babel-parser/test/fixtures/es2022/class-properties/await-in-computed-property-in-params-of-async-arrow/input.js:1:26]
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[babel/packages/babel-parser/test/fixtures/es2022/class-properties/await-in-computed-property-in-params-of-async-arrow/input.js:1:34]
  1 │ async( x = class { [await] = x }) => {}
-   ·                          ─
+   ·                                  ▲
    ╰────
+  help: Try insert a semicolon here
 
   × Unexpected new.target expression
    ╭─[babel/packages/babel-parser/test/fixtures/es2022/class-properties/new-target-invalid/input.js:1:9]
@@ -9815,12 +9791,6 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·   ▲
    ╰────
 
-  × Invalid Number invalid float
-   ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0004/input.js:1:1]
- 1 │ 3e
-   · ──
-   ╰────
-
   × Invalid Character `
   │ `
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0005/input.js:1:4]
@@ -9828,23 +9798,11 @@ Expect to Parse: tasks/coverage/babel/packages/babel-parser/test/fixtures/typesc
    ·    ▲
    ╰────
 
-  × Invalid Number invalid float
-   ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0005/input.js:1:1]
- 1 │ 3e+
-   · ───
-   ╰────
-
   × Invalid Character `
   │ `
    ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0006/input.js:1:4]
  1 │ 3e-
    ·    ▲
-   ╰────
-
-  × Invalid Number invalid float
-   ╭─[babel/packages/babel-parser/test/fixtures/esprima/invalid-syntax/migrated_0006/input.js:1:1]
- 1 │ 3e-
-   · ───
    ╰────
 
   × Invalid characters after number

--- a/tasks/coverage/snapshots/parser_test262.snap
+++ b/tasks/coverage/snapshots/parser_test262.snap
@@ -2670,13 +2670,6 @@ Negative Passed: 4519/4519 (100.00%)
     ·   ──
     ╰────
 
-  × Invalid Unicode escape sequence
-   ╭─[test262/test/language/comments/hashbang/escaped-bang-041.js:1:3]
- 1 │ #\041
-   ·   ─
- 2 │ 
-   ╰────
-
   × Expected `in` but found `throw`
     ╭─[test262/test/language/comments/hashbang/escaped-bang-041.js:20:1]
  19 │ 
@@ -2684,13 +2677,6 @@ Negative Passed: 4519/4519 (100.00%)
     · ──┬──
     ·   ╰── `in` expected
     ╰────
-
-  × Invalid Character `!`
-   ╭─[test262/test/language/comments/hashbang/escaped-bang-u0021.js:1:8]
- 1 │ #\u0021
-   ·        ▲
- 2 │ 
-   ╰────
 
   × Expected `in` but found `throw`
     ╭─[test262/test/language/comments/hashbang/escaped-bang-u0021.js:20:1]
@@ -2700,13 +2686,6 @@ Negative Passed: 4519/4519 (100.00%)
     ·   ╰── `in` expected
     ╰────
 
-  × Invalid Character `!`
-   ╭─[test262/test/language/comments/hashbang/escaped-bang-u21.js:1:8]
- 1 │ #\u{21}
-   ·        ▲
- 2 │ 
-   ╰────
-
   × Expected `in` but found `throw`
     ╭─[test262/test/language/comments/hashbang/escaped-bang-u21.js:20:1]
  19 │ 
@@ -2714,13 +2693,6 @@ Negative Passed: 4519/4519 (100.00%)
     · ──┬──
     ·   ╰── `in` expected
     ╰────
-
-  × Invalid Unicode escape sequence
-   ╭─[test262/test/language/comments/hashbang/escaped-bang-x21.js:1:3]
- 1 │ #\x21
-   ·   ─
- 2 │ 
-   ╰────
 
   × Expected `in` but found `throw`
     ╭─[test262/test/language/comments/hashbang/escaped-bang-x21.js:20:1]
@@ -6675,12 +6647,13 @@ Negative Passed: 4519/4519 (100.00%)
  18 │ 
     ╰────
 
-  × Unexpected token
-    ╭─[test262/test/language/expressions/async-arrow-function/early-errors-arrow-await-in-formals-default.js:15:16]
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+    ╭─[test262/test/language/expressions/async-arrow-function/early-errors-arrow-await-in-formals-default.js:15:17]
  14 │ $DONOTEVALUATE();
  15 │ async(x = await) => {  }
-    ·                ─
+    ·                 ▲
     ╰────
+  help: Try insert a semicolon here
 
   × Cannot use `await` as an identifier in an async context
     ╭─[test262/test/language/expressions/async-arrow-function/early-errors-arrow-await-in-formals.js:15:7]
@@ -34291,11 +34264,11 @@ Negative Passed: 4519/4519 (100.00%)
     ·          ─────
     ╰────
 
-  × Spread must be last element
-    ╭─[test262/test/language/statements/for-in/dstr/array-rest-before-element.js:33:7]
+  × Unexpected token
+    ╭─[test262/test/language/statements/for-in/dstr/array-rest-before-element.js:33:6]
  32 │ 
  33 │ for ([...x, y] in [[]]) ;
-    ·       ────
+    ·      ─────────
     ╰────
 
   × Unexpected trailing comma after rest element
@@ -34305,11 +34278,11 @@ Negative Passed: 4519/4519 (100.00%)
     ·           ─
     ╰────
 
-  × Spread must be last element
-    ╭─[test262/test/language/statements/for-in/dstr/array-rest-before-rest.js:33:7]
+  × Unexpected token
+    ╭─[test262/test/language/statements/for-in/dstr/array-rest-before-rest.js:33:6]
  32 │ 
  33 │ for ([...x, ...y] in [[]]) ;
-    ·       ────
+    ·      ────────────
     ╰────
 
   × Unexpected trailing comma after rest element
@@ -34797,11 +34770,11 @@ Negative Passed: 4519/4519 (100.00%)
     ·          ─────
     ╰────
 
-  × Spread must be last element
-    ╭─[test262/test/language/statements/for-of/dstr/array-rest-before-element.js:33:7]
+  × Unexpected token
+    ╭─[test262/test/language/statements/for-of/dstr/array-rest-before-element.js:33:6]
  32 │ 
  33 │ for ([...x, y] of [[]]) ;
-    ·       ────
+    ·      ─────────
     ╰────
 
   × Unexpected trailing comma after rest element
@@ -34811,11 +34784,11 @@ Negative Passed: 4519/4519 (100.00%)
     ·           ─
     ╰────
 
-  × Spread must be last element
-    ╭─[test262/test/language/statements/for-of/dstr/array-rest-before-rest.js:33:7]
+  × Unexpected token
+    ╭─[test262/test/language/statements/for-of/dstr/array-rest-before-rest.js:33:6]
  32 │ 
  33 │ for ([...x, ...y] of [[]]) ;
-    ·       ────
+    ·      ────────────
     ╰────
 
   × Unexpected trailing comma after rest element

--- a/tasks/coverage/snapshots/parser_typescript.snap
+++ b/tasks/coverage/snapshots/parser_typescript.snap
@@ -12316,12 +12316,11 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╰────
   help: Try insert a semicolon here
 
-  × Expected `<` but found `EOF`
+  × Unexpected token
     ╭─[typescript/tests/cases/compiler/errorSpanForUnclosedJsxTag.tsx:11:18]
  10 │ 
  11 │ let y = <   Baz >Hello
-    ·                  ──┬──
-    ·                    ╰── `<` expected
+    ·                  ─────
     ╰────
 
   × 'with' statements are not allowed
@@ -13219,6 +13218,15 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  2 │ }
  3 │ export default var a = 10;
    ·                ───
+   ╰────
+
+  × Duplicated default export
+   ╭─[typescript/tests/cases/compiler/jsFileCompilationBindMultipleDefaultExports.ts:1:8]
+ 1 │ export default class a {
+   ·        ───────
+ 2 │ }
+ 3 │ export default var a = 10;
+   ·        ───────
    ╰────
 
   × The keyword 'let' is reserved
@@ -15199,14 +15207,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  2 │ }
    ╰────
 
-  × Expected `{` but found `Unknown`
-   ╭─[typescript/tests/cases/compiler/parseErrorInHeritageClause1.ts:1:19]
- 1 │ class C extends A ¬ {
-   ·                   ┬
-   ·                   ╰── `{` expected
- 2 │ }
-   ╰────
-
   × Unexpected token
    ╭─[typescript/tests/cases/compiler/parseErrorIncorrectReturnToken.ts:2:17]
  1 │ type F1 = {
@@ -15434,20 +15434,18 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·    ─
    ╰────
 
-  × Expected `<` but found `EOF`
+  × Unexpected token
    ╭─[typescript/tests/cases/compiler/parseUnaryExpressionNoTypeAssertionInJsx1.ts:2:21]
  1 │ const x = "oops";
  2 │ const y = + <number> x;
-   ·                     ─┬─
-   ·                      ╰── `<` expected
+   ·                     ───
    ╰────
 
-  × Expected `<` but found `EOF`
+  × Unexpected token
    ╭─[typescript/tests/cases/compiler/parseUnaryExpressionNoTypeAssertionInJsx2.ts:2:15]
  1 │ const x = "oops";
  2 │ const y = + <> x;
-   ·               ─┬─
-   ·                ╰── `<` expected
+   ·               ───
    ╰────
 
   × Unexpected token
@@ -17741,6 +17739,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  5 │ f `123qdawdrqw${
    ╰────
 
+  × Unterminated string
+   ╭─[typescript/tests/cases/compiler/taggedTemplatesWithIncompleteTemplateExpressions2.ts:5:20]
+ 4 │ // Incomplete call, enough parameters.
+ 5 │ f `123qdawdrqw${ }${
+   ·                    ─
+   ╰────
+
   × Unexpected token
    ╭─[typescript/tests/cases/compiler/taggedTemplatesWithIncompleteTemplateExpressions2.ts:5:18]
  4 │ // Incomplete call, enough parameters.
@@ -17752,6 +17757,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╭─[typescript/tests/cases/compiler/taggedTemplatesWithIncompleteTemplateExpressions3.ts:5:23]
  4 │ // Incomplete call, not enough parameters.
  5 │ f `123qdawdrqw${ 1 }${
+   ╰────
+
+  × Unterminated string
+   ╭─[typescript/tests/cases/compiler/taggedTemplatesWithIncompleteTemplateExpressions4.ts:5:27]
+ 4 │ // Incomplete call, but too many parameters.
+ 5 │ f `123qdawdrqw${ 1 }${ }${ 
+   ·                           ─
    ╰────
 
   × Unexpected token
@@ -18419,12 +18431,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  2 │ }
    ╰────
 
-  × Unexpected token
-   ╭─[typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction6_es2017.ts:1:27]
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction6_es2017.ts:1:28]
  1 │ var foo = async (a = await): Promise<void> => {
-   ·                           ─
+   ·                            ▲
  2 │ }
    ╰────
+  help: Try insert a semicolon here
 
   × Unexpected token
    ╭─[typescript/tests/cases/conformance/async/es2017/asyncArrowFunction/asyncArrowFunction7_es2017.ts:3:29]
@@ -18507,12 +18520,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  2 │ }
    ╰────
 
-  × Unexpected token
-   ╭─[typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction6_es5.ts:1:27]
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction6_es5.ts:1:28]
  1 │ var foo = async (a = await): Promise<void> => {
-   ·                           ─
+   ·                            ▲
  2 │ }
    ╰────
+  help: Try insert a semicolon here
 
   × Unexpected token
    ╭─[typescript/tests/cases/conformance/async/es5/asyncArrowFunction/asyncArrowFunction7_es5.ts:3:29]
@@ -18648,12 +18662,13 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  2 │ }
    ╰────
 
-  × Unexpected token
-   ╭─[typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction6_es6.ts:1:27]
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction6_es6.ts:1:28]
  1 │ var foo = async (a = await): Promise<void> => {
-   ·                           ─
+   ·                            ▲
  2 │ }
    ╰────
+  help: Try insert a semicolon here
 
   × Unexpected token
    ╭─[typescript/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction7_es6.ts:3:29]
@@ -21585,11 +21600,12 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·           ─
    ╰────
 
-  × Unexpected token
-   ╭─[typescript/tests/cases/conformance/es6/functionPropertyAssignments/FunctionPropertyAssignments6_es6.ts:1:11]
+  × Expected a semicolon or an implicit semicolon after a statement, but found none
+   ╭─[typescript/tests/cases/conformance/es6/functionPropertyAssignments/FunctionPropertyAssignments6_es6.ts:1:17]
  1 │ var v = { *<T>() { } }
-   ·           ─
+   ·                 ▲
    ╰────
+  help: Try insert a semicolon here
 
   × Unexpected token
    ╭─[typescript/tests/cases/conformance/es6/memberFunctionDeclarations/MemberFunctionDeclaration4_es6.ts:2:5]
@@ -25904,15 +25920,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  3 │     return;
    ╰────
 
-  × Expected `}` but found `Unknown`
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/Blocks/parserErrorRecovery_Block2.ts:2:5]
- 1 │ function f() {
- 2 │     ¬
-   ·     ┬
-   ·     ╰── `}` expected
- 3 │     return;
-   ╰────
-
   × Expected a semicolon or an implicit semicolon after a statement, but found none
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/Blocks/parserErrorRecovery_Block3.ts:4:12]
  3 │ 
@@ -25945,15 +25952,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  1 │ module M {
  2 │    ¬
    ·    ─
- 3 │    class C {
-   ╰────
-
-  × Expected `}` but found `Unknown`
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ClassElements/parserErrorRecovery_ClassElement3.ts:2:4]
- 1 │ module M {
- 2 │    ¬
-   ·    ┬
-   ·    ╰── `}` expected
  3 │    class C {
    ╰────
 
@@ -27233,11 +27231,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  1 │ foo(a, \
    ╰────
 
-  × Invalid Unicode escape sequence
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens18.ts:1:8]
- 1 │ foo(a \
-   ╰────
-
   × Expected `,` but found `Identifier`
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens18.ts:1:7]
  1 │ foo(a \
@@ -27263,11 +27256,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ·  ─
    ╰────
 
-  × Invalid Unicode escape sequence
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens20.ts:1:13]
- 1 │ var v: X<T \
-   ╰────
-
   × Expected `,` but found `Identifier`
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens20.ts:1:12]
  1 │ var v: X<T \
@@ -27290,12 +27278,6 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
    ╭─[typescript/tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens4.ts:1:2]
  1 │ \  /regexp/;
    ·  ─
-   ╰────
-
-  × Unexpected token
-   ╭─[typescript/tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens4.ts:1:12]
- 1 │ \  /regexp/;
-   ·            ─
    ╰────
 
   × Invalid Unicode escape sequence
@@ -28342,21 +28324,9 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  1 │ 1e
    ╰────
 
-  × Invalid Number invalid float
-   ╭─[typescript/tests/cases/conformance/scanner/ecmascript3/scannerES3NumericLiteral4.ts:1:1]
- 1 │ 1e
-   · ──
-   ╰────
-
   × Unexpected end of file
    ╭─[typescript/tests/cases/conformance/scanner/ecmascript3/scannerES3NumericLiteral6.ts:1:4]
  1 │ 1e+
-   ╰────
-
-  × Invalid Number invalid float
-   ╭─[typescript/tests/cases/conformance/scanner/ecmascript3/scannerES3NumericLiteral6.ts:1:1]
- 1 │ 1e+
-   · ───
    ╰────
 
   × The keyword 'public' is reserved
@@ -28378,21 +28348,9 @@ Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/salsa/private
  1 │ 1e
    ╰────
 
-  × Invalid Number invalid float
-   ╭─[typescript/tests/cases/conformance/scanner/ecmascript5/scannerNumericLiteral4.ts:1:1]
- 1 │ 1e
-   · ──
-   ╰────
-
   × Unexpected end of file
    ╭─[typescript/tests/cases/conformance/scanner/ecmascript5/scannerNumericLiteral6.ts:1:4]
  1 │ 1e+
-   ╰────
-
-  × Invalid Number invalid float
-   ╭─[typescript/tests/cases/conformance/scanner/ecmascript5/scannerNumericLiteral6.ts:1:1]
- 1 │ 1e+
-   · ───
    ╰────
 
   × Unterminated multiline comment

--- a/tasks/coverage/snapshots/semantic_babel.snap
+++ b/tasks/coverage/snapshots/semantic_babel.snap
@@ -2,7 +2,7 @@ commit: 578ac4df
 
 semantic_babel Summary:
 AST Parsed     : 2322/2322 (100.00%)
-Positive Passed: 1900/2322 (81.83%)
+Positive Passed: 1903/2322 (81.96%)
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/annex-b/enabled/3.3-function-in-if-body/input.js
 Symbol scope ID mismatch for "f":
 after transform: SymbolId(0): ScopeId(4294967294)
@@ -77,17 +77,11 @@ Scope flags mismatch:
 after transform: ScopeId(5): ScopeFlags(StrictMode)
 rebuilt        : ScopeId(7): ScopeFlags(0x0)
 
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-private-properties/await-identifier-in-property-in-arguments-of-async-call/input.js
-Unexpected token
-
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-private-properties/await-in-private-property-in-params-of-async-arrow/input.js
-Unexpected token
+Expected a semicolon or an implicit semicolon after a statement, but found none
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-properties/arguments-in-key/input.js
 'arguments' is not allowed in class field initializer
-
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-properties/await-identifier-in-computed-property-in-arguments-of-async-call/input.js
-Unexpected token
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-properties/await-identifier-in-computed-property-inside-params-of-function-inside-params-of-async-function/input.js
 Bindings mismatch:
@@ -100,11 +94,8 @@ Symbol scope ID mismatch for "_await":
 after transform: SymbolId(3): ScopeId(2)
 rebuilt        : SymbolId(2): ScopeId(0)
 
-semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-properties/await-identifier-in-property-in-arguments-of-async-call/input.js
-Unexpected token
-
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-properties/await-in-property-in-params-of-async-arrow/input.js
-Unexpected token
+Expected a semicolon or an implicit semicolon after a statement, but found none
 
 semantic Error: tasks/coverage/babel/packages/babel-parser/test/fixtures/es2022/class-properties/new-target/input.js
 Unexpected new.target expression


### PR DESCRIPTION
All credits to @overlookmotel

In parser, optimize for common case that file parses successfully.

Instead of parse_* methods returning Result<T>s which are checked with `?` in the caller, always return a valid node T.

In case of a fatal parsing error:

* Record the error in fatal_error property of ParserImpl.
* Also record current length of errors.
* Fast forward the lexer to EOF, so parsing will come to an end swiftly.
* Create a dummy node of the required type and return it.
* At end of parsing, if `fatal_error.is_some()`, then there was a fatal error. In that case:

Truncate errors to the length it was at time of the fatal error (because more errors may occur as the parser finds it's unexpectedly at EOF).
Add fatal_error to errors.
i.e. all parse methods never fail, they just return nonsense if there's a fatal error. This removes all the branches implicit in `?`.

---


Wall clock benchmark:

```
oxc  main ❯ hyperfine './target/release/examples/parser-new ./target/typescript.js' './target/release/examples/parser ./target/typescript.js'
Benchmark 1: ./target/release/examples/parser-new ./target/typescript.js
  Time (mean ± σ):      42.7 ms ±   2.1 ms    [User: 36.7 ms, System: 5.3 ms]
  Range (min … max):    41.6 ms …  59.6 ms    68 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet system without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Benchmark 2: ./target/release/examples/parser ./target/typescript.js
  Time (mean ± σ):      44.2 ms ±   0.7 ms    [User: 38.3 ms, System: 5.4 ms]
  Range (min … max):    43.7 ms …  48.6 ms    64 runs

Summary
  ./target/release/examples/parser-new ./target/typescript.js ran
    1.04 ± 0.05 times faster than ./target/release/examples/parser ./target/typescript.js
```

/usr/bin/time -al:

```
old: 517424069  instructions retired
new: 492334561  instructions retired
```

uses 5% less CPU instructions.

---

Testing:
* passed https://github.com/oxc-project/monitor-oxc
* passed Rolldown
* Did some fuzzing with https://github.com/oxc-project/fuzz-oxc, found no crashes.