### PR TITLE
fix(linter): fix false positive in react/exhaustive deps

### DIFF
--- a/crates/oxc_linter/src/snapshots/react_exhaustive_deps.snap
+++ b/crates/oxc_linter/src/snapshots/react_exhaustive_deps.snap
@@ -1907,6 +1907,15 @@ source: crates/oxc_linter/src/tester.rs
    ╰────
   help: Consider putting the asynchronous code inside a function and calling it from the effect.
 
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useCallback has a missing dependency: 'prop'
+   ╭─[exhaustive_deps.tsx:4:14]
+ 3 │             prop.hello(foo);
+ 4 │           }, [foo]);
+   ·              ─────
+ 5 │           const bar = useCallback(() => {
+   ╰────
+  help: Either include it or remove the dependency array.
+
   ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'local'
    ╭─[exhaustive_deps.tsx:6:31]
  5 │           }
@@ -2246,5 +2255,14 @@ source: crates/oxc_linter/src/tester.rs
  10 │           }, [])
     ·              ──
  11 │ 
+    ╰────
+  help: Either include it or remove the dependency array.
+
+  ⚠ eslint-plugin-react-hooks(exhaustive-deps): React Hook useEffect has a missing dependency: 'log'
+    ╭─[exhaustive_deps.tsx:9:12]
+  8 │           log();
+  9 │         }, []);
+    ·            ──
+ 10 │         }
     ╰────
   help: Either include it or remove the dependency array.


### PR DESCRIPTION
Fix React exhaustive-deps rule to correctly handle useCallback references

This PR fixes the `exhaustive-deps` rule to no longer consider `useCallback` as a stable value, which was causing incorrect linting behavior. The change:

1. Removes `useCallback` from the stable value check, as it should not be treated like `useRef`
2. Updates tests to reflect this change by:
   - Commenting out tests that would cause infinite loops at runtime
   - Uncommenting a test case that should now pass
   - Adding a test case for the specific issue reported in #9788

closes #9788