### PR TITLE
perf(transformer/refresh): reuse existing `Atom`

### DIFF
--- a/crates/oxc_transformer/src/jsx/refresh.rs
+++ b/crates/oxc_transformer/src/jsx/refresh.rs
@@ -169,11 +169,7 @@ impl<'a> Traverse<'a> for ReactRefresh<'a, '_> {
             let callee = self.refresh_reg.to_expression(ctx);
             let arguments = ctx.ast.vec_from_array([
                 Argument::from(binding.create_read_expression(ctx)),
-                Argument::from(ctx.ast.expression_string_literal(
-                    SPAN,
-                    ctx.ast.atom(&persistent_id),
-                    None,
-                )),
+                Argument::from(ctx.ast.expression_string_literal(SPAN, persistent_id, None)),
             ]);
             new_statements.push(ctx.ast.statement_expression(
                 SPAN,


### PR DESCRIPTION
Don't create a new `Atom` and copy string data, when there's an existing `Atom` we can use.