### PR TITLE
perf(transformer/inject_global_variables): do not search string twice

### DIFF
--- a/crates/oxc_transformer_plugins/src/inject_global_variables.rs
+++ b/crates/oxc_transformer_plugins/src/inject_global_variables.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
 
 use cow_utils::CowUtils;
 
@@ -63,9 +63,10 @@ impl InjectImport {
     }
 
     fn replace_name(local: &str) -> Option<CompactStr> {
-        local
-            .contains('.')
-            .then(|| CompactStr::from(format!("$inject_{}", local.cow_replace('.', "_"))))
+        match local.cow_replace('.', "_") {
+            Cow::Owned(local) => Some(CompactStr::from(format!("$inject_{local}"))),
+            Cow::Borrowed(_) => None,
+        }
     }
 }
 


### PR DESCRIPTION
Small optimization. `local.cow_replace('.', "_")` searches the string and returns a `Cow::Borrowed` if it doesn't contain `.`. So use that result instead of an additional search with `local.contains('.')`.