### PR TITLE
fix(transformer/legacy-decorator): should fallback to `Object` when a type reference refers to a type symbol

### DIFF
--- a/tasks/coverage/snapshots/semantic_typescript.snap
+++ b/tasks/coverage/snapshots/semantic_typescript.snap
@@ -36082,19 +36082,13 @@ after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol span mismatch for "BulkEditPreviewProvider":
 after transform: SymbolId(1): Span { start: 106, end: 129 }
-rebuilt        : SymbolId(6): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(5): Span { start: 0, end: 0 }
 Symbol reference IDs mismatch for "BulkEditPreviewProvider":
-after transform: SymbolId(1): [ReferenceId(0), ReferenceId(12), ReferenceId(14), ReferenceId(16), ReferenceId(18)]
-rebuilt        : SymbolId(6): [ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(22)]
+after transform: SymbolId(1): [ReferenceId(0), ReferenceId(8), ReferenceId(10), ReferenceId(12), ReferenceId(14)]
+rebuilt        : SymbolId(5): [ReferenceId(7), ReferenceId(9), ReferenceId(11), ReferenceId(18)]
 Symbol span mismatch for "BulkEditPreviewProvider":
-after transform: SymbolId(5): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(7): Span { start: 106, end: 129 }
-Reference symbol mismatch for "IFoo":
-after transform: SymbolId(0) "IFoo"
-rebuilt        : <None>
-Reference symbol mismatch for "IFoo":
-after transform: SymbolId(0) "IFoo"
-rebuilt        : <None>
+after transform: SymbolId(4): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(6): Span { start: 106, end: 129 }
 Reference symbol mismatch for "IFoo":
 after transform: SymbolId(0) "IFoo"
 rebuilt        : <None>
@@ -36695,35 +36689,23 @@ rebuilt        : ["Function", "Object", "decorator"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorMetadataWithTypeOnlyImport.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["MyComponent", "Service", "_decorate", "_decorateMetadata", "_ref", "decorator"]
-rebuilt        : ScopeId(0): ["MyComponent", "_decorate", "_decorateMetadata", "_ref"]
+after transform: ScopeId(0): ["MyComponent", "Service", "_decorate", "_decorateMetadata", "decorator"]
+rebuilt        : ScopeId(0): ["MyComponent", "_decorate", "_decorateMetadata"]
 Symbol span mismatch for "MyComponent":
 after transform: SymbolId(2): Span { start: 89, end: 100 }
-rebuilt        : SymbolId(3): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol span mismatch for "MyComponent":
-after transform: SymbolId(7): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(4): Span { start: 89, end: 100 }
+after transform: SymbolId(6): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(3): Span { start: 89, end: 100 }
 Reference symbol mismatch for "decorator":
 after transform: SymbolId(1) "decorator"
 rebuilt        : <None>
 Reference symbol mismatch for "decorator":
 after transform: SymbolId(1) "decorator"
 rebuilt        : <None>
-Reference symbol mismatch for "Service":
-after transform: SymbolId(0) "Service"
-rebuilt        : <None>
-Reference flags mismatch for "Service":
-after transform: ReferenceId(3): ReferenceFlags(Type)
-rebuilt        : ReferenceId(14): ReferenceFlags(Read)
-Reference symbol mismatch for "Service":
-after transform: SymbolId(0) "Service"
-rebuilt        : <None>
-Reference flags mismatch for "Service":
-after transform: ReferenceId(4): ReferenceFlags(Type)
-rebuilt        : ReferenceId(15): ReferenceFlags(Read)
 Unresolved references mismatch:
 after transform: ["Function", "Object"]
-rebuilt        : ["Function", "Object", "Service", "decorator"]
+rebuilt        : ["Function", "Object", "decorator"]
 
 semantic Error: tasks/coverage/typescript/tests/cases/conformance/decorators/decoratorMetadataWithTypeOnlyImport2.ts
 Symbol flags mismatch for "Services":

--- a/tasks/transform_conformance/snapshots/oxc.snap.md
+++ b/tasks/transform_conformance/snapshots/oxc.snap.md
@@ -438,22 +438,22 @@ rebuilt        : SymbolId(3): Span { start: 87, end: 94 }
 
 * oxc/metadata/imports/input.ts
 Bindings mismatch:
-after transform: ScopeId(0): ["Bar", "Cls", "Foo", "_ref", "dec"]
+after transform: ScopeId(0): ["Bar", "Cls", "Foo", "Zoo", "_ref", "dec"]
 rebuilt        : ScopeId(0): ["Cls", "Foo", "_ref"]
 Scope children mismatch:
 after transform: ScopeId(0): [ScopeId(1), ScopeId(2)]
 rebuilt        : ScopeId(0): [ScopeId(1)]
 Symbol reference IDs mismatch for "Foo":
-after transform: SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(8), ReferenceId(9)]
-rebuilt        : SymbolId(0): [ReferenceId(7), ReferenceId(8)]
+after transform: SymbolId(0): [ReferenceId(2), ReferenceId(3), ReferenceId(12), ReferenceId(13)]
+rebuilt        : SymbolId(0): [ReferenceId(9), ReferenceId(10)]
 Symbol span mismatch for "Cls":
