### PR TITLE
perf(parser): improve perf of checking for licence/legal comments

### DIFF
--- a/crates/oxc_parser/src/lexer/trivia_builder.rs
+++ b/crates/oxc_parser/src/lexer/trivia_builder.rs
@@ -1,3 +1,4 @@
+use memchr::memchr_iter;
 use oxc_ast::ast::{Comment, CommentAnnotation, CommentKind, CommentPosition};
 use oxc_span::Span;
 
@@ -183,7 +184,7 @@ impl TriviaBuilder {
         {
             comment.annotation = CommentAnnotation::CoverageIgnore;
         } else {
-            if s.contains("@license") || s.contains("@preserve") {
+            if contains_license_or_preserve_comment(s) {
                 comment.annotation = CommentAnnotation::Legal;
             }
             return;
@@ -199,6 +200,38 @@ impl TriviaBuilder {
             self.has_no_side_effects_comment = true;
         }
     }
+}
+
+#[expect(clippy::inline_always)]
+#[inline(always)]
+fn contains_license_or_preserve_comment(s: &str) -> bool {
+    let hay = s.as_bytes();
+
+    if hay.len() < 9 {
+        return false;
+    }
+
+    let search_len = hay.len() - 8;
+
+    for i in memchr_iter(b'@', &hay[..search_len]) {
+        match hay[i + 1] {
+            // spellchecker:off
+            b'l' => {
+                if &hay[i + 2..i + 1 + 7] == b"icense" {
+                    return true;
+                }
+            }
+            b'p' => {
+                if &hay[i + 2..i + 1 + 8] == b"reserve" {
+                    return true;
+                }
+            }
+            // spellchecker:on
+            _ => {}
+        }
+    }
+
+    false
 }
 
 #[cfg(test)]
@@ -429,6 +462,10 @@ token /* Trailing 1 */
             ("/** jsdoc */", CommentAnnotation::Jsdoc),
             ("/**/", CommentAnnotation::None),
             ("/***/", CommentAnnotation::None),
+            ("/*@*/", CommentAnnotation::None),
+            ("/*@xreserve*/", CommentAnnotation::None),
+            ("/*@preserve*/", CommentAnnotation::Legal),
+            ("/*@voidzeroignoreme*/", CommentAnnotation::None),
             ("/****/", CommentAnnotation::None),
             ("/* @vite-ignore */", CommentAnnotation::Vite),
             ("/* @vite-xxx */", CommentAnnotation::Vite),


### PR DESCRIPTION


```
  ./target/release/examples/parser-3 ran
    1.01 ± 0.03 times faster than ./target/release/examples/parser-5
    1.03 ± 0.16 times faster than ./target/release/examples/parser-4
    1.03 ± 0.03 times faster than ./target/release/examples/parser-2
    1.05 ± 0.18 times faster than ./target/release/examples/parser-1
```
```
  ./target/release/examples/lexer-bench-3 ran
    1.02 ± 0.07 times faster than ./target/release/examples/lexer-bench-5
    1.02 ± 0.07 times faster than ./target/release/examples/lexer-bench-2
    1.03 ± 0.07 times faster than ./target/release/examples/lexer-bench-1
    1.03 ± 0.24 times faster than ./target/release/examples/lexer-bench-4
```

<details>
<summary>using cointains</summary>

```rs
s.contains("@license") || s.contains("@preserve")
```

</details>

<details>
<summary>using find && is_some</summary>

```rs
s.find("@license").is_some() || s.find("@preserve").is_some()
```

</details>

<details>
<summary>manual byte iter</summary>

```rs
let mut state = 0;

for b in s.bytes() {
    state = match (state, b) {
        // Start state
        (0, b'@') => 1,

        // Matching @license
        (1, b'l') => 2,
        (2, b'i') => 3,
        (3, b'c') => 4,
        (4, b'e') => 5,
        (5, b'n') => 6,
        (6, b's') => 7,
        (7, b'e') => return true,

        // Matching @preserve
        (1, b'p') => 8,
        (8, b'r') => 9,
        (9, b'e') => 10,
        (10, b's') => 11,
        (11, b'e') => 12,
        (12, b'r') => 13,
        (13, b'v') => 14,
        (14, b'e') => return true,

        // Reset on mismatch
        (_, _) => 0,
    };
}
false
```

</details>

<details>
<summary>manual byte iter + conpare with get unchecked</summary>

```
let b = s.as_bytes();
if b.len() < 9 {
    return false;
}

for i in 0..=b.len() - 9 {
    if b[i] == b'@' {
        // SAFETY: i + 9 ≤ b.len() by construction
        unsafe {
            if b.get_unchecked(i + 1..i + 9) == b"preserve"
                || b.get_unchecked(i + 1..i + 8) == b"license"
            {
                return true;
            }
        }
    }
}
false
```

</details>

<details>
<summary>memchr</summary>

```
use memchr::memchr_iter;

const PAT1: &[u8] = b"license";
const PAT2: &[u8] = b"preserve";

let hay = s.as_bytes();
if hay.len() < 9 {
    return false; // shortest hit = “@license” (8 + 1)
}

// `memchr_iter` is guaranteed to return indices in ascending order.
// Limit search to positions where the 8-byte probe fits.
let search_len = hay.len() - 8;
for i in memchr_iter(b'@', &hay[..search_len]) {
    // SAFETY: `i + 8 ≤ hay.len()` by construction (`search_len`).
    let tail = &hay[i + 1..];

    if tail.starts_with(PAT1) || tail.starts_with(PAT2) {
        return true;
    }
}
false
```

</details>

closes #10592