### PR TITLE
test(ast/estree): skip test for `\r` in template literal

### DIFF
--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -1,13 +1,11 @@
 commit: 15392346
 
 estree_typescript Summary:
-AST Parsed     : 6481/6482 (99.98%)
-Positive Passed: 6470/6482 (99.81%)
+AST Parsed     : 6480/6481 (99.98%)
+Positive Passed: 6470/6481 (99.83%)
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowInstanceofWithSymbolHasInstance.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingUnionToUnion.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/es6/templates/templateStringMultiline3.ts
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithRHSHasSymbolHasInstance.ts
 

--- a/tasks/coverage/src/tools/estree.rs
+++ b/tasks/coverage/src/tools/estree.rs
@@ -290,6 +290,17 @@ impl Case for EstreeTypescriptCase {
             "typescript/tests/cases/conformance/esDecorators/esDecorators-decoratorExpression.1.ts",
         ];
 
+        // Skip tests where `@typescript-eslint/parser` is incorrect, and we can't massage the AST
+        // to align with it
+        const INCORRECT_PATHS: &[&str] = &[
+            // TS-ESLint includes `\r` in `raw` field of `TemplateElement`.
+            // This is incorrect - `\r` should be converted to `\n`, as both Acorn and Espree do.
+            // This matches the `raw` value that you get at runtime in a tagged template in JS.
+            // We perform the `\r` -> `\n` conversion in parser, so we can't match TS-ESTree without
+            // breaking plain JS ESTree.
+            "typescript/tests/cases/conformance/es6/templates/templateStringMultiline3.ts",
+        ];
+
         // Skip tests where fixture starts with a hashbang.
         // We intentionally diverge from TS-ESTree, by including an extra `hashbang` field on `Program`.
         // `acorn-test262` adapts TS-ESLint's AST to add a `hashbang: null` field to `Program`,
@@ -306,7 +317,8 @@ impl Case for EstreeTypescriptCase {
             "typescript/tests/cases/compiler/shebangBeforeReferences.ts",
         ];
 
-        static IGNORE_PATHS: &[&str] = concat_slices!([&str]: PARSE_ERROR_PATHS, HASHBANG_PATHS);
+        static IGNORE_PATHS: &[&str] =
+            concat_slices!([&str]: PARSE_ERROR_PATHS, INCORRECT_PATHS, HASHBANG_PATHS);
 
         // Skip cases where expected to fail to parse
         if self.base.should_fail() {


### PR DESCRIPTION
Skip TS-ESTree conformance test for `\r` in `raw` field of `TemplateElement`. `@typescript-eslint/parser` is wrong on this one, and we can't massage the AST to match them.

We do the `\r` to `\n` conversion in parser, so the information that there were originally `\r` characters in the raw string is lost by the time we get to serialization.

We *could* get the slice of source text from the `Span`, and use that, but that only works if the AST has come direct from parser. If the AST has been through any form of transformation, the content of the `TemplateElement` could have been changed, and it'd be out of sync with the chunk of source text described by the `Span`. This seems like a recipe for bugs.
