### PR TITLE
perf(napi/transform): do not create temp `String`

### DIFF
--- a/napi/transform/src/transformer.rs
+++ b/napi/transform/src/transformer.rs
@@ -652,11 +652,11 @@ impl Compiler {
                                     "Inject plugin did not receive a tuple [string, string].",
                                 )]);
                             }
-                            let source = v[0].to_string();
+                            let source = &v[0];
                             Ok(if v[1] == "*" {
-                                InjectImport::namespace_specifier(&source, &local)
+                                InjectImport::namespace_specifier(source, &local)
                             } else {
-                                InjectImport::named_specifier(&source, Some(&v[1]), &local)
+                                InjectImport::named_specifier(source, Some(&v[1]), &local)
                             })
                         }
                     })


### PR DESCRIPTION
Avoid an allocation. `to_string` here clones a `String` and then immediately converts it back to a `&str`. Avoid that intermediate allocation.