### PR TITLE
fix(playground): playground show ESTree AST for JS files

### DIFF
--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -244,7 +244,11 @@ impl Oxc {
         self.ir = format!("{:#?}", program.body);
         let comments =
             convert_utf8_to_utf16(&source_text, &mut program, &mut module_record, &mut []);
-        self.ast_json = program.to_pretty_estree_ts_json();
+        self.ast_json = if source_type.is_javascript() {
+            program.to_pretty_estree_js_json()
+        } else {
+            program.to_pretty_estree_ts_json()
+        };
         self.comments = comments;
 
         Ok(())


### PR DESCRIPTION
The ESTree AST (for JS files) and TS-ESTree AST (for TS files) are quite different. Display the relevant AST in Playground, depending on source type.

Note: This will likely increase binary size of the WASM file, due to including 2 serializers. But in my opinion, it's worth it. Most people using the Playground will be developers who tend to have pretty fast internet connections.
