### PR TITLE
refactor(ast/estree): `convert_utf8_to_utf16` take `&mut` slice of errors, not `&mut Vec`

### DIFF
--- a/crates/oxc_napi/src/lib.rs
+++ b/crates/oxc_napi/src/lib.rs
@@ -13,7 +13,7 @@ pub fn convert_utf8_to_utf16(
     source_text: &str,
     program: &mut Program,
     module_record: &mut ModuleRecord,
-    errors: &mut Vec<OxcError>,
+    errors: &mut [OxcError],
 ) -> Vec<Comment> {
     let span_converter = Utf8ToUtf16::new(source_text);
     span_converter.convert_program(program);

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -242,9 +242,8 @@ impl Oxc {
         self.codegen_text = codegen_result.code;
         self.codegen_sourcemap_text = codegen_result.map.map(|map| map.to_json_string());
         self.ir = format!("{:#?}", program.body);
-        let mut errors = vec![];
         let comments =
-            convert_utf8_to_utf16(&source_text, &mut program, &mut module_record, &mut errors);
+            convert_utf8_to_utf16(&source_text, &mut program, &mut module_record, &mut []);
         self.ast_json = program.to_pretty_estree_ts_json();
         self.comments = comments;
 


### PR DESCRIPTION
Pure refactor. `convert_utf8_to_utf16` doesn't need to take a `&mut Vec<OxcError>`. `&mut [OxcError]` is sufficient, and the extra indirection of `&mut Vec` is not ideal.
