### PR TITLE
fix(oxc): prevent DCE step crashing after running define plugin

### DIFF
--- a/crates/oxc/src/compiler.rs
+++ b/crates/oxc/src/compiler.rs
@@ -185,9 +185,19 @@ pub trait CompilerInterface {
         }
 
         if let Some(options) = define_options {
-            let ret = ReplaceGlobalDefines::new(&allocator, options).build(scoping, &mut program);
-            Compressor::new(&allocator, CompressOptions::default())
-                .dead_code_elimination_with_scoping(ret.scoping, &mut program);
+            let _ret = ReplaceGlobalDefines::new(&allocator, options).build(scoping, &mut program);
+            // Run DCE if minification is disabled.
+            if self.compress_options().is_none() {
+                // Rebuild semantic because define plugin changed the AST.
+                // DCE assumes semantic data to be correct, it will crash otherwise.
+                scoping = SemanticBuilder::new()
+                    .with_stats(stats)
+                    .build(&program)
+                    .semantic
+                    .into_scoping();
+                Compressor::new(&allocator, CompressOptions::default())
+                    .dead_code_elimination_with_scoping(scoping, &mut program);
+            }
         }
 
         /* Compress */

--- a/crates/oxc_transformer_plugins/src/replace_global_defines.rs
+++ b/crates/oxc_transformer_plugins/src/replace_global_defines.rs
@@ -335,7 +335,6 @@ impl<'a> ReplaceGlobalDefines<'a> {
         for (key, value) in &self.config.0.identifier.identifier_defines {
             if ident.name.as_str() == key {
                 let value = self.parse_value(value);
-
                 return Some(value);
             }
         }

--- a/crates/oxc_transformer_plugins/tests/integrations/replace_global_defines.rs
+++ b/crates/oxc_transformer_plugins/tests/integrations/replace_global_defines.rs
@@ -15,10 +15,11 @@ pub fn test(source_text: &str, expected: &str, config: ReplaceGlobalDefinesConfi
     let ret = Parser::new(&allocator, source_text, source_type).parse();
     let mut program = ret.program;
     let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
-    let ret = ReplaceGlobalDefines::new(&allocator, config).build(scoping, &mut program);
+    let _ = ReplaceGlobalDefines::new(&allocator, config).build(scoping, &mut program);
     // Run DCE, to align pipeline in crates/oxc/src/compiler.rs
+    let scoping = SemanticBuilder::new().build(&program).semantic.into_scoping();
     Compressor::new(&allocator, CompressOptions::default())
-        .dead_code_elimination_with_scoping(ret.scoping, &mut program);
+        .dead_code_elimination_with_scoping(scoping, &mut program);
     let result = CodeGenerator::new()
         .with_options(CodegenOptions { single_quote: true, ..CodegenOptions::default() })
         .build(&program)
@@ -105,7 +106,7 @@ fn dot_nested() {
 #[test]
 fn dot_with_postfix_wildcard() {
     let config = ReplaceGlobalDefinesConfig::new(&[("import.meta.env.*", "undefined")]).unwrap();
-    test("const _ = import.meta.env.result", "const _ = undefined", config.clone());
+    test("const _ = import.meta.env.result", "const _ = void 0", config.clone());
     test("const _ = import.meta.env", "const _ = import.meta.env", config);
 }
 
@@ -118,8 +119,8 @@ fn dot_with_postfix_mixed() {
         ("import.meta", "1"),
     ])
     .unwrap();
-    test("const _ = import.meta.env.result", "const _ = undefined", config.clone());
-    test("const _ = import.meta.env.result.many.nested", "const _ = undefined", config.clone());
+    test("const _ = import.meta.env.result", "const _ = void 0", config.clone());
+    test("const _ = import.meta.env.result.many.nested", "const _ = void 0", config.clone());
     test("const _ = import.meta.env", "const _ = env", config.clone());
     test("const _ = import.meta.somethingelse", "const _ = metaProperty", config.clone());
     test("const _ = import.meta", "const _ = 1", config);
@@ -231,6 +232,15 @@ console.log(
         "console.log([a = 0,b.c = 0,b['c'] = 0], [ident = 0,ident = 0,ident = 0], [dot.chain = 0,dot.chain = 0,dot.chain = 0\n]);",
         config,
     );
+}
+
+#[test]
+fn replace_with_undefined() {
+    let config = ReplaceGlobalDefinesConfig::new(&[("Foo", "undefined")]).unwrap();
+    test("new Foo()", "new (void 0)()", config);
+
+    let config = ReplaceGlobalDefinesConfig::new(&[("Foo", "Bar")]).unwrap();
+    test("Foo = 0", "Bar = 0", config);
 }
 
 #[cfg(not(miri))]

--- a/napi/transform/test/transform.test.ts
+++ b/napi/transform/test/transform.test.ts
@@ -244,6 +244,17 @@ describe('define plugin', () => {
     });
     expect(ret.code).toEqual('console.log({ __TEST_DEFINE__: "replaced" });\n');
   });
+
+  it('replaces undefined', () => {
+    const code = 'new Foo()';
+    const ret = transform('test.js', code, {
+      define: {
+        'Foo': 'undefined',
+      },
+    });
+    // Replaced `undefined` with `void 0` by DCE.
+    expect(ret.code).toEqual('new (void 0)();\n');
+  });
 });
 
 describe('inject plugin', () => {


### PR DESCRIPTION
closes #10577
fixes https://github.com/rolldown/rolldown/issues/4261

DCE assumes semantic is correct, but semantic became sync after running the define global, causing the crash.