### PR TITLE
fix(linter): false positive in no unused vars when importing value used as type

### DIFF
--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/oxc.rs
@@ -1148,6 +1148,7 @@ fn test_type_references() {
             accessor y!: Foo
         }
         ",
+        "import { foo } from 'bar'; export type K = typeof foo",
     ];
 
     let fail = vec![

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/typescript_eslint.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/tests/typescript_eslint.rs
@@ -1402,6 +1402,13 @@ fn test() {
             ",
             None,
         ),
+        (
+            "
+        import { foo } from 'foo';
+        export type Bar = typeof foo;
+            ",
+            None,
+        ),
     ];
 
     let fail = vec![
@@ -1766,13 +1773,6 @@ fn test() {
           },
         };
         export type Bar = (typeof foo)['bar'];
-            ",
-            None,
-        ),
-        (
-            "
-        import { foo } from 'foo';
-        export type Bar = typeof foo;
             ",
             None,
         ),

--- a/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
+++ b/crates/oxc_linter/src/rules/eslint/no_unused_vars/usage.rs
@@ -137,7 +137,7 @@ impl<'a> Symbol<'_, 'a> {
                     continue;
                 }
 
-                if !self.flags().intersects(SymbolFlags::TypeImport)
+                if !self.flags().intersects(SymbolFlags::TypeImport.union(SymbolFlags::Import))
                     && self.reference_contains_type_query(reference)
                 {
                     continue;

--- a/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@typescript-eslint.snap
+++ b/crates/oxc_linter/src/snapshots/eslint_no_unused_vars@typescript-eslint.snap
@@ -400,13 +400,3 @@ source: crates/oxc_linter/src/tester.rs
  3 │           bar: {
    ╰────
   help: Consider removing this declaration.
-
-  ⚠ eslint(no-unused-vars): Identifier 'foo' is imported but never used.
-   ╭─[no_unused_vars.ts:2:18]
- 1 │ 
- 2 │         import { foo } from 'foo';
-   ·                  ─┬─
-   ·                   ╰── 'foo' is imported here
- 3 │         export type Bar = typeof foo;
-   ╰────
-  help: Consider removing this import.


### PR DESCRIPTION
I accidently copied a pass test case to the fail array.

```
import { foo } from '';

export type Foo = typeof foo;
```
 is allowed