### PR TITLE
test(typescript): refactor splitting up TS fixtures into units

### DIFF
--- a/tasks/coverage/src/typescript/meta.rs
+++ b/tasks/coverage/src/typescript/meta.rs
@@ -102,22 +102,20 @@ impl TestCaseContent {
 
         for line in code.lines() {
             if let Some(option) = META_OPTIONS.captures(line) {
-                let meta_name = option.name("name").unwrap().as_str();
-                let meta_name = meta_name.to_lowercase();
-                let meta_value = option.name("value").unwrap().as_str();
-                let meta_value = meta_value.trim();
-                if meta_name != "filename" {
-                    current_file_options.insert(meta_name.clone(), meta_value.to_string());
-                    continue;
+                let meta_name = option.name("name").unwrap().as_str().to_lowercase();
+                let meta_value = option.name("value").unwrap().as_str().trim().to_string();
+                if meta_name == "filename" {
+                    if let Some(file_name) = current_file_name.take() {
+                        test_unit_data.push(TestUnitData {
+                            name: file_name,
+                            content: std::mem::take(&mut current_file_content),
+                            source_type: SourceType::default(),
+                        });
+                    }
+                    current_file_name = Some(meta_value);
+                } else {
+                    current_file_options.insert(meta_name, meta_value);
                 }
-                if let Some(file_name) = current_file_name.take() {
-                    test_unit_data.push(TestUnitData {
-                        name: file_name,
-                        content: std::mem::take(&mut current_file_content),
-                        source_type: SourceType::default(),
-                    });
-                }
-                current_file_name = Some(meta_value.to_string());
             } else {
                 if !current_file_content.is_empty() {
                     current_file_content.push('\n');


### PR DESCRIPTION
Pure refactor. Shorten and clarify the code in conformance tester which splits a TypeScript fixture file into separate units.
