### PR TITLE
fix(linter): cross_module of LintService not being enabled despite enabled import plugin

### DIFF
--- a/apps/oxlint/fixtures/import-cycle/a.ts
+++ b/apps/oxlint/fixtures/import-cycle/a.ts
@@ -1,0 +1,5 @@
+import { B } from "./b";
+
+export class A {
+  value: B;
+}

--- a/apps/oxlint/fixtures/import-cycle/b.ts
+++ b/apps/oxlint/fixtures/import-cycle/b.ts
@@ -1,0 +1,5 @@
+import { A } from "./a";
+
+export class B {
+  value: A;
+}

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -1133,4 +1133,11 @@ mod test {
             .with_cwd("fixtures/cross_module_extended_config".into())
             .test_and_snapshot(args);
     }
+
+    #[test]
+    fn test_import_plugin_being_enabled_correctly() {
+        // https://github.com/oxc-project/oxc/pull/10597
+        let args = &["--import-plugin", "-D", "import/no-cycle"];
+        Tester::new().with_cwd("fixtures/import-cycle".into()).test_and_snapshot(args);
+    }
 }

--- a/apps/oxlint/src/lint.rs
+++ b/apps/oxlint/src/lint.rs
@@ -59,7 +59,7 @@ impl Runner for LintRunner {
             ..
         } = self.options;
 
-        let use_nested_config = !disable_nested_config &&
+        let search_for_nested_configs = !disable_nested_config &&
             // If the `--config` option is explicitly passed, we should not search for nested config files
             // as the passed config file takes absolute precedence.
             basic_options.config.is_none();
@@ -171,7 +171,7 @@ impl Runner for LintRunner {
 
         let handler = GraphicalReportHandler::new();
 
-        if use_nested_config {
+        if search_for_nested_configs {
             // get all of the unique directories among the paths to use for search for
             // oxlint config files in those directories and their ancestors
             // e.g. `/some/file.js` will check `/some` and `/`
@@ -290,10 +290,10 @@ impl Runner for LintRunner {
 
         // TODO(refactor): pull this into a shared function, so that the language server can use
         // the same functionality.
-        let use_cross_module = if use_nested_config {
-            nested_configs.values().any(|config| config.plugins().has_import())
-        } else {
+        let use_cross_module = if nested_configs.is_empty() {
             config_builder.plugins().has_import()
+        } else {
+            nested_configs.values().any(|config| config.plugins().has_import())
         };
         let mut options =
             LintServiceOptions::new(self.cwd, paths).with_cross_module(use_cross_module);
@@ -319,12 +319,12 @@ impl Runner for LintRunner {
             _ => None,
         };
 
-        let linter = if use_nested_config {
-            Linter::new_with_nested_configs(LintOptions::default(), lint_config, nested_configs)
+        let linter = if nested_configs.is_empty() {
+            Linter::new(LintOptions::default(), lint_config)
                 .with_fix(fix_options.fix_kind())
                 .with_report_unused_directives(report_unused_directives)
         } else {
-            Linter::new(LintOptions::default(), lint_config)
+            Linter::new_with_nested_configs(LintOptions::default(), lint_config, nested_configs)
                 .with_fix(fix_options.fix_kind())
                 .with_report_unused_directives(report_unused_directives)
         };

--- a/apps/oxlint/src/snapshots/fixtures__import-cycle_--import-plugin -D import__no-cycle@oxlint.snap
+++ b/apps/oxlint/src/snapshots/fixtures__import-cycle_--import-plugin -D import__no-cycle@oxlint.snap
@@ -1,0 +1,33 @@
+---
+source: apps/oxlint/src/tester.rs
+---
+########## 
+arguments: --import-plugin -D import/no-cycle
+working directory: fixtures/import-cycle
+----------
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html\eslint-plugin-import(no-cycle)]8;;\: Dependency cycle detected
+   ,-[a.ts:1:19]
+ 1 | import { B } from "./b";
+   :                   ^^^^^
+ 2 | 
+   `----
+  help: These paths form a cycle:
+        -> ./b - fixtures/import-cycle/b.ts
+        -> ./a - fixtures/import-cycle/a.ts
+
+  x ]8;;https://oxc.rs/docs/guide/usage/linter/rules/import/no-cycle.html\eslint-plugin-import(no-cycle)]8;;\: Dependency cycle detected
+   ,-[b.ts:1:19]
+ 1 | import { A } from "./a";
+   :                   ^^^^^
+ 2 | 
+   `----
+  help: These paths form a cycle:
+        -> ./a - fixtures/import-cycle/a.ts
+        -> ./b - fixtures/import-cycle/b.ts
+
+Found 0 warnings and 2 errors.
+Finished in <variable>ms on 2 files with 102 rules using 1 threads.
+----------
+CLI result: LintFoundErrors
+----------


### PR DESCRIPTION
Running `oxlint --import-plugin` with no `oxlintrc.json` didn't enable `cross_module` of `LintService`, because `use_nested_config` was `true` and `nested_configs` empty in that case. This leads to rules like `import/no-cycle` not working.