### PR TITLE
feat(codegen): a way to keep legal comments after minification

### DIFF
--- a/crates/oxc_codegen/examples/codegen.rs
+++ b/crates/oxc_codegen/examples/codegen.rs
@@ -69,7 +69,7 @@ fn parse<'a>(
 
 fn codegen(ret: &ParserReturn<'_>, minify: bool) -> String {
     Codegen::new()
-        .with_options(CodegenOptions { minify, ..CodegenOptions::default() })
+        .with_options(if minify { CodegenOptions::minify() } else { CodegenOptions::default() })
         .build(&ret.program)
         .code
 }

--- a/crates/oxc_codegen/src/comment.rs
+++ b/crates/oxc_codegen/src/comment.rs
@@ -11,10 +11,20 @@ pub type CommentsMap = FxHashMap</* attached_to */ u32, Vec<Comment>>;
 impl Codegen<'_> {
     pub(crate) fn build_comments(&mut self, comments: &[Comment]) {
         self.comments.reserve(comments.len());
+        let move_legal_comments = {
+            let legal_comments = &self.options.legal_comments;
+            matches!(
+                legal_comments,
+                LegalComment::Eof | LegalComment::Linked(_) | LegalComment::External
+            )
+        };
         for comment in comments {
             // Omit pure comments because they are handled separately.
             if comment.is_pure() || comment.is_no_side_effects() {
                 continue;
+            }
+            if comment.is_legal() && move_legal_comments {
+                self.legal_comments.push(*comment);
             }
             self.comments.entry(comment.attached_to).or_default().push(*comment);
         }
@@ -30,10 +40,10 @@ impl Codegen<'_> {
         arguments: &[Argument<'_>],
     ) -> (bool, bool) {
         let has_comment_before_right_paren =
-            self.print_comments && span.end > 0 && self.has_comment(span.end - 1);
+            self.print_annotation_comment && span.end > 0 && self.has_comment(span.end - 1);
 
         let has_comment = has_comment_before_right_paren
-            || self.print_comments
+            || self.print_annotation_comment
                 && arguments.iter().any(|item| self.has_comment(item.span().start));
 
         (has_comment, has_comment_before_right_paren)
@@ -45,7 +55,7 @@ impl Codegen<'_> {
     }
 
     pub(crate) fn print_leading_comments(&mut self, start: u32) {
-        if !self.print_comments {
+        if !self.print_any_comment {
             return;
         }
         let Some(comments) = self.comments.remove(&start) else {
@@ -73,7 +83,7 @@ impl Codegen<'_> {
                         continue;
                     }
                     LegalComment::Eof | LegalComment::Linked(_) | LegalComment::External => {
-                        self.legal_comments.push(comment);
+                        /* noop, handled by `build_comments`. */
                         continue;
                     }
                     LegalComment::None => {}
@@ -90,7 +100,7 @@ impl Codegen<'_> {
     /// A statement comment also includes legal comments
     #[inline]
     pub(crate) fn print_statement_comments(&mut self, start: u32) {
-        if self.print_comments {
+        if self.print_any_comment {
             if let Some(comments) = self.get_statement_comments(start) {
                 self.print_comments(&comments);
             }
@@ -178,12 +188,16 @@ impl Codegen<'_> {
         match self.options.legal_comments.clone() {
             LegalComment::Eof => {
                 let comments = self.legal_comments.drain(..).collect::<Vec<_>>();
+                if !comments.is_empty() {
+                    self.print_hard_newline();
+                }
                 for c in comments {
                     self.print_comment(&c);
                     self.print_hard_newline();
                 }
             }
             LegalComment::Linked(path) => {
+                self.print_hard_newline();
                 self.print_str("/*! For license information please see ");
                 self.print_str(&path);
                 self.print_str(" */");

--- a/crates/oxc_codegen/src/lib.rs
+++ b/crates/oxc_codegen/src/lib.rs
@@ -106,8 +106,11 @@ pub struct Codegen<'a> {
 
     /// Fast path for [CodegenOptions::single_quote]
     quote: Quote,
+
     /// Fast path for if print comments
-    print_comments: bool,
+    print_any_comment: bool,
+    print_legal_comment: bool,
+    print_annotation_comment: bool,
 
     // Builders
     comments: CommentsMap,
@@ -143,7 +146,9 @@ impl<'a> Codegen<'a> {
     #[must_use]
     pub fn new() -> Self {
         let options = CodegenOptions::default();
-        let print_comments = options.print_comments();
+        let print_any_comment = options.print_any_comment();
+        let print_legal_comment = options.print_legal_comment();
+        let print_annotation_comment = options.print_annotation_comment();
         Self {
             options,
             source_text: "",
@@ -162,7 +167,9 @@ impl<'a> Codegen<'a> {
             is_jsx: false,
             indent: 0,
             quote: Quote::Double,
-            print_comments,
+            print_any_comment,
+            print_legal_comment,
+            print_annotation_comment,
             comments: CommentsMap::default(),
             legal_comments: vec![],
             sourcemap_builder: None,
@@ -173,7 +180,9 @@ impl<'a> Codegen<'a> {
     #[must_use]
     pub fn with_options(mut self, options: CodegenOptions) -> Self {
         self.quote = if options.single_quote { Quote::Single } else { Quote::Double };
-        self.print_comments = options.print_comments();
+        self.print_any_comment = options.print_any_comment();
+        self.print_legal_comment = options.print_legal_comment();
+        self.print_annotation_comment = options.print_annotation_comment();
         self.options = options;
         self
     }
@@ -195,9 +204,9 @@ impl<'a> Codegen<'a> {
         self.quote = if self.options.single_quote { Quote::Single } else { Quote::Double };
         self.source_text = program.source_text;
         self.code.reserve(program.source_text.len());
-        if self.print_comments {
+        if self.print_any_comment {
             if program.comments.is_empty() {
-                self.print_comments = false;
+                self.print_any_comment = false;
             } else {
                 self.build_comments(&program.comments);
             }

--- a/crates/oxc_codegen/src/options.rs
+++ b/crates/oxc_codegen/src/options.rs
@@ -1,14 +1,90 @@
 use std::path::PathBuf;
 
+/// Codegen Options.
+#[derive(Debug, Clone)]
+pub struct CodegenOptions {
+    /// Use single quotes instead of double quotes.
+    ///
+    /// Default is `false`.
+    pub single_quote: bool,
+
+    /// Remove whitespace.
+    ///
+    /// Default is `false`.
+    pub minify: bool,
+
+    /// Print all comments?
+    ///
+    /// Default is `true`.
+    pub comments: bool,
+
+    /// Print annotation comments, e.g. `/* #__PURE__ */` and `/* #__NO_SIDE_EFFECTS__ */`.
+    ///
+    /// Default is `true`.
+    pub annotation_comments: bool,
+
+    /// Print legal comments.
+    ///
+    /// <https://esbuild.github.io/api/#legal-comments>
+    ///
+    /// Default is [LegalComment::Inline].
+    pub legal_comments: LegalComment,
+
+    /// Override the source map path. This affects the `sourceMappingURL`
+    /// comment at the end of the generated code.
+    ///
+    /// By default, the source map path is the same as the input source code
+    /// (with a `.map` extension).
+    pub source_map_path: Option<PathBuf>,
+}
+
+impl Default for CodegenOptions {
+    fn default() -> Self {
+        Self {
+            single_quote: false,
+            minify: false,
+            comments: true,
+            annotation_comments: true,
+            legal_comments: LegalComment::Inline,
+            source_map_path: None,
+        }
+    }
+}
+
+impl CodegenOptions {
+    /// Minify whitespace and remove comments.
+    pub fn minify() -> Self {
+        Self {
+            single_quote: false,
+            minify: true,
+            comments: false,
+            annotation_comments: false,
+            legal_comments: LegalComment::None,
+            source_map_path: None,
+        }
+    }
+
+    pub(crate) fn print_any_comment(&self) -> bool {
+        self.comments
+    }
+
+    pub(crate) fn print_legal_comment(&self) -> bool {
+        self.comments || !self.legal_comments.is_none()
+    }
+
+    pub(crate) fn print_annotation_comment(&self) -> bool {
+        self.comments || self.annotation_comments
+    }
+}
+
 /// Legal comment
 ///
 /// <https://esbuild.github.io/api/#legal-comments>
-#[derive(Debug, Clone, Eq, PartialEq, Default)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum LegalComment {
-    /// Do not preserve any legal comments (default).
-    #[default]
+    /// Do not preserve any legal comments.
     None,
-    /// Preserve all legal comments.
+    /// Preserve all legal comments (default).
     Inline,
     /// Move all legal comments to the end of the file.
     Eof,
@@ -32,70 +108,5 @@ impl LegalComment {
     /// Is EOF mode.
     pub fn is_eof(&self) -> bool {
         *self == Self::Eof
-    }
-}
-
-/// Codegen Options.
-#[derive(Debug, Clone)]
-pub struct CodegenOptions {
-    /// Use single quotes instead of double quotes.
-    ///
-    /// Default is `false`.
-    pub single_quote: bool,
-
-    /// Remove whitespace.
-    ///
-    /// Default is `false`.
-    pub minify: bool,
-
-    /// Print all comments?
-    ///
-    /// Default is `true`.
-    pub comments: bool,
-
-    /// Print annotation comments, e.g. `/* #__PURE__ */` and `/* #__NO_SIDE_EFFECTS__ */`.
-    ///
-    /// Only takes into effect when `comments` is false.
-    ///
-    /// Default is `false`.
-    pub annotation_comments: bool,
-
-    /// Print legal comments.
-    ///
-    /// Only takes into effect when `comments` is false.
-    ///
-    /// <https://esbuild.github.io/api/#legal-comments>
-    ///
-    /// Default is [LegalComment::None].
-    pub legal_comments: LegalComment,
-
-    /// Override the source map path. This affects the `sourceMappingURL`
-    /// comment at the end of the generated code.
-    ///
-    /// By default, the source map path is the same as the input source code
-    /// (with a `.map` extension).
-    pub source_map_path: Option<PathBuf>,
-}
-
-impl Default for CodegenOptions {
-    fn default() -> Self {
-        Self {
-            single_quote: false,
-            minify: false,
-            comments: true,
-            annotation_comments: false,
-            legal_comments: LegalComment::default(),
-            source_map_path: None,
-        }
-    }
-}
-
-impl CodegenOptions {
-    pub(crate) fn print_comments(&self) -> bool {
-        !self.minify && (self.comments || self.legal_comments.is_inline())
-    }
-
-    pub(crate) fn print_annotation_comments(&self) -> bool {
-        !self.minify && (self.comments || self.annotation_comments)
     }
 }

--- a/crates/oxc_codegen/tests/integration/comments.rs
+++ b/crates/oxc_codegen/tests/integration/comments.rs
@@ -209,6 +209,16 @@ pub mod legal {
     }
 
     #[test]
+    fn legal_eof_minify_comment() {
+        let options = CodegenOptions {
+            minify: true,
+            legal_comments: LegalComment::Eof,
+            ..Default::default()
+        };
+        snapshot_options("legal_eof_minify_comments", &cases(), &options);
+    }
+
+    #[test]
     fn legal_linked_comment() {
         let options = CodegenOptions {
             legal_comments: LegalComment::Linked(String::from("test.js")),

--- a/crates/oxc_codegen/tests/integration/snapshots/legal_eof_minify_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/legal_eof_minify_comments.snap
@@ -6,9 +6,7 @@ source: crates/oxc_codegen/tests/integration/main.rs
 /* @license */
 foo;bar;
 ----------
-foo;
-bar;
-
+foo;bar;
 /* @license */
 /* @license */
 
@@ -17,9 +15,7 @@ bar;
 /* @preserve */
 foo;bar;
 ----------
-foo;
-bar;
-
+foo;bar;
 /* @license */
 /* @preserve */
 
@@ -28,9 +24,7 @@ bar;
 //! KEEP
 foo;bar;
 ----------
-foo;
-bar;
-
+foo;bar;
 /* @license */
 //! KEEP
 
@@ -39,9 +33,7 @@ bar;
 /*! KEEP */
 foo;bar;
 ----------
-foo;
-bar;
-
+foo;bar;
 /* @license */
 /*! KEEP */
 
@@ -49,9 +41,7 @@ bar;
 /* @license *//*! KEEP */
 foo;bar;
 ----------
-foo;
-bar;
-
+foo;bar;
 /* @license */
 /*! KEEP */
 
@@ -64,10 +54,7 @@ function () {
     bar;
 }
 ----------
-function() {
-	bar;
-}
-
+function(){bar}
 /*
 * @license
 * Copyright notice 2
@@ -76,11 +63,7 @@ function() {
 ########## 6
 function bar() { var foo; /*! #__NO_SIDE_EFFECTS__ */ function () { } }
 ----------
-function bar() {
-	var foo;
-	function() {}
-}
-
+function bar(){var foo;function(){}}
 /*! #__NO_SIDE_EFFECTS__ */
 
 ########## 7
@@ -98,15 +81,14 @@ function foo() {
  * @preserve
  */
 ----------
-function foo() {
-	(() => {
-		/**
-		* @preserve
-		*/
-	})();
-	/**
-	* @preserve
-	*/
+function foo(){(()=>{
+/**
+* @preserve
+*/
+})()
+/**
+* @preserve
+*/
 }
 /**
 * @preserve

--- a/crates/oxc_codegen/tests/integration/snapshots/legal_linked_comments.snap
+++ b/crates/oxc_codegen/tests/integration/snapshots/legal_linked_comments.snap
@@ -8,6 +8,7 @@ foo;bar;
 ----------
 foo;
 bar;
+
 /*! For license information please see test.js */
 ########## 1
 /* @license */
@@ -16,6 +17,7 @@ foo;bar;
 ----------
 foo;
 bar;
+
 /*! For license information please see test.js */
 ########## 2
 /* @license */
@@ -24,6 +26,7 @@ foo;bar;
 ----------
 foo;
 bar;
+
 /*! For license information please see test.js */
 ########## 3
 /* @license */
@@ -32,6 +35,7 @@ foo;bar;
 ----------
 foo;
 bar;
+
 /*! For license information please see test.js */
 ########## 4
 /* @license *//*! KEEP */
@@ -39,6 +43,7 @@ foo;bar;
 ----------
 foo;
 bar;
+
 /*! For license information please see test.js */
 ########## 5
 function () {
@@ -52,6 +57,7 @@ function () {
 function() {
 	bar;
 }
+
 /*! For license information please see test.js */
 ########## 6
 function bar() { var foo; /*! #__NO_SIDE_EFFECTS__ */ function () { } }
@@ -60,6 +66,7 @@ function bar() {
 	var foo;
 	function() {}
 }
+
 /*! For license information please see test.js */
 ########## 7
 function foo() {
@@ -88,7 +95,8 @@ function foo() {
 }
 /**
 * @preserve
-*//*! For license information please see test.js */
+*/
+/*! For license information please see test.js */
 ########## 8
 /**
 * @preserve
@@ -98,4 +106,5 @@ function foo() {
 /**
 * @preserve
 */
+
 /*! For license information please see test.js */

--- a/crates/oxc_minifier/examples/minifier.rs
+++ b/crates/oxc_minifier/examples/minifier.rs
@@ -54,7 +54,13 @@ fn minify(
     };
     let ret = Minifier::new(options).build(allocator, &mut program);
     Codegen::new()
-        .with_options(CodegenOptions { minify: nospace, ..CodegenOptions::default() })
+        .with_options(CodegenOptions {
+            minify: nospace,
+            comments: false,
+            annotation_comments: false,
+            legal_comments: oxc_codegen::LegalComment::Eof,
+            ..CodegenOptions::default()
+        })
         .with_scoping(ret.scoping)
         .build(&program)
         .code

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -1871,8 +1871,8 @@ function foobar() {
     }",
             "const __vite_ssr_import_0__ = await __vite_ssr_import__('react', { importedNames: ['default'] });
 const __vite_ssr_import_1__ = await __vite_ssr_import__('foo', { importedNames: ['Foo', 'Slot'] });
-function Bar({ Slot = __vite_ssr_import_0__.default.createElement(__vite_ssr_import_1__.Foo, null) }) {
-  return __vite_ssr_import_0__.default.createElement(__vite_ssr_import_0__.default.Fragment, null, __vite_ssr_import_0__.default.createElement(Slot, null));
+function Bar({ Slot = /* @__PURE__ */ __vite_ssr_import_0__.default.createElement(__vite_ssr_import_1__.Foo, null) }) {
+  return /* @__PURE__ */ __vite_ssr_import_0__.default.createElement(__vite_ssr_import_0__.default.Fragment, null, /* @__PURE__ */ __vite_ssr_import_0__.default.createElement(Slot, null));
 }",
         );
     }

--- a/napi/minify/src/options.rs
+++ b/napi/minify/src/options.rs
@@ -152,10 +152,10 @@ impl Default for CodegenOptions {
 
 impl From<&CodegenOptions> for oxc_codegen::CodegenOptions {
     fn from(o: &CodegenOptions) -> Self {
-        let default = oxc_codegen::CodegenOptions::default();
-        oxc_codegen::CodegenOptions {
-            minify: o.remove_whitespace.unwrap_or(default.minify),
-            ..default
+        if o.remove_whitespace.is_some_and(|b| b) {
+            oxc_codegen::CodegenOptions::minify()
+        } else {
+            oxc_codegen::CodegenOptions::default()
         }
     }
 }

--- a/napi/playground/src/lib.rs
+++ b/napi/playground/src/lib.rs
@@ -12,7 +12,7 @@ use oxc::{
     allocator::Allocator,
     ast::ast::Program,
     ast_visit::Visit,
-    codegen::{Codegen, CodegenOptions},
+    codegen::{Codegen, CodegenOptions, LegalComment},
     diagnostics::OxcDiagnostic,
     isolated_declarations::{IsolatedDeclarations, IsolatedDeclarationsOptions},
     minifier::{CompressOptions, MangleOptions, Minifier, MinifierOptions},
@@ -232,6 +232,9 @@ impl Oxc {
             .with_scoping(symbol_table)
             .with_options(CodegenOptions {
                 minify: minifier_options.whitespace.unwrap_or_default(),
+                comments: true,
+                annotation_comments: true,
+                legal_comments: LegalComment::Inline,
                 source_map_path: codegen_options
                     .enable_sourcemap
                     .unwrap_or_default()

--- a/tasks/minsize/src/lib.rs
+++ b/tasks/minsize/src/lib.rs
@@ -150,7 +150,7 @@ fn minify(source_text: &str, source_type: SourceType) -> String {
     .build(scoping, &mut program);
     let ret = Minifier::new(MinifierOptions::default()).build(&allocator, &mut program);
     Codegen::new()
-        .with_options(CodegenOptions { minify: true, comments: false, ..CodegenOptions::default() })
+        .with_options(CodegenOptions::minify())
         .with_scoping(ret.scoping)
         .build(&program)
         .code


### PR DESCRIPTION
fixes https://github.com/rolldown/rolldown/issues/4118
fixes #10626

At present, there is no option to keep legal comments when minification is turn on.

This PR allows Codegen to set legal comments with minfication turned on, with the following behavior:

* Inline: only if the attached code is not removed
* Eof: move all legal comments to the end of file, regardless of where they appear
* Linked and External: saved into `CodegenReturn::legal_comments` for the caller to use, regardless of where they appear

Code gets moved around or removed if minifier is turned on, so some legal comments may disappear from the final output.

The recommended legal comment option is Eof.

---

For Rolldown to keep legal comments, it should set `LegalComment::Inline` for chunk codegen and `LegalComment::Eof` for minification codegen.