### PR TITLE
fix(ast/estree): correct `this` in `TSTypeName` in TS-ESTree AST

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -770,6 +770,7 @@ pub struct TSTypeReference<'a> {
 #[derive(Debug)]
 #[generate_derive(CloneIn, Dummy, TakeIn, GetSpan, GetSpanMut, GetAddress, ContentEq, ESTree)]
 pub enum TSTypeName<'a> {
+    #[estree(via = TSTypeNameIdentifierReference)]
     IdentifierReference(Box<'a, IdentifierReference<'a>>) = 0,
     QualifiedName(Box<'a, TSQualifiedName<'a>>) = 1,
 }

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -2763,7 +2763,9 @@ impl ESTree for TSTypeReference<'_> {
 impl ESTree for TSTypeName<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
-            Self::IdentifierReference(it) => it.serialize(serializer),
+            Self::IdentifierReference(it) => {
+                crate::serialize::TSTypeNameIdentifierReference(it).serialize(serializer)
+            }
             Self::QualifiedName(it) => it.serialize(serializer),
         }
     }
@@ -3118,7 +3120,9 @@ impl ESTree for TSTypeQueryExprName<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             Self::TSImportType(it) => it.serialize(serializer),
-            Self::IdentifierReference(it) => it.serialize(serializer),
+            Self::IdentifierReference(it) => {
+                crate::serialize::TSTypeNameIdentifierReference(it).serialize(serializer)
+            }
             Self::QualifiedName(it) => it.serialize(serializer),
         }
     }
@@ -3252,7 +3256,9 @@ impl ESTree for TSModuleReference<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             Self::ExternalModuleReference(it) => it.serialize(serializer),
-            Self::IdentifierReference(it) => it.serialize(serializer),
+            Self::IdentifierReference(it) => {
+                crate::serialize::TSTypeNameIdentifierReference(it).serialize(serializer)
+            }
             Self::QualifiedName(it) => it.serialize(serializer),
         }
     }

