### PR TITLE
perf(transformer): avoid copying string data

### DIFF
--- a/crates/oxc_transformer/src/decorator/legacy/metadata.rs
+++ b/crates/oxc_transformer/src/decorator/legacy/metadata.rs
@@ -605,7 +605,7 @@ impl<'a> LegacyDecoratorMetadata<'a, '_> {
     // `_metadata(key, value)
     fn create_metadata_decorate(
         &self,
-        key: &str,
+        key: &'a str,
         value: Expression<'a>,
         ctx: &mut TraverseCtx<'a>,
     ) -> Decorator<'a> {

--- a/crates/oxc_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/oxc_transformer/src/es2018/object_rest_spread.rs
@@ -998,6 +998,7 @@ impl<'a> ObjectRestSpread<'a, '_> {
                 if expr.is_literal() {
                     let span = expr.span();
                     let s = expr.to_js_string(&WithoutGlobalReferenceInformation {}).unwrap();
+                    let s = ctx.ast.atom_from_cow(&s);
                     let expr = ctx.ast.expression_string_literal(span, s, None);
                     return Some(ArrayExpressionElement::from(expr));
                 }

--- a/crates/oxc_transformer_plugins/src/inject_global_variables.rs
+++ b/crates/oxc_transformer_plugins/src/inject_global_variables.rs
@@ -216,13 +216,20 @@ impl<'a> InjectGlobalVariables<'a> {
     fn inject_import_to_specifier(&self, inject: &InjectImport) -> ImportDeclarationSpecifier<'a> {
         match &inject.specifier {
             InjectImportSpecifier::Specifier { imported, local } => {
-                let imported_name = imported.as_deref().unwrap_or("default");
-                let imported = if identifier::is_identifier_name(imported_name) {
-                    self.ast.module_export_name_identifier_name(SPAN, imported_name)
-                } else {
-                    self.ast.module_export_name_string_literal(SPAN, imported_name, None)
+                let imported = match imported {
+                    Some(imported_name) => {
+                        let imported_name = self.ast.atom(imported_name);
+                        if identifier::is_identifier_name(&imported_name) {
+                            self.ast.module_export_name_identifier_name(SPAN, imported_name)
+                        } else {
+                            self.ast.module_export_name_string_literal(SPAN, imported_name, None)
+                        }
+                    }
+                    None => self.ast.module_export_name_identifier_name(SPAN, "default"),
                 };
+
                 let local = inject.replace_value.as_ref().unwrap_or(local).as_str();
+
                 self.ast.import_declaration_specifier_import_specifier(
                     SPAN,
                     imported,

--- a/crates/oxc_transformer_plugins/src/module_runner_transform.rs
+++ b/crates/oxc_transformer_plugins/src/module_runner_transform.rs
@@ -709,7 +709,7 @@ impl<'a> ModuleRunnerTransform<'a> {
 
     // `key: value` or `key() {}`
     fn create_object_property(
-        key: &str,
+        key: &'static str,
         value: Option<Expression<'a>>,
         ctx: &TraverseCtx<'a>,
     ) -> ObjectPropertyKind<'a> {


### PR DESCRIPTION
Avoid unnecessarily copying string data in transformer, via various methods:

1. Alter lifetimes so that `Atom` is created from existing string slice, rather than copying string data into arena.
2. Utilize `AstBuilder::atom_from_cow`. When the existing string is a `Cow<'a, str>`, `atom_from_cow` will not copy the string when it's `Borrowed`.
3. Use `Atom<'static>` for static string `"default"`, instead of copying that string into arena.
