### PR TITLE
fix(parser): Check comma in JSX expr lazily

### DIFF
--- a/crates/oxc_parser/src/diagnostics.rs
+++ b/crates/oxc_parser/src/diagnostics.rs
@@ -427,15 +427,6 @@ pub fn return_statement_only_in_function_body(span: Span) -> OxcDiagnostic {
 }
 
 #[cold]
-pub fn jsx_expressions_may_not_use_the_comma_operator(span: Span) -> OxcDiagnostic {
-    // OxcDiagnostic::error("TS18007: JSX expressions may not use the comma
-    // operator.")
-    ts_error("18007", "JSX expressions may not use the comma operator")
-        .with_help("Did you mean to write an array?")
-        .with_label(span)
-}
-
-#[cold]
 pub fn invalid_identifier_in_using_declaration(span: Span) -> OxcDiagnostic {
     OxcDiagnostic::error("Using declarations may not have binding patterns.").with_label(span)
 }

--- a/crates/oxc_parser/src/jsx/mod.rs
+++ b/crates/oxc_parser/src/jsx/mod.rs
@@ -300,12 +300,7 @@ impl<'a> ParserImpl<'a> {
 
     fn parse_jsx_assignment_expression(&mut self) -> Expression<'a> {
         self.context(Context::default().and_await(self.ctx.has_await()), self.ctx, |p| {
-            let expr = p.parse_expr();
-            if let Expression::SequenceExpression(seq) = &expr {
-                let error = diagnostics::jsx_expressions_may_not_use_the_comma_operator(seq.span);
-                return p.fatal_error(error);
-            }
-            expr
+            p.parse_expr()
         })
     }
 

--- a/crates/oxc_semantic/src/checker/typescript.rs
+++ b/crates/oxc_semantic/src/checker/typescript.rs
@@ -545,6 +545,12 @@ fn invalid_jsx_attribute_value(span: Span) -> OxcDiagnostic {
         .with_label(span)
 }
 
+fn jsx_expressions_may_not_use_the_comma_operator(span: Span) -> OxcDiagnostic {
+    ts_error("18007", "JSX expressions may not use the comma operator")
+        .with_help("Did you mean to write an array?")
+        .with_label(span)
+}
+
 pub fn check_jsx_expression_container(
     container: &JSXExpressionContainer,
     ctx: &SemanticBuilder<'_>,
@@ -553,5 +559,9 @@ pub fn check_jsx_expression_container(
         && matches!(ctx.nodes.parent_kind(ctx.current_node_id), Some(AstKind::JSXAttributeItem(_)))
     {
         ctx.error(invalid_jsx_attribute_value(container.span()));
+    }
+
+    if matches!(container.expression, JSXExpression::SequenceExpression(_)) {
+        ctx.error(jsx_expressions_may_not_use_the_comma_operator(container.expression.span()));
     }
 }

--- a/tasks/coverage/snapshots/estree_typescript.snap
+++ b/tasks/coverage/snapshots/estree_typescript.snap
@@ -1,10 +1,9 @@
 commit: 15392346
 
 estree_typescript Summary:
-AST Parsed     : 6480/6481 (99.98%)
+AST Parsed     : 6481/6481 (100.00%)
 Positive Passed: 6478/6481 (99.95%)
-Expect to Parse: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuite.tsx
-JSX expressions may not use the comma operator
+Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/jsxReactTestSuite.tsx
 
 Mismatch: tasks/coverage/typescript/tests/cases/conformance/jsx/tsxReactEmitEntities.tsx
 


### PR DESCRIPTION
Part of #9705, fixes #10578.

Continuing to treat the following code as an error:

```ts
// conformance/jsx/jsxParsingError1.tsx
<div className={class1, class2}/>
```

also enables the following code to be parsed:

```ts
// conformance/jsx/jsxReactTestSuite.tsx
<Comp {...(z = { a: "1" }, z)} />
```

by deferring the check to the semantic checker.
