### PR TITLE
feat(minifier): remove empty/useless constructors

### DIFF
--- a/crates/oxc_minifier/src/peephole/mod.rs
+++ b/crates/oxc_minifier/src/peephole/mod.rs
@@ -331,6 +331,11 @@ impl<'a> Traverse<'a> for PeepholeOptimizations {
         }
     }
 
+    fn exit_class(&mut self, class: &mut Class<'a>, ctx: &mut TraverseCtx<'a>) {
+        let mut state = State::default();
+        self.remove_dead_code_exit_class(class, &mut state, Ctx(ctx));
+    }
+
     fn exit_method_definition(
         &mut self,
         prop: &mut MethodDefinition<'a>,
@@ -461,5 +466,10 @@ impl<'a> Traverse<'a> for DeadCodeElimination {
         let mut state = State::default();
         self.inner.fold_constants_exit_expression(expr, &mut state, Ctx(ctx));
         self.inner.remove_dead_code_exit_expression(expr, &mut state, Ctx(ctx));
+    }
+
+    fn exit_class(&mut self, class: &mut Class<'a>, ctx: &mut TraverseCtx<'a>) {
+        let mut state = State::default();
+        self.inner.remove_dead_code_exit_class(class, &mut state, Ctx(ctx));
     }
 }

--- a/crates/oxc_minifier/tests/peephole/esbuild.rs
+++ b/crates/oxc_minifier/tests/peephole/esbuild.rs
@@ -114,7 +114,7 @@ fn js_parser_test() {
     );
     test(
         "class Foo { constructor() {} ['constructor']() {} }",
-        "class Foo { constructor() { } ['constructor']() { }}",
+        "class Foo { ['constructor']() { }}",
     );
     test(
         "class Foo { static constructor() {} static ['constructor']() {} }",


### PR DESCRIPTION
> AI generated description b/c im feeling lazy

### TL;DR

Remove empty constructors from classes during minification.

### What changed?

Added a new optimization to the peephole minifier that removes empty constructors from classes that don't extend another class. An empty constructor is one that has no parameters, no decorators, and an empty function body.

The implementation:
- Added `exit_class` methods to both `PeepholeOptimizations` and `DeadCodeElimination` traversal implementations
- Added `remove_dead_code_exit_class` method to handle the optimization logic
- Added `is_empty_constructor` helper method to identify empty constructors
- Added tests to verify the optimization works correctly

### How to test?

Run the existing tests which now include specific test cases for this feature:
```
cargo test -p oxc_minifier
```

The tests verify that:
- Empty constructors are removed from classes without a superclass
- Empty constructors are preserved in classes with a superclass
- Constructors with parameters, decorators, or non-empty bodies are preserved

### Why make this change?

Empty constructors in classes without a superclass are redundant since JavaScript automatically adds them if not specified. Removing them reduces the size of the minified output without changing the behavior of the code.