### PR TITLE
fix(editor): activate extension when astro files are opened too

### DIFF
--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -33,7 +33,8 @@
     "onLanguage:typescript",
     "onLanguage:typescriptreact",
     "onLanguage:vue",
-    "onLanguage:svelte"
+    "onLanguage:svelte",
+    "onLanguage:astro"
   ],
   "main": "./out/main.js",
   "contributes": {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for activating the extension when working with Astro language files in VSCode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->