### PR TITLE
fix(language_server): fix panics when paths contains specials characters like `[` or `]`

### DIFF
--- a/crates/oxc_language_server/src/linter/error_with_position.rs
+++ b/crates/oxc_language_server/src/linter/error_with_position.rs
@@ -1,11 +1,8 @@
-use std::{borrow::Cow, path::PathBuf, str::FromStr};
+use std::{borrow::Cow, str::FromStr};
 
 use oxc_linter::MessageWithPosition;
-use tower_lsp_server::{
-    UriExt,
-    lsp_types::{
-        self, CodeDescription, DiagnosticRelatedInformation, NumberOrString, Position, Range, Uri,
-    },
+use tower_lsp_server::lsp_types::{
+    self, CodeDescription, DiagnosticRelatedInformation, NumberOrString, Position, Range, Uri,
 };
 
 use oxc_diagnostics::Severity;
@@ -32,13 +29,12 @@ fn cmp_range(first: &Range, other: &Range) -> std::cmp::Ordering {
 
 fn message_with_position_to_lsp_diagnostic(
     message: &MessageWithPosition<'_>,
-    path: &PathBuf,
+    uri: &Uri,
 ) -> lsp_types::Diagnostic {
     let severity = match message.severity {
         Severity::Error => Some(lsp_types::DiagnosticSeverity::ERROR),
         _ => Some(lsp_types::DiagnosticSeverity::WARNING),
     };
-    let uri = lsp_types::Uri::from_file_path(path).unwrap();
 
     let related_information = message.labels.as_ref().map(|spans| {
         spans
@@ -103,10 +99,10 @@ fn message_with_position_to_lsp_diagnostic(
 
 pub fn message_with_position_to_lsp_diagnostic_report(
     message: &MessageWithPosition<'_>,
-    path: &PathBuf,
+    uri: &Uri,
 ) -> DiagnosticReport {
     DiagnosticReport {
-        diagnostic: message_with_position_to_lsp_diagnostic(message, path),
+        diagnostic: message_with_position_to_lsp_diagnostic(message, uri),
         fixed_content: message.fix.as_ref().map(|infos| FixedContent {
             message: infos.span.message().map(std::string::ToString::to_string),
             code: infos.content.to_string(),

--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use tower_lsp_server::{UriExt, lsp_types::Uri};
+use tower_lsp_server::lsp_types::Uri;
 
 use oxc_linter::Linter;
 
@@ -35,7 +35,7 @@ impl ServerLinter {
     }
 
     pub fn run_single(&self, uri: &Uri, content: Option<String>) -> Option<Vec<DiagnosticReport>> {
-        self.isolated_linter.run_single(&uri.to_file_path().unwrap(), content)
+        self.isolated_linter.run_single(uri, content)
     }
 }
 
@@ -107,6 +107,8 @@ mod test {
         Tester::new().test_and_snapshot_single_file("fixtures/linter/astro/debugger.astro");
         Tester::new().test_and_snapshot_single_file("fixtures/linter/vue/debugger.vue");
         Tester::new().test_and_snapshot_single_file("fixtures/linter/svelte/debugger.svelte");
+        // ToDo: fix Tester to work only with Uris and do not access the file system
+        // Tester::new().test_and_snapshot_single_file("fixtures/linter/nextjs/%5B%5B..rest%5D%5D/debugger.ts");
     }
 
     #[test]


### PR DESCRIPTION
closes #10575