### PR TITLE
refactor(traverse): take `&str` instead of `CompactStr` in `TraverseScoping::rename_symbol`

### DIFF
--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -96,7 +96,7 @@ use oxc_ast::{NONE, ast::*};
 use oxc_ast_visit::{VisitMut, walk_mut::walk_expression};
 use oxc_data_structures::stack::{NonEmptyStack, SparseStack};
 use oxc_semantic::{ReferenceFlags, SymbolId};
-use oxc_span::{CompactStr, GetSpan, SPAN};
+use oxc_span::{GetSpan, SPAN};
 use oxc_syntax::{
     scope::{ScopeFlags, ScopeId},
     symbol::SymbolFlags,
@@ -1016,9 +1016,9 @@ impl<'a> ArrowFunctionConverter<'a> {
     }
 
     /// Rename the `arguments` symbol to a new name.
-    fn rename_arguments_symbol(symbol_id: SymbolId, name: CompactStr, ctx: &mut TraverseCtx<'a>) {
+    fn rename_arguments_symbol(symbol_id: SymbolId, name: Atom<'a>, ctx: &mut TraverseCtx<'a>) {
         let scope_id = ctx.scoping().symbol_scope_id(symbol_id);
-        ctx.rename_symbol(symbol_id, scope_id, name);
+        ctx.rename_symbol(symbol_id, scope_id, name.as_str());
     }
 
     /// Transform the identifier reference for `arguments` if it's affected after transformation.
@@ -1039,7 +1039,7 @@ impl<'a> ArrowFunctionConverter<'a> {
         let binding = self.arguments_var_stack.last_or_init(|| {
             if let Some(symbol_id) = symbol_id {
                 let arguments_name = ctx.generate_uid_name("arguments");
-                Self::rename_arguments_symbol(symbol_id, arguments_name.into_compact_str(), ctx);
+                Self::rename_arguments_symbol(symbol_id, arguments_name, ctx);
                 // Record the symbol ID as a renamed `arguments` variable.
                 self.renamed_arguments_symbol_ids.insert(symbol_id);
                 BoundIdentifier::new(arguments_name, symbol_id)
@@ -1082,7 +1082,7 @@ impl<'a> ArrowFunctionConverter<'a> {
             let arguments_name = ctx.generate_uid_name("arguments");
             ident.name = arguments_name;
             let symbol_id = ident.symbol_id();
-            Self::rename_arguments_symbol(symbol_id, arguments_name.into_compact_str(), ctx);
+            Self::rename_arguments_symbol(symbol_id, arguments_name, ctx);
             // Record the symbol ID as a renamed `arguments` variable.
             self.renamed_arguments_symbol_ids.insert(symbol_id);
             BoundIdentifier::new(ident.name, symbol_id)

--- a/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
@@ -446,7 +446,7 @@ impl<'a> ClassProperties<'a, '_> {
             // Save replacement name in `clashing_symbols`
             *name = new_name;
             // Rename symbol and binding
-            ctx.rename_symbol(symbol_id, constructor_scope_id, new_name.into_compact_str());
+            ctx.rename_symbol(symbol_id, constructor_scope_id, new_name.as_str());
         }
 
         // Rename identifiers for clashing symbols in constructor params and body

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -4,7 +4,7 @@ use oxc_ast::{
     ast::{Expression, IdentifierReference, Statement},
 };
 use oxc_semantic::Scoping;
-use oxc_span::{Atom, CompactStr, Span};
+use oxc_span::{Atom, Span};
 use oxc_syntax::{
     reference::{ReferenceFlags, ReferenceId},
     scope::{ScopeFlags, ScopeId},
@@ -652,7 +652,7 @@ impl<'a> TraverseCtx<'a> {
     /// Panics in debug mode if either of the above are not satisfied.
     ///
     /// This is a shortcut for `ctx.scoping.rename_symbol`.
-    pub fn rename_symbol(&mut self, symbol_id: SymbolId, scope_id: ScopeId, new_name: CompactStr) {
+    pub fn rename_symbol(&mut self, symbol_id: SymbolId, scope_id: ScopeId, new_name: &str) {
         self.scoping.rename_symbol(symbol_id, scope_id, new_name);
     }
 }

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -7,7 +7,7 @@ use oxc_allocator::{Allocator, String as ArenaString, Vec as ArenaVec};
 use oxc_ast::ast::*;
 use oxc_ast_visit::Visit;
 use oxc_semantic::{NodeId, Reference, Scoping};
-use oxc_span::{CompactStr, SPAN};
+use oxc_span::SPAN;
 use oxc_syntax::{
     reference::{ReferenceFlags, ReferenceId},
     scope::{ScopeFlags, ScopeId},
@@ -437,13 +437,12 @@ impl<'a> TraverseScoping<'a> {
     /// * No binding already exists in scope for `new_name`.
     ///
     /// Panics in debug mode if either of the above are not satisfied.
-    #[expect(clippy::needless_pass_by_value)]
-    pub fn rename_symbol(&mut self, symbol_id: SymbolId, scope_id: ScopeId, new_name: CompactStr) {
+    pub fn rename_symbol(&mut self, symbol_id: SymbolId, scope_id: ScopeId, new_name: &str) {
         // Rename symbol
         // FIXME: remove `to_string`
-        let old_name = self.scoping.set_symbol_name(symbol_id, new_name.as_str()).to_string();
+        let old_name = self.scoping.set_symbol_name(symbol_id, new_name).to_string();
         // Rename binding
-        self.scoping.rename_binding(scope_id, symbol_id, &old_name, new_name.as_str());
+        self.scoping.rename_binding(scope_id, symbol_id, &old_name, new_name);
     }
 }
 


### PR DESCRIPTION
`Scoping` no longer needs a `CompactStr` so `into_compact_str` is unnecessary.