### PR TITLE
feat(ast_tools): support `#[estree(via)]` on fieldless enum variants

### DIFF
--- a/crates/oxc_syntax/src/generated/derive_estree.rs
+++ b/crates/oxc_syntax/src/generated/derive_estree.rs
@@ -35,7 +35,9 @@ impl ESTree for ImportImportName<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             Self::Name(it) => crate::serialize::ImportOrExportNameName(it).serialize(serializer),
-            Self::NamespaceObject => JsonSafeString("namespaceObject").serialize(serializer),
+            Self::NamespaceObject => {
+                crate::serialize::ImportImportNameNamespaceObject(()).serialize(serializer)
+            }
             Self::Default(it) => {
                 crate::serialize::ImportOrExportNameDefault(it).serialize(serializer)
             }
@@ -61,9 +63,11 @@ impl ESTree for ExportImportName<'_> {
     fn serialize<S: Serializer>(&self, serializer: S) {
         match self {
             Self::Name(it) => crate::serialize::ImportOrExportNameName(it).serialize(serializer),
-            Self::All => JsonSafeString("all").serialize(serializer),
-            Self::AllButDefault => JsonSafeString("allButDefault").serialize(serializer),
-            Self::Null => JsonSafeString("null").serialize(serializer),
+            Self::All => crate::serialize::ExportImportNameAll(()).serialize(serializer),
+            Self::AllButDefault => {
+                crate::serialize::ExportImportNameAllButDefault(()).serialize(serializer)
+            }
+            Self::Null => crate::serialize::ExportNameNull(()).serialize(serializer),
         }
     }
 }
@@ -75,7 +79,7 @@ impl ESTree for ExportExportName<'_> {
             Self::Default(it) => {
                 crate::serialize::ImportOrExportNameDefault(it).serialize(serializer)
             }
-            Self::Null => JsonSafeString("null").serialize(serializer),
+            Self::Null => crate::serialize::ExportNameNull(()).serialize(serializer),
         }
     }
 }
@@ -85,7 +89,7 @@ impl ESTree for ExportLocalName<'_> {
         match self {
             Self::Name(it) => crate::serialize::ImportOrExportNameName(it).serialize(serializer),
             Self::Default(it) => crate::serialize::ExportLocalNameDefault(it).serialize(serializer),
-            Self::Null => JsonSafeString("null").serialize(serializer),
+            Self::Null => crate::serialize::ExportNameNull(()).serialize(serializer),
         }
     }
 }

--- a/crates/oxc_syntax/src/serialize.rs
+++ b/crates/oxc_syntax/src/serialize.rs
@@ -48,7 +48,7 @@ dummy_estree_impl!(ExportLocalNameDefault<'_, '_>);
 /// Serializer for `Null` variant of `ExportLocalName`, `ExportExportName`, and `ExportImportName`.
 #[ast_meta]
 #[estree(ts_type = "Dummy", raw_deser = "{kind: 'None', name: null, start: null, end: null}")]
-pub struct ExportNameNull;
+pub struct ExportNameNull(pub ());
 
 dummy_estree_impl!(ExportNameNull);
 
@@ -68,7 +68,7 @@ dummy_estree_impl!(ImportOrExportNameDefault<'_>);
 /// Serializer for `All` variant of `ExportImportName`.
 #[ast_meta]
 #[estree(ts_type = "Dummy", raw_deser = "{kind: 'All', name: null, start: null, end: null}")]
-pub struct ExportImportNameAll;
+pub struct ExportImportNameAll(pub ());
 
 dummy_estree_impl!(ExportImportNameAll);
 
@@ -78,7 +78,7 @@ dummy_estree_impl!(ExportImportNameAll);
     ts_type = "Dummy",
     raw_deser = "{kind: 'AllButDefault', name: null, start: null, end: null}"
 )]
-pub struct ExportImportNameAllButDefault;
+pub struct ExportImportNameAllButDefault(pub ());
 
 dummy_estree_impl!(ExportImportNameAllButDefault);
 
@@ -88,6 +88,6 @@ dummy_estree_impl!(ExportImportNameAllButDefault);
     ts_type = "Dummy",
     raw_deser = "{kind: 'NamespaceObject', name: null, start: null, end: null}"
 )]
-pub struct ImportImportNameNamespaceObject;
+pub struct ImportImportNameNamespaceObject(pub ());
 
 dummy_estree_impl!(ImportImportNameNamespaceObject);

--- a/tasks/ast_tools/src/generators/typescript.rs
+++ b/tasks/ast_tools/src/generators/typescript.rs
@@ -322,12 +322,10 @@ fn generate_ts_type_def_for_enum(enum_def: &EnumDef, schema: &Schema) -> Option<
         .iter()
         .filter(|variant| !should_skip_enum_variant(variant))
         .map(|variant| {
-            if let Some(variant_type) = variant.field_type(schema) {
-                if let Some(converter_name) = &variant.estree.via {
-                    Cow::Borrowed(get_ts_type_for_converter(converter_name, schema).unwrap())
-                } else {
-                    ts_type_name(variant_type, schema)
-                }
+            if let Some(converter_name) = &variant.estree.via {
+                Cow::Borrowed(get_ts_type_for_converter(converter_name, schema).unwrap())
+            } else if let Some(variant_type) = variant.field_type(schema) {
+                ts_type_name(variant_type, schema)
             } else {
                 format_cow!("'{}'", get_fieldless_variant_value(enum_def, variant))
             }


### PR DESCRIPTION
Generators for `ESTree` impls and TS type defs supports `#[estree(via = ...)]` on enum variants where the variant has a field. Extend this support to fieldless variants too.

```rs
#[ast]
#[generate_derive(ESTree)]
enum Foo<'a> {
    // This was already supported
    #[estree(via = FooBar)]
    Bar(Expression<'a>),
    // Add support for this
    #[estree(via = FooQux)]
    Qux,
}
```
