### PR TITLE
test(ast/estree): fix raw transfer tests

### DIFF
--- a/napi/parser/test/parse-raw.test.ts
+++ b/napi/parser/test/parse-raw.test.ts
@@ -193,6 +193,7 @@ function stringify(obj) {
     if (typeof value === 'bigint') return `__BIGINT__: ${value}`;
     if (typeof value === 'object' && value instanceof RegExp) return `__REGEXP__: ${value}`;
     if (value === Infinity) return `__INFINITY__`;
+    return value;
   });
 }
 


### PR DESCRIPTION
The tests for ensuring field order is the same between JSON-based transfer and raw transfer were not working correctly. Fix them. Thankfully they all still pass!
