### PR TITLE
chore(tasks/lint_rules): mark react stylistic rules as not supported

### DIFF
--- a/tasks/lint_rules/src/oxlint-rules.mjs
+++ b/tasks/lint_rules/src/oxlint-rules.mjs
@@ -50,7 +50,12 @@ const NOT_SUPPORTED_RULE_NAMES = new Set([
   'eslint/no-with', // superseded by strict mode
   'eslint/no-new-symbol', // Deprecated as of ESLint v9, but for a while disable manually
   'eslint/no-undef-init', // #6456 unicorn/no-useless-undefined covers this case
-  'import/no-unresolved', // Will always contain false positives due to module resolution complexity
+  'import/no-unresolved', // Will always contain false positives due to module resolution complexity,
+  'react/jsx-equals-spacing', // stylistic rule
+  'react/jsx-curly-spacing', // stylistic rule
+  'react/jsx-indent', // stylistic rule
+  'react/jsx-indent-props', // stylistic rule
+  'react/jsx-props-no-multi-spaces', // stylistic rule
 ]);
 
 /**


### PR DESCRIPTION
related #10699


~/dev/oxc$ node tasks/lint_rules/ --target=react
👀 promise/prefer-catch is implemented but not found in their rules
👀 promise/spec-only is implemented but not found in their rules
👀 unicorn/consistent-assert is implemented but not found in their rules
👀 unicorn/consistent-date-clone is implemented but not found in their rules
👀 unicorn/consistent-existence-index-check is implemented but not found in their rules
👀 unicorn/no-accessor-recursion is implemented but not found in their rules
👀 unicorn/prefer-math-min-max is implemented but not found in their rules

> [!WARNING]
> This comment is maintained by CI. Do not edit this comment directly.
> To update comment template, see https://github.com/oxc-project/oxc/tree/main/tasks/lint_rules

This is tracking issue for `eslint-plugin-react`, `eslint-plugin-react-hooks`.


There are 102(+ 2 deprecated) rules.

- 5/23 recommended rules are remaining as TODO
- 57/79 not recommended rules are remaining as TODO


To get started, run the following command:

```sh
just new-react-rule <RULE_NAME>
```

Then register the rule in `crates/oxc_linter/src/rules.rs` and also `declare_all_lint_rules` at the bottom.


## Recommended rules

<details open>
<summary>
  ✨: 18, 🚫: 0 / total: 23
</summary>

| Status | Name | Docs |
| :----: | :--- | :--- |
|  | react/display-name | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/display-name.md |
| ✨ | react/jsx-key | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-key.md |
| ✨ | react/jsx-no-comment-textnodes | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-no-comment-textnodes.md |
| ✨ | react/jsx-no-duplicate-props | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-no-duplicate-props.md |
| ✨ | react/jsx-no-target-blank | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-no-target-blank.md |
| ✨ | react/jsx-no-undef | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-no-undef.md |
|  | react/jsx-uses-react | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-uses-react.md |
|  | react/jsx-uses-vars | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-uses-vars.md |
| ✨ | react/no-children-prop | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-children-prop.md |
| ✨ | react/no-danger-with-children | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-danger-with-children.md |
|  | react/no-deprecated | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-deprecated.md |
| ✨ | react/no-direct-mutation-state | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-direct-mutation-state.md |
| ✨ | react/no-find-dom-node | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-find-dom-node.md |
| ✨ | react/no-is-mounted | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-is-mounted.md |
| ✨ | react/no-string-refs | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-string-refs.md |
| ✨ | react/no-render-return-value | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-render-return-value.md |
| ✨ | react/no-unescaped-entities | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-unescaped-entities.md |
| ✨ | react/no-unknown-property | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-unknown-property.md |
|  | react/prop-types | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/prop-types.md |
| ✨ | react/react-in-jsx-scope | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/react-in-jsx-scope.md |
| ✨ | react/require-render-return | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/require-render-return.md |
| ✨ | react/rules-of-hooks | https://reactjs.org/docs/hooks-rules.html |
| ✨ | react/exhaustive-deps | https://github.com/facebook/react/issues/14920 |

✨ = Implemented, 🚫 = No need to implement

</details>


## Not recommended rules

<details open>
<summary>
  ✨: 17, 🚫: 5 / total: 79
</summary>

| Status | Name | Docs |
| :----: | :--- | :--- |
|  | react/boolean-prop-naming | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/boolean-prop-naming.md |
| ✨ | react/button-has-type | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/button-has-type.md |
| ✨ | react/checked-requires-onchange-or-readonly | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/checked-requires-onchange-or-readonly.md |
|  | react/default-props-match-prop-types | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/default-props-match-prop-types.md |
|  | react/destructuring-assignment | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/destructuring-assignment.md |
|  | react/forbid-component-props | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/forbid-component-props.md |
|  | react/forbid-dom-props | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/forbid-dom-props.md |
|  | react/forbid-elements | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/forbid-elements.md |
|  | react/forbid-foreign-prop-types | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/forbid-foreign-prop-types.md |
|  | react/forbid-prop-types | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/forbid-prop-types.md |
|  | react/function-component-definition | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/function-component-definition.md |
|  | react/hook-use-state | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/hook-use-state.md |
| ✨ | react/iframe-missing-sandbox | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/iframe-missing-sandbox.md |
| ✨ | react/jsx-boolean-value | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-boolean-value.md |
|  | react/jsx-child-element-spacing | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-child-element-spacing.md |
|  | react/jsx-closing-bracket-location | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-closing-bracket-location.md |
|  | react/jsx-closing-tag-location | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-closing-tag-location.md |
| 🚫 | react/jsx-curly-spacing | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-curly-spacing.md |
|  | react/jsx-curly-newline | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-curly-newline.md |
| 🚫 | react/jsx-equals-spacing | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-equals-spacing.md |
| ✨ | react/jsx-filename-extension | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-filename-extension.md |
|  | react/jsx-first-prop-new-line | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-first-prop-new-line.md |
|  | react/jsx-handler-names | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-handler-names.md |
| 🚫 | react/jsx-indent | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-indent.md |
| 🚫 | react/jsx-indent-props | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-indent-props.md |
|  | react/jsx-max-depth | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-max-depth.md |
|  | react/jsx-max-props-per-line | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-max-props-per-line.md |
|  | react/jsx-newline | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-newline.md |
|  | react/jsx-no-bind | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-no-bind.md |
|  | react/jsx-no-constructed-context-values | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-no-constructed-context-values.md |
|  | react/jsx-no-leaked-render | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-no-leaked-render.md |
|  | react/jsx-no-literals | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-no-literals.md |
| ✨ | react/jsx-no-script-url | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-no-script-url.md |
| ✨ | react/jsx-no-useless-fragment | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-no-useless-fragment.md |
|  | react/jsx-one-expression-per-line | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-one-expression-per-line.md |
| ✨ | react/jsx-curly-brace-presence | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-curly-brace-presence.md |
|  | react/jsx-pascal-case | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-pascal-case.md |
|  | react/jsx-fragments | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-fragments.md |
| 🚫 | react/jsx-props-no-multi-spaces | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-props-no-multi-spaces.md |
|  | react/jsx-props-no-spreading | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-props-no-spreading.md |
| ✨ | react/jsx-props-no-spread-multi | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-props-no-spread-multi.md |
|  | react/jsx-sort-props | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-sort-props.md |
|  | react/jsx-tag-spacing | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-tag-spacing.md |
|  | react/jsx-wrap-multilines | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-wrap-multilines.md |
|  | react/no-invalid-html-attribute | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-invalid-html-attribute.md |
|  | react/no-access-state-in-setstate | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-access-state-in-setstate.md |
|  | react/no-adjacent-inline-elements | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-adjacent-inline-elements.md |
| ✨ | react/no-array-index-key | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-array-index-key.md |
|  | react/no-arrow-function-lifecycle | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-arrow-function-lifecycle.md |
| ✨ | react/no-danger | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-danger.md |
|  | react/no-did-mount-set-state | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-did-mount-set-state.md |
|  | react/no-did-update-set-state | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-did-update-set-state.md |
|  | react/no-multi-comp | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-multi-comp.md |
| ✨ | react/no-namespace | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-namespace.md |
| ✨ | react/no-set-state | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-set-state.md |
|  | react/no-redundant-should-component-update | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-redundant-should-component-update.md |
|  | react/no-this-in-sfc | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-this-in-sfc.md |
|  | react/no-typos | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-typos.md |
|  | react/no-unsafe | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-unsafe.md |
|  | react/no-unstable-nested-components | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-unstable-nested-components.md |
|  | react/no-unused-class-component-methods | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-unused-class-component-methods.md |
|  | react/no-unused-prop-types | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-unused-prop-types.md |
|  | react/no-unused-state | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-unused-state.md |
|  | react/no-object-type-as-default-prop | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-object-type-as-default-prop.md |
|  | react/no-will-update-set-state | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/no-will-update-set-state.md |
| ✨ | react/prefer-es6-class | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/prefer-es6-class.md |
|  | react/prefer-exact-props | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/prefer-exact-props.md |
|  | react/prefer-read-only-props | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/prefer-read-only-props.md |
|  | react/prefer-stateless-function | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/prefer-stateless-function.md |
|  | react/require-default-props | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/require-default-props.md |
|  | react/require-optimization | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/require-optimization.md |
| ✨ | react/self-closing-comp | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/self-closing-comp.md |
|  | react/sort-comp | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/sort-comp.md |
|  | react/sort-default-props | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/sort-default-props.md |
|  | react/sort-prop-types | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/sort-prop-types.md |
|  | react/state-in-constructor | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/state-in-constructor.md |
|  | react/static-property-placement | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/static-property-placement.md |
| ✨ | react/style-prop-object | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/style-prop-object.md |
| ✨ | react/void-dom-elements-no-children | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/void-dom-elements-no-children.md |

✨ = Implemented, 🚫 = No need to implement

</details>


## Deprecated rules

<details >
<summary>
  ✨: 0, 🚫: 0 / total: 2
</summary>

| Status | Name | Docs |
| :----: | :--- | :--- |
|  | react/jsx-sort-default-props | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-sort-default-props.md |
|  | react/jsx-space-before-closing | https://github.com/jsx-eslint/eslint-plugin-react/tree/master/docs/rules/jsx-space-before-closing.md |

✨ = Implemented, 🚫 = No need to implement

</details>
