### PR TITLE
fix(estree): Adjust span for `TSTypePredicate`.`typeAnnotation`

### DIFF
--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1,7 +1,7 @@
 use oxc_allocator::{Box, Vec};
 use oxc_ast::{NONE, ast::*};
-use oxc_syntax::operator::UnaryOperator;
 use oxc_span::GetSpan;
+use oxc_syntax::operator::UnaryOperator;
 
 use crate::{
     Context, ParserImpl, diagnostics,

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -1,6 +1,7 @@
 use oxc_allocator::{Box, Vec};
 use oxc_ast::{NONE, ast::*};
 use oxc_syntax::operator::UnaryOperator;
+use oxc_span::GetSpan;
 
 use crate::{
     Context, ParserImpl, diagnostics,
@@ -649,9 +650,8 @@ impl<'a> ParserImpl<'a> {
         self.bump_any(); // bump `is`
         // TODO: this should go through the ast builder.
         let parameter_name = TSTypePredicateName::This(this_ty);
-        let type_span = self.start_span();
         let ty = self.parse_ts_type();
-        let type_annotation = Some(self.ast.ts_type_annotation(self.end_span(type_span), ty));
+        let type_annotation = Some(self.ast.ts_type_annotation(ty.span(), ty));
         self.ast.ts_type_type_predicate(self.end_span(span), parameter_name, false, type_annotation)
     }
 
@@ -1051,10 +1051,9 @@ impl<'a> ParserImpl<'a> {
     fn parse_type_or_type_predicate(&mut self) -> TSType<'a> {
         let span = self.start_span();
         let type_predicate_variable = self.try_parse(Self::parse_type_predicate_prefix);
-        let type_span = self.start_span();
         let ty = self.parse_ts_type();
         if let Some(parameter_name) = type_predicate_variable {
-            let type_annotation = Some(self.ast.ts_type_annotation(self.end_span(type_span), ty));
+            let type_annotation = Some(self.ast.ts_type_annotation(ty.span(), ty));
             return self.ast.ts_type_type_predicate(
                 self.end_span(span),
                 parameter_name,

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -2,23 +2,11 @@ commit: 15392346
 
 estree_typescript Summary:
 AST Parsed     : 6480/6481 (99.98%)
-Positive Passed: 6472/6481 (99.86%)
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/controlFlowInstanceofWithSymbolHasInstance.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/compiler/narrowingUnionToUnion.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/binaryOperators/instanceofOperator/instanceofOperatorWithRHSHasSymbolHasInstance.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardNarrowsPrimitiveIntersection.ts
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/expressions/typeGuards/typeGuardNarrowsToLiteralTypeUnion.ts
-
+Positive Passed: 6478/6481 (99.95%)
 Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuite.tsx
 JSX expressions may not use the comma operator
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitEntities.tsx
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitNesting.tsx
-
-Mismatch: tasks/coverage/typescript/tests/cases/conformance/types/stringLiteral/stringLiteralTypesAsTags02.ts
 


### PR DESCRIPTION
Part of #9705 

Given code like this:

```ts
function f(v): v is (1|2) {}
```

Currently, `TSTypePredicate`.`type_annotation`.span contains positions for `(` and `)`, but it should not when `preserveParens: false` for TS-ESTree.

> https://playground.oxc.rs/#eNptj01vgzAMhv8KyqmVkAp03QfnqddN25VLCKaKFBxkJ2wV478vKR/bob7EVl4/ft9RKFGK1qNy2mLS7oZ9mQyJ5mSX/xT7ZJwqPByK48Pp8en5JcvvdFGQLZVvVWx1rLBCkQorylGQx/jwFZ38FqUjD6kwGp0oW2k4DKxsD+sPX7vamnVyJJFbS90inlLRS2KgiJTG2K8PcJ7wzTvWDZyXVOt6TxC0A7xLAuQ/Rjx/Y4R+OzFDnaQLBG8CuMjyU0ih2RrpoHkFZSTJyP+HUraBC9wiAsrawKf1pKCT/WwiSDqNutXrPWXRkTXn4D0uDUC15RB/Bk7TL/T+ijY=

---

BTW, `TypePredicate`.`type_annotation` should be just `TSType` instead of `TSTypeAnnotation`(And generate extra `TSTypeAnnotation` for TS-ESTree)?

https://github.com/oxc-project/oxc/blob/7d8efd872e9481821325d58c63f11fbd2ade2dc8/crates/oxc_ast/src/ast/ts.rs#L1123-L1135