### PR TITLE
refactor(ast/estree): remove custom serializer for `TSMappedTypeModifierOperator`

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1462,15 +1462,18 @@ pub struct TSMappedType<'a> {
 #[ast]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[generate_derive(CloneIn, Dummy, ContentEq, ESTree)]
-#[estree(via = TSMappedTypeModifierOperatorConverter)]
 pub enum TSMappedTypeModifierOperator {
     /// e.g. `?` in `{ [P in K]?: T }`
+    #[estree(via = True)]
     True = 0,
     /// e.g. `+?` in `{ [P in K]+?: T }`
+    #[estree(rename = "+")]
     Plus = 1,
     /// e.g. `-?` in `{ [P in K]-?: T }`
+    #[estree(rename = "-")]
     Minus = 2,
     /// No modifier present
+    #[estree(via = Null)]
     None = 3,
 }
 

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -3187,7 +3187,12 @@ impl ESTree for TSMappedType<'_> {
 
 impl ESTree for TSMappedTypeModifierOperator {
     fn serialize<S: Serializer>(&self, serializer: S) {
-        crate::serialize::TSMappedTypeModifierOperatorConverter(self).serialize(serializer)
+        match self {
+            Self::True => crate::serialize::True(()).serialize(serializer),
+            Self::Plus => JsonSafeString("+").serialize(serializer),
+            Self::Minus => JsonSafeString("-").serialize(serializer),
+            Self::None => crate::serialize::Null(()).serialize(serializer),
+        }
     }
 }
 

--- a/crates/oxc_ast/src/serialize.rs
+++ b/crates/oxc_ast/src/serialize.rs
@@ -1294,29 +1294,6 @@ impl ESTree for TSMappedTypeConstraint<'_, '_> {
     }
 }
 
-#[ast_meta]
-#[estree(
-    ts_type = "true | '+' | '-' | null",
-    raw_deser = "
-        const operator = DESER[u8](POS);
-        [true, '+', '-', null][operator]
-    "
-)]
-pub struct TSMappedTypeModifierOperatorConverter<'a>(pub &'a TSMappedTypeModifierOperator);
-
-impl ESTree for TSMappedTypeModifierOperatorConverter<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) {
-        match self.0 {
-            TSMappedTypeModifierOperator::True => true.serialize(serializer),
-            TSMappedTypeModifierOperator::Plus => JsonSafeString("+").serialize(serializer),
-            TSMappedTypeModifierOperator::Minus => JsonSafeString("-").serialize(serializer),
-            // This is typed as `undefined` (= key is not present) in TS-ESTree.
-            // But we serialize it as `null` to align result in snapshot tests.
-            TSMappedTypeModifierOperator::None => Null(()).serialize(serializer),
-        }
-    }
-}
-
 /// Serializer for `IdentifierReference` variant of `TSTypeName`.
 ///
 /// Where is an identifier called `this`, TS-ESTree presents it as a `ThisExpression`.

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -3946,8 +3946,18 @@ function deserializeTSTypeQueryExprName(pos) {
 }
 
 function deserializeTSMappedTypeModifierOperator(pos) {
-  const operator = deserializeU8(pos);
-  return [true, '+', '-', null][operator];
+  switch (uint8[pos]) {
+    case 0:
+      return true;
+    case 1:
+      return '+';
+    case 2:
+      return '-';
+    case 3:
+      return null;
+    default:
+      throw new Error(`Unexpected discriminant ${uint8[pos]} for TSMappedTypeModifierOperator`);
+  }
 }
 
 function deserializeTSModuleReference(pos) {

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -4098,8 +4098,18 @@ function deserializeTSTypeQueryExprName(pos) {
 }
 
 function deserializeTSMappedTypeModifierOperator(pos) {
-  const operator = deserializeU8(pos);
-  return [true, '+', '-', null][operator];
+  switch (uint8[pos]) {
+    case 0:
+      return true;
+    case 1:
+      return '+';
+    case 2:
+      return '-';
+    case 3:
+      return null;
+    default:
+      throw new Error(`Unexpected discriminant ${uint8[pos]} for TSMappedTypeModifierOperator`);
+  }
 }
 
 function deserializeTSModuleReference(pos) {

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -1375,11 +1375,13 @@ export interface TSMappedType extends Span {
   type: 'TSMappedType';
   nameType: TSType | null;
   typeAnnotation: TSType | null;
-  optional: true | '+' | '-' | null;
-  readonly: true | '+' | '-' | null;
+  optional: TSMappedTypeModifierOperator;
+  readonly: TSMappedTypeModifierOperator;
   key: TSTypeParameter['name'];
   constraint: TSTypeParameter['constraint'];
 }
+
+export type TSMappedTypeModifierOperator = true | '+' | '-' | null;
 
 export interface TSTemplateLiteralType extends Span {
   type: 'TSTemplateLiteralType';


### PR DESCRIPTION
Use the support for `#[estree(via = ...)]` on fieldless enum variants added in #10746 to remove custom serializer for `TSMappedTypeModifierOperator`. This serializer can now be auto-generated.

Does not effect output, only simplifies how it's generated.
