### PR TITLE
perf(parser): faster parsing `TemplateElement`s

### DIFF
--- a/crates/oxc_parser/src/cursor.rs
+++ b/crates/oxc_parser/src/cursor.rs
@@ -58,7 +58,7 @@ impl<'a> ParserImpl<'a> {
 
     /// Get current template string
     pub(crate) fn cur_template_string(&self) -> Option<&'a str> {
-        self.lexer.get_template_string(self.token)
+        self.lexer.get_template_string(self.token.start)
     }
 
     /// Peek next token, returns EOF for final peek

--- a/crates/oxc_parser/src/lexer/template.rs
+++ b/crates/oxc_parser/src/lexer/template.rs
@@ -399,20 +399,8 @@ impl<'a> Lexer<'a> {
         self.token.escaped = true;
     }
 
-    pub(crate) fn get_template_string(&self, token: Token) -> Option<&'a str> {
-        if token.escaped {
-            return self.escaped_templates[&token.start];
-        }
-        let raw = &self.source.whole()[token.start as usize..token.end as usize];
-        Some(match token.kind {
-            Kind::NoSubstitutionTemplate | Kind::TemplateTail => {
-                &raw[1..raw.len() - 1] // omit surrounding quotes or leading "}" and trailing "`"
-            }
-            Kind::TemplateHead | Kind::TemplateMiddle => {
-                &raw[1..raw.len() - 2] // omit leading "`" or "}" and trailing "${"
-            }
-            _ => raw,
-        })
+    pub(crate) fn get_template_string(&self, span_start: u32) -> Option<&'a str> {
+        self.escaped_templates[&span_start]
     }
 }
 


### PR DESCRIPTION
Speed up parsing `TemplateElement` a little by:

* Only slice source text once to get `raw` (rather than slicing a slice).
* Fast path for when `TemplateElement` contains no escapes:
  * Don't slice source text again to get `cooked` - just copy the existing `Atom` for `raw`.
  * Don't search for `\r` in `raw` - it can't be there because otherwise `escaped` would be `true`.

This also allows removing some code repetition.