### PR TITLE
fix(language_server): fix max integer values for range position

### DIFF
--- a/crates/oxc_language_server/fixtures/linter/invalid_syntax/debugger.ts
+++ b/crates/oxc_language_server/fixtures/linter/invalid_syntax/debugger.ts
@@ -1,0 +1,1 @@
+debugger }

--- a/crates/oxc_language_server/src/linter/error_with_position.rs
+++ b/crates/oxc_language_server/src/linter/error_with_position.rs
@@ -7,6 +7,10 @@ use tower_lsp_server::lsp_types::{
 
 use oxc_diagnostics::Severity;
 
+// max range for LSP integer is 2^31 - 1
+// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#baseTypes
+const LSP_MAX_INT: u32 = 2u32.pow(31) - 1;
+
 #[derive(Debug, Clone)]
 pub struct DiagnosticReport {
     pub diagnostic: lsp_types::Diagnostic,
@@ -60,13 +64,13 @@ fn message_with_position_to_lsp_diagnostic(
 
     let range = related_information.as_ref().map_or(
         Range {
-            start: Position { line: u32::MAX, character: u32::MAX },
-            end: Position { line: u32::MAX, character: u32::MAX },
+            start: Position { line: LSP_MAX_INT, character: LSP_MAX_INT },
+            end: Position { line: LSP_MAX_INT, character: LSP_MAX_INT },
         },
         |infos: &Vec<DiagnosticRelatedInformation>| {
             let mut ret_range = Range {
-                start: Position { line: u32::MAX, character: u32::MAX },
-                end: Position { line: u32::MAX, character: u32::MAX },
+                start: Position { line: LSP_MAX_INT, character: LSP_MAX_INT },
+                end: Position { line: LSP_MAX_INT, character: LSP_MAX_INT },
             };
             for info in infos {
                 if cmp_range(&ret_range, &info.location.range) == std::cmp::Ordering::Greater {

--- a/crates/oxc_language_server/src/linter/server_linter.rs
+++ b/crates/oxc_language_server/src/linter/server_linter.rs
@@ -112,6 +112,13 @@ mod test {
     }
 
     #[test]
+    fn test_invalid_syntax_file() {
+        Tester::new()
+            .with_snapshot_suffix("invalid_syntax_file")
+            .test_and_snapshot_single_file("fixtures/linter/invalid_syntax/debugger.ts");
+    }
+
+    #[test]
     fn test_cross_module_debugger() {
         let config_store: oxc_linter::ConfigStore = ConfigStoreBuilder::from_oxlintrc(
             false,

--- a/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_invalid_syntax_debugger.ts@invalid_syntax_file.snap
+++ b/crates/oxc_language_server/src/linter/snapshots/fixtures_linter_invalid_syntax_debugger.ts@invalid_syntax_file.snap
@@ -1,0 +1,11 @@
+---
+source: crates/oxc_language_server/src/linter/tester.rs
+---
+code: ""
+code_description.href: "None"
+message: "Unexpected token"
+range: Range { start: Position { line: 2147483647, character: 2147483647 }, end: Position { line: 2147483647, character: 2147483647 } }
+related_information: None
+severity: Some(Error)
+source: Some("oxc")
+tags: None


### PR DESCRIPTION
closes https://github.com/oxc-project/oxc/issues/10609

Would love to have the position of the Unexpected Token, like the CLI does it.
This PR just aligns the Code to the LSP Specs