### PR TITLE
fix(ast/estree): add line comment for hashbang in ESTree AST

### DIFF
--- a/napi/parser/index.js
+++ b/napi/parser/index.js
@@ -62,9 +62,16 @@ function parseSyncRaw(filename, sourceText, options) {
   const astTypeFlagPos = 2147483636;
   let isJsAst = buffer[astTypeFlagPos] === 0;
 
-  const data = isJsAst
-    ? deserializeJS(buffer, sourceText, sourceByteLen)
-    : deserializeTS(buffer, sourceText, sourceByteLen);
+  let data;
+  if (isJsAst) {
+    data = deserializeJS(buffer, sourceText, sourceByteLen);
+    const { hashbang } = data.program;
+    if (hashbang !== null) {
+      data.comments.unshift({ type: 'Line', value: hashbang.value, start: hashbang.start, end: hashbang.end });
+    }
+  } else {
+    data = deserializeTS(buffer, sourceText, sourceByteLen);
+  }
 
   return {
     get program() {

--- a/napi/parser/test/parse-raw.test.ts
+++ b/napi/parser/test/parse-raw.test.ts
@@ -133,6 +133,9 @@ describe('edge cases', () => {
     '`\\uD800\\uDBFF${x}\\uD800\\uDBFF`;',
     '`�\\u{FFFD}${x}�\\u{FFFD}`;',
     '`�\\u{FFFD}\\uD800${x}\\uDBFF�\\u{FFFD}`;',
+    // Hashbangs
+    '#!/usr/bin/env node\nlet x;',
+    '#!/usr/bin/env node\nlet x;\n// foo',
   ])('%s', (sourceText) => {
     assertRawAndStandardMatch('dummy.js', sourceText);
   });

--- a/napi/parser/test/parse.test.ts
+++ b/napi/parser/test/parse.test.ts
@@ -428,6 +428,7 @@ describe('parse', () => {
       expect(ret.errors.length).toBe(0);
       expect(ret.program.body.length).toBe(1);
       expect(ret.program.hashbang).toBeNull();
+      expect(ret.comments).toHaveLength(0);
     });
 
     it('is defined when hashbang', () => {
@@ -440,6 +441,27 @@ describe('parse', () => {
         end: 19,
         value: '/usr/bin/env node',
       });
+    });
+
+    it('is also recorded as a line comment in JS files', () => {
+      const ret = parseSync('test.js', '#!/usr/bin/env node\nlet x; // foo');
+      expect(ret.errors.length).toBe(0);
+      expect(ret.program.body.length).toBe(1);
+      expect(ret.comments).toHaveLength(2);
+      expect(ret.comments[0]).toEqual({
+        type: 'Line',
+        start: 0,
+        end: 19,
+        value: '/usr/bin/env node',
+      });
+    });
+
+    it('is not recorded as a line comment in TS files', () => {
+      const ret = parseSync('test.ts', '#!/usr/bin/env node\nlet x; // foo');
+      expect(ret.errors.length).toBe(0);
+      expect(ret.program.body.length).toBe(1);
+      expect(ret.comments).toHaveLength(1);
+      expect(ret.comments[0].value).toBe(' foo');
     });
   });
 


### PR DESCRIPTION
In ESTree (plain ESTree for JS i.e. Acorn), a hashbang is recorded as a line comment. Follow that behavior in our ESTree AST.

In TS-ESTree, hashbangs are ignored. That's not how it looks in AST explorer, because there's some post-processing going on, but `@typescript-eslint/parser` itself ignores hashbangs. So only add the comment in ESTree AST (not TS-ESTree AST).

More info on this rather confusing subtlety: https://github.com/typescript-eslint/typescript-eslint/issues/6500
