### PR TITLE
refactor(traverse, semantic): move `rename_symbol` from `TraverseScoping` to `Scoping`

### DIFF
--- a/crates/oxc_semantic/src/scoping.rs
+++ b/crates/oxc_semantic/src/scoping.rs
@@ -796,6 +796,21 @@ impl Scoping {
         });
     }
 
+    /// Rename symbol.
+    ///
+    /// The following must be true for successful operation:
+    /// * Binding exists in specified scope for `symbol_id`.
+    /// * No binding already exists in scope for `new_name`.
+    ///
+    /// Panics in debug mode if either of the above are not satisfied.
+    pub fn rename_symbol(&mut self, symbol_id: SymbolId, scope_id: ScopeId, new_name: &str) {
+        // Rename symbol
+        // FIXME: remove `to_string`
+        let old_name = self.set_symbol_name(symbol_id, new_name).to_string();
+        // Rename binding
+        self.rename_binding(scope_id, symbol_id, &old_name, new_name);
+    }
+
     pub fn delete_typescript_bindings(&mut self) {
         self.cell.with_dependent_mut(|_allocator, cell| {
             for bindings in &mut cell.bindings {

--- a/crates/oxc_transformer/src/common/arrow_function_converter.rs
+++ b/crates/oxc_transformer/src/common/arrow_function_converter.rs
@@ -1018,7 +1018,7 @@ impl<'a> ArrowFunctionConverter<'a> {
     /// Rename the `arguments` symbol to a new name.
     fn rename_arguments_symbol(symbol_id: SymbolId, name: Atom<'a>, ctx: &mut TraverseCtx<'a>) {
         let scope_id = ctx.scoping().symbol_scope_id(symbol_id);
-        ctx.rename_symbol(symbol_id, scope_id, name.as_str());
+        ctx.scoping_mut().rename_symbol(symbol_id, scope_id, name.as_str());
     }
 
     /// Transform the identifier reference for `arguments` if it's affected after transformation.

--- a/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
+++ b/crates/oxc_transformer/src/es2022/class_properties/constructor.rs
@@ -446,7 +446,7 @@ impl<'a> ClassProperties<'a, '_> {
             // Save replacement name in `clashing_symbols`
             *name = new_name;
             // Rename symbol and binding
-            ctx.rename_symbol(symbol_id, constructor_scope_id, new_name.as_str());
+            ctx.scoping_mut().rename_symbol(symbol_id, constructor_scope_id, new_name.as_str());
         }
 
         // Rename identifiers for clashing symbols in constructor params and body

--- a/crates/oxc_traverse/src/context/mod.rs
+++ b/crates/oxc_traverse/src/context/mod.rs
@@ -640,21 +640,6 @@ impl<'a> TraverseCtx<'a> {
     pub fn delete_reference_for_identifier(&mut self, ident: &IdentifierReference) {
         self.scoping.delete_reference_for_identifier(ident);
     }
-
-    /// Rename symbol.
-    ///
-    /// Preserves original order of bindings for scope.
-    ///
-    /// The following must be true for successful operation:
-    /// * Binding exists in specified scope for `symbol_id`.
-    /// * No binding already exists in scope for `new_name`.
-    ///
-    /// Panics in debug mode if either of the above are not satisfied.
-    ///
-    /// This is a shortcut for `ctx.scoping.rename_symbol`.
-    pub fn rename_symbol(&mut self, symbol_id: SymbolId, scope_id: ScopeId, new_name: &str) {
-        self.scoping.rename_symbol(symbol_id, scope_id, new_name);
-    }
 }
 
 // Methods used internally within crate

--- a/crates/oxc_traverse/src/context/scoping.rs
+++ b/crates/oxc_traverse/src/context/scoping.rs
@@ -429,21 +429,6 @@ impl<'a> TraverseScoping<'a> {
     pub fn delete_reference_for_identifier(&mut self, ident: &IdentifierReference) {
         self.delete_reference(ident.reference_id(), &ident.name);
     }
-
-    /// Rename symbol.
-    ///
-    /// The following must be true for successful operation:
-    /// * Binding exists in specified scope for `symbol_id`.
-    /// * No binding already exists in scope for `new_name`.
-    ///
-    /// Panics in debug mode if either of the above are not satisfied.
-    pub fn rename_symbol(&mut self, symbol_id: SymbolId, scope_id: ScopeId, new_name: &str) {
-        // Rename symbol
-        // FIXME: remove `to_string`
-        let old_name = self.scoping.set_symbol_name(symbol_id, new_name).to_string();
-        // Rename binding
-        self.scoping.rename_binding(scope_id, symbol_id, &old_name, new_name);
-    }
 }
 
 // Methods used internally within crate


### PR DESCRIPTION
Part of https://github.com/oxc-project/backlog/issues/163

Prepare #10612. I just found that this method has a `to_string` allocation that can be avoided. However, it needs to combine `set_symbol_name` and `rename_binding`, so move to `Semantic`.