### PR TITLE
refactor(ast)!: remove `TSMappedTypeModifierOperator::None` variant

### DIFF
--- a/crates/oxc_ast/src/ast/ts.rs
+++ b/crates/oxc_ast/src/ast/ts.rs
@@ -1437,25 +1437,25 @@ pub struct TSMappedType<'a> {
     /// ## Examples
     /// ```ts
     /// type Foo = { [P in keyof T]?: T[P] }
-    /// //                         ^^ True
+    /// //                         ^  Some(True)
     /// type Bar = { [P in keyof T]+?: T[P] }
-    /// //                         ^^ Plus
+    /// //                         ^^ Some(Plus)
     /// type Baz = { [P in keyof T]-?: T[P] }
-    /// //                         ^^ Minus
+    /// //                         ^^ Some(Minus)
     /// type Qux = { [P in keyof T]: T[P] }
-    /// //                         ^ None
+    /// //                         ^  None
     /// ```
-    pub optional: TSMappedTypeModifierOperator,
+    pub optional: Option<TSMappedTypeModifierOperator>,
     /// Readonly modifier before keyed index signature
     ///
     /// ## Examples
     /// ```ts
-    /// type Foo = { readonly [P in keyof T]: T[P] }  // True
-    /// type Bar = { +readonly [P in keyof T]: T[P] } // Plus
-    /// type Baz = { -readonly [P in keyof T]: T[P] } // Minus
+    /// type Foo = { readonly [P in keyof T]: T[P] }  // Some(True)
+    /// type Bar = { +readonly [P in keyof T]: T[P] } // Some(Plus)
+    /// type Baz = { -readonly [P in keyof T]: T[P] } // Some(Minus)
     /// type Qux = { [P in keyof T]: T[P] }           // None
     /// ```
-    pub readonly: TSMappedTypeModifierOperator,
+    pub readonly: Option<TSMappedTypeModifierOperator>,
     pub scope_id: Cell<Option<ScopeId>>,
 }
 
@@ -1472,9 +1472,6 @@ pub enum TSMappedTypeModifierOperator {
     /// e.g. `-?` in `{ [P in K]-?: T }`
     #[estree(rename = "-")]
     Minus = 2,
-    /// No modifier present
-    #[estree(via = Null)]
-    None = 3,
 }
 
 /// TypeScript Template Literal Type

--- a/crates/oxc_ast/src/generated/ast_builder.rs
+++ b/crates/oxc_ast/src/generated/ast_builder.rs
@@ -10504,8 +10504,8 @@ impl<'a> AstBuilder<'a> {
         type_parameter: T1,
         name_type: Option<TSType<'a>>,
         type_annotation: Option<TSType<'a>>,
-        optional: TSMappedTypeModifierOperator,
-        readonly: TSMappedTypeModifierOperator,
+        optional: Option<TSMappedTypeModifierOperator>,
+        readonly: Option<TSMappedTypeModifierOperator>,
     ) -> TSType<'a>
     where
         T1: IntoIn<'a, Box<'a, TSTypeParameter<'a>>>,
@@ -10539,8 +10539,8 @@ impl<'a> AstBuilder<'a> {
         type_parameter: T1,
         name_type: Option<TSType<'a>>,
         type_annotation: Option<TSType<'a>>,
-        optional: TSMappedTypeModifierOperator,
-        readonly: TSMappedTypeModifierOperator,
+        optional: Option<TSMappedTypeModifierOperator>,
+        readonly: Option<TSMappedTypeModifierOperator>,
         scope_id: ScopeId,
     ) -> TSType<'a>
     where
@@ -13887,8 +13887,8 @@ impl<'a> AstBuilder<'a> {
         type_parameter: T1,
         name_type: Option<TSType<'a>>,
         type_annotation: Option<TSType<'a>>,
-        optional: TSMappedTypeModifierOperator,
-        readonly: TSMappedTypeModifierOperator,
+        optional: Option<TSMappedTypeModifierOperator>,
+        readonly: Option<TSMappedTypeModifierOperator>,
     ) -> TSMappedType<'a>
     where
         T1: IntoIn<'a, Box<'a, TSTypeParameter<'a>>>,
