### PR TITLE
feat(linter): report vars only used as types

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/diagnostic.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/diagnostic.rs
@@ -57,8 +57,13 @@ where
             pronoun_singular.cow_to_ascii_lowercase()
         ))
 }
+
 /// Variable 'x' is declared but never used.
-pub fn declared<R>(symbol: &Symbol<'_, '_>, pat: &IgnorePattern<R>) -> OxcDiagnostic
+pub fn declared<R>(
+    symbol: &Symbol<'_, '_>,
+    pat: &IgnorePattern<R>,
+    only_used_as_type: bool,
+) -> OxcDiagnostic
 where
     R: fmt::Display,
 {
@@ -71,9 +76,13 @@ where
     let (pronoun, pronoun_plural) = pronoun_for_symbol(symbol.flags());
     let suffix = pat.diagnostic_help(pronoun_plural);
 
-    OxcDiagnostic::warn(format!("{pronoun} '{name}' is {verb} but never used.{suffix}"))
-        .with_label(symbol.span().label(format!("'{name}' is declared here")))
-        .with_help(help)
+    OxcDiagnostic::warn(if only_used_as_type {
+        format!("{pronoun} is {verb} but only used as a type{suffix}.",)
+    } else {
+        format!("{pronoun} '{name}' is {verb} but never used.{suffix}")
+    })
+    .with_label(symbol.span().label(format!("'{name}' is declared here")))
+    .with_help(help)
 }
 
 /// Variable 'x' is assigned a value but never used.

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -1119,9 +1119,6 @@ fn test_type_references() {
         export type C = B<A<number>>;
         ",
         "const x: number = 1; function foo(): typeof x { return x }; foo()",
-        // not handled by typescript-eslint. Maybe we'll add this one day
-        "function foo(): typeof foo { }",
-        "function foo(): typeof foo { return foo }",
         // ---
         "type T = number; console.log(3 as T);",
         "type T = number; console.log(((3) as T));",
@@ -1194,6 +1191,8 @@ fn test_type_references() {
 
         // Same is true for interfaces
         "interface LinkedList<T> { next: LinkedList<T> | undefined }",
+        "function foo(): typeof foo { }",
+        "function foo(): typeof foo { return foo }",
     ];
 
     Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/typescript_eslint.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/typescript_eslint.rs
@@ -1013,7 +1013,7 @@ fn test() {
         // https://github.com/typescript-eslint/typescript-eslint/issues/5152
         (
             "
-        function foo<T>(value: T): T {
+        export function foo<T>(value: T): T {
           return { value };
         }
         export type Foo<T> = typeof foo<T>;
@@ -1380,6 +1380,28 @@ fn test() {
             ",
             None,
         ),
+        (
+            "
+        type _Foo = 1;
+        export const x: _Foo = 1;
+            ",
+            Some(json!([{ "varsIgnorePattern": "^_", "reportUnusedIgnorePattern": false }])),
+        ),
+        (
+            "
+        export const foo: number = 1;
+        export type Foo = typeof foo;
+            ",
+            None,
+        ),
+        (
+            "
+        import { foo } from 'foo';
+        export type Foo = typeof foo;
+        export const bar = (): Foo => foo;
+            ",
+            None,
+        ),
     ];
 
     let fail = vec![
@@ -1697,6 +1719,63 @@ fn test() {
             None,
         ),
         ("const foo: number = 1;", None),
+        (
+            "
+         const foo: number = 1;
+         export type Foo = typeof foo;
+             ",
+            None,
+        ),
+        (
+            "
+        declare const foo: number;
+        export type Foo = typeof foo;
+            ",
+            None,
+        ),
+        (
+            "
+        const foo: number = 1;
+        export type Foo = typeof foo | string;
+            ",
+            None,
+        ),
+        (
+            "
+        const foo: number = 1;
+        export type Foo = (typeof foo | string) & { __brand: 'foo' };
+            ",
+            None,
+        ),
+        (
+            "
+        const foo = {
+          bar: {
+            baz: 123,
+          },
+        };
+        export type Bar = typeof foo.bar;
+            ",
+            None,
+        ),
+        (
+            "
+        const foo = {
+          bar: {
+            baz: 123,
+          },
+        };
+        export type Bar = (typeof foo)['bar'];
+            ",
+            None,
+        ),
+        (
+            "
+        import { foo } from 'foo';
+        export type Bar = typeof foo;
+            ",
+            None,
+        ),
     ];
 
     Tester::new(NoUnusedVars::NAME, NoUnusedVars::PLUGIN, pass, fail)

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
@@ -136,6 +136,13 @@ impl<'a> Symbol<'_, 'a> {
                 if do_type_self_usage_checks && self.is_type_self_usage(reference) {
                     continue;
                 }
+
+                if !self.flags().intersects(SymbolFlags::TypeImport)
+                    && self.reference_contains_type_query(reference)
+                {
+                    continue;
+                }
+
                 return true;
             }
 
@@ -778,5 +785,31 @@ impl<'a> Symbol<'_, 'a> {
         }
 
         None
+    }
+
+    pub fn has_reference_used_as_type_query(&self) -> bool {
+        self.references().any(|reference| self.reference_contains_type_query(reference))
+    }
+
+    fn reference_contains_type_query(&self, reference: &Reference) -> bool {
+        let Some(mut node) = self.get_ref_relevant_node(reference) else {
+            debug_assert!(false);
+            return false;
+        };
+
+        loop {
+            node = match node.kind() {
+                AstKind::TSTypeQuery(_) => return true,
+                AstKind::TSQualifiedName(_) | AstKind::TSTypeName(_) => {
+                    if let Some(parent) = self.nodes().parent_node(node.id()) {
+                        parent
+                    } else {
+                        debug_assert!(false);
+                        return false;
+                    }
+                }
+                _ => return false,
+            };
+        }
     }
 }

