### PR TITLE
fix(formatter): do not ignore result of `write!`

### DIFF
--- a/crates/oxc_formatter/src/write/mod.rs
+++ b/crates/oxc_formatter/src/write/mod.rs
@@ -2907,13 +2907,13 @@ impl<'a> FormatWrite<'a> for TSMappedType<'a> {
 
             match self.readonly {
                 TSMappedTypeModifierOperator::True => {
-                    write!(f, ["readonly", space()]);
+                    write!(f, ["readonly", space()])?;
                 }
                 TSMappedTypeModifierOperator::Plus => {
-                    write!(f, ["+readonly", space()]);
+                    write!(f, ["+readonly", space()])?;
                 }
                 TSMappedTypeModifierOperator::Minus => {
-                    write!(f, ["-readonly", space()]);
+                    write!(f, ["-readonly", space()])?;
                 }
                 TSMappedTypeModifierOperator::None => {}
             }


### PR DESCRIPTION
I *think* this is a bug. Everywhere else in formatter, it looks like the result of `write!` is passed on to caller if it's `Err`.