@@ -13923,8 +13923,8 @@ impl<'a> AstBuilder<'a> {
         type_parameter: T1,
         name_type: Option<TSType<'a>>,
         type_annotation: Option<TSType<'a>>,
-        optional: TSMappedTypeModifierOperator,
-        readonly: TSMappedTypeModifierOperator,
+        optional: Option<TSMappedTypeModifierOperator>,
+        readonly: Option<TSMappedTypeModifierOperator>,
     ) -> Box<'a, TSMappedType<'a>>
     where
         T1: IntoIn<'a, Box<'a, TSTypeParameter<'a>>>,
@@ -13962,8 +13962,8 @@ impl<'a> AstBuilder<'a> {
         type_parameter: T1,
         name_type: Option<TSType<'a>>,
         type_annotation: Option<TSType<'a>>,
-        optional: TSMappedTypeModifierOperator,
-        readonly: TSMappedTypeModifierOperator,
+        optional: Option<TSMappedTypeModifierOperator>,
+        readonly: Option<TSMappedTypeModifierOperator>,
         scope_id: ScopeId,
     ) -> TSMappedType<'a>
     where
@@ -14000,8 +14000,8 @@ impl<'a> AstBuilder<'a> {
         type_parameter: T1,
         name_type: Option<TSType<'a>>,
         type_annotation: Option<TSType<'a>>,
-        optional: TSMappedTypeModifierOperator,
-        readonly: TSMappedTypeModifierOperator,
+        optional: Option<TSMappedTypeModifierOperator>,
+        readonly: Option<TSMappedTypeModifierOperator>,
         scope_id: ScopeId,
     ) -> Box<'a, TSMappedType<'a>>
     where

--- a/crates/oxc_ast/src/generated/derive_estree.rs
+++ b/crates/oxc_ast/src/generated/derive_estree.rs
@@ -3191,7 +3191,6 @@ impl ESTree for TSMappedTypeModifierOperator {
             Self::True => crate::serialize::True(()).serialize(serializer),
             Self::Plus => JsonSafeString("+").serialize(serializer),
             Self::Minus => JsonSafeString("-").serialize(serializer),
-            Self::None => crate::serialize::Null(()).serialize(serializer),
         }
     }
 }

--- a/crates/oxc_codegen/src/gen.rs
+++ b/crates/oxc_codegen/src/gen.rs
@@ -3167,16 +3167,10 @@ impl Gen for TSMappedType<'_> {
         p.print_str("{");
         p.print_soft_space();
         match self.readonly {
-            TSMappedTypeModifierOperator::True => {
-                p.print_str("readonly ");
-            }
-            TSMappedTypeModifierOperator::Plus => {
-                p.print_str("+readonly ");
-            }
-            TSMappedTypeModifierOperator::Minus => {
-                p.print_str("-readonly ");
-            }
-            TSMappedTypeModifierOperator::None => {}
+            Some(TSMappedTypeModifierOperator::True) => p.print_str("readonly "),
+            Some(TSMappedTypeModifierOperator::Plus) => p.print_str("+readonly "),
+            Some(TSMappedTypeModifierOperator::Minus) => p.print_str("-readonly "),
+            None => {}
         }
         p.print_str("[");
         self.type_parameter.name.print(p, ctx);
