### PR TITLE
fix(playground): add hashbang as comment in ESTree AST

### DIFF
--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -242,9 +242,23 @@ impl Oxc {
         self.codegen_text = codegen_result.code;
         self.codegen_sourcemap_text = codegen_result.map.map(|map| map.to_json_string());
         self.ir = format!("{:#?}", program.body);
-        let comments =
+        let mut comments =
             convert_utf8_to_utf16(&source_text, &mut program, &mut module_record, &mut []);
+
         self.ast_json = if source_type.is_javascript() {
+            // Add hashbang to start of comments
+            if let Some(hashbang) = &program.hashbang {
+                comments.insert(
+                    0,
+                    Comment {
+                        r#type: "Line".to_string(),
+                        value: hashbang.value.to_string(),
+                        start: hashbang.span.start,
+                        end: hashbang.span.end,
+                    },
+                );
+            }
+
             program.to_pretty_estree_js_json()
         } else {
             program.to_pretty_estree_ts_json()


### PR DESCRIPTION
Same change as made in #10669, but for Playground.
