### PR TITLE
perf(transformer, linter): use `format_compact_str!`

### DIFF
--- a/crates/oxc_linter/src/config/config_builder.rs
+++ b/crates/oxc_linter/src/config/config_builder.rs
@@ -7,7 +7,7 @@ use itertools::Itertools;
 use rustc_hash::FxHashSet;
 
 use oxc_diagnostics::OxcDiagnostic;
-use oxc_span::CompactStr;
+use oxc_span::{CompactStr, format_compact_str};
 
 use crate::{
     AllowWarnDeny, LintConfig, LintFilter, LintFilterKind, Oxlintrc, RuleCategory, RuleEnum,
@@ -364,7 +364,7 @@ fn get_name(plugin_name: &str, rule_name: &str) -> CompactStr {
     if plugin_name == "eslint" {
         CompactStr::from(rule_name)
     } else {
-        CompactStr::from(format!("{plugin_name}/{rule_name}"))
+        format_compact_str!("{plugin_name}/{rule_name}")
     }
 }
 

--- a/crates/oxc_transformer_plugins/src/inject_global_variables.rs
+++ b/crates/oxc_transformer_plugins/src/inject_global_variables.rs
@@ -5,7 +5,7 @@ use cow_utils::CowUtils;
 use oxc_allocator::Allocator;
 use oxc_ast::{AstBuilder, NONE, ast::*};
 use oxc_semantic::Scoping;
-use oxc_span::{CompactStr, SPAN};
+use oxc_span::{CompactStr, SPAN, format_compact_str};
 use oxc_syntax::identifier;
 use oxc_traverse::{Traverse, TraverseCtx, traverse_mut};
 
@@ -64,7 +64,7 @@ impl InjectImport {
 
     fn replace_name(local: &str) -> Option<CompactStr> {
         match local.cow_replace('.', "_") {
-            Cow::Owned(local) => Some(CompactStr::from(format!("$inject_{local}"))),
+            Cow::Owned(local) => Some(format_compact_str!("$inject_{local}")),
             Cow::Borrowed(_) => None,
         }
     }


### PR DESCRIPTION
Replace `CompactStr::from(format!(...))` with `format_compact_str!(...)`. This avoids creating an intermediate `String`.