@@ -3194,16 +3188,10 @@ impl Gen for TSMappedType<'_> {
         }
         p.print_str("]");
         match self.optional {
-            TSMappedTypeModifierOperator::True => {
-                p.print_str("?");
-            }
-            TSMappedTypeModifierOperator::Plus => {
-                p.print_str("+?");
-            }
-            TSMappedTypeModifierOperator::Minus => {
-                p.print_str("-?");
-            }
-            TSMappedTypeModifierOperator::None => {}
+            Some(TSMappedTypeModifierOperator::True) => p.print_str("?"),
+            Some(TSMappedTypeModifierOperator::Plus) => p.print_str("+?"),
+            Some(TSMappedTypeModifierOperator::Minus) => p.print_str("-?"),
+            None => {}
         }
         p.print_soft_space();
         if let Some(type_annotation) = &self.type_annotation {

--- a/crates/oxc_formatter/src/write/mod.rs
+++ b/crates/oxc_formatter/src/write/mod.rs
@@ -2906,16 +2906,10 @@ impl<'a> FormatWrite<'a> for TSMappedType<'a> {
             write!(f, FormatLeadingComments::Comments(comments.dangling_comments(self.span)))?;
 
             match self.readonly {
-                TSMappedTypeModifierOperator::True => {
-                    write!(f, ["readonly", space()])?;
-                }
-                TSMappedTypeModifierOperator::Plus => {
-                    write!(f, ["+readonly", space()])?;
-                }
-                TSMappedTypeModifierOperator::Minus => {
-                    write!(f, ["-readonly", space()])?;
-                }
-                TSMappedTypeModifierOperator::None => {}
+                Some(TSMappedTypeModifierOperator::True) => write!(f, ["readonly", space()])?,
+                Some(TSMappedTypeModifierOperator::Plus) => write!(f, ["+readonly", space()])?,
+                Some(TSMappedTypeModifierOperator::Minus) => write!(f, ["-readonly", space()])?,
+                None => {}
             }
 
             let format_inner_inner = format_with(|f| {
@@ -2934,16 +2928,10 @@ impl<'a> FormatWrite<'a> for TSMappedType<'a> {
             });
 
             match self.optional {
-                TSMappedTypeModifierOperator::True => {
-                    write!(f, "?")?;
-                }
-                TSMappedTypeModifierOperator::Plus => {
-                    write!(f, "+?")?;
-                }
-                TSMappedTypeModifierOperator::Minus => {
-                    write!(f, "-?")?;
-                }
-                TSMappedTypeModifierOperator::None => {}
+                Some(TSMappedTypeModifierOperator::True) => write!(f, "?")?,
+                Some(TSMappedTypeModifierOperator::Plus) => write!(f, "+?")?,
+                Some(TSMappedTypeModifierOperator::Minus) => write!(f, "-?")?,
+                None => {}
             }
 
             write!(f, [space(), group(&format_inner_inner)])?;

--- a/crates/oxc_parser/src/ts/types.rs
+++ b/crates/oxc_parser/src/ts/types.rs
@@ -556,13 +556,13 @@ impl<'a> ParserImpl<'a> {
     fn parse_mapped_type(&mut self) -> TSType<'a> {
         let span = self.start_span();
         self.expect(Kind::LCurly);
-        let mut readonly = TSMappedTypeModifierOperator::None;
+        let mut readonly = None;
         if self.eat(Kind::Readonly) {
-            readonly = TSMappedTypeModifierOperator::True;
+            readonly = Some(TSMappedTypeModifierOperator::True);
         } else if self.eat(Kind::Plus) && self.eat(Kind::Readonly) {
-            readonly = TSMappedTypeModifierOperator::Plus;
+            readonly = Some(TSMappedTypeModifierOperator::Plus);
         } else if self.eat(Kind::Minus) && self.eat(Kind::Readonly) {
-            readonly = TSMappedTypeModifierOperator::Minus;
+            readonly = Some(TSMappedTypeModifierOperator::Minus);
         }
 
         self.expect(Kind::LBrack);
@@ -589,19 +589,19 @@ impl<'a> ParserImpl<'a> {
         let optional = match self.cur_kind() {
             Kind::Question => {
                 self.bump_any();
-                TSMappedTypeModifierOperator::True
+                Some(TSMappedTypeModifierOperator::True)
             }
             Kind::Minus => {
                 self.bump_any();
                 self.expect(Kind::Question);
-                TSMappedTypeModifierOperator::Minus
+                Some(TSMappedTypeModifierOperator::Minus)
             }
             Kind::Plus => {
                 self.bump_any();
                 self.expect(Kind::Question);
-                TSMappedTypeModifierOperator::Plus
+                Some(TSMappedTypeModifierOperator::Plus)
             }
-            _ => TSMappedTypeModifierOperator::None,
+            _ => None,
         };
 
         let type_annotation = self.eat(Kind::Colon).then(|| self.parse_ts_type());

--- a/crates/oxc_traverse/src/generated/ancestor.rs
+++ b/crates/oxc_traverse/src/generated/ancestor.rs
@@ -14781,18 +14781,18 @@ impl<'a, 't> TSMappedTypeWithoutTypeParameter<'a, 't> {
     }
 
     #[inline]
-    pub fn optional(self) -> &'t TSMappedTypeModifierOperator {
+    pub fn optional(self) -> &'t Option<TSMappedTypeModifierOperator> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_MAPPED_TYPE_OPTIONAL)
-                as *const TSMappedTypeModifierOperator)
+                as *const Option<TSMappedTypeModifierOperator>)
         }
     }
 
     #[inline]
