### PR TITLE
fix(codegen): add missing `in` `out` from ts type parameter

### DIFF
--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -3352,6 +3352,12 @@ impl Gen for TSTypeParameter<'_> {
         if self.r#const {
             p.print_str("const ");
         }
+        if self.r#in {
+            p.print_str("in ");
+        }
+        if self.out {
+            p.print_str("out ");
+        }
         self.name.print(p, ctx);
         if let Some(constraint) = &self.constraint {
             p.print_str(" extends ");

--- a/crates/oxc_codegen/tests/integration/ts.rs
+++ b/crates/oxc_codegen/tests/integration/ts.rs
@@ -8,6 +8,8 @@ use crate::{
 #[test]
 fn cases() {
     test_same("({ foo(): string {} });\n");
+    test_same("interface I<in out T,> {}\n");
+    test_same("function F<const in out T,>() {}\n");
 }
 
 #[test]


### PR DESCRIPTION
```ts
interface I<in out T> {}
function F<const in out T>() {}
```