### PR TITLE
perf(transformer/jsx): skip creating temp `String`

### DIFF
--- a/crates/oxc_transformer/src/jsx/jsx_impl.rs
+++ b/crates/oxc_transformer/src/jsx/jsx_impl.rs
@@ -788,7 +788,12 @@ impl<'a> JsxImpl<'a, '_> {
                 if self.options.throw_if_namespace {
                     self.ctx.error(diagnostics::namespace_does_not_support(namespaced.span));
                 }
-                ctx.ast.expression_string_literal(namespaced.span, namespaced.to_string(), None)
+                let namespace_name = ctx.ast.atom_from_strs_array([
+                    &namespaced.namespace.name,
+                    ":",
+                    &namespaced.name.name,
+                ]);
+                ctx.ast.expression_string_literal(namespaced.span, namespace_name, None)
             }
             JSXElementName::ThisExpression(expr) => ctx.ast.expression_this(expr.span),
         }


### PR DESCRIPTION
Small optimization. `JSXNamespacedName::to_string` creates a temporary `String` which is then immediately copied into the arena.

Use `AstBuilder::atom_from_strs_array` instead to construct the string directly in arena. It's probably also cheaper than the `write!` formatter machinery that `impl Display for JSXIdentifier` uses.