-    pub fn readonly(self) -> &'t TSMappedTypeModifierOperator {
+    pub fn readonly(self) -> &'t Option<TSMappedTypeModifierOperator> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_MAPPED_TYPE_READONLY)
-                as *const TSMappedTypeModifierOperator)
+                as *const Option<TSMappedTypeModifierOperator>)
         }
     }
 
@@ -14842,18 +14842,18 @@ impl<'a, 't> TSMappedTypeWithoutNameType<'a, 't> {
     }
 
     #[inline]
-    pub fn optional(self) -> &'t TSMappedTypeModifierOperator {
+    pub fn optional(self) -> &'t Option<TSMappedTypeModifierOperator> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_MAPPED_TYPE_OPTIONAL)
-                as *const TSMappedTypeModifierOperator)
+                as *const Option<TSMappedTypeModifierOperator>)
         }
     }
 
     #[inline]
-    pub fn readonly(self) -> &'t TSMappedTypeModifierOperator {
+    pub fn readonly(self) -> &'t Option<TSMappedTypeModifierOperator> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_MAPPED_TYPE_READONLY)
-                as *const TSMappedTypeModifierOperator)
+                as *const Option<TSMappedTypeModifierOperator>)
         }
     }
 
@@ -14903,18 +14903,18 @@ impl<'a, 't> TSMappedTypeWithoutTypeAnnotation<'a, 't> {
     }
 
     #[inline]
-    pub fn optional(self) -> &'t TSMappedTypeModifierOperator {
+    pub fn optional(self) -> &'t Option<TSMappedTypeModifierOperator> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_MAPPED_TYPE_OPTIONAL)
-                as *const TSMappedTypeModifierOperator)
+                as *const Option<TSMappedTypeModifierOperator>)
         }
     }
 
     #[inline]
-    pub fn readonly(self) -> &'t TSMappedTypeModifierOperator {
+    pub fn readonly(self) -> &'t Option<TSMappedTypeModifierOperator> {
         unsafe {
             &*((self.0 as *const u8).add(OFFSET_TS_MAPPED_TYPE_READONLY)
-                as *const TSMappedTypeModifierOperator)
+                as *const Option<TSMappedTypeModifierOperator>)
         }
     }
 

--- a/napi/parser/generated/deserialize/js.js
+++ b/napi/parser/generated/deserialize/js.js
@@ -1908,8 +1908,8 @@ function deserializeTSMappedType(pos) {
     end: deserializeU32(pos + 4),
     nameType: deserializeOptionTSType(pos + 16),
     typeAnnotation: deserializeOptionTSType(pos + 32),
-    optional: deserializeTSMappedTypeModifierOperator(pos + 48),
-    readonly: deserializeTSMappedTypeModifierOperator(pos + 49),
+    optional: deserializeOptionTSMappedTypeModifierOperator(pos + 48),
+    readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 49),
     key: typeParameter.name,
     constraint: typeParameter.constraint,
   };
