### PR TITLE
test(ast/estree): ignore TS-ESTree tests where fail to parse

### DIFF
--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -1,11 +1,8 @@
 commit: 15392346
 
 estree_typescript Summary:
-AST Parsed     : 6489/6493 (99.94%)
-Positive Passed: 6470/6493 (99.65%)
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/arrayFromAsync.ts
-`await` is only allowed within async functions and at the top levels of modules
-
+AST Parsed     : 6487/6488 (99.98%)
+Positive Passed: 6470/6488 (99.72%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowInstanceofWithSymbolHasInstance.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/emitBundleWithShebang1.ts
@@ -22,19 +19,7 @@ Mismatch: tasks/coverage/typescript/tests/cases/compiler/shebang.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/shebangBeforeReferences.ts
 
-Expect to Parse: tasks/coverage/typescript/tests/cases/compiler/sourceMapValidationDecorators.ts
-Unexpected token
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/classes/propertyMemberDeclarations/staticPropertyNameConflicts.ts
-Classes may not have a static property named prototype
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/es2019/importMeta/importMeta.ts
-The only valid meta property for import is import.meta
-
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringMultiline3.ts
-
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/esDecorators/esDecorators-decoratorExpression.1.ts
-Expected a semicolon or an implicit semicolon after a statement, but found none
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithRHSHasSymbolHasInstance.ts
 


### PR DESCRIPTION
Related to #9705.

Skip tests in TS-ESTree conformance which do fail to parse, but fail because of bugs which are not related to ESTree serialization.

We should eventually try to make these tests pass, but when we do, that'll show up in the parser conformance snapshots. So no need to repeat them in the ESTree conformance snapshot too - so we can more easily see what our ESTree-related problems are.

Note: `typescript/tests/cases/conformance/jsx/jsxReactTestSuite.tsx` is *not* included in ignore list because that's not a fail in parser conformance (see #10578).
