### PR TITLE
fix(linter): handle re-exporting of type correctly in `import/no-cycle`

### DIFF
--- a/crates/oxc_linter/fixtures/import/cycles/typescript/ts-types-re-exporting-type.ts
+++ b/crates/oxc_linter/fixtures/import/cycles/typescript/ts-types-re-exporting-type.ts
@@ -1,0 +1,2 @@
+// @ts-ignore
+export type { foo } from "../depth-zero";

--- a/crates/oxc_linter/src/snapshots/import_no_cycle.snap
+++ b/crates/oxc_linter/src/snapshots/import_no_cycle.snap
@@ -270,3 +270,12 @@ source: crates/oxc_linter/src/tester.rs
   help: These paths form a cycle:
         -> ./typescript/ts-types-some-type-imports - fixtures/import/cycles/typescript/ts-types-some-type-imports.ts
         -> ../depth-zero - fixtures/import/cycles/depth-zero.js
+
+  ⚠ eslint-plugin-import(no-cycle): Dependency cycle detected
+   ╭─[cycles/depth-zero.js:1:21]
+ 1 │ import { foo } from "./typescript/ts-types-re-exporting-type";
+   ·                     ─────────────────────────────────────────
+   ╰────
+  help: These paths form a cycle:
+        -> ./typescript/ts-types-re-exporting-type - fixtures/import/cycles/typescript/ts-types-re-exporting-type.ts
+        -> ../depth-zero - fixtures/import/cycles/depth-zero.js


### PR DESCRIPTION
Handle re-exporting of type correctly in import/no-cycle lint rule.
Added one passing test (ignoreTypes = default/true) and one failing test (ignoreTypes = false).
Closes #10547