### PR TITLE
test(language_server): skip slow test

### DIFF
--- a/crates/oxc_language_server/src/worker.rs
+++ b/crates/oxc_language_server/src/worker.rs
@@ -461,6 +461,7 @@ fn range_overlaps(a: Range, b: Range) -> bool {
 mod tests {
     use super::*;
 
+    #[ignore]
     #[test]
     fn test_get_root_uri() {
         let worker =


### PR DESCRIPTION
Temporary solution for #10657. Disable this test until we can make it faster.