@@ -3953,8 +3953,6 @@ function deserializeTSMappedTypeModifierOperator(pos) {
       return '+';
     case 2:
       return '-';
-    case 3:
-      return null;
     default:
       throw new Error(`Unexpected discriminant ${uint8[pos]} for TSMappedTypeModifierOperator`);
   }
@@ -5578,6 +5576,11 @@ function deserializeOptionBoxObjectExpression(pos) {
 function deserializeOptionTSTypeName(pos) {
   if (uint8[pos] === 2) return null;
   return deserializeTSTypeName(pos);
+}
+
+function deserializeOptionTSMappedTypeModifierOperator(pos) {
+  if (uint8[pos] === 3) return null;
+  return deserializeTSMappedTypeModifierOperator(pos);
 }
 
 function deserializeBoxTSExternalModuleReference(pos) {

--- a/napi/parser/generated/deserialize/ts.js
+++ b/napi/parser/generated/deserialize/ts.js
@@ -2060,8 +2060,8 @@ function deserializeTSMappedType(pos) {
     end: deserializeU32(pos + 4),
     nameType: deserializeOptionTSType(pos + 16),
     typeAnnotation: deserializeOptionTSType(pos + 32),
-    optional: deserializeTSMappedTypeModifierOperator(pos + 48),
-    readonly: deserializeTSMappedTypeModifierOperator(pos + 49),
+    optional: deserializeOptionTSMappedTypeModifierOperator(pos + 48),
+    readonly: deserializeOptionTSMappedTypeModifierOperator(pos + 49),
     key: typeParameter.name,
     constraint: typeParameter.constraint,
   };
@@ -4105,8 +4105,6 @@ function deserializeTSMappedTypeModifierOperator(pos) {
       return '+';
     case 2:
       return '-';
-    case 3:
-      return null;
     default:
       throw new Error(`Unexpected discriminant ${uint8[pos]} for TSMappedTypeModifierOperator`);
   }
@@ -5730,6 +5728,11 @@ function deserializeOptionBoxObjectExpression(pos) {
 function deserializeOptionTSTypeName(pos) {
   if (uint8[pos] === 2) return null;
   return deserializeTSTypeName(pos);
+}
+
+function deserializeOptionTSMappedTypeModifierOperator(pos) {
+  if (uint8[pos] === 3) return null;
+  return deserializeTSMappedTypeModifierOperator(pos);
 }
 
 function deserializeBoxTSExternalModuleReference(pos) {

--- a/npm/oxc-types/types.d.ts
+++ b/npm/oxc-types/types.d.ts
@@ -1375,13 +1375,13 @@ export interface TSMappedType extends Span {
   type: 'TSMappedType';
   nameType: TSType | null;
   typeAnnotation: TSType | null;
-  optional: TSMappedTypeModifierOperator;
-  readonly: TSMappedTypeModifierOperator;
+  optional: TSMappedTypeModifierOperator | null;
+  readonly: TSMappedTypeModifierOperator | null;
   key: TSTypeParameter['name'];
   constraint: TSTypeParameter['constraint'];
 }
 
-export type TSMappedTypeModifierOperator = true | '+' | '-' | null;
+export type TSMappedTypeModifierOperator = true | '+' | '-';
 
 export interface TSTemplateLiteralType extends Span {
   type: 'TSTemplateLiteralType';


### PR DESCRIPTION
It seems odd for `TSMappedTypeModifierOperator` to have a `None` variant. It's more conventional to represent "doesn't exist" as `Option::None`.

Remove the `TSMappedTypeModifierOperator::None` variant, and use `Option<TSMappedTypeModifierOperator>` instead of `TSMappedTypeModifierOperator`.

Both are the same to the compiler due to the niche optimization on `Option` (`Option<TSMappedTypeModifierOperator>` is 1 byte), but it just seems more logical to me this way.

Also an unrelated change: Shorten code in codegen and formatter.