--- a/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@oxc-type-references.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@oxc-type-references.snap
@@ -92,3 +92,19 @@ source: crates/oxc_linter/src/tester.rs
    ·                ╰── 'LinkedList' is declared here
    ╰────
   help: Consider removing this declaration.
+
+  ⚠ eslint(no-unused-vars): Function 'foo' is declared but never used.
+   ╭─[no_unused_vars.ts:1:10]
+ 1 │ function foo(): typeof foo { }
+   ·          ─┬─
+   ·           ╰── 'foo' is declared here
+   ╰────
+  help: Consider removing this declaration.
+
+  ⚠ eslint(no-unused-vars): Function 'foo' is declared but never used.
+   ╭─[no_unused_vars.ts:1:10]
+ 1 │ function foo(): typeof foo { return foo }
+   ·          ─┬─
+   ·           ╰── 'foo' is declared here
+   ╰────
+  help: Consider removing this declaration.

--- a/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@typescript-eslint.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@typescript-eslint.snap
@@ -340,3 +340,73 @@ source: crates/oxc_linter/src/tester.rs
    ·        ╰── 'foo' is declared here
    ╰────
   help: Consider removing this declaration.
+
+  ⚠ eslint(no-unused-vars): Variable is declared but only used as a type Unused variables should start with a '_'..
+   ╭─[no_unused_vars.ts:2:16]
+ 1 │ 
+ 2 │          const foo: number = 1;
+   ·                ─┬─
+   ·                 ╰── 'foo' is declared here
+ 3 │          export type Foo = typeof foo;
+   ╰────
+  help: Consider removing this declaration.
+
+  ⚠ eslint(no-unused-vars): Variable is declared but only used as a type Unused variables should start with a '_'..
+   ╭─[no_unused_vars.ts:2:23]
+ 1 │ 
+ 2 │         declare const foo: number;
+   ·                       ─┬─
+   ·                        ╰── 'foo' is declared here
+ 3 │         export type Foo = typeof foo;
+   ╰────
+  help: Consider removing this declaration.
+
+  ⚠ eslint(no-unused-vars): Variable is declared but only used as a type Unused variables should start with a '_'..
+   ╭─[no_unused_vars.ts:2:15]
+ 1 │ 
+ 2 │         const foo: number = 1;
+   ·               ─┬─
+   ·                ╰── 'foo' is declared here
+ 3 │         export type Foo = typeof foo | string;
+   ╰────
+  help: Consider removing this declaration.
+
+  ⚠ eslint(no-unused-vars): Variable is declared but only used as a type Unused variables should start with a '_'..
+   ╭─[no_unused_vars.ts:2:15]
+ 1 │ 
+ 2 │         const foo: number = 1;
+   ·               ─┬─
+   ·                ╰── 'foo' is declared here
+ 3 │         export type Foo = (typeof foo | string) & { __brand: 'foo' };
+   ╰────
+  help: Consider removing this declaration.
+
+  ⚠ eslint(no-unused-vars): Variable is declared but only used as a type Unused variables should start with a '_'..
+   ╭─[no_unused_vars.ts:2:15]
+ 1 │ 
+ 2 │         const foo = {
+   ·               ─┬─
+   ·                ╰── 'foo' is declared here
+ 3 │           bar: {
+   ╰────
+  help: Consider removing this declaration.
+
+  ⚠ eslint(no-unused-vars): Variable is declared but only used as a type Unused variables should start with a '_'..
+   ╭─[no_unused_vars.ts:2:15]
+ 1 │ 
+ 2 │         const foo = {
+   ·               ─┬─
+   ·                ╰── 'foo' is declared here
+ 3 │           bar: {
+   ╰────
+  help: Consider removing this declaration.
+
+  ⚠ eslint(no-unused-vars): Identifier 'foo' is imported but never used.
+   ╭─[no_unused_vars.ts:2:18]
+ 1 │ 
+ 2 │         import { foo } from 'foo';
+   ·                  ─┬─
+   ·                   ╰── 'foo' is imported here
+ 3 │         export type Bar = typeof foo;
+   ╰────
+  help: Consider removing this import.


### PR DESCRIPTION
closes #8488

I ported accross the additional tests added in https://github.com/typescript-eslint/typescript-eslint/pull/9330/files, then fixed the resulting test cases