### PR TITLE
feat(span): introduce `format_atom!` macro

### DIFF
--- a/crates/oxc_span/src/lib.rs
+++ b/crates/oxc_span/src/lib.rs
@@ -32,4 +32,6 @@ mod generated {
 pub mod __internal {
     // Used by `format_compact_str!` macro defined in `compact_str.rs`
     pub use compact_str::format_compact;
+    // Used by `format_atom!` macro defined in `atom.rs`
+    pub use oxc_allocator::String as ArenaString;
 }


### PR DESCRIPTION
Introduce a `format_atom!` macro. This behaves the same as `std`'s `format!` macro, but constructs the string directly in arena, and returns an `Atom` instead of a `String`.

```rs
let foo_dot_bar: Atom = format_atom!(&allocator, "{}.{}", foo, bar);
```

Can also be used to avoid creating a temp `String` when creating an `Atom` using a `Display` impl:

```rs
// Before
let atom = ctx.ast.atom(&my_display_type.to_string());
// After
let atom = format_atom!(ctx.ast.allocator, "{my_display_type}");
```