-after transform: SymbolId(6): Span { start: 135, end: 138 }
+after transform: SymbolId(7): Span { start: 145, end: 148 }
 rebuilt        : SymbolId(2): Span { start: 0, end: 0 }
 Symbol span mismatch for "Cls":
-after transform: SymbolId(10): Span { start: 0, end: 0 }
-rebuilt        : SymbolId(3): Span { start: 135, end: 138 }
+after transform: SymbolId(13): Span { start: 0, end: 0 }
+rebuilt        : SymbolId(3): Span { start: 145, end: 148 }
 Reference symbol mismatch for "dec":
-after transform: SymbolId(2) "dec"
+after transform: SymbolId(3) "dec"
 rebuilt        : <None>
 Unresolved references mismatch:
 after transform: ["Object", "PropertyDescriptor", "babelHelpers", "console"]

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/imports/input.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/imports/input.ts
@@ -1,4 +1,4 @@
-import { Foo, Bar } from "mod";
+import { Foo, Bar, type Zoo } from "mod";
 
 declare function dec(
   target: any,
@@ -7,7 +7,7 @@ declare function dec(
 ): void;
 
 class Cls {
-  constructor(@dec param: Foo, param2: Foo | Bar) {
-    console.log(param, param2);
+  constructor(@dec param: Foo, param2: Foo | Bar, param3: Zoo, param4: Zoo.o.o) {
+    console.log(param, param2, param3, param4);
   }
 }

--- a/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/imports/output.ts
+++ b/tasks/transform_conformance/tests/legacy-decorators/test/fixtures/oxc/metadata/imports/output.ts
@@ -2,8 +2,8 @@ import { Foo } from "mod";
 var _ref;
 
 let Cls = class Cls {
-	constructor(param, param2) {
-		console.log(param, param2);
+	constructor(param, param2, param3, param4) {
+		console.log(param, param2, param3, param4);
 	}
 };
 
@@ -13,6 +13,8 @@ Cls = babelHelpers.decorate(
 			typeof (_ref = typeof Foo !== "undefined" && Foo) === "function"
 				? _ref
 				: Object,
+			Object,
+			Object,
 			Object,
 		]),
 		babelHelpers.decorateParam(0, dec),


### PR DESCRIPTION
Align TypeScript 

https://www.typescriptlang.org/play/?experimentalDecorators=true&emitDecoratorMetadata=true&target=99#code/JYWwDg9gTgLgBAbzgMQhANHAQgQypmATzAFM4AtNOAXzgDMoIQ4AiECAExYG4AoXjiQDGAGzxk6AVwB2QmMAjS4goQApecODDwBzEjABccHNMLoNcANYlCRgM4wowaTvObBdoU7AxoRgAqMpLCEACIknt6++LwAlEYAbhDAHHy8ojh2dnAAwiLZCBZCig5QknLQqgACKnBgeDggRqgYdQ0gAEzNVAA+2HiY9VCNAMxGlK1DjQAs42gAdBCLsYgWmsXSdhAiJPMiEDqqUyCD7R2nwyAjFzOxfJrUvI9AA
