### PR TITLE
perf(parser): mark error paths as cold

### DIFF
--- a/crates/oxc_parser/src/error_handler.rs
+++ b/crates/oxc_parser/src/error_handler.rs
@@ -40,6 +40,7 @@ impl<'a> ParserImpl<'a> {
     }
 
     /// Push a Syntax Error
+    #[cold]
     pub(crate) fn error(&mut self, error: OxcDiagnostic) {
         self.errors.push(error);
     }
@@ -50,6 +51,7 @@ impl<'a> ParserImpl<'a> {
     }
 
     /// Advance lexer's cursor to end of file.
+    #[cold]
     pub(crate) fn set_fatal_error(&mut self, error: OxcDiagnostic) {
         if self.fatal_error.is_none() {
             self.lexer.advance_to_end();
@@ -57,6 +59,7 @@ impl<'a> ParserImpl<'a> {
         }
     }
 
+    #[cold]
     pub(crate) fn fatal_error<T: Dummy<'a>>(&mut self, error: OxcDiagnostic) -> T {
         self.set_fatal_error(error);
         Dummy::dummy(self.ast.allocator)


### PR DESCRIPTION
## What This PR Does
Adds `#[cold]` to parser functions that record errors.

I'm making a draft for now to run benchmarks and see if my hypothesis is correct. Locally I saw some improvement, but my machine gets finicky when it heats up, so it could be noise.

## Hypothesis
LLVM will [consider call sites of `cold` functions to also be `cold`](https://arc.net/l/quote/byvkkmns) (assuming that the function is always called). By marking error recording functions as `#[cold]`, `if` statements that check for diagnostics _should_ be considered cold themselves, thus hinting to branch predictors that the happy path is more likely. This should give branch prediction a higher success rate and lower the odds the CPU's pipeline gets thrown out.

e.g.
```rs
fn parse_foo(&self) -> FooNode {
  if some_bad_thing {
    // this block post-dominates call to `error`, suggesting that it won't be called
    // frequently
    self.error(diagnostics::bad_thing_happened());
  }
  // happy path continues
}
```
