### PR TITLE
test(ast/estree): skip tests related to hashbangs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1697,6 +1697,7 @@ name = "oxc_coverage"
 version = "0.0.0"
 dependencies = [
  "console",
+ "constcat",
  "cow-utils",
  "encoding_rs",
  "encoding_rs_io",

--- a/tasks/coverage/Cargo.toml
+++ b/tasks/coverage/Cargo.toml
@@ -28,6 +28,7 @@ oxc_tasks_common = { workspace = true }
 oxc_tasks_transform_checker = { workspace = true }
 
 console = { workspace = true }
+constcat = { workspace = true }
 cow-utils = { workspace = true }
 encoding_rs = { workspace = true }
 encoding_rs_io = { workspace = true }

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -1,23 +1,11 @@
 commit: 15392346
 
 estree_typescript Summary:
-AST Parsed     : 6487/6488 (99.98%)
-Positive Passed: 6470/6488 (99.72%)
+AST Parsed     : 6481/6482 (99.98%)
+Positive Passed: 6470/6482 (99.81%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowInstanceofWithSymbolHasInstance.ts
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitBundleWithShebang1.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitBundleWithShebang2.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitBundleWithShebangAndPrologueDirectives1.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitBundleWithShebangAndPrologueDirectives2.ts
-
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingUnionToUnion.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/shebang.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/shebangBeforeReferences.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringMultiline3.ts
 


### PR DESCRIPTION
We intentionally add a `hashbang` field to `Program`, which isn't present in ESTree or TS-ESTree AST. This causes some tests to erroneously fail. So skip them.

#10669 adds hashbangs to `comments` in ESTree AST to align with Acorn, and adds tests relating to hashbangs to `napi/parser`, so our test coverage for hashbangs is maintained, despite skipping these tests.