--- a/napi/parser/deserialize-js.js
+++ b/napi/parser/deserialize-js.js
@@ -3796,7 +3796,9 @@ function deserializeTSTupleElement(pos) {
 function deserializeTSTypeName(pos) {
   switch (uint8[pos]) {
     case 0:
-      return deserializeBoxIdentifierReference(pos + 8);
+      let id = deserializeIdentifierReference(pos + 8);
+      if (id.name === 'this') id = { type: 'ThisExpression', start: id.start, end: id.end };
+      return id;
     case 1:
       return deserializeBoxTSQualifiedName(pos + 8);
     default:
@@ -3896,7 +3898,9 @@ function deserializeTSModuleDeclarationBody(pos) {
 function deserializeTSTypeQueryExprName(pos) {
   switch (uint8[pos]) {
     case 0:
-      return deserializeBoxIdentifierReference(pos + 8);
+      let id = deserializeIdentifierReference(pos + 8);
+      if (id.name === 'this') id = { type: 'ThisExpression', start: id.start, end: id.end };
+      return id;
     case 1:
       return deserializeBoxTSQualifiedName(pos + 8);
     case 2:
@@ -3914,7 +3918,9 @@ function deserializeTSMappedTypeModifierOperator(pos) {
 function deserializeTSModuleReference(pos) {
   switch (uint8[pos]) {
     case 0:
-      return deserializeBoxIdentifierReference(pos + 8);
+      let id = deserializeIdentifierReference(pos + 8);
+      if (id.name === 'this') id = { type: 'ThisExpression', start: id.start, end: id.end };
+      return id;
     case 1:
       return deserializeBoxTSQualifiedName(pos + 8);
     case 2:

--- a/napi/parser/deserialize-ts.js
+++ b/napi/parser/deserialize-ts.js
@@ -3948,7 +3948,9 @@ function deserializeTSTupleElement(pos) {
 function deserializeTSTypeName(pos) {
   switch (uint8[pos]) {
     case 0:
-      return deserializeBoxIdentifierReference(pos + 8);
+      let id = deserializeIdentifierReference(pos + 8);
+      if (id.name === 'this') id = { type: 'ThisExpression', start: id.start, end: id.end };
+      return id;
     case 1:
       return deserializeBoxTSQualifiedName(pos + 8);
     default:
@@ -4048,7 +4050,9 @@ function deserializeTSModuleDeclarationBody(pos) {
 function deserializeTSTypeQueryExprName(pos) {
   switch (uint8[pos]) {
     case 0:
-      return deserializeBoxIdentifierReference(pos + 8);
+      let id = deserializeIdentifierReference(pos + 8);
+      if (id.name === 'this') id = { type: 'ThisExpression', start: id.start, end: id.end };
+      return id;
     case 1:
       return deserializeBoxTSQualifiedName(pos + 8);
     case 2:
@@ -4066,7 +4070,9 @@ function deserializeTSMappedTypeModifierOperator(pos) {
 function deserializeTSModuleReference(pos) {
   switch (uint8[pos]) {
     case 0:
-      return deserializeBoxIdentifierReference(pos + 8);
+      let id = deserializeIdentifierReference(pos + 8);
+      if (id.name === 'this') id = { type: 'ThisExpression', start: id.start, end: id.end };
+      return id;
     case 1:
       return deserializeBoxTSQualifiedName(pos + 8);
     case 2:

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -1176,7 +1176,7 @@ export interface TSTypeReference extends Span {
   typeArguments: TSTypeParameterInstantiation | null;
 }
 
-export type TSTypeName = IdentifierReference | TSQualifiedName;
+export type TSTypeName = IdentifierReference | ThisExpression | TSQualifiedName;
 
 export interface TSQualifiedName extends Span {
   type: 'TSQualifiedName';

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -2,7 +2,7 @@ commit: 15392346
 
 estree_typescript Summary:
 AST Parsed     : 11245/11404 (98.61%)
-Positive Passed: 11065/11404 (97.03%)
+Positive Passed: 11074/11404 (97.11%)
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/ClassDeclarationWithInvalidConstOnPropertyDeclaration.ts
 A class member cannot have the 'const' keyword.
 
@@ -48,8 +48,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/bigintWithoutLib.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/bluebirdStaticThis.ts
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/circularGetAccessor.ts
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/classExpressionPropertyModifiers.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
 
@@ -91,8 +89,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalMod
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declFileWithInternalModuleNameConflictsInExtendsClause3.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitHasTypesRefOnNamespaceUse.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/declarationEmitTypeofThisInClass.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/declareAlreadySeen.ts
 declare' modifier already seen.
@@ -405,10 +401,6 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/strictModeReservedWordI
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/thisAssignmentInNamespaceDeclaration1.ts
 Expected a semicolon or an implicit semicolon after a statement, but found none
 
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/thisInTypeQuery.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/typeofThisInMethodSignature.ts
-
 Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/unusedLocalsInMethod4.ts
 Missing initializer in const declaration
 
@@ -483,10 +475,6 @@ Unexpected token
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/members/privateNames/privateNameJsBadDeclaration.ts
 Unexpected token
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/initializerReferencingConstructorLocals.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/initializerReferencingConstructorParameters.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/propertyNamedConstructor.ts
 Classes can't have a field named 'constructor'
@@ -951,16 +939,10 @@ A rest element must be last in a destructuring pattern
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/rest/restElementMustBeLast.ts
 A rest element must be last in a destructuring pattern
 
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofThis.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/specifyingTypes/typeQueries/typeofThisWithImplicitThis.ts
-
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTags02.ts
 
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesInVariableDeclarations01.ts
 Missing initializer in const declaration
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/thisType/thisTypeInFunctions4.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/tuple/named/namedTupleMembersErrors.ts
 


### PR DESCRIPTION
Part of #9705.

TS-ESTree presents a `TSTypeName` which is an identifier `this` as a `ThisExpression`.

e.g. `type T = typeof this;` or `type T = typeof this.foo;`
