### PR TITLE
fix(codegen): add missing return type from object methods

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -1628,6 +1628,11 @@ impl Gen for ObjectProperty<'_> {
                 p.print_ascii_byte(b'(');
                 func.params.print(p, ctx);
                 p.print_ascii_byte(b')');
+                if let Some(return_type) = &func.return_type {
+                    p.print_colon();
+                    p.print_soft_space();
+                    return_type.print(p, ctx);
+                }
                 if let Some(body) = &func.body {
                     p.print_soft_space();
                     body.print(p, ctx);

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -1,6 +1,20 @@
 use oxc_codegen::CodegenOptions;
 
-use crate::{snapshot, snapshot_options, tester::test_tsx};
+use crate::{
+    snapshot, snapshot_options,
+    tester::{test_same, test_tsx},
+};
+
+#[test]
+fn cases() {
+    test_same("({ foo(): string {} });\n");
+}
+
+#[test]
+fn tsx() {
+    test_tsx("<T,>() => {}", "<T,>() => {};\n");
+    test_tsx("<T, B>() => {}", "<\n\tT,\n\tB\n>() => {};\n");
+}
 
 #[test]
 fn ts() {
@@ -106,10 +120,4 @@ export import b = require("b");
         &cases,
         &CodegenOptions { minify: true, ..CodegenOptions::default() },
     );
-}
-
-#[test]
-fn tsx() {
-    test_tsx("<T,>() => {}", "<T,>() => {};\n");
-    test_tsx("<T, B>() => {}", "<\n\tT,\n\tB\n>() => {};\n");
 }

--- a/tasks/coverage/snapshots/transpile.snap
+++ b/tasks/coverage/snapshots/transpile.snap
@@ -347,9 +347,9 @@ export const inObjectLiteralFnExprBad = { o: function(array: T = [], rParam: str
 export const inObjectLiteralArrowOk1 = { o: (array: number[] = [], rParam: string): void => {} };
 export const inObjectLiteralArrowOk2 = { o: (array: T | undefined = [], rParam: string): void => {} };
 export const inObjectLiteralArrowBad = { o: (array: T = [], rParam: string): void => {} };
-export const inObjectLiteralMethodOk1 = { o(array: number[] = [], rParam: string) {} };
-export const inObjectLiteralMethodOk2 = { o(array: T | undefined = [], rParam: string) {} };
-export const inObjectLiteralMethodBad = { o(array: T = [], rParam: string) {} };
+export const inObjectLiteralMethodOk1 = { o(array: number[] = [], rParam: string): void {} };
+export const inObjectLiteralMethodOk2 = { o(array: T | undefined = [], rParam: string): void {} };
+export const inObjectLiteralMethodBad = { o(array: T = [], rParam: string): void {} };
 export class InClassFnExprOk1 {
 	o = function(array: number[] = [], rParam: string): void {};
 }


### PR DESCRIPTION
```
({ foo(): string {} })
          ^^^^^^
```